### PR TITLE
Draft proposal for improving FindUnlinkedFilesDialog

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesViewModel.java
@@ -1,0 +1,123 @@
+package org.jabref.gui.externalfiles;
+
+import java.io.FileFilter;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.scene.control.TreeItem;
+import javafx.stage.FileChooser;
+
+import org.jabref.gui.util.FileFilterConverter;
+import org.jabref.logic.util.StandardFileType;
+
+import com.sun.star.util.DateTime;
+
+public class FindUnlinkedFilesViewModel {
+    private StringProperty directory = new SimpleStringProperty();
+    private BooleanProperty isDirectorySpecified = new SimpleBooleanProperty();
+    private ObjectProperty<FileFilter> fileFilter;
+    private ObjectProperty<List<UnlinkedFile>>  unlinkedFiles;
+
+    private List<FileChooser.ExtensionFilter> fileFilterList = new LinkedList<FileChooser.ExtensionFilter>();
+    private List<UnlinkedFileRow> unlinkedFilesList = new LinkedList<UnlinkedFileRow>();
+    private TreeItem<UnlinkedFileRow> treeRoot = new TreeItem<>(new UnlinkedFileRow("Unlinked Files"));
+
+
+    private void initialize() {
+        // fetch the file filter from the model
+    }
+
+    public BooleanProperty isDirectorySpecifiedProperty() {
+        return isDirectorySpecified;
+    }
+
+    // fileFilter
+    // https://stackoverflow.com/a/34512438/3830240
+    public ObjectProperty<FileFilter> fileFilterProperty() {
+        return fileFilter;
+    }
+
+    public FileFilter getFileFilter() {
+        return fileFilterProperty().get();
+    }
+
+    public void setFileFilter(FileFilter fileFilter) {
+        fileFilterProperty().set(fileFilter);
+    }
+
+    // UnlinkedFileTable
+    public ObjectProperty<List<UnlinkedFile>> unlinkedFileObjectProperty() {
+        return unlinkedFiles;
+    }
+
+}
+
+class UnlinkedFile {
+    private Path fullPath;
+    private DateTime dateTimeCreated;
+    private boolean directory;
+
+    public Path getFullPath() {
+        return fullPath;
+    }
+
+    public void setFullPath(Path fullPath) {
+        this.fullPath = fullPath;
+    }
+
+    public boolean isDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(boolean directory) {
+        this.directory = directory;
+    }
+
+    public DateTime getDateTimeCreated() {
+        return dateTimeCreated;
+    }
+
+    public void setDateTimeCreated(DateTime dateTimeCreated) {
+        this.dateTimeCreated = dateTimeCreated;
+    }
+}
+
+class UnlinkedFileRow {
+    private UnlinkedFile unlinkedFile;
+    private int fileCount;
+    private String filename;
+
+    UnlinkedFileRow(String filename) {
+        this.filename = filename;
+        this.unlinkedFile = null;
+        fileCount = 0;
+    }
+
+    public boolean isDirectory() {
+        return unlinkedFile.isDirectory();
+    }
+
+    public int getFileCount() {
+        return fileCount;
+    }
+
+    public void setFileCount(int fileCount) {
+        this.fileCount = fileCount;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public void setFilename(String filename) {
+        this.filename = filename;
+    }
+}
+

--- a/src/test/java/org/jabref/gui/externalfiles/FindUnlinkedFilesViewModelTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/FindUnlinkedFilesViewModelTest.java
@@ -1,0 +1,82 @@
+package org.jabref.gui.externalfiles;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class FindUnlinkedFilesViewModelTest {
+    @Test
+    public void disableImportButton() throws Exception {
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No target directory specified
+        Assert.assertFalse(findUnlinkedFilesViewModel.isDirectorySpecifiedProperty().get());
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesProperty().get(), 0);
+    }
+
+    @Test
+    public void disableScanDirectory() throws Exception {
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No target directory specified
+        Assert.assertFalse(findUnlinkedFilesViewModel.isDirectorySpecifiedProperty().get());
+    }
+
+    @Test
+    public void disableSelectAll(){
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesProperty().get(), 0);
+
+        // No unlinked files unselected
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesProperty().get()
+                - findUnlinkedFilesViewModel.totalUnlinkedFilesSelectedProperty().get(), 0);
+    }
+
+    @Test
+    public void disableUnselectAll(){
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesProperty().get(), 0);
+
+        // No unlinked files selected
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesSelectedProperty().get(), 0);
+    }
+
+    @Test
+    public void disableExpandAll(){
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.numberOfUnlinkedFilesProperty().get(), 0);
+
+        // No collapsed trees available
+        Assert.assertEquales(findUnlinkedFilesViewModel.totalTreesCollapsedProperty().get(), 0);
+    }
+
+    @Test
+    public void disableCollapseAll(){
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.numberOfUnlinkedFilesProperty().get(), 0);
+
+        // No expanded trees available
+        Assert.assertEquales(findUnlinkedFilesViewModel.totalTreesProperty().get()
+                - findUnlinkedFilesViewModel.totalTreesCollapsedProperty().get(), 0);
+    }
+
+    @Test
+    public void disableExportSelectedEntries(){
+        FindUnlinkedFilesViewModel findUnlinkedFilesViewModel = new FindUnlinkedFilesViewModel();
+
+        // No unlinked files available
+        Assert.assertEquals(findUnlinkedFilesViewModel.numberOfUnlinkedFilesProperty().get(), 0);
+
+        // No unlinked files selected
+        Assert.assertEquals(findUnlinkedFilesViewModel.totalUnlinkedFilesSelectedProperty().get(), 0);
+    }
+}


### PR DESCRIPTION
Based on the discussion at [#4652](https://github.com/JabRef/jabref/issues/4652), findUnlinkedFilesDialog.java will be converted to the MVVM pattern and filtering functionality based on the date of file creation will be added.

The relevant thing to see ATM is the tests defined for the proposed implementation at FindUnlinkedFilesViewModelTest.java

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
