### PR TITLE
Fix showing multiple icons for one menu entry - fixes #4384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
 - We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
 - We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [#4367](https://github.com/JabRef/jabref/pull/4367)
-- We fixed an issue where the rank submenus would only show the first star icon [#4384](https://github.com/JabRef/jabref/pull/4384)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where author list parser can't generate bibtex for Chinese author. [#4169](https://github.com/JabRef/jabref/issues/4169)
 - We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
 - We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [#4367](https://github.com/JabRef/jabref/pull/4367)
+- We fixed an issue where the rank submenus would only show the first star icon [#4384](https://github.com/JabRef/jabref/pull/4384)
 
 
 

--- a/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
+++ b/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
@@ -57,7 +57,7 @@ public class InternalMaterialDesignIcon implements JabRefIcon {
     public Node getGraphicNode() {
         GlyphIcons icon = icons.get(0);
 
-        Text text = new Text(icon.unicode());
+        Text text = new Text(unicode);
         text.getStyleClass().add("glyph-icon");
         text.setStyle(String.format("-fx-font-family: %s;", icon.fontFamily()));
 


### PR DESCRIPTION
It currently only applies to the Rank menu; the sub-entries were only showing the first star instead of 5 stars

Since `SpecialFieldMenuAction` has been removed and in `RightClickMenu` the following has been removed, the icons are not set correctly anymore.

```
    public static void populateSpecialFieldMenu(JMenu menu, SpecialField field, JabRefFrame frame) {
        SpecialFieldViewModel viewModel = new SpecialFieldViewModel(field);
        menu.setText(viewModel.getLocalization());
        menu.setIcon(viewModel.getRepresentingIcon());
        for (SpecialFieldValue val : field.getValues()) {
            menu.add(new SpecialFieldMenuAction(new SpecialFieldValueViewModel(val), frame));
        }
    }
```

The new way of working is through `ActionFactory` which uses `setGraphic()` instead:

```
    private static void setGraphic(MenuItem node, Action action) {
        node.graphicProperty().unbind();
        action.getIcon().ifPresent(icon -> node.setGraphic(icon.getGraphicNode()));
    }
```

Since the only composite icons are the ones used for rank, using the full `unicode` field of `Node` instead of only the unicode of the first icon won't affect other Actions.

```
    @Override
    public Node getGraphicNode() {
        GlyphIcons icon = icons.get(0);

        Text text = new Text(icon.unicode()); //Replaced with unicode
        text.getStyleClass().add("glyph-icon");
        text.setStyle(String.format("-fx-font-family: %s;", icon.fontFamily()));

        color.ifPresent(color -> text.setStyle(text.getStyle() + String.format("-fx-fill: %s;", ColorUtil.toRGBCode(color))));
        return text;
    }
```