### PR TITLE
fixes #4610. Changed the way the GroupDialog description is displayed. 

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupDescriptions.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDescriptions.java
@@ -14,9 +14,9 @@ public class GroupDescriptions {
     public static String getDescriptionForPreview(String field, String expr, boolean caseSensitive, boolean regExp) {
         String header = regExp ? Localization.lang(
                 "This group contains entries whose <b>%0</b> field contains the regular expression <b>%1</b>",
-                field, StringUtil.quoteForHTML(expr)) : Localization.lang(
+                field, expr) : Localization.lang(
                         "This group contains entries whose <b>%0</b> field contains the keyword <b>%1</b>",
-                        field, StringUtil.quoteForHTML(expr));
+                        field, expr);
         String caseSensitiveText = caseSensitive ? Localization.lang("case sensitive") : Localization
                 .lang("case insensitive");
         String footer = regExp ? Localization
@@ -30,7 +30,7 @@ public class GroupDescriptions {
                                 + "then using the context menu. "
                                 + "This process removes the term <b>%1</b> from "
                                 + "each entry's <b>%0</b> field.",
-                        field, StringUtil.quoteForHTML(expr));
+                        field, expr);
         return String.format("%s (%s). %s", header, caseSensitiveText, footer);
     }
 

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -612,12 +612,12 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         descriptionTextFlow.getChildren().setAll(createFormattedDescription(description));
     }
 
-    private ArrayList<Node> createFormattedDescription(String description) {
+    private ArrayList<Node> createFormattedDescription(String descriptionHTML) {
         ArrayList<Node> nodes = new ArrayList<>();
 
-        description = description.replaceAll("<p>|<br>", "\n");
+        descriptionHTML = descriptionHTML.replaceAll("<p>|<br>", "\n");
 
-        String[] boldSplit = description.split("(?=<b>)|(?<=</b>)|(?=<i>)|(?<=</i>)|(?=<tt>)|(?<=</tt>)|(?=<kbd>)|(?<=</kbd>)");
+        String[] boldSplit = descriptionHTML.split("(?=<b>)|(?<=</b>)|(?=<i>)|(?<=</i>)|(?=<tt>)|(?<=</tt>)|(?=<kbd>)|(?<=</kbd>)");
 
         for (String bs : boldSplit) {
 

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -2,6 +2,7 @@ package org.jabref.gui.groups;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -9,6 +10,7 @@ import java.util.regex.PatternSyntaxException;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
@@ -16,6 +18,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.ScrollPane.ScrollBarPolicy;
+import javafx.scene.control.Separator;
 import javafx.scene.control.TextField;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
@@ -26,7 +29,6 @@ import javafx.scene.text.Font;
 import javafx.scene.text.FontPosture;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
-import javafx.scene.web.WebView;
 
 import org.jabref.Globals;
 import org.jabref.JabRefGUI;
@@ -104,7 +106,7 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
     private final TextField texGroupFilePath = new TextField();
 
     // for all types
-    private final WebView descriptionWebView = new WebView();
+    private final TextFlow descriptionTextFlow = new TextFlow();
     private final StackPane optionsPanel = new StackPane();
 
 
@@ -120,7 +122,10 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
 
         explicitRadioButton.setSelected(true);
 
-        descriptionWebView.setPrefWidth(585);
+        descriptionTextFlow.setMinWidth(585);
+        descriptionTextFlow.setPrefWidth(585);
+        descriptionTextFlow.setMinHeight(180);
+        descriptionTextFlow.setPrefHeight(180);
 
         // set default values (overwritten if editedGroup != null)
         keywordGroupSearchField.setText(jabrefFrame.prefs().get(JabRefPreferences.GROUPS_DEFAULT_FIELD));
@@ -196,26 +201,31 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         selectPanel.setPadding(new Insets(0, 0, 0, 10));
 
         // Description panel
-        ScrollPane descriptionPane = new ScrollPane(descriptionWebView);
+        ScrollPane descriptionPane = new ScrollPane(descriptionTextFlow);
         descriptionPane.setHbarPolicy(ScrollBarPolicy.AS_NEEDED);
         descriptionPane.setVbarPolicy(ScrollBarPolicy.AS_NEEDED);
 
         // create layout
-        VBox mainPanel = new VBox(15);
+        HBox mainPanel = new HBox(15);
         getDialogPane().setContent(mainPanel);
         mainPanel.setPadding(new Insets(5, 15, 5, 15));
         mainPanel.getChildren().setAll(
-                generalPanel,
                 new VBox(5,
-                        new Label(Localization.lang("Type")),
-                        selectPanel
+                        generalPanel,
+                        new VBox(5,
+                                new Label(Localization.lang("Type")),
+                                selectPanel
+                        )
                 ),
-                new VBox(
-                        new Label(Localization.lang("Options")),
-                        optionsPanel
-                ),
-                new Label(Localization.lang("Description")),
-                descriptionPane
+                new Separator(Orientation.VERTICAL),
+                new VBox(5,
+                        new VBox(
+                                new Label(Localization.lang("Options")),
+                                optionsPanel
+                        ),
+                        new Label(Localization.lang("Description")),
+                        descriptionPane
+                )
         );
 
         updateComponents();
@@ -393,6 +403,9 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
                 texGroupFilePath.setText(group.getFilePath().toString());
             }
         }
+
+        setResizable(false);
+        getDialogPane().getScene().getWindow().sizeToScene();
     }
 
     public GroupDialog() {
@@ -517,7 +530,7 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         boolean okEnabled = !nameField.getText().trim().isEmpty();
         if (!okEnabled) {
             setDescription(Localization.lang("Please enter a name for the group."));
-            //TODO: okButton.setDisable(true);
+            getDialogPane().lookupButton(ButtonType.OK).setDisable(true);
             return;
         }
         String s1;
@@ -532,18 +545,18 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
                     try {
                         Pattern.compile(s2);
                         setDescription(GroupDescriptions.getDescriptionForPreview(s1, s2, keywordGroupCaseSensitive.isSelected(),
-                                                                                  keywordGroupRegExp.isSelected()));
+                                keywordGroupRegExp.isSelected()));
                     } catch (PatternSyntaxException e) {
                         okEnabled = false;
                         setDescription(formatRegExException(s2, e));
                     }
                 } else {
                     setDescription(GroupDescriptions.getDescriptionForPreview(s1, s2, keywordGroupCaseSensitive.isSelected(),
-                                                                              keywordGroupRegExp.isSelected()));
+                            keywordGroupRegExp.isSelected()));
                 }
             } else {
                 setDescription(Localization.lang(
-                                                 "Please enter the field to search (e.g. <b>keywords</b>) and the keyword to search it for (e.g. <b>electrical</b>)."));
+                        "Please enter the field to search (e.g. <b>keywords</b>) and the keyword to search it for (e.g. <b>electrical</b>)."));
             }
             setNameFontItalic(true);
         } else if (searchRadioButton.isSelected()) {
@@ -551,8 +564,8 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
             okEnabled = okEnabled & !s1.isEmpty();
             if (okEnabled) {
                 setDescription(fromTextFlowToHTMLString(SearchDescribers.getSearchDescriberFor(
-                                                                                               new SearchQuery(s1, isCaseSensitive(), isRegex()))
-                                                                        .getDescription()));
+                        new SearchQuery(s1, isCaseSensitive(), isRegex()))
+                        .getDescription()));
 
                 if (isRegex()) {
                     try {
@@ -564,17 +577,17 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
                 }
             } else {
                 setDescription(Localization
-                                           .lang("Please enter a search term. For example, to search all fields for <b>Smith</b>, enter:<p>"
-                                                 + "<tt>smith</tt><p>"
-                                                 + "To search the field <b>Author</b> for <b>Smith</b> and the field <b>Title</b> for <b>electrical</b>, enter:<p>"
-                                                 + "<tt>author=smith and title=electrical</tt>"));
+                        .lang("Please enter a search term. For example, to search all fields for <b>Smith</b>, enter:<p>"
+                                + "<tt>smith</tt><p>"
+                                + "To search the field <b>Author</b> for <b>Smith</b> and the field <b>Title</b> for <b>electrical</b>, enter:<p>"
+                                + "<tt>author=smith and title=electrical</tt>"));
             }
             setNameFontItalic(true);
         } else if (explicitRadioButton.isSelected()) {
             setDescription(GroupDescriptions.getDescriptionForPreview());
             setNameFontItalic(false);
         }
-        //TODO: okButton.setDisable(!okEnabled);
+        getDialogPane().lookupButton(ButtonType.OK).setDisable(!okEnabled);
     }
 
     private String fromTextFlowToHTMLString(TextFlow textFlow) {
@@ -596,7 +609,45 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
     }
 
     private void setDescription(String description) {
-        descriptionWebView.getEngine().loadContent("<html>" + description + "</html>");
+        descriptionTextFlow.getChildren().setAll(createFormattedDescription(description));
+    }
+
+    private ArrayList<Node> createFormattedDescription(String description) {
+        ArrayList<Node> nodes = new ArrayList<>();
+
+        description = description.replaceAll("<p>|<br>", "\n");
+
+        String[] boldSplit = description.split("(?=<b>)|(?<=</b>)|(?=<i>)|(?<=</i>)|(?=<tt>)|(?<=</tt>)|(?=<kbd>)|(?<=</kbd>)");
+
+        for (String bs : boldSplit) {
+
+            if (bs.matches("<b>[^<>]*</b>")) {
+
+                bs = bs.replaceAll("<b>|</b>", "");
+                Text textElement = new Text(bs);
+                textElement.setStyle("-fx-font-weight: bold");
+                nodes.add(textElement);
+
+            } else if (bs.matches("<i>[^<>]*</i>")) {
+
+                bs = bs.replaceAll("<i>|</i>", "");
+                Text textElement = new Text(bs);
+                textElement.setStyle("-fx-font-style: italic");
+                nodes.add(textElement);
+
+            } else if (bs.matches("<tt>[^<>]*</tt>|<kbd>[^<>]*</kbd>")) {
+
+                bs = bs.replaceAll("<tt>|</tt>|<kbd>|</kbd>", "");
+                Text textElement = new Text(bs);
+                textElement.setStyle("-fx-font-family: 'Courier New', Courier, monospace");
+                nodes.add(textElement);
+
+            } else {
+                nodes.add(new Text(bs));
+            }
+        }
+
+        return nodes;
     }
 
     /**

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -106,7 +106,12 @@ public class GroupTreeViewModel extends AbstractViewModel {
      * Opens "New Group Dialog" and add the resulting group to the root
      */
     public void addNewGroupToRoot() {
-        addNewSubgroup(rootGroup.get());
+        if (currentDatabase.isPresent()) {
+            addNewSubgroup(rootGroup.get());
+        } else {
+            dialogService.showWarningDialogAndWait(Localization.lang("Cannot create group"), Localization.lang("Cannot create group. Please create a database first."));
+            //dialogService.notify(Localization.lang("Cannot create group. Please create a database first."));
+        }
     }
 
     /**
@@ -124,8 +129,8 @@ public class GroupTreeViewModel extends AbstractViewModel {
             rootGroup.setValue(newRoot);
             this.selectedGroups.setAll(
                     stateManager.getSelectedGroup(newDatabase.get()).stream()
-                                .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup, localDragboard))
-                                .collect(Collectors.toList()));
+                            .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup, localDragboard))
+                            .collect(Collectors.toList()));
         } else {
             rootGroup.setValue(GroupNodeViewModel.getAllEntriesGroup(new BibDatabaseContext(), stateManager, taskExecutor, localDragboard));
         }
@@ -228,7 +233,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
             //panel.getUndoManager().addEdit(undo);
             GroupTreeNode groupNode = group.getGroupNode();
             groupNode.getParent()
-                     .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
+                    .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
             groupNode.removeFromParent();
 
             dialogService.notify(Localization.lang("Removed group \"%0\".", group.getDisplayName()));

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -109,8 +109,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
         if (currentDatabase.isPresent()) {
             addNewSubgroup(rootGroup.get());
         } else {
-            dialogService.showWarningDialogAndWait(Localization.lang("Cannot create group"), Localization.lang("Cannot create group. Please create a database first."));
-            //dialogService.notify(Localization.lang("Cannot create group. Please create a database first."));
+            dialogService.showWarningDialogAndWait(Localization.lang("Cannot create group"), Localization.lang("Cannot create group. Please create a library first."));
         }
     }
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -129,7 +129,7 @@ Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now
 
 Cannot\ create\ group=Gruppe kann nicht erstellt werden
 
-Cannot\ create\ group.\ Please\ create\ a\ database\ first.=Gruppe kann nicht erstellt werden. Erstellen sie zuerst eine Datenbank.
+Cannot\ create\ group.\ Please\ create\ a\ library\ first.=Gruppe kann nicht erstellt werden. Erstellen sie zuerst eine Bibliothek.
 
 Cannot\ merge\ this\ change=Kann diese Änderung nicht einfügen
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -127,6 +127,10 @@ Cancel=Abbrechen
 
 Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Einträge können einer Gruppe nicht hinzugefügt werden, ohne Keys zu generieren. Sollen die Keys jetzt generiert werden?
 
+Cannot\ create\ group=Gruppe kann nicht erstellt werden
+
+Cannot\ create\ group.\ Please\ create\ a\ database\ first.=Gruppe kann nicht erstellt werden. Erstellen sie zuerst eine Datenbank.
+
 Cannot\ merge\ this\ change=Kann diese Änderung nicht einfügen
 
 case\ insensitive=Groß-/Kleinschreibung wird nicht unterschieden

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -119,7 +119,7 @@ Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now
 
 Cannot\ create\ group=Cannot create group
 
-Cannot\ create\ group.\ Please\ create\ a\ database\ first.=Cannot create group. Please create a database first.
+Cannot\ create\ group.\ Please\ create\ a\ library\ first.=Cannot create group. Please create a library first.
 
 Cannot\ merge\ this\ change=Cannot merge this change
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -117,6 +117,10 @@ Cancel=Cancel
 
 Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Cannot add entries to group without generating keys. Generate keys now?
 
+Cannot\ create\ group=Cannot create group
+
+Cannot\ create\ group.\ Please\ create\ a\ database\ first.=Cannot create group. Please create a database first.
+
 Cannot\ merge\ this\ change=Cannot merge this change
 
 case\ insensitive=case insensitive


### PR DESCRIPTION
fixes [#4610](https://github.com/JabRef/jabref/issues/4610)

- Changed GroupDialog description Node to TextFlow
- GroupDialog is no longer resizable
- Changed the layout of the GroupDialog window to be more horizontal
- OK Button is only enabled after some input

![jabrefgroupdialog2](https://user-images.githubusercontent.com/25904972/52920648-3f3d0380-330f-11e9-9c84-2d366ae3bd45.PNG)


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
