### PR TITLE
Fixes throwing an exception when 'id' field is present in bib file

### DIFF
--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -408,10 +408,6 @@ public class BibEntry implements Cloneable {
             return Optional.empty();
         }
 
-        if (BibEntry.ID_FIELD.equals(fieldName)) {
-            throw new IllegalArgumentException("The field name '" + name + "' is reserved");
-        }
-
         changed = true;
 
         fields.put(fieldName, value.intern());

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -45,7 +45,7 @@ public class BibEntry implements Cloneable {
     public static final String OBSOLETE_TYPE_HEADER = "bibtextype";
     public static final String KEY_FIELD = "bibtexkey";
     public static final String DEFAULT_TYPE = "misc";
-    protected static final String ID_FIELD = "id";
+    protected static final String INTERNAL_ID_FIELD = "JabRef-internal-id";
     private static final Logger LOGGER = LoggerFactory.getLogger(BibEntry.class);
     private static final Pattern REMOVE_TRAILING_WHITESPACE = Pattern.compile("\\s+$");
     private final SharedBibEntryData sharedBibEntryData;
@@ -161,7 +161,7 @@ public class BibEntry implements Cloneable {
 
         String oldId = this.id;
 
-        eventBus.post(new FieldChangedEvent(this, BibEntry.ID_FIELD, id, oldId));
+        eventBus.post(new FieldChangedEvent(this, BibEntry.INTERNAL_ID_FIELD, id, oldId));
         this.id = id;
         changed = true;
     }
@@ -458,10 +458,6 @@ public class BibEntry implements Cloneable {
      */
     public Optional<FieldChange> clearField(String name, EntryEventSource eventSource) {
         String fieldName = toLowerCase(name);
-
-        if (BibEntry.ID_FIELD.equals(fieldName)) {
-            throw new IllegalArgumentException("The field name '" + name + "' is reserved");
-        }
 
         Optional<String> oldValue = getField(fieldName);
         if (!oldValue.isPresent()) {

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -29,11 +29,6 @@ public class BibEntryTest {
     }
 
     @Test
-    public void notClearReservedFields() {
-        assertThrows(IllegalArgumentException.class, () -> entry.clearField(BibEntry.ID_FIELD));
-    }
-
-    @Test
     public void getFieldIsCaseInsensitive() throws Exception {
         entry.setField("TeSt", "value");
 

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -29,11 +29,6 @@ public class BibEntryTest {
     }
 
     @Test
-    public void notOverrideReservedFields() {
-        assertThrows(IllegalArgumentException.class, () -> entry.setField(BibEntry.ID_FIELD, "somevalue"));
-    }
-
-    @Test
     public void notClearReservedFields() {
         assertThrows(IllegalArgumentException.class, () -> entry.clearField(BibEntry.ID_FIELD));
     }

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BibEntryTest {
 


### PR DESCRIPTION
Fixes #4905

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
