### PR TITLE
Fix exception when merging entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The "All entries group" is no longer shown when no library is open.
 - We fixed an exception which occurred when closing JabRef. [#5348](https://github.com/JabRef/jabref/issues/5348)
 - We fixed an error where the groups containing an entry loose their highlight color when scrolling. [#5022](https://github.com/JabRef/jabref/issues/5022) 
+- We fixed an error where an exception was thrown when merging entries. [#5169](https://github.com/JabRef/jabref/issues/5169)
 - After assigning an entry to a group, the item count is now properly colored to reflect the new membership of the entry. [#3112](https://github.com/JabRef/jabref/issues/3112)
 - The group panel is now properly updated when switching between libraries (or when closing/opening one). [#3142](https://github.com/JabRef/jabref/issues/3142)
 - We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)

--- a/src/main/java/org/jabref/gui/util/UiThreadList.java
+++ b/src/main/java/org/jabref/gui/util/UiThreadList.java
@@ -1,18 +1,38 @@
 package org.jabref.gui.util;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.TransformationList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class UiThreadList<T> extends TransformationList<T, T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UiThreadList.class);
     public UiThreadList(ObservableList<? extends T> source) {
         super(source);
     }
 
     @Override
     protected void sourceChanged(ListChangeListener.Change<? extends T> change) {
-        Platform.runLater(() -> fireChange(change));
+        if (Platform.isFxApplicationThread()) {
+            fireChange(change);
+        } else {
+            CountDownLatch latch = new CountDownLatch(1);
+            Platform.runLater(() -> {
+                fireChange(change);
+                latch.countDown();
+            });
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                LOGGER.error("Error while running on JavaFX thread", e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
The problem was that `sourceChanged` was invoked asynchronous and thus the information in the change event could be obsolete if another thread changed the underlying list in the meantime. Solution: run `sourceChanged` on the JavaFX thread but synchronously.
Fixes #5169.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
