### PR TITLE
Remove unnecessary sort

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.importer.fetcher;
 
-import java.util.Comparator;
 import java.util.List;
 
 import javafx.beans.property.ListProperty;
@@ -18,7 +17,6 @@ import org.jabref.gui.importer.ImportEntriesDialog;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.SearchBasedFetcher;
-import org.jabref.logic.importer.WebFetcher;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -41,7 +41,6 @@ public class WebSearchPaneViewModel {
         this.dialogService = dialogService;
 
         List<SearchBasedFetcher> allFetchers = WebFetchers.getSearchBasedFetchers(importPreferences);
-        allFetchers.sort(Comparator.comparing(WebFetcher::getName));
         fetchers.setAll(allFetchers);
 
         // Choose last-selected fetcher as default

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -5,6 +5,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+
 import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
 import org.jabref.logic.importer.fetcher.ACS;
 import org.jabref.logic.importer.fetcher.ArXiv;
@@ -76,7 +80,10 @@ public class WebFetchers {
         return Optional.empty();
     }
 
-    public static List<SearchBasedFetcher> getSearchBasedFetchers(ImportFormatPreferences importFormatPreferences) {
+    /**
+     * @return sorted list containing search based fetchers
+     */
+    public static SortedList<SearchBasedFetcher> getSearchBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<SearchBasedFetcher> list = new ArrayList<>();
         list.add(new ArXiv(importFormatPreferences));
         list.add(new INSPIREFetcher(importFormatPreferences));
@@ -93,10 +100,14 @@ public class WebFetchers {
         list.add(new CiteSeer());
         list.add(new DOAJFetcher(importFormatPreferences));
         list.add(new IEEE(importFormatPreferences));
-        list.sort(Comparator.comparing(WebFetcher::getName));
-        return list;
+
+        ObservableList<SearchBasedFetcher> observableList = FXCollections.observableList(list);
+        return new SortedList<>(observableList, Comparator.comparing(WebFetcher::getName));
     }
 
+    /**
+     * @return sorted list containing id based fetchers
+     */
     public static List<IdBasedFetcher> getIdBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<IdBasedFetcher> list = new ArrayList<>();
         list.add(new ArXiv(importFormatPreferences));
@@ -111,10 +122,14 @@ public class WebFetchers {
         list.add(new LibraryOfCongress(importFormatPreferences));
         list.add(new IacrEprintFetcher(importFormatPreferences));
         list.add(new RfcFetcher(importFormatPreferences));
-        list.sort(Comparator.comparing(WebFetcher::getName));
-        return list;
+
+        ObservableList<IdBasedFetcher> observableList = FXCollections.observableList(list);
+        return new SortedList<>(observableList, Comparator.comparing(WebFetcher::getName));
     }
 
+    /**
+     * @return sorted list containing entry based fetchers
+     */
     public static List<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<EntryBasedFetcher> list = new ArrayList<>();
         list.add(new AstrophysicsDataSystem(importFormatPreferences));
@@ -122,18 +137,26 @@ public class WebFetchers {
         list.add(new IsbnFetcher(importFormatPreferences));
         list.add(new MathSciNet(importFormatPreferences));
         list.add(new CrossRef());
-        list.sort(Comparator.comparing(WebFetcher::getName));
-        return list;
+
+        ObservableList<EntryBasedFetcher> observableList = FXCollections.observableList(list);
+        return new SortedList<>(observableList, Comparator.comparing(WebFetcher::getName));
     }
 
-    public static List<IdFetcher> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
+    /**
+     * @return sorted list containing id fetchers
+     */
+    public static SortedList<IdFetcher> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<IdFetcher> list = new ArrayList<>();
         list.add(new CrossRef());
         list.add(new ArXiv(importFormatPreferences));
-        list.sort(Comparator.comparing(WebFetcher::getName));
-        return list;
+
+        ObservableList<IdFetcher> observableList = FXCollections.observableList(list);
+        return new SortedList<>(observableList, Comparator.comparing(WebFetcher::getName));
     }
 
+    /**
+     * @return unsorted list containing fulltext fetchers
+     */
     public static List<FulltextFetcher> getFullTextFetchers(ImportFormatPreferences importFormatPreferences) {
         List<FulltextFetcher> fetchers = new ArrayList<>();
         // Original

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -108,7 +108,7 @@ public class WebFetchers {
     /**
      * @return sorted list containing id based fetchers
      */
-    public static List<IdBasedFetcher> getIdBasedFetchers(ImportFormatPreferences importFormatPreferences) {
+    public static SortedList<IdBasedFetcher> getIdBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<IdBasedFetcher> list = new ArrayList<>();
         list.add(new ArXiv(importFormatPreferences));
         list.add(new AstrophysicsDataSystem(importFormatPreferences));
@@ -130,7 +130,7 @@ public class WebFetchers {
     /**
      * @return sorted list containing entry based fetchers
      */
-    public static List<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
+    public static SortedList<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<EntryBasedFetcher> list = new ArrayList<>();
         list.add(new AstrophysicsDataSystem(importFormatPreferences));
         list.add(new DoiFetcher(importFormatPreferences));


### PR DESCRIPTION
----
The list gets sorted in WebFetchers.getSearchBasedFetchers before 
Therefore its not necessary to sort it again.
- [x]  Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Manually tested changed features in running JabRef
