### PR TITLE
(Grammar Fixes) Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ JabRef supports you in every step of your research work.
 	
 #### Organize
 
-- Group your research into hierarchical collections and organize research items based on keywords/tags, search terms or your own manual assignments
+- Group your research into hierarchical collections and organize research items based on keywords/tags, search terms or your manual assignments
 - Advanced search and filter features
 - Complete and fix bibliographic data by comparing with curated online catalogues such as Google Scholar, Springer or MathSciNet
 - Customizable citation key generator
@@ -48,12 +48,12 @@ JabRef supports you in every step of your research work.
 
 - Native [BibTeX] and [Biblatex] support
 - Cite-as-you-write functionality for external applications such as Emacs, Kile, LyX, Texmaker, TeXstudio, Vim and WinEdt.
-- Format references in one of the many thousand built-in citation styles or create your own style
+- Format references in one of the many thousand built-in citation styles or create your style
 - Support for Word and LibreOffice/OpenOffice for inserting and formatting citations
 	
 #### Share
 
-- Many built-in export options or create your own export format
+- Many built-in export options or create your export format
 - Library is saved as a simple text file and thus it is easy to share with others via Dropbox and is version-control friendly
 - Work in a team: sync the contents of your library via a SQL database
 
@@ -91,7 +91,7 @@ An explanation of donation possibilities and usage of donations is available at 
 
 > Not a programmer? [Learn how to help.](http://contribute.jabref.org)
 
-Want to be part of a free and open-source project that tens of thousands scientist use every day? Check out the ways you can contribute, below:
+Want to be part of a free and open-source project that tens of thousands of scientists use every day? Check out the ways you can contribute, below:
 - For details on how to contribute, have a look at our [guidelines for contributing](CONTRIBUTING.md).
 - You are welcome to contribute new features. To get your code included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and create a [pull request](https://help.github.com/en/articles/about-pull-requests).
 - To work on existing JabRef issues, check out our [issue tracker](https://github.com/JabRef/jabref/issues). New to open source contributing? Look for issues with the ["good first issue"](https://github.com/JabRef/jabref/labels/good%20first%20issue) label to get started.


### PR DESCRIPTION
Grammar fixes
- your and own creates tautology
- preposition was missing in thousands scientist
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
