### PR TITLE
Update citeproc-java to version 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
 
-    compile 'de.undercouch:citeproc-java:1.0.1'
+    compile 'de.undercouch:citeproc-java:2.0.0'
 
     compile group: 'jakarta.activation', name: 'jakarta.activation-api', version: '1.2.1'
     compile group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.2'
@@ -411,14 +411,16 @@ run {
             "--add-opens", "javafx.controls/com.sun.javafx.scene.control.behavior=com.jfoenix",
             "--add-opens", "javafx.base/com.sun.javafx.binding=com.jfoenix",
             "--add-opens", "javafx.graphics/com.sun.javafx.stage=com.jfoenix",
-            "--add-opens", "javafx.base/com.sun.javafx.event=com.jfoenix"
+            "--add-opens", "javafx.base/com.sun.javafx.event=com.jfoenix",
+            '--add-exports', 'com.oracle.truffle.regex/com.oracle.truffle.regex=org.graalvm.truffle'
 
     // TODO: The following code should have the same affect as the above one, but doesn't work for some reason
     // https://github.com/java9-modularity/gradle-modules-plugin/issues/89
     moduleOptions {
         addExports = [
                 'javafx.controls/com.sun.javafx.scene.control' : 'org.jabref',
-                'org.controlsfx.controls/impl.org.controlsfx.skin' : 'org.jabref'
+                'org.controlsfx.controls/impl.org.controlsfx.skin' : 'org.jabref',
+                'com.oracle.truffle.regex/com.oracle.truffle.regex' : 'org.graalvm.truffle'
         ]
 
         addOpens = [

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -59,7 +59,7 @@ open module org.jabref {
     requires jbibtex;
     requires citeproc.java;
     requires antlr.runtime;
-    requires commons.lang3;
+    requires org.graalvm.js;
     requires org.apache.xmpbox;
     requires de.saxsys.mvvmfx.validation;
     requires richtextfx;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

This pull request updates citeproc-java to version 2.0.0. The new version uses GraalVM JavaScript on Java 11 and higher, so it should be significantly faster than the older one. Also, the internal citeproc-js process has been updated to the latest version.

I needed to add a `--add-exports` argument to make the module `com.oracle.truffle.regex` export the package `com.oracle.truffle.regex` to `org.graalvm.truffle`. Otherwise, the polyglot engine was not able to find the `regex` language. This might be a bug in GraalVM (i.e. a missing `exports` statement in the `org.graalvm.truffle` module). I opened an issue for that (https://github.com/oracle/graal/issues/1822).

I wasn't sure if I should amend the CHANGELOG or not. I can do this if you like me to.

All unit tests run successfully after this change.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [X] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
