### PR TITLE
add circle ci config for building gradle jlink

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run: ./gradlew jlink
       - run: mv build/image jabref
       - run: tar cvzf JabRef-linux-${CIRCLE_BRANCH}-latest.tar.gz jabref
-      - run: mv JabRef-latest.tar.gz build/releases/
+      - run: mv JabRef-linux-${CIRCLE_BRANCH}-latest.tar.gz build/releases/
       - save_cache:
           key: gradle
           paths:


### PR DESCRIPTION
Based on the comments in #5299 we now use gradlew jlink to generate a tar.gz archive.

 
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
