### PR TITLE
Sorting of read-status isn't working as expected #4521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the ArXiv Fetcher did not support HTTP URLs [koppor#328](https://github.com/koppor/jabref/issues/328)
 - We fixed an issue where only one PDF file could be imported [#4422](https://github.com/JabRef/jabref/issues/4422)
 - We fixed an issue where "Move to group" would always move the first entry in the library and not the selected [#4414](https://github.com/JabRef/jabref/issues/4414)
-
+- We fixed an issue to support sorting using Read Status(Sorting of read-status isn't working as expected #4521)
 
 
 

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -35,6 +35,7 @@ import org.jabref.gui.specialfields.SpecialFieldViewModel;
 import org.jabref.gui.util.OptionalValueTableCellFactory;
 import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.gui.util.comparator.RankingFieldComparator;
+import org.jabref.gui.util.comparator.ReadStatusFieldComparator;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -199,6 +200,11 @@ class MainTableColumnFactory {
 
         if (specialField == SpecialField.RANKING) {
             column.setComparator(new RankingFieldComparator());
+        }
+
+        // Added comparator for Read Status
+        if (specialField == SpecialField.READ_STATUS) {
+            column.setComparator(new ReadStatusFieldComparator());
         }
 
         column.setSortable(true);

--- a/src/main/java/org/jabref/gui/util/comparator/ReadStatusFieldComparator.java
+++ b/src/main/java/org/jabref/gui/util/comparator/ReadStatusFieldComparator.java
@@ -1,0 +1,32 @@
+package org.jabref.gui.util.comparator;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.jabref.gui.specialfields.SpecialFieldValueViewModel;
+
+public class ReadStatusFieldComparator implements Comparator<Optional<SpecialFieldValueViewModel>> {
+
+    @Override
+    public int compare(Optional<SpecialFieldValueViewModel> val1, Optional<SpecialFieldValueViewModel> val2) {
+        if (val1.isPresent()) {
+            if (val2.isPresent()) {
+                int compareToRes = val1.get().getValue().compareTo(val2.get().getValue());
+                if (compareToRes == 0) {
+                    return 0;
+                } else {
+                    return compareToRes * 1;
+                }
+            } else {
+                return -1;
+            }
+        } else {
+            if (val2.isPresent()) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
*Created Comparator for Read Status by adding new class
*Added above comparator to read status column

Signed-off-by: Aman Jain <aman.jain01@sap.com>
Screenshots : 
 
Ascending Order
![image](https://user-images.githubusercontent.com/8446821/49955311-83371500-ff28-11e8-8069-a63c5a61a930.png)
Descending order
![image](https://user-images.githubusercontent.com/8446821/49955348-9944d580-ff28-11e8-9055-8d5671672803.png)


- [ X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ X] Manually tested changed features in running JabRef
- [ X] Screenshots added in PR description (for bigger UI changes)
- [ X] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
