### PR TITLE
Fix destination for jabref mozilla json

### DIFF
--- a/buildres/linux/postinst
+++ b/buildres/linux/postinst
@@ -19,8 +19,8 @@ set -e
 
 case "$1" in
     configure)
-        INSTALL_PATH="/usr/lib/mozilla/native-messaging-hosts/"
-        install -D -m0755 /opt/jabref/lib/org.jabref.jabref.json $INSTALL_PATH
+        INSTALL_PATH="/usr/lib/mozilla/native-messaging-hosts"
+        install -D -m0755 /opt/jabref/lib/org.jabref.jabref.json $INSTALL_PATH/org.jabref.jabref.json
         DESKTOP_COMMANDS_INSTALL
     ;;
 

--- a/buildres/linux/postrm
+++ b/buildres/linux/postrm
@@ -18,9 +18,9 @@ set -e
 # the debian-policy package
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    INSTALL_PATH="/usr/lib/mozilla/native-messaging-hosts"
-    if grep --quiet '"path": "/opt' $INSTALL_PATH/org.jabref.jabref.json; then
-        rm $INSTALL_PATH/org.jabref.jabref.json
+    NATIVE_MESSAGING_JSON="/usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json"
+    if [ -e $NATIVE_MESSAGING_JSON ] && grep --quiet '"path": "/opt' $NATIVE_MESSAGING_JSON; then
+        rm $NATIVE_MESSAGING_JSON
     fi
     ;;
 


### PR DESCRIPTION
Fixes #5502 
I'd keep the branch open, to enable test  builds of deb/rpm packages while we fix the last jpackage options.