### PR TITLE
Remove BindingsHelper for UI in MainTableDataModel

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -24,7 +24,7 @@ public class MainTableDataModel {
     private final SortedList<BibEntryTableViewModel> entriesSorted;
 
     public MainTableDataModel(BibDatabaseContext context) {
-        ObservableList<BibEntry> allEntries = BindingsHelper.forUI(context.getDatabase().getEntries());
+        ObservableList<BibEntry> allEntries = context.getDatabase().getEntries();
         
         ObservableList<BibEntryTableViewModel> entriesViewModel = BindingsHelper.mapBacked(allEntries, BibEntryTableViewModel::new);
         


### PR DESCRIPTION
Fixes #5036

The problem is that the Maintable findentry() method does not find the new entry.
Further debugging showed that the Observable List with the entries in the maintable model does not yet include the new inserted entry, although it's already in the bib database.
This is because due to the Bindings.forUI around the list in MainTable, it's run on the FX thread. And the FX thread is blocked/busy with the findEntry method.

I know this was added because of not on fx thread exceptions. But I tested cleanup and external modification of file and it was fine. I think the key problem was the old swing stuff at that time.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
