### PR TITLE
Show window before loading files

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -42,19 +43,10 @@ public class JabRefGUI {
     private final List<ParserResult> failed = new ArrayList<>();
     private final List<ParserResult> toOpenTab = new ArrayList<>();
 
-    private final String focusedFile;
-
-    public JabRefGUI(Stage mainStage, List<ParserResult> argsDatabases, boolean isBlank) {
-        this.bibDatabases = argsDatabases;
+    public JabRefGUI(Stage mainStage, List<ParserResult> databases, boolean isBlank) {
+        this.bibDatabases = databases;
         this.isBlank = isBlank;
         mainFrame = new JabRefFrame(mainStage);
-
-        // passed file (we take the first one) should be focused
-        focusedFile = argsDatabases.stream()
-                                    .findFirst()
-                                    .flatMap(ParserResult::getFile)
-                                    .map(File::getAbsolutePath)
-                                    .orElse(Globals.prefs.get(JabRefPreferences.LAST_FOCUSED));
 
         openWindow(mainStage);
         new VersionWorker(Globals.BUILD_INFO.getVersion(), Globals.prefs.getVersionPreferences().getIgnoredVersion(), mainFrame.getDialogService(), Globals.TASK_EXECUTOR)
@@ -64,15 +56,56 @@ public class JabRefGUI {
     private void openWindow(Stage mainStage) {
         applyFontRenderingTweak();
 
+        GUIGlobals.init();
+
+        LOGGER.debug("Initializing frame");
+        mainFrame.init();
+
+        // Restore window location and/or maximised state
+        if (Globals.prefs.getBoolean(JabRefPreferences.WINDOW_MAXIMISED)) {
+            mainStage.setMaximized(true);
+        } else {
+            mainStage.setX(Globals.prefs.getDouble(JabRefPreferences.POS_X));
+            mainStage.setY(Globals.prefs.getDouble(JabRefPreferences.POS_Y));
+            mainStage.setWidth(Globals.prefs.getDouble(JabRefPreferences.SIZE_X));
+            mainStage.setHeight(Globals.prefs.getDouble(JabRefPreferences.SIZE_Y));
+        }
+
+        // We create a decoration pane ourselves for performance reasons
+        // (otherwise it has to be injected later, leading to a complete redraw/relayout of the complete scene)
+        DecorationPane root = new DecorationPane();
+        root.getChildren().add(JabRefGUI.mainFrame);
+
+        Scene scene = new Scene(root, 800, 800);
+        Globals.getThemeLoader().installCss(scene, Globals.prefs);
+        mainStage.setTitle(JabRefFrame.FRAME_TITLE);
+        mainStage.getIcons().addAll(IconTheme.getLogoSetFX());
+        mainStage.setScene(scene);
+        mainStage.show();
+
+        mainStage.setOnCloseRequest(event -> {
+            saveWindowState(mainStage);
+            boolean reallyQuit = mainFrame.quit();
+            if (!reallyQuit) {
+                event.consume();
+            }
+        });
+
+        Platform.runLater(this::openDatabases);
+    }
+
+    private void openDatabases() {
         // If the option is enabled, open the last edited libraries, if any.
         if (!isBlank && Globals.prefs.getBoolean(JabRefPreferences.OPEN_LAST_EDITED)) {
             openLastEditedDatabases();
         }
 
-        GUIGlobals.init();
-
-        LOGGER.debug("Initializing frame");
-        mainFrame.init();
+        // passed file (we take the first one) should be focused
+        String focusedFile = bibDatabases.stream()
+                                         .findFirst()
+                                         .flatMap(ParserResult::getFile)
+                                         .map(File::getAbsolutePath)
+                                         .orElse(Globals.prefs.get(JabRefPreferences.LAST_FOCUSED));
 
         // Add all bibDatabases databases to the frame:
         boolean first = false;
@@ -119,44 +152,11 @@ public class JabRefGUI {
             first = false;
         }
 
-        // If we are set to remember the window location, we also remember the maximised
-        // state. This needs to be set after the window has been made visible, so we
-        // do it here:
-        if (Globals.prefs.getBoolean(JabRefPreferences.WINDOW_MAXIMISED)) {
-            mainStage.setMaximized(true);
-        } else {
-            mainStage.setX(Globals.prefs.getDouble(JabRefPreferences.POS_X));
-            mainStage.setY(Globals.prefs.getDouble(JabRefPreferences.POS_Y));
-            mainStage.setWidth(Globals.prefs.getDouble(JabRefPreferences.SIZE_X));
-            mainStage.setHeight(Globals.prefs.getDouble(JabRefPreferences.SIZE_Y));
-        }
-
-        // We create a decoration pane ourselves for performance reasons
-        // (otherwise it has to be injected later, leading to a complete redraw/relayout of the complete scene)
-        DecorationPane root = new DecorationPane();
-        root.getChildren().add(JabRefGUI.mainFrame);
-
-        Scene scene = new Scene(root, 800, 800);
-        Globals.getThemeLoader().installCss(scene, Globals.prefs);
-        mainStage.setTitle(JabRefFrame.FRAME_TITLE);
-        mainStage.getIcons().addAll(IconTheme.getLogoSetFX());
-        mainStage.setScene(scene);
-        mainStage.show();
-
-        mainStage.setOnCloseRequest(event -> {
-            saveWindowState(mainStage);
-            boolean reallyQuit = mainFrame.quit();
-            if (!reallyQuit) {
-                event.consume();
-            }
-        });
-
         for (ParserResult pr : failed) {
             String message = Localization.lang("Error opening file '%0'.", pr.getFile().get().getName()) + "\n"
                     + pr.getErrorMessage();
 
             mainFrame.getDialogService().showErrorDialogAndWait(Localization.lang("Error opening file"), message);
-
         }
 
         // Display warnings, if any


### PR DESCRIPTION
We now show the window first, and then load the last edited files. This does not really lead to an improvement of performance, but the user gets a quicker visual feedback.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
