### PR TITLE
Support java 9 at start in intellij

### DIFF
--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -4,12 +4,10 @@ import java.net.Authenticator;
 
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.scene.control.Alert;
 import javafx.stage.Stage;
 
 import org.jabref.cli.ArgumentProcessor;
 import org.jabref.cli.JabRefCLI;
-import org.jabref.gui.FXDialog;
 import org.jabref.gui.remote.JabRefMessageHandler;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.l10n.Localization;
@@ -19,8 +17,6 @@ import org.jabref.logic.net.ProxyRegisterer;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
-import org.jabref.logic.util.BuildInfo;
-import org.jabref.logic.util.JavaVersion;
 import org.jabref.logic.util.OS;
 import org.jabref.migrations.PreferencesMigrations;
 import org.jabref.model.database.BibDatabaseMode;
@@ -47,8 +43,6 @@ public class JabRefMain extends Application {
     @Override
     public void start(Stage mainStage) throws Exception {
         try {
-            // Fail on unsupported Java versions
-            ensureCorrectJavaVersion();
             FallbackExceptionHandler.installExceptionHandler();
 
             // Init preferences
@@ -85,56 +79,11 @@ public class JabRefMain extends Application {
             Platform.exit();
         }
     }
-  
+
     @Override
     public void stop() {
         Globals.stopBackgroundTasks();
         Globals.shutdownThreadPools();
-    }
-  
-    /**
-     * Tests if we are running an acceptable Java and terminates JabRef when we are sure the version is not supported.
-     * This test uses the requirements for the Java version as specified in <code>gradle.build</code>. It is possible to
-     * define a minimum version including the built number and to indicate whether Java 9 can be used (which it currently
-     * can't). It tries to compare this version number to the version of the currently running JVM. The check is
-     * optimistic and will rather return true even if we could not exactly determine the version.
-     * <p>
-     * Note: Users with a very old version like 1.6 will not profit from this since class versions are incompatible and
-     * JabRef won't even start. Currently, JabRef won't start with Java 9 either, but the warning that it cannot be used
-     * with this version is helpful anyway to prevent users to update from an old 1.8 directly to version 9. Additionally,
-     * we soon might have a JabRef that does start with Java 9 but is not perfectly compatible. Therefore, we should leave
-     * the Java 9 check alive.
-     */
-    private static void ensureCorrectJavaVersion() {
-        // Check if we are running an acceptable version of Java
-        final BuildInfo buildInfo = Globals.BUILD_INFO;
-        JavaVersion checker = new JavaVersion();
-        final boolean java9Fail = !buildInfo.isAllowJava9() && checker.isJava9();
-        final boolean versionFail = !checker.isAtLeast(buildInfo.getMinRequiredJavaVersion());
-
-        if (java9Fail || versionFail) {
-            StringBuilder versionError = new StringBuilder(
-                                                           Localization.lang("Your current Java version (%0) is not supported. Please install version %1 or higher.",
-                                                                             checker.getJavaVersion(),
-                                                                             buildInfo.getMinRequiredJavaVersion()));
-
-            versionError.append("\n");
-            versionError.append(Localization.lang("Your Java Runtime Environment is located at %0.", checker.getJavaInstallationDirectory()));
-
-            if (!buildInfo.isAllowJava9()) {
-                versionError.append("\n");
-                versionError.append(Localization.lang("Note that currently, JabRef does not run with Java 9."));
-            }
-
-            FXDialog alert = new FXDialog(Alert.AlertType.ERROR, Localization.lang("Error"), true);
-            alert.setHeaderText(null);
-            alert.setContentText(versionError.toString());
-
-            // We exit on Java 9 error since this will definitely not work
-            if (java9Fail) {
-                System.exit(0);
-            }
-        }
     }
 
     private static boolean handleMultipleAppInstances(String[] args) {

--- a/src/main/java/org/jabref/logic/l10n/Localization.java
+++ b/src/main/java/org/jabref/logic/l10n/Localization.java
@@ -141,7 +141,12 @@ public class Localization {
     private static String lookup(LocalizationBundle bundle, String key, String... params) {
         Objects.requireNonNull(key);
 
-        String translation = bundle.containsKey(key) ? bundle.getString(key) : "";
+        String translation;
+        if (bundle == null) {
+            translation = "";
+        } else {
+            translation = bundle.containsKey(key) ? bundle.getString(key) : "";
+        }
         if (translation.isEmpty()) {
             LOGGER.warn("Warning: could not get translation for \"" + key + "\" for locale " + Locale.getDefault());
             translation = key;


### PR DESCRIPTION
I worked on https://github.com/JabRef/jabref/wiki/Guidelines-for-setting-up-a-local-workspace. JabRef did not start, because it wanted to have Java9. This is because an empty build.properties.

Since we go for Java9, we could just remove that code...