### PR TITLE
Fix threading issue with opening from recent libraries

### DIFF
--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -161,6 +161,7 @@ public class OpenDatabaseAction extends SimpleCommand {
             final List<Path> theFiles = Collections.unmodifiableList(filesToOpen);
 
             for (Path theFile : theFiles) {
+                //This method will execute the concrete file opening and loading in a background thread
                 openTheFile(theFile, raisePanel);
             }
 

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -6,7 +6,6 @@ import java.nio.file.Path;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 
-import org.jabref.JabRefExecutorService;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.logic.l10n.Localization;
@@ -71,7 +70,7 @@ public class FileHistoryMenu extends Menu {
             setItems();
             return;
         }
-        JabRefExecutorService.INSTANCE.execute(() -> frame.getOpenDatabaseAction().openFile(file, true));
+        frame.getOpenDatabaseAction().openFile(file, true);
 
     }
 


### PR DESCRIPTION
Fixes #4940

On Windows 10 I could not reproduce the original exception, but I'm very convinced that I found the threading culprit

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
