### PR TITLE
ArXiv fetcher support http url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where files added via the "Attach file" contextmenu of an entry were not made relative. [#4201](https://github.com/JabRef/jabref/issues/4201) and [#4241](https://github.com/JabRef/jabref/issues/4241)
 - We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
 - We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
+- We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [#4367](https://github.com/JabRef/jabref/pull/4367)
 
 
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -263,8 +263,8 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
 
     @Override
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        String cleanedIdentifier = identifier.trim();
-        cleanedIdentifier = identifier.replaceAll(" ", "");
+        String cleanedIdentifier = identifier.replaceAll(" ", "");
+        cleanedIdentifier = ArXivEntry.createIdString(cleanedIdentifier);
 
         return searchForEntryById(cleanedIdentifier).map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.getKeywordSeparator()));
     }
@@ -372,17 +372,18 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
          * Returns the arXiv identifier
          */
         public Optional<String> getIdString() {
+            return urlAbstractPage.map(ArXivEntry::createIdString);
+        }
 
-            return urlAbstractPage.map(abstractUrl -> {
-                Matcher matcher = URL_PATTERN.matcher(abstractUrl);
+        public static String createIdString(String id) {
+
+                Matcher matcher = URL_PATTERN.matcher(id);
                 if (matcher.find()) {
-                    // remove leading http(s)://arxiv.org/abs/ from abstract url to get arXiv ID
-                    return abstractUrl.substring(matcher.group(1).length());
+                    return id.substring(matcher.group(1).length());
                 } else {
-                    return abstractUrl;
+                    return id;
                 }
 
-            });
         }
 
         public Optional<ArXivIdentifier> getId() {

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -376,9 +376,9 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
         }
 
         public static String createIdString(String id) {
-
                 Matcher matcher = URL_PATTERN.matcher(id);
                 if (matcher.find()) {
+                    // Remove leading http(s)://arxiv.org/abs/ from abstract url to get arXiv ID
                     return id.substring(matcher.group(1).length());
                 } else {
                     return id;

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -191,8 +191,24 @@ public class ArXivTest {
 
         assertEquals(ArXivIdentifier.parse("1405.2249v1"), finder.findIdentifier(sliceTheoremPaper));
     }
+
     @Test
     public void searchEmptyId() throws Exception {
         assertEquals(Optional.empty(), finder.performSearchById(""));
+    }
+
+    @Test
+    public void searchWithHttpUrl() throws Exception{
+        assertEquals(Optional.of(sliceTheoremPaper), finder.performSearchById("http://arxiv.org/abs/1405.2249"));
+    }
+
+    @Test
+    public void searchWithHttpsUrl() throws Exception{
+        assertEquals(Optional.of(sliceTheoremPaper), finder.performSearchById("https://arxiv.org/abs/1405.2249"));
+    }
+
+    @Test
+    public void searchWithHttpsUrlNotTrimmed() throws Exception{
+        assertEquals(Optional.of(sliceTheoremPaper), finder.performSearchById("https : // arxiv . org / abs / 1405 . 2249 "));
     }
 }


### PR DESCRIPTION
In this PR I wanted to fix the issue from [koppor#328](https://github.com/koppor/jabref/issues/328). 
I simply used existing code in the same file which just takes the identifier at the end of the URL and perform a search.

For example: _https://arxiv.org/abs/1802.01168_ to _1802.01168_

The error dialog does not appear anymore and a new entry is made.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
