### PR TITLE
Fix eclipse javafx module access 

### DIFF
--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -25,8 +25,9 @@ eclipse {
                 }
 
                 def javafxcontrols = entries.find { isJavafxControls(it) };
-                javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
-                javafxcontrols.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
+                javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref';
+                javafxcontrols.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref';
+
 
                 entries.findAll { isLibrary(it) && isTestScope(it) }.each { //mark test source files
                     it.entryAttributes['test'] = 'true'

--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -24,9 +24,9 @@ eclipse {
                     it.entryAttributes['test'] = 'true'
                 }
 
-                def jreContainer = entries.find { isJREContainer(it) };
-                jreContainer.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
-                jreContainer.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
+                def javafxcontrols = entries.find { isJavafxControls(it) };
+                javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
+                javafxcontrols.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref';
 
                 entries.findAll { isLibrary(it) && isTestScope(it) }.each { //mark test source files
                     it.entryAttributes['test'] = 'true'
@@ -51,9 +51,8 @@ boolean isSource(entry) { return entry.properties.kind.equals('src'); }
 
 boolean isControlsfx(entry) { return entry.properties.path.contains('controlsfx'); }
 
-boolean isJREContainer(entry) {
-    return entry.properties.kind == 'con' && entry.properties.path.startsWith('org.eclipse.jdt.launching.JRE_CONTAINER')
-};
+boolean isJavafxControls(entry) { return entry.properties.path.contains('javafx-controls'); }
+
 
 // add formatter and cleanup settings to Eclipse settings
 // see http://stackoverflow.com/a/27461890/873282


### PR DESCRIPTION
I may need to add some tweaks as well

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
