### PR TITLE
Add link to good first issues in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+After reading through this guide, check out some good first issues to contribute to by clicking here: [Good First Issues](https://github.com/JabRef/jabref/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+
 ## Understanding the basics
 We welcome contributions to JabRef and encourage to create a fork, clone, **create a new branch** (such as `fix-for-issue-121`), **work on the new branch — not master**, and create a pull request.
 Be sure to create a **separate branch** for each improvement you implement.


### PR DESCRIPTION
Added a link to the current open issues with tags 'good first issue' to the beginning of CONTRIBUTING.md to help new contributors find a way to get started.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
