### PR TITLE
Use binding to update global state manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,12 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 
-- Inherit fields from cross-referenced entries as specified by biblatex [#5045](https://github.com/JabRef/jabref/issues/5045)
-- We fixed an issue where it was no longer possible to connect to LibreOffice [#5261](https://github.com/JabRef/jabref/issues/5261)
+- Inherit fields from cross-referenced entries as specified by biblatex. [#5045](https://github.com/JabRef/jabref/issues/5045)
+- We fixed an issue where it was no longer possible to connect to LibreOffice. [#5261](https://github.com/JabRef/jabref/issues/5261)
+- The "All entries group" is no longer shown when no library is open.
+- The group panel is now properly updated when switching between libraries (or when closing/opening one). [#3142](https://github.com/JabRef/jabref/issues/3142)
+- We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)
+- We fixed an error mentioning "javafx.controls/com.sun.javafx.scene.control" that was thrown when interacting with the toolbar.
 
 
 ### Removed

--- a/build.gradle
+++ b/build.gradle
@@ -396,6 +396,7 @@ run {
             '--add-exports', 'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref',
             '--add-opens', 'javafx.controls/javafx.scene.control=org.jabref',
             '--add-opens', 'org.controlsfx.controls/org.controlsfx.control.textfield=org.jabref',
+            '--add-opens', 'javafx.controls/com.sun.javafx.scene.control=org.jabref',
             // Not sure why we need to restate the controlfx exports
             // Taken from here: https://github.com/controlsfx/controlsfx/blob/9.0.0/build.gradle#L1
             "--add-exports", "javafx.graphics/com.sun.javafx.scene=org.controlsfx.controls",

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -6,15 +6,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import javafx.beans.property.ObjectProperty;
-import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
-import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Control;
@@ -84,13 +81,10 @@ public class GroupTreeView {
         dragExpansionHandler = new DragExpansionHandler();
 
         // Set-up bindings
-        Consumer<ObservableList<GroupNodeViewModel>> updateSelectedGroups =
-                (newSelectedGroups) -> newSelectedGroups.forEach(this::selectNode);
-
         BindingsHelper.bindContentBidirectional(
                 groupTree.getSelectionModel().getSelectedItems(),
                 viewModel.selectedGroupsProperty(),
-                updateSelectedGroups,
+                (newSelectedGroups) -> newSelectedGroups.forEach(this::selectNode),
                 this::updateSelection
         );
 
@@ -104,11 +98,17 @@ public class GroupTreeView {
 
         groupTree.rootProperty().bind(
                 EasyBind.map(viewModel.rootGroupProperty(),
-                        group -> new RecursiveTreeItem<>(
-                                group,
-                                GroupNodeViewModel::getChildren,
-                                GroupNodeViewModel::expandedProperty,
-                                viewModel.filterPredicateProperty())));
+                        group -> {
+                            if (group == null) {
+                                return null;
+                            } else {
+                                return new RecursiveTreeItem<>(
+                                        group,
+                                        GroupNodeViewModel::getChildren,
+                                        GroupNodeViewModel::expandedProperty,
+                                        viewModel.filterPredicateProperty());
+                            }
+                        }));
 
         // Icon and group name
         mainColumn.setCellValueFactory(cellData -> cellData.getValue().valueProperty());
@@ -343,7 +343,8 @@ public class GroupTreeView {
         return menu;
     }
 
-    public void addNewGroup(ActionEvent actionEvent) {
+    @FXML
+    private void addNewGroup() {
         viewModel.addNewGroupToRoot();
     }
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -126,12 +126,12 @@ public class GroupTreeViewModel extends AbstractViewModel {
                     .orElse(GroupNodeViewModel.getAllEntriesGroup(newDatabase.get(), stateManager, taskExecutor, localDragboard));
 
             rootGroup.setValue(newRoot);
-            this.selectedGroups.setAll(
+            selectedGroups.setAll(
                     stateManager.getSelectedGroup(newDatabase.get()).stream()
                             .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup, localDragboard))
                             .collect(Collectors.toList()));
         } else {
-            rootGroup.setValue(GroupNodeViewModel.getAllEntriesGroup(new BibDatabaseContext(), stateManager, taskExecutor, localDragboard));
+            rootGroup.setValue(null);
         }
 
         currentDatabase = newDatabase;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Use JavaFX binding instead of a listener to update the global state manager. That seems to work more reliable and fixes a bunch of issues. In particular, fixes #3142  and fixes #4441.

Moreover, I fixed an error that was thrown when interacting with the toolbar (missing open statement but we were using reflection...).

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
