### PR TITLE
Fix #4134: no longer freeze when clicking browse in aux import dialog

### DIFF
--- a/src/main/java/org/jabref/gui/actions/NewSubLibraryAction.java
+++ b/src/main/java/org/jabref/gui/actions/NewSubLibraryAction.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.actions;
 
+import javax.swing.SwingUtilities;
+
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.BasePanelPreferences;
@@ -23,16 +25,18 @@ public class NewSubLibraryAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        FromAuxDialog dialog = new FromAuxDialog(jabRefFrame, "", true, jabRefFrame.getTabbedPane());
+        SwingUtilities.invokeLater(() -> {
+            FromAuxDialog dialog = new FromAuxDialog(jabRefFrame, "", true, jabRefFrame.getTabbedPane());
 
-        dialog.setVisible(true);
+            dialog.setVisible(true);
 
-        if (dialog.generatePressed()) {
-            Defaults defaults = new Defaults(Globals.prefs.getDefaultBibDatabaseMode());
-            BasePanel bp = new BasePanel(jabRefFrame, BasePanelPreferences.from(Globals.prefs), new BibDatabaseContext(dialog.getGenerateDB(), defaults), ExternalFileTypes.getInstance());
-            jabRefFrame.addTab(bp, true);
-            jabRefFrame.output(Localization.lang("New library created."));
-        }
+            if (dialog.generatePressed()) {
+                Defaults defaults = new Defaults(Globals.prefs.getDefaultBibDatabaseMode());
+                BasePanel bp = new BasePanel(jabRefFrame, BasePanelPreferences.from(Globals.prefs), new BibDatabaseContext(dialog.getGenerateDB(), defaults), ExternalFileTypes.getInstance());
+                jabRefFrame.addTab(bp, true);
+                jabRefFrame.output(Localization.lang("New library created."));
+            }
+        });
     }
 
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Yet another interaction between Swing and JavaFX threads...

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
