### PR TITLE
Fix for Issue #4306 - Disable Rename when Filename is the same

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -192,6 +192,21 @@ public class LinkedFileViewModel extends AbstractViewModel {
         }
     }
 
+    public boolean performNameConflictCheck() {
+        /*
+        Get the filepath for current linkedFile and truncate it to only have the filename and
+        not the filepath. Compare to new suggested filename and return boolean result.
+         */
+        Path file = Paths.get(linkedFile.getLink());
+        String oldFileName = file.getFileName().toString();
+        String newFileName = this.linkedFileHandler.getSuggestedFileName();
+
+        if(oldFileName.equals(newFileName))
+            return true;
+        else
+            return false;
+    }
+
     public void rename() {
         if (linkedFile.isOnlineLink()) {
             // Cannot rename remote links

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -201,10 +201,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         String currentFileName = file.getFileName().toString();
         String suggestedFileName = this.linkedFileHandler.getSuggestedFileName();
 
-        if (currentFileName.equals(suggestedFileName))
-            return true;
-        else
-            return false;
+        return currentFileName.equals(suggestedFileName);
     }
 
     public void rename() {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -204,6 +204,23 @@ public class LinkedFileViewModel extends AbstractViewModel {
         return currentFileName.equals(suggestedFileName);
     }
 
+    public boolean performDirectoryConflictCheck() {
+        /*
+        Get the suggested filepath for current linkedFile and compare it to the existing filepath.
+        Return boolean result.
+         */
+        //Get the new path for the file
+        Optional<Path> newDir = databaseContext.getFirstExistingFileDir(filePreferences);
+        Path newDirectory = newDir.get();
+
+        //Get the current path for the file
+        Optional<Path> currentDir = linkedFile.findIn(databaseContext, filePreferences);
+        Path currentDirectory = currentDir.get();
+
+        //Compare the two paths
+        return newDirectory.toString().equals(currentDirectory.getParent().toString());
+    }
+
     public void rename() {
         if (linkedFile.isOnlineLink()) {
             // Cannot rename remote links

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -197,11 +197,11 @@ public class LinkedFileViewModel extends AbstractViewModel {
         Get the filepath for current linkedFile and truncate it to only have the filename and
         not the filepath. Compare to new suggested filename and return boolean result.
          */
-        Path file = Paths.get(linkedFile.getLink());
-        String oldFileName = file.getFileName().toString();
-        String newFileName = this.linkedFileHandler.getSuggestedFileName();
+        Path file = Paths.get(this.linkedFile.getLink());
+        String currentFileName = file.getFileName().toString();
+        String suggestedFileName = this.linkedFileHandler.getSuggestedFileName();
 
-        if(oldFileName.equals(newFileName))
+        if(currentFileName.equals(suggestedFileName))
             return true;
         else
             return false;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -201,7 +201,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         String currentFileName = file.getFileName().toString();
         String suggestedFileName = this.linkedFileHandler.getSuggestedFileName();
 
-        if(currentFileName.equals(suggestedFileName))
+        if (currentFileName.equals(suggestedFileName))
             return true;
         else
             return false;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -252,22 +252,20 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         MenuItem download = new MenuItem(Localization.lang("Download file"));
         download.setOnAction(event -> linkedFile.download());
 
-        //Begin Duplicate Name Checking
-        if(linkedFile.getFile().getLink().equals(linkedFile.getFile().)) {
-
-        }
         MenuItem renameFile = new MenuItem(Localization.lang("Rename file"));
         renameFile.setOnAction(event -> linkedFile.rename());
         renameFile.setDisable(linkedFile.getFile().isOnlineLink());
+        renameFile.setDisable(linkedFile.performNameConflictCheck());
 
         MenuItem moveFile = new MenuItem(Localization.lang("Move file to file directory"));
         moveFile.setOnAction(event -> linkedFile.moveToDefaultDirectory());
         moveFile.setDisable(linkedFile.getFile().isOnlineLink());
+        moveFile.setDisable(linkedFile.performNameConflictCheck());
 
         MenuItem renameAndMoveFile = new MenuItem(Localization.lang("Move file to file directory and rename file"));
         renameAndMoveFile.setOnAction(event -> linkedFile.moveToDefaultDirectoryAndRename());
         renameAndMoveFile.setDisable(linkedFile.getFile().isOnlineLink());
-        //End of Duplicate Name Checking
+        renameAndMoveFile.setDisable(linkedFile.performNameConflictCheck());
 
         MenuItem deleteFile = new MenuItem(Localization.lang("Permanently delete local file"));
         deleteFile.setOnAction(event -> viewModel.deleteFile(linkedFile));

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -252,6 +252,10 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         MenuItem download = new MenuItem(Localization.lang("Download file"));
         download.setOnAction(event -> linkedFile.download());
 
+        //Begin Duplicate Name Checking
+        if(linkedFile.getFile().getLink().equals(linkedFile.getFile().)) {
+
+        }
         MenuItem renameFile = new MenuItem(Localization.lang("Rename file"));
         renameFile.setOnAction(event -> linkedFile.rename());
         renameFile.setDisable(linkedFile.getFile().isOnlineLink());
@@ -263,6 +267,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         MenuItem renameAndMoveFile = new MenuItem(Localization.lang("Move file to file directory and rename file"));
         renameAndMoveFile.setOnAction(event -> linkedFile.moveToDefaultDirectoryAndRename());
         renameAndMoveFile.setDisable(linkedFile.getFile().isOnlineLink());
+        //End of Duplicate Name Checking
 
         MenuItem deleteFile = new MenuItem(Localization.lang("Permanently delete local file"));
         deleteFile.setOnAction(event -> viewModel.deleteFile(linkedFile));

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -254,18 +254,15 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
         MenuItem renameFile = new MenuItem(Localization.lang("Rename file"));
         renameFile.setOnAction(event -> linkedFile.rename());
-        renameFile.setDisable(linkedFile.getFile().isOnlineLink());
-        renameFile.setDisable(linkedFile.performNameConflictCheck());
+        renameFile.setDisable(linkedFile.getFile().isOnlineLink() || linkedFile.performNameConflictCheck());
 
         MenuItem moveFile = new MenuItem(Localization.lang("Move file to file directory"));
         moveFile.setOnAction(event -> linkedFile.moveToDefaultDirectory());
-        moveFile.setDisable(linkedFile.getFile().isOnlineLink());
-        moveFile.setDisable(linkedFile.performNameConflictCheck());
+        moveFile.setDisable(linkedFile.getFile().isOnlineLink() || linkedFile.performDirectoryConflictCheck());
 
         MenuItem renameAndMoveFile = new MenuItem(Localization.lang("Move file to file directory and rename file"));
         renameAndMoveFile.setOnAction(event -> linkedFile.moveToDefaultDirectoryAndRename());
-        renameAndMoveFile.setDisable(linkedFile.getFile().isOnlineLink());
-        renameAndMoveFile.setDisable(linkedFile.performNameConflictCheck());
+        renameAndMoveFile.setDisable(linkedFile.getFile().isOnlineLink() || linkedFile.performDirectoryConflictCheck());
 
         MenuItem deleteFile = new MenuItem(Localization.lang("Permanently delete local file"));
         deleteFile.setOnAction(event -> viewModel.deleteFile(linkedFile));

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -23,7 +23,8 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -54,6 +54,24 @@ class LinkedFileViewModelTest {
     }
 
     @Test
+    void checkNameConflict() {
+        //Debug Statements
+        System.out.println(tempFile.getFileName());
+        System.out.println(tempFile.toAbsolutePath().toString());
+
+        linkedFile = new LinkedFile("", tempFile.toString(), "");
+
+        //Debug Statements
+        System.out.println(linkedFile.toString());
+        System.out.println(linkedFile.getLink());
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences);
+        boolean notEqual = viewModel.performNameConflictCheck();
+
+        assertTrue(!notEqual);
+    }
+
+    @Test
     void deleteWhenFilePathNotPresentReturnsTrue() {
         // Making this a spy, so we can inject an empty optional without digging into the implementation
         linkedFile = spy(new LinkedFile("", "nonexistent file", ""));

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -72,13 +72,13 @@ class LinkedFileViewModelTest {
         System.out.println(linkedFile.toString());
         System.out.println(linkedFile.getLink());
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences);
+        LinkedFileViewModel viewModel = spy(new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences));
         //when(FileUtil.createFileNameFromPattern(any(BibDatabase.class), any(BibEntry.class), any(String.class))).thenReturn("TestFileName.txt");
         when(new LinkedFileHandler(this.linkedFile, this.entry, this.databaseContext, this.preferences.getFilePreferences()).getSuggestedFileName()).thenReturn("temporaryFile");
 
         boolean equalNames = viewModel.performNameConflictCheck();
 
-        assertTrue(equalNames);
+        assertTrue(!equalNames);
     }
 
     @Test

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -3,12 +3,16 @@ package org.jabref.gui.fieldeditors;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Map;
 
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.externalfiles.LinkedFileHandler;
+import org.jabref.logic.util.io.FileUtil;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
@@ -20,11 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Answers;
+import org.mockito.internal.stubbing.BaseStubbing;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -53,23 +57,28 @@ class LinkedFileViewModelTest {
         Files.createFile(tempFile);
     }
 
-    @Test
-    void checkNameConflict() {
-        //Debug Statements
-        System.out.println(tempFile.getFileName());
-        System.out.println(tempFile.toAbsolutePath().toString());
-
-        linkedFile = new LinkedFile("", tempFile.toString(), "");
-
-        //Debug Statements
-        System.out.println(linkedFile.toString());
-        System.out.println(linkedFile.getLink());
-
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences);
-        boolean notEqual = viewModel.performNameConflictCheck();
-
-        assertTrue(!notEqual);
-    }
+      //Failed Implementation for CheckNameConflict
+//    @Test
+//    void checkNameConflict() {
+//        //Debug Statements
+//        System.out.println(tempFile.getFileName());
+//        System.out.println(tempFile.toAbsolutePath().toString());
+//
+//        linkedFile = spy(new LinkedFile("", tempFile.toString(), ""));
+//        doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FilePreferences.class));
+//        when(preferences.getFilePreferences()).thenReturn(new FilePreferences(eq("TestUser"), anyMap(), eq(true), eq("TestPattern"), eq("TestDirectoryPattern")));
+//        when(FileUtil.createFileNameFromPattern(any(BibDatabase.class), any(BibEntry.class), any(String.class))).thenReturn("TestFileName.txt");
+//
+//        //Debug Statements
+//        System.out.println(linkedFile.toString());
+//        System.out.println(linkedFile.getLink());
+//
+//        LinkedFileViewModel viewModel = spy(new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences));
+//
+//        boolean notEqual = viewModel.performNameConflictCheck();
+//
+//        assertTrue(!notEqual);
+//    }
 
     @Test
     void deleteWhenFilePathNotPresentReturnsTrue() {

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -9,7 +9,6 @@ import javafx.scene.control.ButtonType;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.TaskExecutor;
-import org.jabref.logic.externalfiles.LinkedFileHandler;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -57,28 +57,29 @@ class LinkedFileViewModelTest {
         Files.createFile(tempFile);
     }
 
-      //Failed Implementation for CheckNameConflict
-//    @Test
-//    void checkNameConflict() {
-//        //Debug Statements
-//        System.out.println(tempFile.getFileName());
-//        System.out.println(tempFile.toAbsolutePath().toString());
-//
-//        linkedFile = spy(new LinkedFile("", tempFile.toString(), ""));
-//        doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FilePreferences.class));
-//        when(preferences.getFilePreferences()).thenReturn(new FilePreferences(eq("TestUser"), anyMap(), eq(true), eq("TestPattern"), eq("TestDirectoryPattern")));
-//        when(FileUtil.createFileNameFromPattern(any(BibDatabase.class), any(BibEntry.class), any(String.class))).thenReturn("TestFileName.txt");
-//
-//        //Debug Statements
-//        System.out.println(linkedFile.toString());
-//        System.out.println(linkedFile.getLink());
-//
-//        LinkedFileViewModel viewModel = spy(new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences));
-//
-//        boolean notEqual = viewModel.performNameConflictCheck();
-//
-//        assertTrue(!notEqual);
-//    }
+    //In-Progress Implementation for CheckNameConflict
+    @Test
+    void checkNameConflict() {
+        //Debug Statements
+        System.out.println(tempFile.getFileName());
+        System.out.println(tempFile.toAbsolutePath().toString());
+
+        linkedFile = spy(new LinkedFile("", tempFile.toString(), ""));
+        doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FilePreferences.class));
+        //when(preferences.getFilePreferences()).thenReturn(new FilePreferences(eq("TestUser"), anyMap(), eq(true), eq("TestPattern"), eq("TestDirectoryPattern")));
+
+        //Debug Statements
+        System.out.println(linkedFile.toString());
+        System.out.println(linkedFile.getLink());
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences);
+        //when(FileUtil.createFileNameFromPattern(any(BibDatabase.class), any(BibEntry.class), any(String.class))).thenReturn("TestFileName.txt");
+        when(new LinkedFileHandler(this.linkedFile, this.entry, this.databaseContext, this.preferences.getFilePreferences()).getSuggestedFileName()).thenReturn("temporaryFile");
+
+        boolean equalNames = viewModel.performNameConflictCheck();
+
+        assertTrue(equalNames);
+    }
 
     @Test
     void deleteWhenFilePathNotPresentReturnsTrue() {

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -3,7 +3,6 @@ package org.jabref.gui.fieldeditors;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Map;
 
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
@@ -11,8 +10,6 @@ import javafx.scene.control.ButtonType;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.externalfiles.LinkedFileHandler;
-import org.jabref.logic.util.io.FileUtil;
-import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
@@ -24,7 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Answers;
-import org.mockito.internal.stubbing.BaseStubbing;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -55,30 +51,6 @@ class LinkedFileViewModelTest {
 
         tempFile = tempFolder.resolve("temporaryFile");
         Files.createFile(tempFile);
-    }
-
-    //In-Progress Implementation for CheckNameConflict
-    @Test
-    void checkNameConflict() {
-        //Debug Statements
-        System.out.println(tempFile.getFileName());
-        System.out.println(tempFile.toAbsolutePath().toString());
-
-        linkedFile = spy(new LinkedFile("", tempFile.toString(), ""));
-        doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FilePreferences.class));
-        //when(preferences.getFilePreferences()).thenReturn(new FilePreferences(eq("TestUser"), anyMap(), eq(true), eq("TestPattern"), eq("TestDirectoryPattern")));
-
-        //Debug Statements
-        System.out.println(linkedFile.toString());
-        System.out.println(linkedFile.getLink());
-
-        LinkedFileViewModel viewModel = spy(new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences));
-        //when(FileUtil.createFileNameFromPattern(any(BibDatabase.class), any(BibEntry.class), any(String.class))).thenReturn("TestFileName.txt");
-        when(new LinkedFileHandler(this.linkedFile, this.entry, this.databaseContext, this.preferences.getFilePreferences()).getSuggestedFileName()).thenReturn("temporaryFile");
-
-        boolean equalNames = viewModel.performNameConflictCheck();
-
-        assertTrue(!equalNames);
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Potential fix for [#4306](https://github.com/JabRef/jabref/issues/4306). 
The method ``performNameConflictCheck`` added in ``LinkedFileViewModel`` helps check whether or not the filename is already equal to the suggested filename. If so, it returns true, otherwise, it returns false. This method is then called in ``LinkedFilesEditor`` during ``createContextMenuForFile()`` to decide whether or not the Rename, Move, or Rename and Move menu options are to be disabled.

The method itself works as I tested it by running the code live with the JVM. Having the filename == suggested filename indeed disabled those three menu options in the context menu. The issue however, is that I'm having trouble writing my test case for it. I'm running into a couple of nullpointers being thrown when I try to run my test case ``checkNameConflict()`` in ``LinkedFileViewModelTest``. Specifically, it reports that there are nullpointers when accessing the ``getSuggestedFilename()`` called in within ``checkNameConflict`` in the ``LinkedFileViewModel`` class.

----

- [ ] Change in CHANGELOG.md described - ***N/A***
- [ ] Tests created for changes - ***Work In Progress***
- [ ] Manually tested changed features in running JabRef 
- [ ] Screenshots added in PR description (for bigger UI changes) ***N/A***
- [ ] Ensured that [the git commit message is a good one] (https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
