### PR TITLE
[WIP] Try to update jaxb modules

### DIFF
--- a/xjc.gradle
+++ b/xjc.gradle
@@ -1,13 +1,25 @@
 configurations {
     xjc
 }
-
-dependencies {
-    // Cannot be updated.
-    xjc 'com.sun.xml.bind:jaxb-xjc:2.2.4-1'
+repositories {
+        mavenLocal()
+        jcenter()
+        maven {
+            url 'https://oss.sonatype.org/content/groups/public'
+        }
+          maven {
+            url 'https://maven.java.net/content/groups/promoted/'
+        }
 }
 
+dependencies {
+    xjc "javax.xml.bind:jaxb-api:2.4.0-b180725.0427"
+    xjc "org.glassfish.jaxb:jaxb-runtime:2.4.0-b180725.0644"
+    xjc "org.glassfish.jaxb:jaxb-xjc:2.4.0-b180725.0644"
+}
 task xjc {
+    System.setProperty('javax.xml.accessExternalSchema', 'all') //does not yet work
+
     inputs.dir "src/main/resources/xjc/medline/"
     inputs.dir "src/main/resources/xjc/bibtexml/"
     inputs.dir "src/main/resources/xjc/endnote/"
@@ -18,7 +30,6 @@ task xjc {
     outputs.dir "src/main/gen/org/jabref/logic/importer/fileformat/mods"
 
     ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJCTask', classpath: configurations.xjc.asPath)
-
     doLast {
         ant.xjc(destdir: 'src/main/gen/', package: 'org.jabref.logic.importer.fileformat.medline') {
             schema(dir: 'src/main/resources/xjc/medline', includes: 'medline.xsd')
@@ -28,6 +39,8 @@ task xjc {
         }
         ant.xjc(destdir: 'src/main/gen/', package: 'org.jabref.logic.importer.fileformat.endnote') {
             arg(value: '-dtd')
+            arg(value:"-disableXmlSecurity")
+            property('env.)
             schema(dir: 'src/main/resources/xjc/endnote', includes: 'RSXML.dtd')
         }
         ant.xjc(destdir: 'src/main/gen/', package: 'org.jabref.logic.importer.fileformat.mods') {


### PR DESCRIPTION
2.4.x is finally java 9 compatible. This is a kind of POC to check if it is generally working,

Currently it  fails because an external schema cannot be accesed due to security restrictions. There is a switch, a system property-
The problem is that the system property jvm arg is not passed to the ant task. And I don't have any deeper gradle experience. So if someone might take a look at this. 


Fixes https://github.com/koppor/jabref/issues/276

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
