### PR TITLE
Display deprecated fields in misc entry also in optional fields tab

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -25,6 +25,6 @@ public class OptionalFields2Tab extends FieldsEditorTab {
 
     @Override
     protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
-        return entryType.getSecondaryOptionalNotDeprecatedFields();
+        return entryType.getSecondaryOptionalFields();
     }
 }

--- a/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
+++ b/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
@@ -372,7 +372,7 @@ public class BiblatexEntryTypes {
                     FieldName.orFields(FieldName.YEAR, FieldName.DATE));
             addAllOptional(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.LANGUAGE, FieldName.HOWPUBLISHED,
                     FieldName.TYPE, FieldName.VERSION, FieldName.NOTE, FieldName.ORGANIZATION, FieldName.LOCATION,
-                    FieldName.MONTH, FieldName.ADDENDUM, FieldName.PUBSTATE, FieldName.DOI, FieldName.EPRINT,
+                    FieldName.DATE, FieldName.MONTH, FieldName.YEAR, FieldName.ADDENDUM, FieldName.PUBSTATE, FieldName.DOI, FieldName.EPRINT,
                     FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE);
         }
 

--- a/src/main/java/org/jabref/model/entry/EntryType.java
+++ b/src/main/java/org/jabref/model/entry/EntryType.java
@@ -83,12 +83,6 @@ public interface EntryType extends Comparable<EntryType> {
         return deprecatedFields;
     }
 
-    default Set<String> getSecondaryOptionalNotDeprecatedFields() {
-        Set<String> optionalFieldsNotPrimaryOrDeprecated = new LinkedHashSet<>(getSecondaryOptionalFields());
-        optionalFieldsNotPrimaryOrDeprecated.removeAll(getDeprecatedFields());
-        return optionalFieldsNotPrimaryOrDeprecated;
-    }
-
     /**
      * Get list of all optional fields of this entry and their aliases.
      */


### PR DESCRIPTION
Fixes #4388 

The reason for the original code was to fix #3046,  however I couldn't reproduce the issue mentioned there after I removed it. The custom entry types dialog effectively prevents you from adding from the same field twice. 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
