### PR TITLE
Fix postrm in deb

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -595,7 +595,6 @@ jlink {
                     '--linux-menu-group', 'Office;',
                     '--linux-rpm-license-type', 'MIT',
                     // '--license-file', "${projectDir}/LICENSE.md",
-                    '--file-associations', "${projectDir}/buildres/linux/desktop.properties",
                     '--description', 'JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.',
                     '--linux-shortcut'
             ]

--- a/buildres/linux/copyright
+++ b/buildres/linux/copyright
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: APPLICATION_COPYRIGHT
-License: APPLICATION_LICENSE_TEXT
+Copyright: Copyright (C) 2003-2019 JabRef Authors
+License: MIT

--- a/buildres/linux/desktop.properties
+++ b/buildres/linux/desktop.properties
@@ -1,1 +1,0 @@
-mime-type=text/x-bibtex;

--- a/buildres/linux/jabref-JabRef.desktop
+++ b/buildres/linux/jabref-JabRef.desktop
@@ -6,6 +6,7 @@ Exec=APPLICATION_LAUNCHER
 Icon=APPLICATION_ICON
 Terminal=false
 Type=Application
+MimeType=text/x-bibtex;
 Categories=DEPLOY_BUNDLE_CATEGORY
 Keywords=bibtex;biblatex;latex;bibliography
 StartupWMClass=org-jabref-JabRefMain

--- a/buildres/linux/postrm
+++ b/buildres/linux/postrm
@@ -18,9 +18,10 @@ set -e
 # the debian-policy package
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    INSTALL_PATH="/usr/lib/mozilla/native-messaging-hosts/"
-    if grep --quiet '"path": "/opt' /usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json; then
-        rm -D -m0755 /opt/jabref/lib/org.jabref.jabref.json $INSTALL_PATH
+    INSTALL_PATH="/usr/lib/mozilla/native-messaging-hosts"
+    if grep --quiet '"path": "/opt' $INSTALL_PATH/org.jabref.jabref.json; then
+        rm $INSTALL_PATH/org.jabref.jabref.json
+    fi
     ;;
 
     *)


### PR DESCRIPTION
An error in the postrm file could prevent reinstalls

Remove the associations file and set in .desktop
(Avoid having another extra file for a single line declaration)

Manually set license/copyright for deb (rpm in gradle):
(The parsing of the license.md file is not working consistently)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
