### PR TITLE
Create chocolatey package for dev version

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,4 +1,4 @@
-name: Snap
+name: Snap Nightly
 
 on:
   push:

--- a/.github/workflows/update-chocolatey-jabref-nightly.yml
+++ b/.github/workflows/update-chocolatey-jabref-nightly.yml
@@ -42,10 +42,17 @@ jobs:
     steps:
       - name: Determine sha256 sums
         id: checksum
-        shell: bash
+        shell: python
         run: |
-          wget https://builds.jabref.org/master/JabRef-5.1.msi -o /tmp/jabref.msi
-          echo ::set-output checksum::`sha256sum < /tmp/jabref.msi | sed s/ .*//`
+          from urllib.request import urlretrieve
+          import hashlib
+
+          tmpfile, headers = urlretrieve('https://builds.jabref.org/master/JabRef-5.1.msi')
+          hash = hashlib.sha256()
+          with open(tmpfile, "rb") as f:
+              for chunk in iter(lambda: f.read(4096), b""):
+                  hash.update(chunk)
+          print(f'::set-output name=secretspresent::{hash.hexdigest()}')
       - name: Checkout source
         uses: actions/checkout@v2
       - name: Fetch all history for all tags and branches

--- a/.github/workflows/update-chocolatey-jabref-nightly.yml
+++ b/.github/workflows/update-chocolatey-jabref-nightly.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           script: |
             rm /var/www/builds.jabref.org/www/nightly/* || mkdir -p /var/www/builds.jabref.org/www/nightly || true
-            cp /var/www/builds.jabref.org/www/master/JabRef-5.1.msi /var/www/builds.jabref.org/www/nightly/
-            cp /var/www/builds.jabref.org/www/master/JabRef-5.1-portable_windows.zip /var/www/builds.jabref.org/www/nightly/
+            cp -a /var/www/builds.jabref.org/www/master/JabRef-5.1.msi /var/www/builds.jabref.org/www/nightly/
+            cp -a /var/www/builds.jabref.org/www/master/JabRef-5.1-portable_windows.zip /var/www/builds.jabref.org/www/nightly/
           host: build-upload.jabref.org
           port: 9922
           username: jrrsync

--- a/.github/workflows/update-chocolatey-jabref-nightly.yml
+++ b/.github/workflows/update-chocolatey-jabref-nightly.yml
@@ -9,9 +9,8 @@ on:
     - cron: '33 5 * * *'
 
 jobs:
-  build:
-    runs-on: windows-latest
-    name: Create installer and portable version for chocolatey
+  createnightly:
+    runs-on: ubuntu-latest
     steps:
       - name: Check secrets presence
         id: checksecrets
@@ -36,6 +35,11 @@ jobs:
           port: 9922
           username: jrrsync
           key: ${{ secrets.buildJabRefPrivateKey }}
+  createchoco:
+    needs: createnightly
+    runs-on: windows-latest
+    name: Create installer and portable version for chocolatey
+    steps:
       - name: Determine sha256 sums
         id: checksum
         shell: bash

--- a/.github/workflows/update-chocolatey-jabref-nightly.yml
+++ b/.github/workflows/update-chocolatey-jabref-nightly.yml
@@ -1,0 +1,61 @@
+name: Chocolatey Nightly
+
+on:
+  push:
+    branches:
+      - chocoDev
+  schedule:
+    # run on each day
+    - cron: '33 5 * * *'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    name: Create installer and portable version for chocolatey
+    steps:
+      - name: Check secrets presence
+        id: checksecrets
+        shell: bash
+        run: |
+          if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
+            echo ::set-output name=secretspresent::false
+          else
+            echo ::set-output name=secretspresent::true
+          fi
+        env:
+          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
+      - name: Make current master version the nightly build version
+        if: ${{ steps.checksecrets.outputs.secretspresent }}
+        uses: appleboy/ssh-action@v0.0.6
+        with:
+          script: |
+            rm /var/www/builds.jabref.org/www/nightly/* || mkdir -p /var/www/builds.jabref.org/www/nightly || true
+            cp /var/www/builds.jabref.org/www/master/JabRef-5.1.msi /var/www/builds.jabref.org/www/nightly/
+            cp /var/www/builds.jabref.org/www/master/JabRef-5.1-portable_windows.zip /var/www/builds.jabref.org/www/nightly/
+          host: build-upload.jabref.org
+          port: 9922
+          username: jrrsync
+          key: ${{ secrets.buildJabRefPrivateKey }}
+      - name: Determine sha256 sums
+        id: checksum
+        shell: bash
+        run: |
+          wget https://builds.jabref.org/master/JabRef-5.1.msi -o /tmp/jabref.msi
+          echo ::set-output checksum::`sha256sum < /tmp/jabref.msi | sed s/ .*//`
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Fetch all history for all tags and branches
+        run: git fetch --prune --unshallow
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.2
+        with:
+          versionSpec: '5.2.x'
+      - name: Run GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.2
+      - name: Put in version and checksum
+        shell: bash
+        run: |
+          sed -i "s/AssemblySemFileVer/${{ steps.gitversion.outputs.AssemblySemFileVer }}/" buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
+          sed -i "s/CHECKSUM/${{ steps.checksum.outputs.checksum }}/" buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
+          cat buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1

--- a/.gitignore
+++ b/.gitignore
@@ -471,3 +471,4 @@ lib/ojdbc.jar
 
 # do not ignore JabRef icons (they are ignored by the macos setting above)
 !src/main/java/org/jabref/gui/icon
+*.nupkg

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,5 @@
-assembly-versioning-format: '{major}.{minor}.{WeightedPreReleaseNumber}'
+assembly-versioning-format: '{major}.{minor}.{WeightedPreReleaseNumber ?? 0}'
+assembly-file-versioning-format: '{Major}.{Minor}.{Patch}.{WeightedPreReleaseNumber ?? 0}'
 assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{CommitDate}--{ShortSha}'
 mode: ContinuousDeployment
 

--- a/buildres/chocolatey/jabref-dev/jabref-dev.nuspec
+++ b/buildres/chocolatey/jabref-dev/jabref-dev.nuspec
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <id>jabref-dev</id>
+    <!-- version should MATCH as closely as possible with the underlying software -->
+    <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
+    <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
+    <version>5.0.0</version>
+    <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->
+    <owners>JabRef</owners>
+
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <title>JabRef (development version)</title>
+    <authors>https://github.com/JabRef/jabref/blob/master/AUTHORS</authors>
+    <projectUrl>https://www.jabref.org/</projectUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/JabRef/jabref/src/main/resources/images/external/JabRef-icon-128.png</iconUrl>
+    <copyright>JabRef</copyright>
+    <licenseUrl>https://github.com/JabRef/jabref/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/JabRef/jabref/</projectSourceUrl>
+    <docsUrl>https://help.jabref.org/</docsUrl>
+    <mailingListUrl>http://discourse.jabref.org/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/JabRef/jabref/issues</bugTrackerUrl>
+    <tags>jabref bibtex latex bibliography reference database admin</tags>
+    <summary>JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.</summary>
+    <description><![CDATA[
+      ** Please Note: This development version is a special build that allows you to test the latest features and bug fixes before they become available in the next [stable release of JabRef](https://chocolatey.org/packages/jabref)**
+
+JabRef is a graphical Java application for editing BibTeX and Biblatex databases. JabRef lets you organize your entries into overlapping logical groups, and with a single click limit your view to a single group or an intersection or union of several groups. You can customize the entry information shown in the main window, and sort by any of the standard BibTeX fields. JabRef can autogenerate BibTeX keys for your entries. JabRef also lets you easily link to PDF or web sources for your reference entries.
+JabRef can import from and export to several formats, and you can customize export filters. JabRef can be run as a command line application to convert from any import format to any export format.
+]]></description>
+    <releaseNotes>https://github.com/JabRef/jabref/blob/master/CHANGELOG.md</releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/buildres/chocolatey/jabref-dev/jabref-dev.nuspec
+++ b/buildres/chocolatey/jabref-dev/jabref-dev.nuspec
@@ -2,28 +2,27 @@
 
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <!-- == PACKAGE SPECIFIC SECTION == -->
-    <id>jabref-dev</id>
+    <id>jabref-nightly</id>
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>5.0.0</version>
+    <version>AssemblySemFileVer</version>
     <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->
     <owners>JabRef</owners>
 
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>JabRef (development version)</title>
-    <authors>https://github.com/JabRef/jabref/blob/master/AUTHORS</authors>
+    <authors>JabRef Developers</authors>
     <projectUrl>https://www.jabref.org/</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/JabRef/jabref/src/main/resources/images/external/JabRef-icon-128.png</iconUrl>
     <copyright>JabRef</copyright>
     <licenseUrl>https://github.com/JabRef/jabref/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/JabRef/jabref/</projectSourceUrl>
-    <docsUrl>https://help.jabref.org/</docsUrl>
+    <docsUrl>https://docs.jabref.org/</docsUrl>
     <mailingListUrl>http://discourse.jabref.org/</mailingListUrl>
     <bugTrackerUrl>https://github.com/JabRef/jabref/issues</bugTrackerUrl>
-    <tags>jabref bibtex latex bibliography reference database admin</tags>
+    <tags>jabref bibtex biblatex latex bibliography reference database</tags>
     <summary>JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.</summary>
     <description><![CDATA[
       ** Please Note: This development version is a special build that allows you to test the latest features and bug fixes before they become available in the next [stable release of JabRef](https://chocolatey.org/packages/jabref)**

--- a/buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
+++ b/buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
@@ -1,0 +1,29 @@
+﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+$toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+$url        = 'https://builds.jabref.org/master/JabRef-5.0.0.msi'
+
+$packageArgs = @{
+  packageName   = $env:ChocolateyPackageName
+  unzipLocation = $toolsDir
+  fileType      = 'MSI'
+  url           = $url
+  url64bit      = $url
+
+  softwareName  = 'JabRef*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
+
+  # Checksums are now required as of 0.10.0.
+  # To determine checksums, you can get that from the original site if provided. 
+  # You can also use checksum.exe (choco install checksum) and use it 
+  # e.g. checksum -t sha256 -f path\to\file
+  checksum      = ''
+  checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
+  checksum64    = ''
+  checksumType64= 'sha256' #default is checksumType
+
+  # MSI
+  silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
+++ b/buildres/chocolatey/jabref-dev/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$url        = 'https://builds.jabref.org/master/JabRef-5.0.0.msi'
+$url        = 'https://builds.jabref.org/nightly/JabRef-5.1.msi'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -13,12 +13,12 @@ $packageArgs = @{
   softwareName  = 'JabRef*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
 
   # Checksums are now required as of 0.10.0.
-  # To determine checksums, you can get that from the original site if provided. 
-  # You can also use checksum.exe (choco install checksum) and use it 
+  # To determine checksums, you can get that from the original site if provided.
+  # You can also use checksum.exe (choco install checksum) and use it
   # e.g. checksum -t sha256 -f path\to\file
-  checksum      = ''
+  checksum      = 'CHECKSUM'
   checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
-  checksum64    = ''
+  checksum64    = 'CHECKSUM'
   checksumType64= 'sha256' #default is checksumType
 
   # MSI

--- a/docs/adr/0009-offer-jabref-nightly-as-chocolatey-package.md
+++ b/docs/adr/0009-offer-jabref-nightly-as-chocolatey-package.md
@@ -1,0 +1,20 @@
+# Offer jabref-nightly as chocolatey pacakge
+
+## Context and Problem Statement
+
+[@OlafHaag](https://github.com/OlafHaag) maintains the [JabRef chocolatey package](https://chocolatey.org/packages/JabRef).
+It offers the stable version and the beta versions as "pre releases".
+
+JabRef builds on each push into `master` an new version, which gets published at <https://builds.jabref.org/master/>.
+This offers the possibility for users to test the current development snapshots.
+Having the chocolatey mechansim also for development snapshots in place, enables users to automatically update the development snapshots.
+
+## Considered Options
+
+* Offer `jabref-nightly` as chocolatey package
+* Use `--prerelease` of the `jabref` package as channel for nightly builds
+
+## Decision Outcome
+
+Chosen option: "Offer `jabref-nightly` as chocolatey package", because we want to distingish between development versions, beta versions, and releases. Thus, we need three different distributions. When using the chocolatey eco system, there are two different flavours possible for each package.
+This is also in line with [vlc-nightly](https://chocolatey.org/packages/vlc-nightly) chocolatey package.


### PR DESCRIPTION
Fixes #5031.

Things to do:

- [ ] Check that the correct version of JabRef gets uninstalled (if both the stable and the dev version are installed) -> specify unique software name in nuspec
- [ ] Create github action
- [ ] Calculate and add checksum as part of the github action
- [ ] Replace version in jabref-dev.nuspec
- [ ] Specify correct packageSourceUrl

https://chocolatey.org/docs/create-packages