### PR TITLE
Fix NPE and not on FX Thread in PreviewPrefs Tabs

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -923,24 +923,23 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
         );
 
         options.getItems().addAll(
-                factory.createMenuItem(StandardActions.SHOW_PREFS, new ShowPreferencesAction(this)),
+                                  factory.createMenuItem(StandardActions.SHOW_PREFS, new ShowPreferencesAction(this, Globals.TASK_EXECUTOR)),
 
-                new SeparatorMenuItem(),
+                                  new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.SETUP_GENERAL_FIELDS, new SetupGeneralFieldsAction()),
-                factory.createMenuItem(StandardActions.MANAGE_CUSTOM_IMPORTS, new ManageCustomImportsAction()),
-                factory.createMenuItem(StandardActions.MANAGE_CUSTOM_EXPORTS, new ManageCustomExportsAction()),
-                factory.createMenuItem(StandardActions.MANAGE_EXTERNAL_FILETYPES, new EditExternalFileTypesAction()),
-                factory.createMenuItem(StandardActions.MANAGE_JOURNALS, new ManageJournalsAction()),
-                factory.createMenuItem(StandardActions.CUSTOMIZE_KEYBINDING, new CustomizeKeyBindingAction()),
-                factory.createMenuItem(StandardActions.MANAGE_PROTECTED_TERMS, new ManageProtectedTermsAction(this, Globals.protectedTermsLoader)),
+                                  factory.createMenuItem(StandardActions.SETUP_GENERAL_FIELDS, new SetupGeneralFieldsAction()),
+                                  factory.createMenuItem(StandardActions.MANAGE_CUSTOM_IMPORTS, new ManageCustomImportsAction()),
+                                  factory.createMenuItem(StandardActions.MANAGE_CUSTOM_EXPORTS, new ManageCustomExportsAction()),
+                                  factory.createMenuItem(StandardActions.MANAGE_EXTERNAL_FILETYPES, new EditExternalFileTypesAction()),
+                                  factory.createMenuItem(StandardActions.MANAGE_JOURNALS, new ManageJournalsAction()),
+                                  factory.createMenuItem(StandardActions.CUSTOMIZE_KEYBINDING, new CustomizeKeyBindingAction()),
+                                  factory.createMenuItem(StandardActions.MANAGE_PROTECTED_TERMS, new ManageProtectedTermsAction(this, Globals.protectedTermsLoader)),
 
-                new SeparatorMenuItem(),
+                                  new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new OldDatabaseCommandWrapper(Actions.MANAGE_SELECTORS, this, Globals.stateManager)),
-                factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
-                factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this))
-        );
+                                  factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new OldDatabaseCommandWrapper(Actions.MANAGE_SELECTORS, this, Globals.stateManager)),
+                                  factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
+                                  factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this)));
 
         help.getItems().addAll(
                 factory.createMenuItem(StandardActions.HELP, HelpAction.getMainHelpPageCommand()),

--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -94,10 +94,10 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
         this.keyBindingRepository = keyBindingRepository;
 
         fileHandler = new NewDroppedFileHandler(dialogService, databaseContext, externalFileTypes,
-                Globals.prefs.getFilePreferences(),
+                                                Globals.prefs.getFilePreferences(),
                                                 Globals.prefs.getImportFormatPreferences(),
                                                 Globals.prefs.getUpdateFieldPreferences(),
-                Globals.getFileUpdateMonitor());
+                                                Globals.getFileUpdateMonitor());
 
         // Set up scroll pane for preview pane
         setFitToHeight(true);
@@ -231,19 +231,19 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
             if (CitationStyle.isCitationStyleFile(style)) {
                 layout = Optional.empty();
                 CitationStyle.createCitationStyleFromFile(style)
-                        .ifPresent(cs -> {
-                            citationStyle = cs;
-                            if (!init) {
-                                basePanel.get().output(Localization.lang("Preview style changed to: %0", citationStyle.getTitle()));
-                            }
-                        });
+                             .ifPresent(cs -> {
+                                 citationStyle = cs;
+                                 if (!init) {
+                                     basePanel.get().output(Localization.lang("Preview style changed to: %0", citationStyle.getTitle()));
+                                 }
+                             });
                 previewStyle = style;
-            } else {
-                previewStyle = defaultPreviewStyle;
-                updatePreviewLayout(previewPreferences.getPreviewStyle(), previewPreferences.getLayoutFormatterPreferences());
-                if (!init) {
-                    basePanel.get().output(Localization.lang("Preview style changed to: %0", Localization.lang("Preview")));
-                }
+            }
+        } else {
+            previewStyle = defaultPreviewStyle;
+            updatePreviewLayout(previewPreferences.getPreviewStyle(), previewPreferences.getLayoutFormatterPreferences());
+            if (!init) {
+                basePanel.get().output(Localization.lang("Preview style changed to: %0", Localization.lang("Preview")));
             }
         }
 
@@ -301,7 +301,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
                                                         .doLayout(entry, databaseContext.getDatabase())));
             setPreviewLabel(sb.toString());
         } else if (basePanel.isPresent() && bibEntry.isPresent()) {
-            if (citationStyle != null && !previewStyle.equals(defaultPreviewStyle)) {
+            if ((citationStyle != null) && !previewStyle.equals(defaultPreviewStyle)) {
                 basePanel.get().getCitationStyleCache().setCitationStyle(citationStyle);
             }
             Future<?> citationStyleWorker = BackgroundTask

--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -368,11 +368,13 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
     private void copyPreviewToClipBoard() {
         StringBuilder previewStringContent = new StringBuilder();
         Document document = previewView.getEngine().getDocument();
-        NodeList nodeList = document.getElementsByTagName("*");
 
+        NodeList nodeList = document.getElementsByTagName("html");
+
+        //Nodelist does not implement iterable
         for (int i = 0; i < nodeList.getLength(); i++) {
             Element element = (Element) nodeList.item(i);
-            previewStringContent.append(element.getNodeValue()).append("\n");
+            previewStringContent.append(element.getTextContent());
         }
 
         ClipboardContent content = new ClipboardContent();

--- a/src/main/java/org/jabref/gui/actions/ShowPreferencesAction.java
+++ b/src/main/java/org/jabref/gui/actions/ShowPreferencesAction.java
@@ -2,17 +2,21 @@ package org.jabref.gui.actions;
 
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.preferences.PreferencesDialog;
+import org.jabref.gui.util.TaskExecutor;
 
 public class ShowPreferencesAction extends SimpleCommand {
 
     private final JabRefFrame jabRefFrame;
-    public ShowPreferencesAction(JabRefFrame jabRefFrame) {
+    private final TaskExecutor taskExecutor;
+
+    public ShowPreferencesAction(JabRefFrame jabRefFrame, TaskExecutor taskExecutor) {
         this.jabRefFrame = jabRefFrame;
+        this.taskExecutor = taskExecutor;
     }
 
     @Override
     public void execute() {
-        PreferencesDialog preferencesDialog = new PreferencesDialog(jabRefFrame);
+        PreferencesDialog preferencesDialog = new PreferencesDialog(jabRefFrame, taskExecutor);
         preferencesDialog.showAndWait();
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
@@ -25,6 +25,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.gui.util.TaskExecutor;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.exporter.SavePreferences;
@@ -57,7 +58,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
     private final JabRefPreferences prefs;
     private final ObservableList<PrefsTab> preferenceTabs;
 
-    public PreferencesDialog(JabRefFrame parent) {
+    public PreferencesDialog(JabRefFrame parent, TaskExecutor taskExecutor) {
         setTitle(Localization.lang("JabRef preferences"));
         getDialogPane().getScene().getStylesheets().add(this.getClass().getResource("PreferencesDialog.css").toExternalForm());
 
@@ -68,7 +69,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
             close();
         });
 
-        prefs = JabRefPreferences.getInstance();
+        prefs = Globals.prefs;
         frame = parent;
         dialogService = frame.getDialogService();
 
@@ -77,7 +78,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
         preferenceTabs.add(new FileTab(dialogService, prefs));
         preferenceTabs.add(new TablePrefsTab(prefs));
         preferenceTabs.add(new TableColumnsTab(prefs, frame));
-        preferenceTabs.add(new PreviewPrefsTab(dialogService, ExternalFileTypes.getInstance()));
+        preferenceTabs.add(new PreviewPrefsTab(dialogService, ExternalFileTypes.getInstance(), taskExecutor));
         preferenceTabs.add(new ExternalTab(frame, this, prefs));
         preferenceTabs.add(new GroupsPrefsTab(prefs));
         preferenceTabs.add(new EntryEditorPrefsTab(prefs));
@@ -111,8 +112,8 @@ public class PreferencesDialog extends BaseDialog<Void> {
         });
         tabsList.getSelectionModel().selectFirst();
         new ViewModelListCellFactory<PrefsTab>()
-                .withText(PrefsTab::getTabName)
-                .install(tabsList);
+                                                .withText(PrefsTab::getTabName)
+                                                .install(tabsList);
 
         VBox buttonContainer = new VBox();
         buttonContainer.setAlignment(Pos.BOTTOM_LEFT);
@@ -132,21 +133,19 @@ public class PreferencesDialog extends BaseDialog<Void> {
         resetPreferences.setOnAction(e -> resetPreferences());
         resetPreferences.setMaxWidth(Double.MAX_VALUE);
         buttonContainer.getChildren().addAll(
-                importPreferences,
-                exportPreferences,
-                showPreferences,
-                resetPreferences
-        );
+                                             importPreferences,
+                                             exportPreferences,
+                                             showPreferences,
+                                             resetPreferences);
 
         VBox spacer = new VBox();
         spacer.setPrefHeight(10.0);
         VBox.setVgrow(tabsList, Priority.ALWAYS);
         VBox.setVgrow(spacer, Priority.SOMETIMES);
         vBox.getChildren().addAll(
-                tabsList,
-                spacer,
-                buttonContainer
-        );
+                                  tabsList,
+                                  spacer,
+                                  buttonContainer);
 
         container.setLeft(vBox);
 
@@ -155,16 +154,16 @@ public class PreferencesDialog extends BaseDialog<Void> {
 
     private void resetPreferences() {
         boolean resetPreferencesConfirmed = dialogService.showConfirmationDialogAndWait(
-                Localization.lang("Reset preferences"),
-                Localization.lang("Are you sure you want to reset all settings to default values?"),
-                Localization.lang("Reset preferences"),
-                Localization.lang("Cancel"));
+                                                                                        Localization.lang("Reset preferences"),
+                                                                                        Localization.lang("Are you sure you want to reset all settings to default values?"),
+                                                                                        Localization.lang("Reset preferences"),
+                                                                                        Localization.lang("Cancel"));
         if (resetPreferencesConfirmed) {
             try {
                 prefs.clear();
 
                 dialogService.showWarningDialogAndWait(Localization.lang("Reset preferences"),
-                        Localization.lang("You must restart JabRef for this to come into effect."));
+                                                       Localization.lang("You must restart JabRef for this to come into effect."));
             } catch (BackingStoreException ex) {
                 LOGGER.error("Error while resetting preferences", ex);
                 dialogService.showErrorDialogAndWait(Localization.lang("Reset preferences"), ex);
@@ -175,9 +174,9 @@ public class PreferencesDialog extends BaseDialog<Void> {
 
     private void importPreferences() {
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
-                .addExtensionFilter(StandardFileType.XML)
-                .withDefaultExtension(StandardFileType.XML)
-                .withInitialDirectory(prefs.setLastPreferencesExportPath()).build();
+                                                                                               .addExtensionFilter(StandardFileType.XML)
+                                                                                               .withDefaultExtension(StandardFileType.XML)
+                                                                                               .withInitialDirectory(prefs.setLastPreferencesExportPath()).build();
 
         dialogService.showFileOpenDialog(fileDialogConfiguration).ifPresent(file -> {
             try {
@@ -185,7 +184,7 @@ public class PreferencesDialog extends BaseDialog<Void> {
                 updateAfterPreferenceChanges();
 
                 dialogService.showWarningDialogAndWait(Localization.lang("Import preferences"),
-                        Localization.lang("You must restart JabRef for this to come into effect."));
+                                                       Localization.lang("You must restart JabRef for this to come into effect."));
             } catch (JabRefException ex) {
                 LOGGER.error("Error while importing preferences", ex);
                 dialogService.showErrorDialogAndWait(Localization.lang("Import preferences"), ex);
@@ -230,10 +229,10 @@ public class PreferencesDialog extends BaseDialog<Void> {
 
     private void exportPreferences() {
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
-                .addExtensionFilter(StandardFileType.XML)
-                .withDefaultExtension(StandardFileType.XML)
-                .withInitialDirectory(prefs.setLastPreferencesExportPath())
-                .build();
+                                                                                               .addExtensionFilter(StandardFileType.XML)
+                                                                                               .withDefaultExtension(StandardFileType.XML)
+                                                                                               .withInitialDirectory(prefs.setLastPreferencesExportPath())
+                                                                                               .build();
 
         dialogService.showFileSaveDialog(fileDialogConfiguration)
                      .ifPresent(exportFile -> {

--- a/src/main/java/org/jabref/gui/preferences/PreviewPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewPrefsTab.java
@@ -19,6 +19,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
+
 import org.jabref.Globals;
 import org.jabref.JabRefGUI;
 import org.jabref.gui.BasePanel;

--- a/src/main/java/org/jabref/gui/preferences/PreviewPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewPrefsTab.java
@@ -140,7 +140,6 @@ public class PreviewPrefsTab implements PrefsTab {
 
                 DialogPane pane = new DialogPane();
                 pane.setContent(testPane);
-
                 dialogService.showCustomDialogAndWait(Localization.lang("Preview"), pane, ButtonType.OK);
 
             } catch (StringIndexOutOfBoundsException exception) {

--- a/src/main/java/org/jabref/preferences/PreviewPreferences.java
+++ b/src/main/java/org/jabref/preferences/PreviewPreferences.java
@@ -8,7 +8,7 @@ import org.jabref.logic.layout.LayoutFormatterPreferences;
 public class PreviewPreferences {
 
     private final List<String> previewCycle;
-    private int previewCyclePosition;
+    private final int previewCyclePosition;
     private final Number previewPanelDividerPosition;
     private final boolean previewPanelEnabled;
     private final String previewStyle;
@@ -60,13 +60,13 @@ public class PreviewPreferences {
     }
 
     public static class Builder {
+
         private List<String> previewCycle;
         private int previeCyclePosition;
         private Number previewPanelDividerPosition;
         private boolean previewPanelEnabled;
         private String previewStyle;
         private final String previewStyleDefault;
-
 
         public Builder(PreviewPreferences previewPreferences) {
             this.previewCycle = previewPreferences.getPreviewCycle();
@@ -83,11 +83,15 @@ public class PreviewPreferences {
         }
 
         public Builder withPreviewCyclePosition(int position) {
-            previeCyclePosition = position;
-            while (previeCyclePosition < 0) {
-                previeCyclePosition += previewCycle.size();
+            if (previewCycle.isEmpty()) {
+                previeCyclePosition = 0;
+            } else {
+                previeCyclePosition = position;
+                while (previeCyclePosition < 0) {
+                    previeCyclePosition += previewCycle.size();
+                }
+                previeCyclePosition %= previewCycle.size();
             }
-            previeCyclePosition %= previewCycle.size();
             return this;
         }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2216,3 +2216,5 @@ File\ extension\:=File extension\:
 Export\ format\ name\:=Export format name\:
 
 Cleared\ connection\ settings=Cleared connection settings
+
+Error\ adding\ discovered\ CitationStyles=Error adding discovered CitationStyles


### PR DESCRIPTION
Remove obsolete swing stuff
Create proper javafx binding

Fixes #4621
Fixes #4622 
Fixes #4570

I fixed and tuned the copypreview stuff.
Copy Preview copies the HTML formatted stuff for usage in email:

![grafik](https://user-images.githubusercontent.com/320228/52073860-d7ee2800-2588-11e9-9f23-614f764debbb.png)

![grafik](https://user-images.githubusercontent.com/320228/52073897-e9373480-2588-11e9-8da9-6a48501b72d8.png)

Purified text for non html:
```
Incollection (Akerkar:)
 Akerkar, R.

 Processing Big Data for Emergency Management 


 Smart Technologies for Emergency Response and Disaster Management, 


 IGI Global, 
, 144-166 



```


When all styles get removed from the right side, the default "Preview" style is added back again to prevent divide by zero exception

Fix another issue where the Preview style is not set correctly

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
