### PR TITLE
Enable default cursor for new entry

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -3,6 +3,7 @@ package org.jabref.gui;
 import java.util.Collection;
 import java.util.List;
 
+import javafx.application.Platform;
 import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -143,6 +144,7 @@ public class EntryTypeView extends BaseDialog<EntryType> {
             }
         }
 
+        Platform.runLater(() -> idTextField.requestFocus());
     }
 
     public EntryType getChoice() {


### PR DESCRIPTION
Fixes #4600.
Sets text field on focus at the end of initialization by running the javafx thread.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
