### PR TITLE
Remove "automatic bug report" title

### DIFF
--- a/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleViewModel.java
+++ b/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleViewModel.java
@@ -91,17 +91,16 @@ public class ErrorConsoleViewModel extends AbstractViewModel {
      */
     public void reportIssue() {
         try {
-            String issueTitle = "Automatic Bug Report - " + dateFormat.format(date);
-            // system info
+            // System info
             String systemInfo = String.format("JabRef %s%n%s %s %s %nJava %s", buildInfo.getVersion(), BuildInfo.OS,
                     BuildInfo.OS_VERSION, BuildInfo.OS_ARCH, BuildInfo.JAVA_VERSION);
-            // steps to reproduce
+            // Steps to reproduce
             String howToReproduce = "Steps to reproduce:\n\n1. ...\n2. ...\n3. ...";
-            // log messages
+            // Log messages
             String issueDetails = "<details>\n" + "<summary>" + "Detail information:" + "</summary>\n\n```\n"
                     + getLogMessagesAsString(allMessagesData) + "\n```\n\n</details>";
             clipBoardManager.setContent(issueDetails);
-            // bug report body
+            // Bug report body
             String issueBody = systemInfo + "\n\n" + howToReproduce + "\n\n" + "Paste your log details here.";
 
             dialogService.notify(Localization.lang("Issue on GitHub successfully reported."));
@@ -114,7 +113,6 @@ public class ErrorConsoleViewModel extends AbstractViewModel {
             URIBuilder uriBuilder = new URIBuilder()
                     .setScheme("https").setHost("github.com")
                     .setPath("/JabRef/jabref/issues/new")
-                    .setParameter("title", issueTitle)
                     .setParameter("body", issueBody);
             JabRefDesktop.openBrowser(uriBuilder.build().toString());
         } catch (IOException | URISyntaxException e) {


### PR DESCRIPTION
Right now users often forget to change the title to something reasonable.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
