### PR TITLE
Performance improvements for GUI start up

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -42,10 +41,12 @@ public class JabRefGUI {
     private final boolean isBlank;
     private final List<ParserResult> failed = new ArrayList<>();
     private final List<ParserResult> toOpenTab = new ArrayList<>();
+    private final JabRefExecutorService executorService;
 
     public JabRefGUI(Stage mainStage, List<ParserResult> databases, boolean isBlank) {
         this.bibDatabases = databases;
         this.isBlank = isBlank;
+        executorService = JabRefExecutorService.INSTANCE;
         mainFrame = new JabRefFrame(mainStage);
 
         openWindow(mainStage);
@@ -91,7 +92,7 @@ public class JabRefGUI {
             }
         });
 
-        Platform.runLater(this::openDatabases);
+        executorService.execute(this::openDatabases);
     }
 
     private void openDatabases() {

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -139,7 +139,7 @@ public class BasePanel extends StackPane {
     // Used to track whether the base has changed since last save.
     private BibEntry showing;
     private SuggestionProviders suggestionProviders;
-    @SuppressWarnings({ "FieldCanBeLocal", "unused"}) private Subscription dividerPositionSubscription;
+    @SuppressWarnings({"FieldCanBeLocal", "unused"}) private Subscription dividerPositionSubscription;
     // the query the user searches when this BasePanel is active
     private Optional<SearchQuery> currentSearchQuery = Optional.empty();
     private Optional<DatabaseChangeMonitor> changeMonitor = Optional.empty();
@@ -435,9 +435,9 @@ public class BasePanel extends StackPane {
         if (!selectedBibEntries.isEmpty()) {
             // Collect all non-null titles.
             List<String> titles = selectedBibEntries.stream()
-                    .filter(bibEntry -> bibEntry.getTitle().isPresent())
-                    .map(bibEntry -> bibEntry.getTitle().get())
-                    .collect(Collectors.toList());
+                                                    .filter(bibEntry -> bibEntry.getTitle().isPresent())
+                                                    .map(bibEntry -> bibEntry.getTitle().get())
+                                                    .collect(Collectors.toList());
 
             if (titles.isEmpty()) {
                 output(Localization.lang("None of the selected entries have titles."));
@@ -469,8 +469,8 @@ public class BasePanel extends StackPane {
             }
 
             String citeCommand = Optional.ofNullable(Globals.prefs.get(JabRefPreferences.CITE_COMMAND))
-                    .filter(cite -> cite.contains("\\")) // must contain \
-                    .orElse("\\cite");
+                                         .filter(cite -> cite.contains("\\")) // must contain \
+                                         .orElse("\\cite");
             final String copiedCiteCommand = citeCommand + "{" + String.join(",", keys) + '}';
             Globals.clipboardManager.setContent(copiedCiteCommand);
 
@@ -665,11 +665,11 @@ public class BasePanel extends StackPane {
 
         // Update entry editor and preview according to selected entries
         mainTable.addSelectionListener(event -> mainTable.getSelectedEntries()
-                .stream()
-                .findFirst()
-                .ifPresent(entry -> {
-                    entryEditor.setEntry(entry);
-                }));
+                                                         .stream()
+                                                         .findFirst()
+                                                         .ifPresent(entry -> {
+                                                             entryEditor.setEntry(entry);
+                                                         }));
 
         // TODO: Register these actions globally
         /*
@@ -754,12 +754,12 @@ public class BasePanel extends StackPane {
             this.getDatabase().registerListener(new SearchAutoCompleteListener());
             setupAutoCompletion();
         });
-        
+
         // Saves the divider position as soon as it changes
         // We need to keep a reference to the subscription, otherwise the binding gets garbage collected
         dividerPositionSubscription = EasyBind.monadic(Bindings.valueAt(splitPane.getDividers(), 0))
-                .flatMap(SplitPane.Divider::positionProperty)
-                .subscribe((observable, oldValue, newValue) -> saveDividerLocation(newValue));
+                                              .flatMap(SplitPane.Divider::positionProperty)
+                                              .subscribe((observable, oldValue, newValue) -> saveDividerLocation(newValue));
 
         // Add changePane in case a file is present - otherwise just add the splitPane to the panel
         Optional<Path> file = bibDatabaseContext.getDatabasePath();
@@ -1236,10 +1236,10 @@ public class BasePanel extends StackPane {
                     List<LinkedFile> files = bes.get(0).getFiles();
 
                     Optional<LinkedFile> linkedFile = files.stream()
-                            .filter(file -> (StandardField.URL.getName().equalsIgnoreCase(file.getFileType())
-                                    || StandardField.PS.getName().equalsIgnoreCase(file.getFileType())
-                                    || StandardField.PDF.getName().equalsIgnoreCase(file.getFileType())))
-                            .findFirst();
+                                                           .filter(file -> (StandardField.URL.getName().equalsIgnoreCase(file.getFileType())
+                                                                   || StandardField.PS.getName().equalsIgnoreCase(file.getFileType())
+                                                                   || StandardField.PDF.getName().equalsIgnoreCase(file.getFileType())))
+                                                           .findFirst();
 
                     if (linkedFile.isPresent()) {
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -751,9 +751,9 @@ public class BasePanel extends StackPane {
         // Set up name autocompleter for search:
         executorService.execute(() -> {
             instantiateSearchAutoCompleter();
-            this.getDatabase().registerListener(new SearchAutoCompleteListener());
             setupAutoCompletion();
         });
+        this.getDatabase().registerListener(new SearchAutoCompleteListener());
 
         // Saves the divider position as soon as it changes
         // We need to keep a reference to the subscription, otherwise the binding gets garbage collected

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -148,11 +148,10 @@ public class JabRefFrame extends BorderPane {
     private final CountingUndoManager undoManager;
     private final PushToApplicationsManager pushToApplicationsManager;
     private final DialogService dialogService;
+    private final JabRefExecutorService executorService;
     private SidePaneManager sidePaneManager;
     private TabPane tabbedPane;
     private SidePane sidePane;
-
-    private final JabRefExecutorService executorService;
 
     public JabRefFrame(Stage mainStage) {
         this.mainStage = mainStage;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -152,7 +152,7 @@ public class JabRefFrame extends BorderPane {
     private TabPane tabbedPane;
     private SidePane sidePane;
 
-    private JabRefExecutorService executorService;
+    private final JabRefExecutorService executorService;
 
     public JabRefFrame(Stage mainStage) {
         this.mainStage = mainStage;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----
(Partially) fixes issue https://github.com/JabRef/jabref/issues/5362

As requested by @tobiasdiez in the issue, I delegated the initialization of the auto completer to a background thread, to improve performance during start up.

I also moved the parsing process of the bib files into separate background tasks, which should speed up the start up of the GUI significantly (especially for a large amount of bib files to load).

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
