### PR TITLE
Border for group color indicator and some space for tooltip

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -17,6 +17,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
@@ -129,31 +130,36 @@ class MainTableColumnFactory {
     }
 
     private Node createGroupColorRegion(BibEntryTableViewModel entry, List<AbstractGroup> matchedGroups) {
-        Rectangle borderColor = new Rectangle();
-        borderColor.setWidth(5);
-        borderColor.setHeight(20);
-        borderColor.setFill(Color.DARKGRAY);
-        Rectangle groupColor = new Rectangle();
-        groupColor.setWidth(3);
-        groupColor.setHeight(18);
-        Color color = matchedGroups.stream()
-                                   .flatMap(group -> OptionalUtil.toStream(group.getColor()))
-                                   .findFirst()
-                                   .orElse(Color.TRANSPARENT);
-        groupColor.setFill(color);
+        Color groupColor = matchedGroups.stream()
+                .flatMap(group -> OptionalUtil.toStream(group.getColor()))
+                .findFirst()
+                .orElse(Color.TRANSPARENT);
 
-        StackPane container = new StackPane();
-        container.setMinWidth(10);
-        container.setAlignment(Pos.CENTER);
-        container.getChildren().addAll(borderColor,groupColor);
+        if (groupColor != Color.TRANSPARENT) {
+            Rectangle border = new Rectangle();
+            border.setWidth(5);
+            border.setHeight(20);
+            border.setFill(Color.DARKGRAY);
 
-        String matchedGroupsString = matchedGroups.stream()
-                                                  .map(AbstractGroup::getName)
-                                                  .collect(Collectors.joining(", "));
-        Tooltip tooltip = new Tooltip(Localization.lang("Entry is contained in the following groups:") + "\n" + matchedGroupsString);
-        Tooltip.install(container, tooltip);
+            Rectangle groupRectangle = new Rectangle();
+            groupRectangle.setWidth(3);
+            groupRectangle.setHeight(18);
+            groupRectangle.setFill(groupColor);
 
-        return container;
+            StackPane container = new StackPane();
+            container.setMinWidth(10);
+            container.setAlignment(Pos.CENTER);
+
+            container.getChildren().addAll(border,groupRectangle);
+
+            String matchedGroupsString = matchedGroups.stream()
+                    .map(AbstractGroup::getName)
+                    .collect(Collectors.joining(", "));
+            Tooltip tooltip = new Tooltip(Localization.lang("Entry is contained in the following groups:") + "\n" + matchedGroupsString);
+            Tooltip.install(container, tooltip);
+            return container;
+        }
+        return new Pane();
     }
 
     private List<TableColumn<BibEntryTableViewModel, ?>> createNormalColumns() {

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
@@ -16,7 +17,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 
@@ -122,28 +123,36 @@ class MainTableColumnFactory {
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupColorRegion)
                 .install(column);
+        column.setStyle("-fx-padding: 0 0 0 0;");
         column.setSortable(true);
         return column;
     }
 
     private Node createGroupColorRegion(BibEntryTableViewModel entry, List<AbstractGroup> matchedGroups) {
-        Rectangle rectangle = new Rectangle();
-        rectangle.setWidth(3);
-        rectangle.setHeight(20);
+        Rectangle borderColor = new Rectangle();
+        borderColor.setWidth(5);
+        borderColor.setHeight(20);
+        borderColor.setFill(Color.DARKGRAY);
+        Rectangle groupColor = new Rectangle();
+        groupColor.setWidth(3);
+        groupColor.setHeight(18);
         Color color = matchedGroups.stream()
                                    .flatMap(group -> OptionalUtil.toStream(group.getColor()))
                                    .findFirst()
                                    .orElse(Color.TRANSPARENT);
-        rectangle.setFill(color);
+        groupColor.setFill(color);
+
+        StackPane container = new StackPane();
+        container.setMinWidth(10);
+        container.setAlignment(Pos.CENTER);
+        container.getChildren().addAll(borderColor,groupColor);
 
         String matchedGroupsString = matchedGroups.stream()
                                                   .map(AbstractGroup::getName)
                                                   .collect(Collectors.joining(", "));
         Tooltip tooltip = new Tooltip(Localization.lang("Entry is contained in the following groups:") + "\n" + matchedGroupsString);
-        Tooltip.install(rectangle, tooltip);
+        Tooltip.install(container, tooltip);
 
-        BorderPane container = new BorderPane();
-        container.setLeft(rectangle);
         return container;
     }
 


### PR DESCRIPTION
Refs #5152 

One of my groupcolors is white, which made it hard to see in the jabref window.
I added a thin grey border, so one can see even white groups on white background.
Also I made the area, the user can put his mousepointer in to show the tooltip, a little wider (3 pixels were to small)

left before, right after
![groupcolorbefore](https://user-images.githubusercontent.com/50491877/62962782-e783de80-bdff-11e9-9e95-a333b7bdf441.png) ![groupcolorafter](https://user-images.githubusercontent.com/50491877/62962785-e94da200-bdff-11e9-9930-617c466f9f32.png)

ready to review

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
