### PR TITLE
Fix for #5369 - fallback to 0 in case stored preview cycle pos does no longer exist

### DIFF
--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1603,7 +1603,6 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public PreviewPreferences getPreviewPreferences() {
-        int cyclePos = getInt(CYCLE_PREVIEW_POS);
         List<String> cycle = getStringList(CYCLE_PREVIEW);
         double panelHeight = getDouble(PREVIEW_PANEL_HEIGHT);
         String style = get(PREVIEW_STYLE);
@@ -1627,6 +1626,14 @@ public class JabRefPreferences implements PreferencesService {
                                            })
                                            .filter(Objects::nonNull)
                                            .collect(Collectors.toList());
+
+        int cyclePos;
+        int storedCyclePos = getInt(CYCLE_PREVIEW_POS);
+        if (storedCyclePos < layouts.size()) {
+            cyclePos = storedCyclePos;
+        } else {
+            cyclePos = 0; // fallback if stored position is no longer valid
+        }
 
         return new PreviewPreferences(layouts, cyclePos, panelHeight, enabled, style, styleDefault);
     }

--- a/src/main/java/org/jabref/preferences/PreviewPreferences.java
+++ b/src/main/java/org/jabref/preferences/PreviewPreferences.java
@@ -68,7 +68,7 @@ public class PreviewPreferences {
     public static class Builder {
 
         private List<PreviewLayout> previewCycle;
-        private int previeCyclePosition;
+        private int previewCyclePosition;
         private Number previewPanelDividerPosition;
         private boolean previewPanelEnabled;
         private String previewStyle;
@@ -76,7 +76,7 @@ public class PreviewPreferences {
 
         public Builder(PreviewPreferences previewPreferences) {
             this.previewCycle = previewPreferences.getPreviewCycle();
-            this.previeCyclePosition = previewPreferences.getPreviewCyclePosition();
+            this.previewCyclePosition = previewPreferences.getPreviewCyclePosition();
             this.previewPanelDividerPosition = previewPreferences.getPreviewPanelDividerPosition();
             this.previewPanelEnabled = previewPreferences.isPreviewPanelEnabled();
             this.previewStyle = previewPreferences.getPreviewStyle();
@@ -85,18 +85,18 @@ public class PreviewPreferences {
 
         public Builder withPreviewCycle(List<PreviewLayout> previewCycle) {
             this.previewCycle = previewCycle;
-            return withPreviewCyclePosition(previeCyclePosition);
+            return withPreviewCyclePosition(previewCyclePosition);
         }
 
         public Builder withPreviewCyclePosition(int position) {
             if (previewCycle.isEmpty()) {
-                previeCyclePosition = 0;
+                previewCyclePosition = 0;
             } else {
-                previeCyclePosition = position;
-                while (previeCyclePosition < 0) {
-                    previeCyclePosition += previewCycle.size();
+                previewCyclePosition = position;
+                while (previewCyclePosition < 0) {
+                    previewCyclePosition += previewCycle.size();
                 }
-                previeCyclePosition %= previewCycle.size();
+                previewCyclePosition %= previewCycle.size();
             }
             return this;
         }
@@ -117,7 +117,7 @@ public class PreviewPreferences {
         }
 
         public PreviewPreferences build() {
-            return new PreviewPreferences(previewCycle, previeCyclePosition, previewPanelDividerPosition, previewPanelEnabled, previewStyle, previewStyleDefault);
+            return new PreviewPreferences(previewCycle, previewCyclePosition, previewPanelDividerPosition, previewPanelEnabled, previewStyle, previewStyleDefault);
         }
     }
 


### PR DESCRIPTION
Fix for #5369

problem should in theory not happen as always a correct size should be stored - however, if for example CSL styles are not loaded properly the mentioned exception in #5369 might occur.

To prevent this upon creating the preview prefs now the stored cycle position is now compared to the actual list of previews before being set. 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described - I think as this is not a common problem can be omitted?
- ~~[ ] Tests created for changes~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Screenshots added in PR description (for bigger UI changes)~~
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
