### PR TITLE
Add tests for month issue and strings (and some minor code impr…

### DIFF
--- a/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
@@ -473,7 +473,10 @@ public abstract class DBMSProcessor {
                     lastId = selectEntryResultSet.getInt("SHARED_ID");
                 }
 
-                bibEntry.setField(FieldFactory.parseField(selectEntryResultSet.getString("NAME")), Optional.ofNullable(selectEntryResultSet.getString("VALUE")), EntryEventSource.SHARED);
+                String value = selectEntryResultSet.getString("VALUE");
+                if (value != null) {
+                    bibEntry.setField(FieldFactory.parseField(selectEntryResultSet.getString("NAME")), value, EntryEventSource.SHARED);
+                }
             }
         } catch (SQLException e) {
             LOGGER.error("SQL Error", e);

--- a/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
@@ -40,8 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Synchronizes the shared or local databases with their opposite side.
- * Local changes are pushed by {@link EntryEvent} using Google's Guava EventBus.
+ * Synchronizes the shared or local databases with their opposite side. Local changes are pushed by {@link EntryEvent}
+ * using Google's Guava EventBus.
  */
 public class DBMSSynchronizer implements DatabaseSynchronizer {
 
@@ -134,11 +134,10 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
     }
 
     /**
-     * Sets the table structure of shared database if needed and pulls all shared entries
-     * to the new local database.
+     * Sets the table structure of shared database if needed and pulls all shared entries to the new local database.
      *
-     * @throws DatabaseNotSupportedException if the version of shared database does not match
-     *          the version of current shared database support ({@link DBMSProcessor}).
+     * @throws DatabaseNotSupportedException if the version of shared database does not match the version of current
+     *                                       shared database support ({@link DBMSProcessor}).
      */
     public void initializeDatabases() throws DatabaseNotSupportedException {
         try {
@@ -162,8 +161,8 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
     }
 
     /**
-     * Synchronizes the local database with shared one.
-     * Possible update types are removal, update or insert of a {@link BibEntry}.
+     * Synchronizes the local database with shared one. Possible update types are removal, update or insert of a {@link
+     * BibEntry}.
      */
     @Override
     public void synchronizeLocalDatabase() {
@@ -219,7 +218,7 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
      * Removes all local entries which are not present on shared database.
      *
      * @param localEntries List of {@link BibEntry} the entries should be removed from
-     * @param sharedIDs Set of all IDs which are present on shared database
+     * @param sharedIDs    Set of all IDs which are present on shared database
      */
     private void removeNotSharedEntries(List<BibEntry> localEntries, Set<Integer> sharedIDs) {
         for (int i = 0; i < localEntries.size(); i++) {
@@ -324,8 +323,8 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
     }
 
     /**
-     * Checks whether the current SQL connection is valid.
-     * In case that the connection is not valid a new {@link ConnectionLostEvent} is going to be sent.
+     * Checks whether the current SQL connection is valid. In case that the connection is not valid a new {@link
+     * ConnectionLostEvent} is going to be sent.
      *
      * @return <code>true</code> if the connection is valid, else <code>false</code>.
      */
@@ -336,7 +335,6 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
                 eventBus.post(new ConnectionLostEvent(bibDatabaseContext));
             }
             return isValid;
-
         } catch (SQLException e) {
             LOGGER.error("SQL Error:", e);
             return false;
@@ -347,7 +345,8 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
      * Checks whether the {@link EntryEventSource} of an {@link EntryEvent} is crucial for this class.
      *
      * @param event An {@link EntryEvent}
-     * @return <code>true</code> if the event is able to trigger operations in {@link DBMSSynchronizer}, else <code>false</code>
+     * @return <code>true</code> if the event is able to trigger operations in {@link DBMSSynchronizer}, else
+     * <code>false</code>
      */
     public boolean isEventSourceAccepted(EntryEvent event) {
         EntryEventSource eventSource = event.getEntryEventSource();

--- a/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
@@ -192,7 +192,10 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
                             localEntry.getSharedBibEntryData()
                                       .setVersion(sharedEntry.get().getSharedBibEntryData().getVersion());
                             for (Field field : sharedEntry.get().getFields()) {
-                                localEntry.setField(field, sharedEntry.get().getField(field), EntryEventSource.SHARED);
+                                Optional<String> sharedFieldValue = sharedEntry.get().getField(field);
+                                if (sharedFieldValue.isPresent()) {
+                                    localEntry.setField(field, sharedFieldValue.get(), EntryEventSource.SHARED);
+                                }
                             }
 
                             Set<Field> redundantLocalEntryFields = localEntry.getFields();

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -42,6 +42,11 @@ import com.google.common.eventbus.EventBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Represents a BibTex / BibLaTeX entry.
+ *
+ * In case you search for a builder as described in Item 2 of the book "Effective Java", you won't find one. Please use the methods {@link #withCiteKey(String)} and {@link #withField(Field, String)}.
+ */
 public class BibEntry implements Cloneable {
 
     public static final EntryType DEFAULT_TYPE = StandardEntryType.Misc;
@@ -72,41 +77,10 @@ public class BibEntry implements Cloneable {
     private boolean changed;
 
     /**
-     * A simple builder to enable quick creation of BibEntry instances.
-     *
-     * Builder pattern as described in Item 2 of the book "Effective Java".
-     */
-    public static class Builder {
-
-        private BibEntry bibEntry;
-
-        public Builder(EntryType type) {
-            Objects.requireNonNull(type);
-            bibEntry = new BibEntry(type);
-        }
-
-        public Builder citeKey(String citeKey) {
-            bibEntry.setCiteKey(citeKey);
-            return this;
-        }
-
-        public Builder field(Field field, String value) {
-            bibEntry.setField(field, value);
-            return this;
-        }
-
-        public BibEntry build() {
-            return bibEntry;
-        }
-
-    }
-
-    /**
      * Constructs a new BibEntry. The internal ID is set to IdGenerator.next()
      */
     public BibEntry() {
         this(IdGenerator.next(), DEFAULT_TYPE);
-
     }
 
     /**

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -63,12 +63,43 @@ public class BibEntry implements Cloneable {
     private ObservableMap<Field, String> fields = FXCollections.observableMap(new ConcurrentHashMap<>());
     private String parsedSerialization = "";
     private String commentsBeforeEntry = "";
+
     /**
      * Marks whether the complete serialization, which was read from file, should be used.
      *
      * Is set to false, if parts of the entry change. This causes the entry to be serialized based on the internal state (and not based on the old serialization)
      */
     private boolean changed;
+
+    /**
+     * A simple builder to enable quick creation of BibEntry instances.
+     *
+     * Builder pattern as described in Item 2 of the book "Effective Java".
+     */
+    public static class Builder {
+
+        private BibEntry bibEntry;
+
+        public Builder(EntryType type) {
+            Objects.requireNonNull(type);
+            bibEntry = new BibEntry(type);
+        }
+
+        public Builder citeKey(String citeKey) {
+            bibEntry.setCiteKey(citeKey);
+            return this;
+        }
+
+        public Builder field(Field field, String value) {
+            bibEntry.setField(field, value);
+            return this;
+        }
+
+        public BibEntry build() {
+            return bibEntry;
+        }
+
+    }
 
     /**
      * Constructs a new BibEntry. The internal ID is set to IdGenerator.next()
@@ -266,8 +297,9 @@ public class BibEntry implements Cloneable {
     }
 
     /**
-     * Sets this entry's ID, provided the database containing it
-     * doesn't veto the change.
+     * Sets this entry's identifier (ID). It is used internally  to distinguish different BibTeX entries. It is <emph>not</emph> the BibTeX key. The BibTexKey is the {@link InternalField.KEY_FIELD}.
+     *
+     * The entry is also updated in the shared database - provided the database containing it doesn't veto the change.
      *
      * @param id The ID to be used
      */
@@ -521,13 +553,6 @@ public class BibEntry implements Cloneable {
             eventBus.post(new FieldChangedEvent(change, eventSource));
         }
         return Optional.of(change);
-    }
-
-    public Optional<FieldChange> setField(Field field, Optional<String> value, EntryEventSource eventSource) {
-        if (value.isPresent()) {
-            return setField(field, value.get(), eventSource);
-        }
-        return Optional.empty();
     }
 
     /**

--- a/src/main/java/org/jabref/model/entry/field/InternalField.java
+++ b/src/main/java/org/jabref/model/entry/field/InternalField.java
@@ -10,16 +10,17 @@ import java.util.Set;
  * JabRef internal fields
  */
 public enum InternalField implements Field {
-    INTERNAL_ALL_FIELD("all"),
-    INTERNAL_ALL_TEXT_FIELDS_FIELD("all-text-fields"),
-    MARKED_INTERNAL("__markedentry"),
+    MARKED_INTERNAL("__markedentry"), // used in old versions of JabRef. Currently used for conversion only
     OWNER("owner"),
     TIMESTAMP("timestamp", FieldProperty.DATE),
     GROUPS("groups"),
     KEY_FIELD("bibtexkey"),
     TYPE_HEADER("entrytype"),
     OBSOLETE_TYPE_HEADER("bibtextype"),
-    BIBTEX_STRING("__string"),
+    // all field names starting with "Jabref-internal-" are not appearing in .bib files
+    BIBTEX_STRING("JabRef-internal-bibtex-string"), // marker that the content is just a BibTeX string
+    INTERNAL_ALL_FIELD("JabRef-internal-all"), // virtual field to denote "all fields"
+    INTERNAL_ALL_TEXT_FIELDS_FIELD("JabRef-internal-all-text-fields"), // virtual field to denote "all text fields"
     INTERNAL_ID_FIELD("JabRef-internal-id");
 
     private final String name;

--- a/src/main/java/org/jabref/model/entry/field/InternalField.java
+++ b/src/main/java/org/jabref/model/entry/field/InternalField.java
@@ -10,17 +10,17 @@ import java.util.Set;
  * JabRef internal fields
  */
 public enum InternalField implements Field {
-    MARKED_INTERNAL("__markedentry"), // used in old versions of JabRef. Currently used for conversion only
     OWNER("owner"),
     TIMESTAMP("timestamp", FieldProperty.DATE),
     GROUPS("groups"),
     KEY_FIELD("bibtexkey"),
     TYPE_HEADER("entrytype"),
     OBSOLETE_TYPE_HEADER("bibtextype"),
+    MARKED_INTERNAL("__markedentry"), // used in old versions of JabRef. Currently used for conversion only
     // all field names starting with "Jabref-internal-" are not appearing in .bib files
-    BIBTEX_STRING("JabRef-internal-bibtex-string"), // marker that the content is just a BibTeX string
-    INTERNAL_ALL_FIELD("JabRef-internal-all"), // virtual field to denote "all fields"
-    INTERNAL_ALL_TEXT_FIELDS_FIELD("JabRef-internal-all-text-fields"), // virtual field to denote "all text fields"
+    BIBTEX_STRING("__string"), // marker that the content is just a BibTeX string
+    INTERNAL_ALL_FIELD("all"), // virtual field to denote "all fields". Used in the meta data serialiization for save actions.
+    INTERNAL_ALL_TEXT_FIELDS_FIELD("all-text-fields"), // virtual field to denote "all text fields". Used in the meta data serialiization for save actions.
     INTERNAL_ID_FIELD("JabRef-internal-id");
 
     private final String name;

--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -108,30 +108,30 @@ class BibEntryWriterTest {
 
     @Test
     void writeEntryWithOrField() throws Exception {
-            StringWriter stringWriter = new StringWriter();
+        StringWriter stringWriter = new StringWriter();
 
-            BibEntry entry = new BibEntry(StandardEntryType.InBook);
-            //set an required OR field (author/editor)
-            entry.setField(StandardField.EDITOR, "Foo Bar");
-            entry.setField(StandardField.JOURNAL, "International Journal of Something");
-            //set an optional field
-            entry.setField(StandardField.NUMBER, "1");
-            entry.setField(StandardField.NOTE, "some note");
+        BibEntry entry = new BibEntry(StandardEntryType.InBook);
+        //set an required OR field (author/editor)
+        entry.setField(StandardField.EDITOR, "Foo Bar");
+        entry.setField(StandardField.JOURNAL, "International Journal of Something");
+        //set an optional field
+        entry.setField(StandardField.NUMBER, "1");
+        entry.setField(StandardField.NOTE, "some note");
 
-            writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
 
-            String actual = stringWriter.toString();
+        String actual = stringWriter.toString();
 
-            // @formatter:off
-            String expected = OS.NEWLINE + "@InBook{," + OS.NEWLINE +
-                    "  editor  = {Foo Bar}," + OS.NEWLINE +
-                    "  note    = {some note}," + OS.NEWLINE +
-                    "  number  = {1}," + OS.NEWLINE +
-                    "  journal = {International Journal of Something}," + OS.NEWLINE +
-                    "}" + OS.NEWLINE;
-            // @formatter:on
+        // @formatter:off
+        String expected = OS.NEWLINE + "@InBook{," + OS.NEWLINE +
+                "  editor  = {Foo Bar}," + OS.NEWLINE +
+                "  note    = {some note}," + OS.NEWLINE +
+                "  number  = {1}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
+        // @formatter:on
 
-            assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -435,10 +435,10 @@ class BibEntryWriterTest {
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
 
         assertEquals(OS.NEWLINE +
-                "@Misc{," + OS.NEWLINE +
-                "  month = apr," + OS.NEWLINE +
-                "}" + OS.NEWLINE + OS.NEWLINE +
-                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+                        "@Misc{," + OS.NEWLINE +
+                        "  month = apr," + OS.NEWLINE +
+                        "}" + OS.NEWLINE,
+                stringWriter.toString());
     }
 
     @Test
@@ -450,10 +450,10 @@ class BibEntryWriterTest {
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
 
         assertEquals(OS.NEWLINE +
-                "@Misc{," + OS.NEWLINE +
-                "  month = {apr}," + OS.NEWLINE +
-                "}" + OS.NEWLINE + OS.NEWLINE +
-                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+                        "@Misc{," + OS.NEWLINE +
+                        "  month = {apr}," + OS.NEWLINE +
+                        "}" + OS.NEWLINE,
+                stringWriter.toString());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -427,6 +427,36 @@ class BibEntryWriterTest {
     }
 
     @Test
+    void constantMonthApril() throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.MONTH, "#apr#");
+
+        StringWriter stringWriter = new StringWriter();
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        assertEquals(OS.NEWLINE +
+                "@Misc{," + OS.NEWLINE +
+                "  month = apr," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
+                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void monthApril() throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.MONTH, "apr");
+
+        StringWriter stringWriter = new StringWriter();
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+
+        assertEquals(OS.NEWLINE +
+                "@Misc{," + OS.NEWLINE +
+                "  month = {apr}," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
+                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
     void addFieldWithLongerLength() throws IOException {
         // @formatter:off
         String bibtexEntry = OS.NEWLINE + OS.NEWLINE + "@Article{test," + OS.NEWLINE +

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -289,7 +289,56 @@ class BibtexDatabaseWriterTest {
     }
 
     @Test
-    void roundtrip() throws Exception {
+    void writeEntryWithConstantMonthApril() throws Exception {
+        BibEntry entry = new BibEntry.Builder(StandardEntryType.Misc)
+                .field(StandardField.MONTH, "#apr#")
+                .build();
+        database.insertEntry(entry);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
+
+        assertEquals(OS.NEWLINE +
+                "@Misc{," + OS.NEWLINE +
+                "  month = apr," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
+                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void writeEntryWithMonthApril() throws Exception {
+        BibEntry entry = new BibEntry.Builder(StandardEntryType.Misc)
+                .field(StandardField.MONTH, "apr")
+                .build();
+        database.insertEntry(entry);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
+
+        assertEquals(OS.NEWLINE +
+                "@Misc{," + OS.NEWLINE +
+                "  month = {apr}," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
+                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void roundtripWithArticleMonths() throws Exception {
+        Path testBibtexFile = Paths.get("src/test/resources/testbib/articleWithMonths.bib");
+        Charset encoding = StandardCharsets.UTF_8;
+        ParserResult result = new BibtexParser(importFormatPreferences, fileMonitor).parse(Importer.getReader(testBibtexFile, encoding));
+
+        when(preferences.getEncoding()).thenReturn(encoding);
+        when(preferences.isSaveInOriginalOrder()).thenReturn(true);
+        BibDatabaseContext context = new BibDatabaseContext(result.getDatabase(), result.getMetaData(),
+                new Defaults(BibDatabaseMode.BIBTEX));
+
+        databaseWriter.savePartOfDatabase(context, result.getDatabase().getEntries());
+        try (Scanner scanner = new Scanner(testBibtexFile, encoding.name())) {
+            assertEquals(scanner.useDelimiter("\\A").next(), stringWriter.toString());
+        }
+    }
+
+    @Test
+    void roundtripWithComplexBib() throws Exception {
         Path testBibtexFile = Paths.get("src/test/resources/testbib/complex.bib");
         Charset encoding = StandardCharsets.UTF_8;
         ParserResult result = new BibtexParser(importFormatPreferences, fileMonitor).parse(Importer.getReader(testBibtexFile, encoding));

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -289,38 +289,6 @@ class BibtexDatabaseWriterTest {
     }
 
     @Test
-    void writeEntryWithConstantMonthApril() throws Exception {
-        BibEntry entry = new BibEntry.Builder(StandardEntryType.Misc)
-                .field(StandardField.MONTH, "#apr#")
-                .build();
-        database.insertEntry(entry);
-
-        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
-
-        assertEquals(OS.NEWLINE +
-                "@Misc{," + OS.NEWLINE +
-                "  month = apr," + OS.NEWLINE +
-                "}" + OS.NEWLINE + OS.NEWLINE +
-                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
-    }
-
-    @Test
-    void writeEntryWithMonthApril() throws Exception {
-        BibEntry entry = new BibEntry.Builder(StandardEntryType.Misc)
-                .field(StandardField.MONTH, "apr")
-                .build();
-        database.insertEntry(entry);
-
-        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
-
-        assertEquals(OS.NEWLINE +
-                "@Misc{," + OS.NEWLINE +
-                "  month = {apr}," + OS.NEWLINE +
-                "}" + OS.NEWLINE + OS.NEWLINE +
-                "@Comment{jabref-meta: databaseType:bibtex;}" + OS.NEWLINE, stringWriter.toString());
-    }
-
-    @Test
     void roundtripWithArticleMonths() throws Exception {
         Path testBibtexFile = Paths.get("src/test/resources/testbib/articleWithMonths.bib");
         Charset encoding = StandardCharsets.UTF_8;

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -26,6 +26,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.Date;
+import org.jabref.model.entry.Month;
 import org.jabref.model.entry.field.BibField;
 import org.jabref.model.entry.field.FieldPriority;
 import org.jabref.model.entry.field.InternalField;
@@ -1710,5 +1711,79 @@ class BibtexParserTest {
         Optional<BibEntry> result = parser.parseSingleEntry("@ARTICLE{HipKro03, year = {2003} }");
 
         assertEquals(new Date(2003), result.get().getPublicationDate().get());
+    }
+
+    @Test
+    void parseEntryUsingStringConstantsForTwoAuthorsWithEtAsStringConstant() throws ParseException {
+        // source of the example: https://github.com/JabRef/help.jabref.org/blob/gh-pages/en/Strings.md
+        Collection<BibEntry> parsed = parser
+                .parseEntries("@String { kopp = \"Kopp, Oliver\" }" +
+                        "@String { kubovy = \"Kubovy, Jan\" }" +
+                        "@String { et = \" and \" }" +
+                        "@Misc{m1, author = kopp # et # kubovy }" );
+
+        BibEntry expectedEntry = new BibEntry.Builder(StandardEntryType.Misc)
+                .citeKey("m1")
+                .field(StandardField.AUTHOR, "#kopp##et##kubovy#")
+                .build();
+
+        assertEquals(List.of(expectedEntry), parsed);
+    }
+
+    @Test
+    void parseStringConstantsForTwoAuthorsHasCorrectBibTeXEntry() throws ParseException {
+        // source of the example: https://github.com/JabRef/help.jabref.org/blob/gh-pages/en/Strings.md
+        Collection<BibEntry> parsed = parser
+                .parseEntries("@String { kopp = \"Kopp, Oliver\" }" +
+                        "@String { kubovy = \"Kubovy, Jan\" }" +
+                        "@String { et = \" and \" }" +
+                        "@Misc{m2, author = kopp # \" and \" # kubovy }" );
+
+        BibEntry expectedEntry = new BibEntry.Builder(StandardEntryType.Misc)
+                .citeKey("m2")
+                .field(StandardField.AUTHOR, "#kopp# and #kubovy#")
+                .build();
+
+        assertEquals(List.of(expectedEntry), parsed);
+    }
+
+    @Test
+    void parseStringConstantsForTwoAuthors() throws ParseException {
+        // source of the example: https://github.com/JabRef/help.jabref.org/blob/gh-pages/en/Strings.md
+        Collection<BibEntry> parsed = parser
+                .parseEntries("@String { kopp = \"Kopp, Oliver\" }" +
+                        "@String { kubovy = \"Kubovy, Jan\" }" +
+                        "@String { et = \" and \" }" +
+                        "@Misc{m2, author = kopp # \" and \" # kubovy }" );
+
+        assertEquals("#kopp# and #kubovy#", parsed.iterator().next().getField(StandardField.AUTHOR).get());
+    }
+
+    @Test
+    void textAprilIsParsedAsMonthApril() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{m, month = \"apr\" }" );
+
+        assertEquals(Month.APRIL, result.get().getMonth().get());
+    }
+
+    @Test
+    void textAprilIsDisplayedAsConstant() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{m, month = \"apr\" }" );
+
+        assertEquals("apr", result.get().getField(StandardField.MONTH).get());
+    }
+
+    @Test
+    void bibTeXConstantAprilIsParsedAsMonthApril() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{m, month = apr }" );
+
+        assertEquals(Month.APRIL, result.get().getMonth().get());
+    }
+
+    @Test
+    void bibTeXConstantAprilIsDisplayedAsConstant() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{m, month = apr }" );
+
+        assertEquals("#apr#", result.get().getField(StandardField.MONTH).get());
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1722,10 +1722,9 @@ class BibtexParserTest {
                         "@String { et = \" and \" }" +
                         "@Misc{m1, author = kopp # et # kubovy }" );
 
-        BibEntry expectedEntry = new BibEntry.Builder(StandardEntryType.Misc)
-                .citeKey("m1")
-                .field(StandardField.AUTHOR, "#kopp##et##kubovy#")
-                .build();
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Misc)
+                .withCiteKey("m1")
+                .withField(StandardField.AUTHOR, "#kopp##et##kubovy#");
 
         assertEquals(List.of(expectedEntry), parsed);
     }
@@ -1739,10 +1738,9 @@ class BibtexParserTest {
                         "@String { et = \" and \" }" +
                         "@Misc{m2, author = kopp # \" and \" # kubovy }" );
 
-        BibEntry expectedEntry = new BibEntry.Builder(StandardEntryType.Misc)
-                .citeKey("m2")
-                .field(StandardField.AUTHOR, "#kopp# and #kubovy#")
-                .build();
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Misc)
+                .withCiteKey("m2")
+                .withField(StandardField.AUTHOR, "#kopp# and #kubovy#");
 
         assertEquals(List.of(expectedEntry), parsed);
     }

--- a/src/test/java/org/jabref/model/entry/BibtexStringTest.java
+++ b/src/test/java/org/jabref/model/entry/BibtexStringTest.java
@@ -9,35 +9,117 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class BibtexStringTest {
 
     @Test
-    public void test() {
+    public void initalizationWorksCorrectly() {
+        // Instantiate
+        BibtexString bs = new BibtexString("AAA", "An alternative action");
+        assertEquals("AAA", bs.getName());
+        assertEquals("An alternative action", bs.getContent());
+        assertEquals(BibtexString.Type.OTHER, bs.getType());
+    }
+
+    @Test
+    public void idIsUpdatedAtSetId() {
         // Instantiate
         BibtexString bs = new BibtexString("AAA", "An alternative action");
         bs.setId("ID");
         assertEquals("ID", bs.getId());
-        assertEquals("AAA", bs.getName());
-        assertEquals("An alternative action", bs.getContent());
-        assertEquals(BibtexString.Type.OTHER, bs.getType());
+    }
 
-        // Clone
+    @Test
+    public void cloningDoesNotChangeContents() {
+        BibtexString bs = new BibtexString("AAA", "An alternative action");
+        bs.setId("ID");
+
         BibtexString bs2 = (BibtexString) bs.clone();
+
         assertEquals(bs.getId(), bs2.getId());
         assertEquals(bs.getName(), bs2.getName());
         assertEquals(bs.getContent(), bs2.getContent());
         assertEquals(bs.getType(), bs2.getType());
+    }
 
-        // Change cloned BibtexString
+    @Test
+    public void clonedBibtexStringEqualsOriginalString() {
+        BibtexString bibtexString = new BibtexString("AAA", "An alternative action");
+        bibtexString.setId("ID");
+
+        BibtexString clone = (BibtexString) bibtexString.clone();
+
+        assertEquals(bibtexString, clone);
+    }
+
+    @Test
+    public void usingTheIdGeneratorDoesNotHitTheOriginalId() {
+        // Instantiate
+        BibtexString bs = new BibtexString("AAA", "An alternative action");
+        bs.setId("ID");
+        BibtexString bs2 = (BibtexString) bs.clone();
         bs2.setId(IdGenerator.next());
         assertNotEquals(bs.getId(), bs2.getId());
+    }
+
+    @Test
+    public void settingFieldsInACloneWorks() {
+        // Instantiate
+        BibtexString bs = new BibtexString("AAA", "An alternative action");
+        bs.setId("ID");
+        BibtexString bs2 = (BibtexString) bs.clone();
+
+        bs2.setId(IdGenerator.next());
         bs2.setName("aOG");
         assertEquals(BibtexString.Type.AUTHOR, bs2.getType());
+
         bs2.setContent("Oscar Gustafsson");
         assertEquals("aOG", bs2.getName());
         assertEquals("Oscar Gustafsson", bs2.getContent());
     }
 
     @Test
+    public void modifyingACloneDoesNotModifyTheOriginalEntry() {
+        // Instantiate
+        BibtexString original = new BibtexString("AAA", "An alternative action");
+        original.setId("ID");
+
+        BibtexString clone = (BibtexString) original.clone();
+        clone.setId(IdGenerator.next());
+        clone.setName("aOG");
+        clone.setContent("Oscar Gustafsson");
+
+        assertEquals("AAA", original.getName());
+        assertEquals("An alternative action", original.getContent());
+    }
+
+    @Test
     public void getContentNeverReturnsNull() {
         BibtexString bs = new BibtexString("SomeName", null);
         assertNotNull(bs.getContent());
+    }
+
+    @Test
+    public void authorTypeCorrectlyDetermined() {
+        // Source of the example: https://help.jabref.org/en/Strings
+        BibtexString bibtexString = new BibtexString("aKopp", "KoppOliver");
+        assertEquals(BibtexString.Type.AUTHOR, bibtexString.getType());
+    }
+
+    @Test
+    public void institutionTypeCorrectlyDetermined() {
+        // Source of the example: https://help.jabref.org/en/Strings
+        BibtexString bibtexString = new BibtexString("iMIT", "{Massachusetts Institute of Technology ({MIT})}");
+        assertEquals(BibtexString.Type.INSTITUTION, bibtexString.getType());
+    }
+
+    @Test
+    public void otherTypeCorrectlyDeterminedForLowerCase() {
+        // Source of the example: https://help.jabref.org/en/Strings
+        BibtexString bibtexString = new BibtexString("anct", "Anecdote");
+        assertEquals(BibtexString.Type.OTHER, bibtexString.getType());
+    }
+
+    @Test
+    public void otherTypeCorrectlyDeterminedForUpperCase() {
+        // Source of the example: https://help.jabref.org/en/Strings
+        BibtexString bibtexString = new BibtexString("lTOSCA", "Topology and Orchestration Specification for Cloud Applications");
+        assertEquals(BibtexString.Type.OTHER, bibtexString.getType());
     }
 }

--- a/src/test/resources/testbib/articleWithMonths.bib
+++ b/src/test/resources/testbib/articleWithMonths.bib
@@ -1,0 +1,10 @@
+% Encoding: UTF-8
+@Article{constant,
+	month = apr
+}
+
+@Article{text,
+	month = {apr}
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
I wanted to dive into https://github.com/JabRef/jabref/pull/5283 and finish it. I saw that we have no tests for `month = apr` (which is rendered internally as `#apr#`). We also did not cover the examples of https://github.com/JabRef/help.jabref.org/blob/gh-pages/en/Strings.md in test.

This is fixed here. I also did some cleaning in BibEntry. See below for details:

- Add tests for `month = apr` and `month = "apr"`
- Add tests for JabRef's string types
- Remove Optional as method parameter in BibEntry.setField
- Add builder to BibEntry
- Mark "BIBTEX_STRING" as JabRef-internal field
- Sort constants in InternalField.java - and add some comments
