### PR TITLE
Make it easier to rename and move files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed the default keyboard shortcuts for moving between entries when the entry editor is active to ̀<kbd>alt</kbd> + <kbd>up/down</kbd>.
 - Opening a new file now prompts the directory of the currently selected file, instead of the directory of the last opened file.
 - Window state is saved on close and restored on start.
-
+- We streamlined the process to rename and move files by removing the confirmation dialogs.
 
 
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -201,34 +201,19 @@ public class LinkedFileViewModel extends AbstractViewModel {
             // Cannot rename remote links
             return;
         }
-        Optional<Path> fileDir = databaseContext.getFirstExistingFileDir(fileDirectoryPreferences);
-        if (!fileDir.isPresent()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Rename file"), Localization.lang("File directory is not set or does not exist!"));
-            return;
-        }
 
         Optional<Path> file = linkedFile.findIn(databaseContext, fileDirectoryPreferences);
         if ((file.isPresent()) && Files.exists(file.get())) {
             RenamePdfCleanup pdfCleanup = new RenamePdfCleanup(false, databaseContext, fileDirPattern, fileDirectoryPreferences, linkedFile);
-
-            String targetFileName = pdfCleanup.getTargetFileName(linkedFile, entry);
-
-            boolean confirm = dialogService.showConfirmationDialogAndWait(Localization.lang("Rename file"),
-                                                                          Localization.lang("Rename file to") + " " + targetFileName,
-                                                                          Localization.lang("Rename file"),
-                                                                          Localization.lang("Cancel"));
-
-            if (confirm) {
-                Optional<Path> fileConflictCheck = pdfCleanup.findExistingFile(linkedFile, entry);
-                performRenameWithConflictCheck(file, pdfCleanup, targetFileName, fileConflictCheck);
-            }
+            performRenameWithConflictCheck(file.get(), pdfCleanup);
         } else {
             dialogService.showErrorDialogAndWait(Localization.lang("File not found"), Localization.lang("Could not find file '%0'.", linkedFile.getLink()));
         }
     }
 
-    private void performRenameWithConflictCheck(Optional<Path> file, RenamePdfCleanup pdfCleanup, String targetFileName, Optional<Path> fileConflictCheck) {
+    private void performRenameWithConflictCheck(Path file, RenamePdfCleanup pdfCleanup) {
         boolean confirm;
+        Optional<Path> fileConflictCheck = pdfCleanup.findExistingFile(linkedFile, entry);
         if (!fileConflictCheck.isPresent()) {
             try {
                 pdfCleanup.cleanupWithException(entry);
@@ -236,6 +221,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                 dialogService.showErrorDialogAndWait(Localization.lang("Rename failed"), Localization.lang("JabRef cannot access the file because it is being used by another process."));
             }
         } else {
+            String targetFileName = pdfCleanup.getTargetFileName(linkedFile, entry);
             confirm = dialogService.showConfirmationDialogAndWait(Localization.lang("File exists"),
                                                                   Localization.lang("'%0' exists. Overwrite file?", targetFileName),
                                                                   Localization.lang("Overwrite"),
@@ -243,7 +229,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
             if (confirm) {
                 try {
-                    FileUtil.renameFileWithException(fileConflictCheck.get(), file.get(), true);
+                    FileUtil.renameFileWithException(fileConflictCheck.get(), file, true);
                     pdfCleanup.cleanupWithException(entry);
                 } catch (IOException e) {
                     dialogService.showErrorDialogAndWait(Localization.lang("Rename failed"),
@@ -268,13 +254,9 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
         Optional<Path> file = linkedFile.findIn(databaseContext, fileDirectoryPreferences);
         if ((file.isPresent()) && Files.exists(file.get())) {
-            // Linked file exists, so move it
+            // Found the linked file, so move it
             MoveFilesCleanup moveFiles = new MoveFilesCleanup(databaseContext, fileDirPattern, fileDirectoryPreferences, linkedFile);
-
-            boolean confirm = dialogService.showConfirmationDialogAndWait(Localization.lang("Move file"), Localization.lang("Move file to file directory?") + " " + fileDir.get(), Localization.lang("Move file"), Localization.lang("Cancel"));
-            if (confirm) {
-                moveFiles.cleanup(entry);
-            }
+            moveFiles.cleanup(entry);
         } else {
             // File doesn't exist, so we can't move it.
             dialogService.showErrorDialogAndWait(Localization.lang("File not found"), Localization.lang("Could not find file '%0'.", linkedFile.getLink()));

--- a/src/main/java/org/jabref/logic/util/io/FileBasedLock.java
+++ b/src/main/java/org/jabref/logic/util/io/FileBasedLock.java
@@ -11,13 +11,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class FileBasedLock {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedLock.class);
-
     /**
-     * The age in ms of a lockfile before JabRef will offer to "steal" the locked file.
+     * The age in ms of a lock file before JabRef will offer to "steal" the locked file.
      */
     public static final long LOCKFILE_CRITICAL_AGE = 60000;
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedLock.class);
     private static final String LOCKFILE_SUFFIX = ".lock";
 
     // default retry count for acquiring file lock

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1196,7 +1196,6 @@ Error\ while\ fetching\ from\ %0=Error while fetching from %0
 Show\ search\ results\ in\ a\ window=Show search results in a window
 Show\ global\ search\ results\ in\ a\ window=Show global search results in a window
 Search\ in\ all\ open\ libraries=Search in all open libraries
-Move\ file\ to\ file\ directory?=Move file to file directory?
 
 Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Library is protected. Cannot save until external changes have been reviewed.
 Protected\ library=Protected library


### PR DESCRIPTION
Removes confirmation dialogs when renaming or moving files. It is hard to accidentally invoke this action (you have to right click on the file > move/rename) and it is not irreversible. Thus, in my opinion, no confirmation dialog is needed.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
