### PR TITLE
Fix tooltips in CitationsDisplay

### DIFF
--- a/src/main/java/org/jabref/gui/cleanup/FieldFormatterCleanupsPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/FieldFormatterCleanupsPanel.java
@@ -105,7 +105,7 @@ public class FieldFormatterCleanupsPanel extends GridPane {
         actionsList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         new ViewModelListCellFactory<FieldFormatterCleanup>()
                 .withText(action -> action.getField() + ": " + action.getFormatter().getName())
-                .withTooltip(action -> action.getFormatter().getDescription())
+                .withStringTooltip(action -> action.getFormatter().getDescription())
                 .install(actionsList);
         add(actionsList, 1, 1, 3, 1);
 
@@ -171,7 +171,7 @@ public class FieldFormatterCleanupsPanel extends GridPane {
         formattersCombobox = new ComboBox<>(FXCollections.observableArrayList(availableFormatters));
         new ViewModelListCellFactory<Formatter>()
                 .withText(Formatter::getName)
-                .withTooltip(Formatter::getDescription)
+                .withStringTooltip(Formatter::getDescription)
                 .install(formattersCombobox);
         EasyBind.subscribe(formattersCombobox.valueProperty(), e -> updateDescription());
         builder.add(formattersCombobox, 3, 1);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -65,7 +65,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
                   .load();
 
         ViewModelListCellFactory<LinkedFileViewModel> cellFactory = new ViewModelListCellFactory<LinkedFileViewModel>()
-                   .withTooltip(LinkedFileViewModel::getDescription)
+                   .withStringTooltip(LinkedFileViewModel::getDescription)
                    .withGraphic(LinkedFilesEditor::createFileDisplay)
                    .withContextMenu(this::createContextMenuForFile)
                    .withOnMouseClickedEvent(this::handleItemMouseClick)

--- a/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
@@ -84,6 +84,11 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
         return this;
     }
 
+    public ViewModelListCellFactory<T> withTooltip(Callback<T, Tooltip> toTooltip) {
+        this.toTooltip = toTooltip;
+        return this;
+    }
+
     public ViewModelListCellFactory<T> withContextMenu(Callback<T, ContextMenu> toContextMenu) {
         this.toContextMenu = toContextMenu;
         return this;

--- a/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
@@ -32,7 +32,7 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
 
     private Callback<T, String> toText;
     private Callback<T, Node> toGraphic;
-    private Callback<T, String> toTooltip;
+    private Callback<T, Tooltip> toTooltip;
     private BiConsumer<T, ? super MouseEvent> toOnMouseClickedEvent;
     private Callback<T, String> toStyleClass;
     private Callback<T, ContextMenu> toContextMenu;
@@ -58,9 +58,8 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
             GlyphIcons icon = toIcon.call(viewModel);
             if (icon != null) {
                 return MaterialDesignIconFactory.get().createIcon(icon);
-            } else {
-                return null;
             }
+            return null;
         };
         return this;
     }
@@ -74,8 +73,14 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
         return this;
     }
 
-    public ViewModelListCellFactory<T> withTooltip(Callback<T, String> toTooltip) {
-        this.toTooltip = toTooltip;
+    public ViewModelListCellFactory<T> withStringTooltip(Callback<T, String> toStringTooltip) {
+        this.toTooltip = viewModel -> {
+            String tooltipText = toStringTooltip.call(viewModel);
+            if (StringUtil.isNotBlank(tooltipText)) {
+                return new Tooltip(tooltipText);
+            }
+            return null;
+        };
         return this;
     }
 
@@ -89,8 +94,7 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
         return this;
     }
 
-    public ViewModelListCellFactory<T> withOnMouseClickedEvent(
-            BiConsumer<T, ? super MouseEvent> toOnMouseClickedEvent) {
+    public ViewModelListCellFactory<T> withOnMouseClickedEvent(BiConsumer<T, ? super MouseEvent> toOnMouseClickedEvent) {
         this.toOnMouseClickedEvent = toOnMouseClickedEvent;
         return this;
     }
@@ -163,10 +167,7 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
                         getStyleClass().setAll(toStyleClass.call(viewModel));
                     }
                     if (toTooltip != null) {
-                        String tooltipText = toTooltip.call(viewModel);
-                        if (StringUtil.isNotBlank(tooltipText)) {
-                            setTooltip(new Tooltip(tooltipText));
-                        }
+                        setTooltip(toTooltip.call(viewModel));
                     }
                     if (toContextMenu != null) {
                         setContextMenu(toContextMenu.call(viewModel));

--- a/src/main/java/org/jabref/model/texparser/Citation.java
+++ b/src/main/java/org/jabref/model/texparser/Citation.java
@@ -8,7 +8,7 @@ public class Citation {
     /**
      * The total number of characters that are shown around a cite (cite width included).
      */
-    private static final int CONTEXT_WIDTH = 200;
+    private static final int CONTEXT_WIDTH = 300;
 
     private final Path path;
     private final int line;
@@ -66,9 +66,9 @@ public class Citation {
 
         // Add three dots when the string does not contain all the line.
         return String.format("%s%s%s",
-                (start > 0) ? "... " : "",
+                (start > 0) ? "..." : "",
                 lineText.substring(start, end).trim(),
-                (end < lineLength) ? " ..." : "");
+                (end < lineLength) ? "..." : "");
     }
 
     @Override


### PR DESCRIPTION
This patch solves the issue detected by @calixtus in https://github.com/JabRef/jabref/issues/5002#issuecomment-519985132

- [x] Wrap the text inside of the tooltip.
- [x] Highlight the `\cite` command in the tooltip.

Moreover:

- [x] Rename `withTooltip(Callback<T, String>)` to `withStringTooltip(Callback<T, String>)` in `ViewModelListCellFactory`.
- [x] Add `withTooltip(Callback<T, Tooltip>)` to `ViewModelListCellFactory`.

----

Before:

![before](https://user-images.githubusercontent.com/12954316/62854048-79032b80-bcee-11e9-8012-7d0e9f0d610f.png)

After:

![after](https://user-images.githubusercontent.com/12954316/62854051-7accef00-bcee-11e9-99d0-527f979a694d.png)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
