### PR TITLE
Fix enum class cast error in TreeSet by specifying an explicit comparator

### DIFF
--- a/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.collab;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -44,7 +45,7 @@ class EntryChangeViewModel extends DatabaseChangeViewModel {
         LOGGER.debug("Modified entry: " + memEntry.getCiteKeyOptional().orElse("<no BibTeX key set>")
                 + "\n Modified locally: " + isModifiedLocally + " Modifications agree: " + modificationsAgree);
 
-        Set<Field> allFields = new TreeSet<>();
+        Set<Field> allFields = new TreeSet<>(Comparator.comparing(Field::getName));
         allFields.addAll(memEntry.getFields());
         allFields.addAll(tmpEntry.getFields());
         allFields.addAll(diskEntry.getFields());

--- a/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
+++ b/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
@@ -2,6 +2,7 @@ package org.jabref.gui.mergeentries;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -92,8 +93,10 @@ public class FetchAndMergeEntry {
             NamedCompound ce = new NamedCompound(Localization.lang("Merge entry with %0 information", fetcher.getName()));
 
             // Updated the original entry with the new fields
-            Set<Field> jointFields = new TreeSet<>(mergedEntry.get().getFields());
-            Set<Field> originalFields = new TreeSet<>(originalEntry.getFields());
+            Set<Field> jointFields = new TreeSet<>(Comparator.comparing(Field::getName));
+            jointFields.addAll(mergedEntry.get().getFields());
+            Set<Field> originalFields = new TreeSet<>(Comparator.comparing(Field::getName));
+            originalFields.addAll(originalEntry.getFields());
             boolean edited = false;
 
             // entry type

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -46,18 +47,18 @@ public class MergeEntries extends BorderPane {
 
     // Headings
     private final List<String> columnHeadings = Arrays.asList(Localization.lang("Field"),
-            Localization.lang("Left entry"),
-            Localization.lang("Left"),
-            Localization.lang("None"),
-            Localization.lang("Right"),
-            Localization.lang("Right entry"));
+                                                              Localization.lang("Left entry"),
+                                                              Localization.lang("Left"),
+                                                              Localization.lang("None"),
+                                                              Localization.lang("Right"),
+                                                              Localization.lang("Right entry"));
     private final Set<Field> identicalFields = new HashSet<>();
     private final Set<Field> differentFields = new HashSet<>();
     private final BibEntry mergedEntry = new BibEntry();
     private final BibEntry leftEntry;
     private final BibEntry rightEntry;
     private final Map<Field, TextFlow> leftTextPanes = new HashMap<>();
-    private final Set<Field> allFields = new TreeSet<>();
+    private final Set<Field> allFields = new TreeSet<>(Comparator.comparing(Field::getName));
     private final Map<Field, TextFlow> rightTextPanes = new HashMap<>();
     private final Map<Field, List<RadioButton>> radioButtons = new HashMap<>();
     private Boolean identicalTypes;
@@ -80,7 +81,6 @@ public class MergeEntries extends BorderPane {
         setLeftHeaderText(headingLeft);
         setRightHeaderText(headingRight);
     }
-
 
     /**
      * Constructor taking two entries
@@ -240,8 +240,8 @@ public class MergeEntries extends BorderPane {
     private void fillDiffModes() {
         diffMode.setItems(FXCollections.observableList(Arrays.asList(DiffMode.values())));
         new ViewModelListCellFactory<DiffMode>()
-                .withText(MergeEntries::getDisplayText)
-                .install(diffMode);
+                                                .withText(MergeEntries::getDisplayText)
+                                                .install(diffMode);
         DiffMode diffModePref = Globals.prefs.getAsOptional(JabRefPreferences.MERGE_ENTRIES_DIFF_MODE)
                                              .flatMap(DiffMode::parse)
                                              .orElse(DiffMode.WORD);

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -133,7 +133,7 @@ public class BibDatabase {
      * @return set of fieldnames, that are visible
      */
     public Set<Field> getAllVisibleFields() {
-        Set<Field> allFields = new TreeSet<>();
+        Set<Field> allFields = new TreeSet<>(Comparator.comparing(Field::getName));
         for (BibEntry e : getEntries()) {
             allFields.addAll(e.getFields());
         }


### PR DESCRIPTION

because natural order will require same types of the enum

Followup from  #5148

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
