### PR TITLE
Move library specific key pattern dialog call to library menu

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -829,6 +829,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 factory.createMenuItem(StandardActions.LIBRARY_PROPERTIES, new LibraryPropertiesAction(this, dialogService)),
                 factory.createMenuItem(StandardActions.EDIT_PREAMBLE, new PreambleEditor(this)),
                 factory.createMenuItem(StandardActions.EDIT_STRINGS, new BibtexStringEditorAction(this)),
+                factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this)),
                 factory.createMenuItem(StandardActions.MASS_SET_FIELDS, new MassSetFieldsAction(this))
         );
 
@@ -916,10 +917,9 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
 
                 new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new ManageContentSelectorAction(this)),
+                factory.createMenuItem(StandardActions.MANAGE_CONTENT_SELECTORS, new ManageContentSelectorAction(this))
                 // TODO: Reenable customize entry types feature (https://github.com/JabRef/jabref/issues/4719)
                 //factory.createMenuItem(StandardActions.CUSTOMIZE_ENTRY_TYPES, new CustomizeEntryAction(this)),
-                factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this))
         );
 
         help.getItems().addAll(

--- a/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
+++ b/src/main/java/org/jabref/gui/bibtexkeypattern/BibtexKeyPatternDialog.java
@@ -5,6 +5,7 @@ import javafx.scene.control.ButtonType;
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.util.BaseDialog;
+import org.jabref.logic.l10n.Localization;
 import org.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import org.jabref.model.metadata.MetaData;
 
@@ -24,6 +25,8 @@ public class BibtexKeyPatternDialog extends BaseDialog<Void> {
     }
 
     private void init() {
+
+        this.setTitle(Localization.lang("BibTeX key patterns"));
 
         this.getDialogPane().setContent(bibtexKeyPatternPanel.getPanel());
         this.getDialogPane().getButtonTypes().addAll(ButtonType.APPLY, ButtonType.CANCEL);


### PR DESCRIPTION
Follow-up of #4666 and #4707: Menu entry "BibTeX Key patterns" is calling a library specific dialog to set key patterns. The global key patterns are managed using "Options" -> "Preferences".

Thus: Moving it to "library" menu:

![Grabbed_20190310-174125](https://user-images.githubusercontent.com/676652/54088195-bdfbee00-435b-11e9-8fab-063fe84f9805.png)

(Another minor addition: setting title of dialog which was empty before)

----

- ~~Change in CHANGELOG.md described~~
- ~~Tests created for changes~~
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- ~~Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
