### PR TITLE
Fix #4177: New entry dialog freezes no longer

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -28,6 +28,7 @@ import javax.swing.SwingWorker;
 import org.jabref.Globals;
 import org.jabref.gui.importer.ImportInspectionDialog;
 import org.jabref.gui.keyboard.KeyBinding;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.bibtex.DuplicateCheck;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyGenerator;
 import org.jabref.logic.importer.FetcherException;
@@ -331,13 +332,23 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
 
                     dispose();
                 } else if (searchID.trim().isEmpty()) {
-                    frame.getDialogService().showWarningDialogAndWait(Localization.lang("Empty search ID"),
-                            Localization.lang("The given search ID was empty."));
+                    DefaultTaskExecutor.runInJavaFXThread(() -> {
+                        frame.getDialogService().showWarningDialogAndWait(
+                                Localization.lang("Empty search ID"),
+                                Localization.lang("The given search ID was empty."));
+                    });
                 } else if (!fetcherException) {
-                    frame.getDialogService().showErrorDialogAndWait(Localization.lang("No files found.",
-                            Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher.getName(), searchID) + "\n" + fetcherExceptionMessage));
+                    DefaultTaskExecutor.runInJavaFXThread(() -> {
+                        frame.getDialogService().showErrorDialogAndWait(
+                                Localization.lang("No files found."),
+                                Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher.getName(), searchID) + "\n" + fetcherExceptionMessage);
+                    });
                 } else {
-                    frame.getDialogService().showErrorDialogAndWait(Localization.lang("Error"), Localization.lang("Error while fetching from %0", fetcher.getName()) + "." + "\n" + fetcherExceptionMessage);
+                    DefaultTaskExecutor.runInJavaFXThread(() -> {
+                        frame.getDialogService().showErrorDialogAndWait(
+                                Localization.lang("Error"),
+                                Localization.lang("Error while fetching from %0", fetcher.getName()) + "." + "\n" + fetcherExceptionMessage);
+                    });
                 }
                 fetcherWorker = new FetcherWorker();
                 SwingUtilities.invokeLater(() -> {

--- a/src/main/java/org/jabref/gui/actions/NewEntryAction.java
+++ b/src/main/java/org/jabref/gui/actions/NewEntryAction.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.swing.SwingUtilities;
+
 import org.jabref.Globals;
 import org.jabref.gui.EntryTypeDialog;
 import org.jabref.gui.JabRefFrame;
@@ -42,15 +44,17 @@ public class NewEntryAction extends SimpleCommand {
         if (type.isPresent()) {
             jabRefFrame.getCurrentBasePanel().newEntry(type.get());
         } else {
-            EntryTypeDialog typeChoiceDialog = new EntryTypeDialog(jabRefFrame);
-            typeChoiceDialog.setVisible(true);
-            EntryType selectedType = typeChoiceDialog.getChoice();
-            if (selectedType == null) {
-                return;
-            }
+            SwingUtilities.invokeLater(() -> {
+                EntryTypeDialog typeChoiceDialog = new EntryTypeDialog(jabRefFrame);
+                typeChoiceDialog.setVisible(true);
+                EntryType selectedType = typeChoiceDialog.getChoice();
+                if (selectedType == null) {
+                    return;
+                }
 
-            trackNewEntry(selectedType);
-            jabRefFrame.getCurrentBasePanel().newEntry(selectedType);
+                trackNewEntry(selectedType);
+                jabRefFrame.getCurrentBasePanel().newEntry(selectedType);
+            });
         }
     }
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

As usual with these kind of freezes, it was again a problem with the interaction of Swing and JavaFX... it still has the problem that the dialog sometimes opens in the background (I've no idea how to fix it except converting the dialog to JavaFX).

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
