### PR TITLE
fix groups drag and drop

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -198,13 +198,13 @@ public class GroupTreeView {
                 List<String> groupsToMove = new ArrayList<>();
                 for (TreeItem<GroupNodeViewModel> selectedItem : treeTable.getSelectionModel().getSelectedItems()) {
                     if ((selectedItem != null) && (selectedItem.getValue() != null)) {
-                        // Display the group when dragging
                         groupsToMove.add(selectedItem.getValue().getPath());
                     }
                 }
 
                 // Put the group nodes as content
                 Dragboard dragboard = treeTable.startDragAndDrop(TransferMode.MOVE);
+                // Display the group when dragging
                 dragboard.setDragView(row.snapshot(null, null));
                 ClipboardContent content = new ClipboardContent();
                 content.put(DragAndDropDataFormats.GROUP, groupsToMove);

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -195,20 +195,21 @@ public class GroupTreeView {
 
             // Drag and drop support
             row.setOnDragDetected(event -> {
-                TreeItem<GroupNodeViewModel> selectedItem = treeTable.getSelectionModel().getSelectedItem();
-                if ((selectedItem != null) && (selectedItem.getValue() != null)) {
-                    Dragboard dragboard = treeTable.startDragAndDrop(TransferMode.MOVE);
-
-                    // Display the group when dragging
-                    dragboard.setDragView(row.snapshot(null, null));
-
-                    // Put the group node as content
-                    ClipboardContent content = new ClipboardContent();
-                    content.put(DragAndDropDataFormats.GROUP, selectedItem.getValue().getPath());
-                    dragboard.setContent(content);
-
-                    event.consume();
+                List<String> groupsToMove = new ArrayList<>();
+                for (TreeItem<GroupNodeViewModel> selectedItem : treeTable.getSelectionModel().getSelectedItems()) {
+                    if ((selectedItem != null) && (selectedItem.getValue() != null)) {
+                        // Display the group when dragging
+                        groupsToMove.add(selectedItem.getValue().getPath());
+                    }
                 }
+
+                // Put the group nodes as content
+                Dragboard dragboard = treeTable.startDragAndDrop(TransferMode.MOVE);
+                dragboard.setDragView(row.snapshot(null, null));
+                ClipboardContent content = new ClipboardContent();
+                content.put(DragAndDropDataFormats.GROUP, groupsToMove);
+                dragboard.setContent(content);
+                event.consume();
             });
             row.setOnDragOver(event -> {
                 Dragboard dragboard = event.getDragboard();
@@ -240,13 +241,16 @@ public class GroupTreeView {
             row.setOnDragDropped(event -> {
                 Dragboard dragboard = event.getDragboard();
                 boolean success = false;
+
                 if (dragboard.hasContent(DragAndDropDataFormats.GROUP)) {
-                    String pathToSource = (String) dragboard.getContent(DragAndDropDataFormats.GROUP);
-                    Optional<GroupNodeViewModel> source = viewModel.rootGroupProperty().get()
-                            .getChildByPath(pathToSource);
-                    if (source.isPresent()) {
-                        source.get().draggedOn(row.getItem(), getDroppingMouseLocation(row, event));
-                        success = true;
+                    List<String> pathToSources = (List<String>) dragboard.getContent(DragAndDropDataFormats.GROUP);
+                    for (String pathToSource : pathToSources) {
+                        Optional<GroupNodeViewModel> source = viewModel.rootGroupProperty().get()
+                                .getChildByPath(pathToSource);
+                        if (source.isPresent()) {
+                            source.get().draggedOn(row.getItem(), getDroppingMouseLocation(row, event));
+                            success = true;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fix a bug with drag and drop groups.
Steps to reproduce:
1) select more than groups
2) Move it to another group via drag and drop
Groups not moved into another group if you use drag and drop