### PR TITLE
improve styling of preferences side menu

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.css
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.css
@@ -1,5 +1,7 @@
 #sideMenu {
     -fx-background-color: -jr-white;
+    -fx-border-color: -fx-outer-border;
+    -fx-border-width: 1;
 }
 
 #sideMenu > .virtual-flow > .clipped-container > .sheet > .list-cell {

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
@@ -116,20 +116,21 @@ public class PreferencesDialog extends BaseDialog<Void> {
 
         VBox buttonContainer = new VBox();
         buttonContainer.setAlignment(Pos.BOTTOM_LEFT);
+        buttonContainer.setSpacing(3.0);
         Button importPreferences = new Button(Localization.lang("Import preferences"));
         importPreferences.setTooltip(new Tooltip(Localization.lang("Import preferences from file")));
         importPreferences.setOnAction(e -> importPreferences());
-        importPreferences.getStyleClass().add("text-button");
+        importPreferences.setMaxWidth(Double.MAX_VALUE);
         Button exportPreferences = new Button(Localization.lang("Export preferences"));
         exportPreferences.setTooltip(new Tooltip(Localization.lang("Export preferences to file")));
         exportPreferences.setOnAction(e -> exportPreferences());
-        exportPreferences.getStyleClass().add("text-button");
+        exportPreferences.setMaxWidth(Double.MAX_VALUE);
         Button showPreferences = new Button(Localization.lang("Show preferences"));
         showPreferences.setOnAction(e -> new PreferencesFilterDialog(new JabRefPreferencesFilter(prefs)).setVisible(true));
-        showPreferences.getStyleClass().add("text-button");
+        showPreferences.setMaxWidth(Double.MAX_VALUE);
         Button resetPreferences = new Button(Localization.lang("Reset preferences"));
         resetPreferences.setOnAction(e -> resetPreferences());
-        resetPreferences.getStyleClass().add("text-button");
+        resetPreferences.setMaxWidth(Double.MAX_VALUE);
         buttonContainer.getChildren().addAll(
                 importPreferences,
                 exportPreferences,
@@ -138,6 +139,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
         );
 
         VBox spacer = new VBox();
+        spacer.setPrefHeight(10.0);
         VBox.setVgrow(tabsList, Priority.ALWAYS);
         VBox.setVgrow(spacer, Priority.SOMETIMES);
         vBox.getChildren().addAll(


### PR DESCRIPTION
 :christmas_tree: As promised: A small christmas PR improving the styling of the new Java FX preferences dialog.  :christmas_tree:

Before:
![before](https://user-images.githubusercontent.com/676652/50517516-f2784180-0ab0-11e9-846c-c607e456cdc4.png)

After:
![after](https://user-images.githubusercontent.com/676652/50517563-2ce1de80-0ab1-11e9-9a49-4b68cc1b7ed4.png)



----

- [ ] Change in CHANGELOG.md described - not necessary I think?
- ~~[ ] Tests created for changes~~
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
