### PR TITLE
Fix removing entries when source-code-field is out of focus

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -145,7 +145,7 @@ public class SourceTab extends EntryEditorTab {
         // and update source code for every change of entry field values
         BindingsHelper.bindContentBidirectional(entry.getFieldsObservable(), codeArea.focusedProperty(), onFocus -> {
             if (!onFocus) {
-                storeSource(codeArea.textProperty().getValue());
+                storeSource(entry, codeArea.textProperty().getValue());
             }
         }, fields -> {
             DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> {
@@ -163,8 +163,8 @@ public class SourceTab extends EntryEditorTab {
 
     }
 
-    private void storeSource(String text) {
-        if ((currentEntry == null) || text.isEmpty()) {
+    private void storeSource(BibEntry outOfFocusEntry, String text) {
+        if ((outOfFocusEntry == null) || text.isEmpty()) {
             return;
         }
 
@@ -197,42 +197,42 @@ public class SourceTab extends EntryEditorTab {
             String newKey = newEntry.getCiteKeyOptional().orElse(null);
 
             if (newKey != null) {
-                currentEntry.setCiteKey(newKey);
+                outOfFocusEntry.setCiteKey(newKey);
             } else {
-                currentEntry.clearCiteKey();
+                outOfFocusEntry.clearCiteKey();
             }
 
             // First, remove fields that the user has removed.
-            for (Map.Entry<String, String> field : currentEntry.getFieldMap().entrySet()) {
+            for (Map.Entry<String, String> field : outOfFocusEntry.getFieldMap().entrySet()) {
                 String fieldName = field.getKey();
                 String fieldValue = field.getValue();
 
                 if (InternalBibtexFields.isDisplayableField(fieldName) && !newEntry.hasField(fieldName)) {
                     compound.addEdit(
-                            new UndoableFieldChange(currentEntry, fieldName, fieldValue, null));
-                    currentEntry.clearField(fieldName);
+                                     new UndoableFieldChange(outOfFocusEntry, fieldName, fieldValue, null));
+                    outOfFocusEntry.clearField(fieldName);
                 }
             }
 
             // Then set all fields that have been set by the user.
             for (Map.Entry<String, String> field : newEntry.getFieldMap().entrySet()) {
                 String fieldName = field.getKey();
-                String oldValue = currentEntry.getField(fieldName).orElse(null);
+                String oldValue = outOfFocusEntry.getField(fieldName).orElse(null);
                 String newValue = field.getValue();
                 if (!Objects.equals(oldValue, newValue)) {
                     // Test if the field is legally set.
                     new LatexFieldFormatter(fieldFormatterPreferences)
                             .format(newValue, fieldName);
 
-                    compound.addEdit(new UndoableFieldChange(currentEntry, fieldName, oldValue, newValue));
-                    currentEntry.setField(fieldName, newValue);
+                    compound.addEdit(new UndoableFieldChange(outOfFocusEntry, fieldName, oldValue, newValue));
+                    outOfFocusEntry.setField(fieldName, newValue);
                 }
             }
 
             // See if the user has changed the entry type:
-            if (!Objects.equals(newEntry.getType(), currentEntry.getType())) {
-                compound.addEdit(new UndoableChangeType(currentEntry, currentEntry.getType(), newEntry.getType()));
-                currentEntry.setType(newEntry.getType());
+            if (!Objects.equals(newEntry.getType(), outOfFocusEntry.getType())) {
+                compound.addEdit(new UndoableChangeType(outOfFocusEntry, outOfFocusEntry.getType(), newEntry.getType()));
+                outOfFocusEntry.setType(newEntry.getType());
             }
             compound.end();
             undoManager.addEdit(compound);


### PR DESCRIPTION
Fixes #4764

The issue was, `storeSource()` method is called when entry is out of focus, however, if another entry is selected then `currentEntry` is updated to that and `storeSource()` is called with the previous `codeArea` but updating it in the second entry, thus causing a duplication.

Fix was to pass the entry as another argument to `storeSource()`. 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
