### PR TITLE
Adds a delay to the group expansion

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -412,13 +412,16 @@ public class GroupTreeView {
             if (!treeItem.equals(draggedItem)) {
                 this.draggedItem = treeItem;
                 this.dragStarted = System.currentTimeMillis();
-                return false;
+                return this.draggedItem.isExpanded();
             }
 
             if (System.currentTimeMillis() - this.dragStarted > DRAG_TIME_BEFORE_EXPANDING_MS) {
-                return true;
+                // expand or collapse the tree item and reset the time
+                this.dragStarted = System.currentTimeMillis();
+                return !this.draggedItem.isExpanded();
             } else {
-                return false;
+                // leave the expansion state of the tree item as it is
+                return this.draggedItem.isExpanded();
             }
         }
     }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -71,7 +71,7 @@ public class GroupTreeView {
     private GroupTreeViewModel viewModel;
     private CustomLocalDragboard localDragboard;
 
-    private DragOverTreeItem previousDragOverTreeItem;
+    private DragExpansionHandler dragExpansionHandler;
 
     private static void removePseudoClasses(TreeTableRow<GroupNodeViewModel> row, PseudoClass... pseudoClasses) {
         for (PseudoClass pseudoClass : pseudoClasses) {
@@ -86,7 +86,7 @@ public class GroupTreeView {
 
         // Set-up groups tree
         groupTree.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
-        previousDragOverTreeItem = new DragOverTreeItem();
+        dragExpansionHandler = new DragExpansionHandler();
 
         // Set-up bindings
         Consumer<ObservableList<GroupNodeViewModel>> updateSelectedGroups =
@@ -223,7 +223,7 @@ public class GroupTreeView {
                     event.acceptTransferModes(TransferMode.MOVE, TransferMode.LINK);
 
                     //expand node and all children on drag over
-                    row.getTreeItem().setExpanded(previousDragOverTreeItem.expandGroup(row.getTreeItem()));
+                    dragExpansionHandler.expandGroup(row.getTreeItem());
 
                     removePseudoClasses(row, dragOverBottom, dragOverCenter, dragOverTop);
                     switch (getDroppingMouseLocation(row, event)) {
@@ -403,25 +403,26 @@ public class GroupTreeView {
         }
     }
 
-    private class DragOverTreeItem {
+    private class DragExpansionHandler {
         private static final long DRAG_TIME_BEFORE_EXPANDING_MS = 1000;
         private TreeItem<GroupNodeViewModel> draggedItem;
         private long dragStarted;
 
-        public boolean expandGroup(TreeItem<GroupNodeViewModel> treeItem) {
+        public void expandGroup(TreeItem<GroupNodeViewModel> treeItem) {
             if (!treeItem.equals(draggedItem)) {
                 this.draggedItem = treeItem;
                 this.dragStarted = System.currentTimeMillis();
-                return this.draggedItem.isExpanded();
+                this.draggedItem.setExpanded(this.draggedItem.isExpanded());
+                return;
             }
 
             if (System.currentTimeMillis() - this.dragStarted > DRAG_TIME_BEFORE_EXPANDING_MS) {
                 // expand or collapse the tree item and reset the time
                 this.dragStarted = System.currentTimeMillis();
-                return !this.draggedItem.isExpanded();
+                this.draggedItem.setExpanded(!this.draggedItem.isExpanded());
             } else {
                 // leave the expansion state of the tree item as it is
-                return this.draggedItem.isExpanded();
+                this.draggedItem.setExpanded(this.draggedItem.isExpanded());
             }
         }
     }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -71,6 +71,8 @@ public class GroupTreeView {
     private GroupTreeViewModel viewModel;
     private CustomLocalDragboard localDragboard;
 
+    private DragOverTreeItem previousDragOverTreeItem;
+
     private static void removePseudoClasses(TreeTableRow<GroupNodeViewModel> row, PseudoClass... pseudoClasses) {
         for (PseudoClass pseudoClass : pseudoClasses) {
             row.pseudoClassStateChanged(pseudoClass, false);
@@ -84,6 +86,7 @@ public class GroupTreeView {
 
         // Set-up groups tree
         groupTree.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        previousDragOverTreeItem = new DragOverTreeItem();
 
         // Set-up bindings
         Consumer<ObservableList<GroupNodeViewModel>> updateSelectedGroups =
@@ -220,7 +223,7 @@ public class GroupTreeView {
                     event.acceptTransferModes(TransferMode.MOVE, TransferMode.LINK);
 
                     //expand node and all children on drag over
-                    row.getTreeItem().setExpanded(true);
+                    row.getTreeItem().setExpanded(previousDragOverTreeItem.expandGroup(row.getTreeItem()));
 
                     removePseudoClasses(row, dragOverBottom, dragOverCenter, dragOverTop);
                     switch (getDroppingMouseLocation(row, event)) {
@@ -397,6 +400,26 @@ public class GroupTreeView {
             return DroppingMouseLocation.BOTTOM;
         } else {
             return DroppingMouseLocation.CENTER;
+        }
+    }
+
+    private class DragOverTreeItem {
+        private static final long DRAG_TIME_BEFORE_EXPANDING_MS = 1000;
+        private TreeItem<GroupNodeViewModel> draggedItem;
+        private long dragStarted;
+
+        public boolean expandGroup(TreeItem<GroupNodeViewModel> treeItem) {
+            if (!treeItem.equals(draggedItem)) {
+                this.draggedItem = treeItem;
+                this.dragStarted = System.currentTimeMillis();
+                return false;
+            }
+
+            if (System.currentTimeMillis() - this.dragStarted > DRAG_TIME_BEFORE_EXPANDING_MS) {
+                return true;
+            } else {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a delay to the group expansion action. The delay is currently 1 second and only expands the group.

Is there also a need to collapse the item, if an user drags over it after a specific period?

Closes #4674 

----

- [ ] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
