### PR TITLE
Add encoding checker for parsing LaTeX files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     compile 'org.apache.pdfbox:fontbox:2.0.16'
     compile 'org.apache.pdfbox:xmpbox:2.0.16'
 
-    compile group: 'org.apache.tika', name: 'tika-core', version: '1.22'
+    compile group: 'org.apache.tika', name: 'tika-parsers', version: '1.22'
 
     // required for reading write-protected PDFs - see https://github.com/JabRef/jabref/pull/942#issuecomment-209252635
     compile 'org.bouncycastle:bcprov-jdk15on:1.62'

--- a/src/test/java/org/jabref/logic/texparser/DefaultTexParserTest.java
+++ b/src/test/java/org/jabref/logic/texparser/DefaultTexParserTest.java
@@ -70,6 +70,23 @@ public class DefaultTexParserTest {
     }
 
     @Test
+    public void testFileEncoding() throws URISyntaxException {
+        Path texFile = Paths.get(DefaultTexParserTest.class.getResource("utf-8.tex").toURI());
+        Path texFile2 = Paths.get(DefaultTexParserTest.class.getResource("iso-8859-1.tex").toURI());
+        Path texFile3 = Paths.get(DefaultTexParserTest.class.getResource("iso-8859-15.tex").toURI());
+
+        TexParserResult parserResult = new DefaultTexParser().parse(Arrays.asList(texFile, texFile2, texFile3));
+        TexParserResult expectedParserResult = new TexParserResult();
+
+        expectedParserResult.getFileList().addAll(Arrays.asList(texFile, texFile2, texFile3));
+        expectedParserResult.addKey("anschließend", texFile, 1, 11, 30, "Danach wir \\cite{anschließend} mittels.");
+        expectedParserResult.addKey("Lässt", texFile2, 1, 4, 16, "Man \\cite{Lässt} auf verweisen.");
+        expectedParserResult.addKey("Läste", texFile3, 1, 13, 25, "Man einfache \\cite{Läste}.");
+
+        assertEquals(expectedParserResult, parserResult);
+    }
+
+    @Test
     public void testSingleFile() throws URISyntaxException {
         Path texFile = Paths.get(DefaultTexParserTest.class.getResource("paper.tex").toURI());
 

--- a/src/test/resources/org/jabref/logic/texparser/iso-8859-1.tex
+++ b/src/test/resources/org/jabref/logic/texparser/iso-8859-1.tex
@@ -1,0 +1,1 @@
+Man \cite{Lässt} auf verweisen.

--- a/src/test/resources/org/jabref/logic/texparser/iso-8859-15.tex
+++ b/src/test/resources/org/jabref/logic/texparser/iso-8859-15.tex
@@ -1,0 +1,1 @@
+Man einfache \cite{Läste}.

--- a/src/test/resources/org/jabref/logic/texparser/utf-8.tex
+++ b/src/test/resources/org/jabref/logic/texparser/utf-8.tex
@@ -1,0 +1,1 @@
+Danach wir \cite{anschließend} mittels.


### PR DESCRIPTION
We added a file encoding checker for parsing LaTeX files.

This PR adds `tika.parsers` (from `org.apache.tika`) dependency.

----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
