### PR TITLE
All buttons in custom dialogs react on enter

### DIFF
--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -6,6 +6,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.image.Image;
+import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
 
 import org.jabref.Globals;
@@ -22,6 +23,14 @@ public class BaseDialog<T> extends Dialog<T> implements org.jabref.gui.Dialog<T>
                 close();
             } else if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.DEFAULT_DIALOG_ACTION, event)) {
                 getDefaultButton().ifPresent(Button::fire);
+            }
+
+            // all buttons in base dialogs react on enter
+            if (event.getCode() == KeyCode.ENTER) {
+                if (event.getTarget() instanceof Button) {
+                    ((Button) event.getTarget()).fire();
+                    event.consume();
+                }
             }
         });
 


### PR DESCRIPTION
All buttons in custom dialogs react now also on <kbd>enter</kbd>. (The default behavior <kbd>space</kbd> in JavaFX is not affected by this change.)

Fixes #4820 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
