### PR TITLE
Disable search tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added an option in the settings to set the default action in JabRef when right clicking on any entry in any database and selecting "Open folder". [#4763](https://github.com/JabRef/jabref/issues/4763)
 - The Medline fetcher now normalizes the author names according to the BibTeX-Standard [#4345](https://github.com/JabRef/jabref/issues/4345)
 - We added an option on the Linked File Viewer to rename the attached file of an entry directly on the JabRef. [#4844](https://github.com/JabRef/jabref/issues/4844)
+- We disabled the extended help in the search field (as a tooltip). [#3599](https://github.com/JabRef/jabref/issues/3599)
 
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -13,7 +13,6 @@ import javafx.event.Event;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
-import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.Skin;
@@ -27,7 +26,6 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
-import javafx.scene.text.TextFlow;
 import javafx.util.Duration;
 
 import org.jabref.Globals;
@@ -269,7 +267,7 @@ public class GlobalSearchBar extends HBox {
         return searchQuery;
     }
 
-    public void updateResults(int matched, TextFlow description, boolean grammarBasedSearch) {
+    public void updateResults(int matched, boolean grammarBasedSearch) {
         if (matched == 0) {
             currentResults.setText(Localization.lang("No results found."));
             searchField.pseudoClassStateChanged(CLASS_NO_RESULTS, true);
@@ -284,11 +282,6 @@ public class GlobalSearchBar extends HBox {
             // TODO: switch Icon color
             //searchIcon.setIcon(IconTheme.JabRefIcon.SEARCH.getIcon());
         }
-        Tooltip tooltip = new Tooltip();
-        tooltip.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-        tooltip.setGraphic(description);
-        tooltip.setMaxHeight(10);
-        searchField.setTooltip(tooltip);
     }
 
     public void setSearchTerm(String searchTerm) {

--- a/src/main/java/org/jabref/gui/search/SearchWorker.java
+++ b/src/main/java/org/jabref/gui/search/SearchWorker.java
@@ -9,7 +9,6 @@ import javax.swing.SwingWorker;
 
 import org.jabref.JabRefGUI;
 import org.jabref.gui.BasePanel;
-import org.jabref.gui.search.rules.describer.SearchDescribers;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.model.database.BibDatabase;
@@ -60,7 +59,6 @@ class SearchWorker extends SwingWorker<List<BibEntry>, Void> {
 
         DefaultTaskExecutor.runInJavaFXThread(() ->
                 globalSearchBar.updateResults(matchedEntries.size(),
-                        SearchDescribers.getSearchDescriberFor(searchQuery).getDescription(),
                         searchQuery.isGrammarBasedSearch()));
         globalSearchBar.getSearchQueryHighlightObservable().fireSearchlistenerEvent(searchQuery);
     }


### PR DESCRIPTION
Now the extended help in the search field, showed as a tooltip, has been removed. It solves #3599.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
