### PR TITLE
Fix #5551 - Don't remove unwanted characters before first author is s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an exception which occurred when an invalid jstyle was loaded. [#5452](https://github.com/JabRef/jabref/issues/5452)
 - We fixed an error where the preview theme did not adapt to the "Dark" mode [#5463](https://github.com/JabRef/jabref/issues/5463)
 - We fixed an issue where the merge dialog showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
+- We fixed an issue where the author field was not correctly parsed during bibtex key-generation. [#5551](https://github.com/JabRef/jabref/issues/5551)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -843,8 +843,8 @@ public class BracketedPattern {
      * First N chars of the first author's last name.
      */
     public static String authN(String authString, int num, boolean isEnforceLegalKey) {
-        authString = BibtexKeyGenerator.removeUnwantedCharacters(authString, isEnforceLegalKey);
         String fa = firstAuthor(authString);
+        fa = BibtexKeyGenerator.removeUnwantedCharacters(fa, isEnforceLegalKey);
         if (num > fa.length()) {
             num = fa.length();
         }

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -1087,4 +1087,13 @@ public class BibtexKeyGeneratorTest {
 
         assertEquals("Newton-2019", BibtexKeyGenerator.generateKey(entry, "[auth]-[year]"));
     }
+
+    @Test
+    public void generateKeyWithWithFirstNCharacters() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "Newton, Isaac");
+        entry.setField(StandardField.YEAR, "2019");
+
+        assertEquals("newt-2019", BibtexKeyGenerator.generateKey(entry, "[auth4:lower]-[year]"));
+    }
 }


### PR DESCRIPTION
Hey,

I'm copying my comment from the issue page:


I found that in BracketedPattern.java on line 846 the comma is removed and therefore the AuthorList is not correct.
https://github.com/JabRef/jabref/blob/master/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java#L846

I would fix this issue by not applying BibtexKeyGenerator.removeUnwantedCharacters before extracting the author but afterwards. The tests pass, but can anyone think of a problem with that approach?

As it is my first PR to this project, any suggestions are highly appreciated. Thanks for the great work!

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)

![image](https://user-images.githubusercontent.com/4035371/68075812-6ceaaf80-fdad-11e9-9638-0588eed7e545.png)
