### PR TITLE
added add-opens options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -409,7 +409,11 @@ run {
             "--add-exports", "javafx.web/com.sun.webkit=org.controlsfx.controls",
             "--add-exports", "javafx.graphics/com.sun.javafx.css=org.controlsfx.controls",
             "--add-opens", "javafx.controls/javafx.scene.control.skin=org.controlsfx.controls",
-            "--add-opens", "javafx.graphics/javafx.scene=org.controlsfx.controls"
+            "--add-opens", "javafx.graphics/javafx.scene=org.controlsfx.controls",
+            "--add-opens", "javafx.controls/com.sun.javafx.scene.control.behavior=com.jfoenix",
+            "--add-opens", "javafx.base/com.sun.javafx.binding=com.jfoenix",
+            "--add-opens", "javafx.graphics/com.sun.javafx.stage=com.jfoenix",
+            "--add-opens", "javafx.base/com.sun.javafx.event=com.jfoenix"
 
     // TODO: The following code should have the same affect as the above one, but doesn't work for some reason
     // https://github.com/java9-modularity/gradle-modules-plugin/issues/89


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Fixes #5278 
There were a few more not allowed access from within the `com.jfoenix` dependency. But adding the lines with further jvm options from this pull request to the `build.gradle` in the `run` task prevents the Exceptions.
Is this the proper way to adress this or is there a better way to fix such issues?


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
