### PR TITLE
Color special column icons in lighter gray on mouse hover

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTable.css
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.css
@@ -14,7 +14,7 @@
 
 .table-row-cell:hover .empty-special-field {
     visibility: visible;
-    /*-fx-fill: -jr-grayed-text;*/
+    -fx-fill: -jr-gray-2;
 }
 
 .rating > .container {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5037600/47001499-e411bf00-d12a-11e8-99fa-ff20751f6c96.png)

Should make it easier to distinguish these icons from the ones that represent values that are already set.