### PR TITLE
Fix problems with sort order of exports

### DIFF
--- a/src/main/java/org/jabref/gui/SaveOrderConfigDisplay.java
+++ b/src/main/java/org/jabref/gui/SaveOrderConfigDisplay.java
@@ -17,6 +17,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
 import org.jabref.model.metadata.SaveOrderConfig;
+import org.jabref.model.metadata.SaveOrderConfig.SortCriterion;
 
 public class SaveOrderConfigDisplay {
 
@@ -85,12 +86,12 @@ public class SaveOrderConfigDisplay {
 
     public SaveOrderConfig getSaveOrderConfig() {
         SaveOrderConfig saveOrderConfig = new SaveOrderConfig();
-        saveOrderConfig.getSortCriteria().get(0).field = getSelectedItemAsLowerCaseTrim(savePriSort);
-        saveOrderConfig.getSortCriteria().get(0).descending = savePriDesc.isSelected();
-        saveOrderConfig.getSortCriteria().get(1).field = getSelectedItemAsLowerCaseTrim(saveSecSort);
-        saveOrderConfig.getSortCriteria().get(1).descending = saveSecDesc.isSelected();
-        saveOrderConfig.getSortCriteria().get(2).field = getSelectedItemAsLowerCaseTrim(saveTerSort);
-        saveOrderConfig.getSortCriteria().get(2).descending = saveTerDesc.isSelected();
+        SortCriterion primary = new SortCriterion(getSelectedItemAsLowerCaseTrim(savePriSort), savePriDesc.isSelected());
+        saveOrderConfig.getSortCriteria().add(primary);
+        SortCriterion secondary = new SortCriterion(getSelectedItemAsLowerCaseTrim(saveSecSort), saveSecDesc.isSelected());
+        saveOrderConfig.getSortCriteria().add(secondary);
+        SortCriterion tertiary = new SortCriterion(getSelectedItemAsLowerCaseTrim(saveTerSort), saveTerDesc.isSelected());
+        saveOrderConfig.getSortCriteria().add(tertiary);
 
         return saveOrderConfig;
     }

--- a/src/main/java/org/jabref/gui/preferences/ExportSortingPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ExportSortingPrefsTab.java
@@ -6,6 +6,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.Separator;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.shape.Line;
@@ -34,6 +35,11 @@ class ExportSortingPrefsTab extends Pane implements PrefsTab {
         exportInOriginalOrder = new RadioButton(Localization.lang("Export entries in their original order"));
         exportInTableOrder = new RadioButton(Localization.lang("Export in current table sort order"));
         exportInSpecifiedOrder = new RadioButton(Localization.lang("Export entries ordered as specified"));
+
+        final ToggleGroup group = new ToggleGroup();
+        exportInOriginalOrder.setToggleGroup(group);
+        exportInTableOrder.setToggleGroup(group);
+        exportInSpecifiedOrder.setToggleGroup(group);
 
         exportOrderPanel = new SaveOrderConfigDisplay();
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
e83680f18d815ebebc779d239a6eacd8930150fe changed the way the SaveOrderConfig works. These changes caused SaveOrderConfigDisplay to throw IndexOutOfBoundsExceptions when saving the settings. This pull request fixes that issue.
Additionally the RadioButtons allowed the user to select none or multiple order types. This pull request adds them to a ToggleGroup, which prevents these multiselections.

----

- [ ] Change in CHANGELOG.md described
This issue was introduced in this release. Should I still add a changlog entry?
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [X] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
