### PR TITLE
Disable stacktrace on error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,6 @@ plugins {
 // use the gradle build scan feature: https://scans.gradle.com/get-started
 buildScan { termsOfServiceUrl = 'https://gradle.com/terms-of-service'; termsOfServiceAgree = 'yes' }
 
-// show stacktrace on error
-gradle.startParameter.showStacktrace = org.gradle.api.logging.configuration.ShowStacktrace.ALWAYS
-
 apply plugin: 'java'
 apply plugin: 'application'
 apply plugin: 'project-report'


### PR DESCRIPTION
This reverts a change introduced by a bot without even mentioning it in the commit message. https://github.com/JabRef/jabref/commit/4add3167c918dc2b6c33f55a5a8aff70cb5f2bed#diff-c197962302397baf3a4cc36463dce5eaR39
I'd argue that quite often we don't want to see the full stack trace of Gradle. The motivating example for this was checking the outdated dependencies. We do have a error message for this, `There are outdated dependencies in build.gradle!\n Run ./gradlew dependencyUpdates to see which`, but the stacktrace still appeared and distracted from the normal error message.
