### PR TITLE
Fix main class name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ project.ext.threeDotVersion = "5.0.0.1"
 project.ext.install4jDir = hasProperty("install4jDir") ? getProperty("install4jDir") : (OperatingSystem.current().isWindows() ? 'C:/Program Files/install4j8' : 'install4j8')
 sourceCompatibility = 11
 targetCompatibility = 11
-mainClassName = "$moduleName/JabRefLauncher"
+mainClassName = "$moduleName/org.jabref.JabRefLauncher"
 
 // TODO: Ugly workaround to temporarily ignore build errors to dependencies of latex2unicode
 // These should be removed, as well as the files in the lib folder, as soon as they have valid module names

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ project.ext.threeDotVersion = "5.0.0.1"
 project.ext.install4jDir = hasProperty("install4jDir") ? getProperty("install4jDir") : (OperatingSystem.current().isWindows() ? 'C:/Program Files/install4j8' : 'install4j8')
 sourceCompatibility = 11
 targetCompatibility = 11
-mainClassName = "org.jabref.JabRefLauncher"
+mainClassName = "$moduleName/JabRefLauncher"
 
 // TODO: Ugly workaround to temporarily ignore build errors to dependencies of latex2unicode
 // These should be removed, as well as the files in the lib folder, as soon as they have valid module names


### PR DESCRIPTION
Reverts https://github.com/JabRef/jabref/commit/ba60cbe18640611e7d7f0986314c82049668c5f6. According to https://github.com/java9-modularity/gradle-modules-plugin#using-the-application-plugin this is the correct way to specify the main class name.

@davidemdot what was the reason for your change?

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
