### PR TITLE
Fix NPE when opening a non existing file from the recent files menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)
 - We fixed an error mentioning "javafx.controls/com.sun.javafx.scene.control" that was thrown when interacting with the toolbar.
 - We fixed an error where a cleared search was restored after switching libraries. [#4846](https://github.com/JabRef/jabref/issues/4846) 
+- We fixed an exception which occured when trying to open a non existing file from the "Recent files"-menu [#5334](https://github.com/JabRef/jabref/issues/5334)
+
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -143,7 +143,7 @@ public class JabRefFrame extends BorderPane {
     private final GlobalSearchBar globalSearchBar = new GlobalSearchBar(this, Globals.stateManager);
 
     private final ProgressBar progressBar = new ProgressBar();
-    private final FileHistoryMenu fileHistory = new FileHistoryMenu(prefs, this);
+    private final FileHistoryMenu fileHistory;
 
     private final Stage mainStage;
     private final StateManager stateManager;
@@ -160,6 +160,7 @@ public class JabRefFrame extends BorderPane {
         this.stateManager = Globals.stateManager;
         this.pushToApplicationsManager = new PushToApplicationsManager(dialogService, stateManager);
         this.undoManager = Globals.undoManager;
+        this.fileHistory = new FileHistoryMenu(prefs, this);
     }
 
     private static BasePanel getBasePanel(Tab tab) {

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -160,7 +160,7 @@ public class JabRefFrame extends BorderPane {
         this.stateManager = Globals.stateManager;
         this.pushToApplicationsManager = new PushToApplicationsManager(dialogService, stateManager);
         this.undoManager = Globals.undoManager;
-        this.fileHistory = new FileHistoryMenu(prefs, this);
+        this.fileHistory = new FileHistoryMenu(prefs, dialogService, getOpenDatabaseAction());
     }
 
     private static BasePanel getBasePanel(Tab tab) {

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -6,7 +6,6 @@ import java.nio.file.Path;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 
-import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.io.FileHistory;

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -17,14 +17,12 @@ public class FileHistoryMenu extends Menu {
     private final FileHistory history;
     private final JabRefFrame frame;
     private final JabRefPreferences preferences;
-    private final DialogService dialogService;
 
     public FileHistoryMenu(JabRefPreferences preferences, JabRefFrame frame) {
         setText(Localization.lang("Recent libraries"));
 
         this.frame = frame;
         this.preferences = preferences;
-        this.dialogService = frame.getDialogService();
         history = preferences.getFileHistory();
         if (history.isEmpty()) {
             setDisable(true);
@@ -63,7 +61,7 @@ public class FileHistoryMenu extends Menu {
 
     public void openFile(Path file) {
         if (!Files.exists(file)) {
-            dialogService.showErrorDialogAndWait(
+            frame.getDialogService().showErrorDialogAndWait(
                     Localization.lang("File not found"),
                     Localization.lang("File not found") + ": " + file);
             history.removeItem(file);

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -17,12 +17,14 @@ public class FileHistoryMenu extends Menu {
     private final FileHistory history;
     private final JabRefFrame frame;
     private final JabRefPreferences preferences;
+    private final DialogService dialogService;
 
     public FileHistoryMenu(JabRefPreferences preferences, JabRefFrame frame) {
         setText(Localization.lang("Recent libraries"));
 
         this.frame = frame;
         this.preferences = preferences;
+        this.dialogService = frame.getDialogService();
         history = preferences.getFileHistory();
         if (history.isEmpty()) {
             setDisable(true);
@@ -61,7 +63,7 @@ public class FileHistoryMenu extends Menu {
 
     public void openFile(Path file) {
         if (!Files.exists(file)) {
-            frame.getDialogService().showErrorDialogAndWait(
+            this.dialogService.showErrorDialogAndWait(
                     Localization.lang("File not found"),
                     Localization.lang("File not found") + ": " + file);
             history.removeItem(file);

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -7,7 +7,7 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.importer.actions.OpenDatabaseAction;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.io.FileHistory;
 import org.jabref.preferences.JabRefPreferences;
@@ -15,16 +15,16 @@ import org.jabref.preferences.JabRefPreferences;
 public class FileHistoryMenu extends Menu {
 
     private final FileHistory history;
-    private final JabRefFrame frame;
     private final JabRefPreferences preferences;
     private final DialogService dialogService;
+    private final OpenDatabaseAction openDatabaseAction;
 
-    public FileHistoryMenu(JabRefPreferences preferences, JabRefFrame frame) {
+    public FileHistoryMenu(JabRefPreferences preferences, DialogService dialogService, OpenDatabaseAction openDatabaseAction) {
         setText(Localization.lang("Recent libraries"));
 
-        this.frame = frame;
         this.preferences = preferences;
-        this.dialogService = frame.getDialogService();
+        this.dialogService = dialogService;
+        this.openDatabaseAction = openDatabaseAction;
         history = preferences.getFileHistory();
         if (history.isEmpty()) {
             setDisable(true);
@@ -70,7 +70,7 @@ public class FileHistoryMenu extends Menu {
             setItems();
             return;
         }
-        frame.getOpenDatabaseAction().openFile(file, true);
+        openDatabaseAction.openFile(file, true);
 
     }
 

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 
+import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.io.FileHistory;


### PR DESCRIPTION
Fixes #5334 

dialogService object was null, because the FileHistoryMenu class is initialized before the ctor of JabRef frame creates the dialog service object

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
