### PR TITLE
fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 
 ### Fixed
+- We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries [#3112](https://github.com/JabRef/jabref/issues/3112)
 - We fixed an issue where custom exports could not be selected in the 'Export (selected) entries' dialog [#4013](https://github.com/JabRef/jabref/issues/4013)
 - Italic text is now rendered correctly. https://github.com/JabRef/jabref/issues/3356
 - The entry editor no longer gets corrupted after using the source tab. https://github.com/JabRef/jabref/issues/3532 https://github.com/JabRef/jabref/issues/3608 https://github.com/JabRef/jabref/issues/3616

--- a/src/main/java/org/jabref/gui/util/BindingsHelper.java
+++ b/src/main/java/org/jabref/gui/util/BindingsHelper.java
@@ -9,8 +9,6 @@ import java.util.function.Predicate;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.StringBinding;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.BooleanPropertyBase;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.Property;
 import javafx.beans.value.ChangeListener;

--- a/src/main/java/org/jabref/gui/util/BindingsHelper.java
+++ b/src/main/java/org/jabref/gui/util/BindingsHelper.java
@@ -42,7 +42,7 @@ public class BindingsHelper {
     }
 
     public static void includePseudoClassWhen(Node node, PseudoClass pseudoClass, ObservableValue<? extends Boolean> condition) {
-        condition.addListener((obs, oldValue, newValue) -> node.pseudoClassStateChanged(pseudoClass,newValue));
+        condition.addListener((obs, oldValue, newValue) -> node.pseudoClassStateChanged(pseudoClass, newValue));
     }
 
     /**

--- a/src/main/java/org/jabref/gui/util/BindingsHelper.java
+++ b/src/main/java/org/jabref/gui/util/BindingsHelper.java
@@ -44,23 +44,7 @@ public class BindingsHelper {
     }
 
     public static void includePseudoClassWhen(Node node, PseudoClass pseudoClass, ObservableValue<? extends Boolean> condition) {
-        BooleanProperty pseudoClassState = new BooleanPropertyBase(false) {
-            @Override
-            protected void invalidated() {
-                node.pseudoClassStateChanged(pseudoClass, get());
-            }
-
-            @Override
-            public Object getBean() {
-                return node;
-            }
-
-            @Override
-            public String getName() {
-                return pseudoClass.getPseudoClassName();
-            }
-        };
-        pseudoClassState.bind(condition);
+        condition.addListener((obs, oldValue, newValue) -> node.pseudoClassStateChanged(pseudoClass,newValue));
     }
 
     /**


### PR DESCRIPTION
Fixes [#3312](https://github.com/JabRef/jabref/issues/3112)
The cause of this bug is that the local variable "pseudoClassState" is garbaged by java gc. There is no reference to this variable except an weak one from "bind" function.

![peek 2018-10-24 18-21](https://user-images.githubusercontent.com/8992037/47424387-29cd2800-d7ba-11e8-8416-4410aa5a345a.gif)

Note: groups that autonatically created won't highlight at all, for example the _tag_ group in above gif.  I think this shall be another issue.
