### PR TITLE
Adding additional modifiers to be used in bibtex key generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added the ability change the column widths directly in the main table. [#4546](https://github.com/JabRef/jabref/issues/4546)
 - We added the ability to execute default action in dialog by using with <kbd>Ctrl</kbd> + <kbd>Enter</kbd> combination [#4496](https://github.com/JabRef/jabref/issues/4496)
 - We grouped and reordered the Main Menu (File, Edit, Library, Quality, Tools, and View tabs & icons). [#4666](https://github.com/JabRef/jabref/issues/4666) [#4667](https://github.com/JabRef/jabref/issues/4667) [#4668](https://github.com/JabRef/jabref/issues/4668) [#4669](https://github.com/JabRef/jabref/issues/4669) [#4670](https://github.com/JabRef/jabref/issues/4670) [#4671](https://github.com/JabRef/jabref/issues/4671) [#4672](https://github.com/JabRef/jabref/issues/4672) [#4673](https://github.com/JabRef/jabref/issues/4673)
-
+- We added additional modifiers (capitalize, titlecase and sentencecase) to the Bibtex key generator. [#1506](https://github.com/JabRef/jabref/issues/1506)
 
 
 

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -87,6 +87,12 @@ public class Formatters {
                 return Optional.of(new LowerCaseFormatter());
             case "upper":
                 return Optional.of(new UpperCaseFormatter());
+            case "capitalize":
+                return Optional.of(new CapitalizeFormatter());
+            case "titlecase":
+                return Optional.of(new TitleCaseFormatter());
+            case "sentencecase":
+                return Optional.of(new SentenceCaseFormatter());
         }
 
         if (modifier.startsWith(RegexFormatter.KEY)) {

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -1007,4 +1007,58 @@ public class BibtexKeyGeneratorTest {
         entry.setField("title", "The Interesting Title");
         assertEquals("theinterestingtitle", BibtexKeyGenerator.generateKey(entry, "title:lower:(_)"));
     }
+
+    @Test
+    public void generateKeyWithTitleCapitalizeModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "the InTeresting title longer than THREE words");
+        assertEquals("TheInterestingTitleLongerThanThreeWords", BibtexKeyGenerator.generateKey(entry, "title:capitalize"));
+    }
+
+    @Test
+    public void generateKeyWithShortTitleCapitalizeModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "the InTeresting title longer than THREE words");
+        assertEquals("InterestingTitleLonger", BibtexKeyGenerator.generateKey(entry, "shorttitle:capitalize"));
+    }
+
+    @Test
+    public void generateKeyWithTitleTitleCaseModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "A title WITH some of The key words");
+        assertEquals("ATitlewithSomeoftheKeyWords", BibtexKeyGenerator.generateKey(entry, "title:titlecase"));
+    }
+
+    @Test
+    public void generateKeyWithShortTitleTitleCaseModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "the InTeresting title longer than THREE words");
+        assertEquals("InterestingTitleLonger", BibtexKeyGenerator.generateKey(entry, "shorttitle:titlecase"));
+    }
+
+    @Test
+    public void generateKeyWithTitleSentenceCaseModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "A title WITH some of The key words");
+        assertEquals("Atitlewithsomeofthekeywords", BibtexKeyGenerator.generateKey(entry, "title:sentencecase"));
+    }
+
+    @Test
+    public void generateKeyWithAuthUpperYearShortTitleCapitalizeModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("author", AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1);
+        entry.setField("year", "2019");
+        entry.setField("title", "the InTeresting title longer than THREE words");
+        assertEquals("NEWTON2019InterestingTitleLonger", BibtexKeyGenerator.generateKey(entry, "[auth:upper][year][shorttitle:capitalize]"));
+    }
+
+    @Test
+    public void generateKeyWithYearAuthUpperTitleSentenceCaseModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("author", AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_3);
+        entry.setField("year", "2019");
+        entry.setField("title", "the InTeresting title longer than THREE words");
+        assertEquals("NewtonMaxwellEtAl_2019_TheInterestingTitleLongerThanThreeWords", BibtexKeyGenerator.generateKey(entry, "[authors2]_[year]_[title:capitalize]"));
+    }
+
 }


### PR DESCRIPTION
As I currently wanted to have a possibility to have "Capitalized Shorttitles" in my bibtex keys I reused the already existing `CapitalizeFormatter`, `TitleCaseFormatter` and `SentenceCaseFormatter` as "modifiers" to be used also for the BibtexKeyGenerator.

This implements #1506 and is more flexible as the solution developed by @oscargus at the time in  #1894 as it can be applied to all other fields and not only to titles. 


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?) - https://help.jabref.org/en/BibtexKeyPatterns needs to be updated
