### PR TITLE
Fix attach file does not relativize file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the preview pane in entry preview in preferences wasn't showing the citation style selected [#3849](https://github.com/JabRef/jabref/issues/3849)
 - We fixed an issue where the default entry preview style still contained the field `review`. The field `review` in the style is now replaced with comment to be consistent with the entry editor [#4098](https://github.com/JabRef/jabref/issues/4098)
 - We fixed an issue where users were vulnerable to XXE attacks during parsing [#4229](https://github.com/JabRef/jabref/issues/4229)
-- We fixed an issue where files added via the "Attach file" contextmenu of an entry were not made relative. [#4201](https://github.com/JabRef/jabref/issues/4201)
+- We fixed an issue where files added via the "Attach file" contextmenu of an entry were not made relative. [#4201](https://github.com/JabRef/jabref/issues/4201) and [#4241](https://github.com/JabRef/jabref/issues/4241)
 - We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
 
 

--- a/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
@@ -84,11 +84,8 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
             // Store the directory for next time:
             preferences.setWorkingDir(path);
 
-            // If the file is below the file directory, make the path relative:
-            List<Path> fileDirectories = database.getFileDirectoriesAsPaths(preferences.getFileDirectoryPreferences());
-            path = FileUtil.shortenFileName(path, fileDirectories);
+            relativizeFile();
 
-            link.set(path.toString());
             setExternalFileTypeByExtension(link.getValueSafe());
         });
     }
@@ -97,6 +94,7 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
         description.set(linkedFile.getDescription());
         link.set(linkedFile.getLink());
 
+        relativizeFile();
 
         selectedExternalFileType.setValue(null);
 
@@ -130,9 +128,6 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
     }
 
     private void relativizeFile() {
-
-        Optional<Path> file = FileHelper.expandFilename(database, link.get(), preferences.getFileDirectoryPreferences());
-        Path workingDir = file.orElse(preferences.getWorkingDir());
         Path filePath = Paths.get(link.get());
         List<Path> fileDirectories = database.getFileDirectoriesAsPaths(preferences.getFileDirectoryPreferences());
         filePath = FileUtil.shortenFileName(filePath, fileDirectories);

--- a/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
@@ -83,9 +83,7 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
         dialogService.showFileOpenDialog(fileDialogConfiguration).ifPresent(path -> {
             // Store the directory for next time:
             preferences.setWorkingDir(path);
-
-            link.set(path.toString());
-            relativizeFile();
+            link.set(relativize(path));
 
             setExternalFileTypeByExtension(link.getValueSafe());
         });
@@ -93,9 +91,9 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
 
     public void setValues(LinkedFile linkedFile) {
         description.set(linkedFile.getDescription());
-        link.set(linkedFile.getLink());
 
-        relativizeFile();
+        Path linkPath = Paths.get(linkedFile.getLink());
+        link.set(relativize(linkPath));
 
         selectedExternalFileType.setValue(null);
 
@@ -128,12 +126,9 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
         return new LinkedFile(description.getValue(), link.getValue(), monadicSelectedExternalFileType.map(ExternalFileType::toString).getOrElse(""));
     }
 
-    private void relativizeFile() {
-        Path filePath = Paths.get(link.get());
+    private String relativize(Path filePath) {
         List<Path> fileDirectories = database.getFileDirectoriesAsPaths(preferences.getFileDirectoryPreferences());
-        filePath = FileUtil.shortenFileName(filePath, fileDirectories);
-        link.set(filePath.toString());
-
+        return FileUtil.shortenFileName(filePath, fileDirectories).toString();
     }
 
 }

--- a/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
@@ -84,6 +84,7 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
             // Store the directory for next time:
             preferences.setWorkingDir(path);
 
+            link.set(path.toString());
             relativizeFile();
 
             setExternalFileTypeByExtension(link.getValueSafe());

--- a/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/filelist/LinkedFilesEditDialogViewModel.java
@@ -97,6 +97,7 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
         description.set(linkedFile.getDescription());
         link.set(linkedFile.getLink());
 
+
         selectedExternalFileType.setValue(null);
 
         // See what is a reasonable selection for the type combobox:
@@ -126,6 +127,17 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
 
     public LinkedFile getNewLinkedFile() {
         return new LinkedFile(description.getValue(), link.getValue(), monadicSelectedExternalFileType.map(ExternalFileType::toString).getOrElse(""));
+    }
+
+    private void relativizeFile() {
+
+        Optional<Path> file = FileHelper.expandFilename(database, link.get(), preferences.getFileDirectoryPreferences());
+        Path workingDir = file.orElse(preferences.getWorkingDir());
+        Path filePath = Paths.get(link.get());
+        List<Path> fileDirectories = database.getFileDirectoriesAsPaths(preferences.getFileDirectoryPreferences());
+        filePath = FileUtil.shortenFileName(filePath, fileDirectories);
+        link.set(filePath.toString());
+
     }
 
 }


### PR DESCRIPTION
Fixes #4241 

Attached files were only made relative before if you hit the browse button

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
