### PR TITLE
Fix export of corporate author to MSOffice

### DIFF
--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -116,11 +116,12 @@ public class MSBibConverter {
     private static List<MsBibAuthor> getAuthors(BibEntry entry, String authors, String fieldName) {
         List<MsBibAuthor> result = new ArrayList<>();
         boolean corporate = false;
-        //Only one corporate authors is supported
+        //Only one corporate author is supported
         //We have the possible rare case that are multiple authors which start and end with latex , this is currently not considered
         if (authors.startsWith("{") && authors.endsWith("}")) {
             corporate = true;
         }
+        //FIXME: #4152 This is an ugly hack because the latex2unicode formatter kills of all curly braces, so no more corporate author parsing possible
         String authorLatexFree = entry.getLatexFreeField(fieldName).orElse("");
         if (corporate) {
             authorLatexFree = "{" + authorLatexFree + "}";

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -67,7 +67,7 @@ public class MSBibConverter {
         // Value must be converted
         //Currently only english is supported
         entry.getLatexFreeField(FieldName.LANGUAGE)
-                .ifPresent(lang -> result.fields.put("LCID", String.valueOf(MSBibMapping.getLCID(lang))));
+             .ifPresent(lang -> result.fields.put("LCID", String.valueOf(MSBibMapping.getLCID(lang))));
         StringBuilder sbNumber = new StringBuilder();
         entry.getLatexFreeField(FieldName.ISBN).ifPresent(isbn -> sbNumber.append(" ISBN: " + isbn));
         entry.getLatexFreeField(FieldName.ISSN).ifPresent(issn -> sbNumber.append(" ISSN: " + issn));
@@ -106,21 +106,27 @@ public class MSBibConverter {
             result.publicationTitle = entry.getLatexFreeField(FieldName.TITLE).orElse(null);
         }
 
-        entry.getLatexFreeField(FieldName.AUTHOR).ifPresent(authors -> result.authors = getAuthors(authors));
-        entry.getLatexFreeField(FieldName.EDITOR).ifPresent(editors -> result.editors = getAuthors(editors));
-        entry.getLatexFreeField(FieldName.TRANSLATOR).ifPresent(translator -> result.translators = getAuthors(translator));
+        entry.getField(FieldName.AUTHOR).ifPresent(authors -> result.authors = getAuthors(entry, authors, FieldName.AUTHOR));
+        entry.getField(FieldName.EDITOR).ifPresent(editors -> result.editors = getAuthors(entry, editors, FieldName.EDITOR));
+        entry.getField(FieldName.TRANSLATOR).ifPresent(translator -> result.translators = getAuthors(entry, translator, FieldName.EDITOR));
 
         return result;
     }
 
-    private static List<MsBibAuthor> getAuthors(String authors) {
+    private static List<MsBibAuthor> getAuthors(BibEntry entry, String authors, String fieldName) {
         List<MsBibAuthor> result = new ArrayList<>();
         boolean corporate = false;
         //Only one corporate authors is supported
+        //We have the possible rare case that are multiple authors which start and end with latex , this is currently not considered
         if (authors.startsWith("{") && authors.endsWith("}")) {
             corporate = true;
         }
-        AuthorList authorList = AuthorList.parse(authors);
+        String authorLatexFree = entry.getLatexFreeField(fieldName).orElse("");
+        if (corporate) {
+            authorLatexFree = "{" + authorLatexFree + "}";
+        }
+
+        AuthorList authorList = AuthorList.parse(authorLatexFree);
 
         for (Author author : authorList.getAuthors()) {
             result.add(new MsBibAuthor(author, corporate));

--- a/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
@@ -18,7 +18,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -64,7 +63,6 @@ public class MSBibExportFormatTestFiles {
         testImporter = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor());
     }
 
-    @Disabled
     @ParameterizedTest
     @MethodSource("fileNames")
     void testPerformExport(String filename) throws IOException, SaveException {

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest2.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Year>2002</b:Year>
 <b:Volume>44</b:Volume>
 <b:BIBTEX_Entry>phdthesis</b:BIBTEX_Entry>
@@ -16,8 +16,6 @@
 <b:JournalName>Wirtschaftsinformatik</b:JournalName>
 <b:Number>3</b:Number>
 <b:City>a</b:City>
-<b:StateProvince/>
-<b:CountryRegion/>
 <b:ThesisType>type</b:ThesisType>
 </b:Source>
 </b:Sources>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest3.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Year>2002</b:Year>
 <b:Volume>44</b:Volume>
 <b:BIBTEX_Entry>manual</b:BIBTEX_Entry>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest4.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Year>2002</b:Year>
 <b:Volume>44</b:Volume>
 <b:BIBTEX_Entry>inbook</b:BIBTEX_Entry>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest5.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Issue>3</b:Issue>
 <b:Year>2002</b:Year>
 <b:Volume>44</b:Volume>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest6.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTest6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Year>2002</b:Year>
 <b:Volume>44</b:Volume>
 <b:BIBTEX_Entry>mastersthesis</b:BIBTEX_Entry>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibLCID.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibLCID.xml
@@ -2,7 +2,7 @@
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
 <b:Source>
 <b:SourceType>JournalArticle</b:SourceType>
-<b:LCID>0</b:LCID>
+<b:LCID>1033</b:LCID>
 <b:Author/>
 <b:BIBTEX_Entry>article</b:BIBTEX_Entry>
 </b:Source>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibLocationTest.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibLocationTest.xml
@@ -14,7 +14,5 @@
 </b:Author>
 </b:Author>
 <b:City>Berlin</b:City>
-<b:StateProvince/>
-<b:CountryRegion/>
 </b:Source>
 </b:Sources>


### PR DESCRIPTION
Fix tests
Fix  #4329  

The underlying problem is the same as in #4152 
However, I came up with a workaround for MSOffice. 
1. Getting the original field
2. Check for corporate author (braces start and end)
3. get latex free value
4. Readd braces for corporate 
5. Parse author

The only edgecase which can occur if the entry starts with an author in latex braces and ends with an author in latex braces. That one will probably be interpreted as corporate.


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
