### PR TITLE
snap: Add browser proxy for confined browser integration

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,29 +12,31 @@ license: MIT
 architectures:
   - build-on: amd64
 
+apps:
+  jabref:
+    command: bin/JabRef
+    extensions: [gnome-3-28]
+  browser-proxy:
+    command: lib/jabrefHost.py
+    extensions: [gnome-3-28]
+
+environment:
+  _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
 plugs:
+  desktop:
+  desktop-legacy:
+  wayland:
+  unity7:
+  home:
+  opengl:
+  network-bind:
+  removable-media:
   browser-extension:
     interface: system-files
     read:
       - /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts
     write:
       - /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json
-
-apps:
-  jabref:
-    command: bin/JabRef
-    extensions: [gnome-3-28]
-    environment:
-      _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
-    plugs:
-      - desktop
-      - desktop-legacy
-      - wayland
-      - unity7
-      - home
-      - opengl
-      - network-bind
-      - removable-media
 
 parts:
   jabref:
@@ -47,5 +49,5 @@ parts:
     override-build: |
       snapcraftctl build
       snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/JabRef.cfg | grep "app.version=" | cut -d'=' -f2)"
-      sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/jabref/current/lib/jabrefHost.py|g' $SNAPCRAFT_PART_INSTALL/lib/org.jabref.jabref.json
-      
+      sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/org.jabref.jabref.json
+      chmod +x $SNAPCRAFT_PART_INSTALL/lib/jabrefHost.py


### PR DESCRIPTION
Update the snap to keep the confinement enabled
when using the jabfox extension.