### PR TITLE
unifying month format across all bib files

### DIFF
--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest3.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest3.bib
@@ -5,7 +5,7 @@
   issn = {978-1-4822-5326-9},
   journal = {Dermoscopy Image Analysis},
   number = {0},
-  month = {#sep#},
+  month = sep,
   pages = {1-22},
   publisher = {CRC Press},
   series = {Digital Imaging and Computer Vision},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestDate1.1.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestDate1.1.bib
@@ -4,7 +4,7 @@
     doi = {10.1063/1.1954747},
     issn = {0021-9606},
     journal = {J. Chem. Phys.},
-    month = {#jul#},
+    month = jul,
     number = {3},
     pages = {034708},
     publisher = {American Institute of Physics},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestDate1.2.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestDate1.2.bib
@@ -4,7 +4,7 @@
     doi = {10.1063/1.1954747},
     issn = {0021-9606},
     journal = {J. Chem. Phys.},
-    month = {#jul#},
+    month = jul,
     number = {3},
     pages = {034708},
     publisher = {American Institute of Physics},


### PR DESCRIPTION

This change fixes issue [#5116 ](https://github.com/JabRef/jabref/issues/5116), where we have some bib files in which the month is written as {#jul#} rather than jul. This commit fixes this issue.


----

- [ ] Change in CHANGELOG.md described - no need to, no new functionality
- [ ] Tests created for changes - the change is a fix for the tests
- [ ] Manually tested changed features in running JabRef - irrelevant
- [ V ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)

