### PR TITLE
Fix error message related to themeloader

### DIFF
--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -96,7 +96,7 @@ public class ThemeLoader {
                 Path cssPath = Paths.get(cssUri).toAbsolutePath();
                 LOGGER.info("Enabling live reloading of {}", cssPath);
                 fileUpdateMonitor.addListenerForFile(cssPath, () -> {
-                    LOGGER.info("Reload css file " + cssFile);
+                    LOGGER.info("Reload css file {}", cssFile);
                     DefaultTaskExecutor.runInJavaFXThread(() -> {
                         scene.getStylesheets().remove(cssFile.toExternalForm());
                         scene.getStylesheets().add(index, cssFile.toExternalForm());

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -88,23 +88,20 @@ public class ThemeLoader {
         scene.getStylesheets().add(index, cssFile.toExternalForm());
 
         try {
-
+            // If the file is an ordinary file (i.e. not part of a java runtime bundle), we watch it for changes and turn on live reloading
             URI cssUri = cssFile.toURI();
-            if (!cssUri.toString().contains("jar")) {
+            if (!cssUri.toString().contains("jrt")) {
                 LOGGER.debug("CSS URI {}", cssUri);
 
                 Path cssPath = Paths.get(cssUri).toAbsolutePath();
-                // If the file is an ordinary file (i.e. not a resource part of a .jar bundle), we watch it for changes and turn on live reloading
-                if (!cssUri.toString().contains("jar")) {
-                    LOGGER.info("Enabling live reloading of {}", cssPath);
-                    fileUpdateMonitor.addListenerForFile(cssPath, () -> {
-                        LOGGER.info("Reload css file " + cssFile);
-                        DefaultTaskExecutor.runInJavaFXThread(() -> {
-                            scene.getStylesheets().remove(cssFile.toExternalForm());
-                            scene.getStylesheets().add(index, cssFile.toExternalForm());
-                        });
+                LOGGER.info("Enabling live reloading of {}", cssPath);
+                fileUpdateMonitor.addListenerForFile(cssPath, () -> {
+                    LOGGER.info("Reload css file " + cssFile);
+                    DefaultTaskExecutor.runInJavaFXThread(() -> {
+                        scene.getStylesheets().remove(cssFile.toExternalForm());
+                        scene.getStylesheets().add(index, cssFile.toExternalForm());
                     });
-                }
+                });
             }
         } catch (IOException | URISyntaxException | UnsupportedOperationException e) {
             LOGGER.error("Could not watch css file for changes " + cssFile, e);


### PR DESCRIPTION
Fixes the error message
> ERROR ThemeLoader Could not watch css file for changes jrt:/org.jabref/org/jabref/gui/Base.css

when starting JabRef.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
