### PR TITLE
Amend the reference to JabRefReferences initialization

### DIFF
--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -40,7 +40,7 @@ public class Globals {
     public static final RemoteListenerServerLifecycle REMOTE_LISTENER = new RemoteListenerServerLifecycle();
     public static final ImportFormatReader IMPORT_FORMAT_READER = new ImportFormatReader();
     public static final TaskExecutor TASK_EXECUTOR = new DefaultTaskExecutor();
-    // In the main program, this field is initialized in JabRef.java
+    // In the main program, this field is initialized in JabRefMain.java
     // Each test case initializes this field if required
     public static JabRefPreferences prefs;
     /**


### PR DESCRIPTION
The former filename does not exist, the updated file being referred does contain the initialization of JabRefPreferences.
If the previous name is kept, new contributors could potentially be confused when looking for the file.

I do not think this change qualifies as *notable*, therefore I did not include it in the CHANGELOG.md, it is just a correction to a comment. No tests were created either.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
