### PR TITLE
Throw BibEntryNotFound exception in case entry is no longer present 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where ranking an entry would generate an IllegalArgumentException. [#4754](https://github.com/JabRef/jabref/issues/4754)
 - We fixed an issue where special characters where removed from non label key generation pattern parts [#4767](https://github.com/JabRef/jabref/issues/4767)
 - We fixed an issue where the RIS import would overwite the article date with the value of the acessed date [#4816](https://github.com/JabRef/jabref/issues/4816)
+- We fixed an issue where an NullPointer exception was thrown when a referenced entry in an Open/Libre Office was no longer present in the library. Now an error message with the reference marker of the missing entry is shown. [#4932](https://github.com/JabRef/jabref/issues/4932)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where ranking an entry would generate an IllegalArgumentException. [#4754](https://github.com/JabRef/jabref/issues/4754)
 - We fixed an issue where special characters where removed from non label key generation pattern parts [#4767](https://github.com/JabRef/jabref/issues/4767)
 - We fixed an issue where the RIS import would overwite the article date with the value of the acessed date [#4816](https://github.com/JabRef/jabref/issues/4816)
-- We fixed an issue where an NullPointer exception was thrown when a referenced entry in an Open/Libre Office was no longer present in the library. Now an error message with the reference marker of the missing entry is shown. [#4932](https://github.com/JabRef/jabref/issues/4932)
+- We fixed an issue where an NullPointer exception was thrown when a referenced entry in an Open/Libre Office document was no longer present in the library. Now an error message with the reference marker of the missing entry is shown. [#4932](https://github.com/JabRef/jabref/issues/4932)
 
 
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -518,7 +518,8 @@ class OOBibBase {
                     } else {
                         LOGGER.info("BibTeX key not found: '" + keys[j] + '\'');
                         LOGGER.info("Problem with reference mark: '" + names.get(i) + '\'');
-                        cEntries[j] = new UndefinedBibtexEntry(keys[j]);
+                        throw new BibEntryNotFoundException(names.get(i), Localization
+                                                                                      .lang("Could not resolve BibTeX entry for citation marker '%0'.", names.get(i)));
                     }
                 }
 

--- a/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
@@ -714,12 +714,13 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      * @return The resolved field content, or an empty string if the field(s) were empty.
      */
     private String getCitationMarkerField(BibEntry entry, BibDatabase database, String field) {
+        Objects.requireNonNull(entry, "Entry cannot be null");
+        Objects.requireNonNull(database, "database cannot be null");
+
         String authorField = getStringCitProperty(AUTHOR_FIELD);
         String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
 
-            Objects.requireNonNull(entry, "Entry cannot be null");
-            Objects.requireNonNull(database, "database cannot be null");
             Optional<String> content = entry.getResolvedFieldOrAlias(s, database);
 
             if ((content.isPresent()) && !content.get().trim().isEmpty()) {

--- a/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
@@ -718,8 +718,8 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
 
-            Objects.requireNonNull(entry, "Entry cannnot be null");
-            Objects.requireNonNull(database, "database cannnot be null");
+            Objects.requireNonNull(entry, "Entry cannot be null");
+            Objects.requireNonNull(database, "database cannot be null");
             Optional<String> content = entry.getResolvedFieldOrAlias(s, database);
 
             if ((content.isPresent()) && !content.get().trim().isEmpty()) {

--- a/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
@@ -717,6 +717,9 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         String authorField = getStringCitProperty(AUTHOR_FIELD);
         String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
+
+            Objects.requireNonNull(entry, "Entry cannnot be null");
+            Objects.requireNonNull(database, "database cannnot be null");
             Optional<String> content = entry.getResolvedFieldOrAlias(s, database);
 
             if ((content.isPresent()) && !content.get().trim().isEmpty()) {


### PR DESCRIPTION
Fixes #4932 

When an entry got removed a NPE complaining about an empty database was thrown because of some weird UnkownBibTexEntry thing.
Now the correct BibEntryNotFound  Exception is thrown showing the problematic reference mark

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
