### PR TITLE
Pin errorprone dependency to specific version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ repositories {
 configurations {
     antlr3
     antlr4
+    errorprone
 }
 
 dependencies {
@@ -157,6 +158,8 @@ dependencies {
 
     compile 'com.github.tomtung:latex2unicode_2.12:0.2.2'
 
+    errorprone 'com.google.errorprone:error_prone_core:2.3.1'
+
     compile group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '2.1.2'
     compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '2.1.2'
 
@@ -220,7 +223,7 @@ dependencyUpdates.resolutionStrategy = {
                 selection.reject("http://dev.mysql.com/downloads/connector/j/ lists the version 5.* as last stable version.")
             }
         }
-        
+
     }
 }
 


### PR DESCRIPTION
I pinned an errorprone dependency to version 2.3.1, which is the latest version as of August 17, 2018.  As it stands in the master branch, the plugin net.ltgt.errorprone creates a configuration of errorprone that automatically updates to the latest version, which is meant to be overridden.  I overrode that configuration by explicitly creating it in build.grade, and then I added the dependency to the configuration necessary to pin the version.  build.gradle executes the plugins first, but then overrides the configuration afterward.  The issue is [#4176](https://github.com/JabRef/jabref/issues/4176).
