### PR TITLE
[WIP] ISO 9241-303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Within JabRefPreferences.java we updated the MAIN_DEFAULT_SIZE to 12 and updated the OVERRIDE_DEFAULT_FONT_SIZE to true. This was to set the font size in accordance with ISO 9241-303. There are currently some truncating going on but the bounds remain the same.
 - We changed the location of some fields in the entry editor (you might need to reset your preferences for these changes to come into effect)
   - Journal/Year/Month in biblatex mode -> Deprecated (if filled)
   - DOI/URL: General -> Optional

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -690,8 +690,8 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(LAST_USED_EXPORT, "");
         defaults.put(SIDE_PANE_WIDTH, 0.15);
 
-        defaults.put(MAIN_FONT_SIZE, 9);
-        defaults.put(OVERRIDE_DEFAULT_FONT_SIZE, false);
+        defaults.put(MAIN_FONT_SIZE, 12);
+        defaults.put(OVERRIDE_DEFAULT_FONT_SIZE, true);
 
         defaults.put(IMPORT_INSPECTION_DIALOG_WIDTH, 650);
         defaults.put(IMPORT_INSPECTION_DIALOG_HEIGHT, 650);


### PR DESCRIPTION
[4582]https://github.com/JabRef/jabref/issues/4582
Within JabRefPreferences.java we updated the MAIN_DEFAULT_SIZE to 12 and updated the OVERRIDE_DEFAULT_FONT_SIZE to true. This was to set the font size in accordance with ISO 9241-303. There are currently some truncating going on but the bounds remain the same.
![Capture](https://user-images.githubusercontent.com/22826168/55635703-5cc70f00-578f-11e9-99fa-92f4d27482a2.JPG)
![Capture2](https://user-images.githubusercontent.com/22826168/55635709-60f32c80-578f-11e9-97b3-4603d49c6227.JPG)


----

- [x ] Change in CHANGELOG.md described
- [x ] Tests created for changes
- [x ] Manually tested changed features in running JabRef
- [x ] Screenshots added in PR description (for bigger UI changes)
- [x ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
