### PR TITLE
Fix for issue 4641: Remove usage of TempDirectory extension from junit-pioneer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,13 +161,12 @@ dependencies {
     compile group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '2.3.0'
     compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '2.3.0'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'
-    testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.3.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.0'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.4.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.4.0'
     testCompile 'org.junit.platform:junit-platform-launcher:1.3.2'
 
-    testCompile 'org.junit-pioneer:junit-pioneer:0.3.0'
     testRuntime 'org.apache.logging.log4j:log4j-core:2.11.1'
     testRuntime 'org.apache.logging.log4j:log4j-jul:2.11.1'
     testCompile 'org.mockito:mockito-core:2.23.4'
@@ -191,9 +190,6 @@ jacoco {
 dependencyUpdates {
     outputFormatter = "json"
 }
-
-//We have to use this as long as junit-pioneer has no official release
-dependencyUpdates.revision = 'integration'
 
 // We have some dependencies which cannot be updated due to various reasons.
 dependencyUpdates.resolutionStrategy = {

--- a/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -16,15 +16,13 @@ import org.jabref.model.metadata.FilePreferences;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 public class AutoSetFileLinksUtilTest {
 
     private final FilePreferences fileDirPrefs = mock(FilePreferences.class);
@@ -34,7 +32,7 @@ public class AutoSetFileLinksUtilTest {
     private final BibEntry entry = new BibEntry(BibtexEntryTypes.ARTICLE);
 
     @BeforeEach
-    public void setUp(@TempDirectory.TempDir Path folder) throws Exception {
+    public void setUp(@TempDir Path folder) throws Exception {
         Path path = folder.resolve("CiteKey.pdf");
         Files.createFile(path);
         entry.setCiteKey("CiteKey");

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -17,8 +17,7 @@ import org.jabref.preferences.JabRefPreferences;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class LinkedFileViewModelTest {
 
     private Path tempFile;
@@ -43,7 +41,7 @@ class LinkedFileViewModelTest {
     private DialogService dialogService;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path tempFolder) throws Exception {
+    void setUp(@TempDir Path tempFolder) throws Exception {
         entry = new BibEntry();
         databaseContext = new BibDatabaseContext();
         taskExecutor = mock(TaskExecutor.class);

--- a/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
+++ b/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
@@ -23,8 +23,7 @@ import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.jabref.logic.util.OS.NEWLINE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +36,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class ManageJournalAbbreviationsViewModelTest {
 
     private ManageJournalAbbreviationsViewModel viewModel;
@@ -50,7 +48,7 @@ class ManageJournalAbbreviationsViewModelTest {
     private DialogService dialogService;
 
     @BeforeEach
-    void setUpViewModel(@TempDirectory.TempDir Path tempFolder) throws Exception {
+    void setUpViewModel(@TempDir Path tempFolder) throws Exception {
         abbreviationPreferences = mock(JournalAbbreviationPreferences.class);
         PreferencesService preferences = mock(PreferencesService.class);
         when(preferences.getJournalAbbreviationPreferences()).thenReturn(abbreviationPreferences);

--- a/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
+++ b/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
@@ -12,16 +12,14 @@ import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.StandardFileType;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(TempDirectory.class)
 class FileDialogConfigurationTest {
 
     @Test
-    void testWithValidDirectoryString(@TempDirectory.TempDir Path folder) {
+    void testWithValidDirectoryString(@TempDir Path folder) {
         String tempFolder = folder.toAbsolutePath().toString();
 
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
@@ -31,7 +29,7 @@ class FileDialogConfigurationTest {
     }
 
     @Test
-    void testWithValidDirectoryPath(@TempDirectory.TempDir Path tempFolder) {
+    void testWithValidDirectoryPath(@TempDir Path tempFolder) {
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                 .withInitialDirectory(tempFolder).build();
 

--- a/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -34,8 +34,7 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,14 +43,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class CleanupWorkerTest {
 
     private final CleanupPreset emptyPreset = new CleanupPreset(EnumSet.noneOf(CleanupPreset.CleanupStep.class));
     private CleanupWorker worker;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void setUp(@TempDir Path bibFolder) throws IOException {
 
         Path path = bibFolder.resolve("ARandomlyNamedFolder");
         Files.createDirectory(path);
@@ -82,7 +80,7 @@ class CleanupWorkerTest {
     }
 
     @Test
-    void cleanupDoesNothingByDefault(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void cleanupDoesNothingByDefault(@TempDir Path bibFolder) throws IOException {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("Toot");
         entry.setField("pdf", "aPdfFile");
@@ -220,7 +218,7 @@ class CleanupWorkerTest {
     }
 
     @Test
-    void cleanupMoveFilesMovesFileFromSubfolder(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void cleanupMoveFilesMovesFileFromSubfolder(@TempDir Path bibFolder) throws IOException {
         CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.MOVE_PDF);
 
         Path path = bibFolder.resolve("AnotherRandomlyNamedFolder");
@@ -238,7 +236,7 @@ class CleanupWorkerTest {
     }
 
     @Test
-    void cleanupRelativePathsConvertAbsoluteToRelativePath(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void cleanupRelativePathsConvertAbsoluteToRelativePath(@TempDir Path bibFolder) throws IOException {
         CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.MAKE_PATHS_RELATIVE);
 
         Path path = bibFolder.resolve("AnotherRandomlyNamedFile");
@@ -254,7 +252,7 @@ class CleanupWorkerTest {
     }
 
     @Test
-    void cleanupRenamePdfRenamesRelativeFile(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void cleanupRenamePdfRenamesRelativeFile(@TempDir Path bibFolder) throws IOException {
         CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.RENAME_PDF);
 
         Path path = bibFolder.resolve("AnotherRandomlyNamedFile.tmp");

--- a/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -17,8 +17,7 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class MoveFilesCleanupTest {
 
     private Path defaultFileFolder;
@@ -36,7 +34,7 @@ class MoveFilesCleanupTest {
     private FilePreferences filePreferences;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path bibFolder) throws IOException {
+    void setUp(@TempDir Path bibFolder) throws IOException {
         // The folder where the files should be moved to
         defaultFileFolder = bibFolder.resolve("pdf");
         Files.createDirectory(defaultFileFolder);

--- a/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -17,14 +17,12 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class RenamePdfCleanupTest {
 
     private BibEntry entry;
@@ -33,7 +31,7 @@ class RenamePdfCleanupTest {
     private RenamePdfCleanup cleanup;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path testFolder) {
+    void setUp(@TempDir Path testFolder) {
         Path path = testFolder.resolve("test.bib");
         MetaData metaData = new MetaData();
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(), metaData, new Defaults());
@@ -51,7 +49,7 @@ class RenamePdfCleanupTest {
      * Test for #466
      */
     @Test
-    void cleanupRenamePdfRenamesFileEvenIfOnlyDifferenceIsCase(@TempDirectory.TempDir Path testFolder) throws IOException {
+    void cleanupRenamePdfRenamesFileEvenIfOnlyDifferenceIsCase(@TempDir Path testFolder) throws IOException {
         Path path = testFolder.resolve("toot.tmp");
         Files.createFile(path);
 
@@ -66,7 +64,7 @@ class RenamePdfCleanupTest {
     }
 
     @Test
-    void cleanupRenamePdfRenamesWithMultipleFiles(@TempDirectory.TempDir Path testFolder) throws IOException {
+    void cleanupRenamePdfRenamesWithMultipleFiles(@TempDir Path testFolder) throws IOException {
         Path path = testFolder.resolve("Toot.tmp");
         Files.createFile(path);
 
@@ -84,7 +82,7 @@ class RenamePdfCleanupTest {
     }
 
     @Test
-    void cleanupRenamePdfRenamesFileStartingWithBibtexKey(@TempDirectory.TempDir Path testFolder) throws IOException {
+    void cleanupRenamePdfRenamesFileStartingWithBibtexKey(@TempDir Path testFolder) throws IOException {
         Path path = testFolder.resolve("Toot.tmp");
         Files.createFile(path);
 
@@ -100,7 +98,7 @@ class RenamePdfCleanupTest {
     }
 
     @Test
-    void cleanupRenamePdfRenamesFileInSameFolder(@TempDirectory.TempDir Path testFolder) throws IOException {
+    void cleanupRenamePdfRenamesFileInSameFolder(@TempDir Path testFolder) throws IOException {
         Path path = testFolder.resolve("Toot.pdf");
         Files.createFile(path);
         LinkedFile fileField = new LinkedFile("", "Toot.pdf", "PDF");

--- a/src/test/java/org/jabref/logic/exporter/BibTeXMLExporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/BibTeXMLExporterTestFiles.java
@@ -18,10 +18,9 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Answers;
 import org.xmlunit.builder.Input;
 import org.xmlunit.builder.Input.Builder;
@@ -32,7 +31,6 @@ import org.xmlunit.matchers.CompareMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class BibTeXMLExporterTestFiles {
 
     private static Path resourceDir;
@@ -52,7 +50,7 @@ public class BibTeXMLExporterTestFiles {
     }
 
     @BeforeEach
-    public void setUp(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void setUp(@TempDir Path testFolder) throws Exception {
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
         bibtexmlExportFormat = new BibTeXMLExporter();

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -17,14 +17,12 @@ import org.jabref.model.entry.BibEntry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class CsvExportFormatTest {
 
     public BibDatabaseContext databaseContext;
@@ -51,7 +49,7 @@ public class CsvExportFormatTest {
     }
 
     @Test
-    public void testPerformExportForSingleAuthor(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testPerformExportForSingleAuthor(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 
         BibEntry entry = new BibEntry();
@@ -68,7 +66,7 @@ public class CsvExportFormatTest {
     }
 
     @Test
-    public void testPerformExportForMultipleAuthors(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testPerformExportForMultipleAuthors(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 
         BibEntry entry = new BibEntry();
@@ -85,7 +83,7 @@ public class CsvExportFormatTest {
     }
 
     @Test
-    public void testPerformExportForSingleEditor(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testPerformExportForSingleEditor(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
         File tmpFile = path.toFile();
         BibEntry entry = new BibEntry();
@@ -102,7 +100,7 @@ public class CsvExportFormatTest {
     }
 
     @Test
-    public void testPerformExportForMultipleEditors(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testPerformExportForMultipleEditors(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
         File tmpFile = path.toFile();
         BibEntry entry = new BibEntry();

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -20,8 +20,7 @@ import org.jabref.model.entry.FieldName;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 import org.xmlunit.builder.Input;
 import org.xmlunit.builder.Input.Builder;
@@ -32,7 +31,6 @@ import org.xmlunit.matchers.CompareMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class DocBook5ExporterTest {
 
     public BibDatabaseContext databaseContext;
@@ -68,7 +66,7 @@ public class DocBook5ExporterTest {
     }
 
     @Test
-    public void testPerformExportForSingleEntry(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testPerformExportForSingleEntry(@TempDir Path testFolder) throws Exception {
 
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -16,7 +16,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -17,15 +17,14 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junitpioneer.jupiter.TempDirectory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class ExporterTest {
 
     public BibDatabaseContext databaseContext;
@@ -56,7 +55,7 @@ public class ExporterTest {
 
     @ParameterizedTest
     @MethodSource("exportFormats")
-    public void testExportingEmptyDatabaseYieldsEmptyFile(Exporter exportFormat, String name, @TempDirectory.TempDir Path testFolder) throws Exception {
+    public void testExportingEmptyDatabaseYieldsEmptyFile(Exporter exportFormat, String name, @TempDir Path testFolder) throws Exception {
         Path tmpFile = testFolder.resolve("ARandomlyNamedFile");
         Files.createFile(tmpFile);
         exportFormat.export(databaseContext, tmpFile, charset, entries);
@@ -65,7 +64,7 @@ public class ExporterTest {
 
     @ParameterizedTest
     @MethodSource("exportFormats")
-    public void testExportingNullDatabaseThrowsNPE(Exporter exportFormat, String name, @TempDirectory.TempDir Path testFolder) {
+    public void testExportingNullDatabaseThrowsNPE(Exporter exportFormat, String name, @TempDir Path testFolder) {
         assertThrows(NullPointerException.class, () -> {
             Path tmpFile = testFolder.resolve("ARandomlyNamedFile");
             Files.createFile(tmpFile);
@@ -75,7 +74,7 @@ public class ExporterTest {
 
     @ParameterizedTest
     @MethodSource("exportFormats")
-    public void testExportingNullEntriesThrowsNPE(Exporter exportFormat, String name, @TempDirectory.TempDir Path testFolder) {
+    public void testExportingNullEntriesThrowsNPE(Exporter exportFormat, String name, @TempDir Path testFolder) {
         assertThrows(NullPointerException.class, () -> {
             Path tmpFile = testFolder.resolve("ARandomlyNamedFile");
             Files.createFile(tmpFile);

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -16,14 +16,12 @@ import org.jabref.model.entry.BibEntry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class HtmlExportFormatTest {
     public BibDatabaseContext databaseContext;
     public Charset charset;
@@ -55,7 +53,7 @@ public class HtmlExportFormatTest {
     }
 
     @Test
-    public void emitWellFormedHtml(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void emitWellFormedHtml(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
         exportFormat.export(databaseContext, path, charset, entries);
         List<String> lines = Files.readAllLines(path);

--- a/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/MSBibExportFormatTestFiles.java
@@ -18,10 +18,9 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Answers;
 import org.xmlunit.builder.Input;
 import org.xmlunit.builder.Input.Builder;
@@ -32,7 +31,6 @@ import org.xmlunit.matchers.CompareMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class MSBibExportFormatTestFiles {
 
     private static Path resourceDir;
@@ -53,7 +51,7 @@ public class MSBibExportFormatTestFiles {
     }
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path testFolder) throws Exception {
+    void setUp(@TempDir Path testFolder) throws Exception {
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
         msBibExportFormat = new MSBibExporter();

--- a/src/test/java/org/jabref/logic/exporter/ModsExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ModsExportFormatTest.java
@@ -14,14 +14,12 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class ModsExportFormatTest {
 
     public Charset charset;
@@ -38,7 +36,7 @@ public class ModsExportFormatTest {
     }
 
     @Test
-    public final void exportForNoEntriesWritesNothing(@TempDirectory.TempDir Path tempFile) throws Exception {
+    public final void exportForNoEntriesWritesNothing(@TempDir Path tempFile) throws Exception {
         Path file = tempFile.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(file);
         modsExportFormat.export(databaseContext, tempFile, charset, Collections.emptyList());

--- a/src/test/java/org/jabref/logic/exporter/ModsExportFormatTestFiles.java
+++ b/src/test/java/org/jabref/logic/exporter/ModsExportFormatTestFiles.java
@@ -18,10 +18,9 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junitpioneer.jupiter.TempDirectory;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 import org.xmlunit.builder.Input;
@@ -33,7 +32,6 @@ import org.xmlunit.matchers.CompareMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 public class ModsExportFormatTestFiles {
 
     private static Path resourceDir;
@@ -57,7 +55,7 @@ public class ModsExportFormatTestFiles {
     }
 
     @BeforeEach
-    public void setUp(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void setUp(@TempDir Path testFolder) throws Exception {
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
         modsExportFormat = new ModsExporter();

--- a/src/test/java/org/jabref/logic/exporter/MsBibExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MsBibExportFormatTest.java
@@ -13,12 +13,10 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(TempDirectory.class)
 public class MsBibExportFormatTest {
 
     public BibDatabaseContext databaseContext;
@@ -33,7 +31,7 @@ public class MsBibExportFormatTest {
     }
 
     @Test
-    public final void testPerformExportWithNoEntry(@TempDirectory.TempDir Path tempFile) throws IOException, SaveException {
+    public final void testPerformExportWithNoEntry(@TempDir Path tempFile) throws IOException, SaveException {
         Path path = tempFile.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(path);
         List<BibEntry> entries = Collections.emptyList();

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -18,15 +18,13 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 public class XmpExporterTest {
 
     private Exporter exporter;
@@ -48,7 +46,7 @@ public class XmpExporterTest {
     }
 
     @Test
-    public void exportSingleEntry(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void exportSingleEntry(@TempDir Path testFolder) throws Exception {
         Path file = testFolder.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(file);
 
@@ -76,7 +74,7 @@ public class XmpExporterTest {
     }
 
     @Test
-    public void writeMultipleEntriesInASingleFile(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void writeMultipleEntriesInASingleFile(@TempDir Path testFolder) throws Exception {
         Path file = testFolder.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(file);
 
@@ -128,7 +126,7 @@ public class XmpExporterTest {
     }
 
     @Test
-    public void writeMultipleEntriesInDifferentFiles(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void writeMultipleEntriesInDifferentFiles(@TempDir Path testFolder) throws Exception {
         Path file = testFolder.resolve("split");
         Files.createFile(file);
 
@@ -194,7 +192,7 @@ public class XmpExporterTest {
     }
 
     @Test
-    public void exportSingleEntryWithPrivacyFilter(@TempDirectory.TempDir Path testFolder) throws Exception {
+    public void exportSingleEntryWithPrivacyFilter(@TempDir Path testFolder) throws Exception {
         when(xmpPreferences.getXmpPrivacyFilter()).thenReturn(Arrays.asList("author"));
         when(xmpPreferences.isUseXMPPrivacyFilter()).thenReturn(true);
 

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -23,8 +23,7 @@ import org.jabref.model.metadata.FilePreferences;
 import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 class IntegrityCheckTest {
 
     @Test
@@ -220,7 +218,7 @@ class IntegrityCheckTest {
     }
 
     @Test
-    void fileCheckFindsFilesRelativeToBibFile(@TempDirectory.TempDir Path testFolder) throws IOException {
+    void fileCheckFindsFilesRelativeToBibFile(@TempDir Path testFolder) throws IOException {
         Path bibFile = testFolder.resolve("lit.bib");
         Files.createFile(bibFile);
         Path pdfFile = testFolder.resolve("file.pdf");

--- a/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsListTest.java
+++ b/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsListTest.java
@@ -8,21 +8,19 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TempDirectory.class)
 public class ProtectedTermsListTest {
 
     private ProtectedTermsList internalList;
     private ProtectedTermsList externalList;
 
     @BeforeEach
-    public void setUp(@TempDirectory.TempDir Path temporaryFolder) throws IOException {
+    public void setUp(@TempDir Path temporaryFolder) throws IOException {
         Path path = temporaryFolder.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(path);
         String tempFileName = path.toString();

--- a/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
+++ b/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
@@ -14,14 +14,12 @@ import org.jabref.logic.l10n.Localization;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(TempDirectory.class)
 class ProtectedTermsLoaderTest {
 
     private ProtectedTermsLoader loader;
@@ -166,7 +164,7 @@ class ProtectedTermsLoaderTest {
     }
 
     @Test
-    void testAddNewTermListAddsList(@TempDirectory.TempDir Path tempDir) {
+    void testAddNewTermListAddsList(@TempDir Path tempDir) {
 
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
@@ -176,7 +174,7 @@ class ProtectedTermsLoaderTest {
     }
 
     @Test
-    void testAddNewTermListNewListInList(@TempDirectory.TempDir Path tempDir) {
+    void testAddNewTermListNewListInList(@TempDir Path tempDir) {
 
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
@@ -187,7 +185,7 @@ class ProtectedTermsLoaderTest {
     }
 
     @Test
-    void testRemoveTermList(@TempDirectory.TempDir Path tempDir) {
+    void testRemoveTermList(@TempDir Path tempDir) {
 
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
@@ -197,7 +195,7 @@ class ProtectedTermsLoaderTest {
     }
 
     @Test
-    void testRemoveTermListReduceTheCount(@TempDirectory.TempDir Path tempDir) {
+    void testRemoveTermListReduceTheCount(@TempDir Path tempDir) {
 
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
@@ -209,7 +207,7 @@ class ProtectedTermsLoaderTest {
     }
 
     @Test
-    void testAddNewTermListSetsCorrectDescription(@TempDirectory.TempDir Path tempDir) {
+    void testAddNewTermListSetsCorrectDescription(@TempDir Path tempDir) {
 
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),

--- a/src/test/java/org/jabref/logic/util/io/CiteKeyBasedFileFinderTest.java
+++ b/src/test/java/org/jabref/logic/util/io/CiteKeyBasedFileFinderTest.java
@@ -12,12 +12,10 @@ import org.jabref.model.entry.BibtexEntryTypes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(TempDirectory.class)
 class CiteKeyBasedFileFinderTest {
 
     private BibEntry entry;
@@ -28,7 +26,7 @@ class CiteKeyBasedFileFinderTest {
     private Path pdfFile;
 
     @BeforeEach
-    void setUp(@TempDirectory.TempDir Path temporaryFolder) throws IOException {
+    void setUp(@TempDir Path temporaryFolder) throws IOException {
         entry = new BibEntry(BibtexEntryTypes.ARTICLE);
         entry.setCiteKey("HipKro03");
 

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -18,8 +18,7 @@ import org.jabref.model.util.FileHelper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -29,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@ExtendWith(TempDirectory.class)
 class FileUtilTest {
     private final Path nonExistingTestPath = Paths.get("nonExistingTestPath");
     private Path existingTestFile;
@@ -38,7 +36,7 @@ class FileUtilTest {
     private Path rootDir;
 
     @BeforeEach
-    void setUpViewModel(@TempDirectory.TempDir Path temporaryFolder) throws IOException {
+    void setUpViewModel(@TempDir Path temporaryFolder) throws IOException {
         rootDir = temporaryFolder;
         Path subDir = rootDir.resolve("1");
         Files.createDirectory(subDir);
@@ -322,7 +320,7 @@ class FileUtilTest {
     }
 
     @Test
-    void testRenameFileSuccessful(@TempDirectory.TempDir Path otherTemporaryFolder) {
+    void testRenameFileSuccessful(@TempDir Path otherTemporaryFolder) {
         // Be careful. This "otherTemporaryFolder" is the same as the "temporaryFolder"
         // in the @BeforeEach method.
         Path temp = Paths.get(otherTemporaryFolder.resolve("123").toString());

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -15,14 +15,12 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.TempDirectory;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(TempDirectory.class)
 class XmpUtilWriterTest {
 
     private static BibEntry olly2018;
@@ -94,7 +92,7 @@ class XmpUtilWriterTest {
      * Test for writing a PDF file with a single DublinCore metadata entry.
      */
     @Test
-    void testWriteXmp(@TempDirectory.TempDir Path tempDir) throws IOException, TransformerException {
+    void testWriteXmp(@TempDir Path tempDir) throws IOException, TransformerException {
 
         Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
 
@@ -118,7 +116,7 @@ class XmpUtilWriterTest {
      * Test, which writes multiple metadata entries to a PDF and reads them again to test the size.
      */
     @Test
-    void testWriteMultipleBibEntries(@TempDirectory.TempDir Path tempDir) throws IOException, TransformerException {
+    void testWriteMultipleBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
 
         Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
 


### PR DESCRIPTION
Fixes: #4641 
Removed the TempDirectory extension from junit-pioneer with the built-in extension of junit 5.4
----
- [x] Manually tested changed features in running JabRef
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
