### PR TITLE
Add option to allow for integers in field "edition" when running database in bibtex mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We moved the dropdown menu for selecting the push-application from the toolbar into the external application preferences. [#674](https://github.com/JabRef/jabref/issues/674)
 - We removed the alphabetical ordering of the custom tabs and updated the error message when trying to create a general field with a name containing an illegal character. [#5019](https://github.com/JabRef/jabref/issues/5019)
 - We added a context menu to the bib(la)tex-source-editor to copy'n'paste. [#5007](https://github.com/JabRef/jabref/pull/5007)
+- We added a option to allow integer field in edition during check integrity even in Bibtex Mode. [#4680](https://github.com/JabRef/jabref/issues/4680)
 
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.java
@@ -44,6 +44,7 @@ class GeneralTab extends Pane implements PrefsTab {
     private final CheckBox useTimeStamp;
     private final CheckBox updateTimeStamp;
     private final CheckBox overwriteTimeStamp;
+    private final CheckBox allowEditionInteger;
     private final TextField defOwnerField;
     private final GridPane builder = new GridPane();
 
@@ -80,6 +81,7 @@ class GeneralTab extends Pane implements PrefsTab {
         inspectionWarnDupli = new CheckBox(Localization.lang("Warn about unresolved duplicates when closing inspection window"));
         showAdvancedHints = new CheckBox(Localization.lang("Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"));
         shouldCollectTelemetry = new CheckBox(Localization.lang("Collect and share telemetry data to help improve JabRef."));
+        allowEditionInteger = new CheckBox(Localization.lang("Allow edition field Integer when in Bibtex mode"));
         encodings = new ComboBox<>(FXCollections.observableArrayList(Encodings.ENCODINGS));
 
         Label general = new Label(Localization.lang("General"));
@@ -139,6 +141,7 @@ class GeneralTab extends Pane implements PrefsTab {
         builder.add(biblioBox, 1, 29);
 
         builder.add(showAdvancedHints,1,30);
+        builder.add(allowEditionInteger,1,31);
     }
 
     @Override
@@ -169,6 +172,7 @@ class GeneralTab extends Pane implements PrefsTab {
         encodings.setValue(prefs.getDefaultEncoding());
         languageSelection.setValue(prefs.getLanguage());
         showAdvancedHints.setSelected(prefs.getBoolean(JabRefPreferences.SHOW_ADVANCED_HINTS));
+        allowEditionInteger.setSelected(prefs.getBoolean(JabRefPreferences.ALLOW_EDITION_INTEGER));
     }
 
     @Override
@@ -187,6 +191,7 @@ class GeneralTab extends Pane implements PrefsTab {
         }
         prefs.putBoolean(JabRefPreferences.MEMORY_STICK_MODE, memoryStick.isSelected());
         prefs.putBoolean(JabRefPreferences.SHOW_ADVANCED_HINTS, showAdvancedHints.isSelected());
+        prefs.putBoolean(JabRefPreferences.ALLOW_EDITION_INTEGER, allowEditionInteger.isSelected());
         prefs.putBoolean(JabRefPreferences.CONFIRM_DELETE, confirmDelete.isSelected());
         prefs.putBoolean(JabRefPreferences.WARN_ABOUT_DUPLICATES_IN_INSPECTION, inspectionWarnDupli.isSelected());
         String owner = defOwnerField.getText().trim();

--- a/src/main/java/org/jabref/logic/integrity/EditionChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/EditionChecker.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.integrity;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.strings.StringUtil;
@@ -55,7 +56,7 @@ public class EditionChecker implements ValueChecker {
 
         //BibTeX
         if (!bibDatabaseContextEdition.isBiblatexMode()) {
-            if(ONLY_NUMERALS_OR_LITERALS.test(value.trim())){
+            if(StringUtils.isNumeric(value.trim())){
                 if(!prefs.getBoolean(JabRefPreferences.ALLOW_EDITION_INTEGER)){
                     return Optional.of(Localization.lang("should be a String but received a Integer"));
                 }

--- a/src/main/java/org/jabref/logic/integrity/EditionChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/EditionChecker.java
@@ -1,16 +1,15 @@
 package org.jabref.logic.integrity;
 
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
+import org.jabref.preferences.JabRefPreferences;
+
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.jabref.Globals;
-import org.jabref.logic.l10n.Localization;
-import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.strings.StringUtil;
-
-import org.jabref.preferences.JabRefPreferences;
 
 public class EditionChecker implements ValueChecker {
 
@@ -22,11 +21,10 @@ public class EditionChecker implements ValueChecker {
 
     private final BibDatabaseContext bibDatabaseContextEdition;
 
-    private final JabRefPreferences prefs;
+    private final JabRefPreferences prefs = JabRefPreferences.getInstance();
 
 
     public EditionChecker(BibDatabaseContext bibDatabaseContext) {
-        this.prefs = Globals.prefs;
         this.bibDatabaseContextEdition = Objects.requireNonNull(bibDatabaseContext);
     }
 

--- a/src/main/java/org/jabref/logic/integrity/EditionChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/EditionChecker.java
@@ -5,11 +5,15 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import org.jabref.Globals;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.strings.StringUtil;
 
+import org.jabref.preferences.JabRefPreferences;
+
 public class EditionChecker implements ValueChecker {
+
 
     private static final Predicate<String> FIRST_LETTER_CAPITALIZED = Pattern.compile("^[A-Z]").asPredicate();
     private static final Predicate<String> ONLY_NUMERALS_OR_LITERALS = Pattern.compile("^([0-9]+|[^0-9].+)$")
@@ -18,8 +22,11 @@ public class EditionChecker implements ValueChecker {
 
     private final BibDatabaseContext bibDatabaseContextEdition;
 
+    private final JabRefPreferences prefs;
+
 
     public EditionChecker(BibDatabaseContext bibDatabaseContext) {
+        this.prefs = Globals.prefs;
         this.bibDatabaseContextEdition = Objects.requireNonNull(bibDatabaseContext);
     }
 
@@ -49,8 +56,16 @@ public class EditionChecker implements ValueChecker {
         }
 
         //BibTeX
-        if (!bibDatabaseContextEdition.isBiblatexMode() && !FIRST_LETTER_CAPITALIZED.test(value.trim())) {
-            return Optional.of(Localization.lang("should have the first letter capitalized"));
+        if (!bibDatabaseContextEdition.isBiblatexMode()) {
+            if(ONLY_NUMERALS_OR_LITERALS.test(value.trim())){
+                if(!prefs.getBoolean(JabRefPreferences.ALLOW_EDITION_INTEGER)){
+                    return Optional.of(Localization.lang("should be a String but received a Integer"));
+                }
+            }else{
+                if(!FIRST_LETTER_CAPITALIZED.test(value.trim())){
+                    return Optional.of(Localization.lang("should have the first letter capitalized"));
+                }
+            }
         }
 
         return Optional.empty();

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -284,6 +284,7 @@ public class JabRefPreferences implements PreferencesService {
     public static final String WEB_SEARCH_VISIBLE = "webSearchVisible";
     public static final String GROUP_SIDEPANE_VISIBLE = "groupSidepaneVisible";
     public static final String ALLOW_FILE_AUTO_OPEN_BROWSE = "allowFileAutoOpenBrowse";
+    public static final String ALLOW_EDITION_INTEGER = "allowEditionInteger";
     public static final String CUSTOM_TAB_NAME = "customTabName_";
     public static final String CUSTOM_TAB_FIELDS = "customTabFields_";
     public static final String USE_UNIT_FORMATTER_ON_SEARCH = "useUnitFormatterOnSearch";
@@ -704,6 +705,7 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(EMAIL_SUBJECT, Localization.lang("References"));
         defaults.put(OPEN_FOLDERS_OF_ATTACHED_FILES, Boolean.FALSE);
         defaults.put(ALLOW_FILE_AUTO_OPEN_BROWSE, Boolean.TRUE);
+        defaults.put(ALLOW_EDITION_INTEGER, Boolean.FALSE);
         defaults.put(WEB_SEARCH_VISIBLE, Boolean.TRUE);
         defaults.put(GROUP_SIDEPANE_VISIBLE, Boolean.TRUE);
         defaults.put(SELECTED_FETCHER_INDEX, 0);

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2093,3 +2093,6 @@ Import\ BibTeX=Import BibTeX
 Import\ preferences\ from\ a\ file=Import preferences from a file
 Matching=Matching
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Same as --import, but will be imported to the opened tab
+
+Allow\ edition\ field\ Integer\ when\ in\ Bibtex\ mode=Allow edition field Integer when in Bibtex mode
+should\ be\ a\ String\ but\ received\ a\ Integer=should be a String but received a Integer

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -21,6 +21,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
 import org.jabref.model.metadata.FilePreferences;
 import org.jabref.model.metadata.MetaData;
+import org.jabref.preferences.JabRefPreferences;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,6 +33,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
 class IntegrityCheckTest {
+
+    private final JabRefPreferences prefs = JabRefPreferences.getInstance();
 
     @Test
     void testEntryTypeChecks() {
@@ -73,10 +76,14 @@ class IntegrityCheckTest {
 
     @Test
     void testEditionChecks() {
+        Boolean defaultPref = prefs.getBoolean(prefs.ALLOW_EDITION_INTEGER);
         assertCorrect(withMode(createContext("edition", "Second"), BibDatabaseMode.BIBTEX));
         assertCorrect(withMode(createContext("edition", "Third"), BibDatabaseMode.BIBTEX));
         assertWrong(withMode(createContext("edition", "second"), BibDatabaseMode.BIBTEX));
+        prefs.putBoolean(prefs.ALLOW_EDITION_INTEGER, false);
         assertWrong(withMode(createContext("edition", "2"), BibDatabaseMode.BIBTEX));
+        prefs.putBoolean(prefs.ALLOW_EDITION_INTEGER, true);
+        assertCorrect(withMode(createContext("edition", "2"), BibDatabaseMode.BIBTEX));
         assertWrong(withMode(createContext("edition", "2nd"), BibDatabaseMode.BIBTEX));
         assertCorrect(withMode(createContext("edition", "2"), BibDatabaseMode.BIBLATEX));
         assertCorrect(withMode(createContext("edition", "10"), BibDatabaseMode.BIBLATEX));
@@ -85,6 +92,7 @@ class IntegrityCheckTest {
         assertCorrect(withMode(createContext("edition", "Edition 2000"), BibDatabaseMode.BIBLATEX));
         assertWrong(withMode(createContext("edition", "2nd"), BibDatabaseMode.BIBLATEX));
         assertWrong(createContext("edition", "1"));
+        prefs.putBoolean(prefs.ALLOW_EDITION_INTEGER, defaultPref);
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Issue [#4680](https://github.com/JabRef/jabref/issues/4680)

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
