### PR TITLE
Fix the 'Attach file' dialog for starting on the user's main directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where a database exception related to a missing timezone was too big. [#4827](https://github.com/JabRef/jabref/issues/4827)
 - We fixed an issue where the command line help text had several errors, and arguments and descriptions have been rewritten to simplify and detail them better. [#4932](https://github.com/JabRef/jabref/issues/2016)
 - We fixed an issue where the same menu for changing entry type had two different sizes and weights. [#4977](https://github.com/JabRef/jabref/issues/4977)
+- We fixed an issue where the "Attach file" dialog, in the right-click menu for an entry, started on the working directory instead of the user's main directory. [#4995](https://github.com/JabRef/jabref/issues/4995)
 
 
 ### Removed

--- a/src/main/java/org/jabref/gui/filelist/AttachFileAction.java
+++ b/src/main/java/org/jabref/gui/filelist/AttachFileAction.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.filelist;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.jabref.Globals;
@@ -32,14 +34,21 @@ public class AttachFileAction extends SimpleCommand {
             dialogService.notify(Localization.lang("This operation requires exactly one item to be selected."));
             return;
         }
+
         BibEntry entry = panel.getSelectedEntries().get(0);
+
+        Path workingDirectory = panel.getBibDatabaseContext()
+                                     .getFirstExistingFileDir(Globals.prefs.getFilePreferences())
+                                     .orElse(Paths.get(Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY)));
+
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
-                                                                                               .withInitialDirectory(Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY))
-                                                                                               .build();
+                .withInitialDirectory(workingDirectory)
+                .build();
 
         dialogService.showFileOpenDialog(fileDialogConfiguration).ifPresent(newFile -> {
-
-            LinkedFile linkedFile = LinkedFilesEditorViewModel.fromFile(newFile, panel.getBibDatabaseContext().getFileDirectoriesAsPaths(Globals.prefs.getFilePreferences()), ExternalFileTypes.getInstance());
+            LinkedFile linkedFile = LinkedFilesEditorViewModel.fromFile(newFile,
+                    panel.getBibDatabaseContext().getFileDirectoriesAsPaths(Globals.prefs.getFilePreferences()),
+                    ExternalFileTypes.getInstance());
 
             LinkedFileEditDialogView dialog = new LinkedFileEditDialogView(linkedFile);
 


### PR DESCRIPTION
Now the "Attach file" dialog, in the right-click menu for an entry, starts on the working directory instead of the user's main directory. It is the same behavior as when adding a file from the entry editor.

It solves [#4995](https://github.com/JabRef/jabref/issues/4995)

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
