### PR TITLE
Fix that swing dialogs are hidden behind main window

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -35,10 +35,6 @@ import org.slf4j.LoggerFactory;
 
 public class JabRefGUI {
 
-    private static final String NIMBUS_LOOK_AND_FEEL = "javax.swing.plaf.nimbus.NimbusLookAndFeel";
-    private static final String WINDOWS_LOOK_AND_FEEL = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
-    private static final String OSX_AQUA_LOOK_AND_FEEL = "apple.laf.AquaLookAndFeel";
-
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefGUI.class);
 
     private static JabRefFrame mainFrame;

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -455,7 +455,7 @@ public class BasePanel extends StackPane implements ClipboardOwner {
         actions.put(Actions.PREVIOUS_PREVIEW_STYLE, this::previousPreviewStyle);
 
         actions.put(Actions.MANAGE_SELECTORS, () -> {
-            ContentSelectorDialog csd = new ContentSelectorDialog(null, frame, BasePanel.this, false, null);
+            ContentSelectorDialog csd = new ContentSelectorDialog(frame, BasePanel.this, false, null);
             csd.setVisible(true);
         });
 

--- a/src/main/java/org/jabref/gui/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/DuplicateResolverDialog.java
@@ -6,7 +6,6 @@ import java.awt.event.WindowEvent;
 
 import javax.swing.Box;
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 
 import org.jabref.gui.help.HelpAction;
@@ -46,7 +45,7 @@ public class DuplicateResolverDialog extends JabRefDialog {
     private MergeEntries me;
 
     public DuplicateResolverDialog(JabRefFrame frame, BibEntry one, BibEntry two, DuplicateResolverType type) {
-        super((JFrame) null, Localization.lang("Possible duplicate entries"), true, DuplicateResolverDialog.class);
+        super(Localization.lang("Possible duplicate entries"), true, DuplicateResolverDialog.class);
         this.frame = frame;
         init(one, two, type);
     }

--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -66,7 +66,7 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
 
     public EntryTypeDialog(JabRefFrame frame) {
         // modal dialog
-        super(null, true, EntryTypeDialog.class);
+        super(true, EntryTypeDialog.class);
 
         this.frame = frame;
 

--- a/src/main/java/org/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/org/jabref/gui/FindUnlinkedFilesDialog.java
@@ -3,7 +3,6 @@ package org.jabref.gui;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -158,8 +157,8 @@ public class FindUnlinkedFilesDialog extends JabRefDialog {
 
     private boolean checkBoxWhyIsThereNoGetSelectedStupidSwing;
 
-    public FindUnlinkedFilesDialog(Frame owner, JabRefFrame frame) {
-        super(owner, Localization.lang("Find unlinked files"), true, FindUnlinkedFilesDialog.class);
+    public FindUnlinkedFilesDialog(JabRefFrame frame) {
+        super(Localization.lang("Find unlinked files"), true, FindUnlinkedFilesDialog.class);
         this.frame = frame;
 
         restoreSizeOfDialog();

--- a/src/main/java/org/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/org/jabref/gui/GenFieldsCustomizer.java
@@ -16,7 +16,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -51,7 +50,7 @@ public class GenFieldsCustomizer extends JabRefDialog {
     private final JButton revert = new JButton();
 
     public GenFieldsCustomizer(JabRefFrame frame) {
-        super((JFrame) null, Localization.lang("Set general fields"), false, GenFieldsCustomizer.class);
+        super(Localization.lang("Set general fields"), false, GenFieldsCustomizer.class);
         helpBut = new HelpAction(HelpFile.GENERAL_FIELDS).getHelpButton();
         jbInit();
         setSize(new Dimension(650, 300));

--- a/src/main/java/org/jabref/gui/JabRefDialog.java
+++ b/src/main/java/org/jabref/gui/JabRefDialog.java
@@ -1,7 +1,6 @@
 package org.jabref.gui;
 
 import java.awt.Frame;
-import java.awt.Window;
 
 import javax.swing.JDialog;
 
@@ -9,30 +8,20 @@ import org.jabref.Globals;
 
 public class JabRefDialog extends JDialog {
 
-    public <T extends JabRefDialog> JabRefDialog(Frame owner, boolean modal, Class<T> clazz) {
-        super(owner, modal);
-
-        trackDialogOpening(clazz);
+    public <T extends JabRefDialog> JabRefDialog(boolean modal, Class<T> clazz) {
+        this("JabRef", modal, clazz);
     }
 
     public <T extends JabRefDialog> JabRefDialog(Class<T> clazz) {
-        super();
-
-        trackDialogOpening(clazz);
+        this(true, clazz);
     }
 
-    public <T extends JabRefDialog> JabRefDialog(Frame owner, Class<T> clazz) {
-        super(owner);
-
-        trackDialogOpening(clazz);
+    public <T extends JabRefDialog> JabRefDialog(String title, Class<T> clazz) {
+        this(title, true, clazz);
     }
 
-    public <T  extends JabRefDialog> JabRefDialog(Frame owner, String title, Class<T> clazz) {
-        this(owner, title, true, clazz);
-    }
-
-    public <T  extends JabRefDialog> JabRefDialog(Frame owner, String title, boolean modal, Class<T> clazz) {
-        super(owner, title, modal);
+    public <T extends JabRefDialog> JabRefDialog(String title, boolean modal, Class<T> clazz) {
+        super((Frame) null, title, modal);
 
         trackDialogOpening(clazz);
     }
@@ -47,13 +36,19 @@ public class JabRefDialog extends JDialog {
         trackDialogOpening(clazz);
     }
 
-    public <T extends JabRefDialog> JabRefDialog(Window owner, String title, Class<T> clazz) {
-        super(owner, title);
-
-        trackDialogOpening(clazz);
-    }
-
     private <T extends JabRefDialog> void trackDialogOpening(Class<T> clazz) {
         Globals.getTelemetryClient().ifPresent(client -> client.trackPageView(clazz.getName()));
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+
+        if (visible) {
+            // Ugly hack to ensure that new dialogs are not hidden behind the main window
+            setAlwaysOnTop(true);
+            requestFocus();
+            setAlwaysOnTop(false);
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/JabRefDialog.java
+++ b/src/main/java/org/jabref/gui/JabRefDialog.java
@@ -45,7 +45,7 @@ public class JabRefDialog extends JDialog {
         super.setVisible(visible);
 
         if (visible) {
-            // Ugly hack to ensure that new dialogs are not hidden behind the main window
+            // FIXME: Ugly hack to ensure that new dialogs are not hidden behind the main window
             setAlwaysOnTop(true);
             requestFocus();
             setAlwaysOnTop(false);

--- a/src/main/java/org/jabref/gui/MergeDialog.java
+++ b/src/main/java/org/jabref/gui/MergeDialog.java
@@ -13,7 +13,6 @@ import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 
 import org.jabref.Globals;
@@ -41,7 +40,7 @@ public class MergeDialog extends JabRefDialog {
     private boolean okPressed;
 
     public MergeDialog(JabRefFrame frame, String title, boolean modal) {
-        super((JFrame) null, title, modal, MergeDialog.class);
+        super(title, modal, MergeDialog.class);
         jbInit();
         pack();
     }

--- a/src/main/java/org/jabref/gui/ReplaceStringDialog.java
+++ b/src/main/java/org/jabref/gui/ReplaceStringDialog.java
@@ -16,7 +16,6 @@ import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -48,7 +47,7 @@ class ReplaceStringDialog extends JabRefDialog {
 
 
     public ReplaceStringDialog(JabRefFrame parent) {
-        super((JFrame) null, Localization.lang("Replace string"), true, ReplaceStringDialog.class);
+        super(Localization.lang("Replace string"), true, ReplaceStringDialog.class);
 
         ButtonGroup bg = new ButtonGroup();
         bg.add(allFi);

--- a/src/main/java/org/jabref/gui/StringDialog.java
+++ b/src/main/java/org/jabref/gui/StringDialog.java
@@ -66,7 +66,7 @@ class StringDialog extends JabRefDialog {
 
 
     public StringDialog(JabRefFrame frame, BasePanel panel, BibDatabase base) {
-        super(null, StringDialog.class);
+        super(StringDialog.class);
         this.panel = panel;
         this.base = base;
 

--- a/src/main/java/org/jabref/gui/actions/DatabasePropertiesAction.java
+++ b/src/main/java/org/jabref/gui/actions/DatabasePropertiesAction.java
@@ -13,7 +13,7 @@ public class DatabasePropertiesAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        DatabasePropertiesDialog propertiesDialog = new DatabasePropertiesDialog(null, frame.getCurrentBasePanel());
+        DatabasePropertiesDialog propertiesDialog = new DatabasePropertiesDialog(frame.getCurrentBasePanel());
         propertiesDialog.updateEnableStatus();
         propertiesDialog.setVisible(true);
     }

--- a/src/main/java/org/jabref/gui/actions/FindUnlinkedFilesAction.java
+++ b/src/main/java/org/jabref/gui/actions/FindUnlinkedFilesAction.java
@@ -13,7 +13,7 @@ public class FindUnlinkedFilesAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        FindUnlinkedFilesDialog dlg = new FindUnlinkedFilesDialog(null, jabRefFrame);
+        FindUnlinkedFilesDialog dlg = new FindUnlinkedFilesDialog(jabRefFrame);
         dlg.setVisible(true);
     }
 

--- a/src/main/java/org/jabref/gui/actions/WriteXMPAction.java
+++ b/src/main/java/org/jabref/gui/actions/WriteXMPAction.java
@@ -17,7 +17,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
@@ -95,7 +94,7 @@ public class WriteXMPAction extends SimpleCommand {
         errors = entriesChanged = skipped = 0;
 
         if (optionsDialog == null) {
-            optionsDialog = new OptionsDialog(null);
+            optionsDialog = new OptionsDialog();
         }
         optionsDialog.open();
 
@@ -182,9 +181,8 @@ public class WriteXMPAction extends SimpleCommand {
 
         private final JTextArea progressArea;
 
-
-        public OptionsDialog(JFrame parent) {
-            super(parent, Localization.lang("Writing XMP-metadata for selected entries..."), false, WriteXMPAction.OptionsDialog.class);
+        public OptionsDialog() {
+            super(Localization.lang("Writing XMP-metadata for selected entries..."), false, WriteXMPAction.OptionsDialog.class);
             okButton.setEnabled(false);
 
             okButton.addActionListener(e -> dispose());

--- a/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
+++ b/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
@@ -13,7 +13,6 @@ import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
@@ -69,7 +68,7 @@ public class FromAuxDialog extends JabRefDialog {
     private final JabRefFrame parentFrame;
 
     public FromAuxDialog(JabRefFrame frame, String title, boolean modal, TabPane viewedDBs) {
-        super((JFrame) null, title, modal, FromAuxDialog.class);
+        super(title, modal, FromAuxDialog.class);
 
         parentTabbedPane = viewedDBs;
         parentFrame = frame;

--- a/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
+++ b/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
@@ -10,7 +10,6 @@ import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
@@ -31,7 +30,7 @@ public class BibtexKeyPatternDialog extends JabRefDialog {
     private final BibtexKeyPatternPanel bibtexKeyPatternPanel;
 
     public BibtexKeyPatternDialog(BasePanel panel) {
-        super((JFrame) null, Localization.lang("BibTeX key patterns"), true, BibtexKeyPatternDialog.class);
+        super(Localization.lang("BibTeX key patterns"), true, BibtexKeyPatternDialog.class);
         this.bibtexKeyPatternPanel = new BibtexKeyPatternPanel(panel);
         this.panel = panel;
         this.metaData = panel.getBibDatabaseContext().getMetaData();

--- a/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
@@ -9,7 +9,6 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -35,10 +34,9 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
     private JComponent infoShown;
     private boolean okPressed;
 
-
-    public ChangeDisplayDialog(JFrame owner, final BasePanel panel,
-            BibDatabase secondary, final DefaultMutableTreeNode root) {
-        super(owner, Localization.lang("External changes"), true, ChangeDisplayDialog.class);
+    public ChangeDisplayDialog(final BasePanel panel,
+                               BibDatabase secondary, final DefaultMutableTreeNode root) {
+        super(Localization.lang("External changes"), true, ChangeDisplayDialog.class);
         BibDatabase localSecondary;
 
         // Just to be sure, put in an empty secondary base if none is given:

--- a/src/main/java/org/jabref/gui/collab/ChangeScanner.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeScanner.java
@@ -81,7 +81,7 @@ public class ChangeScanner implements Runnable {
     public void displayResult(final DisplayResultCallback fup) {
         if (changes.getChildCount() > 0) {
             SwingUtilities.invokeLater(() -> {
-                ChangeDisplayDialog changeDialog = new ChangeDisplayDialog(null, panel, databaseInTemp.getDatabase(), changes);
+                ChangeDisplayDialog changeDialog = new ChangeDisplayDialog(panel, databaseInTemp.getDatabase(), changes);
                 changeDialog.setVisible(true);
                 fup.scanResultsResolved(changeDialog.isOkPressed());
                 if (changeDialog.isOkPressed()) {

--- a/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialog.java
+++ b/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialog.java
@@ -3,7 +3,6 @@ package org.jabref.gui.contentselector;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
@@ -82,14 +81,13 @@ public class ContentSelectorDialog extends JabRefDialog {
 
     /**
      *
-     * @param owner the parent Window (Dialog or Frame)
      * @param frame the JabRef Frame
      * @param panel the currently selected BasePanel
      * @param modal should this dialog be modal?
      * @param fieldName the field this selector is initialized for. May be null.
      */
-    public ContentSelectorDialog(Window owner, JabRefFrame frame, BasePanel panel, boolean modal, String fieldName) {
-        super(owner, Localization.lang("Manage content selectors"), ContentSelectorDialog.class);
+    public ContentSelectorDialog(JabRefFrame frame, BasePanel panel, boolean modal, String fieldName) {
+        super(Localization.lang("Manage content selectors"), ContentSelectorDialog.class);
         this.setModal(modal);
         this.metaData = panel.getBibDatabaseContext().getMetaData();
         this.frame = frame;

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
@@ -25,7 +25,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
@@ -75,7 +74,7 @@ public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSe
      * Creates a new instance of EntryTypeCustomizationDialog
      */
     public EntryTypeCustomizationDialog(JabRefFrame frame) {
-        super((JFrame) null, Localization.lang("Customize entry types"), false, EntryTypeCustomizationDialog.class);
+        super(Localization.lang("Customize entry types"), false, EntryTypeCustomizationDialog.class);
 
         this.frame = frame;
         initGui();

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -16,7 +16,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
@@ -69,8 +68,8 @@ public class DatabasePropertiesDialog extends JabRefDialog {
 
     private FieldFormatterCleanupsPanel fieldFormatterCleanupsPanel;
 
-    public DatabasePropertiesDialog(JFrame parent, BasePanel panel) {
-        super(parent, Localization.lang("Library properties"), true, DatabasePropertiesDialog.class);
+    public DatabasePropertiesDialog(BasePanel panel) {
+        super(Localization.lang("Library properties"), true, DatabasePropertiesDialog.class);
         encoding = new JComboBox<>();
         encoding.setModel(new DefaultComboBoxModel<>(Encodings.ENCODINGS));
         ok = new JButton(Localization.lang("OK"));

--- a/src/main/java/org/jabref/gui/exporter/CustomExportDialog.java
+++ b/src/main/java/org/jabref/gui/exporter/CustomExportDialog.java
@@ -15,7 +15,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
@@ -57,7 +56,7 @@ class CustomExportDialog extends JabRefDialog {
     }
 
     public CustomExportDialog(final JabRefFrame parent) {
-        super((JFrame) null, Localization.lang("Edit custom export"), true, CustomExportDialog.class);
+        super(Localization.lang("Edit custom export"), true, CustomExportDialog.class);
         frame = parent;
         ActionListener okListener = e -> {
             Path layoutFileDir = Paths.get(layoutFile.getText()).getParent();

--- a/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -13,7 +13,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -44,7 +43,7 @@ public class ExportCustomizationDialog extends JabRefDialog {
 
     public ExportCustomizationDialog(final JabRefFrame frame) {
 
-        super((JFrame) null, Localization.lang("Manage custom exports"), false, ExportCustomizationDialog.class);
+        super(Localization.lang("Manage custom exports"), false, ExportCustomizationDialog.class);
         DefaultEventTableModel<List<String>> tableModel = new DefaultEventTableModel<>(
                 Globals.prefs.customExports.getSortedList(), new ExportTableFormat());
         JTable table = new JTable(tableModel);

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -20,7 +20,6 @@ import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
@@ -149,7 +148,7 @@ class GroupDialog extends JabRefDialog implements Dialog<AbstractGroup> {
      *                    created.
      */
     public GroupDialog(JabRefFrame jabrefFrame, AbstractGroup editedGroup) {
-        super((JFrame) null, Localization.lang("Edit group"), true, GroupDialog.class);
+        super(Localization.lang("Edit group"), true, GroupDialog.class);
 
         // set default values (overwritten if editedGroup != null)
         keywordGroupSearchField.setText(jabrefFrame.prefs().get(JabRefPreferences.GROUPS_DEFAULT_FIELD));

--- a/src/main/java/org/jabref/gui/help/NewVersionDialog.java
+++ b/src/main/java/org/jabref/gui/help/NewVersionDialog.java
@@ -7,7 +7,6 @@ import java.awt.Insets;
 import java.awt.event.MouseEvent;
 
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.event.MouseInputAdapter;
@@ -21,8 +20,8 @@ import org.jabref.preferences.VersionPreferences;
 
 public class NewVersionDialog extends JabRefDialog {
 
-    public NewVersionDialog(JFrame frame, Version currentVersion, Version latestVersion) {
-        super(frame, NewVersionDialog.class);
+    public NewVersionDialog(Version currentVersion, Version latestVersion) {
+        super(NewVersionDialog.class);
         setTitle(Localization.lang("New version available"));
 
         JLabel lblTitle = new JLabel(Localization.lang("A new version of JabRef has been released."));
@@ -87,8 +86,6 @@ public class NewVersionDialog extends JabRefDialog {
 
         add(panel);
         pack();
-        setLocationRelativeTo(frame);
-        setModalityType(ModalityType.APPLICATION_MODAL);
         setVisible(true);
     }
 

--- a/src/main/java/org/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomizationDialog.java
@@ -16,7 +16,6 @@ import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -60,7 +59,7 @@ public class ImportCustomizationDialog extends JabRefDialog {
     private final JTable customImporterTable;
 
     public ImportCustomizationDialog(final JabRefFrame frame) {
-        super((JFrame) null, Localization.lang("Manage custom imports"), false, ImportCustomizationDialog.class);
+        super(Localization.lang("Manage custom imports"), false, ImportCustomizationDialog.class);
 
         DialogService dialogService = frame.getDialogService();
 

--- a/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
@@ -193,7 +193,7 @@ public class ImportInspectionDialog extends JabRefDialog implements ImportInspec
      * @param panel
      */
     public ImportInspectionDialog(JabRefFrame frame, BasePanel panel, String undoName, boolean newDatabase) {
-        super(null, ImportInspectionDialog.class);
+        super(ImportInspectionDialog.class);
         this.frame = frame;
         this.panel = panel;
         this.bibDatabaseContext = (panel == null) ? null : panel.getBibDatabaseContext();

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
@@ -3,7 +3,6 @@ package org.jabref.gui.mergeentries;
 import java.util.List;
 
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JSeparator;
 
 import org.jabref.gui.BasePanel;
@@ -33,7 +32,7 @@ public class MergeEntriesDialog extends JabRefDialog {
     private final DialogService dialogService;
 
     public MergeEntriesDialog(BasePanel panel, DialogService dialogService) {
-        super((JFrame) null, MERGE_ENTRIES, true, MergeEntriesDialog.class);
+        super(MERGE_ENTRIES, true, MergeEntriesDialog.class);
         this.dialogService = dialogService;
         this.panel = panel;
 

--- a/src/main/java/org/jabref/gui/mergeentries/MergeFetchedEntryDialog.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeFetchedEntryDialog.java
@@ -8,7 +8,6 @@ import java.util.TreeSet;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JSeparator;
 
 import org.jabref.gui.BasePanel;
@@ -44,7 +43,7 @@ public class MergeFetchedEntryDialog extends JabRefDialog {
 
 
     public MergeFetchedEntryDialog(BasePanel panel, BibEntry originalEntry, BibEntry fetchedEntry, String type) {
-        super((JFrame) null, Localization.lang("Merge entry with %0 information", type), true, MergeFetchedEntryDialog.class);
+        super(Localization.lang("Merge entry with %0 information", type), true, MergeFetchedEntryDialog.class);
 
         this.panel = panel;
         this.originalEntry = originalEntry;

--- a/src/main/java/org/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/org/jabref/gui/plaintextimport/TextInputDialog.java
@@ -134,7 +134,7 @@ public class TextInputDialog extends JabRefDialog {
 
 
     public TextInputDialog(JabRefFrame frame, BibEntry bibEntry) {
-        super(null, true, TextInputDialog.class);
+        super(true, TextInputDialog.class);
 
         this.frame = Objects.requireNonNull(frame);
 

--- a/src/main/java/org/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreferencesDialog.java
@@ -188,7 +188,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
         });
 
         showPreferences.addActionListener(
-                                          e -> new PreferencesFilterDialog(new JabRefPreferencesFilter(prefs), null).setVisible(true));
+                e -> new PreferencesFilterDialog(new JabRefPreferencesFilter(prefs)).setVisible(true));
         resetPreferences.addActionListener(e -> {
 
             boolean resetPreferencesClicked = DefaultTaskExecutor.runInJavaFXThread(() -> dialogService.showConfirmationDialogAndWait(Localization.lang("Reset preferences"),

--- a/src/main/java/org/jabref/gui/preftabs/PreferencesFilterDialog.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreferencesFilterDialog.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.swing.JCheckBox;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -27,8 +26,8 @@ class PreferencesFilterDialog extends JabRefDialog {
     private final JCheckBox showOnlyDeviatingPreferenceOptions;
     private final JLabel count;
 
-    public PreferencesFilterDialog(JabRefPreferencesFilter preferencesFilter, JFrame frame) {
-        super(frame, true, PreferencesFilterDialog.class); // is modal
+    public PreferencesFilterDialog(JabRefPreferencesFilter preferencesFilter) {
+        super(true, PreferencesFilterDialog.class);
 
         this.preferencesFilter = Objects.requireNonNull(preferencesFilter);
 

--- a/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
@@ -12,7 +12,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
-import javax.swing.JFrame;
 import javax.swing.JTextField;
 
 import org.jabref.Globals;
@@ -49,7 +48,7 @@ public class NewProtectedTermsFileDialog extends JabRefDialog {
     }
 
     public NewProtectedTermsFileDialog(DialogService dialogService, ProtectedTermsLoader loader) {
-        super((JFrame) null, Localization.lang("New protected terms file"), true, NewProtectedTermsFileDialog.class);
+        super(Localization.lang("New protected terms file"), true, NewProtectedTermsFileDialog.class);
         this.loader = loader;
         this.dialogService = dialogService;
         setupDialog();

--- a/src/main/java/org/jabref/gui/shared/ConnectToSharedDatabaseDialog.java
+++ b/src/main/java/org/jabref/gui/shared/ConnectToSharedDatabaseDialog.java
@@ -24,7 +24,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
@@ -102,7 +101,7 @@ public class ConnectToSharedDatabaseDialog extends JabRefDialog {
      * @param frame the JabRef Frame
      */
     public ConnectToSharedDatabaseDialog(JabRefFrame frame) {
-        super((JFrame) null, Localization.lang("Connect to shared database"), ConnectToSharedDatabaseDialog.class);
+        super(Localization.lang("Connect to shared database"), ConnectToSharedDatabaseDialog.class);
         this.frame = frame;
         initLayout();
         updateEnableState();

--- a/src/main/java/org/jabref/gui/worker/VersionWorker.java
+++ b/src/main/java/org/jabref/gui/worker/VersionWorker.java
@@ -112,7 +112,7 @@ public class VersionWorker extends SwingWorker<List<Version>, Void> {
 
         } else {
             // notify the user about a newer version
-            new NewVersionDialog(null, installedVersion, newerVersion.get());
+            new NewVersionDialog(installedVersion, newerVersion.get());
         }
     }
 

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -9,11 +9,9 @@ import java.util.Set;
 import java.util.function.UnaryOperator;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import java.util.stream.Stream;
 
 import org.jabref.Globals;
 import org.jabref.JabRefMain;
-import org.jabref.logic.util.OS;
 import org.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import org.jabref.model.entry.FieldName;
 import org.jabref.preferences.JabRefPreferences;
@@ -43,7 +41,6 @@ public class PreferencesMigrations {
         upgradeStoredCustomEntryTypes(Globals.prefs, mainPrefsNode);
         upgradeKeyBindingsToJavaFX(Globals.prefs);
         addCrossRefRelatedFieldsForAutoComplete(Globals.prefs);
-        upgradeObsoleteLookAndFeels(Globals.prefs);
         upgradePreviewStyleFromReviewToComment(Globals.prefs);
     }
 
@@ -283,28 +280,6 @@ public class PreferencesMigrations {
             keyPattern.addBibtexKeyPattern(key, oldPatternPrefs.get(key, null));
         }
         prefs.putKeyPattern(keyPattern);
-    }
-
-    private static void upgradeObsoleteLookAndFeels(JabRefPreferences prefs) {
-
-        String currentLandF = prefs.getLookAndFeel();
-
-        Stream.of("com.jgoodies.looks.windows.WindowsLookAndFeel", "com.jgoodies.looks.plastic.PlasticLookAndFeel",
-                  "com.jgoodies.looks.plastic.Plastic3DLookAndFeel", "com.jgoodies.looks.plastic.PlasticXPLookAndFeel",
-                  "com.sun.java.swing.plaf.gtk.GTKLookAndFeel")
-              .filter(style -> style.equals(currentLandF))
-              .findAny()
-              .ifPresent(loolAndFeel -> {
-                  if (OS.WINDOWS) {
-                      String windowsLandF = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
-                      prefs.setLookAndFeel(windowsLandF);
-                      LOGGER.info("Switched from obsolete look and feel " + currentLandF + " to " + windowsLandF);
-                  } else {
-                      String nimbusLandF = "javax.swing.plaf.nimbus.NimbusLookAndFeel";
-                      prefs.setLookAndFeel(nimbusLandF);
-                      LOGGER.info("Switched from obsolete look and feel " + currentLandF + " to " + nimbusLandF);
-                  }
-              });
     }
 
     static void upgradePreviewStyleFromReviewToComment(JabRefPreferences prefs) {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -34,8 +34,6 @@ import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
-import javax.swing.UIManager;
-
 import org.jabref.Globals;
 import org.jabref.JabRefException;
 import org.jabref.JabRefMain;
@@ -115,7 +113,6 @@ public class JabRefPreferences implements PreferencesService {
     public static final String LYXPIPE = "lyxpipe";
     public static final String EXTERNAL_FILE_TYPES = "externalFileTypes";
     public static final String FONT_FAMILY = "fontFamily";
-    public static final String WIN_LOOK_AND_FEEL = "lookAndFeel";
     public static final String FX_FONT_RENDERING_TWEAK = "fxFontRenderingTweak";
     public static final String LANGUAGE = "language";
     public static final String NAMES_LAST_ONLY = "namesLastOnly";
@@ -461,15 +458,12 @@ public class JabRefPreferences implements PreferencesService {
 
         if (OS.OS_X) {
             defaults.put(FONT_FAMILY, "SansSerif");
-            defaults.put(WIN_LOOK_AND_FEEL, UIManager.getSystemLookAndFeelClassName());
             defaults.put(EMACS_PATH, "emacsclient");
         } else if (OS.WINDOWS) {
-            defaults.put(WIN_LOOK_AND_FEEL, "com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
             defaults.put(EMACS_PATH, "emacsclient.exe");
         } else {
             // Linux
             defaults.put(FONT_FAMILY, "SansSerif");
-            defaults.put(WIN_LOOK_AND_FEEL, "javax.swing.plaf.nimbus.NimbusLookAndFeel");
             defaults.put(EMACS_PATH, "emacsclient");
         }
 
@@ -1897,14 +1891,6 @@ public class JabRefPreferences implements PreferencesService {
 
     public void setGroupViewMode(GroupViewMode mode) {
         put(GROUP_INTERSECT_UNION_VIEW_MODE, mode.name());
-    }
-
-    public String getLookAndFeel() {
-        return get(WIN_LOOK_AND_FEEL);
-    }
-
-    public void setLookAndFeel(String lookAndFeelClassName) {
-        put(WIN_LOOK_AND_FEEL, lookAndFeelClassName);
     }
 
     public void setPreviewStyle(String previewStyle) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

This fixes some of the issues mentioned in https://github.com/JabRef/jabref/issues/4190, namely that swing dialogs are hidden behind the main window. They are still not modal and not centered at the screen since for this a Swing frame is needed as the owner or parent...but I couldn't find a way to convert our JavaFX main window to a Swing frame or window. 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
