### PR TITLE
Set auto-update checkbox enable/disable when reading preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
 - We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [koppor#328](https://github.com/koppor/jabref/issues/328)
 - We fixed an issue where only one PDF file could be imported [#4422](https://github.com/JabRef/jabref/issues/4422)
+- We fixed an issue where the preference checkbox for automatically updating the timestamp wasn't properly enabled [#4427](https://github.com/JabRef/jabref/issues/4427)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the list of XMP Exclusion fields in the preferences was not be saved [#4072](https://github.com/JabRef/jabref/issues/4072)
 - We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [koppor#328](https://github.com/koppor/jabref/issues/328)
 - We fixed an issue where only one PDF file could be imported [#4422](https://github.com/JabRef/jabref/issues/4422)
-- We fixed an issue where the preference checkbox for automatically updating the timestamp wasn't properly enabled [#4427](https://github.com/JabRef/jabref/issues/4427)
 
 
 

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.java
@@ -4,6 +4,7 @@ import java.nio.charset.Charset;
 import java.time.format.DateTimeFormatter;
 
 import javafx.collections.FXCollections;
+import javafx.event.ActionEvent;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -138,6 +139,7 @@ class GeneralTab extends Pane implements PrefsTab {
         useOwner.setSelected(prefs.getBoolean(JabRefPreferences.USE_OWNER));
         overwriteOwner.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER));
         useTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP));
+        useTimeStamp.getOnAction().handle(new ActionEvent()); // pretend we just clicked on the checkbox so it updates the UI
         overwriteTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP));
         updateTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.UPDATE_TIMESTAMP));
         updateTimeStamp.setSelected(useTimeStamp.isSelected());
@@ -182,9 +184,9 @@ class GeneralTab extends Pane implements PrefsTab {
         // Update name of the time stamp field based on preferences
         InternalBibtexFields.updateTimeStampField(prefs.get(JabRefPreferences.TIME_STAMP_FIELD));
         prefs.setDefaultEncoding(encodings.getValue());
-        prefs.putBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE, biblatexMode.getValue().equals(BibDatabaseMode.BIBLATEX));
+        prefs.putBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE, biblatexMode.getValue() == BibDatabaseMode.BIBLATEX);
 
-        if (!languageSelection.getValue().equals(prefs.getLanguage())) {
+        if (languageSelection.getValue() != prefs.getLanguage()) {
             prefs.setLanguage(languageSelection.getValue());
             Localization.setLanguage(languageSelection.getValue());
 

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.java
@@ -26,6 +26,8 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.InternalBibtexFields;
 import org.jabref.preferences.JabRefPreferences;
 
+import static javafx.beans.binding.Bindings.not;
+
 class GeneralTab extends Pane implements PrefsTab {
 
     private final CheckBox useOwner;
@@ -59,10 +61,7 @@ class GeneralTab extends Pane implements PrefsTab {
         updateTimeStamp = new CheckBox(Localization.lang("Update timestamp on modification"));
         useTimeStamp = new CheckBox(Localization.lang("Mark new entries with addition date") + ". "
                 + Localization.lang("Date format") + ':');
-        if (!useTimeStamp.isSelected()) {
-            updateTimeStamp.setDisable(true);
-        }
-        useTimeStamp.setOnAction(e->setDisableUpdateTimeStamp());
+        updateTimeStamp.disableProperty().bind(not(useTimeStamp.selectedProperty()));
         overwriteOwner = new CheckBox(Localization.lang("Overwrite"));
         overwriteTimeStamp = new CheckBox(Localization.lang("If a pasted or imported entry already has the field set, overwrite."));
         enforceLegalKeys = new CheckBox(Localization.lang("Enforce legal characters in BibTeX keys"));
@@ -133,16 +132,11 @@ class GeneralTab extends Pane implements PrefsTab {
         return builder;
     }
 
-    private void setDisableUpdateTimeStamp() {
-        updateTimeStamp.setDisable(!useTimeStamp.isSelected());
-    }
-
     @Override
     public void setValues() {
         useOwner.setSelected(prefs.getBoolean(JabRefPreferences.USE_OWNER));
         overwriteOwner.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER));
         useTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP));
-        setDisableUpdateTimeStamp();
         overwriteTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP));
         updateTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.UPDATE_TIMESTAMP));
         updateTimeStamp.setSelected(useTimeStamp.isSelected());

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.java
@@ -4,7 +4,6 @@ import java.nio.charset.Charset;
 import java.time.format.DateTimeFormatter;
 
 import javafx.collections.FXCollections;
-import javafx.event.ActionEvent;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -63,7 +62,7 @@ class GeneralTab extends Pane implements PrefsTab {
         if (!useTimeStamp.isSelected()) {
             updateTimeStamp.setDisable(true);
         }
-        useTimeStamp.setOnAction(e->updateTimeStamp.setDisable(!useTimeStamp.isSelected()));
+        useTimeStamp.setOnAction(e->setDisableUpdateTimeStamp());
         overwriteOwner = new CheckBox(Localization.lang("Overwrite"));
         overwriteTimeStamp = new CheckBox(Localization.lang("If a pasted or imported entry already has the field set, overwrite."));
         enforceLegalKeys = new CheckBox(Localization.lang("Enforce legal characters in BibTeX keys"));
@@ -134,12 +133,16 @@ class GeneralTab extends Pane implements PrefsTab {
         return builder;
     }
 
+    private void setDisableUpdateTimeStamp() {
+        updateTimeStamp.setDisable(!useTimeStamp.isSelected());
+    }
+
     @Override
     public void setValues() {
         useOwner.setSelected(prefs.getBoolean(JabRefPreferences.USE_OWNER));
         overwriteOwner.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER));
         useTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP));
-        useTimeStamp.getOnAction().handle(new ActionEvent()); // pretend we just clicked on the checkbox so it updates the UI
+        setDisableUpdateTimeStamp();
         overwriteTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP));
         updateTimeStamp.setSelected(prefs.getBoolean(JabRefPreferences.UPDATE_TIMESTAMP));
         updateTimeStamp.setSelected(useTimeStamp.isSelected());


### PR DESCRIPTION
This patch addresses issue [#4427](https://github.com/JabRef/jabref/issues/4427). Added a call to the existing event handler (which enables/disables the checkbox in response to user clicks) when we set the checkbox value from the preferences.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes) _N/A_
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?) _N/A_
