### PR TITLE
Fix generate bibtex key overwrite warning dialog

### DIFF
--- a/src/main/java/org/jabref/gui/actions/GenerateBibtexKeyAction.java
+++ b/src/main/java/org/jabref/gui/actions/GenerateBibtexKeyAction.java
@@ -8,6 +8,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableKeyChange;
 import org.jabref.gui.util.BackgroundTask;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyGenerator;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
@@ -15,7 +16,7 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class GenerateBibtexKeyAction implements BaseAction {
     private final DialogService dialogService;
-    private BasePanel basePanel;
+    private final BasePanel basePanel;
     private List<BibEntry> entries;
     private boolean isCanceled;
 
@@ -44,6 +45,7 @@ public class GenerateBibtexKeyAction implements BaseAction {
                     Localization.lang("Cancel"),
                     Localization.lang("Disable this confirmation dialog"),
                     optOut -> Globals.prefs.putBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY, !optOut));
+
         } else {
             // Always overwrite keys by default
             return true;
@@ -56,7 +58,7 @@ public class GenerateBibtexKeyAction implements BaseAction {
             entries.removeIf(BibEntry::hasCiteKey);
             // if we're going to override some cite keys warn the user about it
         } else if (entries.parallelStream().anyMatch(BibEntry::hasCiteKey)) {
-            boolean overwriteKeys = confirmOverwriteKeys(dialogService);
+            boolean overwriteKeys = DefaultTaskExecutor.runInJavaFXThread(() -> confirmOverwriteKeys(dialogService));
 
             // The user doesn't want to override cite keys
             if (!overwriteKeys) {

--- a/src/main/java/org/jabref/gui/actions/GenerateBibtexKeyAction.java
+++ b/src/main/java/org/jabref/gui/actions/GenerateBibtexKeyAction.java
@@ -14,6 +14,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.JabRefPreferences;
 
 public class GenerateBibtexKeyAction implements BaseAction {
+
     private final DialogService dialogService;
     private final BasePanel basePanel;
     private List<BibEntry> entries;
@@ -29,7 +30,7 @@ public class GenerateBibtexKeyAction implements BaseAction {
 
         if (entries.isEmpty()) {
             dialogService.showWarningDialogAndWait(Localization.lang("Autogenerate BibTeX keys"),
-                    Localization.lang("First select the entries you want keys to be generated for."));
+                                                   Localization.lang("First select the entries you want keys to be generated for."));
             return;
         }
         basePanel.output(formatOutputMessage(Localization.lang("Generating BibTeX key for"), entries.size()));
@@ -38,12 +39,12 @@ public class GenerateBibtexKeyAction implements BaseAction {
     public static boolean confirmOverwriteKeys(DialogService dialogService) {
         if (Globals.prefs.getBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY)) {
             return dialogService.showConfirmationDialogWithOptOutAndWait(
-                    Localization.lang("Overwrite keys"),
-                    Localization.lang("One or more keys will be overwritten. Continue?"),
-                    Localization.lang("Overwrite keys"),
-                    Localization.lang("Cancel"),
-                    Localization.lang("Disable this confirmation dialog"),
-                    optOut -> Globals.prefs.putBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY, !optOut));
+                                                                         Localization.lang("Overwrite keys"),
+                                                                         Localization.lang("One or more keys will be overwritten. Continue?"),
+                                                                         Localization.lang("Overwrite keys"),
+                                                                         Localization.lang("Cancel"),
+                                                                         Localization.lang("Disable this confirmation dialog"),
+                                                                         optOut -> Globals.prefs.putBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY, !optOut));
 
         } else {
             // Always overwrite keys by default
@@ -89,10 +90,9 @@ public class GenerateBibtexKeyAction implements BaseAction {
         basePanel.output(formatOutputMessage(Localization.lang("Generated BibTeX key for"), entries.size()));
     }
 
-
     private String formatOutputMessage(String start, int count) {
         return String.format("%s %d %s.", start, count,
-                (count > 1 ? Localization.lang("entries") : Localization.lang("entry")));
+                             (count > 1 ? Localization.lang("entries") : Localization.lang("entry")));
     }
 
     @Override


### PR DESCRIPTION
Fixes #4417

The problem was that the GenerateBibtexKeyAction is executed using a TaskExecutor and therefore not run on the FX Thread. Unfortunately the exception was swallowed and not reported.


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
