### PR TITLE
Fix freezes in entry editor

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -29,6 +29,7 @@ import org.jabref.logic.shared.exception.NotASharedDatabaseException;
 import org.jabref.model.database.shared.DatabaseNotSupportedException;
 import org.jabref.preferences.JabRefPreferences;
 
+import impl.org.controlsfx.skin.DecorationPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,7 +144,12 @@ public class JabRefGUI {
             mainStage.setHeight(Globals.prefs.getDouble(JabRefPreferences.SIZE_Y));
         }
 
-        Scene scene = new Scene(JabRefGUI.mainFrame, 800, 800);
+        // We create a decoration pane ourselves for performance reasons
+        // (otherwise it has to be injected later, leading to a complete redraw/relayout of the complete scene)
+        DecorationPane root = new DecorationPane();
+        root.getChildren().add(JabRefGUI.mainFrame);
+
+        Scene scene = new Scene(root, 800, 800);
         Globals.getThemeLoader().installBaseCss(scene, Globals.prefs);
         mainStage.setTitle(JabRefFrame.FRAME_TITLE);
         mainStage.getIcons().addAll(IconTheme.getLogoSetFX());

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -3,7 +3,6 @@ package org.jabref.gui.fieldeditors;
 import javafx.scene.Parent;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionTextInputBinding;
@@ -27,7 +26,7 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
         textInput = isSingleLine
                 ? new EditorTextField()
                 : new EditorTextArea();
-        HBox.setHgrow(textInput, Priority.ALWAYS);
+
         textInput.textProperty().bindBidirectional(viewModel.textProperty());
         ((ContextMenuAddable) textInput).addToContextMenu(EditorMenus.getNameMenu(textInput));
         this.getChildren().add(textInput);


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/4323 and probably fixes https://github.com/JabRef/jabref/issues/4294 as well.
The reason for the freezes were the pull-request https://bitbucket.org/controlsfx/controlsfx/pull-requests/710. These changes mess up the layout for some reason. The fix is to inject a DecorationPane ourselves directly from the beginning. Although this fix started as a workaround for this bug in controlsfx, I think, we should keep it permanently for performance reasons.