### PR TITLE
Fix do not clear wanted special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where only one PDF file could be imported [#4422](https://github.com/JabRef/jabref/issues/4422)
 - We fixed an issue where "Move to group" would always move the first entry in the library and not the selected [#4414](https://github.com/JabRef/jabref/issues/4414)
 - We fixed an issue where an older dialog appears when downloading full texts from the quality menu. [#4489](https://github.com/JabRef/jabref/issues/4489)
-
+- We fixed an issue where special characters where removed from non label key generation pattern parts [#4767](https://github.com/JabRef/jabref/issues/4767)
 
 
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
@@ -133,6 +133,9 @@ public class BibtexKeyGenerator extends BracketedPattern {
                         label = applyModifiers(label, parts, 1);
                     }
 
+                    // Remove all illegal characters from the label.
+                    label = cleanKey(label, bibtexKeyPatternPreferences.isEnforceLegalKey());
+
                     stringBuilder.append(label);
 
                 } else {
@@ -143,8 +146,7 @@ public class BibtexKeyGenerator extends BracketedPattern {
             LOGGER.warn("Cannot make label", e);
         }
 
-        // Remove all illegal characters from the key.
-        key = cleanKey(stringBuilder.toString(), bibtexKeyPatternPreferences.isEnforceLegalKey());
+        key = stringBuilder.toString();
 
         // Remove Regular Expressions while generating Keys
         String regex = bibtexKeyPatternPreferences.getKeyPatternRegex();

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -1073,4 +1073,12 @@ public class BibtexKeyGeneratorTest {
         assertEquals("NewtonMaxwellEtAl_2019_TheInterestingTitleLongerThanThreeWords", BibtexKeyGenerator.generateKey(entry, "[authors2]_[year]_[title:capitalize]"));
     }
 
+    @Test
+    public void generateKeyWithMinusInCitationStyleOutsideAField() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("author", AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1);
+        entry.setField("year", "2019");
+
+        assertEquals("Newton-2019", BibtexKeyGenerator.generateKey(entry, "[auth]-[year]"));
+    }
 }


### PR DESCRIPTION
Moved cleanKey to the field case, so it not clears the wanted special characters. Fix for [#4767](https://github.com/JabRef/jabref/issues/4767).

So now [author]-[year] or [author]:[year] are resolving the keys Kilian-2019 or Kilian:2019.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
