### PR TITLE
Use UTF-8 as default encoding for files

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
@@ -22,7 +22,7 @@ public class DiffHighlighting {
 
     public static List<Text> generateDiffHighlighting(String baseString, String modifiedString, String separator) {
         List<String> stringList = Arrays.asList(baseString.split(separator));
-        List<Text> result = stringList.stream().map(DiffHighlighting::forUnchanged).collect(Collectors.toList());
+        List<Text> result = stringList.stream().map(text -> forUnchanged(text + separator)).collect(Collectors.toList());
         List<AbstractDelta<String>> deltaList;
         try {
             deltaList = DiffUtils.diff(stringList, Arrays.asList(modifiedString.split(separator))).getDeltas();

--- a/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
@@ -22,7 +22,7 @@ public class DiffHighlighting {
 
     public static List<Text> generateDiffHighlighting(String baseString, String modifiedString, String separator) {
         List<String> stringList = Arrays.asList(baseString.split(separator));
-        List<Text> result = stringList.stream().map(text -> forUnchanged(text + separator)).collect(Collectors.toList());
+        List<Text> result = stringList.stream().map(DiffHighlighting::forUnchanged).collect(Collectors.toList());
         List<AbstractDelta<String>> deltaList;
         try {
             deltaList = DiffUtils.diff(stringList, Arrays.asList(modifiedString.split(separator))).getDeltas();

--- a/src/main/java/org/jabref/logic/journals/AbbreviationParser.java
+++ b/src/main/java/org/jabref/logic/journals/AbbreviationParser.java
@@ -4,7 +4,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -39,7 +38,8 @@ public class AbbreviationParser {
     }
 
     public void readJournalListFromFile(File file) throws FileNotFoundException {
-        try (FileReader reader = new FileReader(Objects.requireNonNull(file))) {
+        try (FileInputStream stream = new FileInputStream(Objects.requireNonNull(file));
+             InputStreamReader reader = new InputStreamReader(stream, Objects.requireNonNull(StandardCharsets.UTF_8))) {
             readJournalList(reader);
         } catch (FileNotFoundException e) {
             throw e;

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JournalAbbreviationLoader {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(JournalAbbreviationLoader.class);
 
     // journal initialization


### PR DESCRIPTION
If we create journal abbrev files via the JabRef, they are saved in UTF-8.
So it makes sense to use this as default encoding. Also see https://github.com/JabRef/jabref/issues/5133.