### PR TITLE
Solution for submitting dialog with Ctrl + Enter (#4496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added the ability to have an export preference where previously "File"-->"Export"/"Export selected entries" would not save the user's preference[#4495](https://github.com/JabRef/jabref/issues/4495)
 - We added the ability to add field names from the Preferences Dialog [#4546](https://github.com/JabRef/jabref/issues/4546)
 - We added the ability change the column widths directly in the main table. [#4546](https://github.com/JabRef/jabref/issues/4546)
+- We added the ability to execute default action in dialog by using with <kbd>Ctrl</kbd> + <kbd>Enter</kbd> combination [#4496](https://github.com/JabRef/jabref/issues/4496)
 
 
 

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -25,6 +25,7 @@ public enum KeyBinding {
     ENTRY_EDITOR_PREVIOUS_PANEL_2("Entry editor, previous panel 2", Localization.lang("Entry editor, previous panel 2"), "ctrl+MINUS", KeyBindingCategory.VIEW),
     DECREASE_TABLE_FONT_SIZE("Decrease table font size", Localization.lang("Decrease table font size"), "ctrl+MINUS", KeyBindingCategory.VIEW),
     DELETE_ENTRY("Delete entry", Localization.lang("Delete entry"), "DELETE", KeyBindingCategory.BIBTEX),
+    DEFAULT_DIALOG_ACTION("Execute default action in dialog", Localization.lang("Execute default action in dialog"), "ctrl+ENTER", KeyBindingCategory.VIEW),
     DOWNLOAD_FULL_TEXT("Look up full text documents", Localization.lang("Look up full text documents"), "alt+F7", KeyBindingCategory.QUALITY),
     EDIT_ENTRY("Edit entry", Localization.lang("Edit entry"), "ctrl+E", KeyBindingCategory.BIBTEX),
     EDIT_STRINGS("Edit strings", Localization.lang("Edit strings"), "ctrl+T", KeyBindingCategory.BIBTEX),

--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -1,5 +1,9 @@
 package org.jabref.gui.util;
 
+import java.util.Optional;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
@@ -16,12 +20,25 @@ public class BaseDialog<T> extends Dialog<T> implements org.jabref.gui.Dialog<T>
             KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
             if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
                 close();
+            } else if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
+                getDefaultButton().ifPresent(Button::fire);
             }
         });
 
         setDialogIcon(IconTheme.getJabRefImageFX());
         setResizable(true);
         Globals.getThemeLoader().installCss(getDialogPane().getScene(), Globals.prefs);
+    }
+
+    private Optional<Button> getDefaultButton() {
+        return Optional.ofNullable((Button) getDialogPane().lookupButton(getDefaultButtonType()));
+    }
+
+    private ButtonType getDefaultButtonType() {
+        return getDialogPane().getButtonTypes().stream()
+                .filter(buttonType -> buttonType.getButtonData().isDefaultButton())
+                .findFirst()
+                .orElse(ButtonType.OK);
     }
 
     private void setDialogIcon(Image image) {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -249,6 +249,8 @@ Default\ grouping\ field=Default grouping field
 
 Default\ pattern=Default pattern
 
+Execute\ default\ action\ in\ dialog=Execute default action in dialog
+
 Delete=Delete
 
 Delete\ custom\ format=Delete custom format


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Created solution for suggested improvement described in [#4496](https://github.com/JabRef/jabref/issues/4496)
----

Adjusted BaseDialog class to watch for new KeyBinding combination (default: ctrl + ENTER). When such combination is pressed in any dialog which extends BaseDialog, then system tries to find button with default action. If such button is found, then its event is fired. 

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
