### PR TITLE
Fix Permissions of LaTeXintegration

### DIFF
--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -126,24 +125,22 @@ class ParseTexDialogViewModel extends AbstractViewModel {
                           noFilesFound.set(false);
                           successfulSearch.set(true);
                       })
-                      .onFailure(handleFailure())
+                      .onFailure(this::handleFailure)
                       .executeWith(taskExecutor);
     }
 
-    private Consumer<Exception> handleFailure() {
-        return exception -> {
-            root.set(null);
-            noFilesFound.set(true);
-            searchInProgress.set(false);
-            successfulSearch.set(false);
+    private void handleFailure(Exception exception) {
+        root.set(null);
+        noFilesFound.set(true);
+        searchInProgress.set(false);
+        successfulSearch.set(false);
 
-            final boolean permissionProblem = exception instanceof IOException && exception.getCause() instanceof FileSystemException && exception.getCause().getMessage().endsWith("Operation not permitted");
-            if (permissionProblem) {
-                dialogService.showErrorDialogAndWait(String.format(Localization.lang("JabRef does not have permission to access %s"), exception.getCause().getMessage()));
-            } else {
-                dialogService.showErrorDialogAndWait(exception);
-            }
-        };
+        final boolean permissionProblem = exception instanceof IOException && exception.getCause() instanceof FileSystemException && exception.getCause().getMessage().endsWith("Operation not permitted");
+        if (permissionProblem) {
+            dialogService.showErrorDialogAndWait(String.format(Localization.lang("JabRef does not have permission to access %s"), exception.getCause().getMessage()));
+        } else {
+            dialogService.showErrorDialogAndWait(exception);
+        }
     }
 
     private FileNodeViewModel searchDirectory(Path directory) throws IOException {

--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
@@ -130,11 +130,6 @@ class ParseTexDialogViewModel extends AbstractViewModel {
     }
 
     private void handleFailure(Exception exception) {
-        root.set(null);
-        noFilesFound.set(true);
-        searchInProgress.set(false);
-        successfulSearch.set(false);
-
         final boolean permissionProblem = exception instanceof IOException && exception.getCause() instanceof FileSystemException && exception.getCause().getMessage().endsWith("Operation not permitted");
         if (permissionProblem) {
             dialogService.showErrorDialogAndWait(String.format(Localization.lang("JabRef does not have permission to access %s"), exception.getCause().getMessage()));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1381,6 +1381,7 @@ Open\ %0\ file=Open %0 file
 
 Cannot\ delete\ file=Cannot delete file
 File\ permission\ error=File permission error
+JabRef\ does\ not\ have\ permission\ to\ access\ %s=JabRef does not have permission to access %s
 Push\ to\ %0=Push to %0
 Path\ to\ %0=Path to %0
 Convert=Convert


### PR DESCRIPTION
This fixes one problem of JabRef trying to parse a directory, which it has no permission for.

Instead a generic exception dialog with a StackTrace, a more useful error message is displayed to the users.
![Screen Shot 2019-07-18 at 11 44 20](https://user-images.githubusercontent.com/1254003/61447565-76145580-a951-11e9-95f0-619fc45fead2.png)
