### PR TITLE
Fix XMP null error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - After assigning an entry to a group, the item count is now properly colored to reflect the new membership of the entry. [#3112](https://github.com/JabRef/jabref/issues/3112)
 - The group panel is now properly updated when switching between libraries (or when closing/opening one). [#3142](https://github.com/JabRef/jabref/issues/3142)
 - We fixed an error where the number of matched entries shown in the group pane was not updated correctly. [#4441](https://github.com/JabRef/jabref/issues/4441)
+- We fixed a "null" error when writing XMP metadata. [#5449](https://github.com/JabRef/jabref/issues/5449)
 - We fixed an issue where empty keywords lead to a strange display of automatic keyword groups. [#5333](https://github.com/JabRef/jabref/issues/5333)
 - We fixed an error where the default color of a new group was white instead of dark gray. [#4868](https://github.com/JabRef/jabref/issues/4868)
 - We fixed an issue where the first field in the entry editor got the focus while performing a different action (like searching). [#5084](https://github.com/JabRef/jabref/issues/5084)

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -347,13 +347,11 @@ public class DublinCoreExtractor {
     public void fillDublinCoreSchema() {
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.isUseXMPPrivacyFilter();
-        // Fields for which not to write XMP data later on:
-        Set<Field> filters = new TreeSet<>(xmpPreferences.getXmpPrivacyFilter());
 
         Set<Entry<Field, String>> fieldValues = new TreeSet<>(Comparator.comparing(fieldStringEntry -> fieldStringEntry.getKey().getName()));
         fieldValues.addAll(bibEntry.getFieldMap().entrySet());
         for (Entry<Field, String> field : fieldValues) {
-            if (useXmpPrivacyFilter && filters.contains(field.getKey())) {
+            if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field.getKey())) {
                 continue;
             }
 

--- a/src/main/java/org/jabref/logic/xmp/XmpPreferences.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpPreferences.java
@@ -1,16 +1,16 @@
 package org.jabref.logic.xmp;
 
-import java.util.List;
+import java.util.Set;
 
 import org.jabref.model.entry.field.Field;
 
 public class XmpPreferences {
 
     private final boolean useXMPPrivacyFilter;
-    private final List<Field> xmpPrivacyFilter;
+    private final Set<Field> xmpPrivacyFilter;
     private final Character keywordSeparator;
 
-    public XmpPreferences(boolean useXMPPrivacyFilter, List<Field> xmpPrivacyFilter, Character keywordSeparator) {
+    public XmpPreferences(boolean useXMPPrivacyFilter, Set<Field> xmpPrivacyFilter, Character keywordSeparator) {
         this.useXMPPrivacyFilter = useXMPPrivacyFilter;
         this.xmpPrivacyFilter = xmpPrivacyFilter;
         this.keywordSeparator = keywordSeparator;
@@ -20,7 +20,7 @@ public class XmpPreferences {
         return useXMPPrivacyFilter;
     }
 
-    public List<Field> getXmpPrivacyFilter() {
+    public Set<Field> getXmpPrivacyFilter() {
         return xmpPrivacyFilter;
     }
 

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -249,40 +247,38 @@ public class XmpUtilWriter {
 
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.isUseXMPPrivacyFilter();
-        // Fields for which not to write XMP data later on:
-        Set<Field> filters = new TreeSet<>(xmpPreferences.getXmpPrivacyFilter());
 
         // Set all the values including key and entryType
-        for (Entry<Field, String> field : resolvedEntry.getFieldMap().entrySet()) {
-            Field fieldName = field.getKey();
-            String fieldContent = field.getValue();
+        for (Entry<Field, String> fieldValuePair : resolvedEntry.getFieldMap().entrySet()) {
+            Field field = fieldValuePair.getKey();
+            String fieldContent = fieldValuePair.getValue();
 
-            if (useXmpPrivacyFilter && filters.contains(fieldName)) {
+            if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {
                 // erase field instead of adding it
-                if (StandardField.AUTHOR.equals(fieldName)) {
+                if (StandardField.AUTHOR.equals(field)) {
                     di.setAuthor(null);
-                } else if (StandardField.TITLE.equals(fieldName)) {
+                } else if (StandardField.TITLE.equals(field)) {
                     di.setTitle(null);
-                } else if (StandardField.KEYWORDS.equals(fieldName)) {
+                } else if (StandardField.KEYWORDS.equals(field)) {
                     di.setKeywords(null);
-                } else if (StandardField.ABSTRACT.equals(fieldName)) {
+                } else if (StandardField.ABSTRACT.equals(field)) {
                     di.setSubject(null);
                 } else {
-                    di.setCustomMetadataValue("bibtex/" + fieldName, null);
+                    di.setCustomMetadataValue("bibtex/" + field, null);
                 }
                 continue;
             }
 
-            if (StandardField.AUTHOR.equals(fieldName)) {
+            if (StandardField.AUTHOR.equals(field)) {
                 di.setAuthor(fieldContent);
-            } else if (StandardField.TITLE.equals(fieldName)) {
+            } else if (StandardField.TITLE.equals(field)) {
                 di.setTitle(fieldContent);
-            } else if (StandardField.KEYWORDS.equals(fieldName)) {
+            } else if (StandardField.KEYWORDS.equals(field)) {
                 di.setKeywords(fieldContent);
-            } else if (StandardField.ABSTRACT.equals(fieldName)) {
+            } else if (StandardField.ABSTRACT.equals(field)) {
                 di.setSubject(fieldContent);
             } else {
-                di.setCustomMetadataValue("bibtex/" + fieldName, fieldContent);
+                di.setCustomMetadataValue("bibtex/" + field, fieldContent);
             }
         }
         di.setCustomMetadataValue("bibtex/entrytype", resolvedEntry.getType().getDisplayName());

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1535,7 +1535,7 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public XmpPreferences getXMPPreferences() {
-        return new XmpPreferences(getBoolean(USE_XMP_PRIVACY_FILTER), getStringList(XMP_PRIVACY_FILTERS).stream().map(FieldFactory::parseField).collect(Collectors.toList()),
+        return new XmpPreferences(getBoolean(USE_XMP_PRIVACY_FILTER), getStringList(XMP_PRIVACY_FILTERS).stream().map(FieldFactory::parseField).collect(Collectors.toSet()),
                                   getKeywordDelimiter());
     }
 

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -184,7 +184,7 @@ public class XmpExporterTest {
 
     @Test
     public void exportSingleEntryWithPrivacyFilter(@TempDir Path testFolder) throws Exception {
-        when(xmpPreferences.getXmpPrivacyFilter()).thenReturn(Collections.singletonList(StandardField.AUTHOR));
+        when(xmpPreferences.getXmpPrivacyFilter()).thenReturn(Collections.singleton(StandardField.AUTHOR));
         when(xmpPreferences.isUseXMPPrivacyFilter()).thenReturn(true);
 
         Path file = testFolder.resolve("ThisIsARandomlyNamedFile");


### PR DESCRIPTION
Fixes #5449. Was caused by wrapping a set of fields in a treeset without specifying the comparator.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
