### PR TITLE
Put renaming of file entries in JavaFX thread for cleanup

### DIFF
--- a/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.externalfiles.LinkedFileHandler;
 import org.jabref.model.FieldChange;
 import org.jabref.model.cleanup.CleanupJob;
@@ -54,8 +55,8 @@ public class RenamePdfCleanup implements CleanupJob {
         }
 
         if (changed) {
-            Optional<FieldChange> changes = entry.setFiles(files);
-            return OptionalUtil.toList(changes);
+            Optional<FieldChange> fileFieldChanged = DefaultTaskExecutor.runInJavaFXThread(() -> entry.setFiles(files));
+            return OptionalUtil.toList(fileFieldChanged);
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
closes #4817 

Because field changes must be done in the JavaFX thread, i put the field change in a callable to be executed by the JavaFX thread.

This issue might arise for other cleanup tasks as well.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
