### PR TITLE
Fix command line help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added the ability to execute default action in dialog by using with <kbd>Ctrl</kbd> + <kbd>Enter</kbd> combination [#4496](https://github.com/JabRef/jabref/issues/4496)
 - We grouped and reordered the Main Menu (File, Edit, Library, Quality, Tools, and View tabs & icons). [#4666](https://github.com/JabRef/jabref/issues/4666) [#4667](https://github.com/JabRef/jabref/issues/4667) [#4668](https://github.com/JabRef/jabref/issues/4668) [#4669](https://github.com/JabRef/jabref/issues/4669) [#4670](https://github.com/JabRef/jabref/issues/4670) [#4671](https://github.com/JabRef/jabref/issues/4671) [#4672](https://github.com/JabRef/jabref/issues/4672) [#4673](https://github.com/JabRef/jabref/issues/4673)
 - We added additional modifiers (capitalize, titlecase and sentencecase) to the Bibtex key generator. [#1506](https://github.com/JabRef/jabref/issues/1506)
-- We grouped the toolbar icons and changed the Open Library and Copy icons. [#4584](https://github.com/JabRef/jabref/issues/4584) 
+- We grouped the toolbar icons and changed the Open Library and Copy icons. [#4584](https://github.com/JabRef/jabref/issues/4584)
 - We added a browse button next to the path text field for aux-based groups. [#4586](https://github.com/JabRef/jabref/issues/4586)
 - We changed the title of Group Dialog to "Add subgroup" from "Edit group" when we select Add subgroup option.
 - We enable import button only if entries are selected. [#4755](https://github.com/JabRef/jabref/issues/4755)
@@ -114,7 +114,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where special characters where removed from non label key generation pattern parts [#4767](https://github.com/JabRef/jabref/issues/4767)
 - We fixed an issue where the RIS import would overwite the article date with the value of the acessed date [#4816](https://github.com/JabRef/jabref/issues/4816)
 - We fixed an issue where an NullPointer exception was thrown when a referenced entry in an Open/Libre Office document was no longer present in the library. Now an error message with the reference marker of the missing entry is shown. [#4932](https://github.com/JabRef/jabref/issues/4932)
-
+- We fixed an issue where the command line help text had several errors, and arguments and descriptions have been rewritten to simplify and detail them better. [#4932](https://github.com/JabRef/jabref/issues/2016)
 
 
 ### Removed

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 public class JabRefCLI {
 
+    private static final int WIDTH = 100; // Number of characters per line
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefCLI.class);
     private final CommandLine cl;
     private List<String> leftOver;
@@ -255,7 +256,7 @@ public class JabRefCLI {
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";
 
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp(100, "jabref [OPTIONS] [BIBTEX_FILE]\n\nOptions:", header, getOptions(), footer, true);
+        formatter.printHelp(WIDTH, "jabref [OPTIONS] [BIBTEX_FILE]\n\nOptions:", header, getOptions(), footer, true);
     }
 
     private String getVersionInfo() {

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.jabref.Globals;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.model.database.BibDatabaseMode;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -22,22 +21,19 @@ public class JabRefCLI {
     private List<String> leftOver;
 
     public JabRefCLI(String[] args) {
-
         Options options = getOptions();
-
         try {
             this.cl = new DefaultParser().parse(options, args);
             this.leftOver = cl.getArgList();
         } catch (ParseException e) {
             LOGGER.warn("Problem parsing arguments", e);
-
             this.printUsage();
             throw new RuntimeException();
         }
     }
 
     public static String getExportMatchesSyntax() {
-        return String.format("[%s]searchTerm,outputFile: %s[,%s]",
+        return String.format("[%s]searchTerm,outputFile:%s[,%s]",
                 Localization.lang("field"),
                 Localization.lang("file"),
                 Localization.lang("exportFormat"));
@@ -147,104 +143,97 @@ public class JabRefCLI {
         return cl.getOptionValue("exportMatches");
     }
 
-    public boolean isGenerateBibtexKeys() { return cl.hasOption("generateBibtexKeys"); }
+    public boolean isGenerateBibtexKeys() {
+        return cl.hasOption("generateBibtexKeys");
+    }
 
-    public boolean isAutomaticallySetFileLinks() { return cl.hasOption("automaticallySetFileLinks"); }
+    public boolean isAutomaticallySetFileLinks() {
+        return cl.hasOption("automaticallySetFileLinks");
+    }
 
     private Options getOptions() {
         Options options = new Options();
 
         // boolean options
-        options.addOption("v", "version", false, Localization.lang("Display version"));
-        options.addOption("n", "nogui", false, Localization.lang("No GUI. Only process command line options."));
         options.addOption("h", "help", false, Localization.lang("Display help on command line options"));
+        options.addOption("n", "nogui", false, Localization.lang("No GUI. Only process command line options"));
+        options.addOption("asfl", "automaticallySetFileLinks", false, Localization.lang("Automatically set file links"));
+        options.addOption("g", "generateBibtexKeys", false, Localization.lang("Regenerate all keys for the entries in a BibTeX file"));
         options.addOption("b", "blank", false, Localization.lang("Do not open any files at startup"));
+        options.addOption("v", "version", false, Localization.lang("Display version"));
         options.addOption(null, "debug", false, Localization.lang("Show debug level messages"));
 
         // The "-console" option is handled by the install4j launcher
-        options.addOption(null, "console", false, Localization.lang("Show console output (only necessary when the launcher is used)"));
+        options.addOption(null, "console", false, Localization.lang("Show console output (only when the launcher is used)"));
 
         options.addOption(Option.builder("i").
                 longOpt("import").
-                desc(String.format("%s: %s[,import format]", Localization.lang("Import file"),
-                        Localization.lang("filename"))).
+                desc(String.format("%s: '%s'", Localization.lang("Import file"), "-i library.bib")).
                 hasArg().
-                argName("FILE").build());
-
-        options.addOption(
-                Option.builder("ib")
-                      .longOpt("importBibtex")
-                        .desc(String.format("%s: %s[,importBibtex bibtexString]", Localization.lang("Import") + " " + BibDatabaseMode.BIBTEX.getFormattedName(), Localization.lang("filename")))
-                      .hasArg()
-                      .argName("FILE")
-                      .build());
-
-        options.addOption(Option.builder("o").
-                longOpt("output").
-                desc(String.format("%s: %s[,export format]", Localization.lang("Output or export file"),
-                        Localization.lang("filename"))).
-                hasArg().
-                argName("FILE").
-                build());
-
-        options.addOption(Option.builder("x").
-                longOpt("prexp").
-                desc(Localization.lang("Export preferences to file")).
-                hasArg().
-                argName("FILE").
-                build());
-
-        options.addOption(Option.builder("p").
-                longOpt("primp").
-                desc(Localization.lang("Import preferences from file")).
-                hasArg().
-                argName("FILE").
-                build());
-        options.addOption(Option.builder("d").
-                longOpt("prdef").
-                desc(Localization.lang("Reset preferences (key1,key2,... or 'all')")).
-                hasArg().
-                argName("FILE").
-                build());
-
-        options.addOption(Option.builder("a").
-                longOpt("aux").
-                desc(String.format("%s: %s[.aux],%s[.bib]", Localization.lang("Sublibrary from AUX"),
-                        Localization.lang("file"),
-                        Localization.lang("new"))).
-                hasArg().
-                argName("FILE").
+                argName("FILE[,FORMAT]").
                 build());
 
         options.addOption(Option.builder().
                 longOpt("importToOpen").
-                desc(Localization.lang("Import to open tab")).
+                desc(Localization.lang("Same as --import, but will be imported to the opened tab")).
                 hasArg().
-                argName("FILE").
+                argName("FILE[,FORMAT]").
                 build());
 
-        options.addOption(Option.builder("f").
-                longOpt("fetch").
-                desc(Localization.lang("Run fetcher, e.g. \"--fetch=Medline:cancer\"")).
+        options.addOption(Option.builder("ib").
+                longOpt("importBibtex").
+                desc(String.format("%s: '%s'", Localization.lang("Import BibTeX"), "-ib @article{entry}")).
                 hasArg().
-                argName("FILE").
+                argName("BIBTEXT_STRING").
+                build());
+
+        options.addOption(Option.builder("o").
+                longOpt("output").
+                desc(String.format("%s: '%s'", Localization.lang("Export an input to a file"), "-i db.bib -o db.htm,html")).
+                hasArg().
+                argName("FILE[,FORMAT]").
                 build());
 
         options.addOption(Option.builder("m").
                 longOpt("exportMatches").
-                desc(JabRefCLI.getExportMatchesSyntax()).
+                desc(String.format("%s: '%s'", Localization.lang("Matching"), "-i db.bib -m author=Newton,search.htm,html")).
                 hasArg().
-                argName("FILE").
+                argName("QUERY,FILE[,FORMAT]").
                 build());
 
-        options.addOption(Option.builder("g").
-                longOpt("generateBibtexKeys").
-                desc(Localization.lang("Regenerate all keys for the entries in a BibTeX file"))
-                .build());
+        options.addOption(Option.builder("f").
+                longOpt("fetch").
+                desc(String.format("%s: '%s'", Localization.lang("Run fetcher"), "-f Medline/PubMed:cancer")).
+                hasArg().
+                argName("FETCHER:QUERY").
+                build());
 
-        options.addOption(Option.builder("asfl").
-                longOpt("automaticallySetFileLinks").
-                desc(Localization.lang("Automatically set file links")).
+        options.addOption(Option.builder("a").
+                longOpt("aux").
+                desc(String.format("%s: '%s'", Localization.lang("Sublibrary from AUX to BibTeX"), "-a thesis.aux,new.bib")).
+                hasArg().
+                argName("FILE[.aux],FILE[.bib] FILE").
+                build());
+
+        options.addOption(Option.builder("x").
+                longOpt("prexp").
+                desc(String.format("%s: '%s'", Localization.lang("Export preferences to a file"), "-x prefs.xml")).
+                hasArg().
+                argName("[FILE]").
+                build());
+
+        options.addOption(Option.builder("p").
+                longOpt("primp").
+                desc(String.format("%s: '%s'", Localization.lang("Import preferences from a file"), "-p prefs.xml")).
+                hasArg().
+                argName("[FILE]").
+                build());
+
+        options.addOption(Option.builder("d").
+                longOpt("prdef").
+                desc(String.format("%s: '%s'", Localization.lang("Reset preferences"), "-d mainFontSize,newline' or '-d all")).
+                hasArg().
+                argName("KEY1[,KEY2][,KEYn] | all").
                 build());
 
         return options;
@@ -266,7 +255,7 @@ public class JabRefCLI {
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";
 
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp("jabref [OPTIONS] [BIBTEX_FILE]\n\nOptions:", header, getOptions(), footer, true);
+        formatter.printHelp(100, "jabref [OPTIONS] [BIBTEX_FILE]\n\nOptions:", header, getOptions(), footer, true);
     }
 
     private String getVersionInfo() {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -375,7 +375,6 @@ File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=File directory is not set 
 File\ exists=File exists
 
 File\ not\ found=File not found
-filename=filename
 
 Files\ opened=Files opened
 
@@ -469,8 +468,6 @@ Import\ preferences=Import preferences
 Import\ preferences\ from\ file=Import preferences from file
 
 Import\ strings=Import strings
-
-Import\ to\ open\ tab=Import to open tab
 
 Import\ word\ selector\ definitions=Import word selector definitions
 
@@ -573,7 +570,6 @@ Name\ formatter=Name formatter
 Natbib\ style=Natbib style
 
 nested\ AUX\ files=nested AUX files
-new=new
 
 New\ BibTeX\ sublibrary=New BibTeX sublibrary
 New\ library\ created.=New library created.
@@ -590,7 +586,7 @@ no\ library\ generated=no library generated
 No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=No entries found. Please make sure you are using the correct import filter.
 No\ files\ found.=No files found.
 
-No\ GUI.\ Only\ process\ command\ line\ options.=No GUI. Only process command line options.
+No\ GUI.\ Only\ process\ command\ line\ options=No GUI. Only process command line options
 
 No\ journal\ names\ could\ be\ abbreviated.=No journal names could be abbreviated.
 
@@ -640,8 +636,6 @@ Optional\ fields=Optional fields
 Options=Options
 
 or=or
-
-Output\ or\ export\ file=Output or export file
 
 Override\ default\ file\ directories=Override default file directories
 Overwrite=Overwrite
@@ -886,7 +880,7 @@ Statically\ group\ entries\ by\ manual\ assignment=Statically group entries by m
 Status=Status
 Strings\ for\ library=Strings for library
 
-Sublibrary\ from\ AUX=Sublibrary from AUX
+Sublibrary\ from\ AUX\ to\ BibTeX=Sublibrary from AUX to BibTeX
 
 Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Switches between full and abbreviated journal name if the journal name is known.
 
@@ -1041,7 +1035,7 @@ Unable\ to\ open\ link.=Unable to open link.
 MIME\ type=MIME type
 
 This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef\ instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef\ from\ your\ web\ browser.\ Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=This feature lets new files be opened or imported into an already running instance of JabRef instead of opening a new instance. For instance, this is useful when you open a file in JabRef from your web browser. Note that this will prevent you from running more than one instance of JabRef at a time.
-Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Run fetcher, e.g. "--fetch=Medline:cancer"
+Run\ fetcher=Run fetcher
 
 Reset=Reset
 
@@ -1223,7 +1217,6 @@ Resetting\ preference\ key\ '%0'=Resetting preference key '%0'
 Unknown\ preference\ key\ '%0'=Unknown preference key '%0'
 Unable\ to\ clear\ preferences.=Unable to clear preferences.
 
-Reset\ preferences\ (key1,key2,...\ or\ 'all')=Reset preferences (key1,key2,... or 'all')
 Find\ unlinked\ files=Find unlinked files
 Unselect\ all=Unselect all
 Expand\ all=Expand all
@@ -1907,7 +1900,7 @@ Could\ not\ copy\ file=Could not copy file
 Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=Copied %0 files of %1 sucessfully to %2
 Rename\ failed=Rename failed
 JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=JabRef cannot access the file because it is being used by another process.
-Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Show console output (only necessary when the launcher is used)
+Show\ console\ output\ (only\ when\ the\ launcher\ is\ used)=Show console output (only when the launcher is used)
 
 Remove\ line\ breaks=Remove line breaks
 Removes\ all\ line\ breaks\ in\ the\ field\ content.=Removes all line breaks in the field content.
@@ -2093,3 +2086,9 @@ Rename\ file\ to\ defined\ pattern=Rename file to defined pattern
 
 App\ settings=App settings
 
+Export\ an\ input\ to\ a\ file=Export an input to a file
+Export\ preferences\ to\ a\ file=Export preferences to a file
+Import\ BibTeX=Import BibTeX
+Import\ preferences\ from\ a\ file=Import preferences from a file
+Matching=Matching
+Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Same as --import, but will be imported to the opened tab


### PR DESCRIPTION
Now in the CLI help text, arguments and descriptions have been rewritten for fixing, simplifying, and detailing them better.

It fixes issue #2016.

![CLI help](https://user-images.githubusercontent.com/12954316/57963224-94de7780-7921-11e9-9d06-5e00be984fbe.png)

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
