### PR TITLE
Make global font size customizable

### DIFF
--- a/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
+++ b/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
@@ -7,7 +7,7 @@ import org.jabref.Globals;
 import org.jabref.gui.util.DefaultTaskExecutor;
 
 /**
- * Remove as soon as possible
+ * TODO: Remove as soon as possible
  */
 public class CustomJFXPanel {
 

--- a/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -1,20 +1,25 @@
 package org.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
-import java.awt.Font;
-import java.awt.GridBagLayout;
 
 import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 
+import javafx.embed.swing.JFXPanel;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
 import org.jabref.gui.DialogService;
-import org.jabref.gui.GUIGlobals;
+import org.jabref.gui.customjfx.CustomJFXPanel;
+import org.jabref.gui.util.ControlHelper;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
 
-import com.jgoodies.forms.builder.DefaultFormBuilder;
-import com.jgoodies.forms.layout.FormLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,8 +29,9 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
 
     private final JabRefPreferences prefs;
 
-    private final Font usedFont = GUIGlobals.currentFont;
-    private final JCheckBox fxFontTweaksLAF;
+    private final CheckBox fontTweaksLAF;
+    private final TextField fontSize;
+    private final CheckBox overrideFonts;
 
     private final DialogService dialogService;
 
@@ -39,52 +45,46 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
         this.prefs = prefs;
         setLayout(new BorderLayout());
 
-        FormLayout layout = new FormLayout("1dlu, 8dlu, left:pref, 4dlu, fill:pref, 4dlu, fill:60dlu, 4dlu, fill:pref", "");
-        DefaultFormBuilder builder = new DefaultFormBuilder(layout);
+        overrideFonts = new CheckBox(Localization.lang("Override default font settings"));
+        fontSize = new TextField();
+        fontSize.setTextFormatter(ControlHelper.getIntegerTextFormatter());
+        Label fontSizeLabel = new Label(Localization.lang("Font size:"));
+        HBox fontSizeContainer = new HBox(fontSizeLabel, fontSize);
+        VBox.setMargin(fontSizeContainer, new Insets(0, 0, 0, 35));
+        fontSizeContainer.disableProperty().bind(overrideFonts.selectedProperty().not());
+        fontTweaksLAF = new CheckBox(Localization.lang("Tweak font rendering for entry editor on Linux"));
 
-        fxFontTweaksLAF = new JCheckBox(Localization.lang("Tweak font rendering for entry editor on Linux"));
-        // Only list L&F which are available
+        VBox container = new VBox();
+        container.getChildren().addAll(overrideFonts, fontSizeContainer, fontTweaksLAF);
 
-        // only the default L&F shows the OSX specific first drop-down menu
-
-        builder.append(fxFontTweaksLAF);
-        builder.nextLine();
-
-        builder.leadingColumnOffset(2);
-
-        JPanel upper = new JPanel();
-        JPanel sort = new JPanel();
-        JPanel namesp = new JPanel();
-        JPanel iconCol = new JPanel();
-        GridBagLayout gbl = new GridBagLayout();
-        upper.setLayout(gbl);
-        sort.setLayout(gbl);
-        namesp.setLayout(gbl);
-        iconCol.setLayout(gbl);
-
-        JPanel pan = builder.getPanel();
-        pan.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        add(pan, BorderLayout.CENTER);
+        JFXPanel panel = CustomJFXPanel.wrap(new Scene(container));
+        panel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+        add(panel, BorderLayout.CENTER);
     }
 
     @Override
     public void setValues() {
-        fxFontTweaksLAF.setSelected(prefs.getBoolean(JabRefPreferences.FX_FONT_RENDERING_TWEAK));
+        fontTweaksLAF.setSelected(prefs.getBoolean(JabRefPreferences.FX_FONT_RENDERING_TWEAK));
+        overrideFonts.setSelected(prefs.getBoolean(JabRefPreferences.OVERRIDE_DEFAULT_FONT_SIZE));
+        fontSize.setText(String.valueOf(prefs.getInt(JabRefPreferences.MAIN_FONT_SIZE)));
     }
 
     @Override
     public void storeSettings() {
-        boolean isRestartRequired = false;
+        boolean isRestartRequired;
 
         // Java FX font rendering tweak
         final boolean oldFxTweakValue = prefs.getBoolean(JabRefPreferences.FX_FONT_RENDERING_TWEAK);
-        prefs.putBoolean(JabRefPreferences.FX_FONT_RENDERING_TWEAK, fxFontTweaksLAF.isSelected());
-        isRestartRequired |= oldFxTweakValue != fxFontTweaksLAF.isSelected();
+        prefs.putBoolean(JabRefPreferences.FX_FONT_RENDERING_TWEAK, fontTweaksLAF.isSelected());
+        isRestartRequired = oldFxTweakValue != fontTweaksLAF.isSelected();
 
-        prefs.put(JabRefPreferences.FONT_FAMILY, usedFont.getFamily());
-        prefs.putInt(JabRefPreferences.FONT_STYLE, usedFont.getStyle());
-        prefs.putInt(JabRefPreferences.FONT_SIZE, usedFont.getSize());
-        GUIGlobals.currentFont = usedFont;
+        final boolean oldOverrideDefaultFontSize = prefs.getBoolean(JabRefPreferences.OVERRIDE_DEFAULT_FONT_SIZE);
+        final int oldFontSize = prefs.getInt(JabRefPreferences.MAIN_FONT_SIZE);
+        prefs.putBoolean(JabRefPreferences.OVERRIDE_DEFAULT_FONT_SIZE, overrideFonts.isSelected());
+        int newFontSize = Integer.parseInt(fontSize.getText());
+        prefs.putInt(JabRefPreferences.MAIN_FONT_SIZE, newFontSize);
+        isRestartRequired |= oldOverrideDefaultFontSize != overrideFonts.isSelected();
+        isRestartRequired |= oldFontSize != newFontSize;
 
         if (isRestartRequired) {
             dialogService.showWarningDialogAndWait(Localization.lang("Settings"),

--- a/src/main/java/org/jabref/gui/util/ControlHelper.java
+++ b/src/main/java/org/jabref/gui/util/ControlHelper.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.util;
 
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 import javax.swing.JComponent;
 
@@ -11,6 +12,7 @@ import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.DialogPane;
+import javafx.scene.control.TextFormatter;
 
 public class ControlHelper {
 
@@ -38,5 +40,21 @@ public class ControlHelper {
                 return child.isFocused();
             }
         });
+    }
+
+    /**
+     * Returns a text formatter that restricts input to integers
+     */
+    public static TextFormatter<String> getIntegerTextFormatter() {
+        UnaryOperator<TextFormatter.Change> filter = change -> {
+            String text = change.getText();
+
+            if (text.matches("[0-9]*")) {
+                return change;
+            }
+
+            return null;
+        };
+        return new TextFormatter<>(filter);
     }
 }

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 
+import org.jabref.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -58,6 +59,8 @@ public class ThemeLoader {
                 addAndWatchForChanges(scene, cssUrl, 1);
             }
         }
+
+        Globals.prefs.getFontSize().ifPresent(size -> scene.getRoot().setStyle("-fx-font-size: " + size + "pt;"));
     }
 
     private void addAndWatchForChanges(Scene scene, String cssUrl, int index) {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -217,6 +217,8 @@ public class JabRefPreferences implements PreferencesService {
     public static final String ICON_ENABLED_COLOR = "iconEnabledColor";
     public static final String ICON_DISABLED_COLOR = "iconDisabledColor";
     public static final String FONT_SIZE = "fontSize";
+    public static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize";
+    public static final String MAIN_FONT_SIZE = "mainFontSize";
     public static final String FONT_STYLE = "fontStyle";
     public static final String RECENT_DATABASES = "recentDatabases";
     public static final String RENAME_ON_MOVE_FILE_TO_FILE_DIR = "renameOnMoveFileToFileDir";
@@ -687,6 +689,9 @@ public class JabRefPreferences implements PreferencesService {
 
         defaults.put(LAST_USED_EXPORT, "");
         defaults.put(SIDE_PANE_WIDTH, 0.15);
+
+        defaults.put(MAIN_FONT_SIZE, 9);
+        defaults.put(OVERRIDE_DEFAULT_FONT_SIZE, false);
 
         defaults.put(IMPORT_INSPECTION_DIALOG_WIDTH, 650);
         defaults.put(IMPORT_INSPECTION_DIALOG_HEIGHT, 650);
@@ -1910,4 +1915,11 @@ public class JabRefPreferences implements PreferencesService {
         return get(PREVIEW_STYLE);
     }
 
+    public Optional<Integer> getFontSize() {
+        if (getBoolean(OVERRIDE_DEFAULT_FONT_SIZE)) {
+            return Optional.of(getInt(MAIN_FONT_SIZE));
+        } else {
+            return Optional.empty();
+        }
+    }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Font size customization was removed in https://github.com/JabRef/jabref/pull/4109 since it didn't work properly (i.e. only some elements of the ui were scaled). With this PR the global font size can be controlled by the user (in the Appearance tab of the preference dialog) and changes there affect every JavaFX control.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
