### PR TITLE
Add UUID for upgrading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -582,7 +582,7 @@ jlink {
             installerOptions = [
                     '--vendor', 'JabRef',
                     '--app-version', "${project.version}",
-                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36'
+                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36',
                     '--win-dir-chooser',
                     '--win-shortcut'
             ]

--- a/build.gradle
+++ b/build.gradle
@@ -582,6 +582,7 @@ jlink {
             installerOptions = [
                     '--vendor', 'JabRef',
                     '--app-version', "${project.version}",
+                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36'
                     '--win-dir-chooser',
                     '--win-shortcut'
             ]


### PR DESCRIPTION
In my understanding generating two installers with different versions and same --win-upgrade-uuid should uninstall another version during installation, i.e. this is needed to have a proper upgrade instead of a parallel installation of two JabRef versions.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
