### PR TITLE
Fix that web search pane steals input

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
@@ -71,11 +71,12 @@ public class WebSearchPane extends SidePaneComponent {
 
         // Create text field for query input
         TextField query = SearchTextField.create();
+        query.setOnAction(event -> viewModel.search());
         viewModel.queryProperty().bind(query.textProperty());
 
         // Create button that triggers search
         Button search = new Button(Localization.lang("Search"));
-        search.setDefaultButton(true);
+        search.setDefaultButton(false);
         search.setOnAction(event -> viewModel.search());
 
         // Put everything together


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/4330 by making the search button in the web search pane not the default button.