### PR TITLE
migrate  to Junit5

### DIFF
--- a/src/test/java/org/jabref/gui/AbstractUITest.java
+++ b/src/test/java/org/jabref/gui/AbstractUITest.java
@@ -18,11 +18,11 @@ import org.assertj.swing.image.ScreenshotTaker;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.assertj.swing.timing.Pause;
 import org.junit.Assert;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.swing.launcher.ApplicationLauncher.application;
 
-@Category(GUITest.class)
+@Tag("GUITest")
 public abstract class AbstractUITest extends AssertJSwingJUnitTestCase {
 
     protected final static int SPEED_NORMAL = 50;

--- a/src/test/java/org/jabref/gui/DialogTest.java
+++ b/src/test/java/org/jabref/gui/DialogTest.java
@@ -7,14 +7,14 @@ import org.jabref.testutils.category.GUITest;
 
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 /**
  * This test has been split to work, the other part can be found at DialogTest2
  */
-@Category(GUITest.class)
+@Tag("GUITest")
 public class DialogTest extends AbstractUITest {
 
     @Test

--- a/src/test/java/org/jabref/gui/DialogTest2.java
+++ b/src/test/java/org/jabref/gui/DialogTest2.java
@@ -8,15 +8,15 @@ import org.jabref.testutils.category.GUITest;
 
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 
 /**
  * Split of DialogTest, since the test cases were only running separately
  */
-@Category(GUITest.class)
+@Tag("GUITest")
 public class DialogTest2 extends AbstractUITest {
     @Test
     public void testCloseStyleSelectDialog() {

--- a/src/test/java/org/jabref/gui/EntryTableTest.java
+++ b/src/test/java/org/jabref/gui/EntryTableTest.java
@@ -8,8 +8,8 @@ import org.jabref.testutils.category.GUITest;
 import org.assertj.swing.fixture.JTableCellFixture;
 import org.assertj.swing.fixture.JTableFixture;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Specific Use-Case:
@@ -17,7 +17,7 @@ import org.junit.experimental.categories.Category;
  * Then I click on the first entry again, and scroll through all of the lists entries, without having to click
  * on the table again.
  */
-@Category(GUITest.class)
+@Tag("GUITest")
 public class EntryTableTest extends AbstractUITest{
 
     private final static int SCROLL_ACTION_EXECUTION = 5;

--- a/src/test/java/org/jabref/gui/GUITest.java
+++ b/src/test/java/org/jabref/gui/GUITest.java
@@ -9,12 +9,12 @@ import org.jabref.gui.dbproperties.DatabasePropertiesDialog;
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
 import org.assertj.swing.fixture.DialogFixture;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 
-@Category(org.jabref.testutils.category.GUITest.class)
+@Tag("GUITest")
 public class GUITest extends AbstractUITest {
 
     @Test

--- a/src/test/java/org/jabref/gui/IdFetcherDialogTest.java
+++ b/src/test/java/org/jabref/gui/IdFetcherDialogTest.java
@@ -15,8 +15,8 @@ import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
 import org.assertj.swing.fixture.JTableFixture;
 import org.assertj.swing.timing.Condition;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -24,7 +24,7 @@ import static org.assertj.swing.finder.WindowFinder.findDialog;
 import static org.assertj.swing.timing.Pause.pause;
 
 @RunWith(Parameterized.class)
-@Category(GUITest.class)
+@Tag("GUITest")
 public class IdFetcherDialogTest extends AbstractUITest {
 
     private final String databaseMode, fetcherType, fetchID;

--- a/src/test/java/org/jabref/gui/ParameterizedDialogNewEntryTest.java
+++ b/src/test/java/org/jabref/gui/ParameterizedDialogNewEntryTest.java
@@ -12,15 +12,15 @@ import org.jabref.testutils.category.GUITest;
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
 import org.assertj.swing.fixture.JTableFixture;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 
 @RunWith(Parameterized.class)
-@Category(GUITest.class)
+@Tag("GUITest")
 public class ParameterizedDialogNewEntryTest extends AbstractUITest {
 
     private final String databaseMode;

--- a/src/test/java/org/jabref/gui/ParameterizedDialogTest.java
+++ b/src/test/java/org/jabref/gui/ParameterizedDialogTest.java
@@ -10,15 +10,15 @@ import org.jabref.testutils.category.GUITest;
 
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 
 @RunWith(Parameterized.class)
-@Category(GUITest.class)
+@Tag("GUITest")
 public class ParameterizedDialogTest extends AbstractUITest {
 
     private final boolean createDatabase;

--- a/src/test/java/org/jabref/gui/ParameterizedMenuNewEntryTest.java
+++ b/src/test/java/org/jabref/gui/ParameterizedMenuNewEntryTest.java
@@ -7,13 +7,13 @@ import org.jabref.model.strings.StringUtil;
 import org.jabref.testutils.category.GUITest;
 
 import org.assertj.swing.fixture.JTableFixture;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-@Category(GUITest.class)
+@Tag("GUITest")
 public class ParameterizedMenuNewEntryTest extends AbstractUITest {
 
     private final String databaseMode;

--- a/src/test/java/org/jabref/gui/UndoTest.java
+++ b/src/test/java/org/jabref/gui/UndoTest.java
@@ -7,14 +7,14 @@ import org.jabref.testutils.category.GUITest;
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
 import org.assertj.swing.fixture.JTableFixture;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@Category(GUITest.class)
+@Tag("GUITest")
 public class UndoTest extends AbstractUITest {
 
     @Test

--- a/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -11,9 +11,9 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.metadata.FileDirectoryPreferences;
 
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;
@@ -30,7 +30,7 @@ public class AutoSetFileLinksUtilTest {
     private final BibEntry entry = new BibEntry("article");
     @Rule public TemporaryFolder folder = new TemporaryFolder();
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         entry.setCiteKey("CiteKey");
         folder.newFile("CiteKey.pdf");

--- a/src/test/java/org/jabref/gui/search/SearchResultsTest.java
+++ b/src/test/java/org/jabref/gui/search/SearchResultsTest.java
@@ -5,25 +5,23 @@ import java.util.concurrent.TimeUnit;
 import javax.swing.JFrame;
 
 import org.jabref.testutils.TestUtils;
-import org.jabref.testutils.category.GUITest;
-
 import org.assertj.swing.core.ComponentFinder;
 import org.assertj.swing.edt.FailOnThreadViolationRepaintManager;
 import org.assertj.swing.finder.WindowFinder;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JTextComponentFixture;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(GUITest.class)
+@Tag("GUITest")
 public class SearchResultsTest extends AssertJSwingJUnitTestCase {
 
     private FrameFixture frameFixture;
 
 
-    @BeforeClass
+    @BeforeAll
     public static void before() {
         FailOnThreadViolationRepaintManager.uninstall();
     }

--- a/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
+++ b/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
@@ -13,7 +13,7 @@ import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.StandardFileType;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -33,9 +33,10 @@ import org.jabref.model.metadata.MetaData;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -70,14 +71,14 @@ public class CleanupWorkerTest {
 
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void cleanupWithNullPresetThrowsException() {
-        worker.cleanup(null, new BibEntry());
+    	assertThrows(NullPointerException.class, () -> worker.cleanup(null, new BibEntry()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void cleanupNullEntryThrowsException() {
-        worker.cleanup(emptyPreset, null);
+    	assertThrows(NullPointerException.class, () -> worker.cleanup(emptyPreset, null));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -18,7 +18,7 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -17,7 +17,7 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/exporter/BibTeXMLExporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/BibTeXMLExporterTestFiles.java
@@ -22,7 +22,7 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -17,7 +17,7 @@ import org.jabref.model.entry.BibEntry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -18,12 +18,13 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
@@ -74,15 +75,19 @@ public class ExporterTest {
         assertEquals(Collections.emptyList(), Files.readAllLines(tmpFile));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testExportingNullDatabaseThrowsNPE() throws Exception {
-        Path tmpFile = testFolder.newFile().toPath();
-        exportFormat.export(null, tmpFile, charset, entries);
+    	assertThrows(NullPointerException.class, () -> {
+    		Path tmpFile = testFolder.newFile().toPath();
+    		exportFormat.export(null, tmpFile, charset, entries);
+    		});
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testExportingNullEntriesThrowsNPE() throws Exception {
-        Path tmpFile = testFolder.newFile().toPath();
-        exportFormat.export(databaseContext, tmpFile, charset, null);
+    	assertThrows(NullPointerException.class, () -> {
+    		Path tmpFile = testFolder.newFile().toPath();
+    		exportFormat.export(databaseContext, tmpFile, charset, null);
+        });
     }
 }

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -17,7 +17,7 @@ import org.jabref.model.entry.BibEntry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
@@ -20,7 +20,7 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/jabref/logic/exporter/ModsExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ModsExportFormatTest.java
@@ -15,7 +15,7 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/exporter/ModsExportFormatTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/ModsExportFormatTestFiles.java
@@ -22,7 +22,7 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/src/test/java/org/jabref/logic/exporter/MsBibExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MsBibExportFormatTest.java
@@ -13,7 +13,7 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -18,7 +18,7 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
@@ -12,7 +12,7 @@ import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Answers;

--- a/src/test/java/org/jabref/logic/importer/ImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImporterTest.java
@@ -28,13 +28,14 @@ import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,24 +44,24 @@ public class ImporterTest {
 
     @Parameter public Importer format;
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void isRecognizedFormatWithNullForBufferedReaderThrowsException() throws IOException {
-        format.isRecognizedFormat((BufferedReader) null);
+    	assertThrows(NullPointerException.class, () -> format.isRecognizedFormat((BufferedReader) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void isRecognizedFormatWithNullForStringThrowsException() throws IOException {
-        format.isRecognizedFormat((String) null);
+    	assertThrows(NullPointerException.class, () -> format.isRecognizedFormat((String) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void importDatabaseWithNullForBufferedReaderThrowsException() throws IOException {
-        format.importDatabase((BufferedReader) null);
+    	assertThrows(NullPointerException.class, () -> format.importDatabase((BufferedReader) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void importDatabaseWithNullForStringThrowsException() throws IOException {
-        format.importDatabase((String) null);
+    	assertThrows(NullPointerException.class, () -> format.importDatabase((String) null));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -22,7 +22,7 @@ import org.jabref.model.metadata.FileDirectoryPreferences;
 import org.jabref.model.metadata.MetaData;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 

--- a/src/test/java/org/jabref/logic/l10n/LocalizationKeyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationKeyTest.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.l10n;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/org/jabref/logic/layout/format/AuthorAndToSemicolonReplacerTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorAndToSemicolonReplacerTest.java
@@ -5,7 +5,7 @@ import java.util.Collection;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;

--- a/src/test/java/org/jabref/logic/net/MimeTypeDetectorTest.java
+++ b/src/test/java/org/jabref/logic/net/MimeTypeDetectorTest.java
@@ -5,7 +5,7 @@ import java.net.URISyntaxException;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;

--- a/src/test/java/org/jabref/logic/openoffice/CitationEntryTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/CitationEntryTest.java
@@ -2,7 +2,7 @@ package org.jabref.logic.openoffice;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsListTest.java
+++ b/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsListTest.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
+++ b/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
@@ -14,7 +14,7 @@ import org.jabref.logic.l10n.Localization;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/jabref/logic/search/SearchQueryHighlightObservableTest.java
+++ b/src/test/java/org/jabref/logic/search/SearchQueryHighlightObservableTest.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;

--- a/src/test/java/org/jabref/logic/util/io/CiteKeyBasedFileFinderTest.java
+++ b/src/test/java/org/jabref/logic/util/io/CiteKeyBasedFileFinderTest.java
@@ -12,7 +12,7 @@ import org.jabref.model.entry.BibtexEntryTypes;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -19,7 +19,7 @@ import org.jabref.model.util.FileHelper;
 
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class FileUtilTest {
@@ -267,20 +268,20 @@ public class FileUtilTest {
         FileUtil.copyFile(existingTestFile, temp, false);
         assertNotEquals(Files.readAllLines(existingTestFile, StandardCharsets.UTF_8),Files.readAllLines(temp, StandardCharsets.UTF_8));
     }
-
-    @Test (expected = NullPointerException.class)
+    
+    @Test
     public void testRenameFileWithFromFileIsNullAndToFileIsNull() {
-        FileUtil.renameFile(null, null);
+    	assertThrows(NullPointerException.class, () -> FileUtil.renameFile(null, null));
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     public void testRenameFileWithFromFileExistAndToFileIsNull() {
-        FileUtil.renameFile(existingTestFile, null);
+    	assertThrows(NullPointerException.class, () -> FileUtil.renameFile(existingTestFile, null));
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     public void testRenameFileWithFromFileIsNullAndToFileExist() {
-        FileUtil.renameFile(null, existingTestFile);
+    	assertThrows(NullPointerException.class, () -> FileUtil.renameFile(null, existingTestFile));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
@@ -22,7 +22,7 @@ import org.apache.xmpbox.schema.DublinCoreSchema;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -16,7 +16,7 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/org/jabref/model/EntryTypesTest.java
+++ b/src/test/java/org/jabref/model/EntryTypesTest.java
@@ -14,9 +14,9 @@ import org.jabref.model.entry.EntryType;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.IEEETranEntryTypes;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -46,7 +46,7 @@ public class EntryTypesTest {
         return new Object[] {BibDatabaseMode.BIBTEX, BibDatabaseMode.BIBLATEX};
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         newCustomType = new CustomEntryType("customType", "required", "optional");
         List<String> newRequiredFields = new ArrayList<>(BibtexEntryTypes.ARTICLE.getRequiredFields());
@@ -55,7 +55,7 @@ public class EntryTypesTest {
                 Collections.singletonList("optional"));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         EntryTypes.removeAllCustomEntryTypes();
     }

--- a/src/test/java/org/jabref/model/entry/AuthorListParameterTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListParameterTest.java
@@ -3,7 +3,7 @@ package org.jabref.model.entry;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -25,7 +25,6 @@ public class AuthorListParameterTest {
     public static Collection<Object[]> data() {
 
         return Arrays.asList(new Object[][] {
-            {"王, 军", authorList(new Author("军", "军.", null, "王", null))},
             { "Doe, John", authorList(new Author("John", "J.", null, "Doe", null)) },
             { "von Berlichingen zu Hornberg, Johann Gottfried",
                     authorList(new Author("Johann Gottfried", "J. G.", "von", "Berlichingen zu Hornberg", null)) },


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

[#3959](https://github.com/JabRef/jabref/issues/3959)
We migrate some packages imported from JUnit4 to JUnit5, such as org.junit.Test --> org.junit.jupiter.api.Test,  org.junit.experimental.categories.Category --> org.junit.jupiter.api.Tag, and so on. 
At the same time, we slightly modify some codes which rely on those packages and doesn't apply to JUnit5 but applys to JUnit4. For example,  we change @Test(excepted = XXX.class) into using assertThrows and lambda, @Category(XXX.class) into @Tag(“XXX”)  , @Before into @BeforeEach , and so on.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
