### PR TITLE
Add citation commands to TexParser

### DIFF
--- a/src/main/java/org/jabref/logic/texparser/DefaultTexParser.java
+++ b/src/main/java/org/jabref/logic/texparser/DefaultTexParser.java
@@ -31,12 +31,12 @@ public class DefaultTexParser implements TexParser {
      */
     private static final String[] CITE_COMMANDS = {
             "[cC]ite(alt|alp|author|authorfull|date|num|p|t|text|title|url|year|yearpar)?",
-            "([aA]|fnote|foot|footfull|full|no|[nN]ote|[pP]aren|[pP]note|[tT]ext|[sS]mart|super)cite",
-            "footcitetext"
+            "([aA]|[aA]uto|fnote|foot|footfull|full|no|[nN]ote|[pP]aren|[pP]note|[tT]ext|[sS]mart|super)cite",
+            "footcitetext", "(block|text)cquote"
     };
     private static final String CITE_GROUP = "key";
     private static final Pattern CITE_PATTERN = Pattern.compile(
-            String.format("\\\\(%s)\\*?(?:\\[(?:[^\\]]*)\\]){0,2}\\{(?<%s>[^\\}]*)\\}",
+            String.format("\\\\(%s)\\*?(?:\\[(?:[^\\]]*)\\]){0,2}\\{(?<%s>[^\\}]*)\\}(?:\\{[^\\}]*\\})?",
                     String.join("|", CITE_COMMANDS), CITE_GROUP));
 
     private static final String INCLUDE_GROUP = "file";

--- a/src/test/java/org/jabref/logic/texparser/DefaultTexParserTest.java
+++ b/src/test/java/org/jabref/logic/texparser/DefaultTexParserTest.java
@@ -45,6 +45,10 @@ public class DefaultTexParserTest {
         testMatchCite(UNRESOLVED, "\\parencite[post]{UnresolvedKey}");
         testMatchCite(UNRESOLVED, "\\cite[pre][post]{UnresolvedKey}");
         testMatchCite(EINSTEIN_C, "\\citep{Einstein1920c}");
+        testMatchCite(EINSTEIN_C, "\\autocite{Einstein1920c}");
+        testMatchCite(EINSTEIN_C, "\\Autocite{Einstein1920c}");
+        testMatchCite(DARWIN, "\\blockcquote[p. 28]{Darwin1888}{some text}");
+        testMatchCite(DARWIN, "\\textcquote[p. 18]{Darwin1888}{blablabla}");
 
         testNonMatchCite("\\citet21312{123U123n123resolvedKey}");
         testNonMatchCite("\\1cite[pr234e][post]{UnresolvedKey}");


### PR DESCRIPTION
We added a few more citation commands: `autocite`, `Autocite`, `blockcquote`, and `textcquote`.

This PR fixes #5194.

----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
