### PR TITLE
snap: disable tests build, add removable media and specify architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ status.md
 # Install4J
 install4j6/
 
+# Snap
+parts/
+stage/
+prime/
+*.snap
+jabref_source.tar.bz2
+snap/.snapcraft/
+
 # Gradle
 # generated when `gradlew --gui` is called
 ui/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,18 +1,22 @@
 name: jabref
 version: "git"
 version-script: cat build.gradle | grep "^version =" | cut -d'"' -f2
-#icon: snap/gui/icon.png
+icon: snap/gui/jabref.png
 summary: Bibliography manager
 description: JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.
 
 grade: devel
 confinement: strict
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+
 apps:
   jabref:
     command: desktop-launch java -jar $SNAP/jar/JabRef-$SNAP_VERSION.jar
     environment:
-      _JAVA_OPTIONS: "-Djava.util.prefs.systemRoot=$SNAP_USER_DATA/.java/etc/.java -Djava.util.prefs.userRoot=$SNAP_USER_DATA/.java/.userPrefs"
+      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
     plugs:
       - desktop
       - desktop-legacy
@@ -21,6 +25,7 @@ apps:
       - home
       - opengl
       - network-bind
+      - removable-media
 
 parts:
   jabref:
@@ -30,6 +35,6 @@ parts:
       - openjdk-8-jre
       - openjfx
       - x11-utils
-    gradle-options: [snapJar]
+    gradle-options: [snapJar, -xtest]
     gradle-output-dir: 'build/releases'
     after: [desktop-gtk3]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,7 @@ parts:
   jabref:
     plugin: gradle
     source: .
+    source-type: git
     stage-packages:
       - openjdk-8-jre
       - openjfx

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: jabref
 version: "git"
 version-script: cat build.gradle | grep "^version =" | cut -d'"' -f2
-icon: snap/gui/jabref.png
+#icon: snap/gui/jabref.png
 summary: Bibliography manager
 description: JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.
 
@@ -37,4 +37,4 @@ parts:
       - x11-utils
     gradle-options: [snapJar, -xtest]
     gradle-output-dir: 'build/releases'
-    after: [desktop-gtk3]
+    after: [desktop-gtk2]


### PR DESCRIPTION
This picks up from the previous snap (#4615),
it adds the explicit build architectures, the removable-media plug (not autoconnected) and disables tests on gradlwe build