### PR TITLE
Delete the Deprecated BibEntry Constructor

### DIFF
--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -83,17 +83,6 @@ public class BibEntry implements Cloneable {
     }
 
     /**
-     * Constructs a new BibEntry with the given type
-     *
-     * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.
-     * @deprecated use {{@link #BibEntry(EntryType)}} instead
-     */
-    @Deprecated
-    public BibEntry(String type) {
-        this(IdGenerator.next(), type);
-    }
-
-    /**
      * Constructs a new BibEntry with the given ID and given type
      *
      * @param id   The ID to be used


### PR DESCRIPTION
This is the followup for https://github.com/JabRef/jabref/pull/4554, which removed the usage of this constructor. This PR also deleted this code.