### PR TITLE
Fix 5359: Writing of Editor field is duplicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an exception which occured when trying to open a non existing file from the "Recent files"-menu [#5334](https://github.com/JabRef/jabref/issues/5334)
 - The context menu for fields in the entry editor is back. [#5254](https://github.com/JabRef/jabref/issues/5254)
 - We fixed an exception which occurred when trying to open a non existing file from the "Recent files"-menu [#5334](https://github.com/JabRef/jabref/issues/5334)
+- We fixed a problem where the "editor" information has been duplicated during saving a .bib-Database. [#5359](https://github.com/JabRef/jabref/issues/5359)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -111,7 +111,7 @@ public class BibEntryWriter {
             for (OrFields value : type.get().getRequiredFields()) {
                 for (Field field : value) {
                     writeField(entry, out, field, indentation);
-                    written.add(value.getPrimary());
+                    written.add(field);
                 }
             }
             // Then optional fields.

--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -107,6 +107,64 @@ public class BibEntryWriterTest {
     }
 
     @Test
+    void writeEntryWithOrField() throws Exception {
+            StringWriter stringWriter = new StringWriter();
+
+            BibEntry entry = new BibEntry(StandardEntryType.InBook);
+            //set an required OR field (author/editor)
+            entry.setField(StandardField.EDITOR, "Foo Bar");
+            entry.setField(StandardField.JOURNAL, "International Journal of Something");
+            //set an optional field
+            entry.setField(StandardField.NUMBER, "1");
+            entry.setField(StandardField.NOTE, "some note");
+
+            writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+            String actual = stringWriter.toString();
+
+            // @formatter:off
+            String expected = OS.NEWLINE + "@InBook{," + OS.NEWLINE +
+                    "  editor  = {Foo Bar}," + OS.NEWLINE +
+                    "  note    = {some note}," + OS.NEWLINE +
+                    "  number  = {1}," + OS.NEWLINE +
+                    "  journal = {International Journal of Something}," + OS.NEWLINE +
+                    "}" + OS.NEWLINE;
+            // @formatter:on
+
+            assertEquals(expected, actual);
+    }
+
+    @Test
+    void writeEntryWithOrFieldBothFieldsPresent() throws Exception {
+        StringWriter stringWriter = new StringWriter();
+
+        BibEntry entry = new BibEntry(StandardEntryType.InBook);
+        //set an required OR field with both fields(author/editor)
+        entry.setField(StandardField.AUTHOR, "Foo Thor");
+        entry.setField(StandardField.EDITOR, "Edi Bar");
+        entry.setField(StandardField.JOURNAL, "International Journal of Something");
+        //set an optional field
+        entry.setField(StandardField.NUMBER, "1");
+        entry.setField(StandardField.NOTE, "some note");
+
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = OS.NEWLINE + "@InBook{," + OS.NEWLINE +
+                "  author  = {Foo Thor}," + OS.NEWLINE +
+                "  editor  = {Edi Bar}," + OS.NEWLINE +
+                "  note    = {some note}," + OS.NEWLINE +
+                "  number  = {1}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
+        // @formatter:on
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void writeReallyUnknownTypeTest() throws Exception {
         String expected = OS.NEWLINE + "@Reallyunknowntype{test," + OS.NEWLINE +
                 "  comment = {testentry}," + OS.NEWLINE +


### PR DESCRIPTION
Fixes #5359 
Serialization of `OrFields` was not implemented properly as the currently written field was not stored correctly.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- ~~ Screenshots added in PR description (for bigger UI changes) ~~
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- ~~Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
