### PR TITLE
Reusable method create to get last focused tab preferences

### DIFF
--- a/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
@@ -62,15 +62,20 @@ public class Benchmarks {
             entry.setField("rnd", "2" + randomizer.nextInt());
             database.insertEntry(entry);
         }
-        StringWriter outputWriter = new StringWriter();
-        BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(outputWriter, mock(SavePreferences.class));
-        databaseWriter.savePartOfDatabase(
-                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries());
-        bibtexString = outputWriter.toString();
+
+        bibtexString = getOutputWriter().toString();
 
         latexConversionString = "{A} \\textbf{bold} approach {\\it to} ${{\\Sigma}}{\\Delta}$ modulator \\textsuperscript{2} \\$";
 
         htmlConversionString = "<b>&Ouml;sterreich</b> &#8211; &amp; characters &#x2aa2; <i>italic</i>";
+    }
+
+    private StringWriter getOutputWriter() throws IOException {
+        StringWriter outputWriter = new StringWriter();
+        BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(outputWriter, mock(SavePreferences.class));
+        databaseWriter.savePartOfDatabase(
+                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries());
+        return outputWriter;
     }
 
     @Benchmark
@@ -81,10 +86,7 @@ public class Benchmarks {
 
     @Benchmark
     public String write() throws Exception {
-        StringWriter outputWriter = new StringWriter();
-        BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(outputWriter, mock(SavePreferences.class));
-        databaseWriter.savePartOfDatabase(new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries());
-        return outputWriter.toString();
+        return getOutputWriter().toString();
     }
 
     @Benchmark

--- a/src/jmh/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/jmh/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
@@ -8,39 +8,38 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LastFocusedTabPreferencesTest {
+class LastFocusedTabPreferencesTest {
 
     private static String previousValue;
 
     @BeforeAll
-    public static void savePreferenceLastFocus() {
+    static void savePreferenceLastFocus() {
         previousValue = JabRefPreferences.getInstance().get(JabRefPreferences.LAST_FOCUSED);
     }
 
     @AfterAll
-    public static void restorePreferenceLastFocus() {
+    static void restorePreferenceLastFocus() {
         if (previousValue != null) {
             JabRefPreferences.getInstance().put(JabRefPreferences.LAST_FOCUSED, previousValue);
         }
     }
 
     @Test
-    public void testLastFocusedTab() {
-        getFocusedTabPreferences();
-    }
-
-    @Test
-    public void testLastFocusedTabNull() {
-        File whatever = new File("whatever");
-        getFocusedTabPreferences().setLastFocusedTab(null);
-        assertTrue(getFocusedTabPreferences().hadLastFocus(whatever));
-    }
-
-    private LastFocusedTabPreferences getFocusedTabPreferences(){
+    void testLastFocusedTab() {
         LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
         File whatever = new File("whatever");
         prefs.setLastFocusedTab(whatever);
         assertTrue(prefs.hadLastFocus(whatever));
-        return prefs;
+    }
+
+    @Test
+    void testLastFocusedTabNull() {
+        LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
+        File whatever = new File("whatever");
+        prefs.setLastFocusedTab(whatever);
+        assertTrue(prefs.hadLastFocus(whatever));
+
+        prefs.setLastFocusedTab(null);
+        assertTrue(prefs.hadLastFocus(whatever));
     }
 }

--- a/src/jmh/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/jmh/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
@@ -26,20 +26,21 @@ public class LastFocusedTabPreferencesTest {
 
     @Test
     public void testLastFocusedTab() {
-        LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
-        File whatever = new File("whatever");
-        prefs.setLastFocusedTab(whatever);
-        assertTrue(prefs.hadLastFocus(whatever));
+        getFocusedTabPreferences();
     }
 
     @Test
     public void testLastFocusedTabNull() {
+        File whatever = new File("whatever");
+        getFocusedTabPreferences().setLastFocusedTab(null);
+        assertTrue(getFocusedTabPreferences().hadLastFocus(whatever));
+    }
+
+    private LastFocusedTabPreferences getFocusedTabPreferences(){
         LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
         File whatever = new File("whatever");
         prefs.setLastFocusedTab(whatever);
         assertTrue(prefs.hadLastFocus(whatever));
-
-        prefs.setLastFocusedTab(null);
-        assertTrue(prefs.hadLastFocus(whatever));
+        return prefs;
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
