### PR TITLE
Feature: implement search filter in show preferences

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -25,7 +25,7 @@
             </bottom>
             <top>
                 <HBox>
-                    <TextField fx:id="searchField" promptText="Search"/>
+                    <TextField fx:id="searchField" promptText="%Search"/>
                     <HBox HBox.hgrow="ALWAYS"/>
                 </HBox>
             </top>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -10,22 +10,24 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="600.0" prefWidth="950.0"
             xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.gui.preferences.PreferencesFilterDialog">
 
     <content>
         <BorderPane>
             <bottom>
-                <HBox>
-                    <CheckBox fx:id="showOnlyDeviatingPreferenceOptions"
-                              text="%Show only preferences deviating from their default value"/>
-                    <HBox HBox.hgrow="ALWAYS"/>
+                <HBox alignment="BOTTOM_RIGHT">
                     <Label fx:id="count"/>
                 </HBox>
             </bottom>
             <top>
-                <HBox>
+                <HBox spacing="20">
                     <TextField fx:id="searchField" promptText="%Search"/>
+                    <VBox alignment="CENTER">
+                        <CheckBox fx:id="showOnlyDeviatingPreferenceOptions"
+                            text="%Show only preferences deviating from their default value" alignment="bottom_right"/>
+                    </VBox>
                     <HBox HBox.hgrow="ALWAYS"/>
                 </HBox>
             </top>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -24,11 +24,11 @@
                 </HBox>
             </bottom>
             <top>
-            	<HBox>
-					<TextField fx:id="searchField" promptText="Search"/>
-					<HBox HBox.hgrow="ALWAYS"/>
-				</HBox>
-			</top>
+                <HBox>
+                    <TextField fx:id="searchField" promptText="Search"/>
+                    <HBox HBox.hgrow="ALWAYS"/>
+                </HBox>
+            </top>
             <center>
                 <TableView fx:id="table">
                     <columns>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="600.0" prefWidth="950.0"
@@ -22,6 +23,12 @@
                     <Label fx:id="count"/>
                 </HBox>
             </bottom>
+            <top>
+            	<HBox>
+					<TextField fx:id="searchField" promptText="Search"/>
+					<HBox HBox.hgrow="ALWAYS"/>
+				</HBox>
+			</top>
             <center>
                 <TableView fx:id="table">
                     <columns>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.preferences;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -82,7 +83,7 @@ public class PreferencesFilterDialog extends BaseDialog<Void> {
         }
 
         List<JabRefPreferencesFilter.PreferenceOption> filteredOptions = auxillaryPreferenceOptions.stream()
-                                                                                                   .filter(p -> p.getKey().toLowerCase().contains(searchText))
+                                                                                                   .filter(p -> p.getKey().toLowerCase(Locale.ROOT).contains(searchText))
                                                                                                    .collect(Collectors.toList());
         preferenceOptions.setAll(filteredOptions);
     }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
@@ -74,6 +74,7 @@ public class PreferencesFilterDialog extends BaseDialog<Void> {
         } else {
             preferenceOptions.setAll(preferencesFilter.getPreferenceOptions());
         }
+        count.setText(String.format("(%d)", preferenceOptions.size()));
     }
 
 }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
@@ -65,6 +65,7 @@ public class PreferencesFilterDialog extends BaseDialog<Void> {
         columnValue.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getValue()));
         columnDefaultValue.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getDefaultValue().orElse("")));
         table.setItems(filteredOptions);
+        count.textProperty().bind(Bindings.size(table.getItems()).asString("(%d)"));
         updateModel();
     }
 
@@ -74,7 +75,6 @@ public class PreferencesFilterDialog extends BaseDialog<Void> {
         } else {
             preferenceOptions.setAll(preferencesFilter.getPreferenceOptions());
         }
-        count.setText(String.format("(%d)", preferenceOptions.size()));
     }
 
 }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.java
@@ -52,7 +52,7 @@ public class PreferencesFilterDialog extends BaseDialog<Void> {
     @FXML
     private void initialize() {
         showOnlyDeviatingPreferenceOptions.setOnAction(event -> updateModel());
-        searchField.textProperty().addListener((observable, previousText, newText) -> filterPreferences(newText.toLowerCase()));
+        searchField.textProperty().addListener((observable, previousText, newText) -> filterPreferences(newText.toLowerCase(Locale.ROOT)));
         columnType.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getType()));
         columnKey.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().getKey()));
         columnValue.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getValue()));


### PR DESCRIPTION
Add a search box in show preferences window to allow users to filter
preference options.

Resolves #1019

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

![preferences](https://user-images.githubusercontent.com/21019116/54366500-bfe4ea80-4696-11e9-8d07-e0cd0428ed66.png)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
