### PR TITLE
fix encoding issues in xjc code generation

### DIFF
--- a/buildSrc/src/main/groovy/org/jabref/build/xjc/XjcTask.groovy
+++ b/buildSrc/src/main/groovy/org/jabref/build/xjc/XjcTask.groovy
@@ -12,13 +12,14 @@ class XjcTask extends DefaultTask {
     private def bindingFile
     private def outputDirectory
     private String javaPackage
+    private String encoding
     @Optional
     private String arguments
 
     @TaskAction
     def generateClasses() {
         project.mkdir(outputDirectory)
-        project.ant.xjc(destdir: outputDirectory, package: javaPackage) {
+        project.ant.xjc(destdir: outputDirectory, package: javaPackage, encoding: getEncoding()) {
             schema(dir: schemaFile.getParent(), includes: schemaFile.getName())
             if (bindingFile != null) {
                 binding(dir: bindingFile.getParent(), includes: bindingFile.getName())
@@ -60,6 +61,19 @@ class XjcTask extends DefaultTask {
     void setJavaPackage(String javaPackage) {
         this.javaPackage = javaPackage
         updateOutput()
+    }
+
+    String getEncoding() {
+        if(encoding == null ) {
+            // use UTF-8 as default encoding
+            return "UTF-8"
+        } else {
+            return encoding
+        }
+    }
+
+    void setEncoding(String encoding) {
+        this.encoding = encoding
     }
 
     String getArguments() {


### PR DESCRIPTION
As mentioned in gitter chat there were currently some encoding issues with the XJC generation of java files based on XSDs.

I've added the encoding parameter to our XJC gradle task with default value of UTF8.


----

- ~~[ ] Change in CHANGELOG.md described~~
- ~~[ ] Tests created for changes~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Screenshots added in PR description (for bigger UI changes)~~
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
