### PR TITLE
Fix DBLPFetcherTest -- dblp changed the format

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
@@ -12,7 +12,7 @@ import javafx.scene.layout.HBox;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
-import org.jabref.logic.formatter.bibtexfields.CleanupURLFormatter;
+import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.TrimWhitespaceFormatter;
 import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
@@ -34,12 +34,11 @@ public class UrlEditor extends HBox implements FieldEditorFX {
                   .load();
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
-        Supplier<List<MenuItem>> contextMenuSupplier = EditorMenus.getCleanupURLMenu(textArea);
+        Supplier<List<MenuItem>> contextMenuSupplier = EditorMenus.getCleanupUrlMenu(textArea);
         textArea.addToContextMenu(contextMenuSupplier);
 
-        // init paste handler for URLEditor to format pasted url link in textArea
-        textArea.setPasteActionHandler(() -> textArea.setText(new CleanupURLFormatter().format(new TrimWhitespaceFormatter().format(textArea.getText()))));
-
+        // init paste handler for UrlEditor to format pasted url link in textArea
+        textArea.setPasteActionHandler(() -> textArea.setText(new CleanupUrlFormatter().format(new TrimWhitespaceFormatter().format(textArea.getText()))));
 
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/EditorMenus.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/EditorMenus.java
@@ -16,7 +16,7 @@ import org.jabref.Globals;
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.edit.CopyDoiUrlAction;
-import org.jabref.logic.formatter.bibtexfields.CleanupURLFormatter;
+import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
 import org.jabref.logic.l10n.Localization;
 
@@ -91,11 +91,11 @@ public class EditorMenus {
      * @param textArea text-area that this menu will be connected to
      * @return menu containing items of the default menu and an item to cleanup a URL
      */
-    public static Supplier<List<MenuItem>> getCleanupURLMenu(TextArea textArea) {
+    public static Supplier<List<MenuItem>> getCleanupUrlMenu(TextArea textArea) {
         return () -> {
             CustomMenuItem cleanupURL = new CustomMenuItem(new Label(Localization.lang("Cleanup URL link")));
             cleanupURL.setDisable(textArea.textProperty().isEmpty().get());
-            cleanupURL.setOnAction(event -> textArea.setText(new CleanupURLFormatter().format(textArea.getText())));
+            cleanupURL.setOnAction(event -> textArea.setText(new CleanupUrlFormatter().format(textArea.getText())));
 
             List<MenuItem> menuItems = new ArrayList<>();
             menuItems.add(cleanupURL);

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.jabref.logic.formatter.bibtexfields.CleanupURLFormatter;
+import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeUnderscoresFormatter;
 import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
@@ -58,7 +58,7 @@ public class Formatters {
     public static List<Formatter> getOthers() {
         return Arrays.asList(
                 new ClearFormatter(),
-                new CleanupURLFormatter(),
+                new CleanupUrlFormatter(),
                 new LatexCleanupFormatter(),
                 new MinifyNameListFormatter(),
                 new NormalizeDateFormatter(),

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
@@ -7,7 +7,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import org.jabref.model.cleanup.Formatter;
 
 import org.apache.commons.logging.Log;
@@ -47,8 +46,7 @@ public class CleanupUrlFormatter extends Formatter {
             LOGGER.warn("Used unsupported character encoding", e);
         }
 
-        String result = new RemoveLatexCommandsFormatter().format(decodedLink);
-        return result;
+        return decodedLink;
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import org.jabref.model.cleanup.Formatter;
 
 import org.apache.commons.logging.Log;
@@ -15,9 +16,9 @@ import org.apache.commons.logging.LogFactory;
 /**
  * Cleanup URL link
  */
-public class CleanupURLFormatter extends Formatter {
+public class CleanupUrlFormatter extends Formatter {
 
-    private static final Log LOGGER = LogFactory.getLog(CleanupURLFormatter.class);
+    private static final Log LOGGER = LogFactory.getLog(CleanupUrlFormatter.class);
     // This regexp find "url=" or "to=" parameter in full link and get text after them
     private static final Pattern PATTERN_URL = Pattern.compile("(?:url|to)=([^&]*)");
 
@@ -38,16 +39,16 @@ public class CleanupURLFormatter extends Formatter {
 
         Matcher matcher = PATTERN_URL.matcher(value);
         if (matcher.find()) {
-        toDecode = matcher.group(1);
-
+            toDecode = matcher.group(1);
         }
         try {
             decodedLink = URLDecoder.decode(toDecode, StandardCharsets.UTF_8.name());
-        }
-        catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException e) {
             LOGGER.warn("Used unsupported character encoding", e);
         }
-        return decodedLink;
+
+        String result = new RemoveLatexCommandsFormatter().format(decodedLink);
+        return result;
     }
 
     @Override
@@ -61,6 +62,5 @@ public class CleanupURLFormatter extends Formatter {
                 "rja&uact=8&ved=0ahUKEwjg3ZrB_ZPXAhVGuhoKHYdOBOg4ChAWCCYwAA&url=" +
                 "http%3A%2F%2Fwww.focus.de%2Fgesundheit%2Fratgeber%2Fherz%2Ftest%2" +
                 "Flebenserwartung-werden-sie-100-jahre-alt_aid_363828.html" + "&usg=AOvVaw1G6m2jf-pTHYkXceii4hXU";
-  }
-
+    }
 }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
@@ -5,6 +5,9 @@ import java.util.regex.Pattern;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.cleanup.Formatter;
 
+/**
+ * Simplifies LaTeX syntax. {@see org.jabref.logic.layout.format.RemoveLatexCommandsFormatter} for a formatter removing LaTeX commands completely.
+ */
 public class LatexCleanupFormatter extends Formatter {
 
     private static final Pattern REMOVE_REDUNDANT = Pattern

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatter.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import org.jabref.logic.importer.util.ShortDOIService;
 import org.jabref.logic.importer.util.ShortDOIServiceException;
@@ -29,22 +28,15 @@ public class ShortenDOIFormatter extends Formatter {
     @Override
     public String format(String value) {
         Objects.requireNonNull(value);
-
-        ShortDOIService shortDOIService = new ShortDOIService();
-
-        Optional<DOI> doi = Optional.empty();
-
-        try {
-            doi = DOI.parse(value);
-
-            if (doi.isPresent()) {
-                return shortDOIService.getShortDOI(doi.get()).getDOI();
-            }
-        } catch (ShortDOIServiceException e) {
-            LOGGER.error(e.getMessage(), e);
-        }
-
-        return value;
+        return DOI.parse(value)
+                  .map(doi -> {
+                      try {
+                          return new ShortDOIService().getShortDOI(doi).getDOI();
+                      } catch (ShortDOIServiceException e) {
+                          LOGGER.error(e.getMessage(), e);
+                          return value;
+                      }
+                  }).orElse(value);
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/DBLPFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DBLPFetcher.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.jabref.logic.cleanup.DoiCleanup;
+import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
@@ -17,6 +18,7 @@ import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.model.cleanup.FieldFormatterCleanup;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.apache.http.client.utils.URIBuilder;
@@ -57,13 +59,13 @@ public class DBLPFetcher implements SearchBasedParserFetcher {
     @Override
     public void doPostCleanup(BibEntry entry) {
         DoiCleanup doiCleaner = new DoiCleanup();
-
-        FieldFormatterCleanup clearTimestampFormatter = new FieldFormatterCleanup(InternalField.TIMESTAMP,
-                new ClearFormatter());
-
         doiCleaner.cleanup(entry);
+
+        FieldFormatterCleanup clearTimestampFormatter = new FieldFormatterCleanup(InternalField.TIMESTAMP, new ClearFormatter());
         clearTimestampFormatter.cleanup(entry);
 
+        FieldFormatterCleanup cleanUpUrlFormatter = new FieldFormatterCleanup(StandardField.URL, new CleanupUrlFormatter());
+        cleanUpUrlFormatter.cleanup(entry);
     }
 
     @Override
@@ -75,5 +77,4 @@ public class DBLPFetcher implements SearchBasedParserFetcher {
     public Optional<HelpFile> getHelpPage() {
         return Optional.of(HelpFile.FETCHER_DBLP);
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/DBLPFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DBLPFetcher.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.jabref.logic.cleanup.DoiCleanup;
-import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
@@ -15,6 +14,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fileformat.BibtexParser;
+import org.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import org.jabref.model.cleanup.FieldFormatterCleanup;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.InternalField;
@@ -64,8 +64,10 @@ public class DBLPFetcher implements SearchBasedParserFetcher {
         FieldFormatterCleanup clearTimestampFormatter = new FieldFormatterCleanup(InternalField.TIMESTAMP, new ClearFormatter());
         clearTimestampFormatter.cleanup(entry);
 
-        FieldFormatterCleanup cleanUpUrlFormatter = new FieldFormatterCleanup(StandardField.URL, new CleanupUrlFormatter());
-        cleanUpUrlFormatter.cleanup(entry);
+        // unescape the the contents of the URL field
+        entry.getField(StandardField.URL)
+             .map(url -> new RemoveLatexCommandsFormatter().format(url))
+             .ifPresent(url -> entry.setField(StandardField.URL, url));
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/Layout.java
+++ b/src/main/java/org/jabref/logic/layout/Layout.java
@@ -12,9 +12,6 @@ import org.jabref.model.entry.BibEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Main class for formatting DOCUMENT ME!
- */
 public class Layout {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Layout.class);

--- a/src/main/java/org/jabref/logic/layout/LayoutFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutFormatter.java
@@ -2,14 +2,12 @@ package org.jabref.logic.layout;
 
 /**
  * The LayoutFormatter is used for a Filter design-pattern.
- *
+ * <p>
  * Implementing classes have to accept a String and returned a formatted version of it.
- *
+ * <p>
  * Example:
- *
- *   "John von Neumann" => "von Neumann, John"
- *
- * @version 1.2 - Documentation CO
+ * <p>
+ * "John von Neumann" => "von Neumann, John"
  */
 @FunctionalInterface
 public interface LayoutFormatter {
@@ -17,14 +15,12 @@ public interface LayoutFormatter {
     /**
      * Failure Mode:
      * <p>
-     * Formatters should be robust in the sense that they always return some
-     * relevant string.
+     * Formatters should be robust in the sense that they always return some relevant string.
      * <p>
-     * If the formatter can detect an invalid input it should return the
-     * original string otherwise it may simply return a wrong output.
+     * If the formatter can detect an invalid input it should return the original string otherwise it may simply return
+     * a wrong output.
      *
-     * @param fieldText
-     *            The text to layout.
+     * @param fieldText The text to layout.
      * @return The layouted text.
      */
     String format(String fieldText);

--- a/src/main/java/org/jabref/logic/layout/LayoutFormatterBasedFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutFormatterBasedFormatter.java
@@ -1,0 +1,40 @@
+package org.jabref.logic.layout;
+
+import org.jabref.model.cleanup.Formatter;
+
+/**
+ * When having to use a LayoutFormatter as Formatter, this class is helpful. One usecase is {@link org.jabref.model.cleanup.FieldFormatterCleanup}
+ */
+public class LayoutFormatterBasedFormatter extends Formatter {
+
+    private final LayoutFormatter layoutFormatter;
+
+    public LayoutFormatterBasedFormatter(LayoutFormatter layoutFormatter) {
+        this.layoutFormatter = layoutFormatter;
+    }
+
+    @Override
+    public String getName() {
+        return layoutFormatter.getClass().getName();
+    }
+
+    @Override
+    public String getKey() {
+        return layoutFormatter.getClass().getName();
+    }
+
+    @Override
+    public String format(String value) {
+        return layoutFormatter.format(value);
+    }
+
+    @Override
+    public String getDescription() {
+        return layoutFormatter.getClass().getName();
+    }
+
+    @Override
+    public String getExampleInput() {
+        return layoutFormatter.getClass().getName();
+    }
+}

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -67,27 +67,24 @@ public class LayoutHelper {
 
     private void doBracketedField(final int field) throws IOException {
         StringBuilder buffer = null;
-        int c;
+        int currentCharacter;
         boolean start = false;
 
         while (!endOfFile) {
-            c = read();
+            currentCharacter = read();
 
-            if (c == -1) {
+            if (currentCharacter == -1) {
                 endOfFile = true;
-
                 if (buffer != null) {
                     parsedEntries.add(new StringInt(buffer.toString(), field));
                 }
-
                 return;
             }
 
-            if ((c == '{') || (c == '}')) {
-                if (c == '}') {
+            if ((currentCharacter == '{') || (currentCharacter == '}')) {
+                if (currentCharacter == '}') {
                     if (buffer != null) {
                         parsedEntries.add(new StringInt(buffer.toString(), field));
-
                         return;
                     }
                 } else {
@@ -98,16 +95,13 @@ public class LayoutHelper {
                     buffer = new StringBuilder(100);
                 }
 
-                if (start && (c != '}')) {
-                    buffer.append((char) c);
+                if (start && (currentCharacter != '}')) {
+                    buffer.append((char) currentCharacter);
                 }
             }
         }
     }
 
-    /**
-     *
-     */
     private void doBracketedOptionField() throws IOException {
         StringBuilder buffer = null;
         int c;

--- a/src/main/java/org/jabref/model/cleanup/FieldFormatterCleanups.java
+++ b/src/main/java/org/jabref/model/cleanup/FieldFormatterCleanups.java
@@ -62,7 +62,7 @@ public class FieldFormatterCleanups {
         if (enabled) {
             return applyAllActions(entry);
         } else {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/org/jabref/model/cleanup/Formatter.java
+++ b/src/main/java/org/jabref/model/cleanup/Formatter.java
@@ -1,13 +1,12 @@
 package org.jabref.model.cleanup;
 
 /**
- * The Formatter is used for a Filter design-pattern. Extending classes have to accept a String and returned a
- * formatted version of it. Implementations have to reside in the logic package.
- *
+ * The Formatter is used for a Filter design-pattern. Extending classes have to accept a String and returned a formatted
+ * version of it. Implementations have to reside in the logic package.
+ * <p>
  * Example:
- *
+ * <p>
  * "John von Neumann" => "von Neumann, John"
- *
  */
 public abstract class Formatter {
 
@@ -20,13 +19,14 @@ public abstract class Formatter {
 
     /**
      * Returns a unique key for the formatter that can be used for its identification
+     *
      * @return the key of the formatter, always not null
      */
     public abstract String getKey();
 
     /**
      * Formats a field value by with a particular formatter transformation.
-     *
+     * <p>
      * Calling this method with a null argument results in a NullPointerException.
      *
      * @param value the input String
@@ -42,8 +42,8 @@ public abstract class Formatter {
     public abstract String getDescription();
 
     /**
-     * Returns an example input string of the formatter.
-     * This example is used as input to the formatter to demonstrate its functionality
+     * Returns an example input string of the formatter. This example is used as input to the formatter to demonstrate
+     * its functionality
      *
      * @return the example input string, always non empty
      */
@@ -68,7 +68,7 @@ public abstract class Formatter {
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof Formatter) {
-            return getKey().equals(((Formatter)obj).getKey());
+            return getKey().equals(((Formatter) obj).getKey());
         } else {
             return false;
         }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
@@ -10,11 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class CleanupUrlFormatterTest {
 
-    private CleanupURLFormatter formatter;
+    private CleanupUrlFormatter formatter;
 
     @BeforeEach
     void setUp() {
-        formatter = new CleanupURLFormatter();
+        formatter = new CleanupUrlFormatter();
     }
 
     @Test
@@ -27,6 +27,11 @@ class CleanupUrlFormatterTest {
     void extractURLFormLink() {
         assertEquals("http://wikipedia.org",
                 formatter.format("away.php?to=http%3A%2F%2Fwikipedia.org&a=snippet"));
+    }
+
+    @Test
+    void latexCommandsRemoved() {
+        assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
@@ -30,8 +30,8 @@ class CleanupUrlFormatterTest {
     }
 
     @Test
-    void latexCommandsRemoved() {
-        assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
+    void latexCommandsNotRemoved() {
+        assertEquals("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
@@ -35,6 +35,12 @@ class CleanupUrlFormatterTest {
     }
 
     @Test
+    void urlencodedSlashesAreAlsoConverted() {
+        // the caller has to pay attention that this does not happen
+        assertEquals("jabref.org/test/test", formatter.format("jabref.org/test%2Ftest"));
+    }
+
+    @Test
     void formatExample() {
         assertEquals("http://www.focus.de/" +
                         "gesundheit/ratgeber/herz/test/lebenserwartung-werden-sie-100-jahre-alt_aid_363828.html",

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatterTest.java
@@ -20,8 +20,8 @@ class ShortenDOIFormatterTest {
     @Test
     public void formatDoi() {
         assertEquals("10/adc", formatter.format("10.1006/jmbi.1998.2354"));
-
     }
+
     @Test
     public void invalidDoiIsKept() {
         assertEquals("invalid-doi", formatter.format("invalid-doi"));

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatterTest.java
@@ -20,5 +20,10 @@ class ShortenDOIFormatterTest {
     @Test
     public void formatDoi() {
         assertEquals("10/adc", formatter.format("10.1006/jmbi.1998.2354"));
+
+    }
+    @Test
+    public void invalidDoiIsKept() {
+        assertEquals("invalid-doi", formatter.format("invalid-doi"));
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
@@ -16,10 +16,22 @@ public class RemoveBracketsTest {
     }
 
     @Test
-    public void testFormat() throws Exception {
+    public void bracePairCorrectlyRemoved() throws Exception {
         assertEquals("some text", formatter.format("{some text}"));
+    }
+
+    @Test
+    public void singleOpeningBraceCorrectlyRemoved() throws Exception {
         assertEquals("some text", formatter.format("{some text"));
+    }
+
+    @Test
+    public void singleClosingBraceCorrectlyRemoved() throws Exception {
         assertEquals("some text", formatter.format("some text}"));
+    }
+
+    @Test
+    public void bracePairWithEscapedBackslashCorrectlyRemoved() throws Exception {
         assertEquals("\\some text\\", formatter.format("\\{some text\\}"));
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
@@ -1,0 +1,61 @@
+package org.jabref.logic.layout.format;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RemoveLatexCommandsFormatterTest {
+
+    private RemoveLatexCommandsFormatter formatter;
+
+    @BeforeEach
+    public void setUp() {
+        formatter = new RemoveLatexCommandsFormatter();
+    }
+
+    @Test
+    public void withoutLatexCommandsUnmodified() {
+        assertEquals("some text", formatter.format("some text"));
+    }
+
+    @Test
+    public void singleCommandWiped() {
+        assertEquals("", formatter.format("\\sometext"));
+    }
+
+    @Test
+    public void singleSpaceAfterCommandRemoved() {
+        assertEquals("text", formatter.format("\\some text"));
+    }
+
+    @Test
+    public void multipleSpacesAfterCommandRemoved() {
+        assertEquals("text", formatter.format("\\some     text"));
+    }
+
+    @Test
+    public void escapedBackslashBecomesBackslash() {
+        assertEquals("\\", formatter.format("\\\\"));
+    }
+
+    @Test
+    public void escapedBackslashFollowedByTextBecomesBackslashFollowedByText() {
+        assertEquals("\\some text", formatter.format("\\\\some text"));
+    }
+
+    @Test
+    public void escapedBackslashKept() {
+        assertEquals("\\some text\\", formatter.format("\\\\some text\\\\"));
+    }
+
+    @Test
+    public void escapedUnderscoreReplaces() {
+        assertEquals("some_text", formatter.format("some\\_text"));
+    }
+
+    @Test
+    public void exampleUrlCorrectlyCleaned() {
+        assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
+    }
+}


### PR DESCRIPTION
dblp changed the format of URLs - `_` is now escaped.

Clean URLs in DBLPFetcher.

Additionally:

- Style RemoveLatexCommandsFormatter
- Add tests for RemoveLatexCommandsFormatter
- Add support for removing single and multiple whitespaces after a command
- Split tests in RemoveBracketsTest
- Fix casing in CleanupUrlFormatter (to match style and current name of test class CleanUpFormatterTest)
- Fix casing in some ...Url.. method names
- Format CleanupUrlFormatter

