### PR TITLE
Fix metadata serialization order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed a few problems that prevented JabFox to communicate with JabRef. [#4737](https://github.com/JabRef/jabref/issues/4737) [#4303](https://github.com/JabRef/jabref/issues/4303)
 - We fixed an error where the groups containing an entry loose their highlight color when scrolling. [#5022](https://github.com/JabRef/jabref/issues/5022) 
 - We fixed an error where an exception was thrown when merging entries. [#5169](https://github.com/JabRef/jabref/issues/5169)
+- We fixed an error where certain metadata items were not serialized alphabetically. 
 - After assigning an entry to a group, the item count is now properly colored to reflect the new membership of the entry. [#3112](https://github.com/JabRef/jabref/issues/3112)
 - The group panel is now properly updated when switching between libraries (or when closing/opening one). [#3142](https://github.com/JabRef/jabref/issues/3142)
 - We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)

--- a/src/main/java/org/jabref/model/cleanup/FieldFormatterCleanups.java
+++ b/src/main/java/org/jabref/model/cleanup/FieldFormatterCleanups.java
@@ -2,11 +2,12 @@ package org.jabref.model.cleanup;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
@@ -91,7 +92,7 @@ public class FieldFormatterCleanups {
 
     private static String getMetaDataString(List<FieldFormatterCleanup> actionList, String newline) {
         //first, group all formatters by the field for which they apply
-        Map<Field, List<String>> groupedByField = new HashMap<>();
+        Map<Field, List<String>> groupedByField = new TreeMap<>(Comparator.comparing(Field::getName));
         for (FieldFormatterCleanup cleanup : actionList) {
             Field key = cleanup.getField();
 

--- a/src/main/java/org/jabref/model/entry/BibEntryTypesManager.java
+++ b/src/main/java/org/jabref/model/entry/BibEntryTypesManager.java
@@ -1,6 +1,7 @@
 package org.jabref.model.entry;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -10,6 +11,7 @@ import java.util.stream.Stream;
 
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.field.BibField;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
 import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
 import org.jabref.model.entry.types.BibtexEntryTypeDefinitions;
@@ -56,7 +58,12 @@ public class BibEntryTypesManager {
         builder.append(": req[");
         builder.append(FieldFactory.serializeOrFieldsList(entryType.getRequiredFields()));
         builder.append("] opt[");
-        builder.append(FieldFactory.serializeFieldsList(entryType.getOptionalFields().stream().map(BibField::getField).collect(Collectors.toSet())));
+        builder.append(FieldFactory.serializeFieldsList(
+                entryType.getOptionalFields()
+                         .stream()
+                         .map(BibField::getField)
+                         .sorted(Comparator.comparing(Field::getName))
+                         .collect(Collectors.toList())));
         builder.append("]");
         return builder.toString();
     }

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.Scanner;
 
 import org.jabref.logic.formatter.casechanger.LowerCaseFormatter;
+import org.jabref.logic.formatter.casechanger.TitleCaseFormatter;
+import org.jabref.logic.formatter.casechanger.UpperCaseFormatter;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.Importer;
 import org.jabref.logic.importer.ParserResult;
@@ -260,8 +262,17 @@ class BibtexDatabaseWriterTest {
         EntryType customizedType = new UnknownEntryType("customizedType");
         BibEntryType customizedBibType = new BibEntryType(
                 customizedType,
-                Arrays.asList(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT), new BibField(StandardField.YEAR, FieldPriority.IMPORTANT)),
-                Collections.singleton(new OrFields(StandardField.TITLE)));
+                Arrays.asList(
+                        new BibField(StandardField.TITLE, FieldPriority.IMPORTANT),
+                        new BibField(StandardField.AUTHOR, FieldPriority.IMPORTANT),
+                        new BibField(StandardField.DATE, FieldPriority.IMPORTANT),
+                        new BibField(StandardField.YEAR, FieldPriority.IMPORTANT),
+                        new BibField(StandardField.MONTH, FieldPriority.IMPORTANT),
+                        new BibField(StandardField.PUBLISHER, FieldPriority.IMPORTANT)),
+                Arrays.asList(
+                        new OrFields(StandardField.TITLE),
+                        new OrFields(StandardField.AUTHOR),
+                        new OrFields(StandardField.DATE)));
         entryTypesManager.addCustomizedEntryType(customizedBibType, BibDatabaseMode.BIBTEX);
         BibEntry entry = new BibEntry(customizedType);
         database.insertEntry(entry);
@@ -273,7 +284,7 @@ class BibtexDatabaseWriterTest {
                         "@Customizedtype{," + OS.NEWLINE + "}" + OS.NEWLINE + OS.NEWLINE
                         + "@Comment{jabref-meta: databaseType:bibtex;}"
                         + OS.NEWLINE + OS.NEWLINE
-                        + "@Comment{jabref-entrytype: customizedtype: req[title] opt[year]}" + OS.NEWLINE,
+                        + "@Comment{jabref-entrytype: customizedtype: req[author;date;title] opt[month;publisher;year]}" + OS.NEWLINE,
                 stringWriter.toString());
     }
 
@@ -433,13 +444,23 @@ class BibtexDatabaseWriterTest {
     @Test
     void writeSaveActions() throws Exception {
         FieldFormatterCleanups saveActions = new FieldFormatterCleanups(true,
-                Collections.singletonList(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())));
+                Arrays.asList(
+                        new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter()),
+                        new FieldFormatterCleanup(StandardField.JOURNAL, new TitleCaseFormatter()),
+                        new FieldFormatterCleanup(StandardField.DAY, new UpperCaseFormatter())));
         metaData.setSaveActions(saveActions);
 
         databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
 
-        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + OS.NEWLINE
-                + "title[lower_case]" + OS.NEWLINE + ";}" + OS.NEWLINE, stringWriter.toString());
+        assertEquals(
+                OS.NEWLINE +
+                        "@Comment{jabref-meta: saveActions:enabled;"
+                        + OS.NEWLINE
+                        + "day[upper_case]" + OS.NEWLINE
+                        + "journal[title_case]" + OS.NEWLINE
+                        + "title[lower_case]" + OS.NEWLINE
+                        + ";}"
+                        + OS.NEWLINE, stringWriter.toString());
     }
 
     @Test


### PR DESCRIPTION
The save actions and/or customized entry types were not serialized alphabetically. This lead to constant changes when used with version control systems.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
