### PR TITLE
Fix exception when closing JabRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,13 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Inherit fields from cross-referenced entries as specified by biblatex. [#5045](https://github.com/JabRef/jabref/issues/5045)
 - We fixed an issue where it was no longer possible to connect to LibreOffice. [#5261](https://github.com/JabRef/jabref/issues/5261)
 - The "All entries group" is no longer shown when no library is open.
+- We fixed an exception which occurred when closing JabRef. [#5348](https://github.com/JabRef/jabref/issues/5348)
 - After assigning an entry to a group, the item count is now properly colored to reflect the new membership of the entry. [#3112](https://github.com/JabRef/jabref/issues/3112)
 - The group panel is now properly updated when switching between libraries (or when closing/opening one). [#3142](https://github.com/JabRef/jabref/issues/3142)
 - We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)
 - We fixed an error mentioning "javafx.controls/com.sun.javafx.scene.control" that was thrown when interacting with the toolbar.
 - We fixed an error where a cleared search was restored after switching libraries. [#4846](https://github.com/JabRef/jabref/issues/4846) 
-- We fixed an exception which occured when trying to open a non existing file from the "Recent files"-menu [#5334](https://github.com/JabRef/jabref/issues/5334)
+- We fixed an exception which occurred when trying to open a non existing file from the "Recent files"-menu [#5334](https://github.com/JabRef/jabref/issues/5334)
 
 
 ### Removed

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -366,11 +366,6 @@ public class JabRefFrame extends BorderPane {
 
         fileHistory.storeHistory();
         prefs.flush();
-
-        // Close all open windows
-        for (Window window : Window.getWindows()) {
-            window.hide();
-        }
     }
 
     /**

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -41,7 +41,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Stage;
-import javafx.stage.Window;
 
 import org.jabref.Globals;
 import org.jabref.JabRefExecutorService;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1,6 +1,5 @@
 package org.jabref.gui;
 
-import java.awt.Window;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -42,6 +41,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Stage;
+import javafx.stage.Window;
 
 import org.jabref.Globals;
 import org.jabref.JabRefExecutorService;
@@ -367,11 +367,9 @@ public class JabRefFrame extends BorderPane {
         fileHistory.storeHistory();
         prefs.flush();
 
-        // dispose all windows, even if they are not displayed anymore
-        // TODO: javafx variant only avaiable in java 9 and updwards
-        // https://docs.oracle.com/javase/9/docs/api/javafx/stage/Window.html#getWindows--
+        // Close all open windows
         for (Window window : Window.getWindows()) {
-            window.dispose();
+            window.hide();
         }
     }
 


### PR DESCRIPTION
Fixes #5348 by using JavaFX windows instead of awt windows.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
