### PR TITLE
Fixed radiobuttons in preference menu (#4409)

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/EntryEditorPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/EntryEditorPrefsTab.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.Separator;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 
@@ -102,18 +103,26 @@ class EntryEditorPrefsTab extends Pane implements PrefsTab {
 
         Label nameFormat = new Label(Localization.lang("Name format used for autocompletion"));
         nameFormat.getStyleClass().add("sectionHeader");
+        final ToggleGroup autocompletionToggleGroup = new ToggleGroup();
         builder.add(nameFormat, 1, 14);
         builder.add(autoCompFF, 1, 15);
         builder.add(autoCompLF,  1, 16);
         builder.add(autoCompBoth,  1, 17);
+        autoCompFF.setToggleGroup(autocompletionToggleGroup);
+        autoCompLF.setToggleGroup(autocompletionToggleGroup);
+        autoCompBoth.setToggleGroup(autocompletionToggleGroup);
         builder.add(new Label(""), 1, 18);
 
         Label treatment = new Label(Localization.lang("Treatment of first names"));
         treatment.getStyleClass().add("sectionHeader");
+        final ToggleGroup treatmentOfFirstNamesToggleGroup = new ToggleGroup();
         builder.add(treatment, 1, 19);
         builder.add(firstNameModeAbbr,  1, 20);
         builder.add(firstNameModeFull, 1, 21);
         builder.add(firstNameModeBoth,  1, 22);
+        firstNameModeAbbr.setToggleGroup(treatmentOfFirstNamesToggleGroup);
+        firstNameModeFull.setToggleGroup(treatmentOfFirstNamesToggleGroup);
+        firstNameModeBoth.setToggleGroup(treatmentOfFirstNamesToggleGroup);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/preferences/ExternalTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTab.java
@@ -13,6 +13,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 
 import org.jabref.Globals;
@@ -69,6 +70,9 @@ class ExternalTab extends JPanel implements PrefsTab {
         browseAdobeAcrobatReader.setOnAction(e -> showAdobeChooser());
 
         GridPane consoleOptionPanel = new GridPane();
+        final ToggleGroup consoleGroup = new ToggleGroup();
+        defaultConsole.setToggleGroup(consoleGroup);
+        executeConsole.setToggleGroup(consoleGroup);
         consoleOptionPanel.add(defaultConsole,  1, 1);
         consoleOptionPanel.add(executeConsole,  1, 2);
         consoleOptionPanel.add(consoleCommand,  2, 2);
@@ -76,13 +80,16 @@ class ExternalTab extends JPanel implements PrefsTab {
         consoleOptionPanel.add(commandDescription,  2, 3);
 
         GridPane pdfOptionPanel = new GridPane();
+        final ToggleGroup pdfReaderGroup = new ToggleGroup();
         pdfOptionPanel.add(adobeAcrobatReader,  1, 1);
         pdfOptionPanel.add(adobeAcrobatReaderPath,  2, 1);
+        adobeAcrobatReader.setToggleGroup(pdfReaderGroup);
         pdfOptionPanel.add(browseAdobeAcrobatReader,  3, 1);
 
         if (OS.WINDOWS) {
             browseSumatraReader.setOnAction(e -> showSumatraChooser());
             pdfOptionPanel.add(sumatraReader,  1, 2);
+            sumatraReader.setToggleGroup(pdfReaderGroup);
             pdfOptionPanel.add(sumatraReaderPath,  2, 2);
             pdfOptionPanel.add(browseSumatraReader,  3, 2);
         }

--- a/src/main/java/org/jabref/gui/preferences/FileTab.java
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.java
@@ -12,6 +12,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 
@@ -95,11 +96,13 @@ class FileTab extends Pane implements PrefsTab {
         builder.add(backup, 1, 3);
         Label label = new Label(Localization.lang("Do not wrap the following fields when saving") + ":");
         builder.add(label, 1, 4);
+        final ToggleGroup resolveGroup = new ToggleGroup();
         builder.add(nonWrappableFields, 2, 4);
         builder.add(resolveStringsStandard,  1, 5);
         builder.add(resolveStringsAll, 1, 6);
         builder.add(doNotResolveStringsFor, 2, 6);
-
+        resolveStringsStandard.setToggleGroup(resolveGroup);
+        resolveStringsAll.setToggleGroup(resolveGroup);
         Label newlineSeparatorLabel = new Label(Localization.lang("Newline separator") + ":");
         builder.add(newlineSeparatorLabel, 1, 7);
         builder.add(newlineSeparator, 2, 7);
@@ -125,10 +128,14 @@ class FileTab extends Pane implements PrefsTab {
         });
         builder.add(browse, 3, 12);
         builder.add(bibLocAsPrimaryDir, 1, 13);
+        final ToggleGroup autolinkGroup = new ToggleGroup();
         builder.add(matchStartsWithKey,  1, 14);
         builder.add(matchExactKeyOnly,  1, 15);
         builder.add(useRegExpComboBox, 1, 16);
         builder.add(regExpTextField, 2, 16);
+        matchStartsWithKey.setToggleGroup(autolinkGroup);
+        matchExactKeyOnly.setToggleGroup(autolinkGroup);
+        useRegExpComboBox.setToggleGroup(autolinkGroup);
 
         Button help = new Button("?");
         help.setOnAction(event -> new HelpAction(Localization.lang("Help on regular expression search"),

--- a/src/main/java/org/jabref/gui/preferences/GroupsPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/GroupsPrefsTab.java
@@ -7,6 +7,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 
@@ -45,8 +46,11 @@ class GroupsPrefsTab extends Pane implements PrefsTab {
         builder.add(view, 1, 1);
         builder.add(hideNonHits, 2, 2);
         builder.add(grayOut, 2, 3);
+        final ToggleGroup selectionModeGroup = new ToggleGroup();
         builder.add(multiSelectionModeIntersection, 2, 4);
         builder.add(multiSelectionModeUnion, 2, 5);
+        multiSelectionModeIntersection.setToggleGroup(selectionModeGroup);
+        multiSelectionModeUnion.setToggleGroup(selectionModeGroup);
         builder.add(autoAssignGroup, 2, 6);
         builder.add(new Label(""), 1, 7);
 

--- a/src/main/java/org/jabref/gui/preferences/ImportSettingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ImportSettingsTab.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.Separator;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 
@@ -60,11 +61,16 @@ public class ImportSettingsTab extends Pane implements PrefsTab {
         Label defaultImportStyle = new Label(Localization.lang("Default import style for drag and drop of PDFs"));
         defaultImportStyle.getStyleClass().add("sectionHeader");
         builder.add(defaultImportStyle, 1, 1);
+        final ToggleGroup defaultImportStyleDragDropPdfs = new ToggleGroup();
         builder.add(new Separator(), 2, 1);
         builder.add(radioButtonNoMeta, 2, 2);
         builder.add(radioButtonXmp, 2, 3);
         builder.add(radioButtonPDFcontent, 2, 4);
         builder.add(radioButtononlyAttachPDF, 2, 5);
+        radioButtonNoMeta.setToggleGroup(defaultImportStyleDragDropPdfs);
+        radioButtonXmp.setToggleGroup(defaultImportStyleDragDropPdfs);
+        radioButtonPDFcontent.setToggleGroup(defaultImportStyleDragDropPdfs);
+        radioButtononlyAttachPDF.setToggleGroup(defaultImportStyleDragDropPdfs);
         builder.add(useDefaultPDFImportStyle, 2, 6);
         builder.add(new Label(""), 1, 7);
 

--- a/src/main/java/org/jabref/gui/preferences/TableColumnsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/TableColumnsTab.java
@@ -24,6 +24,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.layout.BorderPane;
@@ -284,14 +285,20 @@ class TableColumnsTab extends Pane implements PrefsTab {
         specialTableColumnsBuilder.add(priorityColumn, 1, 5);
         specialTableColumnsBuilder.add(printedColumn, 1, 6);
         specialTableColumnsBuilder.add(readStatusColumn, 1, 7);
+        final ToggleGroup syncGroup = new ToggleGroup();
         specialTableColumnsBuilder.add(syncKeywords, 1, 8);
         specialTableColumnsBuilder.add(writeSpecialFields, 1, 9);
+        syncKeywords.setToggleGroup(syncGroup);
+        writeSpecialFields.setToggleGroup(syncGroup);
         specialTableColumnsBuilder.add(helpButton, 1, 10);
 
         specialTableColumnsBuilder.add(fileColumn, 2, 1);
         specialTableColumnsBuilder.add(urlColumn, 2, 2);
+        final ToggleGroup preferUrlOrDoi = new ToggleGroup();
         specialTableColumnsBuilder.add(preferUrl, 2 ,3);
         specialTableColumnsBuilder.add(preferDoi, 2, 4);
+        preferUrl.setToggleGroup(preferUrlOrDoi);
+        preferDoi.setToggleGroup(preferUrlOrDoi);
         specialTableColumnsBuilder.add(arxivColumn, 2, 5);
 
         specialTableColumnsBuilder.add(extraFileColumns,2, 6);

--- a/src/main/java/org/jabref/gui/preferences/TablePrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/TablePrefsTab.java
@@ -4,6 +4,7 @@ import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 
@@ -54,26 +55,33 @@ class TablePrefsTab extends Pane implements PrefsTab {
         Label formatOfAuthor = new Label(Localization.lang("Format of author and editor names"));
         formatOfAuthor.getStyleClass().add("sectionHeader");
         builder.add(formatOfAuthor, 1, 1);
+        final ToggleGroup formatNamesToggleGroup = new ToggleGroup();
+        final ToggleGroup nameAbbrevToggleGroup = new ToggleGroup();
         builder.add(namesAsIs, 1, 2);
+        namesAsIs.setToggleGroup(formatNamesToggleGroup);
         builder.add(noAbbrNames, 2, 2);
+        noAbbrNames.setToggleGroup(nameAbbrevToggleGroup);
         builder.add(namesFf, 1, 3);
+        namesFf.setToggleGroup(formatNamesToggleGroup);
         builder.add(abbrNames, 2, 3);
+        abbrNames.setToggleGroup(nameAbbrevToggleGroup);
         builder.add(namesFl, 1, 4);
+        namesFl.setToggleGroup(formatNamesToggleGroup);
         builder.add(lastNamesOnly, 2, 4);
+        lastNamesOnly.setToggleGroup(nameAbbrevToggleGroup);
         builder.add(namesNatbib, 1, 5);
-
+        namesNatbib.setToggleGroup(formatNamesToggleGroup);
         Label label1 = new Label("");
         builder.add(label1, 1, 6);
-
         Label general = new Label(Localization.lang("General"));
         general.getStyleClass().add("sectionHeader");
         builder.add(general, 1, 7);
         builder.add(autoResizeMode, 1, 8);
-        namesNatbib.setOnAction(e -> {
-            abbrNames.setDisable(namesNatbib.isSelected());
-            lastNamesOnly.setDisable(namesNatbib.isSelected());
-            noAbbrNames.setDisable(namesNatbib.isSelected());
-        });
+
+        abbrNames.disableProperty().bind(namesNatbib.selectedProperty());
+        lastNamesOnly.disableProperty().bind(namesNatbib.selectedProperty());
+        noAbbrNames.disableProperty().bind(namesNatbib.selectedProperty());
+
     }
 
     @Override
@@ -101,10 +109,6 @@ class TablePrefsTab extends Pane implements PrefsTab {
         } else {
             noAbbrNames.setSelected(true);
         }
-
-        abbrNames.setDisable(namesNatbib.isSelected());
-        lastNamesOnly.setDisable(namesNatbib.isSelected());
-        noAbbrNames.setDisable(namesNatbib.isSelected());
 
     }
 


### PR DESCRIPTION
Previously multiple radiobuttons in preference menu belonging to the same group were selectable simultaneously. This issue is now fixed on multiple occasions, allowing only one option per group to be selected at the same time. Issue: [#4409](https://github.com/JabRef/jabref/issues/4409)