### PR TITLE
Run snapcraft push from docker image

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -89,7 +89,9 @@ jobs:
         SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}
       run: |
           docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "apt update -qq && cd $(pwd) && snapcraft && mv jabref*.snap build/distribution/"
-          cd build/distribution/ && mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg && snapcraft push --release=edge *.snap || true
+          cd build/distribution/
+          mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
+          docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "snapcraft push --release=edge *.snap || true"
       shell: bash
     - name: Upload to builds.jabref.org
       uses: garygrossgarten/github-action-scp@release


### PR DESCRIPTION
We (I) forgot that snapcraft needs to run from the docker image..
The same applies to the push command.
The settings can be applies outside, but the push command should be run in docker.
Should it be just one `docker run` with both the build and push commands?
It shouldn't make much difference...

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
