### PR TITLE
Changes the title of Group Dialog to Add subgroup when adding a new subgroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added additional modifiers (capitalize, titlecase and sentencecase) to the Bibtex key generator. [#1506](https://github.com/JabRef/jabref/issues/1506)
 - We grouped the toolbar icons and changed the Open Library and Copy icons. [#4584](https://github.com/JabRef/jabref/issues/4584) 
 - We added a browse button next to the path text field for aux-based groups. [#4586](https://github.com/JabRef/jabref/issues/4586)
+- We changed the title of Group Dialog to "Add subgroup" from "Edit group" when we select Add subgroup option.
 
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -128,7 +128,12 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
      *                    created.
      */
     public GroupDialog(DialogService dialogService, BasePanel basePanel, JabRefPreferences prefs, AbstractGroup editedGroup) {
-        this.setTitle(Localization.lang("Edit group"));
+
+        if (editedGroup == null) {
+            this.setTitle(Localization.lang("Add subgroup"));
+        } else {
+            this.setTitle(Localization.lang("Edit group"));
+        }
 
         explicitRadioButton.setSelected(true);
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Changes the title of Group Dialog to "Add subgroup" from "Edit group" when we select Add subgroup option.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
![add_subgroup](https://user-images.githubusercontent.com/36728314/54215630-43270480-450e-11e9-98b7-a55d560382fb.jpg)
