### PR TITLE
Fix NPE in Duplicate Resolver Dialog

### DIFF
--- a/src/main/java/org/jabref/gui/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/DuplicateResolverDialog.java
@@ -39,8 +39,8 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
 
     public DuplicateResolverDialog(BibEntry one, BibEntry two, DuplicateResolverType type, BibDatabaseContext database) {
         this.setTitle(Localization.lang("Possible duplicate entries"));
-        init(one, two, type);
         this.database = database;
+        init(one, two, type);
     }
 
     private void init(BibEntry one, BibEntry two, DuplicateResolverType type) {

--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -84,7 +84,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
 
     /**
      * @param panel           (may be null) Only set this if the preview is associated to the main window.
-     * @param databaseContext Used for resolving pdf directories for links. Must not be null.
+     * @param databaseContext Used for resolving pdf directories for links. Must not be null, just pass a new empty BibDatabaseContext()
      */
     public PreviewPanel(BasePanel panel, BibDatabaseContext databaseContext, KeyBindingRepository keyBindingRepository, PreviewPreferences preferences, DialogService dialogService, ExternalFileTypes externalFileTypes) {
         this.databaseContext = Objects.requireNonNull(databaseContext);

--- a/src/main/java/org/jabref/gui/collab/EntryAddChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryAddChangeViewModel.java
@@ -29,7 +29,7 @@ class EntryAddChangeViewModel extends DatabaseChangeViewModel {
 
     @Override
     public Node description() {
-        PreviewPanel previewPanel = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), new FXDialogService(), ExternalFileTypes.getInstance());
+        PreviewPanel previewPanel = new PreviewPanel(null, new BibDatabaseContext(), Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), new FXDialogService(), ExternalFileTypes.getInstance());
         previewPanel.setEntry(diskEntry);
         return previewPanel;
     }

--- a/src/main/java/org/jabref/gui/search/SearchResultFrame.java
+++ b/src/main/java/org/jabref/gui/search/SearchResultFrame.java
@@ -55,6 +55,7 @@ import org.jabref.logic.bibtex.comparator.EntryComparator;
 import org.jabref.logic.bibtex.comparator.FieldComparator;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.search.SearchQuery;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.FieldProperty;
@@ -122,7 +123,7 @@ public class SearchResultFrame {
         searchResultFrame.setTitle(title);
         searchResultFrame.setIconImages(IconTheme.getLogoSet());
 
-        preview = new PreviewPanel(null, null, Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), frame.getDialogService(), ExternalFileTypes.getInstance());
+        preview = new PreviewPanel(null, new BibDatabaseContext(), Globals.getKeyPrefs(), Globals.prefs.getPreviewPreferences(), frame.getDialogService(), ExternalFileTypes.getInstance());
 
         sortedEntries = new SortedList<>(entries, new EntryComparator(false, true, FieldName.AUTHOR));
         model = (DefaultEventTableModel<BibEntry>) GlazedListsSwing.eventTableModelWithThreadProxyList(sortedEntries,


### PR DESCRIPTION
Fixes #4785
init method was accessing the database field before it was initialized.
Fixes #4786
Pass a new BibDatabsecontext()


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
