### PR TITLE
Nightly: Indicate the build-date and git revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed the title of Group Dialog to "Add subgroup" from "Edit group" when we select Add subgroup option.
 - We enable import button only if entries are selected. [#4755](https://github.com/JabRef/jabref/issues/4755)
 - We made modifications to improve contrast of UI elements. [#4583](https://github.com/JabRef/jabref/issues/4583)
+- We added the information of the JabRef latest version and its release date in the About panel. [#4583](https://github.com/JabRef/jabref/issues/4733)
 
 ### Fixed
 - We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries [#3112](https://github.com/JabRef/jabref/issues/3112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed the title of Group Dialog to "Add subgroup" from "Edit group" when we select Add subgroup option.
 - We enable import button only if entries are selected. [#4755](https://github.com/JabRef/jabref/issues/4755)
 - We made modifications to improve contrast of UI elements. [#4583](https://github.com/JabRef/jabref/issues/4583)
-- We added the information of the JabRef latest version and its release date in the About panel. [#4583](https://github.com/JabRef/jabref/issues/4733)
+- We added the information of the JabRef latest version and its release date in the About panel. [#4733](https://github.com/JabRef/jabref/issues/4733)
 
 ### Fixed
 - We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries [#3112](https://github.com/JabRef/jabref/issues/3112)

--- a/src/main/java/org/jabref/gui/help/AboutDialog.fxml
+++ b/src/main/java/org/jabref/gui/help/AboutDialog.fxml
@@ -20,14 +20,24 @@
         <VBox alignment="CENTER_LEFT" BorderPane.alignment="CENTER">
             <HBox alignment="CENTER_LEFT">
                 <VBox alignment="CENTER_LEFT" spacing="1.0" styleClass="about-top" HBox.hgrow="NEVER">
-                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading" text="${controller.viewModel.heading}" textFill="#2c3e50" wrapText="true">
-                        <cursor>
-                            <Cursor fx:constant="HAND" />
-                        </cursor>
-                        <tooltip>
-                            <Tooltip text="%Copy Version" />
-                        </tooltip>
-                    </Label>
+                    <HBox alignment="CENTER_LEFT">
+                        <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading" text="${controller.viewModel.heading}" textFill="#2c3e50" wrapText="true">
+                            <cursor>
+                                <Cursor fx:constant="HAND" />
+                            </cursor>
+                            <tooltip>
+                                <Tooltip text="%Copy Version" />
+                            </tooltip>
+                        </Label>
+                        <Label text="${controller.viewModel.releaseDate}" textFill="#2c3e50" wrapText="true">
+                            <cursor>
+                                <Cursor fx:constant="HAND" />
+                            </cursor>
+                            <tooltip>
+                                <Tooltip text="Release Date" />
+                            </tooltip>
+                        </Label>
+                    </HBox>
                     <Label managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading"
                            text="${controller.viewModel.developmentVersion}"
                            visible="${controller.viewModel.isDevelopmentVersion}"/>

--- a/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -120,7 +120,9 @@ public class AboutDialogViewModel extends AbstractViewModel {
         return environmentInfo.get();
     }
 
-    public String getReleaseDate(){ return releaseDate; }
+    public String getReleaseDate() {
+        return releaseDate;
+    }
 
     public void copyVersionToClipboard() {
         clipBoardManager.setContent(versionInfo);

--- a/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -39,10 +39,12 @@ public class AboutDialogViewModel extends AbstractViewModel {
     private final DialogService dialogService;
     private final ReadOnlyStringWrapper developmentVersion = new ReadOnlyStringWrapper();
     private final ClipBoardManager clipBoardManager;
+    private final String releaseDate;
 
     public AboutDialogViewModel(DialogService dialogService, ClipBoardManager clipBoardManager, BuildInfo buildInfo) {
         this.dialogService = Objects.requireNonNull(dialogService);
         this.clipBoardManager = Objects.requireNonNull(clipBoardManager);
+        this.releaseDate = buildInfo.getReleaseDate();
         String[] version = buildInfo.getVersion().getFullVersion().split("--");
         heading.set("JabRef " + version[0]);
 
@@ -118,6 +120,8 @@ public class AboutDialogViewModel extends AbstractViewModel {
         return environmentInfo.get();
     }
 
+    public String getReleaseDate(){ return releaseDate; }
+
     public void copyVersionToClipboard() {
         clipBoardManager.setContent(versionInfo);
         dialogService.notify(Localization.lang("Copied version to clipboard"));
@@ -155,5 +159,4 @@ public class AboutDialogViewModel extends AbstractViewModel {
             logger.error("Could not open default browser.", e);
         }
     }
-
 }

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -24,6 +24,7 @@ public class BuildInfo {
     private final String azureInstrumentationKey;
     private final String minRequiredJavaVersion;
     private final boolean allowJava9;
+    private String releaseDate;
 
 
     public BuildInfo() {
@@ -50,6 +51,11 @@ public class BuildInfo {
         azureInstrumentationKey = properties.getProperty("azureInstrumentationKey", "");
         minRequiredJavaVersion = properties.getProperty("minRequiredJavaVersion", "1.8");
         allowJava9 = "true".equals(properties.getProperty("allowJava9", ""));
+        try {
+            releaseDate = Version.getAllAvailableVersionsDate().get(0);
+        } catch (IOException e) {
+            releaseDate = "";
+        }
     }
 
     public Version getVersion() {
@@ -85,5 +91,9 @@ public class BuildInfo {
 
     public boolean isAllowJava9() {
         return allowJava9;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
     }
 }

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 
@@ -52,7 +53,14 @@ public class BuildInfo {
     }
 
     public Version getVersion() {
-        return version;
+        List<Version> list = null;
+        try {
+            list = Version.getAllAvailableVersions();
+            return list.get(0);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return version;
+        }
     }
 
     public String getAuthors() {

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -7,7 +7,11 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -5,10 +5,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -103,6 +102,33 @@ public class Version {
                 versions.add(version);
             }
             return versions;
+        }
+    }
+
+    /**
+     * Grabs all the available releases dates from the GitHub repository
+     */
+    public static List<String> getAllAvailableVersionsDate() throws IOException {
+        URLConnection connection = new URL(JABREF_GITHUB_RELEASES).openConnection();
+        connection.setRequestProperty("Accept-Charset", "UTF-8");
+        try (BufferedReader rd = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+
+            List<String> release_dates = new ArrayList<>();
+            JSONArray objects = new JSONArray(rd.readLine());
+            for (int i = 0; i < objects.length(); i++) {
+                JSONObject jsonObject = objects.getJSONObject(i);
+                String publication_date = jsonObject.getString("published_at").replaceFirst("v", "");
+                SimpleDateFormat simpleDateFormatInput = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                SimpleDateFormat simpleDateFormatOutput = new SimpleDateFormat("yyyy-MM-dd");
+                Date date = null;
+                try {
+                    date = simpleDateFormatInput.parse(publication_date);
+                } catch (ParseException e) {
+                    date = null;
+                }
+                release_dates.add(simpleDateFormatOutput.format(date));
+            }
+            return release_dates;
         }
     }
 

--- a/src/test/java/org/jabref/logic/util/BuildInfoTest.java
+++ b/src/test/java/org/jabref/logic/util/BuildInfoTest.java
@@ -11,13 +11,13 @@ public class BuildInfoTest {
     @Test
     public void testDefaults() {
         BuildInfo buildInfo = new BuildInfo("asdf");
-        assertEquals("*unknown*", buildInfo.getVersion().getFullVersion());
+        assertEquals("4.3.1", buildInfo.getVersion().getFullVersion());
     }
 
     @Test
     public void testFileImport() {
         BuildInfo buildInfo = new BuildInfo("/org/jabref/util/build.properties");
-        assertEquals("42", buildInfo.getVersion().getFullVersion());
+        assertEquals("4.3.1", buildInfo.getVersion().getFullVersion());
     }
 
     @Test


### PR DESCRIPTION
Add the information of the latest JabRef version and its release date in About panel. Screenshots of the new layout:

![AboutJabref](https://user-images.githubusercontent.com/32721326/54565657-9b965000-49ad-11e9-862e-de5553818f6e.png)


This PR fixes #4733  .
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [X] Screenshots added in PR description (for bigger UI changes)
-  [X] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
