### PR TITLE
Fix issue 5152, tooltip and icon added to group cell

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -65,7 +65,7 @@ class MainTableColumnFactory {
     private final CellFactory cellFactory;
     private final UndoManager undoManager;
     private final DialogService dialogService;
-   
+
 
     public MainTableColumnFactory(BibDatabaseContext database, ColumnPreferences preferences, ExternalFileTypes externalFileTypes, UndoManager undoManager, DialogService dialogService) {
         this.database = Objects.requireNonNull(database);
@@ -77,6 +77,8 @@ class MainTableColumnFactory {
     }
 
     public List<TableColumn<BibEntryTableViewModel, ?>> createColumns() {
+
+
         List<TableColumn<BibEntryTableViewModel, ?>> columns = new ArrayList<>();
 
         columns.add(createGroupColumn());
@@ -116,8 +118,11 @@ class MainTableColumnFactory {
 
     private TableColumn<BibEntryTableViewModel, ?> createGroupColumn() {
         TableColumn<BibEntryTableViewModel, List<AbstractGroup>> column = new TableColumn<>();
-        column.getStyleClass().add(GROUP_COLUMN);
-        setExactWidth(column, 20);
+        Node headerGraphic = IconTheme.JabRefIcons.DEFAULT_GROUP_ICON.getGraphicNode();
+        Tooltip.install(headerGraphic, new Tooltip(Localization.lang("Group color")));
+        column.setGraphic(headerGraphic);
+        column.getStyleClass().add(ICON_COLUMN);
+        setExactWidth(column, GUIGlobals.WIDTH_ICON_COL);
         column.setCellValueFactory(cellData -> cellData.getValue().getMatchedGroups(database));
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupColorRegion)

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -77,12 +77,8 @@ class MainTableColumnFactory {
     }
 
     public List<TableColumn<BibEntryTableViewModel, ?>> createColumns() {
-
-
         List<TableColumn<BibEntryTableViewModel, ?>> columns = new ArrayList<>();
-
         columns.add(createGroupColumn());
-
         // Add column for linked files
         if (preferences.showFileColumn()) {
             columns.add(createFileColumn());

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2114,3 +2114,4 @@ No\ LaTeX\ files\ containing\ this\ entry\ were\ found.=No LaTeX files containin
 Selected\ entry\ does\ not\ have\ an\ associated\ BibTeX\ key.=Selected entry does not have an associated BibTeX key.
 Current\ search\ directory\:=Current search directory:
 Set\ LaTeX\ file\ directory=Set LaTeX file directory
+Group\ color=Group color


### PR DESCRIPTION
Fiyes #5152 

Fix issue with a missing tooltip and icon in the color group column. I used DEFAULT_GROUP_ICON from JabRefICons to supplement the missing icon. 
