### PR TITLE
Fix wrong icon size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added an option in the preference dialog box that allows user to enable helpful tooltips.[#3599](https://github.com/JabRef/jabref/issues/3599)
 - We moved the dropdown menu for selecting the push-application from the toolbar into the tools menu.[#674](https://github.com/JabRef/jabref/issues/674)
 
+
 ### Fixed
 - We fixed an issue where JabRef died silently for the user without enough inotify instances [#4874](https://github.com/JabRef/jabref/issues/4847)
 - We fixed an issue where corresponding groups are sometimes not highlighted when clicking on entries [#3112](https://github.com/JabRef/jabref/issues/3112)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The Medline fetcher now normalizes the author names according to the BibTeX-Standard [#4345](https://github.com/JabRef/jabref/issues/4345)
 - We added an option on the Linked File Viewer to rename the attached file of an entry directly on the JabRef. [#4844](https://github.com/JabRef/jabref/issues/4844)
 - We added an option in the preference dialog box that allows user to enable helpful tooltips.[#3599](https://github.com/JabRef/jabref/issues/3599)
-
+- We moved the dropdown menu for selecting the push-application from the toolbar into the tools menu.[#674](https://github.com/JabRef/jabref/issues/674)
 
 ### Fixed
 - We fixed an issue where JabRef died silently for the user without enough inotify instances [#4874](https://github.com/JabRef/jabref/issues/4847)

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -765,21 +765,23 @@ public class JabRefFrame extends BorderPane {
         );
 
         final PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushApplications(), this.getDialogService());
-        MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
+        final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
 
         final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.PUSH_APPLICATION);
         final ToggleGroup pushToToggleGroup = new ToggleGroup();
-        RadioMenuItem pushApplication;
+        RadioMenuItem pushToApplication;
         PushToApplicationMenuAction pushToApplicationMenuAction;
+        final String activePushToApplication = Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION);
 
         for (PushToApplication application : JabRefFrame.this.getPushApplications().getApplications()) {
             pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationMenuItem);
-            pushApplication = factory.createRadioMenuItem(pushToApplicationMenuAction.getActionInformation(),
-                                                                        pushToApplicationMenuAction,
-                                                                        application.getApplicationName().equals(
-                                                                                Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION)));
-            pushApplicationsMenu.getItems().add(pushApplication);
-            pushApplication.setToggleGroup(pushToToggleGroup);
+            pushToApplication = factory.createRadioMenuItem(
+                    pushToApplicationMenuAction.getActionInformation(),
+                    pushToApplicationMenuAction,
+                    application.getApplicationName().equals(activePushToApplication));
+
+            pushApplicationsMenu.getItems().add(pushToApplication);
+            pushToApplication.setToggleGroup(pushToToggleGroup);
         }
 
         tools.getItems().addAll(

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -28,13 +28,16 @@ import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.ProgressBar;
+import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.Separator;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.ToolBar;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.DataFormat;
@@ -95,7 +98,9 @@ import org.jabref.gui.metadata.BibtexStringEditorAction;
 import org.jabref.gui.metadata.PreambleEditor;
 import org.jabref.gui.preferences.ShowPreferencesAction;
 import org.jabref.gui.protectedterms.ManageProtectedTermsAction;
+import org.jabref.gui.push.PushToApplication;
 import org.jabref.gui.push.PushToApplicationAction;
+import org.jabref.gui.push.PushToApplicationMenuAction;
 import org.jabref.gui.push.PushToApplicationsManager;
 import org.jabref.gui.search.GlobalSearchBar;
 import org.jabref.gui.shared.ConnectToSharedDatabaseCommand;
@@ -760,6 +765,23 @@ public class JabRefFrame extends BorderPane {
         );
 
         final PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushApplications(), this.getDialogService());
+        MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
+
+        final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.PUSH_APPLICATION);
+        final ToggleGroup pushToToggleGroup = new ToggleGroup();
+        RadioMenuItem pushApplication;
+        PushToApplicationMenuAction pushToApplicationMenuAction;
+
+        for (PushToApplication application : JabRefFrame.this.getPushApplications().getApplications()) {
+            pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationMenuItem);
+            pushApplication = factory.createRadioMenuItem(pushToApplicationMenuAction.getActionInformation(),
+                                                                        pushToApplicationMenuAction,
+                                                                        application.getApplicationName().equals(
+                                                                                Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION)));
+            pushApplicationsMenu.getItems().add(pushApplication);
+            pushApplication.setToggleGroup(pushToToggleGroup);
+        }
+
         tools.getItems().addAll(
                 factory.createMenuItem(StandardActions.NEW_SUB_LIBRARY_FROM_AUX, new NewSubLibraryAction(this, stateManager)),
                 factory.createMenuItem(StandardActions.FIND_UNLINKED_FILES, new FindUnlinkedFilesAction(this, stateManager)),
@@ -776,7 +798,8 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.GENERATE_CITE_KEYS, new OldDatabaseCommandWrapper(Actions.MAKE_KEY, this, stateManager)),
                 factory.createMenuItem(StandardActions.REPLACE_ALL, new OldDatabaseCommandWrapper(Actions.REPLACE_ALL, this, stateManager)),
                 factory.createMenuItem(StandardActions.SEND_AS_EMAIL, new OldDatabaseCommandWrapper(Actions.SEND_AS_EMAIL, this, stateManager)),
-                factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction),
+                pushApplicationsMenu,
+                pushToApplicationMenuItem,
 
                 factory.createSubMenu(StandardActions.ABBREVIATE,
                         factory.createMenuItem(StandardActions.ABBREVIATE_ISO, new OldDatabaseCommandWrapper(Actions.ABBREVIATE_ISO, this, stateManager)),

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -773,7 +773,7 @@ public class JabRefFrame extends BorderPane {
         PushToApplicationMenuAction pushToApplicationMenuAction;
         final String activePushToApplication = Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION);
 
-        for (PushToApplication application : JabRefFrame.this.getPushToApplicationsManager().getApplications()) {
+        for (PushToApplication application : pushToApplicationsManager.getApplications()) {
             pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationMenuItem);
             pushToApplication = factory.createRadioMenuItem(
                     pushToApplicationMenuAction.getActionInformation(),

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -526,6 +526,9 @@ public class JabRefFrame extends BorderPane {
         leftSide.maxWidthProperty().bind(sidePane.widthProperty());
 
         final PushToApplicationAction pushToApplicationAction = getPushToApplicationsManager().getPushToApplicationAction();
+        final Button pushToApplicationButton = factory.createIconButton(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
+        pushToApplicationsManager.setToolBarButton(pushToApplicationButton);
+
         HBox rightSide = new HBox(
                 factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE, dialogService, Globals.prefs, stateManager)),
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
@@ -536,7 +539,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createIconButton(StandardActions.COPY, new OldDatabaseCommandWrapper(Actions.COPY, this, stateManager)),
                 factory.createIconButton(StandardActions.PASTE, new OldDatabaseCommandWrapper(Actions.PASTE, this, stateManager)),
                 new Separator(Orientation.VERTICAL),
-                factory.createIconButton(pushToApplicationAction.getActionInformation(), pushToApplicationAction),
+                pushToApplicationButton,
                 factory.createIconButton(StandardActions.GENERATE_CITE_KEYS, new OldDatabaseCommandWrapper(Actions.MAKE_KEY, this, stateManager)),
                 factory.createIconButton(StandardActions.CLEANUP_ENTRIES, new OldDatabaseCommandWrapper(Actions.CLEANUP, this, stateManager)),
                 new Separator(Orientation.VERTICAL),
@@ -766,6 +769,7 @@ public class JabRefFrame extends BorderPane {
 
         final PushToApplicationAction pushToApplicationAction = pushToApplicationsManager.getPushToApplicationAction();
         final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
+        pushToApplicationsManager.setMenuItem(pushToApplicationMenuItem);
 
         final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.SELECT_PUSH_APPLICATION);
         final ToggleGroup pushToToggleGroup = new ToggleGroup();
@@ -774,7 +778,7 @@ public class JabRefFrame extends BorderPane {
         final String activePushToApplication = Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION);
 
         for (PushToApplication application : pushToApplicationsManager.getApplications()) {
-            pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationMenuItem);
+            pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationsManager);
             pushToApplication = factory.createRadioMenuItem(
                     pushToApplicationMenuAction.getActionInformation(),
                     pushToApplicationMenuAction,

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -159,7 +159,7 @@ public class JabRefFrame extends BorderPane {
     private final CountingUndoManager undoManager;
     private SidePaneManager sidePaneManager;
     private TabPane tabbedPane;
-    private PushToApplicationsManager pushApplications;
+    private PushToApplicationsManager pushToApplicationsManager;
     private final DialogService dialogService;
     private SidePane sidePane;
 
@@ -454,7 +454,7 @@ public class JabRefFrame extends BorderPane {
     private void initLayout() {
         setProgressBarVisible(false);
 
-        pushApplications = new PushToApplicationsManager(this.getDialogService());
+        pushToApplicationsManager = new PushToApplicationsManager(this.getDialogService());
 
         BorderPane head = new BorderPane();
         head.setTop(createMenu());
@@ -525,7 +525,7 @@ public class JabRefFrame extends BorderPane {
         leftSide.prefWidthProperty().bind(sidePane.widthProperty());
         leftSide.maxWidthProperty().bind(sidePane.widthProperty());
 
-        PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushApplications(), this.getDialogService());
+        PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushToApplicationsManager(), this.getDialogService());
         HBox rightSide = new HBox(
                 factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE, dialogService, Globals.prefs, stateManager)),
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
@@ -764,7 +764,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.SET_FILE_LINKS, new AutoLinkFilesAction(this, prefs, stateManager, undoManager))
         );
 
-        final PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushApplications(), this.getDialogService());
+        final PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushToApplicationsManager(), this.getDialogService());
         final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
 
         final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.PUSH_APPLICATION);
@@ -773,7 +773,7 @@ public class JabRefFrame extends BorderPane {
         PushToApplicationMenuAction pushToApplicationMenuAction;
         final String activePushToApplication = Globals.prefs.get(JabRefPreferences.PUSH_TO_APPLICATION);
 
-        for (PushToApplication application : JabRefFrame.this.getPushApplications().getApplications()) {
+        for (PushToApplication application : JabRefFrame.this.getPushToApplicationsManager().getApplications()) {
             pushToApplicationMenuAction = new PushToApplicationMenuAction(application, pushToApplicationAction, pushToApplicationMenuItem);
             pushToApplication = factory.createRadioMenuItem(
                     pushToApplicationMenuAction.getActionInformation(),
@@ -1217,8 +1217,8 @@ public class JabRefFrame extends BorderPane {
         return sidePaneManager;
     }
 
-    public PushToApplicationsManager getPushApplications() {
-        return pushApplications;
+    public PushToApplicationsManager getPushToApplicationsManager() {
+        return pushToApplicationsManager;
     }
 
     public GlobalSearchBar getGlobalSearchBar() {

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -767,7 +767,7 @@ public class JabRefFrame extends BorderPane {
         final PushToApplicationAction pushToApplicationAction = pushToApplicationsManager.getPushToApplicationAction();
         final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
 
-        final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.PUSH_APPLICATION);
+        final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.SELECT_PUSH_APPLICATION);
         final ToggleGroup pushToToggleGroup = new ToggleGroup();
         RadioMenuItem pushToApplication;
         PushToApplicationMenuAction pushToApplicationMenuAction;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -454,7 +454,7 @@ public class JabRefFrame extends BorderPane {
     private void initLayout() {
         setProgressBarVisible(false);
 
-        pushToApplicationsManager = new PushToApplicationsManager(this.getDialogService());
+        pushToApplicationsManager = new PushToApplicationsManager(dialogService, stateManager);
 
         BorderPane head = new BorderPane();
         head.setTop(createMenu());
@@ -525,7 +525,7 @@ public class JabRefFrame extends BorderPane {
         leftSide.prefWidthProperty().bind(sidePane.widthProperty());
         leftSide.maxWidthProperty().bind(sidePane.widthProperty());
 
-        PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushToApplicationsManager(), this.getDialogService());
+        final PushToApplicationAction pushToApplicationAction = getPushToApplicationsManager().getPushToApplicationAction();
         HBox rightSide = new HBox(
                 factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE, dialogService, Globals.prefs, stateManager)),
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
@@ -764,7 +764,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.SET_FILE_LINKS, new AutoLinkFilesAction(this, prefs, stateManager, undoManager))
         );
 
-        final PushToApplicationAction pushToApplicationAction = new PushToApplicationAction(stateManager, this.getPushToApplicationsManager(), this.getDialogService());
+        final PushToApplicationAction pushToApplicationAction = pushToApplicationsManager.getPushToApplicationAction();
         final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);
 
         final Menu pushApplicationsMenu = factory.createSubMenu(StandardActions.PUSH_APPLICATION);

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -4,7 +4,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
-import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.CheckMenuItem;
@@ -157,13 +156,9 @@ public class ActionFactory {
         button.getStyleClass().add("icon-button");
 
         // For some reason the graphic is not set correctly, so let's fix this
+        // ToDO: Find a way to reuse JabRefIconView
         button.graphicProperty().unbind();
-        action.getIcon().ifPresent(icon -> {
-            // ToDO: Find a way to reuse JabRefIconView
-            Node graphicNode = icon.getGraphicNode();
-            graphicNode.setStyle(String.format("-fx-font-family: %s; -fx-font-size: %s;", icon.fontFamily(), "1em"));
-            button.setGraphic(graphicNode);
-        });
+        action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));
 
         return button;
     }

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -11,6 +11,7 @@ import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.keyboard.KeyBindingRepository;
@@ -111,6 +112,14 @@ public class ActionFactory {
         setGraphic(checkMenuItem, action);
 
         return checkMenuItem;
+    }
+
+    public RadioMenuItem createRadioMenuItem(Action action, Command command, boolean selected) {
+        RadioMenuItem radioMenuItem = ActionUtils.createRadioMenuItem(new JabRefAction(action, command, keyBindingRepository));
+        radioMenuItem.setSelected(selected);
+        setGraphic(radioMenuItem, action);
+
+        return radioMenuItem;
     }
 
     public Menu createMenu(Action action) {

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -92,6 +92,7 @@ public enum StandardActions implements Action {
     OPEN_CONSOLE(Localization.lang("Open terminal here"), Localization.lang("Open terminal here"), IconTheme.JabRefIcons.CONSOLE, KeyBinding.OPEN_CONSOLE),
     COPY_LINKED_FILES(Localization.lang("Copy linked files to folder...")),
     COPY_DOI(Localization.lang("Copy DOI url")),
+    PUSH_APPLICATION(Localization.lang("Push-application")),
     ABBREVIATE(Localization.lang("Abbreviate journal names")),
     ABBREVIATE_ISO("ISO", Localization.lang("Abbreviate journal names of the selected entries (ISO abbreviation)"), KeyBinding.ABBREVIATE),
     ABBREVIATE_MEDLINE("MEDLINE", Localization.lang("Abbreviate journal names of the selected entries (MEDLINE abbreviation)")),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -92,7 +92,7 @@ public enum StandardActions implements Action {
     OPEN_CONSOLE(Localization.lang("Open terminal here"), Localization.lang("Open terminal here"), IconTheme.JabRefIcons.CONSOLE, KeyBinding.OPEN_CONSOLE),
     COPY_LINKED_FILES(Localization.lang("Copy linked files to folder...")),
     COPY_DOI(Localization.lang("Copy DOI url")),
-    PUSH_APPLICATION(Localization.lang("Push-application")),
+    SELECT_PUSH_APPLICATION(Localization.lang("Select external application")),
     ABBREVIATE(Localization.lang("Abbreviate journal names")),
     ABBREVIATE_ISO("ISO", Localization.lang("Abbreviate journal names of the selected entries (ISO abbreviation)"), KeyBinding.ABBREVIATE),
     ABBREVIATE_MEDLINE("MEDLINE", Localization.lang("Abbreviate journal names of the selected entries (MEDLINE abbreviation)")),

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -40,7 +40,14 @@
                     <Tooltip text="%Change entry type"/>
                 </tooltip>
             </Button>
-            <Button fx:id="generateCiteKeyButton" styleClass="narrow"/>
+            <Button styleClass="icon-button,narrow" onAction="#generateCiteKeyButton">
+                <graphic>
+                    <JabRefIconView glyph="MAKE_KEY"/>
+                </graphic>
+                <tooltip>
+                    <Tooltip text="%Generate BibTeX key"/>
+                </tooltip>
+            </Button>
             <Button fx:id="fetcherButton" styleClass="icon-button,narrow">
                 <graphic>
                     <JabRefIconView glyph="REFRESH"/>

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -27,8 +27,6 @@ import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.GUIGlobals;
-import org.jabref.gui.actions.ActionFactory;
-import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.bibtexkeypattern.GenerateBibtexKeySingleAction;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
 import org.jabref.gui.externalfiles.ExternalFilesEntryLinker;
@@ -87,7 +85,6 @@ public class EntryEditor extends BorderPane {
     @FXML private Button typeChangeButton;
     @FXML private Button fetcherButton;
     @FXML private Label typeLabel;
-    @FXML private Button generateCiteKeyButton;
 
     private final EntryEditorPreferences preferences;
     private final DialogService dialogService;
@@ -262,6 +259,12 @@ public class EntryEditor extends BorderPane {
     }
 
     @FXML
+    void generateCiteKeyButton() {
+        GenerateBibtexKeySingleAction action = new GenerateBibtexKeySingleAction(getEntry(), databaseContext, dialogService, preferences, undoManager);
+        action.execute();
+    }
+
+    @FXML
     private void navigateToPreviousEntry() {
         panel.selectPreviousEntry();
     }
@@ -387,13 +390,6 @@ public class EntryEditor extends BorderPane {
             fetcherMenu.getItems().add(fetcherMenuItem);
         }
         fetcherButton.setOnMouseClicked(event -> fetcherMenu.show(fetcherButton, Side.RIGHT, 0, 0));
-
-        // Configure cite key button
-        new ActionFactory(preferences.getKeyBindings())
-                .configureIconButton(
-                        StandardActions.GENERATE_CITE_KEY,
-                        new GenerateBibtexKeySingleAction(getEntry(), databaseContext, dialogService, preferences, undoManager),
-                        generateCiteKeyButton);
     }
 
     private void fetchAndMerge(EntryBasedFetcher fetcher) {

--- a/src/main/java/org/jabref/gui/preferences/ExternalTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTab.java
@@ -149,7 +149,7 @@ class ExternalTab implements PrefsTab {
 
         GridPane butpan = new GridPane();
         int index = 0;
-        for (PushToApplication pushToApplication : frame.getPushApplications().getApplications()) {
+        for (PushToApplication pushToApplication : frame.getPushToApplicationsManager().getApplications()) {
             addSettingsButton(pushToApplication, butpan, index);
             index++;
         }
@@ -198,7 +198,7 @@ class ExternalTab implements PrefsTab {
     }
 
     private void addSettingsButton(final PushToApplication application, GridPane panel, int index) {
-        PushToApplicationSettings settings = frame.getPushApplications().getSettings(application);
+        PushToApplicationSettings settings = frame.getPushToApplicationsManager().getSettings(application);
         Button button = new Button(Localization.lang("Settings for %0", application.getApplicationName()));
         button.setPrefSize(150, 20);
         button.setOnAction(e -> PushToApplicationSettingsDialog.showSettingsDialog(dialogService, settings, index));

--- a/src/main/java/org/jabref/gui/push/PushToApplicationAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationAction.java
@@ -25,22 +25,34 @@ import static org.jabref.gui.actions.ActionHelper.needsEntriesSelected;
  */
 public class PushToApplicationAction extends SimpleCommand {
 
-    private final PushToApplication operation;
+    private PushToApplication operation;
     private final StateManager stateManager;
     private final DialogService dialogService;
 
+    private Action action;
+
     public PushToApplicationAction(StateManager stateManager, PushToApplicationsManager pushToApplicationsManager, DialogService dialogService) {
-        this.operation = pushToApplicationsManager.getLastUsedApplication(Globals.prefs);
+        this.operation = pushToApplicationsManager.getActiveApplication(Globals.prefs);
         this.stateManager = stateManager;
         this.dialogService = dialogService;
 
         this.executable.bind(needsDatabase(stateManager).and(needsEntriesSelected(stateManager)));
         this.statusMessage.bind(BindingsHelper.ifThenElse(this.executable, "", Localization.lang("This operation requires one or more entries to be selected.")));
+
+        updateAction();
+    }
+
+    public void updateApplication (PushToApplication application) {
+        this.operation = application;
+        updateAction();
     }
 
     public Action getActionInformation() {
-        return new Action() {
+        return action;
+    }
 
+    public void updateAction() {
+        action = new Action() {
             @Override
             public Optional<JabRefIcon> getIcon() {
                 return Optional.of(operation.getIcon());

--- a/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
@@ -9,7 +9,6 @@ import org.jabref.gui.actions.Action;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.icon.JabRefIcon;
 import org.jabref.gui.keyboard.KeyBinding;
-import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
 
 /**
@@ -42,7 +41,7 @@ public class PushToApplicationMenuAction extends SimpleCommand {
 
             @Override
             public String getText() {
-                return Localization.lang(application.getApplicationName());
+                return application.getApplicationName();
             }
 
             @Override

--- a/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
@@ -1,0 +1,61 @@
+package org.jabref.gui.push;
+
+import java.util.Optional;
+
+import javafx.scene.control.MenuItem;
+
+import org.jabref.Globals;
+import org.jabref.gui.actions.Action;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.icon.JabRefIcon;
+import org.jabref.gui.keyboard.KeyBinding;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.preferences.JabRefPreferences;
+
+/**
+ * An Action class representing the process of invoking a PushToApplicationMenu operation.
+ */
+public class PushToApplicationMenuAction extends SimpleCommand {
+
+    private final PushToApplication application;
+    private final PushToApplicationAction pushToApplicationAction;
+    private MenuItem pushToApplicationMenuItem;
+
+    public PushToApplicationMenuAction(PushToApplication pushToApplication, PushToApplicationAction pushToApplicationAction, MenuItem pushToApplicationMenuItem) {
+        this.application = pushToApplication;
+        this.pushToApplicationAction = pushToApplicationAction;
+        this.pushToApplicationMenuItem = pushToApplicationMenuItem;
+    }
+
+    public Action getActionInformation() {
+        return new Action() {
+
+            @Override
+            public Optional<JabRefIcon> getIcon() {
+                return Optional.of(application.getIcon());
+            }
+
+            @Override
+            public Optional<KeyBinding> getKeyBinding() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String getText() {
+                return Localization.lang(application.getApplicationName());
+            }
+
+            @Override
+            public String getDescription() {
+                return "";
+            }
+        };
+    }
+
+    @Override
+    public void execute() {
+        Globals.prefs.put(JabRefPreferences.PUSH_TO_APPLICATION, application.getApplicationName());
+        pushToApplicationAction.updateApplication(application);
+        //pushToApplicationMenuItem.setText(pushToApplicationAction.getActionInformation().getText());
+    }
+}

--- a/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
@@ -65,14 +65,10 @@ public class PushToApplicationMenuAction extends SimpleCommand {
 
         if(menuItem != null) {
             factory.configureMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction, menuItem);
-
-            //manager.getMenuItem().textProperty().unbind();
-            //manager.getMenuItem().setText(pushToApplicationAction.getActionInformation().getText());
         }
 
         if(toolBarButton != null) {
             factory.configureIconButton(pushToApplicationAction.getActionInformation(),pushToApplicationAction, toolBarButton);
-            //pushToApplicationAction.getActionInformation().getIcon().ifPresent(icon -> toolBarButton.setGraphic(icon.getGraphicNode()));
         }
     }
 }

--- a/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
@@ -2,10 +2,12 @@ package org.jabref.gui.push;
 
 import java.util.Optional;
 
+import javafx.scene.control.Button;
 import javafx.scene.control.MenuItem;
 
 import org.jabref.Globals;
 import org.jabref.gui.actions.Action;
+import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.icon.JabRefIcon;
 import org.jabref.gui.keyboard.KeyBinding;
@@ -18,12 +20,13 @@ public class PushToApplicationMenuAction extends SimpleCommand {
 
     private final PushToApplication application;
     private final PushToApplicationAction pushToApplicationAction;
-    private MenuItem pushToApplicationMenuItem;
 
-    public PushToApplicationMenuAction(PushToApplication pushToApplication, PushToApplicationAction pushToApplicationAction, MenuItem pushToApplicationMenuItem) {
+    private PushToApplicationsManager manager;
+
+    public PushToApplicationMenuAction(PushToApplication pushToApplication, PushToApplicationAction pushToApplicationAction, PushToApplicationsManager manager) {
         this.application = pushToApplication;
         this.pushToApplicationAction = pushToApplicationAction;
-        this.pushToApplicationMenuItem = pushToApplicationMenuItem;
+        this.manager = manager;
     }
 
     public Action getActionInformation() {
@@ -55,6 +58,21 @@ public class PushToApplicationMenuAction extends SimpleCommand {
     public void execute() {
         Globals.prefs.put(JabRefPreferences.PUSH_TO_APPLICATION, application.getApplicationName());
         pushToApplicationAction.updateApplication(application);
-        //pushToApplicationMenuItem.setText(pushToApplicationAction.getActionInformation().getText());
+        ActionFactory factory = new ActionFactory(Globals.getKeyPrefs());
+
+        MenuItem menuItem = manager.getMenuItem();
+        Button toolBarButton = manager.getToolBarButton();
+
+        if(menuItem != null) {
+            factory.configureMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction, menuItem);
+
+            //manager.getMenuItem().textProperty().unbind();
+            //manager.getMenuItem().setText(pushToApplicationAction.getActionInformation().getText());
+        }
+
+        if(toolBarButton != null) {
+            factory.configureIconButton(pushToApplicationAction.getActionInformation(),pushToApplicationAction, toolBarButton);
+            //pushToApplicationAction.getActionInformation().getIcon().ifPresent(icon -> toolBarButton.setGraphic(icon.getGraphicNode()));
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationMenuAction.java
@@ -63,11 +63,11 @@ public class PushToApplicationMenuAction extends SimpleCommand {
         MenuItem menuItem = manager.getMenuItem();
         Button toolBarButton = manager.getToolBarButton();
 
-        if(menuItem != null) {
+        if (menuItem != null) {
             factory.configureMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction, menuItem);
         }
 
-        if(toolBarButton != null) {
+        if (toolBarButton != null) {
             factory.configureIconButton(pushToApplicationAction.getActionInformation(),pushToApplicationAction, toolBarButton);
         }
     }

--- a/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
 import org.jabref.preferences.JabRefPreferences;
 
 public class PushToApplicationsManager {
@@ -12,7 +13,9 @@ public class PushToApplicationsManager {
 
     private final DialogService dialogService;
 
-    public PushToApplicationsManager(DialogService dialogService) {
+    private final PushToApplicationAction pushToApplicationAction;
+
+    public PushToApplicationsManager(DialogService dialogService, StateManager stateManager) {
         this.dialogService = dialogService;
         // Set up the current available choices:
         applications = new ArrayList<>();
@@ -22,10 +25,16 @@ public class PushToApplicationsManager {
         applications.add(new PushToTeXstudio(dialogService));
         applications.add(new PushToVim(dialogService));
         applications.add(new PushToWinEdt(dialogService));
+
+        this.pushToApplicationAction = new PushToApplicationAction(stateManager, this, dialogService);
     }
 
     public List<PushToApplication> getApplications() {
         return applications;
+    }
+
+    public PushToApplicationAction getPushToApplicationAction() {
+        return pushToApplicationAction;
     }
 
     public PushToApplicationSettings getSettings(PushToApplication application) {

--- a/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
@@ -40,7 +40,7 @@ public class PushToApplicationsManager {
         }
     }
 
-    public PushToApplication getLastUsedApplication(JabRefPreferences preferences) {
+    public PushToApplication getActiveApplication(JabRefPreferences preferences) {
         String appSelected = preferences.get(JabRefPreferences.PUSH_TO_APPLICATION);
         return applications.stream()
                            .filter(application -> application.getApplicationName().equals(appSelected))

--- a/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationsManager.java
@@ -3,6 +3,9 @@ package org.jabref.gui.push;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.scene.control.Button;
+import javafx.scene.control.MenuItem;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.preferences.JabRefPreferences;
@@ -14,6 +17,8 @@ public class PushToApplicationsManager {
     private final DialogService dialogService;
 
     private final PushToApplicationAction pushToApplicationAction;
+    private MenuItem menuItem;
+    private Button toolBarButton;
 
     public PushToApplicationsManager(DialogService dialogService, StateManager stateManager) {
         this.dialogService = dialogService;
@@ -27,6 +32,22 @@ public class PushToApplicationsManager {
         applications.add(new PushToWinEdt(dialogService));
 
         this.pushToApplicationAction = new PushToApplicationAction(stateManager, this, dialogService);
+    }
+
+    public void setMenuItem(MenuItem menuItem) {
+        this.menuItem = menuItem;
+    }
+
+    public MenuItem getMenuItem() {
+        return menuItem;
+    }
+
+    public void setToolBarButton(Button pushToApplicationToolBarButton) {
+        this.toolBarButton = pushToApplicationToolBarButton;
+    }
+
+    public Button getToolBarButton() {
+        return toolBarButton;
     }
 
     public List<PushToApplication> getApplications() {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1370,6 +1370,7 @@ Open\ %0\ file=Open %0 file
 
 Cannot\ delete\ file=Cannot delete file
 File\ permission\ error=File permission error
+Select\ external\ application=Select external application
 Push\ to\ %0=Push to %0
 Path\ to\ %0=Path to %0
 Convert=Convert


### PR DESCRIPTION
The entry-editor showed a slightly smaller icon for the GenerateBibtexKey-Button, this bug also had an effect on the display of icon size in #4991

The GenereatBibtexKey-Button is now a Button like every other Button, the ActionObject was put into a standard-FXML-method. Everything works, including Undo and asking before overwriting.

edit:
Oh no, sorry, I am a newbie to git. I forked my branch of the branch of the other Pull Request, so everything is in here twice. Im so stupid.
This one has to wait, until the other one is merged. or not.

The new commit in this pull request is [this one](https://github.com/JabRef/jabref/pull/4992/commits/015f3e06e1014cc41fd8f615bad67b3584091bdc)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
