### PR TITLE
fix "save" button in preference dialog not response

### DIFF
--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -69,10 +69,10 @@ public class ThemeLoader {
             if (Files.isReadable(path)) {
                 String cssUrl = path.toUri().toString();
                 addAndWatchForChanges(scene, cssUrl, 0);
-            }else{
+            } else {
                 LOGGER.warn(path.toAbsolutePath() + " is not readable");
             }
-        }else{
+        } else {
             addAndWatchForChanges(scene, DEFAULT_PATH_MAIN_CSS, 0);
         }
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -780,6 +780,8 @@ public class JabRefPreferences implements PreferencesService {
                                     + "\\begin{comment}<BR><BR><b>Comment: </b> \\format[HTMLChars]{\\comment} \\end{comment}"
                                     + "</dd>__NEWLINE__<p></p></font>");
 
+        // set default theme
+        defaults.put(JabRefPreferences.FX_THEME, "Base.css");
         setLanguageDependentDefaultValues();
     }
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -51,6 +51,7 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.maintable.ColumnPreferences;
 import org.jabref.gui.maintable.MainTablePreferences;
 import org.jabref.gui.preferences.ImportSettingsTab;
+import org.jabref.gui.util.ThemeLoader;
 import org.jabref.logic.bibtex.FieldContentParserPreferences;
 import org.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
@@ -781,7 +782,7 @@ public class JabRefPreferences implements PreferencesService {
                                     + "</dd>__NEWLINE__<p></p></font>");
 
         // set default theme
-        defaults.put(JabRefPreferences.FX_THEME, "Base.css");
+        defaults.put(JabRefPreferences.FX_THEME, ThemeLoader.DEFAULT_MAIN_CSS);
         setLanguageDependentDefaultValues();
     }
 


### PR DESCRIPTION
I notice there is a dark theme in recent commit. So I tried it, and find out an issue that you can not save preference. "Save" button have no response. The issue starts from _Provide access to dark theme in preferences_ (https://github.com/JabRef/jabref/pull/4372). 

The reason is that default value for key "fxTheme" is not set, thus cause a null exception when access this option. Solution is simple, just to set default value "Base.css" for key "fxTheme" in preference.

Finally, I have to say dark theme is a great job. thanks

