### PR TITLE
Remove jacoco append property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -472,10 +472,6 @@ processTestResources.dependsOn copyTestResources
 
 tasks.withType(Test) {
     reports.html.destination = file("${reporting.baseDir}/${name}")
-
-    jacoco {
-        append = true
-    }
 }
 
 task jacocoMerge(type: JacocoMerge) {


### PR DESCRIPTION
[ #5428](https://github.com/JabRef/jabref/issues/5428) - Issue this PR solves

Gradle was warning about deprecated feature usage. Logs show jacoco append to be the feature that is deprecated.From my understandind the propery is currently ignored.

Removed the Jacoco append property from build.gradle and builds don't throw any deprecation warnings anymore.

The append property in Jacoco is meant to write to the same coverage file. But as mentioned in this [issue](https://github.com/gradle/gradle/issues/5269) setting it to true broke the build caching capability. So starting Gradle 5.0 a breaking change was introduced where they did away with the append property. The default behavior was set to behave as if append is initially false to enable build caching and then append is set to true before passing to the jacoco agent.
This meant that multiple tasks could not use the same coverage file but Jacoco merge is a feature that let's you achieve the same functionality. The gradle for the project does use Jacoco Merge to merge the various .exec file results, so removing the append property should not break coverage.


----
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
