### PR TITLE
Fix "Manage journal abbreviations" dialog

### DIFF
--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviations.css
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviations.css
@@ -1,8 +1,3 @@
-.custom-buttons {
-    -fx-margin-top: 10px;
-    -fx-padding: 5px;
-}
-
 .abbreviations-table {
 	-fx-table-cell-border-color: transparent;
 }
@@ -19,9 +14,4 @@
 
 .table-row-cell:selected > .table-cell > .icon, .table-row-cell:pressed > .table-cell > .icon {
    -fx-fill: white;
-}
-
-.dialog-pane *.button-bar {
-	-fx-max-height: 0;
-	-fx-pref-height: 0;
 }

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviations.fxml
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviations.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ButtonBar?>
+<?import javafx.scene.control.ButtonType?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Label?>
@@ -9,57 +9,51 @@
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
 <?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="400.0" prefWidth="600.0"
             xmlns="http://javafx.com/javafx/8.0.65"
             fx:controller="org.jabref.gui.journals.ManageJournalAbbreviationsView">
    <content>
-      <BorderPane prefHeight="200.0" prefWidth="200.0">
-         <center>
-            <TableView fx:id="journalAbbreviationsTable" editable="true" styleClass="abbreviations-table" BorderPane.alignment="CENTER">
+       <TableView fx:id="journalAbbreviationsTable" editable="true" styleClass="abbreviations-table">
               <columns>
-                <TableColumn fx:id="journalTableNameColumn" prefWidth="200.0" text="%Full journal name" />
-                <TableColumn fx:id="journalTableAbbreviationColumn" prefWidth="200.0" text="%Abbreviation name" />
-                  <TableColumn fx:id="journalTableEditColumn" maxWidth="40" minWidth="40.0" prefWidth="40.0" />
-                  <TableColumn fx:id="journalTableDeleteColumn" maxWidth="40" minWidth="40.0" prefWidth="40.0" />
+                  <TableColumn fx:id="journalTableNameColumn" prefWidth="200.0" text="%Full journal name"/>
+                  <TableColumn fx:id="journalTableAbbreviationColumn" prefWidth="200.0" text="%Abbreviation name"/>
+                  <TableColumn fx:id="journalTableEditColumn" maxWidth="40" minWidth="40.0" prefWidth="40.0"/>
+                  <TableColumn fx:id="journalTableDeleteColumn" maxWidth="40" minWidth="40.0" prefWidth="40.0"/>
               </columns>
-               <columnResizePolicy>
-                  <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-               </columnResizePolicy>
-            </TableView>
-         </center>
-         <bottom>
-            <ButtonBar prefHeight="40.0" styleClass="custom-buttons" BorderPane.alignment="CENTER">
-              <buttons>
-                  <Label fx:id="loadingLabel" maxHeight="30.0" text="%Loading built in lists" ButtonBar.buttonData="LEFT" ButtonBar.buttonUniformSize="false" />
-                  <ProgressIndicator fx:id="progressIndicator" maxHeight="30.0" opacity="0.4" ButtonBar.buttonData="LEFT" ButtonBar.buttonUniformSize="false" />
-                <Button fx:id="cancelButton" cancelButton="true" mnemonicParsing="false" onAction="#closeDialog" text="%Cancel" ButtonBar.buttonData="CANCEL_CLOSE" />
-                  <Button fx:id="saveButton" defaultButton="true" mnemonicParsing="false" onAction="#saveAbbreviationsAndCloseDialog" text="%Save changes" ButtonBar.buttonData="OK_DONE" />
-              </buttons>
-            </ButtonBar>
-         </bottom>
-      </BorderPane>
+           <columnResizePolicy>
+               <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
+           </columnResizePolicy>
+           <placeholder>
+               <Label fx:id="loadingLabel" maxHeight="30.0" text="%Loading built in lists"/>
+               <ProgressIndicator fx:id="progressIndicator" maxHeight="30.0" opacity="0.4"/>
+           </placeholder>
+       </TableView>
    </content>
    <header>
-      <HBox spacing="10.0" styleClass="custom-header">
-         <children>
-            <ComboBox fx:id="journalFilesBox" minWidth="200.0" promptText="%No abbreviation files loaded" styleClass="journal-lists" HBox.hgrow="ALWAYS" />
-            <Pane HBox.hgrow="ALWAYS" />
-            <Button fx:id="addNewJournalFileButton" mnemonicParsing="false" onAction="#addNewFile" styleClass="icon">
+       <HBox spacing="10.0" styleClass="custom-header">
+           <ComboBox fx:id="journalFilesBox" minWidth="200.0" promptText="%No abbreviation files loaded"
+                     HBox.hgrow="ALWAYS"/>
+           <Pane HBox.hgrow="ALWAYS"/>
+           <Button fx:id="addNewJournalFileButton" mnemonicParsing="false" onAction="#addNewFile" styleClass="icon">
                <tooltip>
-                  <Tooltip autoHide="true" text="%Create new list" />
-               </tooltip></Button>
-          <Button fx:id="addJournalFileButton" mnemonicParsing="false" onAction="#openFile" styleClass="icon">
+                   <Tooltip autoHide="true" text="%Create new list"/>
+               </tooltip>
+           </Button>
+           <Button fx:id="addJournalFileButton" mnemonicParsing="false" onAction="#openFile" styleClass="icon">
                <tooltip>
-                  <Tooltip autoHide="true" text="%Add existing file" />
-               </tooltip></Button>
-            <Button fx:id="removeJournalAbbreviationsButton" mnemonicParsing="false" onAction="#removeList" styleClass="icon">
+                   <Tooltip autoHide="true" text="%Add existing file"/>
+               </tooltip>
+           </Button>
+           <Button fx:id="removeJournalAbbreviationsButton" mnemonicParsing="false" onAction="#removeList"
+                   styleClass="icon">
                <tooltip>
-                  <Tooltip autoHide="true" text="%Remove list" />
-               </tooltip></Button>
-         </children>
-      </HBox>
+                   <Tooltip autoHide="true" text="%Remove list"/>
+               </tooltip>
+           </Button>
+       </HBox>
    </header>
+    <ButtonType fx:id="saveButton" text="%Save changes" buttonData="OK_DONE"/>
+    <ButtonType fx:constant="CANCEL"/>
 </DialogPane>

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
@@ -2,7 +2,6 @@ package org.jabref.gui.journals;
 
 import javax.inject.Inject;
 
-import javafx.concurrent.Task;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
@@ -186,15 +185,7 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
 
     @FXML
     private void saveAbbreviationsAndCloseDialog() {
-        Task<Void> task = new Task<Void>() {
-
-            @Override
-            protected Void call() {
-                viewModel.saveEverythingAndUpdateAutoCompleter();
-                return null;
-            }
-        };
-        new Thread(task).start();
+        viewModel.saveEverythingAndUpdateAutoCompleter();
         close();
     }
 

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import javafx.concurrent.Task;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
@@ -13,11 +14,11 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
-import javafx.stage.Stage;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -34,12 +35,12 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
 
     @FXML public Label loadingLabel;
     @FXML public ProgressIndicator progressIndicator;
+    @FXML private ButtonType saveButton;
     @FXML private TableView<AbbreviationViewModel> journalAbbreviationsTable;
     @FXML private TableColumn<AbbreviationViewModel, String> journalTableNameColumn;
     @FXML private TableColumn<AbbreviationViewModel, String> journalTableAbbreviationColumn;
     @FXML private TableColumn<AbbreviationViewModel, Boolean> journalTableEditColumn;
     @FXML private TableColumn<AbbreviationViewModel, Boolean> journalTableDeleteColumn;
-    @FXML private Button cancelButton;
     @FXML private ComboBox<AbbreviationsFileViewModel> journalFilesBox;
     @FXML private Button addJournalFileButton;
     @FXML private Button addNewJournalFileButton;
@@ -57,6 +58,8 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);
+
+        ControlHelper.setAction(saveButton, getDialogPane(), event -> saveAbbreviationsAndCloseDialog());
     }
 
     @FXML
@@ -129,11 +132,7 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
     private void setBindings() {
         journalAbbreviationsTable.itemsProperty().bindBidirectional(viewModel.abbreviationsProperty());
         journalFilesBox.itemsProperty().bindBidirectional(viewModel.journalFilesProperty());
-
-        viewModel.currentFileProperty().addListener((observable, oldvalue, newvalue) ->
-                journalFilesBox.getSelectionModel().select(newvalue));
-        journalFilesBox.getSelectionModel().selectedItemProperty()
-                .addListener((observable, oldvalue, newvalue) -> viewModel.currentFileProperty().set(newvalue));
+        journalFilesBox.valueProperty().bindBidirectional(viewModel.currentFileProperty());
 
         viewModel.currentAbbreviationProperty().addListener((observable, oldvalue, newvalue) ->
                 journalAbbreviationsTable.getSelectionModel().select(newvalue));
@@ -186,12 +185,6 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
     }
 
     @FXML
-    private void closeDialog() {
-        Stage stage = (Stage) cancelButton.getScene().getWindow();
-        stage.close();
-    }
-
-    @FXML
     private void saveAbbreviationsAndCloseDialog() {
         Task<Void> task = new Task<Void>() {
 
@@ -202,7 +195,7 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
             }
         };
         new Thread(task).start();
-        closeDialog();
+        close();
     }
 
 

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
@@ -99,7 +99,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
                 }
             }
         });
-        isLoading.bind(isLoadingBuiltIn.and(isLoadingBuiltIn));
+        isLoading.bind(isLoadingBuiltIn.or(isLoadingIeee));
     }
 
     public SimpleBooleanProperty isLoadingProperty() {
@@ -121,6 +121,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
                 .onSuccess(result -> {
                     isLoadingBuiltIn.setValue(false);
                     addList(Localization.lang("JabRef built in list"), result);
+                    selectLastJournalFile();
                 })
                 .onFailure(dialogService::showErrorDialogAndWait)
                 .executeWith(taskExecutor);

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
@@ -351,17 +351,19 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
      * {@link JournalAbbreviationLoader#update(JournalAbbreviationPreferences)}.
      */
     public void saveEverythingAndUpdateAutoCompleter() {
-        saveExternalFilesList();
+        BackgroundTask.wrap(() -> {
+            saveExternalFilesList();
 
-        if (shouldWriteLists) {
-            saveJournalAbbreviationFiles();
-            shouldWriteLists = false;
-        }
+            if (shouldWriteLists) {
+                saveJournalAbbreviationFiles();
+                shouldWriteLists = false;
+            }
 
-        // Update journal abbreviation loader
-        journalAbbreviationLoader.update(abbreviationsPreferences);
+            // Update journal abbreviation loader
+            journalAbbreviationLoader.update(abbreviationsPreferences);
 
-        preferences.storeJournalAbbreviationPreferences(abbreviationsPreferences);
+            preferences.storeJournalAbbreviationPreferences(abbreviationsPreferences);
+        }).executeWith(taskExecutor);
     }
 
     public SimpleListProperty<AbbreviationsFileViewModel> journalFilesProperty() {


### PR DESCRIPTION
Make it possible to close the "Manage journal abbreviations" dialog using the x-button. Fixes part of https://github.com/JabRef/jabref/issues/4190.