### PR TITLE
4467 - fix save button

### DIFF
--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -163,7 +163,14 @@ public class SaveDatabaseAction {
             panel.frame().output(Localization.lang("Saving library") + "...");
             panel.setSaving(true);
             return doSave();
+        } else {
+            Optional<Path> savePath = getSavePath();
+            if (savePath.isPresent()) {
+                saveAs(savePath.get());
+                return true;
+            }
         }
+
         return false;
     }
 


### PR DESCRIPTION
fix issue: #4467 
When you click `save` and there is no database selected. That will act as `save as`.
