### PR TITLE
convert bibtexkeypatterndlg to javafx as well

### DIFF
--- a/src/main/java/org/jabref/gui/actions/BibtexKeyPatternAction.java
+++ b/src/main/java/org/jabref/gui/actions/BibtexKeyPatternAction.java
@@ -13,7 +13,6 @@ public class BibtexKeyPatternAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        BibtexKeyPatternDialog dlg = new BibtexKeyPatternDialog(frame.getCurrentBasePanel());
-        dlg.showAndWait();
+       new BibtexKeyPatternDialog(frame.getCurrentBasePanel()).showAndWait();
     }
 }

--- a/src/main/java/org/jabref/gui/actions/BibtexKeyPatternAction.java
+++ b/src/main/java/org/jabref/gui/actions/BibtexKeyPatternAction.java
@@ -5,7 +5,7 @@ import org.jabref.gui.bibtexkeypattern.BibtexKeyPatternDialog;
 
 public class BibtexKeyPatternAction extends SimpleCommand {
 
-    private JabRefFrame frame;
+    private final JabRefFrame frame;
 
     public BibtexKeyPatternAction(JabRefFrame frame) {
         this.frame = frame;
@@ -13,8 +13,7 @@ public class BibtexKeyPatternAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        BibtexKeyPatternDialog bibtexKeyPatternDialog = new BibtexKeyPatternDialog(frame.getCurrentBasePanel());
-        bibtexKeyPatternDialog.setLocationRelativeTo(null);
-        bibtexKeyPatternDialog.setVisible(true);
+        BibtexKeyPatternDialog dlg = new BibtexKeyPatternDialog(frame.getCurrentBasePanel());
+        dlg.showAndWait();
     }
 }

--- a/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
+++ b/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
@@ -32,9 +32,8 @@ public class BibtexKeyPatternDialog extends BaseDialog<Void> {
             if (button == ButtonType.APPLY) {
                 metaData.setCiteKeyPattern(bibtexKeyPatternPanel.getKeyPatternAsDatabaseBibtexKeyPattern());
                 panel.markNonUndoableBaseChanged();
-            } else {
-                return null;
             }
+
             return null;
         });
 

--- a/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
+++ b/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
@@ -1,40 +1,20 @@
 package org.jabref.gui.bibtexkeypattern;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.WindowEvent;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JPanel;
-import javax.swing.WindowConstants;
-
-import javafx.embed.swing.JFXPanel;
-import javafx.scene.Scene;
+import javafx.scene.control.ButtonType;
 
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
-import org.jabref.gui.JabRefDialog;
-import org.jabref.gui.customjfx.CustomJFXPanel;
-import org.jabref.gui.keyboard.KeyBinder;
-import org.jabref.logic.l10n.Localization;
+import org.jabref.gui.util.BaseDialog;
 import org.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import org.jabref.model.metadata.MetaData;
 
-import com.jgoodies.forms.builder.ButtonBarBuilder;
-
-public class BibtexKeyPatternDialog extends JabRefDialog {
+public class BibtexKeyPatternDialog extends BaseDialog<Void> {
 
     private final MetaData metaData;
     private final BasePanel panel;
     private final BibtexKeyPatternPanel bibtexKeyPatternPanel;
 
     public BibtexKeyPatternDialog(BasePanel panel) {
-        super(Localization.lang("BibTeX key patterns"), true, BibtexKeyPatternDialog.class);
         this.bibtexKeyPatternPanel = new BibtexKeyPatternPanel(panel);
         this.panel = panel;
         this.metaData = panel.getBibDatabaseContext().getMetaData();
@@ -44,53 +24,20 @@ public class BibtexKeyPatternDialog extends JabRefDialog {
     }
 
     private void init() {
-        getContentPane().setLayout(new BorderLayout());
-        JFXPanel bibPanel = CustomJFXPanel.wrap(new Scene(bibtexKeyPatternPanel));
-        getContentPane().add(bibPanel, BorderLayout.CENTER);
 
-        JButton ok = new JButton(Localization.lang("OK"));
-        JButton cancel = new JButton(); // label of "cancel" is set later as the label is overwritten by assigning an action to the button
+        this.getDialogPane().setContent(bibtexKeyPatternPanel.getPanel());
+        this.getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);
 
-        JPanel lower = new JPanel();
-        lower.setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
-        ButtonBarBuilder bb = new ButtonBarBuilder(lower);
-        bb.addGlue();
-        bb.addButton(ok);
-        bb.addButton(cancel);
-        bb.addGlue();
-
-        getContentPane().add(lower, BorderLayout.SOUTH);
-
-        this.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        getContentPane().setPreferredSize(new Dimension(500, 600));
-        pack();
-
-        ok.addActionListener(e -> {
-            metaData.setCiteKeyPattern(bibtexKeyPatternPanel.getKeyPatternAsDatabaseBibtexKeyPattern());
-            panel.markNonUndoableBaseChanged();
-            dispose();
+        this.setResultConverter(button -> {
+            if (button == ButtonType.APPLY) {
+                metaData.setCiteKeyPattern(bibtexKeyPatternPanel.getKeyPatternAsDatabaseBibtexKeyPattern());
+                panel.markNonUndoableBaseChanged();
+            } else {
+                return null;
+            }
+            return null;
         });
 
-        final JDialog dialog = this;
-
-        Action cancelAction = new AbstractAction() {
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
-            }
-        };
-        cancel.setAction(cancelAction);
-        cancel.setText(Localization.lang("Cancel"));
-
-        KeyBinder.bindCloseDialogKeyToCancelAction(this.getRootPane(), cancelAction);
-    }
-
-    @Override
-    public void setVisible(boolean visible) {
-        if (visible) {
-            super.setVisible(visible);
-        }
     }
 
 }

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesDialogView.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesDialogView.java
@@ -26,7 +26,6 @@ public class CopyFilesDialogView extends BaseDialog<Void> {
 
     public CopyFilesDialogView(BibDatabaseContext bibDatabaseContext, CopyFilesResultListDependency results) {
         this.setTitle(Localization.lang("Result"));
-        this.setResizable(true);
 
         this.getDialogPane().getButtonTypes().addAll(ButtonType.OK);
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
@@ -41,7 +41,6 @@ public class DocumentViewerView extends BaseDialog<Void> {
     public DocumentViewerView() {
         this.setTitle(Localization.lang("Document viewer"));
         this.initModality(Modality.NONE);
-        this.setResizable(true);
 
         ViewLoader.view(this)
                   .load()

--- a/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -47,7 +47,6 @@ public class ErrorConsoleView extends BaseDialog<Void> {
 
     public ErrorConsoleView() {
         this.setTitle(Localization.lang("Event log"));
-        this.setResizable(true);
         this.initModality(Modality.NONE);
 
         ViewLoader.view(this)
@@ -97,7 +96,7 @@ public class ErrorConsoleView extends BaseDialog<Void> {
             public void updateItem(LogEventViewModel event, boolean empty) {
                 super.updateItem(event, empty);
 
-                if (event == null || empty) {
+                if ((event == null) || empty) {
                     setGraphic(null);
                 } else {
                     icon = event.getIcon().getGraphicNode();

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypeEditor.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypeEditor.java
@@ -53,7 +53,6 @@ public class ExternalFileTypeEditor extends BaseDialog<Void> {
     public ExternalFileTypeEditor() {
         this.setTitle(Localization.lang("Manage external file types"));
         this.initModality(Modality.APPLICATION_MODAL);
-        this.setResizable(true);
         this.getDialogPane().setPrefSize(600, 500);
 
         init();

--- a/src/main/java/org/jabref/gui/help/AboutDialogView.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogView.java
@@ -28,7 +28,6 @@ public class AboutDialogView extends BaseDialog<Void> {
 
     public AboutDialogView() {
         this.setTitle(Localization.lang("About JabRef"));
-        this.setResizable(true);
 
         ViewLoader.view(this)
                   .load()

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsView.java
@@ -52,7 +52,6 @@ public class ManageJournalAbbreviationsView extends BaseDialog<Void> {
 
     public ManageJournalAbbreviationsView() {
         this.setTitle(Localization.lang("Journal abbreviations"));
-        this.setResizable(true);
 
         ViewLoader.view(this)
                   .load()

--- a/src/main/java/org/jabref/gui/keyboard/KeyBindingsDialogView.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBindingsDialogView.java
@@ -39,7 +39,6 @@ public class KeyBindingsDialogView extends BaseDialog<Void> {
     public KeyBindingsDialogView() {
         this.setTitle(Localization.lang("Key bindings"));
         this.getDialogPane().setPrefSize(375, 475);
-        this.setResizable(true);
 
         ViewLoader.view(this)
                   .load()

--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -20,7 +20,7 @@ public class BaseDialog<T> extends Dialog<T> {
         });
 
         setDialogIcon(IconTheme.getJabRefImageFX());
-
+        setResizable(true);
         Globals.getThemeLoader().installBaseCss(getDialogPane().getScene(), Globals.prefs);
     }
 


### PR DESCRIPTION
Followup from #4253  in the Bibtex key pattern panel there was an exception thrown if you had defined custom entry types or used biblatex mode.

@Super-Tang In your PR you used a fixed size for the number of labels and buttons. However, as it is possible in JabRef to customize the entry types, e.g. add new ones, the size is no longer fixed. Therefore if the number of entry types was > 19 the array threw an exception.
I now used the size of the entry type list to setup the array size and wrapped it in a Scroll Pane

Edit// I set colspan to remaining, so it uses all space
![grafik](https://user-images.githubusercontent.com/320228/44346016-34ef9900-a495-11e8-8243-ae48330955ab.png)



<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
