### PR TITLE
JabRefExecutorService improvement

### DIFF
--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Responsible for managing of all threads (except GUI threads) in JabRef
+ * @deprecated Use {@link org.jabref.gui.util.BackgroundTask} instead
  */
 @Deprecated
 public class JabRefExecutorService {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -103,6 +103,15 @@ public class JabRefExecutorService {
         return CompletableFuture.supplyAsync(supplier, executorService);
     }
 
+    public <T> CompletableFuture<T> executeInterruptible(Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, lowPriorityExecutorService);
+    }
+
+    public <T> List<CompletableFuture<T>> executeAllInterruptible(List<Supplier<T>> supplierList) {
+        return supplierList.stream().map(supplier -> CompletableFuture.supplyAsync(supplier, lowPriorityExecutorService))
+                           .collect(Collectors.toList());
+    }
+
     public <T> List<CompletableFuture<T>> executeAll(List<Supplier<T>> supplierList) {
         return supplierList.stream().map(supplier -> CompletableFuture.supplyAsync(supplier, executorService))
                            .collect(Collectors.toList());

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Responsible for managing of all threads (except GUI threads) in JabRef
  */
+@Deprecated
 public class JabRefExecutorService {
 
     public static final JabRefExecutorService INSTANCE = new JabRefExecutorService();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TimerTask;
+import java.util.concurrent.Callable;
 
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -1044,7 +1045,7 @@ public class JabRefFrame extends BorderPane {
      * @param entries The entries to add.
      */
     private void addImportedEntries(final BasePanel panel, final List<BibEntry> entries) {
-        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap(() -> entries);
+        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap((Callable<List<BibEntry>>) () -> entries);
         ImportEntriesDialog dialog = new ImportEntriesDialog(panel.getBibDatabaseContext(), task);
         dialog.setTitle(Localization.lang("Import"));
         dialog.showAndWait();

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
@@ -47,7 +48,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     public void fileUpdated() {
         // File on disk has changed, thus look for notable changes and notify listeners in case there are such changes
         ChangeScanner scanner = new ChangeScanner(database, referenceFile);
-        BackgroundTask.wrap(scanner::scanForChanges)
+        BackgroundTask.wrap((Callable<List<DatabaseChangeViewModel>>) scanner::scanForChanges)
                       .onSuccess(changes -> {
                           if (!changes.isEmpty()) {
                               listeners.forEach(listener -> listener.databaseChanged(changes));

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesAction.java
@@ -11,6 +11,7 @@ import org.jabref.Globals;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
@@ -56,7 +57,7 @@ public class CopyFilesAction extends SimpleCommand {
                     Localization.lang("Copy linked files to folder..."),
                     Localization.lang("Copy linked files to folder..."),
                     exportTask);
-            Globals.TASK_EXECUTOR.execute(exportTask);
+            BackgroundTask.wrap(exportTask).executeWith(Globals.TASK_EXECUTOR);
             exportTask.setOnSucceeded((e) -> showDialog(exportTask.getValue()));
         });
     }

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
@@ -3,6 +3,7 @@ package org.jabref.gui.documentviewer;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import javafx.animation.FadeTransition;
 import javafx.beans.property.DoubleProperty;
@@ -157,7 +158,7 @@ public class DocumentViewerControl extends StackPane {
             background.setStyle("-fx-fill: WHITE");
             //imageView.setImage(new WritableImage(getDesiredWidth(), getDesiredHeight()));
             BackgroundTask<Image> generateImage = BackgroundTask
-                    .wrap(() -> renderPage(initialPage))
+                    .wrap((Callable<Image>) () -> renderPage(initialPage))
                     .onSuccess(image -> {
                         imageView.setImage(image);
                         progress.setVisible(false);
@@ -197,7 +198,7 @@ public class DocumentViewerControl extends StackPane {
             imageView.setOpacity(0);
 
             BackgroundTask<Image> generateImage = BackgroundTask
-                    .wrap(() -> renderPage(page))
+                    .wrap((Callable<Image>) () -> renderPage(page))
                     .onSuccess(image -> {
                         imageView.setImage(image);
 

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -11,6 +11,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.jabref.Globals;
 import org.jabref.JabRefExecutorService;
@@ -69,7 +70,7 @@ public class DuplicateSearch extends SimpleCommand {
         }
 
         JabRefExecutorService.INSTANCE.executeInterruptableTask(() -> searchPossibleDuplicates(entries, database.getMode()), "DuplicateSearcher");
-        BackgroundTask.wrap(this::verifyDuplicates)
+        BackgroundTask.wrap((Supplier<DuplicateSearchResult>) this::verifyDuplicates)
                       .onSuccess(this::handleDuplicates)
                       .executeWith(Globals.TASK_EXECUTOR);
 

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -103,7 +104,7 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
     }
 
     private void startSearch(String citeKey) {
-        searchTask = BackgroundTask.wrap(() -> searchAndParse(citeKey))
+        searchTask = BackgroundTask.wrap((Callable<Collection<Citation>>) () -> searchAndParse(citeKey))
                                    .onRunning(() -> status.set(Status.IN_PROGRESS))
                                    .onSuccess(result -> {
                                        citationList.setAll(result);

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -2,6 +2,7 @@ package org.jabref.gui.entryeditor;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -61,18 +62,18 @@ public class RelatedArticlesTab extends EntryEditorTab {
         MrDLibFetcher fetcher = new MrDLibFetcher(Globals.prefs.get(JabRefPreferences.LANGUAGE),
                                                   Globals.BUILD_INFO.getVersion());
         BackgroundTask
-                      .wrap(() -> fetcher.performSearch(entry))
-                      .onRunning(() -> progress.setVisible(true))
-                      .onSuccess(relatedArticles -> {
+                .wrap((Callable<List<BibEntry>>) () -> fetcher.performSearch(entry))
+                .onRunning(() -> progress.setVisible(true))
+                .onSuccess(relatedArticles -> {
                           progress.setVisible(false);
                           root.getChildren().add(getRelatedArticleInfo(relatedArticles, fetcher));
                       })
-                      .onFailure(exception -> {
+                .onFailure(exception -> {
                           LOGGER.error("Error while fetching from Mr. DLib", exception);
                           progress.setVisible(false);
                           root.getChildren().add(getErrorInfo());
                       })
-                      .executeWith(Globals.TASK_EXECUTOR);
+                .executeWith(Globals.TASK_EXECUTOR);
 
         root.getChildren().add(progress);
 

--- a/src/main/java/org/jabref/gui/exporter/ExportCommand.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCommand.java
@@ -3,6 +3,7 @@ package org.jabref.gui.exporter;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import javafx.stage.FileChooser;
@@ -102,7 +103,7 @@ public class ExportCommand extends SimpleCommand {
 
         final List<BibEntry> finEntries = entries;
         BackgroundTask
-                .wrap(() -> {
+                .wrap((Callable<Object>) () -> {
                     format.export(frame.getCurrentBasePanel().getBibDatabaseContext(),
                             file,
                             frame.getCurrentBasePanel()

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import javafx.scene.input.ClipboardContent;
@@ -76,10 +77,10 @@ public class ExportToClipboardAction extends SimpleCommand {
         Optional<Exporter> selectedExporter = dialogService.showChoiceDialogAndWait(Localization.lang("Export"), Localization.lang("Select export format"),
                 Localization.lang("Export"), defaultChoice, exporters);
 
-        selectedExporter.ifPresent(exporter -> BackgroundTask.wrap(() -> exportToClipboard(exporter))
-                                                                .onSuccess(this::setContentToClipboard)
-                                                                .onFailure(ex -> { /* swallow as already logged */ })
-                                                                .executeWith(Globals.TASK_EXECUTOR));
+        selectedExporter.ifPresent(exporter -> BackgroundTask.wrap((Callable<ExportResult>) () -> exportToClipboard(exporter))
+                                                             .onSuccess(this::setContentToClipboard)
+                                                             .onFailure(ex -> { /* swallow as already logged */ })
+                                                             .executeWith(Globals.TASK_EXECUTOR));
     }
 
     private ExportResult exportToClipboard(Exporter exporter) throws Exception {

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.fieldeditors;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -76,7 +77,6 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
                     }
                 }
         );
-
     }
 
     public boolean getIdentifierLookupInProgress() {
@@ -94,7 +94,7 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
     public void lookupIdentifier(BibEntry entry) {
         WebFetchers.getIdFetcherForField(field).ifPresent(idFetcher -> {
             BackgroundTask
-                    .wrap(() -> idFetcher.findIdentifier(entry))
+                    .wrap((Callable<Optional<? extends Identifier>>) () -> idFetcher.findIdentifier(entry))
                     .onRunning(() -> identifierLookupInProgress.setValue(true))
                     .onFinished(() -> identifierLookupInProgress.setValue(false))
                     .onSuccess(identifier -> {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.function.BiPredicate;
 
 import javax.xml.transform.TransformerException;
@@ -369,7 +370,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
     public void writeXMPMetadata() {
         // Localization.lang("Writing XMP-metadata...")
-        BackgroundTask<Void> writeTask = BackgroundTask.wrap(() -> {
+        BackgroundTask<Void> writeTask = BackgroundTask.wrap((Callable<Void>) () -> {
             Optional<Path> file = linkedFile.findIn(databaseContext, filePreferences);
             if (!file.isPresent()) {
                 // TODO: Print error message
@@ -418,7 +419,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
     public BackgroundTask<Path> prepareDownloadTask(Path targetDirectory, URLDownload urlDownload) {
         BackgroundTask<Path> downloadTask = BackgroundTask
-                .wrap(() -> {
+                .wrap((Callable<Path>) () -> {
                     Optional<ExternalFileType> suggestedType = inferFileType(urlDownload);
                     String suggestedTypeName = suggestedType.map(ExternalFileType::getName).orElse("");
                     linkedFile.setFileType(suggestedTypeName);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
@@ -148,8 +149,8 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
 
         if (entry != null) {
             BackgroundTask<List<LinkedFileViewModel>> findAssociatedNotLinkedFiles = BackgroundTask
-                                                                                                   .wrap(() -> findAssociatedNotLinkedFiles(entry))
-                                                                                                   .onSuccess(files::addAll);
+                    .wrap((Callable<List<LinkedFileViewModel>>) () -> findAssociatedNotLinkedFiles(entry))
+                    .onSuccess(files::addAll);
             taskExecutor.execute(findAssociatedNotLinkedFiles);
         }
     }
@@ -178,17 +179,17 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
     public void fetchFulltext() {
         FulltextFetchers fetcher = new FulltextFetchers(preferences.getImportFormatPreferences());
         BackgroundTask
-                      .wrap(() -> fetcher.findFullTextPDF(entry))
-                      .onRunning(() -> fulltextLookupInProgress.setValue(true))
-                      .onFinished(() -> fulltextLookupInProgress.setValue(false))
-                      .onSuccess(url -> {
+                .wrap((Callable<Optional<URL>>) () -> fetcher.findFullTextPDF(entry))
+                .onRunning(() -> fulltextLookupInProgress.setValue(true))
+                .onFinished(() -> fulltextLookupInProgress.setValue(false))
+                .onSuccess(url -> {
                           if (url.isPresent()) {
                               addFromURL(url.get());
                           } else {
                               dialogService.notify(Localization.lang("No full text document found"));
                           }
                       })
-                      .executeWith(taskExecutor);
+                .executeWith(taskExecutor);
     }
 
     public void addFromURL() {

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import javafx.beans.binding.Bindings;
@@ -226,7 +227,7 @@ public class GroupNodeViewModel {
         // We could be more intelligent and try to figure out the new number of hits based on the entry change
         // for example, a previously matched entry gets removed -> hits = hits - 1
         BackgroundTask
-                .wrap(() -> groupNode.calculateNumberOfMatches(databaseContext.getDatabase()))
+                .wrap((Callable<Long>) () -> groupNode.calculateNumberOfMatches(databaseContext.getDatabase()))
                 .onSuccess(hits::setValue)
                 .executeWith(taskExecutor);
     }

--- a/src/main/java/org/jabref/gui/help/VersionWorker.java
+++ b/src/main/java/org/jabref/gui/help/VersionWorker.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.jabref.gui.DialogService;
@@ -56,14 +57,14 @@ public class VersionWorker {
     }
 
     public void checkForNewVersionAsync() {
-        BackgroundTask.wrap(this::getNewVersion)
+        BackgroundTask.wrap((Callable<Optional<Version>>) this::getNewVersion)
                       .onSuccess(version -> showUpdateInfo(version, true))
                       .onFailure(exception -> showConnectionError(exception, true))
                       .executeWith(taskExecutor);
     }
 
     public void checkForNewVersionDelayed() {
-        BackgroundTask.wrap(this::getNewVersion)
+        BackgroundTask.wrap((Callable<Optional<Version>>) this::getNewVersion)
                       .onSuccess(version -> showUpdateInfo(version, false))
                       .onFailure(exception -> showConnectionError(exception, false))
                       .scheduleWith(taskExecutor, 30, TimeUnit.SECONDS);

--- a/src/main/java/org/jabref/gui/importer/ImportAction.java
+++ b/src/main/java/org/jabref/gui/importer/ImportAction.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import org.jabref.Globals;
@@ -51,7 +52,7 @@ public class ImportAction {
      */
     public void automatedImport(List<String> filenames) {
         List<Path> files = filenames.stream().map(Paths::get).collect(Collectors.toList());
-        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap(() -> {
+        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap((Callable<List<BibEntry>>) () -> {
             List<ImportFormatReader.UnknownFormatImport> imports = doImport(files);
             // Ok, done. Then try to gather in all we have found. Since we might
             // have found

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -2,6 +2,7 @@ package org.jabref.gui.importer;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 import javax.swing.undo.UndoManager;
@@ -112,7 +113,7 @@ public class ImportEntriesDialog extends BaseDialog<Void> {
                     container.getStyleClass().add("entry-container");
                     BindingsHelper.includePseudoClassWhen(container, entrySelected, addToggle.selectedProperty());
 
-                    BackgroundTask.wrap(() -> viewModel.hasDuplicate(entry)).onSuccess(duplicateFound -> {
+                    BackgroundTask.wrap((Callable<Boolean>) () -> viewModel.hasDuplicate(entry)).onSuccess(duplicateFound -> {
                         if (duplicateFound) {
                             Button duplicateButton = IconTheme.JabRefIcons.DUPLICATE.asButton();
                             duplicateButton.setTooltip(new Tooltip(Localization.lang("Possible duplicate of existing entry. Click to resolve.")));

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.importer;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import javax.swing.undo.UndoManager;
 
@@ -76,8 +77,8 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         // Check if we are supposed to warn about duplicates.
         // If so, then see if there are duplicates, and warn if yes.
         if (preferences.shouldWarnAboutDuplicatesForImport()) {
-            BackgroundTask.wrap(() -> entriesToImport.stream()
-                    .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
+            BackgroundTask.wrap((Callable<Boolean>) () -> entriesToImport.stream()
+                                                                         .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
                             Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),

--- a/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import javax.swing.undo.CompoundEdit;
 
@@ -165,7 +166,7 @@ public class AppendDatabaseAction implements BaseAction {
 
             for (Path file : filesToOpen) {
                 // Run the actual open in a thread to prevent the program locking until the file is loaded.
-                BackgroundTask.wrap(() -> openIt(file, dialog.importEntries(), dialog.importStrings(), dialog.importGroups(), dialog.importSelectorWords()))
+                BackgroundTask.wrap((Callable<String>) () -> openIt(file, dialog.importEntries(), dialog.importStrings(), dialog.importGroups(), dialog.importSelectorWords()))
                               .onSuccess(fileName -> dialogService.notify(Localization.lang("Imported from library") + " '" + fileName + "'"))
                               .onFailure(exception -> {
                                   LOGGER.warn("Could not open database", exception);

--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import org.jabref.Globals;
@@ -188,7 +189,7 @@ public class OpenDatabaseAction extends SimpleCommand {
         Objects.requireNonNull(file);
         if (Files.exists(file)) {
 
-            BackgroundTask.wrap(() -> loadDatabase(file))
+            BackgroundTask.wrap((Callable<ParserResult>) () -> loadDatabase(file))
                           .onSuccess(result -> {
                               BasePanel panel = addNewDatabase(result, file, raisePanel);
                               OpenDatabaseAction.performPostOpenActions(panel, result);

--- a/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
@@ -2,6 +2,7 @@ package org.jabref.gui.importer.fetcher;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import javax.swing.undo.UndoManager;
 
@@ -53,7 +54,7 @@ public class LookupIdentifierAction<T extends Identifier> extends SimpleCommand 
     @Override
     public void execute() {
         try {
-            BackgroundTask.wrap(() -> lookupIdentifiers(stateManager.getSelectedEntries()))
+            BackgroundTask.wrap((Callable<String>) () -> lookupIdentifiers(stateManager.getSelectedEntries()))
                           .onSuccess(frame.getDialogService()::notify)
                           .executeWith(Globals.TASK_EXECUTOR);
         } catch (Exception e) {

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.importer.fetcher;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
@@ -94,7 +95,7 @@ public class WebSearchPaneViewModel {
 
         SearchBasedFetcher activeFetcher = getSelectedFetcher();
 
-        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap(() -> activeFetcher.performSearch(getQuery().trim()))
+        BackgroundTask<List<BibEntry>> task = BackgroundTask.wrap((Callable<List<BibEntry>>) () -> activeFetcher.performSearch(getQuery().trim()))
                                                             .withInitialMessage(Localization.lang("Processing %0", getQuery()));
 
         task.onFailure(ex -> dialogService.showErrorDialogAndWait(ex));

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.function.Supplier;
 
 import org.jabref.Globals;
 import org.jabref.JabRefExecutorService;
@@ -39,7 +40,7 @@ public class AbbreviateAction implements BaseAction {
     @Override
     public void action() {
         panel.output(Localization.lang("Abbreviating..."));
-        BackgroundTask.wrap(this::abbreviate)
+        BackgroundTask.wrap((Supplier<String>) this::abbreviate)
                       .onSuccess(panel::output)
                       .executeWith(Globals.TASK_EXECUTOR);
 

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -116,7 +117,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
      */
     void addBuiltInLists() {
         BackgroundTask
-                .wrap(JournalAbbreviationLoader::getBuiltInAbbreviations)
+                .wrap((Callable<List<Abbreviation>>) JournalAbbreviationLoader::getBuiltInAbbreviations)
                 .onRunning(() -> isLoadingBuiltIn.setValue(true))
                 .onSuccess(result -> {
                     isLoadingBuiltIn.setValue(false);
@@ -127,7 +128,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
                 .executeWith(taskExecutor);
 
         BackgroundTask
-                .wrap(() -> {
+                .wrap((Callable<List<Abbreviation>>) () -> {
                     if (abbreviationsPreferences.useIEEEAbbreviations()) {
                         return JournalAbbreviationLoader.getOfficialIEEEAbbreviations();
                     } else {

--- a/src/main/java/org/jabref/gui/journals/UnabbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/UnabbreviateAction.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.journals;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
@@ -26,7 +27,7 @@ public class UnabbreviateAction implements BaseAction {
     @Override
     public void action() {
         panel.output(Localization.lang("Unabbreviating..."));
-        BackgroundTask.wrap(this::unabbreviate)
+        BackgroundTask.wrap((Supplier<String>) this::unabbreviate)
                       .onSuccess(panel::output)
                       .executeWith(Globals.TASK_EXECUTOR);
     }

--- a/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
+++ b/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
 
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
@@ -62,7 +63,7 @@ public class FetchAndMergeEntry {
             if (fieldContent.isPresent()) {
                 Optional<IdBasedFetcher> fetcher = WebFetchers.getIdBasedFetcherForField(field, Globals.prefs.getImportFormatPreferences());
                 if (fetcher.isPresent()) {
-                    BackgroundTask.wrap(() -> fetcher.get().performSearchById(fieldContent.get()))
+                    BackgroundTask.wrap((Callable<Optional<BibEntry>>) () -> fetcher.get().performSearchById(fieldContent.get()))
                                   .onSuccess(fetchedEntry -> {
                                       String type = field.getDisplayName();
                                       if (fetchedEntry.isPresent()) {
@@ -144,7 +145,7 @@ public class FetchAndMergeEntry {
     }
 
     public void fetchAndMerge(BibEntry entry, EntryBasedFetcher fetcher) {
-        BackgroundTask.wrap(() -> fetcher.performSearch(entry).stream().findFirst())
+        BackgroundTask.wrap((Callable<Optional<BibEntry>>) () -> fetcher.performSearch(entry).stream().findFirst())
                       .onSuccess(fetchedEntry -> {
                           if (fetchedEntry.isPresent()) {
                               showMergeDialog(entry, fetchedEntry.get(), fetcher);

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -105,7 +106,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             availableListProperty.getValue().add(previewPreferences.getTextBasedPreviewLayout());
         }
 
-        BackgroundTask.wrap(CitationStyle::discoverCitationStyles)
+        BackgroundTask.wrap((Callable<List<CitationStyle>>) CitationStyle::discoverCitationStyles)
                       .onSuccess(styles -> styles.stream()
                                                  .map(CitationStylePreviewLayout::new)
                                                  .filter(style -> chosenListProperty.getValue().filtered(item ->

--- a/src/main/java/org/jabref/gui/preview/CitationStyleToClipboardWorker.java
+++ b/src/main/java/org/jabref/gui/preview/CitationStyleToClipboardWorker.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import javafx.scene.input.ClipboardContent;
 
@@ -55,7 +56,7 @@ public class CitationStyleToClipboardWorker {
     }
 
     public void copyCitationStyleToClipboard(TaskExecutor taskExecutor) {
-        BackgroundTask.wrap(this::generateCitations)
+        BackgroundTask.wrap((Callable<List<String>>) this::generateCitations)
                       .onFailure(ex -> LOGGER.error("Error while copying citations to the clipboard", ex))
                       .onSuccess(this::setClipBoardContent)
                       .executeWith(taskExecutor);

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -2,6 +2,7 @@ package org.jabref.gui.preview;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import javafx.beans.InvalidationListener;
@@ -134,14 +135,14 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
         ExporterFactory.entryNumber = 1; // Set entry number in case that is included in the preview layout.
 
         BackgroundTask
-                      .wrap(() -> layout.generatePreview(entry.get(), database.getDatabase()))
-                      .onRunning(() -> setPreviewText("<i>" + Localization.lang("Processing %0", Localization.lang("Citation Style")) + ": " + layout.getName() + " ..." + "</i>"))
-                      .onSuccess(this::setPreviewText)
-                      .onFailure(exception -> {
+                .wrap((Callable<String>) () -> layout.generatePreview(entry.get(), database.getDatabase()))
+                .onRunning(() -> setPreviewText("<i>" + Localization.lang("Processing %0", Localization.lang("Citation Style")) + ": " + layout.getName() + " ..." + "</i>"))
+                .onSuccess(this::setPreviewText)
+                .onFailure(exception -> {
                           LOGGER.error("Error while generating citation style", exception);
                           setPreviewText(Localization.lang("Error while generating citation style"));
                       })
-                      .executeWith(taskExecutor);
+                .executeWith(taskExecutor);
     }
 
     private void setPreviewText(String text) {

--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,6 +32,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.texparser.DefaultTexParser;
 import org.jabref.logic.texparser.TexBibEntriesResolver;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.texparser.TexBibEntriesResolverResult;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
@@ -121,7 +123,7 @@ public class ParseTexDialogViewModel extends AbstractViewModel {
      * Run a recursive search in a background task.
      */
     public void searchButtonClicked() {
-        BackgroundTask.wrap(() -> searchDirectory(Paths.get(texDirectory.get())))
+        BackgroundTask.wrap((Callable<FileNodeViewModel>) () -> searchDirectory(Paths.get(texDirectory.get())))
                       .onRunning(() -> {
                           root.set(null);
                           noFilesFound.set(true);
@@ -201,7 +203,7 @@ public class ParseTexDialogViewModel extends AbstractViewModel {
         TexBibEntriesResolver entriesResolver = new TexBibEntriesResolver(databaseContext.getDatabase(),
                 preferencesService.getImportFormatPreferences(), fileMonitor);
 
-        BackgroundTask.wrap(() -> entriesResolver.resolve(new DefaultTexParser().parse(fileList)))
+        BackgroundTask.wrap((Callable<TexBibEntriesResolverResult>) () -> entriesResolver.resolve(new DefaultTexParser().parse(fileList)))
                       .onRunning(() -> searchInProgress.set(true))
                       .onFinished(() -> searchInProgress.set(false))
                       .onSuccess(result -> new ParseTexResultView(result, databaseContext, Paths.get(texDirectory.get())).showAndWait())

--- a/src/main/java/org/jabref/gui/texparser/ParseTexResultViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexResultViewModel.java
@@ -2,8 +2,10 @@ package org.jabref.gui.texparser;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
@@ -17,6 +19,7 @@ import org.jabref.gui.importer.ImportEntriesDialog;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.texparser.Citation;
 import org.jabref.model.texparser.TexBibEntriesResolverResult;
 
@@ -70,7 +73,7 @@ public class ParseTexResultViewModel extends AbstractViewModel {
      * Search and import unknown references from associated BIB files.
      */
     public void importButtonClicked() {
-        ImportEntriesDialog dialog = new ImportEntriesDialog(databaseContext, BackgroundTask.wrap(() ->
+        ImportEntriesDialog dialog = new ImportEntriesDialog(databaseContext, BackgroundTask.wrap((Callable<List<BibEntry>>) () ->
                 new ArrayList<>(resolverResult.getNewEntries())));
 
         dialog.setTitle(Localization.lang("Import entries from LaTeX files"));

--- a/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
@@ -2,6 +2,7 @@ package org.jabref.gui.util;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -92,19 +93,20 @@ public class DefaultTaskExecutor implements TaskExecutor {
     }
 
     @Override
-    public <V> Future<V> execute(BackgroundTask<V> task) {
+    public <V> CompletableFuture<V> execute(BackgroundTask<V> task) {
         return execute(getJavaFXTask(task));
     }
 
     @Override
-    public <V> Future<V> execute(Task<V> task) {
-        executor.submit(task);
-        return task;
+    public <V> CompletableFuture<V> execute(Task<V> task) {
+        CompletableFuture<V> future = new CompletableFuture<>();
+        executor.submit((Callable<V>) task::get);
+        return future;
     }
 
     @Override
-    public <V> Future<?> schedule(BackgroundTask<V> task, long delay, TimeUnit unit) {
-        return scheduledExecutor.schedule(getJavaFXTask(task), delay, unit);
+    public <V> Future<V> schedule(BackgroundTask<V> task, long delay, TimeUnit unit) {
+        return scheduledExecutor.schedule(task::call, delay, unit);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/util/TaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/TaskExecutor.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.util;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -19,7 +20,7 @@ public interface TaskExecutor {
      * @param <V>  type of return value of the task
      * @param task the task to run
      */
-    <V> Future<V> execute(BackgroundTask<V> task);
+    <V> CompletableFuture<V> execute(BackgroundTask<V> task);
 
     /**
      * Runs the given task and returns a Future representing that task. Usually, you want to use the other method {@link
@@ -28,7 +29,7 @@ public interface TaskExecutor {
      * @param <V>  type of return value of the task
      * @param task the task to run
      */
-    <V> Future<V> execute(Task<V> task);
+    <V> CompletableFuture<V> execute(Task<V> task);
 
     /**
      * Submits a one-shot task that becomes enabled after the given delay.
@@ -40,7 +41,7 @@ public interface TaskExecutor {
      *         the task and whose {@code get()} method will return
      *         {@code null} upon completion
      */
-    <V> Future<?> schedule(BackgroundTask<V> task, long delay, TimeUnit unit);
+    <V> Future<V> schedule(BackgroundTask<V> task, long delay, TimeUnit unit);
 
     /**
      * Shutdown the task executor.

--- a/src/main/java/org/jabref/gui/worker/SendAsEMailAction.java
+++ b/src/main/java/org/jabref/gui/worker/SendAsEMailAction.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
@@ -45,7 +46,7 @@ public class SendAsEMailAction implements BaseAction {
 
     @Override
     public void action() {
-        BackgroundTask.wrap(this::sendEmail)
+        BackgroundTask.wrap((Callable<String>) this::sendEmail)
                       .onSuccess(frame.getDialogService()::notify)
                       .onFailure(e -> {
                           String message = Localization.lang("Error creating email");


### PR DESCRIPTION
I made a very minor update on the current JabRefExecutorService to support the very modern way of handling asynchronous tasks by using CompletableFuture objects. Using CompletableFuture instad of the usual Future object allows chaining of several asynchronous tasks very easily. This is a much more flexible way of dealing with asynchronous operations. I highly recomment using those methods I added instead of the old ones.

For those that are unfamiliar with the CompletableFuture pattern, they might want to have a look at my personal [project](https://github.com/Brainsucker92/picalculator/blob/master/src/main/java/calculator/impl/ChudnovskyCalculator.java) where I used this to split and chain some very expensive calculations which gave me a very simple but huge increase in throughput.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
