### PR TITLE
Fix button sizes in issue #4437

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/TableColumnsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/TableColumnsTab.java
@@ -314,10 +314,10 @@ class TableColumnsTab extends Pane implements PrefsTab {
         builder.add(tabPanel, 1, 5);
 
         Button buttonWidth = new Button("Update to current column widths");
-        buttonWidth.setPrefSize(200, 30);
+        buttonWidth.setPrefSize(300, 30);
         buttonWidth.setOnAction(e->new UpdateWidthsAction());
         Button buttonOrder = new Button("Update to current column order");
-        buttonOrder.setPrefSize(200, 30);
+        buttonOrder.setPrefSize(300, 30);
         buttonOrder.setOnAction(e->new UpdateOrderAction());
         builder.add(buttonWidth, 1, 6);
         builder.add(buttonOrder, 1, 7);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 

[#4437]https://github.com/JabRef/jabref/issues/4437

Changed the sizes of buttons "Update to current column widths" and "Update to current column order"

![screen shot 2018-12-05 at 11 23 39 pm](https://user-images.githubusercontent.com/33430757/49594266-b549e500-f932-11e8-9129-3ef62c0beac6.png)

There is still more to fix in this issue:
The Field name is not editable
The value in Field name is not identical with table header

     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ X ] Change in CHANGELOG.md described
- [ X ] Tests created for changes
- [ X ] Manually tested changed features in running JabRef
- [ X ] Screenshots added in PR description (for bigger UI changes)
- [ X ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ X ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
