### PR TITLE
FIx chinese author bibtex key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the "Convert to BibTeX-Cleanup" moved the content of the `file` field to the `pdf` field [#4120](https://github.com/JabRef/jabref/issues/4120)
 - We fixed an issue where the preview pane in entry preview in preferences wasn't showing the citation style selected [#3849](https://github.com/JabRef/jabref/issues/3849)
 - We fixed an issue where the default entry preview style still contained the field `review`. The field `review` in the style is now replaced with comment to be consistent with the entry editor [#4098](https://github.com/JabRef/jabref/issues/4098)
--We fixed an issue where the default bibtexkey's generation is incorrect for Chinese authors.[#4169](https://github.com/JabRef/jabref/issues/4169)
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the "Convert to BibTeX-Cleanup" moved the content of the `file` field to the `pdf` field [#4120](https://github.com/JabRef/jabref/issues/4120)
 - We fixed an issue where the preview pane in entry preview in preferences wasn't showing the citation style selected [#3849](https://github.com/JabRef/jabref/issues/3849)
 - We fixed an issue where the default entry preview style still contained the field `review`. The field `review` in the style is now replaced with comment to be consistent with the entry editor [#4098](https://github.com/JabRef/jabref/issues/4098)
--We fixed an issue where the default bibtexkey's generation is incorrect for Chinese authors.[#4169](https://github.com/JabRef/jabref/issues/4169)
+- We fixed an issue where the default bibtexkey's generation is incorrect for Chinese authors.[#4169](https://github.com/JabRef/jabref/issues/4169)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the "Convert to BibTeX-Cleanup" moved the content of the `file` field to the `pdf` field [#4120](https://github.com/JabRef/jabref/issues/4120)
 - We fixed an issue where the preview pane in entry preview in preferences wasn't showing the citation style selected [#3849](https://github.com/JabRef/jabref/issues/3849)
 - We fixed an issue where the default entry preview style still contained the field `review`. The field `review` in the style is now replaced with comment to be consistent with the entry editor [#4098](https://github.com/JabRef/jabref/issues/4098)
-
+-We fixed an issue where the default bibtexkey's generation is incorrect for Chinese authors.[#4169](https://github.com/JabRef/jabref/issues/4169)
 
 
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -570,7 +570,7 @@ public class BracketedPattern {
         if (authorList.isEmpty()) {
             return "";
         }
-        if (authorList.getAuthor(0).getVon().toString().equals("Optional.empty")) {
+        if (!authorList.getAuthor(0).getVon().isPresent()) {
             Character.UnicodeBlock ub = Character.UnicodeBlock.of(authorList.getAuthor(0).getLast().orElse("").charAt(0));
             if ((ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS)
                 || (ub == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS)

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -570,6 +570,32 @@ public class BracketedPattern {
         if (authorList.isEmpty()) {
             return "";
         }
+        if (authorList.getAuthor(0).getVon().toString().equals("Optional.empty")) {
+            Character.UnicodeBlock ub = Character.UnicodeBlock.of(authorList.getAuthor(0).getLast().orElse("").charAt(0));
+            if ((ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS)
+                || (ub == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS)
+                || (ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A)
+                || (ub == Character.UnicodeBlock.GENERAL_PUNCTUATION)
+                || (ub == Character.UnicodeBlock.CJK_SYMBOLS_AND_PUNCTUATION)
+                || (ub == Character.UnicodeBlock.HALFWIDTH_AND_FULLWIDTH_FORMS)) {
+                String authorLasttemp = authorList.getAuthor(0).getLast().orElse("");
+                if (!authorLasttemp.isEmpty()) {
+                    return authorLasttemp.substring(0, authorLasttemp.indexOf(" "));
+                }
+            }
+        } else {
+            Character.UnicodeBlock ub = Character.UnicodeBlock.of(authorList.getAuthor(0).getVon().orElse("").charAt(0));
+            if ((ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS)
+                || (ub == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS)
+                || (ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A)
+                || (ub == Character.UnicodeBlock.GENERAL_PUNCTUATION)
+                || (ub == Character.UnicodeBlock.CJK_SYMBOLS_AND_PUNCTUATION)
+                || (ub == Character.UnicodeBlock.HALFWIDTH_AND_FULLWIDTH_FORMS)) {
+                return authorList.getAuthor(0).getVon().orElse("");
+            }
+        }
+        /**/
+
         return authorList.getAuthor(0).getLast().orElse("");
 
     }
@@ -590,6 +616,7 @@ public class BracketedPattern {
         if (authorList.isEmpty()) {
             return "";
         }
+
         return authorList.getAuthor(0).getFirstAbbr().map(s -> s.substring(0, 1)).orElse("");
     }
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -570,7 +570,7 @@ public class BracketedPattern {
         if (authorList.isEmpty()) {
             return "";
         }
-        if (!authorList.getAuthor(0).getVon().isPresent()) {
+        if (authorList.getAuthor(0).getVon().toString().equals("Optional.empty")) {
             Character.UnicodeBlock ub = Character.UnicodeBlock.of(authorList.getAuthor(0).getLast().orElse("").charAt(0));
             if ((ub == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS)
                 || (ub == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS)

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -255,6 +255,7 @@ public class Author {
      * @return first name of the author (may consist of several tokens)
      */
     public Optional<String> getFirst() {
+
         return Optional.ofNullable(firstPart);
     }
 
@@ -285,6 +286,7 @@ public class Author {
      * @return last name of the author (may consist of several tokens)
      */
     public Optional<String> getLast() {
+
         return Optional.ofNullable(lastPart);
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -33,6 +33,8 @@ public class BibtexKeyGeneratorTest {
     private static final String AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3 = "I. Newton and J. Maxwell and A. Einstein";
     private static final String AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4 = "I. Newton and J. Maxwell and A. Einstein and N. Bohr";
     private static final String AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5 = "I. Newton and J. Maxwell and A. Einstein and N. Bohr and Harry Unknown";
+    private static final String AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_6 = "李 杨 and 刘刚 and 陈诚 and N. Bohr";
+    private static final String AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_7 = "李,杨 and 刘,刚 and 陈,诚 and N. Bohr";
 
     private static final String TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH = "application migration effort in the cloud - the case of cloud platforms";
     private static final String TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON = "{BPEL} conformance in open source engines: the case of static analysis";
@@ -294,7 +296,8 @@ public class BibtexKeyGeneratorTest {
     public void testFirstAuthor() {
         assertEquals("Newton", BibtexKeyGenerator.firstAuthor(AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5));
         assertEquals("Newton", BibtexKeyGenerator.firstAuthor(AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1));
-
+        assertEquals("李", BibtexKeyGenerator.firstAuthor(AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_6));
+        assertEquals("李", BibtexKeyGenerator.firstAuthor(AUTHOR_STRING_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_7));
         // https://sourceforge.net/forum/message.php?msg_id=4498555
         assertEquals("K{\\\"o}ning", BibtexKeyGenerator.firstAuthor("K{\\\"o}ning"));
 


### PR DESCRIPTION
-We fixed an issue where the default bibtexkey's generation is incorrect for Chinese authors.
For example:
suppose that the author field such as 王, 阳 and 张, 家发 and 胡, 喜军 and 李, 保明, the year is 1000 and the default bibtexkey's generation is [author][year]
the original output is:
1000 (it is obviously incorrect)
we add some code to address it
now the output is:
王1000 (which is specified as user guide)
well, we also add some test code and passed these tests successfully

Fixes #4169
