### PR TITLE
Remove testing on OracleJDK - we stick to OpenJDK only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk11
   - openjdk11
 
 # we test at Ubuntu Trusty (Ubuntu 14.04 LTS)


### PR DESCRIPTION
When getting JabRef close to a release, waiting 30 minutes, until all TravisCI tests pass is not amusing. OpenJDK is open source, OracleJDK is some closed source distribution. I would vote for testing JabRef with OpenJDK only. In case OracleJDK makes something worse, user will complain then. I think, however, it is very unlikely, that OracleJDK will fail when OpenJDK will not.