### PR TITLE
Improve parser warnings

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -703,21 +703,21 @@ public class BibtexParser implements Parser {
                     }
 
                     // Finished, now reverse newKey and remove whitespaces:
-                    parserResult.addWarning(
-                            Localization.lang("Line %0: Found corrupted BibTeX key.", String.valueOf(line)));
                     key = newKey.reverse();
+                    parserResult.addWarning(
+                            Localization.lang("Line %0: Found corrupted BibTeX key %1.", String.valueOf(line), key.toString()));
                 }
             }
             break;
 
         case ',':
-            parserResult.addWarning(Localization.lang("Line %0: Found corrupted BibTeX key (contains whitespaces).",
-                    String.valueOf(line)));
+            parserResult.addWarning(
+                    Localization.lang("Line %0: Found corrupted BibTeX key %1 (contains whitespaces).", String.valueOf(line), key.toString()));
             break;
 
         case '\n':
             parserResult.addWarning(
-                    Localization.lang("Line %0: Found corrupted BibTeX key (comma missing).", String.valueOf(line)));
+                    Localization.lang("Line %0: Found corrupted BibTeX key %1 (comma missing).", String.valueOf(line), key.toString()));
             break;
 
         default:

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1160,10 +1160,9 @@ Use\ IEEE\ LaTeX\ abbreviations=Use IEEE LaTeX abbreviations
 
 When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=When opening file link, search for matching file if no link is defined
 Settings\ for\ %0=Settings for %0
-
-Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Line %0: Found corrupted BibTeX key.
-Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Line %0: Found corrupted BibTeX key (contains whitespaces).
-Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Line %0: Found corrupted BibTeX key (comma missing).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ %1.=Line %0: Found corrupted BibTeX key %1.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ %1\ (contains\ whitespaces).=Line %0: Found corrupted BibTeX key %1 (contains whitespaces).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ %1\ (comma\ missing).=Line %0: Found corrupted BibTeX key %1 (comma missing).
 No\ full\ text\ document\ found=No full text document found
 Update\ to\ current\ column\ order=Update to current column order
 Download\ from\ URL=Download from URL


### PR DESCRIPTION
Based on http://discourse.jabref.org/t/warnings-by-jabref-start/1532, in which a user (rightfully) complained that the error message is not very helpful.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
