### PR TITLE
Fix closing of library not handling backup and autosave manager shutdown

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1154,7 +1154,10 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
             // add tab
             Tab newTab = new Tab(basePanel.getTabTitle(), basePanel);
             tabbedPane.getTabs().add(newTab);
-            newTab.setOnCloseRequest(event -> closeTab((BasePanel) newTab.getContent()));
+            newTab.setOnCloseRequest(event -> {
+                closeTab((BasePanel) newTab.getContent());
+                event.consume();
+            });
 
             // update all tab titles
             updateAllTabTitles();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1344,6 +1344,8 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
         if (panel.isModified() && (context.getLocation() == DatabaseLocation.LOCAL)) {
             if (confirmClose(panel)) {
                 removeTab(panel);
+            } else {
+                return;
             }
         } else if (context.getLocation() == DatabaseLocation.SHARED) {
             context.convertToLocalDatabase();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1154,6 +1154,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
             // add tab
             Tab newTab = new Tab(basePanel.getTabTitle(), basePanel);
             tabbedPane.getTabs().add(newTab);
+            newTab.setOnCloseRequest(event -> closeTab((BasePanel) newTab.getContent()));
 
             // update all tab titles
             updateAllTabTitles();


### PR DESCRIPTION
Fixes #4789

The issue was when the tab is closed by clicking 'x' it did not call
the method `closeTab()` which handles the closing of backup and
autosave manager.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
