### PR TITLE
Improve full text search for several files

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
@@ -86,7 +86,7 @@ public class FindFullTextAction extends SimpleCommand {
         findFullTextsTask.setOnSucceeded(value -> downloadFullTexts(findFullTextsTask.getValue()));
 
         dialogService.showProgressDialogAndWait(
-                Localization.lang("Looking for full text document..."),
+                Localization.lang("Look up full text documents"),
                 Localization.lang("Looking for full text document..."),
                 findFullTextsTask);
 
@@ -119,10 +119,11 @@ public class FindFullTextAction extends SimpleCommand {
 
     /**
      * This method attaches a linked file from a URL (if not already linked) to an entry using the key and value pair
-     * from the findFullTexts map
+     * from the findFullTexts map and then downloads the file into the given targetDirectory
      *
      * @param url   the url "key"
      * @param entry the entry "value"
+     * @param targetDirectory the target directory for the downloaded file
      */
     private void addLinkedFileFromURL(URL url, BibEntry entry, Path targetDirectory) {
         LinkedFile newLinkedFile = new LinkedFile(url, "");


### PR DESCRIPTION
Solution proposal for #4854 

In `FindFullTextAction`, `Task` is now used instead of `BackgroundTask` to be able to show a progress dialog which shows the progress for searching files online.

![lookupDialog](https://user-images.githubusercontent.com/24212145/55612578-cabc0800-5788-11e9-92b4-ec4081977b7d.PNG)

Furthermore, the functionality for downloading a file in `LinkedFileViewModel` is split into `download` and `prepareDownloadTask` to be able to define a custom onSucess-action for the background task. This is used in `FindFullTextAction` to add the downloaded file to the entry instead of the URL.

The functionality provided by `LinkedFileViewModel.dowload` remains as it is, so it does not affect the download of a single file via the EntryEditor.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
