### PR TITLE
Remove module exports for JabRef

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,17 +1,4 @@
 open module org.jabref {
-    exports org.jabref;
-
-    exports org.jabref.gui;
-    exports org.jabref.gui.logging;
-    exports org.jabref.gui.maintable;
-    exports org.jabref.gui.specialfields;
-
-    exports org.jabref.model.database;
-
-    exports org.jabref.logic;
-    exports org.jabref.logic.citationstyle;
-    exports org.jabref.logic.search;
-
     // Swing
     requires java.desktop;
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

As we are not providing a JabRef library, we don't need to export anything. This should also resolve all these warnings shown in the IDE.

@calixtus This one is for you ;-).

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
