### PR TITLE
Fix NPE with bibdatabasecontext in preview style dialog

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -228,7 +228,6 @@ public class BasePanel extends StackPane {
         this.preview = new PreviewPanel(this, getBibDatabaseContext(), preferences.getKeyBindings(), preferences.getPreviewPreferences(), dialogService, externalFileTypes);
         frame().getGlobalSearchBar().getSearchQueryHighlightObservable().addSearchListener(preview);
 
-
     }
 
     @Subscribe

--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
@@ -70,7 +71,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
     /**
      * If a database is set, the preview will attempt to resolve strings in the previewed entry using that database.
      */
-    private Optional<BibDatabaseContext> databaseContext = Optional.empty();
+    private BibDatabaseContext databaseContext;
     private final WebView previewView;
     private Optional<Future<?>> citationStyleFuture = Optional.empty();
 
@@ -78,10 +79,10 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
 
     /**
      * @param panel           (may be null) Only set this if the preview is associated to the main window.
-     * @param databaseContext (may be null) Used for resolving pdf directories for links.
+     * @param databaseContext Used for resolving pdf directories for links. Must not be null.
      */
     public PreviewPanel(BasePanel panel, BibDatabaseContext databaseContext, KeyBindingRepository keyBindingRepository, PreviewPreferences preferences, DialogService dialogService, ExternalFileTypes externalFileTypes) {
-        this.databaseContext = Optional.ofNullable(databaseContext);
+        this.databaseContext = Objects.requireNonNull(databaseContext);
         this.basePanel = Optional.ofNullable(panel);
         this.dialogService = dialogService;
         this.clipBoardManager = Globals.clipboardManager;
@@ -198,7 +199,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
     }
 
     public void setDatabaseContext(BibDatabaseContext databaseContext) {
-        this.databaseContext = Optional.ofNullable(databaseContext);
+        this.databaseContext = databaseContext;
     }
 
     public Optional<BasePanel> getBasePanel() {
@@ -281,7 +282,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
         if (layout.isPresent()) {
             StringBuilder sb = new StringBuilder();
             bibEntry.ifPresent(entry -> sb.append(layout.get()
-                                                        .doLayout(entry, databaseContext.map(BibDatabaseContext::getDatabase).orElse(null))));
+                                                        .doLayout(entry, databaseContext.getDatabase())));
             setPreviewLabel(sb.toString());
         } else if (basePanel.isPresent() && bibEntry.isPresent()) {
             Future<?> citationStyleWorker = BackgroundTask

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.java
@@ -53,6 +53,7 @@ import org.jabref.logic.openoffice.OpenOfficePreferences;
 import org.jabref.logic.openoffice.StyleLoader;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.util.TestEntry;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.JabRefPreferences;
 
@@ -134,7 +135,7 @@ class StyleSelectDialog {
         // Create a preview panel for previewing styles
         // Must be done before creating the table to avoid NPEs
         DefaultTaskExecutor.runInJavaFXThread(() -> {
-            preview = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), dialogService, ExternalFileTypes.getInstance());
+            preview = new PreviewPanel(null, new BibDatabaseContext(), Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), dialogService, ExternalFileTypes.getInstance());
             // Use the test entry from the Preview settings tab in Preferences:
             preview.setEntry(prevEntry);
         });

--- a/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -128,7 +128,7 @@ public class PreviewPrefsTab extends JPanel implements PrefsTab {
         btnTest.setOnAction(event -> {
             try {
                 DefaultTaskExecutor.runInJavaFXThread(() -> {
-                    PreviewPanel testPane = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), dialogService, externalFileTypes);
+                    PreviewPanel testPane = new PreviewPanel(null, new BibDatabaseContext(), Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), dialogService, externalFileTypes);
                     if (chosen.getSelectionModel().getSelectedItems().isEmpty()) {
                         testPane.setFixedLayout(layout.getText());
                         testPane.setEntry(TestEntry.getTestEntry());


### PR DESCRIPTION
Followup from #3765. I discovered an NPE with the bibdatabasecontext in the NewDroppedFileHandler.
The reason is that the move files cleanup operation requires a non null bibdatabasecontext and when calling the preview panel from the preferences, no context was there.


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
