### PR TITLE
Fixes OK button enabling property in Group Dialog

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javafx.beans.binding.Bindings;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -545,7 +546,8 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         boolean okEnabled = !nameField.getText().trim().isEmpty();
         if (!okEnabled) {
             setDescription(Localization.lang("Please enter a name for the group."));
-            getDialogPane().lookupButton(ButtonType.OK).setDisable(true);
+            Button btn = (Button) getDialogPane().lookupButton(ButtonType.OK);
+            btn.disableProperty().bind(Bindings.isEmpty(nameField.textProperty()));
             return;
         }
         String s1;

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import javafx.beans.binding.Bindings;
+import javafx.beans.binding.BooleanBinding;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -546,8 +547,9 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         boolean okEnabled = !nameField.getText().trim().isEmpty();
         if (!okEnabled) {
             setDescription(Localization.lang("Please enter a name for the group."));
+            BooleanBinding booleanBind = Bindings.isEmpty(nameField.textProperty());
             Button btn = (Button) getDialogPane().lookupButton(ButtonType.OK);
-            btn.disableProperty().bind(Bindings.isEmpty(nameField.textProperty()));
+            btn.disableProperty().bind(booleanBind);
             return;
         }
         String s1;

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -606,7 +606,6 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
             setDescription(GroupDescriptions.getDescriptionForPreview());
             setNameFontItalic(false);
         }
-        getDialogPane().lookupButton(ButtonType.OK).setDisable(!okEnabled);
     }
 
     private void openBrowseDialog() {

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -557,11 +557,11 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
         String s1;
         String s2;
         if (keywordsRadioButton.isSelected()) {
+            boolean okEnabled = !booleanBind.get();
             s1 = keywordGroupSearchField.getText().trim();
-            boolean okEnabled = !booleanBind.get() && s1.matches("\\w+");
+            okEnabled = okEnabled && s1.matches("\\w+");
             s2 = keywordGroupSearchTerm.getText().trim();
-            BooleanBinding searchTermEmpty = Bindings.isEmpty(keywordGroupSearchTerm.textProperty());
-            okEnabled = okEnabled && !searchTermEmpty.get();
+            okEnabled = okEnabled && !s2.isEmpty();
             if (okEnabled) {
                 if (keywordGroupRegExp.isSelected()) {
                     try {
@@ -583,9 +583,9 @@ class GroupDialog extends BaseDialog<AbstractGroup> {
             setNameFontItalic(true);
             okDisabled = new SimpleBooleanProperty(!okEnabled);
         } else if (searchRadioButton.isSelected()) {
+            boolean okEnabled = !booleanBind.get();
             s1 = searchGroupSearchExpression.getText().trim();
-            BooleanBinding searchExpressionEmpty = Bindings.isEmpty(searchGroupSearchExpression.textProperty());
-            boolean okEnabled = !booleanBind.get() && !searchExpressionEmpty.get();
+            okEnabled = okEnabled && !s1.isEmpty();
             if (okEnabled) {
                 setDescription(fromTextFlowToHTMLString(SearchDescribers.getSearchDescriberFor(
                         new SearchQuery(s1, isCaseSensitive(), isRegex()))


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes issue [#4783](https://github.com/JabRef/jabref/issues/4783)

Binded `nameField.textProperty()` to the OK button so that OK button gets enabled as soon as we enter name of the Group.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
