### PR TITLE
Rearrange the padding of the "Append library" dialog

### DIFF
--- a/src/main/java/org/jabref/gui/importer/AppendDatabaseDialog.java
+++ b/src/main/java/org/jabref/gui/importer/AppendDatabaseDialog.java
@@ -38,12 +38,11 @@ public class AppendDatabaseDialog extends BaseDialog<Boolean> {
         getDialogPane().setContent(container);
         container.setHgap(10);
         container.setVgap(10);
-        container.setPadding(new Insets(15, 5, 0, 0));
         container.add(entries, 0, 0);
         container.add(strings, 0, 1);
         container.add(groups, 0, 2);
         container.add(selector, 0, 3);
-        container.setPadding(new Insets(15, 5, 0, 0));
+        container.setPadding(new Insets(15, 5, 0, 5));
         container.setGridLinesVisible(false);
     }
 


### PR DESCRIPTION
I have added a 5 pixels padding on the left of the container in AppendDatabaseDialog.
Also removed a duplicate line related to the padding.

![append_library](https://user-images.githubusercontent.com/37243770/56583113-1b30c380-65d9-11e9-9097-36810f0d7437.png)


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
