### PR TITLE
Fix fail on testPerformExportForSingleEntry from DocBook5ExporterTest

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -261,7 +261,7 @@ public class TemplateExporter extends Exporter {
                 if (layouts.containsKey(type)) {
                     layout = layouts.get(type);
                 } else {
-                    try (Reader reader = getReader(lfFileName + '.' + type + LAYOUT_EXTENSION)) {
+                    try (Reader reader = getReader(lfFileName + '.' + type.getName() + LAYOUT_EXTENSION)) {
                         // We try to get a type-specific layout for this entry.
                         layoutHelper = new LayoutHelper(reader, layoutPreferences);
                         layout = layoutHelper.getLayoutFromText();

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -76,7 +76,6 @@ public class DocBook5ExporterTest {
 
         assertThat(test, CompareMatcher.isSimilarTo(control)
                                        .normalizeWhitespace()
-                                       .ignoreComments()
                                        .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)).throwComparisonFailure());
     }
 }

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -17,7 +17,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.StandardEntryType;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.support.DisabledOnCIServer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,7 +66,6 @@ public class DocBook5ExporterTest {
     }
 
     @Test
-    @DisabledOnCIServer("Fails on CI for some reason")
     void testPerformExportForSingleEntry(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 
@@ -77,6 +75,8 @@ public class DocBook5ExporterTest {
         Builder test = Input.from(Files.newInputStream(path));
 
         assertThat(test, CompareMatcher.isSimilarTo(control)
+                                       .normalizeWhitespace()
+                                       .ignoreComments()
                                        .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)).throwComparisonFailure());
     }
 }

--- a/src/test/resources/org/jabref/logic/exporter/Docbook5ExportFormat.xml
+++ b/src/test/resources/org/jabref/logic/exporter/Docbook5ExportFormat.xml
@@ -16,6 +16,19 @@
    <!--TITLE-->
            <citetitle pubwork="book">my paper title</citetitle> 
     
+<!--BOOK booktitle, edition, (pages), publisher-->
+    <biblioset relation="book">
+        
+		
+        <pubdate>2018</pubdate>
+        
+        
+		<publishername></publishername>
+        <address></address>
+        
+	</biblioset>
+    
+    
 <!-- IDENTIFIERS-->
     
     

--- a/src/test/resources/org/jabref/logic/exporter/Docbook5ExportFormat.xml
+++ b/src/test/resources/org/jabref/logic/exporter/Docbook5ExportFormat.xml
@@ -16,19 +16,6 @@
    <!--TITLE-->
            <citetitle pubwork="book">my paper title</citetitle> 
     
-<!--BOOK booktitle, edition, (pages), publisher-->
-    <biblioset relation="book">
-        
-		
-        <pubdate>2018</pubdate>
-        
-        
-		<publishername></publishername>
-        <address></address>
-        
-	</biblioset>
-    
-    
 <!-- IDENTIFIERS-->
     
     


### PR DESCRIPTION
Fix a bug that appeared on `DocBook5ExporterTest` (`testPerformExportForSingleEntry`) since the last commit in the master branch (https://github.com/JabRef/jabref/commit/4b39b78e4afcd6c36b385f5c46f1d9a4eac2e29b).

The point is that the `<biblioset>` node is not contained in the export file. Also, I have used `normalizeWhitespace()` and `ignoreComments()` methods.

I have added the [WIP] mark because I still want to check if there is any trouble with the exporter. Any help about this?