### PR TITLE
Show more than one group color bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 
 - We added a short DOI field formatter which shortens DOI to more human readable form. [koppor#343](https://github.com/koppor/jabref/issues/343)
+- We improved the display of group memberships by adding multiple colored bars if the entry belongs to more than one group. [#4574](https://github.com/JabRef/jabref/issues/4574)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
 
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
@@ -137,7 +138,8 @@ class MainTableColumnFactory {
             HBox container = new HBox();
             container.setSpacing(2);
             container.setMinWidth(10);
-            container.setAlignment(Pos.CENTER);
+            container.setAlignment(Pos.CENTER_RIGHT);
+            container.setPadding(new Insets(0, 2, 0, 2));
 
             for (Color groupColor : groupColors) {
                 Rectangle groupRectangle = new Rectangle();

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -17,8 +17,8 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 
@@ -129,27 +129,26 @@ class MainTableColumnFactory {
     }
 
     private Node createGroupColorRegion(BibEntryTableViewModel entry, List<AbstractGroup> matchedGroups) {
-        Color groupColor = matchedGroups.stream()
-                .flatMap(group -> OptionalUtil.toStream(group.getColor()))
-                .findFirst()
-                .orElse(Color.TRANSPARENT);
+        List<Color> groupColors = matchedGroups.stream()
+                                               .flatMap(group -> OptionalUtil.toStream(group.getColor()))
+                                               .collect(Collectors.toList());
 
-        if (groupColor != Color.TRANSPARENT) {
-            Rectangle border = new Rectangle();
-            border.setWidth(5);
-            border.setHeight(20);
-            border.setFill(Color.DARKGRAY);
-
-            Rectangle groupRectangle = new Rectangle();
-            groupRectangle.setWidth(3);
-            groupRectangle.setHeight(18);
-            groupRectangle.setFill(groupColor);
-
-            StackPane container = new StackPane();
+        if (!groupColors.isEmpty()) {
+            HBox container = new HBox();
+            container.setSpacing(2);
             container.setMinWidth(10);
             container.setAlignment(Pos.CENTER);
 
-            container.getChildren().addAll(border,groupRectangle);
+            for (Color groupColor : groupColors) {
+                Rectangle groupRectangle = new Rectangle();
+                groupRectangle.setWidth(3);
+                groupRectangle.setHeight(18);
+                groupRectangle.setFill(groupColor);
+                groupRectangle.setStroke(Color.DARKGRAY);
+                groupRectangle.setStrokeWidth(1);
+
+                container.getChildren().add(groupRectangle);
+            }
 
             String matchedGroupsString = matchedGroups.stream()
                     .map(AbstractGroup::getName)

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -138,7 +138,7 @@ class MainTableColumnFactory {
             HBox container = new HBox();
             container.setSpacing(2);
             container.setMinWidth(10);
-            container.setAlignment(Pos.CENTER_RIGHT);
+            container.setAlignment(Pos.CENTER_LEFT);
             container.setPadding(new Insets(0, 2, 0, 2));
 
             for (Color groupColor : groupColors) {

--- a/src/test/java/org/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/OOBibStyleTest.java
@@ -4,19 +4,15 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.jabref.logic.importer.ImportFormatPreferences;
-import org.jabref.logic.importer.Importer;
-import org.jabref.logic.importer.ParserResult;
-import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.model.database.BibDatabase;
@@ -24,7 +20,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.entry.types.UnknownEntryType;
-import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,18 +31,16 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class OOBibStyleTest {
+class OOBibStyleTest {
     private LayoutFormatterPreferences layoutFormatterPreferences;
-    private ImportFormatPreferences importFormatPreferences;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
     }
 
     @Test
-    public void testAuthorYear() throws IOException {
+    void testAuthorYear() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, layoutFormatterPreferences);
         assertTrue(style.isValid());
         assertTrue(style.isFromResource());
@@ -60,7 +53,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testAuthorYearAsFile() throws URISyntaxException, IOException {
+    void testAuthorYearAsFile() throws URISyntaxException, IOException {
         File defFile = Paths.get(OOBibStyleTest.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                             .toFile();
         OOBibStyle style = new OOBibStyle(defFile, layoutFormatterPreferences, StandardCharsets.UTF_8);
@@ -75,7 +68,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testNumerical() throws IOException {
+    void testNumerical() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         assertTrue(style.isValid());
@@ -88,7 +81,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetNumCitationMarker() throws IOException {
+    void testGetNumCitationMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         assertEquals("[1] ", style.getNumCitationMarker(Arrays.asList(1), -1, true));
@@ -105,7 +98,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetNumCitationMarkerUndefined() throws IOException {
+    void testGetNumCitationMarkerUndefined() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         assertEquals("[" + OOBibStyle.UNDEFINED_CITATION_MARKER + "; 2-4] ",
@@ -123,7 +116,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetCitProperty() throws IOException {
+    void testGetCitProperty() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         assertEquals(", ", style.getStringCitProperty("AuthorSeparator"));
@@ -135,59 +128,59 @@ public class OOBibStyleTest {
         assertTrue(journals.contains("Journal name 1"));
     }
 
-    /**
-     * In IntelliJ: When running this test, ensure that the working directory is <code>%MODULE_WORKING_DIR%"</code>
-     */
     @Test
-    public void testGetCitationMarker() throws IOException {
-        Path testBibtexFile = Paths.get("src/test/resources/testbib/complex.bib");
-        ParserResult result = new BibtexParser(importFormatPreferences, new DummyFileUpdateMonitor()).parse(Importer.getReader(testBibtexFile, StandardCharsets.UTF_8));
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+    void testGetCitationMarker() throws IOException {
+        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.AUTHOR, "Gustav Bostr\\\"{o}m and Jaana W\\\"{a}yrynen and Marine Bod\\'{e}n and Konstantin Beznosov and Philippe Kruchten")
+                .withField(StandardField.YEAR, "2006")
+                .withField(StandardField.BOOKTITLE, "SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems")
+                .withField(StandardField.PUBLISHER, "ACM")
+                .withField(StandardField.TITLE, "Extending XP practices to support security requirements engineering")
+                .withField(StandardField.PAGES, "11--18");
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(entry);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
-        BibDatabase db = result.getDatabase();
-        for (BibEntry entry : db.getEntries()) {
-            entryDBMap.put(entry, db);
-        }
+        entryDBMap.put(entry, database);
 
-        BibEntry entry = db.getEntryByKey("1137631").get();
         assertEquals("[Boström et al., 2006]",
-                style.getCitationMarker(Arrays.asList(entry), entryDBMap, true, null, null));
+                style.getCitationMarker(Collections.singletonList(entry), entryDBMap, true, null, null));
         assertEquals("Boström et al. [2006]",
-                style.getCitationMarker(Arrays.asList(entry), entryDBMap, false, null, new int[]{3}));
+                style.getCitationMarker(Collections.singletonList(entry), entryDBMap, false, null, new int[]{3}));
         assertEquals("[Boström, Wäyrynen, Bodén, Beznosov & Kruchten, 2006]",
-                style.getCitationMarker(Arrays.asList(entry), entryDBMap, true, null, new int[]{5}));
+                style.getCitationMarker(Collections.singletonList(entry), entryDBMap, true, null, new int[]{5}));
     }
 
-    /**
-     * In IntelliJ: When running this test, ensure that the working directory is <code>%MODULE_WORKING_DIR%"</code>
-     */
     @Test
-    public void testLayout() throws IOException {
-        Path testBibtexFile = Paths.get("src/test/resources/testbib/complex.bib");
-        ParserResult result = new BibtexParser(importFormatPreferences, new DummyFileUpdateMonitor()).parse(Importer.getReader(testBibtexFile, StandardCharsets.UTF_8));
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
-        BibDatabase db = result.getDatabase();
+    void testLayout() throws IOException {
+        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
+
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.AUTHOR, "Gustav Bostr\\\"{o}m and Jaana W\\\"{a}yrynen and Marine Bod\\'{e}n and Konstantin Beznosov and Philippe Kruchten")
+                .withField(StandardField.YEAR, "2006")
+                .withField(StandardField.BOOKTITLE, "SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems")
+                .withField(StandardField.PUBLISHER, "ACM")
+                .withField(StandardField.TITLE, "Extending XP practices to support security requirements engineering")
+                .withField(StandardField.PAGES, "11--18");
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(entry);
 
         Layout l = style.getReferenceFormat(new UnknownEntryType("default"));
         l.setPostFormatter(new OOPreFormatter());
-        BibEntry entry = db.getEntryByKey("1137631").get();
         assertEquals(
                 "Boström, G.; Wäyrynen, J.; Bodén, M.; Beznosov, K. and Kruchten, P. (<b>2006</b>). <i>Extending XP practices to support security requirements engineering</i>,   : 11-18.",
-                l.doLayout(entry, db));
+                l.doLayout(entry, database));
 
         l = style.getReferenceFormat(StandardEntryType.InCollection);
         l.setPostFormatter(new OOPreFormatter());
         assertEquals(
                 "Boström, G.; Wäyrynen, J.; Bodén, M.; Beznosov, K. and Kruchten, P. (<b>2006</b>). <i>Extending XP practices to support security requirements engineering</i>. In:  (Ed.), <i>SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems</i>, ACM.",
-                l.doLayout(entry, db));
+                l.doLayout(entry, database));
     }
 
     @Test
-    public void testInstitutionAuthor() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+    void testInstitutionAuthor() throws IOException {
+        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat(StandardEntryType.Article);
@@ -204,7 +197,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testVonAuthor() throws IOException {
+    void testVonAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         BibDatabase database = new BibDatabase();
@@ -223,7 +216,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testInstitutionAuthorMarker() throws IOException {
+    void testInstitutionAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -243,7 +236,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testVonAuthorMarker() throws IOException {
+    void testVonAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -263,7 +256,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testNullAuthorMarker() throws IOException {
+    void testNullAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -281,7 +274,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testNullYearMarker() throws IOException {
+    void testNullYearMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -299,7 +292,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testEmptyEntryMarker() throws IOException {
+    void testEmptyEntryMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -316,7 +309,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetCitationMarkerInParenthesisUniquefiers() throws IOException {
+    void testGetCitationMarkerInParenthesisUniquefiers() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -352,7 +345,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetCitationMarkerInTextUniquefiers() throws IOException {
+    void testGetCitationMarkerInTextUniquefiers() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -388,7 +381,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetCitationMarkerInParenthesisUniquefiersThreeSameAuthor() throws IOException {
+    void testGetCitationMarkerInParenthesisUniquefiersThreeSameAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -423,7 +416,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testGetCitationMarkerInTextUniquefiersThreeSameAuthor() throws IOException {
+    void testGetCitationMarkerInTextUniquefiersThreeSameAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
 
@@ -459,7 +452,7 @@ public class OOBibStyleTest {
 
     @Test
     // TODO: equals only work when initialized from file, not from reader
-    public void testEquals() throws IOException {
+    void testEquals() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
@@ -469,7 +462,7 @@ public class OOBibStyleTest {
 
     @Test
     // TODO: equals only work when initialized from file, not from reader
-    public void testNotEquals() throws IOException {
+    void testNotEquals() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
@@ -478,7 +471,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testCompareToEqual() throws IOException {
+    void testCompareToEqual() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
@@ -487,7 +480,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testCompareToNotEqual() throws IOException {
+    void testCompareToNotEqual() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
                 layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
@@ -497,7 +490,7 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testEmptyStringPropertyAndOxfordComma() throws URISyntaxException, IOException {
+    void testEmptyStringPropertyAndOxfordComma() throws URISyntaxException, IOException {
         OOBibStyle style = new OOBibStyle("test.jstyle", layoutFormatterPreferences);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -21,78 +21,81 @@ This is some user comment in front of a string, should also be preserved.
 @Article{1102917,
   author     = {E. Bardram},
   title      = {The trouble with login: on usability and computer security in ubiquitous computing},
-  journal    = {Personal Ubiquitous Comput.},
-  year       = {2005},
-  volume     = {9},
+  doi        = {http://dx.doi.org/10.1007/s00779-005-0347-6},
+  issn       = {1617-4909},
   number     = {6},
   pages      = {357--367},
-  issn       = {1617-4909},
-  doi        = {http://dx.doi.org/10.1007/s00779-005-0347-6},
+  volume     = {9},
   address    = {London, UK},
   bdsk-url-1 = {http://dx.doi.org/10.1007/s00779-005-0347-6},
+  groups     = {TestOne, TestTwo},
+  journal    = {Personal Ubiquitous Comput.},
   priority   = {prio1},
   publisher  = {Springer-Verlag},
+  year       = {2005},
 }
 
 @InProceedings{1137631,
-  author     = {Gustav Bostr\"{o}m and Jaana W\"{a}yrynen and Marine Bod\'{e}n and Konstantin Beznosov and Philippe Kruchten},
-  title      = {Extending XP practices to support security requirements engineering},
+  author     = {Gustav Bostr\"{o}m and Jaana W\"{a}yrynen and Marine Bod\'{e}n and Konstantin Beznosov and Philippe Kruchten, Churchill},
   booktitle  = {SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems},
-  year       = {2006},
-  publisher  = {ACM},
-  location   = {Shanghai, China},
-  isbn       = {1-59593-411-1},
-  pages      = {11--18},
+  title      = {Extending XP practices to support security requirements engineering},
   doi        = {http://doi.acm.org/10.1145/1137627.1137631},
+  isbn       = {1-59593-411-1},
+  location   = {Shanghai, China},
+  pages      = {11--18},
+  publisher  = {ACM},
   address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1137627.1137631},
   file       = {:/Volumes/iDisk/Freie Universität Berlin/Semester 9/Softwareprozesse/p11-bostrom.pdf:PDF},
-  groups     = {StaticGroup},
+  groups     = {StaticGroup, TestOneSubOne, TestOneSubTwo, TestOne, TestTwo},
+  year       = {2006},
 }
 
-@INPROCEEDINGS{1132768,
-  author = {Christina Braz and Jean-Marc Robert},
-  title = {Security and usability: the case of the user authentication methods},
-  booktitle = {IHM '06: Proceedings of the 18th International Conferenceof the Association
-	Francophone d'Interaction Homme-Machine},
-  year = {2006},
-  pages = {199--203},
-  address = {New York, NY, USA},
-  publisher = {ACM},
+@InProceedings{1132768,
+  author     = {Christina Braz and Jean-Marc Robert},
+  booktitle  = {IHM '06: Proceedings of the 18th International Conferenceof the Association Francophone d'Interaction Homme-Machine},
+  title      = {Security and usability: the case of the user authentication methods},
+  doi        = {http://doi.acm.org/10.1145/1132736.1132768},
+  isbn       = {1-59593-350-6},
+  location   = {Montreal, Canada},
+  pages      = {199--203},
+  publisher  = {ACM},
+  address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1132736.1132768},
-  doi = {http://doi.acm.org/10.1145/1132736.1132768},
-  isbn = {1-59593-350-6},
-  location = {Montreal, Canada}
+  groups     = {TestOneSubTwo, TestOneSubOne},
+  year       = {2006},
 }
 
 @InProceedings{1137628,
   author     = {Danilo Bruschi and Bart De Win and Mattia Monga},
-  title      = {Introduction to software engineering for secure systems: SESS06 -- secure by design},
   booktitle  = {SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems},
-  year       = {2006},
-  publisher  = {ACM},
-  location   = {Shanghai, China},
-  isbn       = {1-59593-411-1},
-  pages      = {1--2},
+  title      = {Introduction to software engineering for secure systems: SESS06 -- secure by design},
   doi        = {http://doi.acm.org/10.1145/1137627.1137628},
+  isbn       = {1-59593-411-1},
+  location   = {Shanghai, China},
+  pages      = {1--2},
+  publisher  = {ACM},
   address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1137627.1137628},
+  groups     = {TestTwo},
   readstatus = {read},
+  year       = {2006},
 }
 
-@ARTICLE{1373163,
-  author = {Elizabeth Churchill and Les Nelson and Diana K. Smetters},
-  title = {Useful Computer Security},
-  journal = {IEEE Internet Computing},
-  year = {2008},
-  volume = {12},
-  pages = {10--12},
-  number = {3},
-  address = {Piscataway, NJ, USA},
+@Article{1373163,
+  author     = {Elizabeth Churchill and Les Nelson and Diana K. Smetters},
+  title      = {Useful Computer Security},
+  doi        = {http://dx.doi.org/10.1109/MIC.2008.67},
+  issn       = {1089-7801},
+  number     = {3},
+  pages      = {10--12},
+  volume     = {12},
+  address    = {Piscataway, NJ, USA},
   bdsk-url-1 = {http://dx.doi.org/10.1109/MIC.2008.67},
-  doi = {http://dx.doi.org/10.1109/MIC.2008.67},
-  issn = {1089-7801},
-  publisher = {IEEE Educational Activities Department}
+  groups     = {TestOne},
+  journal    = {IEEE Internet Computing},
+  publisher  = {IEEE Educational Activities Department},
+  year       = {2008},
 }
 
 @Article{820136,
@@ -136,17 +139,17 @@ This is some user comment in front of a string, should also be preserved.
 
 @InProceedings{1233448,
   author     = {Cheryl Hinds and Chinedu Ekwueme},
-  title      = {Increasing security and usability of computer systems with graphical passwords},
   booktitle  = {ACM-SE 45: Proceedings of the 45th annual southeast regional conference},
-  publisher  = {ACM},
-  location   = {Winston-Salem, North Carolina},
-  isbn       = {978-1-59593-629-5},
-  pages      = {529--530},
+  title      = {Increasing security and usability of computer systems with graphical passwords},
   doi        = {http://doi.acm.org/10.1145/1233341.1233448},
-  abstract   = {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id bibendum magna, ac tristique nulla. Aliquam ut vulputate velit, ac vulputate leo. Sed malesuada nisi eget lacus rhoncus, et feugiat libero suscipit. Sed vitae ultricies diam. Phasellus arcu tellus, scelerisque a lorem quis, molestie fermentum mi. Morbi nibh ante, sodales at nisl nec, tincidunt dapibus leo. Praesent auctor egestas commodo. Cras elit erat, accumsan a felis at, malesuada iaculis risus. Nunc in tincidunt metus. },
+  isbn       = {978-1-59593-629-5},
+  location   = {Winston-Salem, North Carolina},
+  pages      = {529--530},
+  publisher  = {ACM},
+  abstract   = {Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec id bibendum magna, ac tristique nulla. Aliquam ut vulputate velit, ac vulputate leo. Sed malesuada nisi eget lacus rhoncus, et feugiat libero suscipit. Sed vitae ultricies diam. Phasellus arcu tellus, scelerisque a lorem quis, molestie fermentum mi. Morbi nibh ante, sodales at nisl nec, tincidunt dapibus leo. Praesent auctor egestas commodo. Cras elit erat, accumsan a felis at, malesuada iaculis risus. Nunc in tincidunt metus.},
   address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1233341.1233448},
-  groups     = {StaticGroup},
+  groups     = {StaticGroup, TestOneSubOne},
   year       = {2007},
 }
 
@@ -303,8 +306,12 @@ This is some user comment in front of a string, should also be preserved.
 @Comment{jabref-meta: grouping:
 0 AllEntriesGroup:;
 1 StaticGroup:StaticGroup\;0\;1\;0x6d74baff\;\;A test static group\;;
-1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;0x5eba7dff\;\;\;;
-1 AutomaticPersonsGroup:Automatic group (Authors)\;0\;author\;1\;\;\;Automatic group for all authors\;;
+1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;0\;0x5eba7dff\;\;\;;
+1 AutomaticPersonsGroup:Automatic group (Authors)\;0\;author\;0\;\;\;Automatic group for all authors\;;
+1 StaticGroup:TestOne\;0\;1\;0x311b92ff\;\;\;;
+2 StaticGroup:TestOneSubOne\;0\;1\;0xff7043ff\;\;\;;
+2 StaticGroup:TestOneSubTwo\;0\;1\;0x00bcd4ff\;\;\;;
+1 StaticGroup:TestTwo\;0\;0\;0x5d4037ff\;\;\;;
 }
 
 @Comment{jabref-meta: keypattern_article:articleTest;}


### PR DESCRIPTION
Shows multiple colored bars if the entry belongs to more than one group (with color). Implements #4574.
![image](https://user-images.githubusercontent.com/5037600/65716295-25cb1980-e09f-11e9-9e94-e4a0f3a324cb.png)


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
