### PR TITLE
Improve page checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the custom file column were sorted incorrectly. https://github.com/JabRef/jabref/issues/3119
 - We fixed an issues where the entry losses focus when a field is edited and at the same time used for sorting. https://github.com/JabRef/jabref/issues/3373
 - We fixed an issue where the menu on Mac OS was not displayed in the usual Mac-specific way. https://github.com/JabRef/jabref/issues/3146
+- We improved the integrity check for page numbers. [#4113](https://github.com/JabRef/jabref/issues/4113) and [feature request in the forum](http://discourse.jabref.org/t/pages-field-allow-use-of-en-dash/1199)
 - We fixed an issue where the order of fields in customized entry types was not saved correctly. [#4033](http://github.com/JabRef/jabref/issues/4033)
 - We fixed an issue where the groups tree of the last database was still shown even after the database was already closed.
 - We fixed an issue where the "Open file dialog" may disappear behind other windows. https://github.com/JabRef/jabref/issues/3410

--- a/src/main/java/org/jabref/logic/integrity/PagesChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/PagesChecker.java
@@ -10,27 +10,29 @@ import org.jabref.model.strings.StringUtil;
 
 public class PagesChecker implements ValueChecker {
 
-    private static final String PAGES_EXP_BIBTEX = "" + "\\A" // begin String
-            + "\\d+" // number
-            + "(?:" // non-capture group
-            + "\\+|\\-{2}\\d+" // + or --number (range)
-            + ")?" // optional group
-            + "(?:" // non-capture group
-            + "," // comma
-            + "\\d+(?:\\+|\\-{2}\\d+)?" // repeat former pattern
-            + ")*" // repeat group 0,*
-            + "\\z"; // end String
+    private static final String PAGES_EXP_BIBTEX = ""
+            + "\\A"                 // begin String
+            + "("
+            + "[A-Za-z]?\\d*"     // optional prefix and number
+            + "("
+            + "\\+|-{2}"    // separator
+            + "[A-Za-z]?\\d*" // optional prefix and number
+            + ")?"
+            + ",?"                // page range separation
+            + ")*"
+            + "\\z";                // end String
 
-    private static final String PAGES_EXP_BIBLATEX = "" + "\\A" // begin String
-            + "\\d+" // number
-            + "(?:" // non-capture group
-            + "\\+|\\-{1,2}\\d+" // + or --number (range)
-            + ")?" // optional group
-            + "(?:" // non-capture group
-            + "," // comma
-            + "\\d+(?:\\+|\\-{1,2}\\d+)?" // repeat former pattern
-            + ")*" // repeat group 0,*
-            + "\\z"; // end String
+    private static final String PAGES_EXP_BIBLATEX = ""
+            + "\\A"                 // begin String
+            + "("
+            + "[A-Za-z]?\\d*"     // optional prefix and number
+            + "("
+            + "\\+|-{1,2}|\u2013" // separator
+            + "[A-Za-z]?\\d*" // optional prefix and number
+            + ")?"
+            + ",?"                // page range separation
+            + ")*"
+            + "\\z";                // end String
 
     private final Predicate<String> isValidPageNumber;
 

--- a/src/test/java/org/jabref/logic/integrity/PagesCheckerBibLatexTest.java
+++ b/src/test/java/org/jabref/logic/integrity/PagesCheckerBibLatexTest.java
@@ -1,0 +1,73 @@
+package org.jabref.logic.integrity;
+
+import java.util.Optional;
+
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.database.BibDatabaseMode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PagesCheckerBibLatexTest {
+
+    private PagesChecker checker;
+
+    @BeforeEach
+    void setUp() {
+        BibDatabaseContext database = new BibDatabaseContext();
+        database.setMode(BibDatabaseMode.BIBLATEX);
+        checker = new PagesChecker(database);
+    }
+
+    @Test
+    void acceptsSinglePage() {
+        assertEquals(Optional.empty(), checker.checkValue("12"));
+    }
+
+    @Test
+    void acceptsSinglePageRange() {
+        assertEquals(Optional.empty(), checker.checkValue("12-15"));
+    }
+
+    @Test
+    void acceptsSinglePageRangeWithDoubleDashes() {
+        assertEquals(Optional.empty(), checker.checkValue("12--15"));
+    }
+
+    @Test
+    void acceptsSinglePageRangeWithEnDashes() {
+        assertEquals(Optional.empty(), checker.checkValue("12–15"));
+    }
+
+    @Test
+    void acceptsSinglePageRangeWithPagePrefix() {
+        assertEquals(Optional.empty(), checker.checkValue("R795--R804"));
+    }
+
+    @Test
+    void acceptsMultiplePageRange() {
+        assertEquals(Optional.empty(), checker.checkValue("12-15,18-29"));
+    }
+
+    @Test
+    void acceptsOpenEndPageRange() {
+        assertEquals(Optional.empty(), checker.checkValue("-15"));
+    }
+
+    @Test
+    void acceptsOpenStartPageRange() {
+        assertEquals(Optional.empty(), checker.checkValue("12-"));
+    }
+
+    @Test
+    void complainsAboutPPrefix() {
+        assertEquals(Optional.of("should contain a valid page number range"), checker.checkValue("p. 12"));
+    }
+
+    @Test
+    void complainsAboutPPPrefix() {
+        assertEquals(Optional.of("should contain a valid page number range"), checker.checkValue("pp. 12-15"));
+    }
+}


### PR DESCRIPTION
Superseeds the PR #4188 and fixes #4113. Now page ranges like `R2-R5` are considered to be correct.