### PR TITLE
[WIP] Fix field formatter save actions throwing exception on autosave

### DIFF
--- a/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -33,6 +33,8 @@ import javafx.scene.control.TextInputControl;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 
+import org.jabref.gui.util.DefaultTaskExecutor;
+
 import org.controlsfx.control.textfield.AutoCompletionBinding;
 
 /**
@@ -51,7 +53,7 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
     private AutoCompletionStrategy inputAnalyzer;
     private final ChangeListener<String> textChangeListener = (obs, oldText, newText) -> {
         if (getCompletionTarget().isFocused()) {
-            setUserInputText(newText);
+            DefaultTaskExecutor.runInJavaFXThread(() -> setUserInputText(newText)); //we need to wrap this as it is called from a non fx thread in autosave
         }
     };
     private boolean showOnFocus;
@@ -73,9 +75,9 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
                                            Callback<ISuggestionRequest, Collection<T>> suggestionProvider) {
 
         this(textInputControl,
-                suggestionProvider,
-                AutoCompletionTextInputBinding.defaultStringConverter(),
-                new ReplaceStrategy());
+             suggestionProvider,
+             AutoCompletionTextInputBinding.defaultStringConverter(),
+             new ReplaceStrategy());
     }
 
     private AutoCompletionTextInputBinding(final TextInputControl textInputControl,
@@ -99,6 +101,7 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
 
     private static <T> StringConverter<T> defaultStringConverter() {
         return new StringConverter<T>() {
+
             @Override
             public String toString(T t) {
                 return t == null ? null : t.toString();


### PR DESCRIPTION
Fixes #4958

In my opinion this is an ugly hack but still the only option without violating our architecture.
Problem is that the autocompleter has an input binding which is triggered whenever setField in BibEntry is called, in this case part of the apply save actions.
On autosave we have a Background thread in the BackupoManager which executes the saveDatabaseAction which itself executes the save actions.

Exectuted in a background thread:
https://github.com/JabRef/jabref/blob/e83680f18d815ebebc779d239a6eacd8930150fe/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java#L120-L124

https://github.com/JabRef/jabref/blob/e83680f18d815ebebc779d239a6eacd8930150fe/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java#L170-L177


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
