### PR TITLE
Bump Jsoup to 1.12.1 and switch Jsoup's StringUtil for JabRef's StringUtil

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     // Cannot be updated to 9.*.* until Jabref works with Java 9
     compile 'org.controlsfx:controlsfx:8.40.15-SNAPSHOT'
 
-    compile 'org.jsoup:jsoup:1.11.3'
+    compile 'org.jsoup:jsoup:1.12.1'
     compile 'com.mashape.unirest:unirest-java:1.4.9'
 
     // >1.8.0-beta is required for java 9 compatibility

--- a/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
@@ -11,8 +11,8 @@ import java.util.Optional;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.cleanup.Formatter;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.strings.StringUtil;
 
-import org.jsoup.helper.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -11,8 +11,7 @@ import java.util.List;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.cleanup.Formatter;
 import org.jabref.model.entry.BibEntry;
-
-import org.jsoup.helper.StringUtil;
+import org.jabref.model.strings.StringUtil;
 
 /**
  * Provides a convenient interface for search-based fetcher, which follow the usual three-step procedure:

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -30,10 +30,10 @@ import org.jabref.logic.net.URLDownload;
 import org.jabref.model.cleanup.FieldFormatterCleanup;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.apache.http.client.utils.URIBuilder;
-import org.jsoup.helper.StringUtil;
 
 /**
  * Fetches data from the SAO/NASA Astrophysics Data System (http://www.adsabs.harvard.edu/)

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
@@ -11,9 +11,9 @@ import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.OptionalUtil;
 
-import org.jsoup.helper.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaChimboriFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaChimboriFetcher.java
@@ -10,11 +10,11 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.strings.StringUtil;
 
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import org.jsoup.helper.StringUtil;
 
 /**
  * Fetcher for ISBN using https://bibtex.chimbori.com/, which in turn uses Amazon's API.


### PR DESCRIPTION
Here is a correction for #4968: it bumps Jsoup from 1.11.3 to 1.12.1 and, also, it switchs Jsoup's StringUtil for JabRef's StringUtil in all files that used it.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
