### PR TITLE
Select the first tab which matches the search query in preferences window

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.java
@@ -122,6 +122,8 @@ public class PreferencesDialog extends BaseDialog<Void> {
                 ScrollPane preferencePaneContainer = new ScrollPane(tab.getBuilder());
                 preferencePaneContainer.getStyleClass().add("preferencePaneContainer");
                 container.setCenter(preferencePaneContainer);
+            } else {
+                container.setCenter(null);
             }
         });
         tabsList.getSelectionModel().selectFirst();
@@ -136,6 +138,8 @@ public class PreferencesDialog extends BaseDialog<Void> {
         tabsList.itemsProperty().bindBidirectional(searchHandler.filteredPreferenceTabsProperty());
         searchBox.textProperty().addListener((observable, previousText, newText) -> {
             searchHandler.filterTabs(newText.toLowerCase(Locale.ROOT));
+            tabsList.getSelectionModel().clearSelection();
+            tabsList.getSelectionModel().selectFirst();
         });
 
         VBox buttonContainer = new VBox();


### PR DESCRIPTION
After every search clear the selection of tabs and select the first
tab in the tabsList.


![preferences](https://user-images.githubusercontent.com/21019116/55240556-1fc6be00-525f-11e9-9690-b5a1744ad4fa.gif)

Fixes #4824

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
