### PR TITLE
Renenable WebFetchers test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
     }
 
 
-    compile "io.github.classgraph:classgraph:4.8.47"
+    testCompile 'io.github.classgraph:classgraph:4.8.47'
     testCompile 'junit:junit:4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,8 @@ dependencies {
         exclude module: "log4j-core"
     }
 
+
+    compile "io.github.classgraph:classgraph:4.8.47"
     testCompile 'junit:junit:4.12'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.5.2'
@@ -207,9 +209,6 @@ dependencies {
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '3.0.0-20190915.182552-364'
     testCompile 'org.mockito:mockito-core:3.0.0'
     //testCompile 'com.github.tomakehurst:wiremock:2.24.1'
-    testCompile ('org.reflections:reflections:0.9.11') {
-        exclude module: "jsr305"
-    }
     testCompile 'org.xmlunit:xmlunit-core:2.6.3'
     testCompile 'org.xmlunit:xmlunit-matchers:2.6.3'
     testCompile 'com.tngtech.archunit:archunit-junit5-api:0.11.0'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -65,4 +65,5 @@ open module org.jabref {
     requires de.saxsys.mvvmfx.validation;
     requires richtextfx;
     requires unirest.java;
+    requires io.github.classgraph;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -65,5 +65,4 @@ open module org.jabref {
     requires de.saxsys.mvvmfx.validation;
     requires richtextfx;
     requires unirest.java;
-    requires io.github.classgraph;
 }

--- a/src/test/java/module-info.test
+++ b/src/test/java/module-info.test
@@ -38,3 +38,9 @@
 --add-opens
     // Needed for localization tests
     javafx.fxml/javafx.fxml=org.jabref
+
+--add-modules
+    io.github.classgraph
+
+--add-reads
+   org.jabref=io.github.classgraph

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -10,20 +10,19 @@ import org.jabref.logic.importer.fetcher.IsbnViaEbookDeFetcher;
 import org.jabref.logic.importer.fetcher.IsbnViaOttoBibFetcher;
 import org.jabref.logic.importer.fetcher.MrDLibFetcher;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.reflections.Reflections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-// TODO: Reenable as soon as https://github.com/ronmamo/reflections/issues/202 is fixed
-@Disabled
 class WebFetchersTest {
 
-    private Reflections reflections = new Reflections("org.jabref");
     private ImportFormatPreferences importFormatPreferences;
+    private ClassGraph classGraph = new ClassGraph().enableAllInfo().whitelistPackages("org.jabref");
 
     @BeforeEach
     void setUp() throws Exception {
@@ -34,50 +33,69 @@ class WebFetchersTest {
     void getIdBasedFetchersReturnsAllFetcherDerivingFromIdBasedFetcher() throws Exception {
         List<IdBasedFetcher> idFetchers = WebFetchers.getIdBasedFetchers(importFormatPreferences);
 
-        Set<Class<? extends IdBasedFetcher>> expected = reflections.getSubTypesOf(IdBasedFetcher.class);
-        expected.remove(AbstractIsbnFetcher.class);
-        expected.remove(IdBasedParserFetcher.class);
-        // Remove special ISBN fetcher since we don't want to expose them to the user
-        expected.remove(IsbnViaChimboriFetcher.class);
-        expected.remove(IsbnViaEbookDeFetcher.class);
-        expected.remove(IsbnViaOttoBibFetcher.class);
-        assertEquals(expected, getClasses(idFetchers));
+        try (ScanResult scanResult = classGraph.scan()) {
+
+            ClassInfoList controlClasses = scanResult.getClassesImplementing(IdBasedFetcher.class.getCanonicalName());
+            Set<Class<?>> expected = controlClasses.loadClasses().stream().collect(Collectors.toSet());
+
+            expected.remove(AbstractIsbnFetcher.class);
+            expected.remove(IdBasedParserFetcher.class);
+            // Remove special ISBN fetcher since we don't want to expose them to the user
+            expected.remove(IsbnViaChimboriFetcher.class);
+            expected.remove(IsbnViaEbookDeFetcher.class);
+            expected.remove(IsbnViaOttoBibFetcher.class);
+            assertEquals(expected, getClasses(idFetchers));
+        }
     }
 
     @Test
     void getEntryBasedFetchersReturnsAllFetcherDerivingFromEntryBasedFetcher() throws Exception {
         List<EntryBasedFetcher> idFetchers = WebFetchers.getEntryBasedFetchers(importFormatPreferences);
 
-        Set<Class<? extends EntryBasedFetcher>> expected = reflections.getSubTypesOf(EntryBasedFetcher.class);
-        expected.remove(EntryBasedParserFetcher.class);
-        expected.remove(MrDLibFetcher.class);
-        assertEquals(expected, getClasses(idFetchers));
+        try (ScanResult scanResult = classGraph.scan()) {
+            ClassInfoList controlClasses = scanResult.getClassesImplementing(EntryBasedFetcher.class.getCanonicalName());
+            Set<Class<?>> expected = controlClasses.loadClasses().stream().collect(Collectors.toSet());
+
+            expected.remove(EntryBasedParserFetcher.class);
+            expected.remove(MrDLibFetcher.class);
+            assertEquals(expected, getClasses(idFetchers));
+        }
     }
 
     @Test
     void getSearchBasedFetchersReturnsAllFetcherDerivingFromSearchBasedFetcher() throws Exception {
         List<SearchBasedFetcher> searchBasedFetchers = WebFetchers.getSearchBasedFetchers(importFormatPreferences);
+        try (ScanResult scanResult = classGraph.scan()) {
+            ClassInfoList controlClasses = scanResult.getClassesImplementing(SearchBasedFetcher.class.getCanonicalName());
+            Set<Class<?>> expected = controlClasses.loadClasses().stream().collect(Collectors.toSet());
 
-        Set<Class<? extends SearchBasedFetcher>> expected = reflections.getSubTypesOf(SearchBasedFetcher.class);
-        expected.remove(SearchBasedParserFetcher.class);
-        assertEquals(expected, getClasses(searchBasedFetchers));
+            expected.remove(SearchBasedParserFetcher.class);
+            assertEquals(expected, getClasses(searchBasedFetchers));
+        }
     }
 
     @Test
     void getFullTextFetchersReturnsAllFetcherDerivingFromFullTextFetcher() throws Exception {
         List<FulltextFetcher> fullTextFetchers = WebFetchers.getFullTextFetchers(importFormatPreferences);
 
-        Set<Class<? extends FulltextFetcher>> expected = reflections.getSubTypesOf(FulltextFetcher.class);
-        assertEquals(expected, getClasses(fullTextFetchers));
+        try (ScanResult scanResult = classGraph.scan()) {
+            ClassInfoList controlClasses = scanResult.getClassesImplementing(FulltextFetcher.class.getCanonicalName());
+            Set<Class<?>> expected = controlClasses.loadClasses().stream().collect(Collectors.toSet());
+            assertEquals(expected, getClasses(fullTextFetchers));
+        }
     }
 
     @Test
     void getIdFetchersReturnsAllFetcherDerivingFromIdFetcher() throws Exception {
         List<IdFetcher> idFetchers = WebFetchers.getIdFetchers(importFormatPreferences);
 
-        Set<Class<? extends IdFetcher>> expected = reflections.getSubTypesOf(IdFetcher.class);
-        expected.remove(IdParserFetcher.class);
-        assertEquals(expected, getClasses(idFetchers));
+        try (ScanResult scanResult = classGraph.scan()) {
+            ClassInfoList controlClasses = scanResult.getClassesImplementing(IdFetcher.class.getCanonicalName());
+            Set<Class<?>> expected = controlClasses.loadClasses().stream().collect(Collectors.toSet());
+
+            expected.remove(IdParserFetcher.class);
+            assertEquals(expected, getClasses(idFetchers));
+        }
     }
 
     private Set<? extends Class<?>> getClasses(List<?> objects) {


### PR DESCRIPTION
Replace outdated reflection library with [classgraph](https://github.com/classgraph/classgraph) library

Fixes part of #5226 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
