### PR TITLE
Add ADR-007: Provide a human-readable changelog

### DIFF
--- a/docs/adr/0007-human-readable-changelog.md
+++ b/docs/adr/0007-human-readable-changelog.md
@@ -1,0 +1,22 @@
+# Provide a human-readable changelog
+
+## Context and Problem Statement
+
+Changes of a release have to be communicated.
+How and which stile to use?
+
+## Considered Options
+
+* Keep-a-changelog format with freedom in the bullet points
+* Keep-a-changelog format and fixed terms
+
+## Decision Outcome
+
+Chosen option: "Keep-a-changelog format with freedom in the bullet points", because
+
+- [Keep-a-changelog](https://keepachangelog.com/) structures the changelog
+- Each entry can be structured to be understandable
+- Forcing to prefix each line with `We fixed`, `We changed`, ... seems to be read strange.
+  We nevertheless try to follow that style.
+
+Further discussion can be found at [#2277](https://github.com/JabRef/jabref/issues/2277).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ This log lists the architectural decisions for JabRef.
 - [ADR-0004](0004-use-mariadb-connector.md) - Use MariaDB Connector
 - [ADR-0005](0005-fully-support-utf8-only-for-latex-files.md) - Fully Support UTF-8 Only For LaTeX Files
 - [ADR-0006](0006-only-translated-strings-in-language-file.md) - Only translated strings in language file
+- [ADR-0007](0007-human-readable-changelog.md) - Provide a human-readable changelog
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
I read the CHANGELOG and wondered, why we did not always prefix each line with `We`. I found https://github.com/JabRef/jabref/issues/2277 - and thought, I should write it down.

I am not fully satisfied; however: better than nothing.