### PR TITLE
Remove empty customization warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where it was no longer possible to connect to LibreOffice. [#5261](https://github.com/JabRef/jabref/issues/5261)
 - The "All entries group" is no longer shown when no library is open.
 - We fixed an exception which occurred when closing JabRef. [#5348](https://github.com/JabRef/jabref/issues/5348)
+- We fixed an issue where JabRef reports incorrectly about customized entry types. [#5332](https://github.com/JabRef/jabref/issues/5332) 
 - We fixed a few problems that prevented JabFox to communicate with JabRef. [#4737](https://github.com/JabRef/jabref/issues/4737) [#4303](https://github.com/JabRef/jabref/issues/4303)
 - We fixed an error where the groups containing an entry loose their highlight color when scrolling. [#5022](https://github.com/JabRef/jabref/issues/5022) 
 - We fixed an error where scrollbars were not shown. [#5374](https://github.com/JabRef/jabref/issues/5374)

--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -85,13 +85,13 @@ public class JabRefMain extends Application {
             Platform.exit();
         }
     }
-  
+
     @Override
     public void stop() {
         Globals.stopBackgroundTasks();
         Globals.shutdownThreadPools();
     }
-  
+
     /**
      * Tests if we are running an acceptable Java and terminates JabRef when we are sure the version is not supported.
      * This test uses the requirements for the Java version as specified in <code>gradle.build</code>. It is possible to
@@ -166,7 +166,7 @@ public class JabRefMain extends Application {
         // Build list of Import and Export formats
         Globals.IMPORT_FORMAT_READER.resetImportFormats(Globals.prefs.getImportFormatPreferences(),
                                                         Globals.prefs.getXMPPreferences(), Globals.getFileUpdateMonitor());
-        Globals.entryTypesManager.addCustomizedEntryTypes(preferences.loadBibEntryTypes(BibDatabaseMode.BIBTEX),
+        Globals.entryTypesManager.addCustomOrModifiedTypes(preferences.loadBibEntryTypes(BibDatabaseMode.BIBTEX),
                 preferences.loadBibEntryTypes(BibDatabaseMode.BIBLATEX));
         Globals.exportFactory = Globals.prefs.getExporterFactory(Globals.journalAbbreviationLoader);
 

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -458,7 +458,7 @@ public class ArgumentProcessor {
     private void importPreferences() {
         try {
             Globals.prefs.importPreferences(cli.getPreferencesImport());
-            Globals.entryTypesManager.addCustomizedEntryTypes(Globals.prefs.loadBibEntryTypes(BibDatabaseMode.BIBTEX),
+            Globals.entryTypesManager.addCustomOrModifiedTypes(Globals.prefs.loadBibEntryTypes(BibDatabaseMode.BIBTEX),
                     Globals.prefs.loadBibEntryTypes(BibDatabaseMode.BIBLATEX));
             List<TemplateExporter> customExporters = Globals.prefs.getCustomExportFormats(Globals.journalAbbreviationLoader);
             LayoutFormatterPreferences layoutPreferences = Globals.prefs

--- a/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.fxml
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.fxml
@@ -9,7 +9,7 @@
             xmlns="http://javafx.com/javafx/8.0.171"
             fx:controller="org.jabref.gui.importer.ImportCustomEntryTypesDialog">
    <content>
-      <VBox minHeight="-Infinity" prefHeight="113.0" prefWidth="571.0" spacing="1.0">
+       <VBox spacing="1.0">
          <children>
             <Label text="%Custom entry types found in file" />
             <Label text="%Select all customized types to be stored in local preferences:" />

--- a/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.java
@@ -45,13 +45,13 @@ public class ImportCustomEntryTypesDialog extends BaseDialog<Void> {
         });
 
         setTitle(Localization.lang("Custom entry types"));
-
     }
 
     @FXML
     public void initialize() {
         viewModel = new ImportCustomEntryTypesDialogViewModel(mode, customEntryTypes, preferencesService);
 
+        boxDifferentCustomization.visibleProperty().bind(Bindings.isNotEmpty(viewModel.differentCustomizations()));
         boxDifferentCustomization.managedProperty().bind(Bindings.isNotEmpty(viewModel.differentCustomizations()));
         unknownEntryTypesCheckList.setItems(viewModel.newTypes());
         differentCustomizationCheckList.setItems(viewModel.differentCustomizations());

--- a/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialogViewModel.java
@@ -26,7 +26,7 @@ public class ImportCustomEntryTypesDialogViewModel {
 
         for (BibEntryType customType : entryTypes) {
             Optional<BibEntryType> currentlyStoredType = Globals.entryTypesManager.enrich(customType.getType(), mode);
-            if (!currentlyStoredType.isPresent()) {
+            if (currentlyStoredType.isEmpty()) {
                 newTypes.add(customType);
             } else {
                 if (!EntryTypeFactory.isEqualNameAndFieldBased(customType, currentlyStoredType.get())) {
@@ -47,11 +47,11 @@ public class ImportCustomEntryTypesDialogViewModel {
 
     public void importBibEntryTypes(List<BibEntryType> checkedUnknownEntryTypes, List<BibEntryType> checkedDifferentEntryTypes) {
         if (!checkedUnknownEntryTypes.isEmpty()) {
-            checkedUnknownEntryTypes.forEach(type -> Globals.entryTypesManager.addCustomizedEntryType(type, mode));
+            checkedUnknownEntryTypes.forEach(type -> Globals.entryTypesManager.addCustomOrModifiedType(type, mode));
             preferencesService.saveCustomEntryTypes();
         }
         if (!checkedDifferentEntryTypes.isEmpty()) {
-            checkedUnknownEntryTypes.forEach(type -> Globals.entryTypesManager.addCustomizedEntryType(type, mode));
+            checkedUnknownEntryTypes.forEach(type -> Globals.entryTypesManager.addCustomOrModifiedType(type, mode));
             preferencesService.saveCustomEntryTypes();
         }
 

--- a/src/main/java/org/jabref/gui/importer/actions/CheckForNewEntryTypesAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/CheckForNewEntryTypesAction.java
@@ -27,7 +27,6 @@ public class CheckForNewEntryTypesAction implements GUIPostOpenAction {
 
         ImportCustomEntryTypesDialog importBibEntryTypesDialog = new ImportCustomEntryTypesDialog(mode, getListOfUnknownAndUnequalCustomizations(parserResult));
         importBibEntryTypesDialog.showAndWait();
-
     }
 
     private List<BibEntryType> getListOfUnknownAndUnequalCustomizations(ParserResult parserResult) {
@@ -35,7 +34,7 @@ public class CheckForNewEntryTypesAction implements GUIPostOpenAction {
 
         return parserResult.getEntryTypes()
                            .stream()
-                           .filter(type -> Globals.entryTypesManager.isCustomizedType(type, mode))
+                           .filter(type -> Globals.entryTypesManager.isDifferentCustomOrModifiedType(type, mode))
                            .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/jabref/migrations/CustomEntryTypePreferenceMigration.java
+++ b/src/main/java/org/jabref/migrations/CustomEntryTypePreferenceMigration.java
@@ -32,7 +32,7 @@ class CustomEntryTypePreferenceMigration {
         int number = 0;
         Optional<BibEntryType> type;
         while ((type = getBibEntryType(number)).isPresent()) {
-            Globals.entryTypesManager.addCustomizedEntryType(type.get(), defaultBibDatabaseMode);
+            Globals.entryTypesManager.addCustomOrModifiedType(type.get(), defaultBibDatabaseMode);
             storedOldTypes.add(type.get());
             number++;
         }

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -273,7 +273,7 @@ class BibtexDatabaseWriterTest {
                         new OrFields(StandardField.TITLE),
                         new OrFields(StandardField.AUTHOR),
                         new OrFields(StandardField.DATE)));
-        entryTypesManager.addCustomizedEntryType(customizedBibType, BibDatabaseMode.BIBTEX);
+        entryTypesManager.addCustomOrModifiedType(customizedBibType, BibDatabaseMode.BIBTEX);
         BibEntry entry = new BibEntry(customizedType);
         database.insertEntry(entry);
 

--- a/src/test/java/org/jabref/model/entry/BibEntryTypesManagerTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTypesManagerTest.java
@@ -1,4 +1,4 @@
-package org.jabref.model;
+package org.jabref.model.entry;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -6,8 +6,6 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import org.jabref.model.database.BibDatabaseMode;
-import org.jabref.model.entry.BibEntryType;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.BibField;
 import org.jabref.model.entry.field.FieldPriority;
 import org.jabref.model.entry.field.StandardField;
@@ -25,8 +23,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class BibEntryTypeFactoryTest {
+class BibEntryTypesManagerTest {
 
     private static final EntryType UNKNOWN_TYPE = new UnknownEntryType("unknownType");
     private static final EntryType CUSTOM_TYPE = new UnknownEntryType("customType");
@@ -49,6 +48,13 @@ class BibEntryTypeFactoryTest {
                 Collections.singleton(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT)),
                 Collections.emptySet());
         entryTypesManager = new BibEntryTypesManager();
+    }
+
+    @ParameterizedTest
+    @MethodSource("mode")
+    void isCustomOrModifiedTypeReturnsTrueForModifiedStandardEntryType(BibDatabaseMode mode) {
+        entryTypesManager.addCustomOrModifiedType(overwrittenStandardType, mode);
+        assertTrue(entryTypesManager.isCustomOrModifiedType(overwrittenStandardType, mode));
     }
 
     @Test
@@ -75,53 +81,53 @@ class BibEntryTypeFactoryTest {
     @ParameterizedTest
     @MethodSource("mode")
     void newCustomEntryTypeFound(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(newCustomType, mode);
+        entryTypesManager.addCustomOrModifiedType(newCustomType, mode);
         assertEquals(Optional.of(newCustomType), entryTypesManager.enrich(CUSTOM_TYPE, mode));
     }
 
     @ParameterizedTest
     @MethodSource("mode")
     void registeredBibEntryTypeIsContainedInListOfCustomizedEntryTypes(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(newCustomType, mode);
+        entryTypesManager.addCustomOrModifiedType(newCustomType, mode);
         assertEquals(Collections.singletonList(newCustomType), entryTypesManager.getAllCustomTypes(mode));
     }
 
     @Test
     void registerBibEntryTypeDoesNotAffectOtherMode() {
-        entryTypesManager.addCustomizedEntryType(newCustomType, BibDatabaseMode.BIBTEX);
+        entryTypesManager.addCustomOrModifiedType(newCustomType, BibDatabaseMode.BIBTEX);
         assertFalse(entryTypesManager.getAllTypes(BibDatabaseMode.BIBLATEX).contains(newCustomType));
     }
 
     @ParameterizedTest
     @MethodSource("mode")
     void overwriteBibEntryTypeFields(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(newCustomType, mode);
+        entryTypesManager.addCustomOrModifiedType(newCustomType, mode);
         BibEntryType newBibEntryTypeTitle = new BibEntryType(
                 CUSTOM_TYPE,
                 Collections.singleton(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT)),
                 Collections.emptySet());
-        entryTypesManager.addCustomizedEntryType(newBibEntryTypeTitle, mode);
+        entryTypesManager.addCustomOrModifiedType(newBibEntryTypeTitle, mode);
         assertEquals(Optional.of(newBibEntryTypeTitle), entryTypesManager.enrich(CUSTOM_TYPE, mode));
     }
 
     @ParameterizedTest
     @MethodSource("mode")
     void overwriteStandardTypeRequiredFields(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(overwrittenStandardType, mode);
+        entryTypesManager.addCustomOrModifiedType(overwrittenStandardType, mode);
         assertEquals(Optional.of(overwrittenStandardType), entryTypesManager.enrich(overwrittenStandardType.getType(), mode));
     }
 
     @ParameterizedTest
     @MethodSource("mode")
     void registeredCustomizedStandardEntryTypeIsNotContainedInListOfCustomEntryTypes(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(overwrittenStandardType, mode);
+        entryTypesManager.addCustomOrModifiedType(overwrittenStandardType, mode);
         assertEquals(Collections.emptyList(), entryTypesManager.getAllCustomTypes(mode));
     }
 
     @ParameterizedTest
     @MethodSource("mode")
     void standardTypeIsStillAccessibleIfOverwritten(BibDatabaseMode mode) {
-        entryTypesManager.addCustomizedEntryType(overwrittenStandardType, mode);
+        entryTypesManager.addCustomOrModifiedType(overwrittenStandardType, mode);
         assertFalse(entryTypesManager.isCustomType(overwrittenStandardType.getType(), mode));
     }
 }


### PR DESCRIPTION
Fixes #5332. Problem was that the dialog was shown whenever the library contained customized entry types, even if the customizations were equal to the customization stored in the global preferences. A bit of refactoring/renaming along the way.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
