### PR TITLE
Change jlink launcher to JabRefLauncher instead of JabRefMain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -615,7 +615,7 @@ task snapJar(dependsOn: "releaseJar", type: Delete) {
 jlink {
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
     launcher {
-        name = 'JabRefMain'
+        name = 'JabRefLauncher'
     }
 
     addOptions("--bind-services")


### PR DESCRIPTION
I have no idea if this changes anything

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
