### PR TITLE
Temporarily remove "Customize entry types"

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -941,6 +941,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 new SeparatorMenuItem(),
 
                 factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new ManageContentSelectorAction(this)),
+                // TODO: Reenable customize entry types feature (https://github.com/JabRef/jabref/issues/4719)
                 //factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
                 factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this)));
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -58,7 +58,6 @@ import org.jabref.gui.actions.AutoLinkFilesAction;
 import org.jabref.gui.actions.BibtexKeyPatternAction;
 import org.jabref.gui.actions.ConnectToSharedDatabaseCommand;
 import org.jabref.gui.actions.CopyFilesAction;
-import org.jabref.gui.actions.CustomizeEntryAction;
 import org.jabref.gui.actions.CustomizeKeyBindingAction;
 import org.jabref.gui.actions.DatabasePropertiesAction;
 import org.jabref.gui.actions.EditExternalFileTypesAction;
@@ -942,7 +941,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 new SeparatorMenuItem(),
 
                 factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new ManageContentSelectorAction(this)),
-                factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
+                //factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
                 factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this)));
 
         help.getItems().addAll(

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryAction.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryAction.java
@@ -1,9 +1,7 @@
-package org.jabref.gui.actions;
-
-import javax.swing.JDialog;
+package org.jabref.gui.customentrytypes;
 
 import org.jabref.gui.JabRefFrame;
-import org.jabref.gui.customentrytypes.EntryTypeCustomizationDialog;
+import org.jabref.gui.actions.SimpleCommand;
 
 public class CustomizeEntryAction extends SimpleCommand {
 
@@ -15,7 +13,7 @@ public class CustomizeEntryAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        JDialog dialog = new EntryTypeCustomizationDialog(frame);
-        dialog.setVisible(true);
+        EntryTypeCustomizationDialog dialog = new EntryTypeCustomizationDialog();
+        dialog.showAndWait();
     }
 }

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
@@ -4,6 +4,7 @@ import org.jabref.gui.util.BaseDialog;
 
 public class EntryTypeCustomizationDialog extends BaseDialog<Void> {
 
+    // TODO: Re-implement customize entry types feature (https://github.com/JabRef/jabref/issues/4719)
     /*
     protected GridBagLayout gbl = new GridBagLayout();
     protected GridBagConstraints con = new GridBagConstraints();

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
@@ -1,56 +1,10 @@
 package org.jabref.gui.customentrytypes;
 
-import java.awt.BorderLayout;
-import java.awt.Container;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import org.jabref.gui.util.BaseDialog;
 
-import javax.swing.AbstractAction;
-import javax.swing.ActionMap;
-import javax.swing.BorderFactory;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.ListSelectionModel;
-import javax.swing.event.ListDataEvent;
-import javax.swing.event.ListDataListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
+public class EntryTypeCustomizationDialog extends BaseDialog<Void> {
 
-import org.jabref.Globals;
-import org.jabref.gui.BasePanel;
-import org.jabref.gui.JabRefDialog;
-import org.jabref.gui.JabRefFrame;
-import org.jabref.gui.keyboard.KeyBinding;
-import org.jabref.logic.l10n.Localization;
-import org.jabref.model.EntryTypes;
-import org.jabref.model.database.BibDatabaseMode;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.CustomEntryType;
-import org.jabref.model.entry.EntryType;
-import org.jabref.model.entry.InternalBibtexFields;
-import org.jabref.model.strings.StringUtil;
-
-import com.jgoodies.forms.builder.ButtonBarBuilder;
-
-public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSelectionListener {
-
+    /*
     protected GridBagLayout gbl = new GridBagLayout();
     protected GridBagConstraints con = new GridBagConstraints();
     protected JButton delete;
@@ -70,9 +24,6 @@ public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSe
     private boolean biblatexMode;
     private BibDatabaseMode bibDatabaseMode;
 
-    /**
-     * Creates a new instance of EntryTypeCustomizationDialog
-     */
     public EntryTypeCustomizationDialog(JabRefFrame frame) {
         super(Localization.lang("Customize entry types"), false, EntryTypeCustomizationDialog.class);
 
@@ -419,6 +370,7 @@ public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSe
             changed.add(lastSelected);
             typeComp.enable(lastSelected, true);
         }
-
     }
+
+    */
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

As discussed in the devcall, we might temporarily remove (or disable) some of the old Swing dialog instead of converting them directly to JavaFX. The "Customize entry types" dialog is one of these dialogs, because it is not yet clear how entries should be displayed in the entry editor (especially how to group fields) and these decisions directly translate to changes to the customization dialog.

After merging, an issue for the re-implementation should be opened.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
