### PR TITLE
Checkout submodule

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,7 +32,6 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v1
       with:
-        fetch-depth: 1
         submodules: true
     - name: Set up JDK
       uses: actions/setup-java@v1

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v1
       with:
+        depth: 1
         submodules: true
     - name: Set up JDK
       uses: actions/setup-java@v1

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 1
+        submodules: true
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -582,7 +582,7 @@ jlink {
             installerOptions = [
                     '--vendor', 'JabRef',
                     '--app-version', "${project.version}",
-                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36'
+                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36',
                     '--win-dir-chooser',
                     '--win-shortcut'
             ]

--- a/build.gradle
+++ b/build.gradle
@@ -582,6 +582,7 @@ jlink {
             installerOptions = [
                     '--vendor', 'JabRef',
                     '--app-version', "${project.version}",
+                    '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36'
                     '--win-dir-chooser',
                     '--win-shortcut'
             ]


### PR DESCRIPTION
Actually the CSL styles are not properly loaded into the build artifacts due to missing usage of submodules.

I needed to revert 3fbe0a2b57340f03d7d1271eeeb30a061d724134 with fetch limiting as this is breaking the submodule  usage (see https://github.com/JabRef/jabref/commit/baa47ff95f13764f6ecb9f9ab38762f56752c342/checks?check_suite_id=252636752) - however, as far as I understood this limitation is nonetheless not necessary as the problem referred to by @Siedlerchr in #5364 was only the temporary problem in the java setup action.

New build is now containing the files again (and is 14MB bigger ;-))

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
