### PR TITLE
Fix text colour in Merge dialogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - After successful import of one or multiple bib entries the main table scrolls to the first imported entry [#5383](https://github.com/JabRef/jabref/issues/5383)
 - We fixed an exception which occurred when an invalid jstyle was loaded. [#5452](https://github.com/JabRef/jabref/issues/5452)
 - We fixed an error where the preview theme did not adapt to the "Dark" mode [#5463](https://github.com/JabRef/jabref/issues/5463)
+- We fixed an issue where the merge dialogue showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - After successful import of one or multiple bib entries the main table scrolls to the first imported entry [#5383](https://github.com/JabRef/jabref/issues/5383)
 - We fixed an exception which occurred when an invalid jstyle was loaded. [#5452](https://github.com/JabRef/jabref/issues/5452)
 - We fixed an error where the preview theme did not adapt to the "Dark" mode [#5463](https://github.com/JabRef/jabref/issues/5463)
-- We fixed an issue where the merge dialogue showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
+- We fixed an issue where the merge dialog showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -55,3 +55,7 @@
     background-color: #272b38; /* -fx-control-inner-background*/
     color : #7d8591; /* -fx-mid-text-color*/
 }
+
+.text-unchanged {
+    -fx-fill: -fx-light-text-color;
+}

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -59,3 +59,8 @@
 .text-unchanged {
     -fx-fill: -fx-light-text-color;
 }
+
+.radio-button > .radio {
+    -fx-background-color: -fx-light-text-color, -fx-control-inner-background;
+}
+

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
@@ -3,7 +3,7 @@
 }
 
 .text-unchanged {
-
+    -fx-fill: -fx-light-text-color;
 }
 
 .text-added {

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
@@ -2,10 +2,6 @@
     -fx-fill: darkgreen;
 }
 
-.text-unchanged {
-    -fx-fill: -fx-light-text-color;
-}
-
 .text-added {
     -fx-fill: blue;
 }
@@ -13,3 +9,4 @@
 .text-removed {
     -fx-fill: red;
 }
+


### PR DESCRIPTION
fixes: #5516

The colour of the textfields in the Merge dialogue was set to black, I set that to `-fx-light-text-color` (#9aa3af) in MergeEntries.css

No need for documentation update.

Tested manually on local environment.
Open to suggestion for test cases. 😄 

PS: Forgive me if I missed something, this is my first PR to a relatively large project ✨ 



<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

Changes:
<img width="843" alt="Screenshot 2019-10-26 at 10 36 00" src="https://user-images.githubusercontent.com/17515408/67618546-cde01980-f7e8-11e9-8f51-f304d822f3df.png">
