### PR TITLE
Fix Russian translation

### DIFF
--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -48,7 +48,7 @@ Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ 
 
 Advanced=Расширенные
 All\ entries=Все записи
-All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Все записи этого типа будут объявлены записями 'без типа'. Продолжть?
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Все записи этого типа будут объявлены записями 'без типа'. Продолжить?
 
 Always\ reformat\ BIB\ file\ on\ save\ and\ export=Всегда преобразовывать формат файла BIB при сохранении и экспорте
 
@@ -252,7 +252,7 @@ Do\ not\ open\ any\ files\ at\ startup=Не открывать файлы при
 Do\ not\ overwrite\ existing\ keys=Не перезаписывать существующие ключи
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Не сворачивать следующие поля при сохранении
-Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Не записывать следующие поля в метаданные XMP\:
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Не записывать следующие поля в метаданные XMP:
 
 Donate\ to\ JabRef=Поддержать JabRef
 
@@ -419,7 +419,7 @@ Hierarchical\ context=Иерархический контекст
 
 Highlight=Выделение
 
-Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Подсказка\: Для поиска только по определенным полям, напр.\:<p><tt>автор\=smith и заглавие\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Подсказка: Для поиска только по определенным полям, напр.:<p><tt>автор=smith и заглавие=electrical</tt>
 
 HTML\ table=Таблица HTML
 HTML\ table\ (with\ Abstract\ &\ BibTeX)=Таблица HTML (с резюме & BibTeX)
@@ -460,9 +460,9 @@ Importing=Импорт
 
 Importing\ in\ unknown\ format=Импорт неизвестного формата
 
-Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Включить подгруппы\: Просмотр записей, содержащихся в этой группе или ее подгруппах (если выбрано)
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Включить подгруппы: Просмотр записей, содержащихся в этой группе или ее подгруппах (если выбрано)
 
-Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Независимая группа\: Просмотр записей только этой группы (если выбрано)
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Независимая группа: Просмотр записей только этой группы (если выбрано)
 Insert\ rows=Вставить строки
 
 Intersection=Пересечение
@@ -635,7 +635,7 @@ PDF\ does\ not\ exist=PDF не существует
 
 Please\ enter\ a\ name\ for\ the\ group.=Введите имя для группы.
 
-Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Введите условие поиска. Например, для поиска всех полей со значением <b>Smith</b>, введите\:<p><tt>smith</tt><p>Для поиска в поле <b>Автор</b> значения <b>Smith</b> а в поле <b>Заглавие</b> значения <b>electrical</b>, введите\:<p><tt>автор\=smith и заглавие\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Введите условие поиска. Например, для поиска всех полей со значением <b>Smith</b>, введите:<p><tt>smith</tt><p>Для поиска в поле <b>Автор</b> значения <b>Smith</b> а в поле <b>Заглавие</b> значения <b>electrical</b>, введите:<p><tt>автор=smith и заглавие=electrical</tt>
 
 Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Введите поле для поиска (напр., <b>ключевые слова</b>) и ключевое слово для поиска (напр., <b>electrical</b>).
 
@@ -665,7 +665,7 @@ Quit\ JabRef=Выход из JabRef
 
 Redo=Повторить
 
-Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Детализировать супергруппу\: Просмотр записей, содержащихся в группе и ее супергруппе (если выбрано)
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Детализировать супергруппу: Просмотр записей, содержащихся в группе и ее супергруппе (если выбрано)
 
 regular\ expression=Регулярное выражение
 
@@ -713,7 +713,7 @@ Removed\ string=Строка удалена
 
 Renamed\ string=Строка переименована
 
-Find\:=Найти\:
+Find\:=Найти:
 Find\ and\ Replace=Найти и заменить
 
 Replace\ (regular\ expression)=Заменить (регулярное выражение)
@@ -850,7 +850,7 @@ The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Метка �
 
 The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Параметры вывода зависят от допустимых параметров импорта.
 
-The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Регулярное выражение <b>%0</b> недопустимо\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Регулярное выражение <b>%0</b> недопустимо:
 
 The\ search\ is\ case\ insensitive.=Поиск без учета регистра.
 
@@ -950,7 +950,7 @@ You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Д
 
 Your\ new\ key\ bindings\ have\ been\ stored.=Новые назначения функциональных клавиш сохранены.
 
-The\ following\ fetchers\ are\ available\:=Доступны следующие инструменты выборки\:
+The\ following\ fetchers\ are\ available\:=Доступны следующие инструменты выборки:
 Could\ not\ find\ fetcher\ '%0'=Не удалось найти инструмент выборки '%0'
 Running\ query\ '%0'\ with\ fetcher\ '%1'.=Выполняется запрос '%0' для инструмента выборки '%1'.
 
@@ -972,7 +972,7 @@ Unable\ to\ open\ link.=Не удалось перейти по ссылке.
 MIME\ type=MIME-тип
 
 This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef\ instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef\ from\ your\ web\ browser.\ Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Эта функция позволяет открывать или импортировать файлы в работающий экземпляр JabRef<BR>без запуска нового экземпляра приложения. Например, при передаче файла в JabRef<br>из веб-браузера.<BR>Обратите внимание, что эта функция позволяет не запускать несколько экземпляров JabRef одновременно.
-Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Запуск инструмента выборки, напр.\: "--fetch\=Medline\:cancer"
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Запуск инструмента выборки, напр.: "--fetch=Medline:cancer"
 
 Reset=Инициализировать
 
@@ -997,7 +997,7 @@ Export\ in\ current\ table\ sort\ order=Экспорт в текущем пор�
 Export\ entries\ in\ their\ original\ order=Экспорт записей в исходном порядке
 Error\ opening\ file\ '%0'.=Ошибка при открытии файла '%0'.
 
-Formatter\ not\ found\:\ %0=Не найдена программа форматирования\: %0
+Formatter\ not\ found\:\ %0=Не найдена программа форматирования: %0
 
 Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Сохранение не удалось, файл заблокирован другим экземпляром JabRef.
 Current\ tmp\ value=Текущее значение TMP
@@ -1031,7 +1031,7 @@ Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Проверка уника�
 
 General\ file\ directory=Общий каталог файлов
 User-specific\ file\ directory=Пользовательский каталог файлов
-Search\ failed\:\ illegal\ search\ expression=Ошибка поиска\: недопустимое выражение для поиска
+Search\ failed\:\ illegal\ search\ expression=Ошибка поиска: недопустимое выражение для поиска
 Show\ ArXiv\ column=Показать столбец ArXiv
 
 You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Необходимо ввести целое число из интервала 1025-65535 в текстовое поле для
@@ -1096,7 +1096,7 @@ Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Поиск записей Bi
 Autodetecting\ paths...=Выполняется автоопределение путей...
 Could\ not\ find\ OpenOffice/LibreOffice\ installation=Не удалось найти установленное приложение OpenOffice/LibreOffice
 Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Найдено несколько приложений OpenOffice/LibreOffice.
-Please\ choose\ which\ one\ to\ connect\ to\:=Укажите одно для подключения\:
+Please\ choose\ which\ one\ to\ connect\ to\:=Укажите одно для подключения:
 Choose\ OpenOffice/LibreOffice\ executable=Выбор приложения OpenOffice/LibreOffice
 Select\ document=Выбрать документ
 HTML\ list=Список HTML
@@ -1155,7 +1155,7 @@ Scan\ directory=Сканировать каталог файлов
 Searches\ the\ selected\ directory\ for\ unlinked\ files.=Выполняет поиск несвязанных файлов в выбранном каталоге файлов.
 Starts\ the\ import\ of\ BibTeX\ entries.=Начинает импорт записей BibTeX.
 Select\ a\ directory\ where\ the\ search\ shall\ start.=Выбирает каталог файлов для начала поиска.
-Select\ file\ type\:=Выбор типа файла\:
+Select\ file\ type\:=Выбор типа файла:
 These\ files\ are\ not\ linked\ in\ the\ active\ library.=Эти файлы не связаны в активной БД.
 Searching\ file\ system...=Выполняется поиск в файловой системе...
 Select\ directory=Выбрать каталог файлов
@@ -1205,7 +1205,7 @@ Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Испра�
 Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Не удалось подключиться к работающему приложению OpenOffice/LibreOffice.
 Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Убедитесь, что установлен OpenOffice/LibreOffice с поддержкой Java.
 If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=При подключении вручную, проверьте правильность путей для приложения и библиотеки.
-Error\ message\:=Сообщение об ошибке\:
+Error\ message\:=Сообщение об ошибке:
 If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Перезаписать, если поле для вставленной или импортированной записи уже задано.
 Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Отсутствует подключение к документу Writer. Убедитесь, что документ открыт и нажмите кнопку 'Выбрать документ Writer' для подключения.
 Removed\ all\ subgroups\ of\ group\ "%0".=Все подгруппы группы "%0" удалены.
@@ -1271,11 +1271,11 @@ Deprecated\ fields=Устаревшие поля
 No\ read\ status\ information=Без сведений статуса "чтение"
 Printed=Напечатано
 Read\ status=Статус 'чтение'
-Read\ status\ read=Статус чтения \: 'чтение'
-Read\ status\ skimmed=Статус чтения \: 'просмотр'
+Read\ status\ read=Статус чтения: 'чтение'
+Read\ status\ skimmed=Статус чтения: 'просмотр'
 Save\ selected\ as\ plain\ BibTeX...=Сохранить выбранное как неформатированный BibTeX...
-Set\ read\ status\ to\ read=Установить статус чтения \: 'чтение'
-Set\ read\ status\ to\ skimmed=Установить статус чтения \: 'просмотр'
+Set\ read\ status\ to\ read=Установить статус чтения: 'чтение'
+Set\ read\ status\ to\ skimmed=Установить статус чтения: 'просмотр'
 Show\ deprecated\ BibTeX\ fields=Показать устаревшие поля BibTeX
 
 Show\ printed\ status=Показать статус 'печать'
@@ -1331,9 +1331,9 @@ Save\ changes=Сохранить изменения
 Discard\ changes=Отменить изменения
 Library\ '%0'\ has\ changed.=БД '%0' изменена.
 Print\ entry\ preview=Предварительный просмотр записи для печати
-Copy\ \\cite{BibTeX\ key}=Копировать \\цитировать{ключ BibTeX}
+Copy\ \\cite{BibTeX\ key}=Копировать \\city{ключ BibTeX}
 Copy\ BibTeX\ key\ and\ title=Копировать ключ и заголовок BibTeX
-Invalid\ DOI\:\ '%0'.=Недопустимый DOI-адрес\: '%0'.
+Invalid\ DOI\:\ '%0'.=Недопустимый DOI-адрес: '%0'.
 should\ start\ with\ a\ name=должно начинаться с имени
 should\ end\ with\ a\ name=должно заканчиваться именем
 unexpected\ closing\ curly\ bracket=непредвиденная закрывающая фигурная скобка
@@ -1425,13 +1425,13 @@ Ill-formed\ entrytype\ comment\ in\ BIB\ file=Неверный формат ко
 Move\ linked\ files\ to\ default\ file\ directory\ %0=Переместить связанные файлы в каталог файлов по умолчанию %0
 
 Do\ you\ still\ want\ to\ continue?=Продолжить?
-This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Это действие изменит минимум одну запись в каждом из следующих полей\:
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Это действие изменит минимум одну запись в каждом из следующих полей:
 This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Это может привести к нежелательным изменениям ваших записей.
-Run\ field\ formatter\:=Запуск средства форматирования полей\:
-Table\ font\ size\ is\ %0=Размер шрифта в таблице\: %0
+Run\ field\ formatter\:=Запуск средства форматирования полей:
+Table\ font\ size\ is\ %0=Размер шрифта в таблице: %0
 Internal\ style=Встроенный стиль
 Add\ style\ file=Добавить файл стиля
-Current\ style\ is\ '%0'=Текущий стиль\: '%0'
+Current\ style\ is\ '%0'=Текущий стиль: '%0'
 Remove\ style=Удалить стиль
 You\ must\ select\ a\ valid\ style\ file.=Необходимо выбрать допустимый файл стиля.
 
@@ -1477,7 +1477,7 @@ Does\ nothing.=Не выполнять действий.
 Identity=Идентичность
 Clears\ the\ field\ completely.=Полная очистка поля.
 Directory\ not\ found=Каталог не найден
-Main\ file\ directory\ not\ set\!=Не указан основной каталог файлов\!
+Main\ file\ directory\ not\ set\!=Не указан основной каталог файлов!
 This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Для этой операции необходимо выбрать только одну запись.
 Importing\ in\ %0\ format=Импорт в формате %0
 Female\ name=Имя женского рода
@@ -1524,7 +1524,7 @@ U.S.\ patent\ request=Запрос патента (США)
 Verse=Стихотворение
 
 change\ entries\ of\ group=изменить записи в группе
-odd\ number\ of\ unescaped\ '\#'=нечетное число несброшенных '\#'
+odd\ number\ of\ unescaped\ '\#'=нечетное число несброшенных '#'
 
 Plain\ text=Обычный текст
 Show\ diff=Показать разницу
@@ -1635,8 +1635,8 @@ Local\ entry=Локальная запись
 Shared\ entry=Запись с общим доступом
 Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Не удалось выполнить обновление из-за существующих конфликтов изменений.
 You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Вы используете не самую последнюю версию BibEntry.
-Local\ version\:\ %0=Локальная версия\: %0
-Shared\ version\:\ %0=Версия с общим доступом\: %0
+Local\ version\:\ %0=Локальная версия: %0
+Shared\ version\:\ %0=Версия с общим доступом: %0
 Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Объедините запись с общим доступом и вашу запись, а затем нажмите "Объединение записей" для разрешения этой проблемы.
 Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=При отмене этой операции ваши изменения не будут синхронизированы. Отменить операцию?
 
@@ -1652,7 +1652,7 @@ Open\ OpenOffice/LibreOffice\ connection=Установить подключен
 You\ must\ enter\ at\ least\ one\ field\ name=Необходимо ввести минимум одно имя поля
 Non-ASCII\ encoded\ character\ found=Обнаружен символ не в кодировке ASCII
 Toggle\ web\ search\ interface=Переключение интерфейса веб-поиска
-%0\ files\ found=Найдено файлов\: %0
+%0\ files\ found=Найдено файлов: %0
 One\ file\ found=Найден один файл
 
 Look\ up\ full\ text\ documents=Поиск цитируемых документов


### PR DESCRIPTION
Should fix this bug when select Russian translation
```
java.lang.IllegalStateException: It is not allowed that the toReplace string: '<tt>author=smith and title=electrical</tt>' does not exist in the original string
	at org.jabref.gui.util.TooltipTextUtil.splitReplace(TooltipTextUtil.java:92)
	at org.jabref.gui.util.TooltipTextUtil.formatToTexts(TooltipTextUtil.java:62)
	at org.jabref.gui.search.GlobalSearchBar.setHintTooltip(GlobalSearchBar.java:291)
...
```

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
