### PR TITLE
Fix EntryType dialog not closed after generate button

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -75,8 +75,8 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         btnGenerate.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> (searching) ? Localization.lang("Searching...") : Localization.lang("Generate")));
         btnGenerate.disableProperty().bind(viewModel.searchingProperty());
 
-        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), value->{
-            if(value) {
+        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), value -> {
+            if (value) {
                 setEntryTypeForReturnAndClose(null);
             }
         });

--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -74,6 +74,13 @@ public class EntryTypeView extends BaseDialog<EntryType> {
 
         btnGenerate.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> (searching) ? Localization.lang("Searching...") : Localization.lang("Generate")));
         btnGenerate.disableProperty().bind(viewModel.searchingProperty());
+
+        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), value->{
+            if(value) {
+                setEntryTypeForReturnAndClose(null);
+            }
+        });
+
     }
 
     private void addEntriesToPane(FlowPane pane, Collection<? extends EntryType> entries) {

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -36,6 +36,7 @@ public class EntryTypeViewModel {
 
     private final JabRefPreferences prefs;
     private final BooleanProperty searchingProperty = new SimpleBooleanProperty();
+    private final BooleanProperty searchSuccesfulProperty = new SimpleBooleanProperty();
     private final ObjectProperty<IdBasedFetcher> selectedItemProperty = new SimpleObjectProperty<>();
     private final ListProperty<IdBasedFetcher> fetchers = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final StringProperty idText = new SimpleStringProperty();
@@ -51,6 +52,10 @@ public class EntryTypeViewModel {
         fetchers.addAll(WebFetchers.getIdBasedFetchers(preferences.getImportFormatPreferences()));
         selectedItemProperty.setValue(getLastSelectedFetcher());
 
+    }
+
+    public BooleanProperty searchSuccesfulProperty() {
+        return searchSuccesfulProperty;
     }
 
     public BooleanProperty searchingProperty() {
@@ -110,6 +115,7 @@ public class EntryTypeViewModel {
     }
 
     public void runFetcherWorker() {
+        searchSuccesfulProperty.set(false);
         fetcherWorker.run();
         fetcherWorker.setOnFailed(event -> {
             Throwable exception = fetcherWorker.getException();
@@ -124,7 +130,9 @@ public class EntryTypeViewModel {
             LOGGER.error(String.format("Exception during fetching when using fetcher '%s' with entry id '%s'.", searchId, fetcher), exception);
 
             searchingProperty.set(false);
+
             fetcherWorker = new FetcherWorker();
+
         });
 
         fetcherWorker.setOnSucceeded(evt -> {
@@ -143,6 +151,7 @@ public class EntryTypeViewModel {
                     new BibtexKeyGenerator(basePanel.getBibDatabaseContext(), prefs.getBibtexKeyPatternPreferences()).generateAndSetKey(bibEntry);
                     basePanel.insertEntry(bibEntry);
                 }
+                searchSuccesfulProperty.set(true);
 
                 // close();
             } else if (StringUtil.isBlank(idText.getValue())) {

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -153,7 +153,6 @@ public class EntryTypeViewModel {
                 }
                 searchSuccesfulProperty.set(true);
 
-                // close();
             } else if (StringUtil.isBlank(idText.getValue())) {
                 dialogService.showWarningDialogAndWait(Localization.lang("Empty search ID"), Localization.lang("The given search ID was empty."));
             }


### PR DESCRIPTION
When generating an entry from an DOI or similar, the entry was inserted, but the dialog not closed.

Followup from the conversion to javafx

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
