### PR TITLE
Fix author list parser (#4169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Window state is saved on close and restored on start.
 - Files without a defined external file type are now directly opened with the default aplication of the operating system
 - We streamlined the process to rename and move files by removing the confirmation dialogs.
-- We removed the redundant new lines of markings and wrapped the summary in the File annotation tab. [#3823](https://github.com/JabRef/jabref/issues/3823)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Window state is saved on close and restored on start.
 - Files without a defined external file type are now directly opened with the default aplication of the operating system
 - We streamlined the process to rename and move files by removing the confirmation dialogs.
+- We removed the redundant new lines of markings and wrapped the summary in the File annotation tab. [#3823](https://github.com/JabRef/jabref/issues/3823)
 
 
 
@@ -62,7 +63,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the default entry preview style still contained the field `review`. The field `review` in the style is now replaced with comment to be consistent with the entry editor [#4098](https://github.com/JabRef/jabref/issues/4098)
 - We fixed an issue where users were vulnerable to XXE attacks during parsing [#4229](https://github.com/JabRef/jabref/issues/4229)
 - We fixed an issue where files added via the "Attach file" contextmenu of an entry were not made relative. [#4201](https://github.com/JabRef/jabref/issues/4201)
-
+- We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
 
 
 

--- a/src/main/java/org/jabref/model/entry/AuthorListParser.java
+++ b/src/main/java/org/jabref/model/entry/AuthorListParser.java
@@ -264,7 +264,8 @@ public class AuthorListParser {
                 false);
         String jrPart = jrPartStart < 0 ? null : concatTokens(tokens, jrPartStart, jrPartEnd, OFFSET_TOKEN, false);
 
-        if ((firstPart != null) && (lastPart != null) && lastPart.equals(lastPart.toUpperCase(Locale.ROOT)) && (lastPart.length() < 5)) {
+        if ((firstPart != null) && (lastPart != null) && lastPart.equals(lastPart.toUpperCase(Locale.ROOT)) && (lastPart.length() < 5)
+            && (Character.UnicodeScript.of(lastPart.charAt(0)) != Character.UnicodeScript.HAN)) {
             // The last part is a small string in complete upper case, so interpret it as initial of the first name
             // This is the case for example in "Smith SH" which we think of as lastname=Smith and firstname=SH
             // The length < 5 constraint should allow for "Smith S.H." as input
@@ -378,7 +379,7 @@ public class AuthorListParser {
             }
             if (!firstLetterIsFound && (currentBackslash < 0) && Character.isLetter(c)) {
                 if (bracesLevel == 0) {
-                    tokenCase = Character.isUpperCase(c);
+                    tokenCase = Character.isUpperCase(c) || (Character.UnicodeScript.of(c) == Character.UnicodeScript.HAN);
                 } else {
                     // If this is a particle in braces, always treat it as if it starts with
                     // an upper case letter. Otherwise a name such as "{van den Bergen}, Hans"

--- a/src/test/java/org/jabref/model/entry/AuthorListParameterTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListParameterTest.java
@@ -25,6 +25,7 @@ public class AuthorListParameterTest {
     public static Collection<Object[]> data() {
 
         return Arrays.asList(new Object[][] {
+            {"王, 军", authorList(new Author("军", "军.", null, "王", null))},
             { "Doe, John", authorList(new Author("John", "J.", null, "Doe", null)) },
             { "von Berlichingen zu Hornberg, Johann Gottfried",
                     authorList(new Author("Johann Gottfried", "J. G.", "von", "Berlichingen zu Hornberg", null)) },


### PR DESCRIPTION
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

We have fixed an issue where author list parser can't generate bibtexkey for <B>Chinese author.</B> [#4169](https://github.com/JabRef/jabref/issues/4169)

<h2>Before fix: </h2>

![2018-08-07_181055](https://user-images.githubusercontent.com/34236718/43770455-012d255e-9a6f-11e8-8223-ade499586d93.png)
The default bibtexkey is [author][year], actually it only shows [year]. Obviously the [author] can't be generated normally. <br/>
<h2>After fix: </h2>

![2018-08-07_180216](https://user-images.githubusercontent.com/34236718/43770899-33854ada-9a70-11e8-8daa-73a27bfe2717.png)
Now it can generate bibtexkey for <B>Chinese author.</B><br/>
We have used correct logic so that if author's name is not Chinese name, it won't do anything.