### PR TITLE
"Set up general fields" character check not correct & alphabetical ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added an option on the Linked File Viewer to rename the attached file of an entry directly on the JabRef. [#4844](https://github.com/JabRef/jabref/issues/4844)
 - We added an option in the preference dialog box that allows user to enable helpful tooltips.[#3599](https://github.com/JabRef/jabref/issues/3599)
 - We moved the dropdown menu for selecting the push-application from the toolbar into the external application preferences. [#674](https://github.com/JabRef/jabref/issues/674)
+- We added the option to set up a general field with a name containing "-" and removed the alphabetical ordering of the tabs. [#5019](https://github.com/JabRef/jabref/issues/5019)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added an option on the Linked File Viewer to rename the attached file of an entry directly on the JabRef. [#4844](https://github.com/JabRef/jabref/issues/4844)
 - We added an option in the preference dialog box that allows user to enable helpful tooltips.[#3599](https://github.com/JabRef/jabref/issues/3599)
 - We moved the dropdown menu for selecting the push-application from the toolbar into the external application preferences. [#674](https://github.com/JabRef/jabref/issues/674)
-- We added the option to set up a general field with a name containing "-" and removed the alphabetical ordering of the tabs. [#5019](https://github.com/JabRef/jabref/issues/5019)
+- We removed the alphabetical ordering of the custom tabs and updated the error message when trying to create a general field with a name containing an illegal character. [#5019](https://github.com/JabRef/jabref/issues/5019)
 
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/customizefields/CustomizeGeneralFieldsDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/customizefields/CustomizeGeneralFieldsDialogViewModel.java
@@ -60,7 +60,7 @@ public class CustomizeGeneralFieldsDialogViewModel {
                 String title = Localization.lang("Error");
                 String content = Localization.lang("Field names are not allowed to contain white space or the following "
                                                    + "characters")
-                                 + ": # { } ~ , ^ &";
+                                 + ": # { } ( ) ~ , ^ & - \" ' ` ʹ \\";
                 dialogService.showInformationDialogAndWait(title, content);
                 return;
             }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabList.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabList.java
@@ -1,9 +1,9 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 
 import org.jabref.preferences.JabRefPreferences;
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabList.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabList.java
@@ -3,7 +3,7 @@ package org.jabref.gui.entryeditor;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.LinkedHashMap;
 
 import org.jabref.preferences.JabRefPreferences;
 
@@ -17,7 +17,7 @@ public final class EntryEditorTabList {
     }
 
     public static Map<String, List<String>> create(JabRefPreferences preferences) {
-        Map<String, List<String>> tabs = new TreeMap<>();
+        Map<String, List<String>> tabs = new LinkedHashMap<>();
         int i = 0;
         String name;
         if (preferences.hasKey(JabRefPreferences.CUSTOM_TAB_NAME + 0)) {

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
@@ -26,8 +26,8 @@ public class BibtexKeyGenerator extends BracketedPattern {
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     private static final Logger LOGGER = LoggerFactory.getLogger(BibtexKeyGenerator.class);
-    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"#~^:'`ʹ";
-    private static final String KEY_UNWANTED_CHARACTERS = "{}(),\\\"";
+    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"-#~^:'`ʹ";
+    private static final String KEY_UNWANTED_CHARACTERS = "{}(),\\\"-";
     private final AbstractBibtexKeyPattern citeKeyPattern;
     private final BibDatabase database;
     private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
@@ -26,8 +26,8 @@ public class BibtexKeyGenerator extends BracketedPattern {
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     private static final Logger LOGGER = LoggerFactory.getLogger(BibtexKeyGenerator.class);
-    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"-#~^:'`ʹ";
-    private static final String KEY_UNWANTED_CHARACTERS = "{}(),\\\"-";
+    private static final String KEY_ILLEGAL_CHARACTERS = "{}(),\\\"#~^:'`ʹ";
+    private static final String KEY_UNWANTED_CHARACTERS = "{}(),\\\"";
     private final AbstractBibtexKeyPattern citeKeyPattern;
     private final BibDatabase database;
     private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;


### PR DESCRIPTION


As asked, the character '-' was included on the error message, also we included other characters that were not being mentioned on the message. We tried to remove the character '-' from KEY_ILLEGAL_CHARACTERS and KEY_UNWANTED_CHARACTERS on BibtexKeyGenerator.java, but we did not know if it would be a good idea because it violates some tests.
About the order of the tabs, we removed the alphabetical ordering so now it is following the order defined when the tabs are created on the "Set up general fields" option.

![hyphen](https://user-images.githubusercontent.com/32721326/58997611-c2596b00-87d3-11e9-9c02-1aaab904788a.jpg)
![order](https://user-images.githubusercontent.com/32721326/58997612-c2596b00-87d3-11e9-9a63-ba8f79af0fa9.jpg)

This PR fixes #5019.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [X] Screenshots added in PR description (for bigger UI changes)
- [X] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
