### PR TITLE
Fix not on javafx thread exception in "generate data from doi"

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
@@ -34,6 +34,7 @@ import org.jabref.Globals;
 import org.jabref.gui.FXDialogService;
 import org.jabref.gui.PreviewPanel;
 import org.jabref.gui.customjfx.CustomJFXPanel;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.component.DiffHighlightingTextPane;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.LatexFieldFormatter;
@@ -178,10 +179,12 @@ public class MergeEntries {
         // Setup a PreviewPanel and a Bibtex source box for the merged entry
         mainPanel.add(boldFontLabel(Localization.lang("Merged entry")), CELL_CONSTRAINTS.xyw(1, 6, 6));
 
-        entryPreview = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), new FXDialogService());
-        entryPreview.setEntry(mergedEntry);
-        JFXPanel container = CustomJFXPanel.wrap(new Scene(entryPreview));
-        mainPanel.add(container, CELL_CONSTRAINTS.xyw(1, 8, 6));
+        DefaultTaskExecutor.runInJavaFXThread(() -> {
+            entryPreview = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), new FXDialogService());
+            entryPreview.setEntry(mergedEntry);
+            JFXPanel container = CustomJFXPanel.wrap(new Scene(entryPreview));
+            mainPanel.add(container, CELL_CONSTRAINTS.xyw(1, 8, 6));
+        });
 
         mainPanel.add(boldFontLabel(Localization.lang("Merged BibTeX source code")), CELL_CONSTRAINTS.xyw(8, 6, 4));
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

And another threading issue fixed...

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
