### PR TITLE
Fix overwriting of date in RIS import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where "Move to group" would always move the first entry in the library and not the selected [#4414](https://github.com/JabRef/jabref/issues/4414)
 - We fixed an issue where an older dialog appears when downloading full texts from the quality menu. [#4489](https://github.com/JabRef/jabref/issues/4489)
 - We fixed an issue where special characters where removed from non label key generation pattern parts [#4767](https://github.com/JabRef/jabref/issues/4767)
+- We fixed an issue where the RIS import would overwite the article date with the value of the acessed date [#4816](https://github.com/JabRef/jabref/issues/4816)
 
 
 

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest3.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest3.bib
@@ -4,7 +4,6 @@
   doi = {10.1201/b19107-2},
   issn = {978-1-4822-5326-9},
   journal = {Dermoscopy Image Analysis},
-  month = {#nov#},
   number = {0},
   pages = {1-22},
   publisher = {CRC Press},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest6.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest6.bib
@@ -4,7 +4,6 @@
   database = {PMC},
   issn = {1537-744X},
   journal = {The Scientific World Journal},
-  month = {#mar#},
   number = {PMC3654245},
   pages = {219840},
   publisher = {Hindawi Publishing Corporation},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest8_date.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest8_date.bib
@@ -1,0 +1,15 @@
+@article{,
+  author = {Valle-Delgado, J. J. and Molina-Bolívar, J. A. and Galisteo-González, F. and Gálvez-Ruiz, M. J. and Feiler, A. and Rutland, M. W.},
+  comment = {doi: 10.1063/1.1954747},
+  doi = {10.1063/1.1954747},
+  issn = {0021-9606},
+  journal = {J. Chem. Phys.},
+  month = {#jul#},
+  number = {3},
+  pages = {034708},
+  publisher = {American Institute of Physics},
+  title = {Hydration forces between silica surfaces: Experimental data and predictions from different theories},
+  url = {https://doi.org/10.1063/1.1954747},
+  volume = {123},
+  year = {2005}
+}

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest8_date.ris
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest8_date.ris
@@ -1,0 +1,30 @@
+
+
+
+
+
+TY  - JOUR
+T1  - Hydration forces between silica surfaces: Experimental data and predictions from different theories
+AU  - Valle-Delgado,J. J. 
+AU  - Molina-Bolívar,J. A. 
+AU  - Galisteo-González,F. 
+AU  - Gálvez-Ruiz,M. J. 
+AU  - Feiler,A. 
+AU  - Rutland,M. W. 
+Y1  - 2005/07/15
+PY  - 2005
+DA  - 2005/07/15
+N1  - doi: 10.1063/1.1954747
+DO  - 10.1063/1.1954747
+T2  - The Journal of Chemical Physics
+JF  - The Journal of Chemical Physics
+JO  - J. Chem. Phys.
+SP  - 034708
+VL  - 123
+IS  - 3
+PB  - American Institute of Physics
+SN  - 0021-9606
+M3  - doi: 10.1063/1.1954747
+UR  - https://doi.org/10.1063/1.1954747
+Y2  - 2019/03/28
+ER  - 


### PR DESCRIPTION
Now the first valid year is taken into account. Previously the year was overwritten when another field containing year was found.
Adjusted the tests to reflect the new behavior. This required adjusting the month field in the test files

Fixes #4816
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
