### PR TITLE
Fix style issues in about dialog

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -150,7 +150,7 @@ public class JabRefGUI {
         }
 
         Scene scene = new Scene(JabRefGUI.mainFrame, 800, 800);
-        Globals.getThemeLoader().installBaseCss(scene);
+        Globals.getThemeLoader().installBaseCss(scene, Globals.prefs);
         mainStage.setTitle(JabRefFrame.FRAME_TITLE);
         mainStage.getIcons().addAll(IconTheme.getLogoSetFX());
         mainStage.setScene(scene);

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -365,6 +365,15 @@
     -fx-background-color: derive(-fx-default-button, -20%);
 }
 
+.text-button {
+    -fx-border-width: 0px;
+}
+
+.contained-button {
+    -fx-background-color: -jr-accent;
+    -fx-border-color: -jr-accent;
+}
+
 .menu-bar {
     -fx-background-color: -jr-menu-background;
     -fx-background-insets: 0;

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -352,6 +352,18 @@
     -fx-background-color: rgba(0, 0, 0, 0.3);
 }
 
+.button:default {
+    -fx-background-color: -jr-accent;
+}
+
+.button:default:hover {
+    -fx-background-color: derive(-jr-accent, -10%);
+}
+
+.button:default:focused,
+.button:default:pressed {
+    -fx-background-color: derive(-jr-accent, -20%);
+}
 
 .menu-bar {
     -fx-background-color: -jr-menu-background;

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -335,6 +335,24 @@
     -fx-text-fill: -fx-text-base-color;
 }
 
+.button {
+    -fx-background-color: transparent;
+    -fx-border-color: rgba(0, 0, 0, 0.23);
+    -fx-border-width: 1px;
+    -fx-border-radius: 4px;
+    -fx-padding: 0.5em 1em 0.5em 1em;
+}
+
+.button:hover {
+    -fx-background-color: rgba(0, 0, 0, 0.12);
+}
+
+.button:focused,
+.button:pressed {
+    -fx-background-color: rgba(0, 0, 0, 0.3);
+}
+
+
 .menu-bar {
     -fx-background-color: -jr-menu-background;
     -fx-background-insets: 0;

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -353,16 +353,16 @@
 }
 
 .button:default {
-    -fx-background-color: -jr-accent;
+    -fx-background-color: -fx-default-button;
 }
 
 .button:default:hover {
-    -fx-background-color: derive(-jr-accent, -10%);
+    -fx-background-color: derive(-fx-default-button, -10%);
 }
 
 .button:default:focused,
 .button:default:pressed {
-    -fx-background-color: derive(-jr-accent, -20%);
+    -fx-background-color: derive(-fx-default-button, -20%);
 }
 
 .menu-bar {

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -282,44 +282,6 @@
     -fx-font-family: monospace;
 }
 
-.flatButtonNoSpaceBottom,
-.flatButtonNoSpaceTop,
-.flatButton {
-    -fx-shadow-highlight-color: black;
-    -fx-outer-border: red;
-    -fx-inner-border: purple;
-    -fx-faint-focus-color: transparent;
-    -fx-background-color: -jr-icon-background;
-    -fx-text-background-color: blue;
-    -fx-padding: 0.5em;
-}
-
-.flatButtonNoSpaceBottom:hover,
-.flatButtonNoSpaceTop:hover,
-.flatButton:hover {
-    -fx-background-color: -jr-icon-background-active;
-}
-
-.flatButtonNoSpaceBottom:armed,
-.flatButtonNoSpaceTop:armed,
-.flatButton:armed {
-    -fx-background-color: -jr-icon-background-armed;
-}
-
-.flatButton:selected {
-    -fx-background-color: -jr-icon-background-active;
-    -fx-text-fill: white;
-    -fx-fill: white;
-}
-
-.flatButtonNoSpaceBottom {
-    -fx-padding: 0.5em 0.5em -0.1em 0.5em;
-}
-
-.flatButtonNoSpaceTop {
-    -fx-padding: -0.1em 0.5em 0.5em 0.5em;
-}
-
 .button,
 .toggle-button,
 .radio-button > .radio,
@@ -372,6 +334,40 @@
 .contained-button {
     -fx-background-color: -jr-accent;
     -fx-border-color: -jr-accent;
+}
+
+.icon-buttonNoSpaceBottom,
+.icon-buttonNoSpaceTop,
+.icon-button {
+    -fx-border-width: 0px;
+    -fx-background-color: -jr-icon-background;
+    -fx-padding: 0.5em;
+}
+
+.icon-buttonNoSpaceBottom:hover,
+.icon-buttonNoSpaceTop:hover,
+.icon-button:hover {
+    -fx-background-color: -jr-icon-background-active;
+}
+
+.icon-buttonNoSpaceBottom:armed,
+.icon-buttonNoSpaceTop:armed,
+.icon-button:armed {
+    -fx-background-color: -jr-icon-background-armed;
+}
+
+.icon-button:selected {
+    -fx-background-color: -jr-icon-background-active;
+    -fx-text-fill: white;
+    -fx-fill: white;
+}
+
+.icon-buttonNoSpaceBottom {
+    -fx-padding: 0.5em 0.5em -0.1em 0.5em;
+}
+
+.icon-buttonNoSpaceTop {
+    -fx-padding: -0.1em 0.5em 0.5em 0.5em;
 }
 
 .menu-bar {

--- a/src/main/java/org/jabref/gui/GUIGlobals.java
+++ b/src/main/java/org/jabref/gui/GUIGlobals.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.awt.Font;
 
 import org.jabref.Globals;
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.keyboard.EmacsKeyBindings;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
@@ -55,6 +56,7 @@ public class GUIGlobals {
         // Set up entry editor colors, first time:
         GUIGlobals.updateEntryEditorColors();
 
+        IconTheme.loadFonts();
         GUIGlobals.currentFont = new Font(Globals.prefs.get(JabRefPreferences.FONT_FAMILY),
                 Globals.prefs.getInt(JabRefPreferences.FONT_STYLE), Globals.prefs.getInt(JabRefPreferences.FONT_SIZE));
     }

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -60,7 +60,7 @@ public class ActionFactory {
     public Button createIconButton(Action action, Command command) {
         Button button = ActionUtils.createButton(new JabRefAction(action, command, keyBindingRepository), ActionUtils.ActionTextBehavior.HIDE);
 
-        button.getStyleClass().setAll("flatButton");
+        button.getStyleClass().setAll("icon-button");
 
         // For some reason the graphic is not set correctly, so let's fix this
         button.graphicProperty().unbind();
@@ -75,7 +75,7 @@ public class ActionFactory {
                 button,
                 ActionUtils.ActionTextBehavior.HIDE);
 
-        button.getStyleClass().add("flatButton");
+        button.getStyleClass().add("icon-button");
 
         // For some reason the graphic is not set correctly, so let's fix this
         button.graphicProperty().unbind();

--- a/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
+++ b/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
@@ -13,7 +13,7 @@ public class CustomJFXPanel {
 
     public static JFXPanel wrap(Scene scene) {
         JFXPanel container = new JFXPanel();
-        Globals.getThemeLoader().installBaseCss(scene);
+        Globals.getThemeLoader().installBaseCss(scene, Globals.prefs);
         DefaultTaskExecutor.runInJavaFXThread(() -> container.setScene(scene));
         return container;
     }

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewer.fxml
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewer.fxml
@@ -23,15 +23,15 @@
             </fx:define>
             <top>
                 <ToolBar fx:id="topPane" BorderPane.alignment="CENTER_RIGHT">
-                    <ComboBox fx:id="fileChoice" minWidth="200.0" styleClass="flatButton"/>
+                    <ComboBox fx:id="fileChoice" minWidth="200.0" styleClass="icon-button"/>
                     <HBox alignment="CENTER_RIGHT" spacing="10.0" HBox.hgrow="ALWAYS">
-                        <ToggleButton fx:id="modeLive" mnemonicParsing="false" selected="true" styleClass="flatButton"
+                        <ToggleButton fx:id="modeLive" mnemonicParsing="false" selected="true" styleClass="icon-button"
                                       text="%Live" toggleGroup="$toggleGroupMode">
                             <tooltip>
                                 <Tooltip text="%Show the document of the currently selected entry."/>
                             </tooltip>
                         </ToggleButton>
-                        <ToggleButton mnemonicParsing="false" styleClass="flatButton" text="%Locked"
+                        <ToggleButton mnemonicParsing="false" styleClass="icon-button" text="%Locked"
                                       toggleGroup="$toggleGroupMode">
                             <tooltip>
                                 <Tooltip text="%Show this document until unlocked."/>
@@ -46,7 +46,7 @@
             <bottom>
                 <ToolBar>
                     <HBox alignment="CENTER" spacing="5.0" HBox.hgrow="ALWAYS">
-                        <Button onAction="#previousPage" styleClass="flatButton">
+                        <Button onAction="#previousPage" styleClass="icon-button">
                             <graphic>
                                 <JabRefIconView glyph="PREVIOUS_LEFT"/>
                             </graphic>
@@ -57,7 +57,7 @@
                         <TextField fx:id="currentPage" minWidth="30.0" prefWidth="40.0"/>
                         <Label text="of"/>
                         <Label fx:id="maxPages"/>
-                        <Button onAction="#nextPage" styleClass="flatButton">
+                        <Button onAction="#nextPage" styleClass="icon-button">
                             <graphic>
                                 <JabRefIconView glyph="NEXT_RIGHT"/>
                             </graphic>
@@ -67,7 +67,7 @@
                         </Button>
                     </HBox>
                     <HBox fx:id="zoomBar" alignment="CENTER_RIGHT">
-                        <Button styleClass="flatButton" onAction="#fitWidth">
+                        <Button styleClass="icon-button" onAction="#fitWidth">
                             <graphic>
                                 <JabRefIconView glyph="FIT_WIDTH"/>
                             </graphic>
@@ -75,7 +75,7 @@
                                 <Tooltip text="%Fit width"/>
                             </tooltip>
                         </Button>
-                        <Button styleClass="flatButton" onAction="#fitSinglePage">
+                        <Button styleClass="icon-button" onAction="#fitSinglePage">
                             <graphic>
                                 <JabRefIconView glyph="FIT_SINGLE_PAGE"/>
                             </graphic>
@@ -83,7 +83,7 @@
                                 <Tooltip text="%Fit a single page"/>
                             </tooltip>
                         </Button>
-                        <Button styleClass="flatButton" onAction="#zoomOut">
+                        <Button styleClass="icon-button" onAction="#zoomOut">
                             <graphic>
                                 <JabRefIconView glyph="ZOOM_OUT"/>
                             </graphic>
@@ -91,7 +91,7 @@
                                 <Tooltip text="%Zoom out"/>
                             </tooltip>
                         </Button>
-                        <Button styleClass="flatButton" onAction="#zoomIn">
+                        <Button styleClass="icon-button" onAction="#zoomIn">
                             <graphic>
                                 <JabRefIconView glyph="ZOOM_IN"/>
                             </graphic>

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -31,15 +31,15 @@
     -fx-background-color: -jr-icon-background-active;
 }
 
-.flatButton.narrow {
+.icon-button.narrow {
     -fx-padding: 0.1em;
 }
 
-.flatButtonNoSpaceBottom.narrow {
+.icon-buttonNoSpaceBottom.narrow {
     -fx-padding: 0.1em 0.1em -0.2em 0.1em;
 }
 
-.flatButtonNoSpaceTop.narrow {
+.icon-buttonNoSpaceTop.narrow {
     -fx-padding: -0.2em 0.1em 0.1em 0.1em;
 }
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -15,7 +15,7 @@
          fx:controller="org.jabref.gui.entryeditor.EntryEditor">
     <left>
         <ToolBar orientation="VERTICAL">
-            <Button styleClass="flatButton,narrow" onAction="#close">
+            <Button styleClass="icon-button,narrow" onAction="#close">
                 <graphic>
                     <JabRefIconView glyph="CLOSE"/>
                 </graphic>
@@ -32,7 +32,7 @@
                 </Label>
             </Group>
             <Pane prefHeight="10" VBox.vgrow="ALWAYS"/>
-            <Button fx:id="typeChangeButton" styleClass="flatButton,narrow">
+            <Button fx:id="typeChangeButton" styleClass="icon-button,narrow">
                 <graphic>
                     <JabRefIconView glyph="ENTRY_TYPE"/>
                 </graphic>
@@ -41,7 +41,7 @@
                 </tooltip>
             </Button>
             <Button fx:id="generateCiteKeyButton" styleClass="narrow"/>
-            <Button fx:id="fetcherButton" styleClass="flatButton,narrow">
+            <Button fx:id="fetcherButton" styleClass="icon-button,narrow">
                 <graphic>
                     <JabRefIconView glyph="REFRESH"/>
                 </graphic>
@@ -49,7 +49,7 @@
                     <Tooltip text="%Update with bibliographic information from the web"/>
                 </tooltip>
             </Button>
-            <Button styleClass="flatButton,narrow" onAction="#deleteEntry">
+            <Button styleClass="icon-button,narrow" onAction="#deleteEntry">
                 <graphic>
                     <JabRefIconView glyph="DELETE_ENTRY"/>
                 </graphic>
@@ -58,7 +58,7 @@
                 </tooltip>
             </Button>
             <Separator/>
-            <Button styleClass="flatButtonNoSpaceBottom,narrow" onAction="#navigateToPreviousEntry">
+            <Button styleClass="icon-buttonNoSpaceBottom,narrow" onAction="#navigateToPreviousEntry">
                 <graphic>
                     <JabRefIconView glyph="PREVIOUS_UP"/>
                 </graphic>
@@ -66,7 +66,7 @@
                     <Tooltip text="%Previous entry"/>
                 </tooltip>
             </Button>
-            <Button styleClass="flatButtonNoSpaceTop,narrow" onAction="#navigateToNextEntry">
+            <Button styleClass="icon-buttonNoSpaceTop,narrow" onAction="#navigateToNextEntry">
                 <graphic>
                     <JabRefIconView glyph="NEXT_DOWN"/>
                 </graphic>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -35,7 +35,7 @@
                 <HBox>
                     <Label fx:id="author" />
                     <Pane HBox.hgrow="ALWAYS" />
-                    <Button onAction="#copy" styleClass="flatButton">
+                    <Button onAction="#copy" styleClass="icon-button">
                         <graphic>
                             <JabRefIconView glyph="COPY"/>
                         </graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/BibtexKeyEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/BibtexKeyEditor.fxml
@@ -6,5 +6,5 @@
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.BibtexKeyEditor">
     <EditorTextArea fx:id="textArea" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
-    <Button fx:id="generateCiteKeyButton" styleClass="flatButton"/>
+    <Button fx:id="generateCiteKeyButton" styleClass="icon-button"/>
 </fx:root>

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.fxml
@@ -11,7 +11,7 @@
          fx:controller="org.jabref.gui.fieldeditors.IdentifierEditor">
     <EditorTextArea fx:id="textArea" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button disable="${controller.viewModel.validIdentifierIsNotPresent}" onAction="#openExternalLink"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="OPEN_LINK"/>
         </graphic>
@@ -19,7 +19,7 @@
             <Tooltip text="%Open" />
         </tooltip>
     </Button>
-    <Button fx:id="lookupIdentifierButton" onAction="#lookupIdentifier" styleClass="flatButton"
+    <Button fx:id="lookupIdentifierButton" onAction="#lookupIdentifier" styleClass="icon-button"
             visible="${controller.viewModel.idFetcherAvailable}" managed="${controller.viewModel.idFetcherAvailable}">
         <graphic>
             <StackPane>
@@ -32,7 +32,7 @@
     </Button>
     <Button fx:id="fetchInformationByIdentifierButton" disable="${controller.viewModel.validIdentifierIsNotPresent}"
             onAction="#fetchInformationByIdentifier"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="FETCH_BY_IDENTIFIER"/>
         </graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.fxml
@@ -9,7 +9,7 @@
          fx:controller="org.jabref.gui.fieldeditors.JournalEditor">
     <EditorTextArea fx:id="textArea" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button onAction="#toggleAbbreviation"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="TOGGLE_ABBREVIATION"/>
         </graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -11,7 +11,7 @@
          fx:controller="org.jabref.gui.fieldeditors.LinkedFilesEditor">
     <ListView fx:id="listView" prefHeight="0" HBox.hgrow="ALWAYS" maxHeight="100"/>
     <Button onAction="#addNewFile"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="NEW_FILE"/>
         </graphic>
@@ -19,7 +19,7 @@
             <Tooltip text="%Open"/>
         </tooltip>
     </Button>
-    <Button onAction="#fetchFulltext" styleClass="flatButton">
+    <Button onAction="#fetchFulltext" styleClass="icon-button">
         <graphic>
             <StackPane>
                 <JabRefIconView glyph="FETCH_FULLTEXT"
@@ -34,7 +34,7 @@
     </Button>
     <Button
             onAction="#addFromURL"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="DOWNLOAD"/>
         </graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -172,13 +172,13 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         acceptAutoLinkedFile.setTooltip(new Tooltip(Localization.lang("This file was found automatically. Do you want to link it to this entry?")));
         acceptAutoLinkedFile.visibleProperty().bind(linkedFile.isAutomaticallyFoundProperty());
         acceptAutoLinkedFile.setOnAction(event -> linkedFile.acceptAsLinked());
-        acceptAutoLinkedFile.getStyleClass().setAll("flatButton");
+        acceptAutoLinkedFile.getStyleClass().setAll("icon-button");
 
         Button writeXMPMetadata = MaterialDesignIconFactory.get().createIconButton(MaterialDesignIcon.IMPORT);
         writeXMPMetadata.setTooltip(new Tooltip(Localization.lang("Write BibTeXEntry as XMP-metadata to PDF.")));
         writeXMPMetadata.visibleProperty().bind(linkedFile.canWriteXMPMetadataProperty());
         writeXMPMetadata.setOnAction(event -> linkedFile.writeXMPMetadata());
-        writeXMPMetadata.getStyleClass().setAll("flatButton");
+        writeXMPMetadata.getStyleClass().setAll("icon-button");
 
         HBox container = new HBox(10);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);

--- a/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.fxml
@@ -9,7 +9,7 @@
          fx:controller="org.jabref.gui.fieldeditors.OwnerEditor">
     <EditorTextArea fx:id="textArea" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button onAction="#setOwner"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="OWNER"/>
         </graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.fxml
@@ -9,7 +9,7 @@
          fx:controller="org.jabref.gui.fieldeditors.UrlEditor">
     <EditorTextArea fx:id="textArea" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
     <Button disable="${controller.viewModel.validUrlIsNotPresent}" onAction="#openExternalLink"
-            styleClass="flatButton">
+            styleClass="icon-button">
         <graphic>
             <JabRefIconView glyph="OPEN_LINK"/>
         </graphic>

--- a/src/main/java/org/jabref/gui/groups/GroupTree.fxml
+++ b/src/main/java/org/jabref/gui/groups/GroupTree.fxml
@@ -30,7 +30,7 @@
         <HBox fx:id="barBottom" alignment="CENTER">
             <ButtonBar fx:id="buttonBarBottom">
                 <buttons>
-                    <Button fx:id="newGroupButton" onAction="#addNewGroup" styleClass="flatButton"
+                    <Button fx:id="newGroupButton" onAction="#addNewGroup" styleClass="icon-button"
                             ButtonBar.buttonData="LEFT">
                         <graphic>
                             <JabRefIconView glyph="NEW_GROUP" glyphSize="18"/>

--- a/src/main/java/org/jabref/gui/help/AboutDialog.css
+++ b/src/main/java/org/jabref/gui/help/AboutDialog.css
@@ -36,15 +36,6 @@
 	-fx-padding: 5px;
 }
 
-.custom-buttons {
-	-fx-padding: 10 0 0 0;
-}
-
-.dialog-pane *.button-bar {
-	-fx-max-height: 0;
-	-fx-pref-height: 0;
-}
-
 .logo-pane {
     fx-fill: transparent;
 }

--- a/src/main/java/org/jabref/gui/help/AboutDialog.fxml
+++ b/src/main/java/org/jabref/gui/help/AboutDialog.fxml
@@ -28,7 +28,9 @@
                             <Tooltip text="%Copy Version" />
                         </tooltip>
                     </Label>
-                    <Label fx:id="devVersionLabel" managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading" text="${controller.viewModel.developmentVersion}" visible="${controller.viewModel.isDevelopmentVersion}" />
+                    <Label managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading"
+                           text="${controller.viewModel.developmentVersion}"
+                           visible="${controller.viewModel.isDevelopmentVersion}"/>
                     <Hyperlink onAction="#openChangeLog" styleClass="top-padding" text="%What's new in this version?" />
                     <Label styleClass="filler" />
                     <HBox alignment="CENTER_LEFT">
@@ -46,7 +48,8 @@
                 </VBox>
                 <BorderPane BorderPane.alignment="CENTER" HBox.hgrow="ALWAYS">
                     <center>
-                        <StackPane onMouseClicked="#openJabrefWebsite" scaleX="0.6" scaleY="0.6" prefWidth="140" prefHeight="140" BorderPane.alignment="CENTER">
+                        <StackPane onMouseClicked="#openJabrefWebsite" prefHeight="140" prefWidth="140" scaleX="0.6"
+                                   scaleY="0.6" BorderPane.alignment="CENTER">
                             <!-- SVGPaths need to be wrapped in a Pane to get them to the same size -->
                             <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
                                 <SVGPath content="M97.2 87.1C93.2 33.8 18.4 14.6 18.2 15.6c-0.1 6.7-0.3 13.3-0.4 20 17.8 3.6 61.7 20.1 79.4 51.5" />
@@ -80,12 +83,10 @@
                     </bottom>
                 </BorderPane>
             </HBox>
-            <Label styleClass="sub-heading" text="%Developers">
-            </Label>
+            <Label styleClass="sub-heading" text="%Developers"/>
             <Label alignment="CENTER" styleClass="info-sections" text="${controller.viewModel.developers}" textAlignment="JUSTIFY" wrapText="true" />
-            <Label styleClass="sub-heading" text="%Authors">
-            </Label>
-            <HBox alignment="CENTER" VBox.vgrow="ALWAYS">
+            <Label styleClass="sub-heading" text="%Authors"/>
+            <HBox alignment="CENTER" VBox.vgrow="ALWAYS" prefHeight="100">
                 <ScrollPane fitToWidth="true">
                     <Label styleClass="info-sections" text="${controller.viewModel.authors}" textAlignment="JUSTIFY" wrapText="true" BorderPane.alignment="CENTER" />
                 </ScrollPane>
@@ -95,6 +96,6 @@
     </content>
     <header>
     </header>
-    <ButtonType fx:id="copyVersionButton" text="%Copy Version" />
+    <ButtonType fx:id="copyVersionButton" text="%Copy Version" buttonData="LEFT"/>
     <ButtonType fx:constant="CLOSE" />
 </DialogPane>

--- a/src/main/java/org/jabref/gui/help/AboutDialogView.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogView.java
@@ -28,12 +28,17 @@ public class AboutDialogView extends BaseDialog<Void> {
 
     public AboutDialogView() {
         this.setTitle(Localization.lang("About JabRef"));
+        this.setResizable(true);
 
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);
 
         ControlHelper.setAction(copyVersionButton, getDialogPane(), event -> copyVersionToClipboard());
+    }
+
+    public AboutDialogViewModel getViewModel() {
+        return viewModel;
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -50,7 +50,7 @@ public class IconTheme {
     private static final Map<String, String> KEY_TO_ICON = readIconThemeFile(
             IconTheme.class.getResource("/images/Icons.properties"), "/images/external/");
 
-    static {
+    public static void loadFonts() {
         try (InputStream stream = getMaterialDesignIconsStream()) {
             FONT = Font.createFont(Font.TRUETYPE_FONT, stream);
         } catch (FontFormatException | IOException e) {

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -362,14 +362,14 @@ public class IconTheme {
         public Button asButton() {
             Button button = new Button();
             button.setGraphic(getGraphicNode());
-            button.getStyleClass().add("flatButton");
+            button.getStyleClass().add("icon-button");
             return button;
         }
 
         public ToggleButton asToggleButton() {
             ToggleButton button = new ToggleButton();
             button.setGraphic(getGraphicNode());
-            button.getStyleClass().add("flatButton");
+            button.getStyleClass().add("icon-button");
             return button;
         }
     }

--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -21,7 +21,7 @@ public class BaseDialog<T> extends Dialog<T> {
 
         setDialogIcon(IconTheme.getJabRefImageFX());
 
-        Globals.getThemeLoader().installBaseCss(getDialogPane().getScene());
+        Globals.getThemeLoader().installBaseCss(getDialogPane().getScene(), Globals.prefs);
     }
 
     private void setDialogIcon(Image image) {

--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -69,6 +69,10 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
 
     @Override
     public void addListenerForFile(Path file, FileUpdateListener listener) throws IOException {
+        if (watcher == null) {
+            throw new IllegalStateException("You need to start the file monitor before watching files");
+        }
+
         // We can't watch files directly, so monitor their parent directory for updates
         Path directory = file.toAbsolutePath().getParent();
         directory.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -11,10 +11,10 @@ import java.util.Objects;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 
-import org.jabref.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.FileUpdateMonitor;
+import org.jabref.preferences.JabRefPreferences;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ public class ThemeLoader {
      * Installs the base css file as a stylesheet in the given scene.
      * Changes in the css file lead to a redraw of the scene using the new css file.
      */
-    public void installBaseCss(Scene scene) {
+    public void installBaseCss(Scene scene, JabRefPreferences preferences) {
         addAndWatchForChanges(scene, DEFAULT_PATH_MAIN_CSS, 0);
 
         if (StringUtil.isNotBlank(CSS_SYSTEM_PROPERTY)) {
@@ -60,7 +60,7 @@ public class ThemeLoader {
             }
         }
 
-        Globals.prefs.getFontSize().ifPresent(size -> scene.getRoot().setStyle("-fx-font-size: " + size + "pt;"));
+        preferences.getFontSize().ifPresent(size -> scene.getRoot().setStyle("-fx-font-size: " + size + "pt;"));
     }
 
     private void addAndWatchForChanges(Scene scene, String cssUrl, int index) {

--- a/src/main/java/org/jabref/gui/util/component/Tag.fxml
+++ b/src/main/java/org/jabref/gui/util/component/Tag.fxml
@@ -14,7 +14,7 @@
         </HBox.margin>
     </Label>
     <Button
-            styleClass="flatButton"
+            styleClass="icon-button"
             onAction="#removeButtonClicked">
         <graphic>
             <JabRefIconView glyph="CLOSE"/>

--- a/src/main/java/org/jabref/styletester/StyleTester.fxml
+++ b/src/main/java/org/jabref/styletester/StyleTester.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuButton?>
@@ -30,283 +31,303 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<AnchorPane xmlns:fx="http://javafx.com/fxml"
-            xmlns="http://javafx.com/javafx"
-            fx:controller="org.jabref.styletester.StyleTesterView"
-            prefHeight="400.0" prefWidth="600.0">
-    <children>
-        <VBox layoutX="194.0" layoutY="14.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0"
-              AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-            <children>
-                <MenuBar>
-                    <menus>
-                        <Menu mnemonicParsing="false" text="File">
-                            <items>
-                                <MenuItem mnemonicParsing="false" text="Load Stylesheet...">
-                                    <accelerator>
-                                        <KeyCodeCombination alt="UP" code="O" control="DOWN" meta="UP" shift="UP"
-                                                            shortcut="UP"/>
-                                    </accelerator>
-                                </MenuItem>
-                                <MenuItem mnemonicParsing="false" text="Reload Stylesheet">
-                                    <accelerator>
-                                        <KeyCodeCombination alt="UP" code="R" control="DOWN" meta="UP" shift="UP"
-                                                            shortcut="UP"/>
-                                    </accelerator>
-                                </MenuItem>
-                            </items>
-                        </Menu>
-                    </menus>
-                </MenuBar>
-                <HBox prefHeight="652.0" prefWidth="1124.0" spacing="5.0">
-                    <children>
-                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
-                            <children>
-                                <ComboBox maxWidth="1.7976931348623157E308" prefWidth="150.0" promptText="Combo Box">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ComboBox>
-                                <ComboBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
-                                          promptText="Combo Box (Disabled)">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ComboBox>
-                                <Separator prefWidth="200.0"/>
-                                <ComboBox editable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
-                                          promptText="Combo Box">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ComboBox>
-                                <ComboBox disable="true" editable="true" maxWidth="1.7976931348623157E308"
-                                          prefWidth="150.0" promptText="Combo Box (Disabled)">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ComboBox>
-                                <Separator prefWidth="200.0"/>
-                                <ChoiceBox maxWidth="1.7976931348623157E308" prefWidth="150.0">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ChoiceBox>
-                                <ChoiceBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0">
-                                    <items>
-                                        <FXCollections fx:factory="observableArrayList">
-                                            <String fx:value="Apple"/>
-                                            <String fx:value="Orange"/>
-                                            <String fx:value="Pear"/>
-                                        </FXCollections>
-                                    </items>
-                                </ChoiceBox>
-                                <Separator prefWidth="200.0"/>
-                                <TextField promptText="Text Field"/>
-                                <TextField editable="false" text="Text Field (non-editable)"/>
-                                <TextField disable="true" text="Text Field (disabled)"/>
-                                <Separator prefWidth="200.0"/>
-                                <PasswordField promptText="Password"/>
-                                <PasswordField editable="false" promptText="Password (non-editable)"
-                                               text="Password (non-editable)"/>
-                                <PasswordField disable="true" text="Password (disabled)"/>
-                                <Separator prefWidth="200.0"/>
-                                <HBox prefHeight="100.0" prefWidth="200.0">
-                                    <children>
-                                        <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
-                                              HBox.hgrow="SOMETIMES">
-                                            <children>
-                                                <CheckBox allowIndeterminate="true" mnemonicParsing="false"
-                                                          text="CheckBox"/>
-                                                <CheckBox allowIndeterminate="true" mnemonicParsing="false"
-                                                          selected="true" text="CheckBox"/>
-                                                <CheckBox allowIndeterminate="true" disable="true"
-                                                          mnemonicParsing="false" text="CheckBox"/>
-                                                <CheckBox allowIndeterminate="true" disable="true"
-                                                          mnemonicParsing="false" selected="true" text="CheckBox"/>
-                                                <CheckBox allowIndeterminate="true" disable="true" indeterminate="true"
-                                                          mnemonicParsing="false" text="CheckBox"/>
-                                            </children>
-                                        </VBox>
-                                        <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
-                                              HBox.hgrow="SOMETIMES">
-                                            <children>
-                                                <RadioButton mnemonicParsing="false" text="RadioButton">
-                                                    <toggleGroup>
-                                                        <ToggleGroup fx:id="radios"/>
-                                                    </toggleGroup>
-                                                </RadioButton>
-                                                <RadioButton mnemonicParsing="false" selected="true" text="RadioButton"
-                                                             toggleGroup="$radios"/>
-                                                <RadioButton disable="true" mnemonicParsing="false" text="RadioButton"/>
-                                                <RadioButton disable="true" mnemonicParsing="false" selected="true"
-                                                             text="RadioButton"/>
-                                            </children>
-                                        </VBox>
-                                    </children>
-                                </HBox>
-                            </children>
-                        </VBox>
-                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
-                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
-                            <children>
-                                <MenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="MenuButton">
-                                    <items>
-                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
-                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
-                                    </items>
-                                </MenuButton>
-                                <MenuButton disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                            text="MenuButton (Disabled)">
-                                    <items>
-                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
-                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
-                                    </items>
-                                </MenuButton>
-                                <Separator prefWidth="200.0"/>
-                                <SplitMenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                                 text="SplitMenuButton">
-                                    <items>
-                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
-                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
-                                    </items>
-                                </SplitMenuButton>
-                                <SplitMenuButton disable="true" maxWidth="1.7976931348623157E308"
-                                                 mnemonicParsing="false" text="SplitMenuButton (Disabled)">
-                                    <items>
-                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
-                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
-                                    </items>
-                                </SplitMenuButton>
-                                <Separator prefWidth="200.0"/>
-                                <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Button"/>
-                                <Button disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                        text="Button (Disabled)"/>
-                                <Button defaultButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                        text="Button (Default)"/>
-                                <Button cancelButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                                        text="Button (Cancel)"/>
-                                <Separator prefWidth="200.0"/>
-                                <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink"/>
-                                <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink (Visited)" visited="true"/>
-                                <Separator prefWidth="200.0"/>
-                            </children>
-                        </VBox>
-                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
-                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
-                            <children>
-                                <Slider value="35.0"/>
-                                <Slider showTickMarks="true" snapToTicks="true" value="35.0"/>
-                                <Slider showTickLabels="true" showTickMarks="true" snapToTicks="true" value="35.0"/>
-                                <FlowPane alignment="CENTER" columnHalignment="CENTER" hgap="10.0" prefHeight="200.0"
-                                          prefWidth="200.0" vgap="10.0">
-                                    <children>
-                                        <Slider orientation="VERTICAL"/>
-                                        <Slider orientation="VERTICAL" showTickMarks="true"/>
-                                        <Slider orientation="VERTICAL" showTickLabels="true" showTickMarks="true"/>
-                                    </children>
-                                </FlowPane>
-                                <Separator prefWidth="200.0"/>
-                                <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0" progress="0.3"/>
-                                <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0"/>
-                                <ProgressIndicator progress="0.3"/>
-                                <ProgressIndicator/>
-                            </children>
-                        </VBox>
-                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
-                        <VBox prefHeight="385.0" prefWidth="236.0" HBox.hgrow="ALWAYS">
-                            <children>
-                                <TextArea prefHeight="71.0" prefWidth="268.0" promptText="Text Area" wrapText="true"/>
-                            </children>
-                        </VBox>
-                    </children>
-                    <padding>
-                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
-                    </padding>
+<AnchorPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="400.0" prefWidth="600.0"
+            xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.styletester.StyleTesterView">
+    <TabPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+             AnchorPane.topAnchor="0.0">
+        <Tab text="Buttons">
+            <FlowPane>
+                <Label>Normal buttons:</Label>
+                <HBox spacing="16">
+                    <Button text="Normal"/>
+                    <Button text="Hover" fx:id="normalButtonHover"/>
+                    <Button text="Pressed" fx:id="normalButtonPressed"/>
+                    <Button text="Focused" fx:id="normalButtonFocused"/>
+                    <Button disable="true" text="Disabled"/>
+                    <Button defaultButton="true" text="Default"/>
+                    <Button cancelButton="true" text="Cancel"/>
                 </HBox>
-                <SplitPane dividerPositions="0.45566502463054187" prefHeight="160.0" prefWidth="200.0"
-                           VBox.vgrow="ALWAYS">
-                    <items>
-                        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
-                            <children>
-                                <TabPane prefHeight="173.0" prefWidth="259.0" side="BOTTOM"
-                                         AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
-                                         AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                    <tabs>
-                                        <Tab text="Lorem">
-                                            <content>
-                                                <AnchorPane/>
-                                            </content>
-                                        </Tab>
-                                        <Tab text="Ipsum">
-                                            <content>
-                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                                            prefWidth="200.0"/>
-                                            </content>
-                                        </Tab>
-                                        <Tab text="Dolor">
-                                            <content>
-                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                                            prefWidth="200.0"/>
-                                            </content>
-                                        </Tab>
-                                    </tabs>
-                                </TabPane>
-                            </children>
-                        </AnchorPane>
-                        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
-                            <children>
-                                <TabPane prefHeight="173.0" prefWidth="294.0" side="LEFT" AnchorPane.bottomAnchor="0.0"
-                                         AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
-                                         AnchorPane.topAnchor="0.0">
-                                    <tabs>
-                                        <Tab text="Lorem">
-                                            <content>
-                                                <AnchorPane/>
-                                            </content>
-                                        </Tab>
-                                        <Tab text="Ipsum">
-                                            <content>
-                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                                            prefWidth="200.0"/>
-                                            </content>
-                                        </Tab>
-                                        <Tab text="Dolor">
-                                            <content>
-                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
-                                                            prefWidth="200.0"/>
-                                            </content>
-                                        </Tab>
-                                    </tabs>
-                                </TabPane>
-                            </children>
-                        </AnchorPane>
-                    </items>
-                    <padding>
-                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
-                    </padding>
-                </SplitPane>
-            </children>
-        </VBox>
-    </children>
+            </FlowPane>
+        </Tab>
+        <Tab>
+            <VBox layoutX="194.0" layoutY="14.0" prefHeight="200.0" prefWidth="100.0">
+                <children>
+                    <MenuBar>
+                        <menus>
+                            <Menu mnemonicParsing="false" text="File">
+                                <items>
+                                    <MenuItem mnemonicParsing="false" text="Load Stylesheet...">
+                                        <accelerator>
+                                            <KeyCodeCombination alt="UP" code="O" control="DOWN" meta="UP" shift="UP"
+                                                                shortcut="UP"/>
+                                        </accelerator>
+                                    </MenuItem>
+                                    <MenuItem mnemonicParsing="false" text="Reload Stylesheet">
+                                        <accelerator>
+                                            <KeyCodeCombination alt="UP" code="R" control="DOWN" meta="UP" shift="UP"
+                                                                shortcut="UP"/>
+                                        </accelerator>
+                                    </MenuItem>
+                                </items>
+                            </Menu>
+                        </menus>
+                    </MenuBar>
+                    <HBox prefHeight="652.0" prefWidth="1124.0" spacing="5.0">
+                        <children>
+                            <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                                <children>
+                                    <ComboBox maxWidth="1.7976931348623157E308" prefWidth="150.0"
+                                              promptText="Combo Box">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ComboBox>
+                                    <ComboBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
+                                              promptText="Combo Box (Disabled)">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ComboBox>
+                                    <Separator prefWidth="200.0"/>
+                                    <ComboBox editable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
+                                              promptText="Combo Box">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ComboBox>
+                                    <ComboBox disable="true" editable="true" maxWidth="1.7976931348623157E308"
+                                              prefWidth="150.0" promptText="Combo Box (Disabled)">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ComboBox>
+                                    <Separator prefWidth="200.0"/>
+                                    <ChoiceBox maxWidth="1.7976931348623157E308" prefWidth="150.0">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ChoiceBox>
+                                    <ChoiceBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0">
+                                        <items>
+                                            <FXCollections fx:factory="observableArrayList">
+                                                <String fx:value="Apple"/>
+                                                <String fx:value="Orange"/>
+                                                <String fx:value="Pear"/>
+                                            </FXCollections>
+                                        </items>
+                                    </ChoiceBox>
+                                    <Separator prefWidth="200.0"/>
+                                    <TextField promptText="Text Field"/>
+                                    <TextField editable="false" text="Text Field (non-editable)"/>
+                                    <TextField disable="true" text="Text Field (disabled)"/>
+                                    <Separator prefWidth="200.0"/>
+                                    <PasswordField promptText="Password"/>
+                                    <PasswordField editable="false" promptText="Password (non-editable)"
+                                                   text="Password (non-editable)"/>
+                                    <PasswordField disable="true" text="Password (disabled)"/>
+                                    <Separator prefWidth="200.0"/>
+                                    <HBox prefHeight="100.0" prefWidth="200.0">
+                                        <children>
+                                            <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
+                                                  HBox.hgrow="SOMETIMES">
+                                                <children>
+                                                    <CheckBox allowIndeterminate="true" mnemonicParsing="false"
+                                                              text="CheckBox"/>
+                                                    <CheckBox allowIndeterminate="true" mnemonicParsing="false"
+                                                              selected="true" text="CheckBox"/>
+                                                    <CheckBox allowIndeterminate="true" disable="true"
+                                                              mnemonicParsing="false" text="CheckBox"/>
+                                                    <CheckBox allowIndeterminate="true" disable="true"
+                                                              mnemonicParsing="false" selected="true" text="CheckBox"/>
+                                                    <CheckBox allowIndeterminate="true" disable="true"
+                                                              indeterminate="true" mnemonicParsing="false"
+                                                              text="CheckBox"/>
+                                                </children>
+                                            </VBox>
+                                            <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
+                                                  HBox.hgrow="SOMETIMES">
+                                                <children>
+                                                    <RadioButton mnemonicParsing="false" text="RadioButton">
+                                                        <toggleGroup>
+                                                            <ToggleGroup fx:id="radios"/>
+                                                        </toggleGroup>
+                                                    </RadioButton>
+                                                    <RadioButton mnemonicParsing="false" selected="true"
+                                                                 text="RadioButton" toggleGroup="$radios"/>
+                                                    <RadioButton disable="true" mnemonicParsing="false"
+                                                                 text="RadioButton"/>
+                                                    <RadioButton disable="true" mnemonicParsing="false" selected="true"
+                                                                 text="RadioButton"/>
+                                                </children>
+                                            </VBox>
+                                        </children>
+                                    </HBox>
+                                </children>
+                            </VBox>
+                            <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                            <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                                <children>
+                                    <MenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                                text="MenuButton">
+                                        <items>
+                                            <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                            <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                        </items>
+                                    </MenuButton>
+                                    <MenuButton disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                                text="MenuButton (Disabled)">
+                                        <items>
+                                            <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                            <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                        </items>
+                                    </MenuButton>
+                                    <Separator prefWidth="200.0"/>
+                                    <SplitMenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                                     text="SplitMenuButton">
+                                        <items>
+                                            <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                            <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                        </items>
+                                    </SplitMenuButton>
+                                    <SplitMenuButton disable="true" maxWidth="1.7976931348623157E308"
+                                                     mnemonicParsing="false" text="SplitMenuButton (Disabled)">
+                                        <items>
+                                            <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                            <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                        </items>
+                                    </SplitMenuButton>
+                                    <Separator prefWidth="200.0"/>
+                                    <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Button"/>
+                                    <Button disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                            text="Button (Disabled)"/>
+                                    <Button defaultButton="true" maxWidth="1.7976931348623157E308"
+                                            mnemonicParsing="false" text="Button (Default)"/>
+                                    <Button cancelButton="true" maxWidth="1.7976931348623157E308"
+                                            mnemonicParsing="false" text="Button (Cancel)"/>
+                                    <Separator prefWidth="200.0"/>
+                                    <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink"/>
+                                    <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink (Visited)"
+                                               visited="true"/>
+                                    <Separator prefWidth="200.0"/>
+                                </children>
+                            </VBox>
+                            <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                            <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                                <children>
+                                    <Slider value="35.0"/>
+                                    <Slider showTickMarks="true" snapToTicks="true" value="35.0"/>
+                                    <Slider showTickLabels="true" showTickMarks="true" snapToTicks="true" value="35.0"/>
+                                    <FlowPane alignment="CENTER" columnHalignment="CENTER" hgap="10.0"
+                                              prefHeight="200.0" prefWidth="200.0" vgap="10.0">
+                                        <children>
+                                            <Slider orientation="VERTICAL"/>
+                                            <Slider orientation="VERTICAL" showTickMarks="true"/>
+                                            <Slider orientation="VERTICAL" showTickLabels="true" showTickMarks="true"/>
+                                        </children>
+                                    </FlowPane>
+                                    <Separator prefWidth="200.0"/>
+                                    <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0" progress="0.3"/>
+                                    <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0"/>
+                                    <ProgressIndicator progress="0.3"/>
+                                    <ProgressIndicator/>
+                                </children>
+                            </VBox>
+                            <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                            <VBox prefHeight="385.0" prefWidth="236.0" HBox.hgrow="ALWAYS">
+                                <children>
+                                    <TextArea prefHeight="71.0" prefWidth="268.0" promptText="Text Area"
+                                              wrapText="true"/>
+                                </children>
+                            </VBox>
+                        </children>
+                        <padding>
+                            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                        </padding>
+                    </HBox>
+                    <SplitPane dividerPositions="0.45566502463054187" prefHeight="160.0" prefWidth="200.0"
+                               VBox.vgrow="ALWAYS">
+                        <items>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                                <children>
+                                    <TabPane prefHeight="173.0" prefWidth="259.0" side="BOTTOM"
+                                             AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                                             AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                        <tabs>
+                                            <Tab text="Lorem">
+                                                <content>
+                                                    <AnchorPane/>
+                                                </content>
+                                            </Tab>
+                                            <Tab text="Ipsum">
+                                                <content>
+                                                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                                prefWidth="200.0"/>
+                                                </content>
+                                            </Tab>
+                                            <Tab text="Dolor">
+                                                <content>
+                                                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                                prefWidth="200.0"/>
+                                                </content>
+                                            </Tab>
+                                        </tabs>
+                                    </TabPane>
+                                </children>
+                            </AnchorPane>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                                <children>
+                                    <TabPane prefHeight="173.0" prefWidth="294.0" side="LEFT"
+                                             AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                                             AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                        <tabs>
+                                            <Tab text="Lorem">
+                                                <content>
+                                                    <AnchorPane/>
+                                                </content>
+                                            </Tab>
+                                            <Tab text="Ipsum">
+                                                <content>
+                                                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                                prefWidth="200.0"/>
+                                                </content>
+                                            </Tab>
+                                            <Tab text="Dolor">
+                                                <content>
+                                                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                                prefWidth="200.0"/>
+                                                </content>
+                                            </Tab>
+                                        </tabs>
+                                    </TabPane>
+                                </children>
+                            </AnchorPane>
+                        </items>
+                        <padding>
+                            <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                        </padding>
+                    </SplitPane>
+                </children>
+            </VBox>
+        </Tab>
+    </TabPane>
 </AnchorPane>

--- a/src/main/java/org/jabref/styletester/StyleTester.fxml
+++ b/src/main/java/org/jabref/styletester/StyleTester.fxml
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.String?>
+<?import javafx.collections.FXCollections?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Hyperlink?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.Slider?>
+<?import javafx.scene.control.SplitMenuButton?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.input.KeyCodeCombination?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<AnchorPane xmlns:fx="http://javafx.com/fxml"
+            xmlns="http://javafx.com/javafx"
+            fx:controller="org.jabref.styletester.StyleTesterView"
+            prefHeight="400.0" prefWidth="600.0">
+    <children>
+        <VBox layoutX="194.0" layoutY="14.0" prefHeight="200.0" prefWidth="100.0" AnchorPane.bottomAnchor="0.0"
+              AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <children>
+                <MenuBar>
+                    <menus>
+                        <Menu mnemonicParsing="false" text="File">
+                            <items>
+                                <MenuItem mnemonicParsing="false" text="Load Stylesheet...">
+                                    <accelerator>
+                                        <KeyCodeCombination alt="UP" code="O" control="DOWN" meta="UP" shift="UP"
+                                                            shortcut="UP"/>
+                                    </accelerator>
+                                </MenuItem>
+                                <MenuItem mnemonicParsing="false" text="Reload Stylesheet">
+                                    <accelerator>
+                                        <KeyCodeCombination alt="UP" code="R" control="DOWN" meta="UP" shift="UP"
+                                                            shortcut="UP"/>
+                                    </accelerator>
+                                </MenuItem>
+                            </items>
+                        </Menu>
+                    </menus>
+                </MenuBar>
+                <HBox prefHeight="652.0" prefWidth="1124.0" spacing="5.0">
+                    <children>
+                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                            <children>
+                                <ComboBox maxWidth="1.7976931348623157E308" prefWidth="150.0" promptText="Combo Box">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ComboBox>
+                                <ComboBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
+                                          promptText="Combo Box (Disabled)">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ComboBox>
+                                <Separator prefWidth="200.0"/>
+                                <ComboBox editable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0"
+                                          promptText="Combo Box">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ComboBox>
+                                <ComboBox disable="true" editable="true" maxWidth="1.7976931348623157E308"
+                                          prefWidth="150.0" promptText="Combo Box (Disabled)">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ComboBox>
+                                <Separator prefWidth="200.0"/>
+                                <ChoiceBox maxWidth="1.7976931348623157E308" prefWidth="150.0">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ChoiceBox>
+                                <ChoiceBox disable="true" maxWidth="1.7976931348623157E308" prefWidth="150.0">
+                                    <items>
+                                        <FXCollections fx:factory="observableArrayList">
+                                            <String fx:value="Apple"/>
+                                            <String fx:value="Orange"/>
+                                            <String fx:value="Pear"/>
+                                        </FXCollections>
+                                    </items>
+                                </ChoiceBox>
+                                <Separator prefWidth="200.0"/>
+                                <TextField promptText="Text Field"/>
+                                <TextField editable="false" text="Text Field (non-editable)"/>
+                                <TextField disable="true" text="Text Field (disabled)"/>
+                                <Separator prefWidth="200.0"/>
+                                <PasswordField promptText="Password"/>
+                                <PasswordField editable="false" promptText="Password (non-editable)"
+                                               text="Password (non-editable)"/>
+                                <PasswordField disable="true" text="Password (disabled)"/>
+                                <Separator prefWidth="200.0"/>
+                                <HBox prefHeight="100.0" prefWidth="200.0">
+                                    <children>
+                                        <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
+                                              HBox.hgrow="SOMETIMES">
+                                            <children>
+                                                <CheckBox allowIndeterminate="true" mnemonicParsing="false"
+                                                          text="CheckBox"/>
+                                                <CheckBox allowIndeterminate="true" mnemonicParsing="false"
+                                                          selected="true" text="CheckBox"/>
+                                                <CheckBox allowIndeterminate="true" disable="true"
+                                                          mnemonicParsing="false" text="CheckBox"/>
+                                                <CheckBox allowIndeterminate="true" disable="true"
+                                                          mnemonicParsing="false" selected="true" text="CheckBox"/>
+                                                <CheckBox allowIndeterminate="true" disable="true" indeterminate="true"
+                                                          mnemonicParsing="false" text="CheckBox"/>
+                                            </children>
+                                        </VBox>
+                                        <VBox prefHeight="200.0" prefWidth="100.0" spacing="10.0"
+                                              HBox.hgrow="SOMETIMES">
+                                            <children>
+                                                <RadioButton mnemonicParsing="false" text="RadioButton">
+                                                    <toggleGroup>
+                                                        <ToggleGroup fx:id="radios"/>
+                                                    </toggleGroup>
+                                                </RadioButton>
+                                                <RadioButton mnemonicParsing="false" selected="true" text="RadioButton"
+                                                             toggleGroup="$radios"/>
+                                                <RadioButton disable="true" mnemonicParsing="false" text="RadioButton"/>
+                                                <RadioButton disable="true" mnemonicParsing="false" selected="true"
+                                                             text="RadioButton"/>
+                                            </children>
+                                        </VBox>
+                                    </children>
+                                </HBox>
+                            </children>
+                        </VBox>
+                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                            <children>
+                                <MenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="MenuButton">
+                                    <items>
+                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                    </items>
+                                </MenuButton>
+                                <MenuButton disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                            text="MenuButton (Disabled)">
+                                    <items>
+                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                    </items>
+                                </MenuButton>
+                                <Separator prefWidth="200.0"/>
+                                <SplitMenuButton maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                                 text="SplitMenuButton">
+                                    <items>
+                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                    </items>
+                                </SplitMenuButton>
+                                <SplitMenuButton disable="true" maxWidth="1.7976931348623157E308"
+                                                 mnemonicParsing="false" text="SplitMenuButton (Disabled)">
+                                    <items>
+                                        <MenuItem mnemonicParsing="false" text="Action 1"/>
+                                        <MenuItem mnemonicParsing="false" text="Action 2"/>
+                                    </items>
+                                </SplitMenuButton>
+                                <Separator prefWidth="200.0"/>
+                                <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Button"/>
+                                <Button disable="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                        text="Button (Disabled)"/>
+                                <Button defaultButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                        text="Button (Default)"/>
+                                <Button cancelButton="true" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                                        text="Button (Cancel)"/>
+                                <Separator prefWidth="200.0"/>
+                                <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink"/>
+                                <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink (Visited)" visited="true"/>
+                                <Separator prefWidth="200.0"/>
+                            </children>
+                        </VBox>
+                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                        <VBox prefHeight="385.0" prefWidth="236.0" spacing="10.0" HBox.hgrow="ALWAYS">
+                            <children>
+                                <Slider value="35.0"/>
+                                <Slider showTickMarks="true" snapToTicks="true" value="35.0"/>
+                                <Slider showTickLabels="true" showTickMarks="true" snapToTicks="true" value="35.0"/>
+                                <FlowPane alignment="CENTER" columnHalignment="CENTER" hgap="10.0" prefHeight="200.0"
+                                          prefWidth="200.0" vgap="10.0">
+                                    <children>
+                                        <Slider orientation="VERTICAL"/>
+                                        <Slider orientation="VERTICAL" showTickMarks="true"/>
+                                        <Slider orientation="VERTICAL" showTickLabels="true" showTickMarks="true"/>
+                                    </children>
+                                </FlowPane>
+                                <Separator prefWidth="200.0"/>
+                                <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0" progress="0.3"/>
+                                <ProgressBar maxWidth="1.7976931348623157E308" prefWidth="200.0"/>
+                                <ProgressIndicator progress="0.3"/>
+                                <ProgressIndicator/>
+                            </children>
+                        </VBox>
+                        <Separator orientation="VERTICAL" prefHeight="200.0"/>
+                        <VBox prefHeight="385.0" prefWidth="236.0" HBox.hgrow="ALWAYS">
+                            <children>
+                                <TextArea prefHeight="71.0" prefWidth="268.0" promptText="Text Area" wrapText="true"/>
+                            </children>
+                        </VBox>
+                    </children>
+                    <padding>
+                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                    </padding>
+                </HBox>
+                <SplitPane dividerPositions="0.45566502463054187" prefHeight="160.0" prefWidth="200.0"
+                           VBox.vgrow="ALWAYS">
+                    <items>
+                        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                            <children>
+                                <TabPane prefHeight="173.0" prefWidth="259.0" side="BOTTOM"
+                                         AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+                                         AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                    <tabs>
+                                        <Tab text="Lorem">
+                                            <content>
+                                                <AnchorPane/>
+                                            </content>
+                                        </Tab>
+                                        <Tab text="Ipsum">
+                                            <content>
+                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                            prefWidth="200.0"/>
+                                            </content>
+                                        </Tab>
+                                        <Tab text="Dolor">
+                                            <content>
+                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                            prefWidth="200.0"/>
+                                            </content>
+                                        </Tab>
+                                    </tabs>
+                                </TabPane>
+                            </children>
+                        </AnchorPane>
+                        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="160.0" prefWidth="100.0">
+                            <children>
+                                <TabPane prefHeight="173.0" prefWidth="294.0" side="LEFT" AnchorPane.bottomAnchor="0.0"
+                                         AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+                                         AnchorPane.topAnchor="0.0">
+                                    <tabs>
+                                        <Tab text="Lorem">
+                                            <content>
+                                                <AnchorPane/>
+                                            </content>
+                                        </Tab>
+                                        <Tab text="Ipsum">
+                                            <content>
+                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                            prefWidth="200.0"/>
+                                            </content>
+                                        </Tab>
+                                        <Tab text="Dolor">
+                                            <content>
+                                                <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0"
+                                                            prefWidth="200.0"/>
+                                            </content>
+                                        </Tab>
+                                    </tabs>
+                                </TabPane>
+                            </children>
+                        </AnchorPane>
+                    </items>
+                    <padding>
+                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
+                    </padding>
+                </SplitPane>
+            </children>
+        </VBox>
+    </children>
+</AnchorPane>

--- a/src/main/java/org/jabref/styletester/StyleTester.fxml
+++ b/src/main/java/org/jabref/styletester/StyleTester.fxml
@@ -29,25 +29,137 @@
 <?import javafx.scene.input.KeyCodeCombination?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<AnchorPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="400.0" prefWidth="600.0"
+<?import org.jabref.gui.icon.JabRefIconView?>
+<AnchorPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="400.0" prefWidth="700.0"
             xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.styletester.StyleTesterView">
     <TabPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
              AnchorPane.topAnchor="0.0">
         <Tab text="Buttons">
-            <FlowPane>
-                <Label>Normal buttons:</Label>
-                <HBox spacing="16">
-                    <Button text="Normal"/>
-                    <Button text="Hover" fx:id="normalButtonHover"/>
-                    <Button text="Pressed" fx:id="normalButtonPressed"/>
-                    <Button text="Focused" fx:id="normalButtonFocused"/>
-                    <Button disable="true" text="Disabled"/>
-                    <Button defaultButton="true" text="Default"/>
-                    <Button cancelButton="true" text="Cancel"/>
-                </HBox>
-            </FlowPane>
+            <GridPane vgap="16" hgap="32" style="-fx-padding: 20 30 20 30;">
+                <Label GridPane.rowIndex="0" GridPane.columnIndex="0" GridPane.columnSpan="6">Normal buttons:</Label>
+                <Button text="Normal" GridPane.rowIndex="1" GridPane.columnIndex="0">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Hover" fx:id="normalButtonHover" GridPane.rowIndex="1" GridPane.columnIndex="1">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Pressed" fx:id="normalButtonPressed" GridPane.rowIndex="1" GridPane.columnIndex="2">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Focused" fx:id="normalButtonFocused" GridPane.rowIndex="1" GridPane.columnIndex="3">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button disable="true" text="Disabled" GridPane.rowIndex="1" GridPane.columnIndex="4">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button defaultButton="true" text="Default" GridPane.rowIndex="1" GridPane.columnIndex="5">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button cancelButton="true" text="Cancel" GridPane.rowIndex="1" GridPane.columnIndex="6">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Label GridPane.rowIndex="2" GridPane.columnIndex="0" GridPane.columnSpan="6">Text buttons:</Label>
+                <Button text="Normal" styleClass="text-button" GridPane.rowIndex="3" GridPane.columnIndex="0">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Hover" fx:id="textButtonHover" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="1">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Pressed" fx:id="textButtonPressed" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="2">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Focused" fx:id="textButtonFocused" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="3">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button disable="true" text="Disabled" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="4">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button defaultButton="true" text="Default" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="5">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button cancelButton="true" text="Cancel" styleClass="text-button" GridPane.rowIndex="3"
+                        GridPane.columnIndex="6">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Label GridPane.rowIndex="4" GridPane.columnIndex="0" GridPane.columnSpan="6">Contained buttons:</Label>
+                <Button text="Normal" styleClass="contained-button" GridPane.rowIndex="5" GridPane.columnIndex="0">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Hover" fx:id="containedButtonHover" styleClass="contained-button" GridPane.rowIndex="5"
+                        GridPane.columnIndex="1">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Pressed" fx:id="containedButtonPressed" styleClass="contained-button"
+                        GridPane.rowIndex="5" GridPane.columnIndex="2">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button text="Focused" fx:id="containedButtonFocused" styleClass="contained-button"
+                        GridPane.rowIndex="5" GridPane.columnIndex="3">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button disable="true" text="Disabled" styleClass="contained-button" GridPane.rowIndex="5"
+                        GridPane.columnIndex="4">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button defaultButton="true" text="Default" styleClass="contained-button" GridPane.rowIndex="5"
+                        GridPane.columnIndex="5">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+                <Button cancelButton="true" text="Cancel" styleClass="contained-button" GridPane.rowIndex="5"
+                        GridPane.columnIndex="6">
+                    <graphic>
+                        <JabRefIconView glyph="ADD_NOBOX"/>
+                    </graphic>
+                </Button>
+            </GridPane>
         </Tab>
         <Tab>
             <VBox layoutX="194.0" layoutY="14.0" prefHeight="200.0" prefWidth="100.0">

--- a/src/main/java/org/jabref/styletester/StyleTesterMain.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterMain.java
@@ -4,8 +4,9 @@ import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
+import org.jabref.JabRefExecutorService;
+import org.jabref.gui.util.DefaultFileUpdateMonitor;
 import org.jabref.gui.util.ThemeLoader;
-import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.preferences.JabRefPreferences;
 
 /**
@@ -18,11 +19,14 @@ public class StyleTesterMain extends Application {
     }
 
     @Override
-    public void start(Stage stage) throws Exception {
+    public void start(Stage stage) {
         StyleTesterView view = new StyleTesterView();
 
+        DefaultFileUpdateMonitor fileUpdateMonitor = new DefaultFileUpdateMonitor();
+        JabRefExecutorService.INSTANCE.executeInterruptableTask(fileUpdateMonitor, "FileUpdateMonitor");
+
         Scene scene = new Scene(view.getContent());
-        new ThemeLoader(new DummyFileUpdateMonitor()).installBaseCss(scene, JabRefPreferences.getInstance());
+        new ThemeLoader(fileUpdateMonitor).installBaseCss(scene, JabRefPreferences.getInstance());
         stage.setScene(scene);
         stage.show();
     }

--- a/src/main/java/org/jabref/styletester/StyleTesterMain.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterMain.java
@@ -5,6 +5,7 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 import org.jabref.JabRefExecutorService;
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.DefaultFileUpdateMonitor;
 import org.jabref.gui.util.ThemeLoader;
 import org.jabref.preferences.JabRefPreferences;
@@ -21,6 +22,8 @@ public class StyleTesterMain extends Application {
     @Override
     public void start(Stage stage) {
         StyleTesterView view = new StyleTesterView();
+
+        IconTheme.loadFonts();
 
         DefaultFileUpdateMonitor fileUpdateMonitor = new DefaultFileUpdateMonitor();
         JabRefExecutorService.INSTANCE.executeInterruptableTask(fileUpdateMonitor, "FileUpdateMonitor");

--- a/src/main/java/org/jabref/styletester/StyleTesterMain.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterMain.java
@@ -1,0 +1,29 @@
+package org.jabref.styletester;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import org.jabref.gui.util.ThemeLoader;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.preferences.JabRefPreferences;
+
+/**
+ * Useful for checking the display of different controls. Not needed inside of JabRef.
+ */
+public class StyleTesterMain extends Application {
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        StyleTesterView view = new StyleTesterView();
+
+        Scene scene = new Scene(view.getContent());
+        new ThemeLoader(new DummyFileUpdateMonitor()).installBaseCss(scene, JabRefPreferences.getInstance());
+        stage.setScene(scene);
+        stage.show();
+    }
+}

--- a/src/main/java/org/jabref/styletester/StyleTesterView.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterView.java
@@ -11,6 +11,12 @@ public class StyleTesterView {
     @FXML private Button normalButtonHover;
     @FXML private Button normalButtonPressed;
     @FXML private Button normalButtonFocused;
+    @FXML private Button textButtonHover;
+    @FXML private Button textButtonPressed;
+    @FXML private Button textButtonFocused;
+    @FXML private Button containedButtonHover;
+    @FXML private Button containedButtonPressed;
+    @FXML private Button containedButtonFocused;
     private Parent content;
 
     StyleTesterView() {
@@ -24,12 +30,18 @@ public class StyleTesterView {
     private void setStates() {
         PseudoClass hover = PseudoClass.getPseudoClass("hover");
         normalButtonHover.pseudoClassStateChanged(hover, true);
+        textButtonHover.pseudoClassStateChanged(hover, true);
+        containedButtonHover.pseudoClassStateChanged(hover, true);
 
         PseudoClass pressed = PseudoClass.getPseudoClass("pressed");
         normalButtonPressed.pseudoClassStateChanged(pressed, true);
+        textButtonPressed.pseudoClassStateChanged(pressed, true);
+        containedButtonPressed.pseudoClassStateChanged(pressed, true);
 
         PseudoClass focused = PseudoClass.getPseudoClass("focused");
         normalButtonFocused.pseudoClassStateChanged(focused, true);
+        textButtonFocused.pseudoClassStateChanged(focused, true);
+        containedButtonFocused.pseudoClassStateChanged(focused, true);
     }
 
     public Parent getContent() {

--- a/src/main/java/org/jabref/styletester/StyleTesterView.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterView.java
@@ -1,16 +1,35 @@
 package org.jabref.styletester;
 
+import javafx.css.PseudoClass;
+import javafx.fxml.FXML;
 import javafx.scene.Parent;
+import javafx.scene.control.Button;
 
 import com.airhacks.afterburner.views.ViewLoader;
 
 public class StyleTesterView {
+    @FXML private Button normalButtonHover;
+    @FXML private Button normalButtonPressed;
+    @FXML private Button normalButtonFocused;
     private Parent content;
 
-    public StyleTesterView() {
+    StyleTesterView() {
         content = ViewLoader.view(this)
                             .load()
                             .getView();
+
+        setStates();
+    }
+
+    private void setStates() {
+        PseudoClass hover = PseudoClass.getPseudoClass("hover");
+        normalButtonHover.pseudoClassStateChanged(hover, true);
+
+        PseudoClass pressed = PseudoClass.getPseudoClass("pressed");
+        normalButtonPressed.pseudoClassStateChanged(pressed, true);
+
+        PseudoClass focused = PseudoClass.getPseudoClass("focused");
+        normalButtonFocused.pseudoClassStateChanged(focused, true);
     }
 
     public Parent getContent() {

--- a/src/main/java/org/jabref/styletester/StyleTesterView.java
+++ b/src/main/java/org/jabref/styletester/StyleTesterView.java
@@ -1,0 +1,19 @@
+package org.jabref.styletester;
+
+import javafx.scene.Parent;
+
+import com.airhacks.afterburner.views.ViewLoader;
+
+public class StyleTesterView {
+    private Parent content;
+
+    public StyleTesterView() {
+        content = ViewLoader.view(this)
+                            .load()
+                            .getView();
+    }
+
+    public Parent getContent() {
+        return content;
+    }
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes #4202 and a few other small style related issues. I also created a little new app that make it simple to test the display of JavaFX controls. As of now, I only added a lot of buttons in different styles and states:
![image](https://user-images.githubusercontent.com/5037600/43546917-155834c2-95da-11e8-89d8-485544d0cd45.png)

Please merge instead of squashing the commits.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
