### PR TITLE
Improve Snackbar Dialogs for Copy to Clipboard Menu

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -468,7 +468,7 @@ public class BasePanel extends StackPane {
 
             if (titles.size() == selectedBibEntries.size()) {
                 // All entries had titles.
-                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedTitles) + "'.");
+                output(Localization.lang("Copied") + " '" + JabRefDialogService.shortenDialogMessage(copiedTitles) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined title.", Integer.toString(selectedBibEntries.size() - titles.size()), Integer.toString(selectedBibEntries.size())));
             }
@@ -496,7 +496,7 @@ public class BasePanel extends StackPane {
 
             if (keys.size() == bes.size()) {
                 // All entries had keys.
-                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedCiteCommand) + "'.");
+                output(Localization.lang("Copied") + " '" + JabRefDialogService.shortenDialogMessage(copiedCiteCommand) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - keys.size()), Integer.toString(bes.size())));
             }
@@ -521,7 +521,7 @@ public class BasePanel extends StackPane {
 
             if (keys.size() == bes.size()) {
                 // All entries had keys.
-                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedKeys) + "'.");
+                output(Localization.lang("Copied") + " '" + JabRefDialogService.shortenDialogMessage(copiedKeys) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - keys.size()), Integer.toString(bes.size())));
             }
@@ -563,18 +563,11 @@ public class BasePanel extends StackPane {
 
             if (copied == bes.size()) {
                 // All entries had keys.
-                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedKeysAndTitles) + "'.");
+                output(Localization.lang("Copied") + " '" + JabRefDialogService.shortenDialogMessage(copiedKeysAndTitles) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - copied), Integer.toString(bes.size())));
             }
         }
-    }
-
-    private String shortenDialogMessage(String dialogMessage) {
-        if (dialogMessage.length() < JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT) {
-            return dialogMessage;
-        }
-        return dialogMessage.substring(0, Math.min(dialogMessage.length(), JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT)) + "...";
     }
 
     private void openExternalFile() {

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -190,7 +190,6 @@ public class BasePanel extends StackPane {
 
         this.preview = new PreviewPanel(this, getBibDatabaseContext(), preferences.getKeyBindings(), preferences.getPreviewPreferences(), dialogService, externalFileTypes);
         frame().getGlobalSearchBar().getSearchQueryHighlightObservable().addSearchListener(preview);
-
     }
 
     @Subscribe
@@ -464,11 +463,12 @@ public class BasePanel extends StackPane {
                 output(Localization.lang("None of the selected entries have titles."));
                 return;
             }
-            Globals.clipboardManager.setContent(String.join("\n", titles));
+            final String copiedTitles = String.join("\n", titles);
+            Globals.clipboardManager.setContent(copiedTitles);
 
             if (titles.size() == selectedBibEntries.size()) {
                 // All entries had titles.
-                output((selectedBibEntries.size() > 1 ? Localization.lang("Copied titles") : Localization.lang("Copied title")) + '.');
+                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedTitles) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined title.", Integer.toString(selectedBibEntries.size() - titles.size()), Integer.toString(selectedBibEntries.size())));
             }
@@ -488,15 +488,15 @@ public class BasePanel extends StackPane {
                 return;
             }
 
-            String sb = String.join(",", keys);
             String citeCommand = Optional.ofNullable(Globals.prefs.get(JabRefPreferences.CITE_COMMAND))
                                          .filter(cite -> cite.contains("\\")) // must contain \
                                          .orElse("\\cite");
-            Globals.clipboardManager.setContent(citeCommand + "{" + sb + '}');
+            final String copiedCiteCommand = citeCommand + "{" + String.join(",", keys) + '}';
+            Globals.clipboardManager.setContent(copiedCiteCommand);
 
             if (keys.size() == bes.size()) {
                 // All entries had keys.
-                output(bes.size() > 1 ? Localization.lang("Copied keys") : Localization.lang("Copied key") + '.');
+                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedCiteCommand) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - keys.size()), Integer.toString(bes.size())));
             }
@@ -516,11 +516,12 @@ public class BasePanel extends StackPane {
                 return;
             }
 
-            Globals.clipboardManager.setContent(String.join(",", keys));
+            final String copiedKeys = String.join(",", keys);
+            Globals.clipboardManager.setContent(copiedKeys);
 
             if (keys.size() == bes.size()) {
                 // All entries had keys.
-                output((bes.size() > 1 ? Localization.lang("Copied keys") : Localization.lang("Copied key")) + '.');
+                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedKeys) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - keys.size()), Integer.toString(bes.size())));
             }
@@ -557,15 +558,23 @@ public class BasePanel extends StackPane {
                 return;
             }
 
-            Globals.clipboardManager.setContent(sb.toString());
+            final String copiedKeysAndTitles = sb.toString();
+            Globals.clipboardManager.setContent(copiedKeysAndTitles);
 
             if (copied == bes.size()) {
                 // All entries had keys.
-                output((bes.size() > 1 ? Localization.lang("Copied keys") : Localization.lang("Copied key")) + '.');
+                output(Localization.lang("Copied") + " '" + shortenDialogMessage(copiedKeysAndTitles) + "'.");
             } else {
                 output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(bes.size() - copied), Integer.toString(bes.size())));
             }
         }
+    }
+
+    private String shortenDialogMessage(String dialogMessage) {
+        if (dialogMessage.length() < JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT) {
+            return dialogMessage;
+        }
+        return dialogMessage.substring(0, Math.min(dialogMessage.length(), JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT)) + "...";
     }
 
     private void openExternalFile() {
@@ -952,7 +961,7 @@ public class BasePanel extends StackPane {
      */
     public void ensureNotShowingBottomPanel(BibEntry entry) {
         if (((mode == BasePanelMode.SHOWING_EDITOR) && (entryEditor.getEntry() == entry))
-            || ((mode == BasePanelMode.SHOWING_PREVIEW) && (preview.getEntry() == entry))) {
+                || ((mode == BasePanelMode.SHOWING_PREVIEW) && (preview.getEntry() == entry))) {
             closeBottomPane();
         }
     }

--- a/src/main/java/org/jabref/gui/FXDialogService.java
+++ b/src/main/java/org/jabref/gui/FXDialogService.java
@@ -59,7 +59,6 @@ public class FXDialogService implements DialogService {
 
     private static final Duration TOAST_MESSAGE_DISPLAY_TIME = Duration.millis(3000);
     private static final Logger LOGGER = LoggerFactory.getLogger(FXDialogService.class);
-
     private final Window mainWindow;
     private final JFXSnackbar statusLine;
 
@@ -118,7 +117,6 @@ public class FXDialogService implements DialogService {
         choiceDialog.setTitle(title);
         choiceDialog.setContentText(content);
         return choiceDialog.showAndWait();
-
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -55,14 +55,16 @@ import org.slf4j.LoggerFactory;
  * rather than complex windows. For more complex dialogs it is
  * advised to rather create a new sub class of {@link FXDialog}.
  */
-public class FXDialogService implements DialogService {
+public class JabRefDialogService implements DialogService {
+    // Snackbar dialog maximum size
+    public static final int DIALOG_SIZE_LIMIT = 300;
 
     private static final Duration TOAST_MESSAGE_DISPLAY_TIME = Duration.millis(3000);
-    private static final Logger LOGGER = LoggerFactory.getLogger(FXDialogService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JabRefDialogService.class);
     private final Window mainWindow;
     private final JFXSnackbar statusLine;
 
-    public FXDialogService(Window mainWindow, Pane mainPane) {
+    public JabRefDialogService(Window mainWindow, Pane mainPane) {
         this.mainWindow = mainWindow;
         this.statusLine = new JFXSnackbar(mainPane);
     }
@@ -106,6 +108,13 @@ public class FXDialogService implements DialogService {
         alert.setContentText(content);
         alert.getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
         return alert;
+    }
+
+    public static String shortenDialogMessage(String dialogMessage) {
+        if (dialogMessage.length() < JabRefDialogService.DIALOG_SIZE_LIMIT) {
+            return dialogMessage.trim();
+        }
+        return (dialogMessage.substring(0, Math.min(dialogMessage.length(), JabRefDialogService.DIALOG_SIZE_LIMIT)) + "...").trim();
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -175,7 +175,7 @@ public class JabRefFrame extends BorderPane {
 
     public JabRefFrame(Stage mainStage) {
         this.mainStage = mainStage;
-        this.dialogService = new FXDialogService(mainStage, this);
+        this.dialogService = new JabRefDialogService(mainStage, this);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -5,13 +5,13 @@ import java.util.stream.Collectors;
 
 import org.jabref.JabRefGUI;
 import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.JabRefDialogService;
 import org.jabref.gui.maintable.MainTable;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
-import org.jabref.preferences.JabRefPreferences;
 
 /**
  * This class will copy each selected entry's BibTeX key as a hyperlink to its url to the clipboard.
@@ -54,7 +54,7 @@ public class CopyBibTeXKeyAndLinkAction implements BaseAction {
             int toCopy = entries.size();
             if (copied == toCopy) {
                 // All entries had keys.
-                JabRefGUI.getMainFrame().getDialogService().notify(Localization.lang("Copied") + " '" + keyAndLink.substring(0, Math.min(keyAndLink.length(), JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT)) + "'.");
+                JabRefGUI.getMainFrame().getDialogService().notify(Localization.lang("Copied") + " '" + JabRefDialogService.shortenDialogMessage(keyAndLink) + "'.");
             } else {
                 JabRefGUI.getMainFrame().getDialogService().notify(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.",
                         Long.toString(toCopy - copied), Integer.toString(toCopy)));

--- a/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -11,6 +11,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+import org.jabref.preferences.JabRefPreferences;
 
 /**
  * This class will copy each selected entry's BibTeX key as a hyperlink to its url to the clipboard.
@@ -46,14 +47,14 @@ public class CopyBibTeXKeyAndLinkAction implements BaseAction {
                 sb.append(url.isEmpty() ? key : String.format("<a href=\"%s\">%s</a>", url, key));
                 sb.append(OS.NEWLINE);
             }
-
-            DefaultTaskExecutor.runInJavaFXThread(() -> clipboardManager.setHtmlContent(sb.toString()));
+            final String keyAndLink = sb.toString();
+            DefaultTaskExecutor.runInJavaFXThread(() -> clipboardManager.setHtmlContent(keyAndLink));
 
             int copied = entriesWithKey.size();
             int toCopy = entries.size();
             if (copied == toCopy) {
                 // All entries had keys.
-                JabRefGUI.getMainFrame().getDialogService().notify((entries.size() > 1 ? Localization.lang("Copied keys") : Localization.lang("Copied key")) + '.');
+                JabRefGUI.getMainFrame().getDialogService().notify(Localization.lang("Copied") + " '" + keyAndLink.substring(0, Math.min(keyAndLink.length(), JabRefPreferences.SNACKBAR_DIALOG_SIZE_LIMIT)) + "'.");
             } else {
                 JabRefGUI.getMainFrame().getDialogService().notify(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.",
                         Long.toString(toCopy - copied), Integer.toString(toCopy)));

--- a/src/main/java/org/jabref/gui/worker/CitationStyleToClipboardWorker.java
+++ b/src/main/java/org/jabref/gui/worker/CitationStyleToClipboardWorker.java
@@ -54,7 +54,6 @@ public class CitationStyleToClipboardWorker {
     }
 
     public void copyCitationStyleToClipboard(TaskExecutor taskExecutor) {
-        dialogService.notify(Localization.lang("Copying..."));
         BackgroundTask.wrap(this::generateCitations)
                       .onFailure(ex -> LOGGER.error("Error while copying citations to the clipboard", ex))
                       .onSuccess(this::setClipBoardContent)

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -399,6 +399,9 @@ public class JabRefPreferences implements PreferencesService {
     // Dialog states
     private static final String PREFS_EXPORT_PATH = "prefsExportPath";
 
+    // Snackbar dialog maximum size
+    public static final int SNACKBAR_DIALOG_SIZE_LIMIT = 300;
+
     // Helper string
     private static final String USER_HOME = System.getProperty("user.home");
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -355,9 +355,6 @@ public class JabRefPreferences implements PreferencesService {
     // Id Entry Generator Preferences
     public static final String ID_ENTRY_GENERATOR = "idEntryGenerator";
 
-    // Snackbar dialog maximum size
-    public static final int SNACKBAR_DIALOG_SIZE_LIMIT = 300;
-
     //File linking Options for entry editor
     public static final String ENTRY_EDITOR_DRAG_DROP_PREFERENCE_TYPE = "DragDropPreferenceType";
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -355,6 +355,8 @@ public class JabRefPreferences implements PreferencesService {
     // Id Entry Generator Preferences
     public static final String ID_ENTRY_GENERATOR = "idEntryGenerator";
 
+    // Snackbar dialog maximum size
+    public static final int SNACKBAR_DIALOG_SIZE_LIMIT = 300;
 
     //File linking Options for entry editor
     public static final String ENTRY_EDITOR_DRAG_DROP_PREFERENCE_TYPE = "DragDropPreferenceType";
@@ -398,9 +400,6 @@ public class JabRefPreferences implements PreferencesService {
 
     // Dialog states
     private static final String PREFS_EXPORT_PATH = "prefsExportPath";
-
-    // Snackbar dialog maximum size
-    public static final int SNACKBAR_DIALOG_SIZE_LIMIT = 300;
 
     // Helper string
     private static final String USER_HOME = System.getProperty("user.home");

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -154,13 +154,6 @@ Content=Content
 
 Copied=Copied
 
-Copied\ title=Copied title
-
-Copied\ key=Copied key
-
-Copied\ titles=Copied titles
-
-Copied\ keys=Copied keys
 
 Copy=Copy
 
@@ -1869,7 +1862,6 @@ Different\ customization,\ current\ settings\ will\ be\ overwritten=Different cu
 Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=Entry type %0 is only defined for Biblatex but not for BibTeX
 
 Copied\ %0\ citations.=Copied %0 citations.
-Copying...=Copying...
 
 journal\ not\ found\ in\ abbreviation\ list=journal not found in abbreviation list
 Unhandled\ exception\ occurred.=Unhandled exception occurred.


### PR DESCRIPTION
- [X] Removed an unnecessary message when copying to clipboard (see `CitationStyleToClipboardWorker.copyCitationStyleToClipboard()`)
- [X] Added the contents of the (new) clipboard to the Dialog, limited to 300 chars.

- [X] Manually tested changed features in running JabRef

