### PR TITLE
Add a variable to track the change in preview style

### DIFF
--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -61,6 +61,8 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
     private final DialogService dialogService;
     private final KeyBindingRepository keyBindingRepository;
 
+    private String previewStyle;
+    private final String defaultPreviewStyle = "Preview";
     private Optional<BasePanel> basePanel = Optional.empty();
 
     private boolean fixedLayout;
@@ -220,21 +222,26 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
         }
 
         String style = previewPreferences.getCurrentPreviewStyle();
-        if (CitationStyle.isCitationStyleFile(style)) {
-            if (basePanel.isPresent()) {
+        if (previewStyle == null) {
+            previewStyle = style;
+        }
+        if (basePanel.isPresent() && !previewStyle.equals(style)) {
+            if (CitationStyle.isCitationStyleFile(style)) {
                 layout = Optional.empty();
                 CitationStyle.createCitationStyleFromFile(style)
-                             .ifPresent(citationStyle -> {
-                                 basePanel.get().getCitationStyleCache().setCitationStyle(citationStyle);
-                                 if (!init) {
-                                     basePanel.get().output(Localization.lang("Preview style changed to: %0", citationStyle.getTitle()));
-                                 }
-                             });
-            }
-        } else {
-            updatePreviewLayout(previewPreferences.getPreviewStyle(), previewPreferences.getLayoutFormatterPreferences());
-            if (!init) {
-                basePanel.ifPresent(panel -> panel.output(Localization.lang("Preview style changed to: %0", Localization.lang("Preview"))));
+                        .ifPresent(citationStyle -> {
+                            basePanel.get().getCitationStyleCache().setCitationStyle(citationStyle);
+                            if (!init) {
+                                basePanel.get().output(Localization.lang("Preview style changed to: %0", citationStyle.getTitle()));
+                            }
+                        });
+                previewStyle = style;
+            } else {
+                previewStyle = defaultPreviewStyle;
+                updatePreviewLayout(previewPreferences.getPreviewStyle(), previewPreferences.getLayoutFormatterPreferences());
+                if (!init) {
+                    basePanel.get().output(Localization.lang("Preview style changed to: %0", Localization.lang("Preview")));
+                }
             }
         }
 


### PR DESCRIPTION
Proposed solution for #4580:
I have added a previewStyle variable to check when the preview style changes.
From my observation, the layout is updated every time tabs are switched or preview styles are cycled through. With the addition of a variable, these 2 situations can be differentiated to print out the notification more appropriately.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
