### PR TITLE
Fix height of entry editor fields

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -120,14 +120,12 @@ abstract class FieldsEditorTab extends EntryEditorTab {
 
             setCompressedRowLayout(gridPane, rows);
         } else {
-            rows = fields.size();
-
             addColumn(gridPane, 0, labels);
             addColumn(gridPane, 1, editors.values().stream().map(FieldEditorFX::getNode));
 
             gridPane.getColumnConstraints().addAll(columnDoNotContract, columnExpand);
 
-            setRegularRowLayout(gridPane, rows);
+            setRegularRowLayout(gridPane);
         }
 
         // Warp everything in a scroll-pane
@@ -140,17 +138,17 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         return scrollPane;
     }
 
-    private void setRegularRowLayout(GridPane gridPane, int rows) {
-        List<RowConstraints> constraints = new ArrayList<>(rows);
+    private void setRegularRowLayout(GridPane gridPane) {
+        double totalWeight = fields.stream()
+                                   .mapToDouble(field -> editors.get(field).getWeight())
+                                   .sum();
+
+        List<RowConstraints> constraints = new ArrayList<>();
         for (String field : fields) {
             RowConstraints rowExpand = new RowConstraints();
             rowExpand.setVgrow(Priority.ALWAYS);
             rowExpand.setValignment(VPos.TOP);
-            if (rows == 0) {
-                rowExpand.setPercentHeight(100);
-            } else {
-                rowExpand.setPercentHeight(100 / rows * editors.get(field).getWeight());
-            }
+            rowExpand.setPercentHeight(100 * editors.get(field).getWeight() / totalWeight);
             constraints.add(rowExpand);
         }
         gridPane.getRowConstraints().addAll(constraints);
@@ -163,7 +161,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         if (rows == 0) {
             rowExpand.setPercentHeight(100);
         } else {
-            rowExpand.setPercentHeight(100 / rows);
+            rowExpand.setPercentHeight(100 / (double) rows);
         }
         for (int i = 0; i < rows; i++) {
             gridPane.getRowConstraints().add(rowExpand);

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -9,12 +9,13 @@ import java.util.function.Supplier;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 
 import com.sun.javafx.scene.control.skin.TextAreaSkin;
 
-public class EditorTextArea extends javafx.scene.control.TextArea implements Initializable, ContextMenuAddable {
+public class EditorTextArea extends TextArea implements Initializable, ContextMenuAddable {
 
     /**
      *  Variable that contains user-defined behavior for paste action.
@@ -30,8 +31,6 @@ public class EditorTextArea extends javafx.scene.control.TextArea implements Ini
     public EditorTextArea(final String text) {
         super(text);
 
-        setMinHeight(1);
-        setMinWidth(200);
 
         // Hide horizontal scrollbar and always wrap text
         setWrapText(true);

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -22,8 +22,8 @@ public class EditorTextField extends javafx.scene.control.TextField implements I
     public EditorTextField(final String text) {
         super(text);
 
-        setMinHeight(1);
-        setMinWidth(200);
+        // Always fill out all the available vertical space
+        this.setPrefHeight(Double.POSITIVE_INFINITY);
 
         // Should behave as a normal text field with respect to TAB behaviour
         addEventFilter(KeyEvent.KEY_PRESSED, event -> {

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.fieldeditors;
 
-import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.layout.HBox;
@@ -15,9 +14,8 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class PersonsEditor extends HBox implements FieldEditorFX {
 
-    @FXML private final PersonsEditorViewModel viewModel;
-
-    private TextInputControl textInput;
+    private final PersonsEditorViewModel viewModel;
+    private final TextInputControl textInput;
 
     public PersonsEditor(final String fieldName,
                          final AutoCompleteSuggestionProvider<?> suggestionProvider,

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.fieldeditors;
 
-import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.layout.HBox;
@@ -16,7 +15,8 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class SimpleEditor extends HBox implements FieldEditorFX {
 
-    @FXML private final SimpleEditorViewModel viewModel;
+    private final SimpleEditorViewModel viewModel;
+    private final TextInputControl textInput;
 
     public SimpleEditor(final String fieldName,
                         final AutoCompleteSuggestionProvider<?> suggestionProvider,
@@ -25,10 +25,11 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
                         final boolean isSingleLine) {
         this.viewModel = new SimpleEditorViewModel(fieldName, suggestionProvider, fieldCheckers);
 
-        TextInputControl textInput = isSingleLine
+        textInput = isSingleLine
                 ? new EditorTextField()
                 : new EditorTextArea();
         HBox.setHgrow(textInput, Priority.ALWAYS);
+
         textInput.textProperty().bindBidirectional(viewModel.textProperty());
         ((ContextMenuAddable) textInput).addToContextMenu(EditorMenus.getDefaultMenu(textInput));
         this.getChildren().add(textInput);
@@ -58,5 +59,10 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
     @Override
     public Parent getNode() {
         return this;
+    }
+
+    @Override
+    public void requestFocus() {
+        textInput.requestFocus();
     }
 }

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -308,7 +308,7 @@ public class IconTheme {
         LOOKUP_IDENTIFIER(MaterialDesignIcon.MAGNIFY), // TODO: use WEB_SEARCH instead as soon as it is available
         FETCH_FULLTEXT(MaterialDesignIcon.MAGNIFY), // TODO: use WEB_SEARCH instead as soon as it is available
         FETCH_BY_IDENTIFIER(MaterialDesignIcon.CLIPBOARD_ARROW_DOWN),
-        TOGGLE_ABBREVIATION(MaterialDesignIcon.TEXT_SHADOW),
+        TOGGLE_ABBREVIATION(MaterialDesignIcon.FORMAT_ALIGN_CENTER),
         NEW_FILE(MaterialDesignIcon.PLUS),
         DOWNLOAD(MaterialDesignIcon.DOWNLOAD),
         OWNER(MaterialDesignIcon.ACCOUNT),


### PR DESCRIPTION
Some of the text fields didn't use all the available height, which resulted in a unharmonic display. This is now fixed.