### PR TITLE
Convert Springer fetcher to new interface

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/EntryFetchers.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/EntryFetchers.java
@@ -19,7 +19,6 @@ public class EntryFetchers {
         // entryFetchers.add(new OAI2Fetcher()); - new arXiv fetcher in place, see below
         entryFetchers.add(new ACMPortalFetcher());
         entryFetchers.add(new DOAJFetcher());
-        entryFetchers.add(new SpringerFetcher());
 
         WebFetchers.getSearchBasedFetchers(Globals.prefs.getImportFormatPreferences()).stream()
                 .map(SearchBasedEntryFetcher::new)

--- a/src/main/java/org/jabref/gui/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/SpringerFetcher.java
@@ -1,111 +1,38 @@
 package org.jabref.gui.importer.fetcher;
 
-import java.io.IOException;
-import java.net.URLEncoder;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-
-import org.jabref.gui.importer.ImportInspectionDialog;
 import org.jabref.logic.help.HelpFile;
-import org.jabref.logic.importer.ImportInspector;
-import org.jabref.logic.importer.OutputPrinter;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.Parser;
+import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.util.JSONEntryParser;
-import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.JsonNode;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.http.client.utils.URIBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class SpringerFetcher implements EntryFetcher {
+/**
+ * Fetches data from the Springer
+ *
+ * @implNote see <a href="https://dev.springernature.com/">API documentation</a> for more details
+ */
+public class SpringerFetcher implements SearchBasedParserFetcher {
 
-    private static final String API_URL = "http://api.springer.com/metadata/json?q=";
+    private static final String API_URL = "http://api.springernature.com/meta/v1/json?q=";
     private static final String API_KEY = "b0c7151179b3d9c1119cf325bca8460d";
-    private static final Logger LOGGER = LoggerFactory.getLogger(SpringerFetcher.class);
-    private static final int MAX_PER_PAGE = 100;
-    private boolean shouldContinue;
 
     @Override
-    public void stopFetching() {
-        shouldContinue = false;
-    }
-
-    @Override
-    public boolean processQuery(String query, ImportInspector inspector, OutputPrinter status) {
-        shouldContinue = true;
-        try {
-            status.setStatus(Localization.lang("Searching..."));
-            HttpResponse<JsonNode> jsonResponse;
-            String encodedQuery = URLEncoder.encode(query, "UTF-8");
-            jsonResponse = Unirest.get(API_URL + encodedQuery + "&api_key=" + API_KEY + "&p=1")
-                    .header("accept", "application/json")
-                    .asJson();
-            JSONObject jo = jsonResponse.getBody().getObject();
-            int numberToFetch = jo.getJSONArray("result").getJSONObject(0).getInt("total");
-            if (numberToFetch > 0) {
-                if (numberToFetch > MAX_PER_PAGE) {
-                    boolean numberEntered = false;
-                    do {
-                        String strCount = JOptionPane.showInputDialog(Localization.lang("%0 references found. Number of references to fetch?", String.valueOf(numberToFetch)));
-
-                        if (strCount == null) {
-                            status.setStatus(Localization.lang("%0 import canceled", getTitle()));
-                            return false;
-                        }
-
-                        try {
-                            numberToFetch = Integer.parseInt(strCount.trim());
-                            numberEntered = true;
-                        } catch (NumberFormatException ex) {
-                            status.showMessage(Localization.lang("Please enter a valid number"));
-                        }
-                    } while (!numberEntered);
-                }
-
-                int fetched = 0; // Keep track of number of items fetched for the progress bar
-                for (int startItem = 1; startItem <= numberToFetch; startItem += MAX_PER_PAGE) {
-                    if (!shouldContinue) {
-                        break;
-                    }
-
-                    int noToFetch = Math.min(MAX_PER_PAGE, (numberToFetch - startItem) + 1);
-                    jsonResponse = Unirest
-                            .get(API_URL + encodedQuery + "&api_key=" + API_KEY + "&p=" + noToFetch + "&s=" + startItem)
-                            .header("accept", "application/json").asJson();
-                    jo = jsonResponse.getBody().getObject();
-                    if (jo.has("records")) {
-                        JSONArray results = jo.getJSONArray("records");
-                        for (int i = 0; i < results.length(); i++) {
-                            JSONObject springerJsonEntry = results.getJSONObject(i);
-                            BibEntry entry = JSONEntryParser.parseSpringerJSONtoBibtex(springerJsonEntry);
-                            inspector.addEntry(entry);
-                            fetched++;
-                            inspector.setProgress(fetched, numberToFetch);
-                        }
-                    }
-                }
-                return true;
-            } else {
-                status.showMessage(Localization.lang("No entries found for the search string '%0'", encodedQuery),
-                        Localization.lang("Search %0", getTitle()), JOptionPane.INFORMATION_MESSAGE);
-                return false;
-            }
-        } catch (IOException | UnirestException e) {
-            LOGGER.error("Error while fetching from " + getTitle(), e);
-            ((ImportInspectionDialog)inspector).showErrorMessage(this.getTitle(), e.getLocalizedMessage());
-        }
-        return false;
-
-    }
-
-    @Override
-    public String getTitle() {
+    public String getName() {
         return "Springer";
     }
 
@@ -115,8 +42,32 @@ public class SpringerFetcher implements EntryFetcher {
     }
 
     @Override
-    public JPanel getOptionsPanel() {
-        // No additional options available
-        return null;
+    public URL getURLForQuery(String query) throws URISyntaxException, MalformedURLException, FetcherException {
+        URIBuilder uriBuilder = new URIBuilder(API_URL);
+        uriBuilder.addParameter("q", query); // Search query
+        uriBuilder.addParameter("api_key", API_KEY); // API key
+        uriBuilder.addParameter("p", "20"); // Number of results to return
+        //uriBuilder.addParameter("s", "1"); // Start item (not needed at the moment)
+        return uriBuilder.build().toURL();
+    }
+
+    @Override
+    public Parser getParser() {
+        return inputStream -> {
+            String response = new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining(OS.NEWLINE));
+            JSONObject jsonObject = new JSONObject(response);
+
+            List<BibEntry> entries = new ArrayList<>();
+            if (jsonObject.has("records")) {
+                JSONArray results = jsonObject.getJSONArray("records");
+                for (int i = 0; i < results.length(); i++) {
+                    JSONObject jsonEntry = results.getJSONObject(i);
+                    BibEntry entry = JSONEntryParser.parseSpringerJSONtoBibtex(jsonEntry);
+                    entries.add(entry);
+                }
+            }
+
+            return entries;
+        };
     }
 }

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
+import org.jabref.gui.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fetcher.ACS;
 import org.jabref.logic.importer.fetcher.ArXiv;
 import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
@@ -81,6 +82,7 @@ public class WebFetchers {
         list.add(new ZbMATH(importFormatPreferences));
         list.add(new GoogleScholar(importFormatPreferences));
         list.add(new DBLPFetcher(importFormatPreferences));
+        list.add(new SpringerFetcher());
         list.add(new CrossRef());
         list.sort(Comparator.comparing(WebFetcher::getName));
         return list;

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.gui.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fetcher.ACS;
 import org.jabref.logic.importer.fetcher.ArXiv;
 import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
@@ -25,6 +24,7 @@ import org.jabref.logic.importer.fetcher.MedlineFetcher;
 import org.jabref.logic.importer.fetcher.OpenAccessDoi;
 import org.jabref.logic.importer.fetcher.RfcFetcher;
 import org.jabref.logic.importer.fetcher.ScienceDirect;
+import org.jabref.logic.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fetcher.SpringerLink;
 import org.jabref.logic.importer.fetcher.TitleFetcher;
 import org.jabref.logic.importer.fetcher.ZbMATH;

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -1,4 +1,4 @@
-package org.jabref.gui.importer.fetcher;
+package org.jabref.logic.importer.fetcher;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/src/main/java/org/jabref/logic/importer/util/JSONEntryParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/JSONEntryParser.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.Month;
 
 import org.json.JSONArray;
@@ -181,9 +182,9 @@ public class JSONEntryParser {
 
         // Page numbers
         if (springerJsonEntry.has("startingPage") && !(springerJsonEntry.getString("startingPage").isEmpty())) {
-            if (springerJsonEntry.has("endPage") && !(springerJsonEntry.getString("endPage").isEmpty())) {
+            if (springerJsonEntry.has("endingPage") && !(springerJsonEntry.getString("endingPage").isEmpty())) {
                 entry.setField(FieldName.PAGES,
-                        springerJsonEntry.getString("startingPage") + "--" + springerJsonEntry.getString("endPage"));
+                        springerJsonEntry.getString("startingPage") + "--" + springerJsonEntry.getString("endingPage"));
             } else {
                 entry.setField(FieldName.PAGES, springerJsonEntry.getString("startingPage"));
             }
@@ -194,13 +195,18 @@ public class JSONEntryParser {
             entry.setField(nametype, springerJsonEntry.getString("publicationName"));
         }
 
-        // URL
+        // Online file
         if (springerJsonEntry.has("url")) {
-            JSONArray urlarray = springerJsonEntry.optJSONArray("url");
-            if (urlarray == null) {
+            JSONArray urls = springerJsonEntry.optJSONArray("url");
+            if (urls == null) {
                 entry.setField(FieldName.URL, springerJsonEntry.optString("url"));
             } else {
-                entry.setField(FieldName.URL, urlarray.getJSONObject(0).optString("value"));
+                urls.forEach(data -> {
+                    JSONObject url = (JSONObject) data;
+                    if (url.optString("format").equalsIgnoreCase("pdf")) {
+                        entry.addFile(new LinkedFile("online", url.optString("value"), "PDF"));
+                    }
+                });
             }
         }
 

--- a/src/test/java/org/jabref/gui/importer/fetcher/SpringerFetcherTest.java
+++ b/src/test/java/org/jabref/gui/importer/fetcher/SpringerFetcherTest.java
@@ -1,0 +1,42 @@
+package org.jabref.gui.importer.fetcher;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibtexEntryTypes;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpringerFetcherTest {
+
+    SpringerFetcher fetcher;
+
+    @BeforeEach
+    void setUp() {
+        fetcher = new SpringerFetcher();
+    }
+
+    @Test
+    void searchByQueryFindsEntry() throws Exception {
+        BibEntry expected = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
+        expected.setField("author", "Steinmacher, Igor and Gerosa, Marco and Conte, Tayana U. and Redmiles, David F.");
+        expected.setField("date", "2018-06-14");
+        expected.setField("doi", "10.1007/s10606-018-9335-z");
+        expected.setField("issn", "0925-9724");
+        expected.setField("journal", "Computer Supported Cooperative Work (CSCW)");
+        expected.setField("month", "#jun#");
+        expected.setField("pages", "1--44");
+        expected.setField("publisher", "Springer");
+        expected.setField("title", "Overcoming Social Barriers When Contributing to Open Source Software Projects");
+        expected.setField("year", "2018");
+        expected.setField("file", "online:http\\://link.springer.com/openurl/pdf?id=doi\\:10.1007/s10606-018-9335-z:PDF");
+        expected.setField("abstract", "An influx of newcomers is critical to the survival, long-term success, and continuity of many Open Source Software (OSS) community-based projects. However, newcomers face many barriers when making their first contribution, leading in many cases to dropouts. Due to the collaborative nature of community-based OSS projects, newcomers may be susceptible to social barriers, such as communication breakdowns and reception issues. In this article, we report a two-phase study aimed at better understanding social barriers faced by newcomers. In the first phase, we qualitatively analyzed the literature and data collected from practitioners to identify barriers that hinder newcomers’ first contribution. We designed a model composed of 58 barriers, including 13 social barriers. In the second phase, based on the barriers model, we developed FLOSScoach, a portal to support newcomers making their first contribution. We evaluated the portal in a diary-based study and found that the portal guided the newcomers and reduced the need for communication. Our results provide insights for communities that want to support newcomers and lay a foundation for building better onboarding tools. The contributions of this paper include identifying and gathering empirical evidence of social barriers faced by newcomers; understanding how social barriers can be reduced or avoided by using a portal that organizes proper information for newcomers (FLOSScoach); presenting guidelines for communities and newcomers on how to reduce or avoid social barriers; and identifying new streams of research.");
+
+        List<BibEntry> fetchedEntries = fetcher.performSearch("JabRef Social Barriers Steinmacher");
+        assertEquals(Collections.singletonList(expected), fetchedEntries);
+    }
+}

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
@@ -1,4 +1,4 @@
-package org.jabref.gui.importer.fetcher;
+package org.jabref.logic.importer.fetcher;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

The Springer fetcher is now implemented according to the new fetcher infrastructure. Instead of pagination support, the fetcher now only returns the first 20 items matched by the search query. 

I used the opportunity and fixed a few small things: url to pdf is now added as online file link (instead of in the url field) and the ending page is correctly parsed.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
