### PR TITLE
fix loading and storing of XMP Field Exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where users were vulnerable to XXE attacks during parsing [#4229](https://github.com/JabRef/jabref/issues/4229)
 - We fixed an issue where files added via the "Attach file" contextmenu of an entry were not made relative. [#4201](https://github.com/JabRef/jabref/issues/4201) and [#4241](https://github.com/JabRef/jabref/issues/4241)
 - We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
+- We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
 
 
 

--- a/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
@@ -12,12 +12,12 @@ import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.CellEditEvent;
 import javafx.scene.control.TableView;
-import javafx.scene.control.TextField;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
@@ -25,6 +25,7 @@ import javafx.scene.layout.Pane;
 
 import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.InternalBibtexFields;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.preferences.JabRefPreferences;
 
@@ -60,10 +61,8 @@ class XmpPrefsTab extends Pane implements PrefsTab {
 
         column.setPrefWidth(350);
         tableView.getColumns().add(column);
+        ComboBox<String> bibtexFields = new ComboBox<>(FXCollections.observableArrayList(InternalBibtexFields.getAllPublicAndInternalFieldNames()));
 
-        TextField addName = new TextField();
-        addName.setPromptText("name");
-        addName.setPrefSize(200, 30);
         BorderPane tablePanel = new BorderPane();
         ScrollPane scrollPane = new ScrollPane();
         scrollPane.setMaxHeight(400);
@@ -74,9 +73,8 @@ class XmpPrefsTab extends Pane implements PrefsTab {
         Button add = new Button("Add");
         add.setPrefSize(80, 20);
         add.setOnAction(e -> {
-            if (!addName.getText().isEmpty()) {
-                XMPPrivacyFilter tableRow = new XMPPrivacyFilter(addName.getText());
-                addName.clear();
+            if (!StringUtil.isNullOrEmpty(bibtexFields.getSelectionModel().getSelectedItem())) {
+                XMPPrivacyFilter tableRow = new XMPPrivacyFilter(bibtexFields.getSelectionModel().getSelectedItem());
                 fields.add(tableRow);
             }
         });
@@ -90,7 +88,7 @@ class XmpPrefsTab extends Pane implements PrefsTab {
 
             }
         });
-        HBox toolbar = new HBox(addName, add, delete);
+        HBox toolbar = new HBox(bibtexFields, add, delete);
         tablePanel.setBottom(toolbar);
 
         // Build Prefs Tabs
@@ -125,13 +123,10 @@ class XmpPrefsTab extends Pane implements PrefsTab {
      */
     @Override
     public void storeSettings() {
-        if (privacyFilterCheckBox.isSelected()) {
 
-            fields.stream().filter(s -> StringUtil.isNullOrEmpty(s.getField())).forEach(fields::remove);
-            prefs.putStringList(JabRefPreferences.XMP_PRIVACY_FILTERS,
-                                fields.stream().map(XMPPrivacyFilter::getField).collect(Collectors.toList()));
-        }
-
+        fields.stream().filter(s -> StringUtil.isNullOrEmpty(s.getField())).forEach(fields::remove);
+        prefs.putStringList(JabRefPreferences.XMP_PRIVACY_FILTERS,
+                            fields.stream().map(XMPPrivacyFilter::getField).collect(Collectors.toList()));
         prefs.putBoolean(JabRefPreferences.USE_XMP_PRIVACY_FILTER, privacyFilterCheckBox.isSelected());
     }
 

--- a/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
@@ -62,6 +62,7 @@ class XmpPrefsTab extends Pane implements PrefsTab {
         column.setPrefWidth(350);
         tableView.getColumns().add(column);
         ComboBox<String> bibtexFields = new ComboBox<>(FXCollections.observableArrayList(InternalBibtexFields.getAllPublicAndInternalFieldNames()));
+        bibtexFields.setEditable(true);
 
         BorderPane tablePanel = new BorderPane();
         ScrollPane scrollPane = new ScrollPane();
@@ -71,7 +72,6 @@ class XmpPrefsTab extends Pane implements PrefsTab {
         tablePanel.setCenter(scrollPane);
 
         Button add = new Button("Add");
-        add.setPrefSize(80, 20);
         add.setOnAction(e -> {
             if (!StringUtil.isNullOrEmpty(bibtexFields.getSelectionModel().getSelectedItem())) {
                 XMPPrivacyFilter tableRow = new XMPPrivacyFilter(bibtexFields.getSelectionModel().getSelectedItem());
@@ -79,7 +79,6 @@ class XmpPrefsTab extends Pane implements PrefsTab {
             }
         });
         Button delete = new Button("Delete");
-        delete.setPrefSize(80, 20);
         delete.setOnAction(e -> {
             if ((tableView.getFocusModel() != null) && (tableView.getFocusModel().getFocusedIndex() != -1)) {
                 int row = tableView.getFocusModel().getFocusedIndex();

--- a/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrefsTab.java
@@ -51,7 +51,7 @@ class XmpPrefsTab extends Pane implements PrefsTab {
         tableView.itemsProperty().bindBidirectional(fields);
         TableColumn<XMPPrivacyFilter, String> column = new TableColumn<>();
 
-        column.setCellValueFactory(cellData -> cellData.getValue().filterName());
+        column.setCellValueFactory(cellData -> cellData.getValue().fieldName());
         new ValueTableCellFactory<XMPPrivacyFilter, String>().withText(item -> item).install(column);
 
         column.setOnEditCommit((CellEditEvent<XMPPrivacyFilter, String> cell) -> {
@@ -161,7 +161,7 @@ class XmpPrefsTab extends Pane implements PrefsTab {
             return field.get();
         }
 
-        public StringProperty filterName() {
+        public StringProperty fieldName() {
             return field;
         }
 

--- a/src/main/java/org/jabref/gui/util/ValueTableCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ValueTableCellFactory.java
@@ -122,7 +122,7 @@ public class ValueTableCellFactory<S, T> implements Callback<TableColumn<S, T>, 
                             toOnMouseClickedEvent.apply(rowItem, item).handle(event);
                         }
 
-                        if (menuFactory != null && !event.isConsumed()) {
+                        if ((menuFactory != null) && !event.isConsumed()) {
                             if (event.getButton() == MouseButton.PRIMARY) {
                                 ContextMenu menu = menuFactory.apply(rowItem, item);
                                 if (menu != null) {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -420,8 +420,6 @@ field=field
 Field\ name=Field name
 Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Field names are not allowed to contain white space or the following characters
 
-Field\ to\ filter=Field to filter
-
 Field\ to\ group\ by=Field to group by
 
 File=File

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -57,7 +57,7 @@ public class XmpExporterTest {
         entry.setField("author", "Alan Turing");
 
         exporter.export(databaseContext, file, encoding, Collections.singletonList(entry));
-        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \r\n would fail
         String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
                           "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
                           "      <dc:creator>\n" +
@@ -90,7 +90,7 @@ public class XmpExporterTest {
 
         exporter.export(databaseContext, file, encoding, Arrays.asList(entryTuring, entryArmbrust));
 
-        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
                           "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
@@ -147,7 +147,7 @@ public class XmpExporterTest {
 
         Path fileTuring = Paths.get(file.getParent().toString() + "/" + entryTuring.getId() + "_null.xmp");
         List<String> linesTuring = Files.readAllLines(fileTuring);
-        String actualTuring = Files.readAllLines(fileTuring).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+        String actualTuring = Files.readAllLines(fileTuring).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expectedTuring = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
                                 "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
@@ -168,7 +168,7 @@ public class XmpExporterTest {
         assertEquals(expectedTuring, actualTuring);
 
         Path fileArmbrust = Paths.get(file.getParent().toString() + "/" + entryArmbrust.getId() + "_Armbrust2010.xmp");
-        String actualArmbrust = Files.readAllLines(fileArmbrust).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+        String actualArmbrust = Files.readAllLines(fileArmbrust).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expectedArmbrust = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
                                   "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
@@ -24,6 +25,7 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(TempDirectory.class)
 public class XmpExporterTest {
@@ -31,13 +33,13 @@ public class XmpExporterTest {
     private Exporter exporter;
     private BibDatabaseContext databaseContext;
     private Charset encoding;
+    private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
 
     @BeforeEach
     public void setUp() {
         Map<String, TemplateExporter> customFormats = new HashMap<>();
         LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
         SavePreferences savePreferences = mock(SavePreferences.class);
-        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
         ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
 
         exporter = exporterFactory.getExporterByName("xmp").get();
@@ -55,10 +57,23 @@ public class XmpExporterTest {
         entry.setField("author", "Alan Turing");
 
         exporter.export(databaseContext, file, encoding, Collections.singletonList(entry));
-
-        List<String> lines = Files.readAllLines(file);
-        assertEquals(15, lines.size());
-        assertEquals("<rdf:li>Alan Turing</rdf:li>", lines.get(4).trim());
+        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+                          "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                          "      <dc:creator>\n" +
+                          "        <rdf:Seq>\n" +
+                          "          <rdf:li>Alan Turing</rdf:li>\n" +
+                          "        </rdf:Seq>\n" +
+                          "      </dc:creator>\n" +
+                          "      <dc:format>application/pdf</dc:format>\n" +
+                          "      <dc:type>\n" +
+                          "        <rdf:Bag>\n" +
+                          "          <rdf:li>Misc</rdf:li>\n" +
+                          "        </rdf:Bag>\n" +
+                          "      </dc:type>\n" +
+                          "    </rdf:Description>\n" +
+                          "  </rdf:RDF>";
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -75,10 +90,42 @@ public class XmpExporterTest {
 
         exporter.export(databaseContext, file, encoding, Arrays.asList(entryTuring, entryArmbrust));
 
-        List<String> lines = Files.readAllLines(file);
-        assertEquals(33, lines.size());
-        assertEquals("<rdf:li>Alan Turing</rdf:li>", lines.get(4).trim());
-        assertEquals("<rdf:li>Michael Armbrust</rdf:li>", lines.get(17).trim());
+        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+
+        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+                          "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                          "      <dc:creator>\n" +
+                          "        <rdf:Seq>\n" +
+                          "          <rdf:li>Alan Turing</rdf:li>\n" +
+                          "        </rdf:Seq>\n" +
+                          "      </dc:creator>\n" +
+                          "      <dc:format>application/pdf</dc:format>\n" +
+                          "      <dc:type>\n" +
+                          "        <rdf:Bag>\n" +
+                          "          <rdf:li>Misc</rdf:li>\n" +
+                          "        </rdf:Bag>\n" +
+                          "      </dc:type>\n" +
+                          "    </rdf:Description>\n" +
+                          "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                          "      <dc:creator>\n" +
+                          "        <rdf:Seq>\n" +
+                          "          <rdf:li>Michael Armbrust</rdf:li>\n" +
+                          "        </rdf:Seq>\n" +
+                          "      </dc:creator>\n" +
+                          "      <dc:relation>\n" +
+                          "        <rdf:Bag>\n" +
+                          "          <rdf:li>bibtex/bibtexkey/Armbrust2010</rdf:li>\n" +
+                          "        </rdf:Bag>\n" +
+                          "      </dc:relation>\n" +
+                          "      <dc:format>application/pdf</dc:format>\n" +
+                          "      <dc:type>\n" +
+                          "        <rdf:Bag>\n" +
+                          "          <rdf:li>Misc</rdf:li>\n" +
+                          "        </rdf:Bag>\n" +
+                          "      </dc:type>\n" +
+                          "    </rdf:Description>\n" +
+                          "  </rdf:RDF>";
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -100,12 +147,76 @@ public class XmpExporterTest {
 
         Path fileTuring = Paths.get(file.getParent().toString() + "/" + entryTuring.getId() + "_null.xmp");
         List<String> linesTuring = Files.readAllLines(fileTuring);
-        assertEquals(15, linesTuring.size());
-        assertEquals("<rdf:li>Alan Turing</rdf:li>", linesTuring.get(4).trim());
+        String actualTuring = Files.readAllLines(fileTuring).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+
+        String expectedTuring = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+                                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                                "      <dc:creator>\n" +
+                                "        <rdf:Seq>\n" +
+                                "          <rdf:li>Alan Turing</rdf:li>\n" +
+                                "        </rdf:Seq>\n" +
+                                "      </dc:creator>\n" +
+                                "      <dc:format>application/pdf</dc:format>\n" +
+                                "      <dc:type>\n" +
+                                "        <rdf:Bag>\n" +
+                                "          <rdf:li>Misc</rdf:li>\n" +
+                                "        </rdf:Bag>\n" +
+                                "      </dc:type>\n" +
+                                "    </rdf:Description>\n" +
+                                "  </rdf:RDF>";
+
+        assertEquals(expectedTuring, actualTuring);
 
         Path fileArmbrust = Paths.get(file.getParent().toString() + "/" + entryArmbrust.getId() + "_Armbrust2010.xmp");
-        List<String> linesArmbrust = Files.readAllLines(fileArmbrust);
-        assertEquals(20, linesArmbrust.size());
-        assertEquals("<rdf:li>Michael Armbrust</rdf:li>", linesArmbrust.get(4).trim());
+        String actualArmbrust = Files.readAllLines(fileArmbrust).stream().collect(Collectors.joining("\n")); //we are using \n to join, so we need it in the expected string as well, \n would fail
+
+        String expectedArmbrust = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+                                  "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                                  "      <dc:creator>\n" +
+                                  "        <rdf:Seq>\n" +
+                                  "          <rdf:li>Michael Armbrust</rdf:li>\n" +
+                                  "        </rdf:Seq>\n" +
+                                  "      </dc:creator>\n" +
+                                  "      <dc:relation>\n" +
+                                  "        <rdf:Bag>\n" +
+                                  "          <rdf:li>bibtex/bibtexkey/Armbrust2010</rdf:li>\n" +
+                                  "        </rdf:Bag>\n" +
+                                  "      </dc:relation>\n" +
+                                  "      <dc:format>application/pdf</dc:format>\n" +
+                                  "      <dc:type>\n" +
+                                  "        <rdf:Bag>\n" +
+                                  "          <rdf:li>Misc</rdf:li>\n" +
+                                  "        </rdf:Bag>\n" +
+                                  "      </dc:type>\n" +
+                                  "    </rdf:Description>\n" +
+                                  "  </rdf:RDF>";
+
+        assertEquals(expectedArmbrust, actualArmbrust);
+    }
+
+    @Test
+    public void exportSingleEntryWithPrivacyFilter(@TempDirectory.TempDir Path testFolder) throws Exception {
+        when(xmpPreferences.getXmpPrivacyFilter()).thenReturn(Arrays.asList("author"));
+        when(xmpPreferences.isUseXMPPrivacyFilter()).thenReturn(true);
+
+        Path file = testFolder.resolve("ThisIsARandomlyNamedFile");
+        Files.createFile(file);
+
+        BibEntry entry = new BibEntry();
+        entry.setField("author", "Alan Turing");
+
+        exporter.export(databaseContext, file, encoding, Collections.singletonList(entry));
+        String actual = Files.readAllLines(file).stream().collect(Collectors.joining("\n"));
+        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+                          "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
+                          "      <dc:format>application/pdf</dc:format>\n" +
+                          "      <dc:type>\n" +
+                          "        <rdf:Bag>\n" +
+                          "          <rdf:li>Misc</rdf:li>\n" +
+                          "        </rdf:Bag>\n" +
+                          "      </dc:type>\n" +
+                          "    </rdf:Description>\n" +
+                          "  </rdf:RDF>";
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Fixes #4072 

@koppor  I am not that into the XMP stuff, are those "fields" I can add there bibtexfields which I can exclude from the export? 
Then it would make sense to have a combobox analogous to the Cleanup panel with all fields

Edit// Decided to add the combobox with all fields

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
![grafik](https://user-images.githubusercontent.com/320228/44588230-6cbc5080-a7b5-11e8-909e-ac190ceedc95.png)


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
