### PR TITLE
Update java-diff-utils from 2.1.1 to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     compile "org.libreoffice:ridl:5.4.2"
     compile "org.libreoffice:unoil:5.4.2"
 
-    compile 'com.github.bkromhout:java-diff-utils:2.1.1'
+    compile 'io.github.java-diff-utils:java-diff-utils:2.2.0'
     compile 'info.debatty:java-string-similarity:1.1.0'
 
     antlr3 'org.antlr:antlr:3.5.2'

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -40,11 +40,6 @@ Project: AppleJavaExtensions
 URL:     https://developer.apple.com/legacy/library/samplecode/AppleJavaExtensions/Introduction/Intro.html
 License: Apple License
 
-Id:      com.github.bkromhout:java-diff-utils
-Project: java-diff-utils
-URL:     https://github.com/bkromhout/java-diff-utils
-License: Apache-2.0
-
 Id:      com.github.tomtung
 Project: latex2unicode
 URL:     https://github.com/tomtung/latex2unicode
@@ -119,6 +114,11 @@ Id:      info.debatty:java-string-similarity
 Project: Java String Similarity
 URL:     https://github.com/tdebatty/java-string-similarity
 License: MIT
+
+Id:      io.github.java-diff-utils:java-diff-utils
+Project: java-diff-utils
+URL:     https://github.com/java-diff-utils/java-diff-utils
+License: Apache-1.1
 
 Id:      mysql:mysql-connector-java
 Project: MySQL Connector/J


### PR DESCRIPTION
There have been licensing issues at java-diff-utils. I resolved them (see https://github.com/java-diff-utils/java-diff-utils#license). This PR updates the dependency to the library version with a clean license.