### PR TITLE
Fix for the issue #4912

### DIFF
--- a/src/main/java/org/jabref/gui/importer/AppendDatabaseDialog.java
+++ b/src/main/java/org/jabref/gui/importer/AppendDatabaseDialog.java
@@ -38,12 +38,11 @@ public class AppendDatabaseDialog extends BaseDialog<Boolean> {
         getDialogPane().setContent(container);
         container.setHgap(10);
         container.setVgap(10);
-        container.setPadding(new Insets(15, 5, 0, 0));
         container.add(entries, 0, 0);
         container.add(strings, 0, 1);
         container.add(groups, 0, 2);
         container.add(selector, 0, 3);
-        container.setPadding(new Insets(15, 5, 0, 0));
+        container.setPadding(new Insets(15, 5, 0, 5));
         container.setGridLinesVisible(false);
     }
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
@@ -26,7 +26,7 @@ public class BibtexKeyGenerator extends BracketedPattern {
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     private static final Logger LOGGER = LoggerFactory.getLogger(BibtexKeyGenerator.class);
-    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"-#~^':`";
+    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"-#~^:`";
     private static final String KEY_UNWANTED_CHARACTERS = "{}(),\\\"-";
     private final AbstractBibtexKeyPattern citeKeyPattern;
     private final BibDatabase database;


### PR DESCRIPTION
Apostrophe character removed from KEY_ILLEGAL_CHARACTERS in BibtexKeyGenerator

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
