### PR TITLE
Fix icon size - the second

### DIFF
--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -4,7 +4,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
-import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.CheckMenuItem;
@@ -148,13 +147,9 @@ public class ActionFactory {
         button.getStyleClass().add("icon-button");
 
         // For some reason the graphic is not set correctly, so let's fix this
+        // ToDO: Find a way to reuse JabRefIconView
         button.graphicProperty().unbind();
-        action.getIcon().ifPresent(icon -> {
-            // ToDO: Find a way to reuse JabRefIconView
-            Node graphicNode = icon.getGraphicNode();
-            graphicNode.setStyle(String.format("-fx-font-family: %s; -fx-font-size: %s;", icon.fontFamily(), "1em"));
-            button.setGraphic(graphicNode);
-        });
+        action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));
 
         return button;
     }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -40,7 +40,14 @@
                     <Tooltip text="%Change entry type"/>
                 </tooltip>
             </Button>
-            <Button fx:id="generateCiteKeyButton" styleClass="narrow"/>
+            <Button styleClass="icon-button,narrow" onAction="#generateCiteKeyButton">
+                <graphic>
+                    <JabRefIconView glyph="MAKE_KEY"/>
+                </graphic>
+                <tooltip>
+                    <Tooltip text="%Generate BibTeX key"/>
+                </tooltip>
+            </Button>
             <Button fx:id="fetcherButton" styleClass="icon-button,narrow">
                 <graphic>
                     <JabRefIconView glyph="REFRESH"/>

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -27,8 +27,6 @@ import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.GUIGlobals;
-import org.jabref.gui.actions.ActionFactory;
-import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.bibtexkeypattern.GenerateBibtexKeySingleAction;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
 import org.jabref.gui.externalfiles.ExternalFilesEntryLinker;
@@ -87,7 +85,6 @@ public class EntryEditor extends BorderPane {
     @FXML private Button typeChangeButton;
     @FXML private Button fetcherButton;
     @FXML private Label typeLabel;
-    @FXML private Button generateCiteKeyButton;
 
     private final EntryEditorPreferences preferences;
     private final DialogService dialogService;
@@ -262,6 +259,12 @@ public class EntryEditor extends BorderPane {
     }
 
     @FXML
+    void generateCiteKeyButton() {
+        GenerateBibtexKeySingleAction action = new GenerateBibtexKeySingleAction(getEntry(), databaseContext, dialogService, preferences, undoManager);
+        action.execute();
+    }
+
+    @FXML
     private void navigateToPreviousEntry() {
         panel.selectPreviousEntry();
     }
@@ -387,13 +390,6 @@ public class EntryEditor extends BorderPane {
             fetcherMenu.getItems().add(fetcherMenuItem);
         }
         fetcherButton.setOnMouseClicked(event -> fetcherMenu.show(fetcherButton, Side.RIGHT, 0, 0));
-
-        // Configure cite key button
-        new ActionFactory(preferences.getKeyBindings())
-                .configureIconButton(
-                        StandardActions.GENERATE_CITE_KEY,
-                        new GenerateBibtexKeySingleAction(getEntry(), databaseContext, dialogService, preferences, undoManager),
-                        generateCiteKeyButton);
     }
 
     private void fetchAndMerge(EntryBasedFetcher fetcher) {


### PR DESCRIPTION
The entry-editor showed a slightly smaller icon for the GenerateBibtexKey-Button, this bug also had an effect on the display of icon size in #4991

The GenerateBibtexKey-Button is now a Button like every other Button in FXML, the ActionObject was put into a standard-FXML-method. Everything works, including Undo and asking before overwriting.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
