### PR TITLE
Removed unused method

### DIFF
--- a/src/main/java/org/jabref/model/bibtexkeypattern/AbstractBibtexKeyPattern.java
+++ b/src/main/java/org/jabref/model/bibtexkeypattern/AbstractBibtexKeyPattern.java
@@ -52,15 +52,6 @@ public abstract class AbstractBibtexKeyPattern {
     }
 
     /**
-     * Remove a Bibtex key pattern from the BibtexKeyPattern.
-     *
-     * @param type a <code>String</code>
-     */
-    public void removeBibtexKeyPattern(String type) {
-        data.remove(type);
-    }
-
-    /**
      * Gets an object for a desired key from this BibtexKeyPattern or one of it's
      * parents (in the case of DatabaseBibtexKeyPattern). This method first tries to obtain the object from this
      * BibtexKeyPattern via the <code>get</code> method of <code>Hashtable</code>.


### PR DESCRIPTION
Fixes 

```
src\main\java\org\jabref\model\bibtexkeypattern\AbstractBibtexKeyPattern.java:60: error: [CollectionIncompatibleType] Argument 'type' should not be passed to this method; its type String is not compatible with its collection's type argument EntryType
        data.remove(type);
                   ^
    (see https://errorprone.info/bugpattern/CollectionIncompatibleType)
```