### PR TITLE
Adding DOI to test entry - fixes #5013

### DIFF
--- a/src/main/java/org/jabref/logic/util/TestEntry.java
+++ b/src/main/java/org/jabref/logic/util/TestEntry.java
@@ -20,7 +20,7 @@ public class TestEntry {
         entry.setField(FieldName.TITLE, "Title of the test entry");
         entry.setField(FieldName.NUMBER, "3");
         entry.setField(FieldName.VOLUME, "34");
-        entry.setField(FieldName.ISSUE, "34:3");
+        entry.setField(FieldName.ISSUE, "3");
         entry.setField(FieldName.YEAR, "2016");
         entry.setField(FieldName.PAGES, "45--67");
         entry.setField(FieldName.MONTH, "July");

--- a/src/main/java/org/jabref/logic/util/TestEntry.java
+++ b/src/main/java/org/jabref/logic/util/TestEntry.java
@@ -26,6 +26,7 @@ public class TestEntry {
         entry.setField(FieldName.PUBLISHER, "JabRef Publishing");
         entry.setField(FieldName.ADDRESS, "Trondheim");
         entry.setField(FieldName.URL, "https://github.com/JabRef");
+        entry.setField(FieldName.DOI, "10.1001/bla.blubb");
         entry.setField(FieldName.ABSTRACT,
                 "This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger.");
         return entry;

--- a/src/main/java/org/jabref/logic/util/TestEntry.java
+++ b/src/main/java/org/jabref/logic/util/TestEntry.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.util;
 
+import java.util.Arrays;
+
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexEntryTypes;
 import org.jabref.model.entry.FieldName;
@@ -18,6 +20,7 @@ public class TestEntry {
         entry.setField(FieldName.TITLE, "Title of the test entry");
         entry.setField(FieldName.NUMBER, "3");
         entry.setField(FieldName.VOLUME, "34");
+        entry.setField(FieldName.ISSUE, "34:3");
         entry.setField(FieldName.YEAR, "2016");
         entry.setField(FieldName.PAGES, "45--67");
         entry.setField(FieldName.MONTH, "July");
@@ -29,6 +32,12 @@ public class TestEntry {
         entry.setField(FieldName.DOI, "10.1001/bla.blubb");
         entry.setField(FieldName.ABSTRACT,
                 "This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger.");
+        entry.setField(FieldName.COMMENT, "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et " +
+                "dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. " +
+                "Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non " +
+                "proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+        entry.putKeywords(Arrays.asList("KeyWord1", "KeyWord2", "KeyWord3", "Keyword4"), ';');
+
         return entry;
     }
 


### PR DESCRIPTION
One liner to have also a DOI available in the entry to test the preview function.

@noMicrosoftBuhtz any more suggestions what should be added?


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
