### PR TITLE
Make entry editor DND behave as specified in settings

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -137,53 +137,20 @@ public class EntryEditor extends BorderPane {
                 FileDragDropPreferenceType dragDropPreferencesType = preferencesService.getEntryEditorFileLinkPreference();
 
                 if (dragDropPreferencesType == FileDragDropPreferenceType.MOVE) {
-                    if (event.getTransferMode() == TransferMode.LINK) {
-                        // Alt on Windows
-                        LOGGER.debug("Mode LINK");
-                        fileLinker.addFilesToEntry(entry, files);
-                    } else if (event.getTransferMode() == TransferMode.COPY) {
-                        // Ctrl on Windows, no modifier on Xubuntu
-                        LOGGER.debug("Mode COPY");
-                        fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
-                    } else {
-                        // Shift on Windows or no modifier
-                        LOGGER.debug("Mode MOVE");
-                        fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
-                    }
+                    LOGGER.debug("Mode MOVE");
+                    fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
                     success = true;
                 }
 
                 if (dragDropPreferencesType == FileDragDropPreferenceType.COPY) {
-                    if (event.getTransferMode() == TransferMode.COPY) {
-                        // Ctrl on Windows, no modifier on Xubuntu
-                        LOGGER.debug("Mode MOVE");
-                        fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
-                    } else if (event.getTransferMode() == TransferMode.LINK) {
-                        // Alt on Windows
-                        LOGGER.debug("Mode LINK");
-                        fileLinker.addFilesToEntry(entry, files);
-                    } else {
-                        // Shift on Windows or no modifier
-                        LOGGER.debug("Mode COPY");
-                        fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
-                    }
+                    LOGGER.debug("Mode COPY");
+                    fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
                     success = true;
                 }
 
                 if (dragDropPreferencesType == FileDragDropPreferenceType.LINK) {
-                    if (event.getTransferMode() == TransferMode.COPY) {
-                        // Ctrl on Windows, no modifier on Xubuntu
-                        LOGGER.debug("Mode COPY");
-                        fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
-                    } else if (event.getTransferMode() == TransferMode.LINK) {
-                        // Alt on Windows
-                        LOGGER.debug("Mode MOVE");
-                        fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
-                    } else {
-                        // Shift on Windows or no modifier
-                        LOGGER.debug("Mode LINK");
-                        fileLinker.addFilesToEntry(entry, files);
-                    }
+                    LOGGER.debug("Mode LINK");
+                    fileLinker.addFilesToEntry(entry, files);
                     success = true;
                 }
             }

--- a/src/main/java/org/jabref/gui/entryeditor/FileDragDropPreferenceType.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FileDragDropPreferenceType.java
@@ -1,7 +1,16 @@
 package org.jabref.gui.entryeditor;
 
 public enum FileDragDropPreferenceType {
+    /**
+     *  Copy file to default file folder
+     */
     COPY,
+    /**
+     *  Link file (without copying)
+     */
     LINK,
+    /**
+     * Copy, rename and link file
+     */
     MOVE;
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Fixes #5546 

The setting only applies to the entry editor. The maintainable is still differentiating between the DND Modifiers as implemented in the linked PR
@koppor  

Refs #3765
----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
