### PR TITLE
Issue #5223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [5.0-alpha] – 2019-08-25
 
 ### Changed
-
+- We added eventitle, eventdate and venue fields to @unpublished entry type.
+- We added @software and @dataSet entry type to biblatex.
 - All fields are now properly sorted alphabetically (in the subgroups of required/optional fields) when the entry is written to the bib file.
 - We fixed an issue where some importers used the field `pubstatus` instead of the standard BibTeX field `pubstate`.
 - We changed the latex command removal for docbook exporter. [#3838](https://github.com/JabRef/jabref/issues/3838)

--- a/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
@@ -414,8 +414,22 @@ public class BiblatexEntryTypeDefinitions {
             .withRequiredFields(ONLINE.getRequiredFields())
             .build();
 
+    private static final BibEntryType SOFTWARE = new BibEntryTypeBuilder()
+            .withType(StandardEntryType.Software)
+            .withImportantFields(
+                    StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.HOWPUBLISHED, StandardField.LOCATION, StandardField.DOI,
+                    StandardField.EPRINT, StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
+            .withRequiredFields(new OrFields(StandardField.AUTHOR, StandardField.EDITOR), StandardField.TITLE, StandardField.DATE)
+            .withDetailFields(StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.LANGUAGE, StandardField.HOWPUBLISHED,
+                    StandardField.TYPE, StandardField.VERSION, StandardField.NOTE, StandardField.ORGANIZATION, StandardField.LOCATION,
+                    StandardField.ADDENDUM, StandardField.PUBSTATE, StandardField.DOI, StandardField.EPRINT,
+                    StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
+            .build();
+
+
+
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, BOOK, MVBOOK, INBOOK, BOOKINBOOK, SUPPBOOK,
             BOOKLET, COLLECTION, MVCOLLECTION, INCOLLECTION, SUPPCOLLECTION, MANUAL, MISC, ONLINE, PATENT, PERIODICAL,
             SUPPPERIODICAL, PROCEEDINGS, MVPROCEEDINGS, INPROCEEDINGS, REFERENCE, MVREFERENCE, INREFERENCE, REPORT, SET,
-            THESIS, UNPUBLISHED, CONFERENCE, ELECTRONIC, MASTERSTHESIS, PHDTHESIS, TECHREPORT, WWW);
+            THESIS, UNPUBLISHED, CONFERENCE, ELECTRONIC, MASTERSTHESIS, PHDTHESIS, TECHREPORT, WWW, SOFTWARE);
 }

--- a/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
@@ -426,10 +426,22 @@ public class BiblatexEntryTypeDefinitions {
                     StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
             .build();
 
+    private static final BibEntryType DATASET = new BibEntryTypeBuilder()
+            .withType(StandardEntryType.DATESET)
+            .withImportantFields(
+                    StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.HOWPUBLISHED, StandardField.LOCATION, StandardField.DOI,
+                    StandardField.EPRINT, StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
+            .withRequiredFields(new OrFields(StandardField.AUTHOR, StandardField.EDITOR), StandardField.TITLE, StandardField.DATE)
+            .withDetailFields(StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.LANGUAGE, StandardField.HOWPUBLISHED,
+                    StandardField.TYPE, StandardField.VERSION, StandardField.NOTE, StandardField.ORGANIZATION, StandardField.LOCATION,
+                    StandardField.ADDENDUM, StandardField.PUBSTATE, StandardField.DOI, StandardField.EPRINT,
+                    StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
+            .build();
+
 
 
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, BOOK, MVBOOK, INBOOK, BOOKINBOOK, SUPPBOOK,
             BOOKLET, COLLECTION, MVCOLLECTION, INCOLLECTION, SUPPCOLLECTION, MANUAL, MISC, ONLINE, PATENT, PERIODICAL,
             SUPPPERIODICAL, PROCEEDINGS, MVPROCEEDINGS, INPROCEEDINGS, REFERENCE, MVREFERENCE, INREFERENCE, REPORT, SET,
-            THESIS, UNPUBLISHED, CONFERENCE, ELECTRONIC, MASTERSTHESIS, PHDTHESIS, TECHREPORT, WWW, SOFTWARE);
+            THESIS, UNPUBLISHED, CONFERENCE, ELECTRONIC, MASTERSTHESIS, PHDTHESIS, TECHREPORT, WWW, SOFTWARE, DATASET);
 }

--- a/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
@@ -351,8 +351,8 @@ public class BiblatexEntryTypeDefinitions {
                     StandardField.PUBSTATE, StandardField.URL, StandardField.URLDATE)
             .withRequiredFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.DATE)
             .withDetailFields(StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.LANGUAGE, StandardField.HOWPUBLISHED,
-                    StandardField.NOTE, StandardField.LOCATION, StandardField.ADDENDUM, StandardField.PUBSTATE,
-                    StandardField.URL, StandardField.URLDATE)
+                    StandardField.NOTE, StandardField.LOCATION, StandardField.ADDENDUM, StandardField.PUBSTATE, StandardField.EVENTTITLE,
+                    StandardField.EVENTDATE,StandardField.VENUE, StandardField.URL, StandardField.URLDATE)
             .build();
 
     private static final BibEntryType CONFERENCE = new BibEntryTypeBuilder()

--- a/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BiblatexEntryTypeDefinitions.java
@@ -432,7 +432,7 @@ public class BiblatexEntryTypeDefinitions {
                     StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.HOWPUBLISHED, StandardField.LOCATION, StandardField.DOI,
                     StandardField.EPRINT, StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)
             .withRequiredFields(new OrFields(StandardField.AUTHOR, StandardField.EDITOR), StandardField.TITLE, StandardField.DATE)
-            .withDetailFields(StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.LANGUAGE, StandardField.HOWPUBLISHED,
+            .withDetailFields(StandardField.SUBTITLE, StandardField.TITLEADDON, StandardField.LANGUAGE, StandardField.EDITION, StandardField.HOWPUBLISHED,
                     StandardField.TYPE, StandardField.VERSION, StandardField.NOTE, StandardField.ORGANIZATION, StandardField.LOCATION,
                     StandardField.ADDENDUM, StandardField.PUBSTATE, StandardField.DOI, StandardField.EPRINT,
                     StandardField.EPRINTCLASS, StandardField.EPRINTTYPE, StandardField.URL, StandardField.URLDATE)

--- a/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
@@ -177,8 +177,14 @@ public class BibtexEntryTypeDefinitions {
             .withImportantFields(StandardField.MONTH, StandardField.YEAR)
             .build();
 
+
     private static final BibEntryType SOFTWARE = new BibEntryTypeBuilder()
             .withType(StandardEntryType.Software)
+            .withImportantFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.HOWPUBLISHED, StandardField.MONTH, StandardField.YEAR, StandardField.NOTE)
+            .build();
+
+    private static final BibEntryType DATESET = new BibEntryTypeBuilder()
+            .withType(StandardEntryType.DATESET)
             .withImportantFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.HOWPUBLISHED, StandardField.MONTH, StandardField.YEAR, StandardField.NOTE)
             .build();
 
@@ -186,7 +192,7 @@ public class BibtexEntryTypeDefinitions {
 
 
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
-            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC, SOFTWARE);
+            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC, SOFTWARE, DATESET );
 
     private BibtexEntryTypeDefinitions() {
     }

--- a/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
@@ -178,21 +178,8 @@ public class BibtexEntryTypeDefinitions {
             .build();
 
 
-    private static final BibEntryType SOFTWARE = new BibEntryTypeBuilder()
-            .withType(StandardEntryType.Software)
-            .withImportantFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.HOWPUBLISHED, StandardField.MONTH, StandardField.YEAR, StandardField.NOTE)
-            .build();
-
-    private static final BibEntryType DATESET = new BibEntryTypeBuilder()
-            .withType(StandardEntryType.DATESET)
-            .withImportantFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.HOWPUBLISHED, StandardField.MONTH, StandardField.YEAR, StandardField.NOTE)
-            .build();
-
-
-
-
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
-            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC, SOFTWARE, DATESET );
+            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC );
 
     private BibtexEntryTypeDefinitions() {
     }

--- a/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
@@ -177,8 +177,16 @@ public class BibtexEntryTypeDefinitions {
             .withImportantFields(StandardField.MONTH, StandardField.YEAR)
             .build();
 
+    private static final BibEntryType SOFTWARE = new BibEntryTypeBuilder()
+            .withType(StandardEntryType.Software)
+            .withImportantFields(StandardField.AUTHOR, StandardField.TITLE, StandardField.HOWPUBLISHED, StandardField.MONTH, StandardField.YEAR, StandardField.NOTE)
+            .build();
+
+
+
+
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
-            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC);
+            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC, SOFTWARE);
 
     private BibtexEntryTypeDefinitions() {
     }

--- a/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
@@ -177,7 +177,6 @@ public class BibtexEntryTypeDefinitions {
             .withImportantFields(StandardField.MONTH, StandardField.YEAR)
             .build();
 
-
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
             INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC);
 

--- a/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
+++ b/src/main/java/org/jabref/model/entry/types/BibtexEntryTypeDefinitions.java
@@ -179,7 +179,7 @@ public class BibtexEntryTypeDefinitions {
 
 
     public static final List<BibEntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
-            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC );
+            INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC);
 
     private BibtexEntryTypeDefinitions() {
     }

--- a/src/main/java/org/jabref/model/entry/types/StandardEntryType.java
+++ b/src/main/java/org/jabref/model/entry/types/StandardEntryType.java
@@ -35,7 +35,8 @@ public enum StandardEntryType implements EntryType {
     SuppPeriodical("SuppPeriodical"),
     Thesis("Thesis"),
     WWW("WWW"),
-    Software("Software");
+    Software("Software"),
+    DATESET("DataSet");
 
 
 

--- a/src/main/java/org/jabref/model/entry/types/StandardEntryType.java
+++ b/src/main/java/org/jabref/model/entry/types/StandardEntryType.java
@@ -34,7 +34,10 @@ public enum StandardEntryType implements EntryType {
     SuppCollection("SuppCollection"),
     SuppPeriodical("SuppPeriodical"),
     Thesis("Thesis"),
-    WWW("WWW");
+    WWW("WWW"),
+    Software("Software");
+
+
 
     private final String displayName;
 


### PR DESCRIPTION

issue #5223 
Add @Software and  @Dataset entrytype as an option in the Biblatex and Bibtex. Add fields eventitle, eventdate and venue to @unpublished entry type. I used the MISC set of fields to supplement Software and DataSet, couldn't find documentation about specific fields that should be included in @Software and @DataSet entry type. 
![entrytype](https://user-images.githubusercontent.com/41503450/64082532-e2d08d00-cd10-11e9-95f9-fec5d57d0f0d.PNG)
![entryTypePreferences](https://user-images.githubusercontent.com/41503450/64082551-0a275a00-cd11-11e9-9af6-b16a5394865d.PNG)




----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [X] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
