### PR TITLE
Improve Remote messaging

### DIFF
--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -141,6 +141,8 @@ public class JabRefMain extends Application {
                     // So we assume it's all taken care of, and quit.
                     LOGGER.info(Localization.lang("Arguments passed on to running JabRef instance. Shutting down."));
                     return false;
+                } else {
+                    LOGGER.warn("Could not communicate with other running JabRef instance.");
                 }
             } else {
                 // We are alone, so we start the server

--- a/src/main/java/org/jabref/gui/remote/JabRefMessageHandler.java
+++ b/src/main/java/org/jabref/gui/remote/JabRefMessageHandler.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.remote;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javafx.application.Platform;
@@ -15,9 +14,6 @@ public class JabRefMessageHandler implements MessageHandler {
     @Override
     public void handleCommandLineArguments(String[] message) {
         ArgumentProcessor argumentProcessor = new ArgumentProcessor(message, ArgumentProcessor.Mode.REMOTE_START);
-        if (!(argumentProcessor.hasParserResults())) {
-            throw new IllegalStateException("Could not start JabRef with arguments " + Arrays.toString(message));
-        }
 
         List<ParserResult> loaded = argumentProcessor.getParserResults();
         for (int i = 0; i < loaded.size(); i++) {

--- a/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
+++ b/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.remote.client;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 
 import javafx.util.Pair;
@@ -17,8 +18,8 @@ public class RemoteClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteClient.class);
 
-    private static final int TIMEOUT = 2000;
-    private int port;
+    private static final int TIMEOUT = 200;
+    private final int port;
 
     public RemoteClient(int port) {
         this.port = port;
@@ -61,8 +62,9 @@ public class RemoteClient {
     }
 
     private Protocol openNewConnection() throws IOException {
-        Socket socket = new Socket(RemotePreferences.getIpAddress(), port);
+        Socket socket = new Socket();
         socket.setSoTimeout(TIMEOUT);
+        socket.connect(new InetSocketAddress(RemotePreferences.getIpAddress(), port), TIMEOUT);
         return new Protocol(socket);
     }
 }

--- a/src/main/java/org/jabref/logic/remote/server/RemoteListenerServer.java
+++ b/src/main/java/org/jabref/logic/remote/server/RemoteListenerServer.java
@@ -19,7 +19,7 @@ public class RemoteListenerServer implements Runnable {
 
     private static final int BACKLOG = 1;
 
-    private static final int ONE_SECOND_TIMEOUT = 1000;
+    private static final int TIMEOUT = 1000;
 
     private final MessageHandler messageHandler;
     private final ServerSocket serverSocket;
@@ -35,7 +35,7 @@ public class RemoteListenerServer implements Runnable {
         try {
             while (!Thread.interrupted()) {
                 try (Socket socket = serverSocket.accept()) {
-                    socket.setSoTimeout(ONE_SECOND_TIMEOUT);
+                    socket.setSoTimeout(TIMEOUT);
 
                     try (Protocol protocol = new Protocol(socket)) {
                         Pair<RemoteMessage, Object> input = protocol.receiveMessage();


### PR DESCRIPTION
Fixes #4023 (multiple instances possible) and should fix #4481 by reducing the timeout (thus JabRef does no longer waits seconds if a proxy prevents us from connecting to localhast). Surpasses #4460.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
