### PR TITLE
Escape quotes in import command

### DIFF
--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -13,7 +13,7 @@ import logging
 import shutil
 from pathlib import Path
 
-# We assume that this python script is located in "jabref/lib" while the executable is "jabref/bin/JabRef"
+# We assume that this python script is located in 'jabref/lib' while the executable is 'jabref/bin/JabRef'
 script_dir = Path(__file__).resolve().parent.parent
 JABREF_PATH = script_dir / "bin/JabRef"
 if not JABREF_PATH.exists():
@@ -28,14 +28,14 @@ logging.basicConfig(filename=logging_dir / "jabref_browser_extension.log")
 def get_message():
     raw_length = sys.stdin.buffer.read(4)
     if not raw_length:
-        logging.error("Raw_length \n")
+        logging.error("Raw_length null")
         sys.exit(0)
     message_length = struct.unpack("=I", raw_length)[0]
-    logging.info("Got length: {} bytes to be read\n".format(message_length))
+    logging.info(f"Got length: {message_length} bytes to be read")
     message = sys.stdin.buffer.read(message_length).decode("utf-8")
-    logging.info("Got message of {} chars\n".format(len(message)))
+    logging.info(f"Got message of {len(message)} chars")
     data = json.loads(message)
-    logging.info("Successfully retrieved JSON\n")
+    logging.info("Successfully retrieved JSON")
     return data
 
 
@@ -63,7 +63,7 @@ def add_jabref_entry(data):
     try:
         response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
-        logging.error("Failed to call JabRef: %s %s", exc.returncode, exc.output)
+        logging.error(f"Failed to call JabRef: {exc.returncode} {exc.output}")
     else:
         logging.info(f"Called JabRef and got: {response}")
     return response
@@ -82,7 +82,7 @@ if "status" in message and message["status"] == "validate":
     try:
         response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
-        logging.error("Failed to call JabRef: %s %s", exc.returncode, exc.output)
+        logging.error(f"Failed to call JabRef: {exc.returncode} {exc.output}")
         send_message({"message": "jarNotFound", "path": JABREF_PATH})
     else:
         logging.info(f"{response}")

--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -22,7 +22,7 @@ if not JABREF_PATH.exists():
 logging_dir = Path.home() / ".mozilla/native-messaging-hosts/"
 if not logging_dir.exists():
     logging_dir.mkdir(parents=True)
-logging.basicConfig(filename=logging_dir / 'jabref_browser_extension.log')
+logging.basicConfig(filename=logging_dir / "jabref_browser_extension.log")
 
 # Read a message from stdin and decode it.
 def get_message():
@@ -30,7 +30,7 @@ def get_message():
     if not raw_length:
         logging.error("Raw_length \n")
         sys.exit(0)
-    message_length = struct.unpack('=I', raw_length)[0]
+    message_length = struct.unpack("=I", raw_length)[0]
     logging.info("Got length: {} bytes to be read\n".format(message_length))
     message = sys.stdin.buffer.read(message_length).decode("utf-8")
     logging.info("Got message of {} chars\n".format(len(message)))
@@ -42,25 +42,30 @@ def get_message():
 # Encode a message for transmission, given its content.
 def encode_message(message_content):
     encoded_content = json.dumps(message_content).encode("utf-8")
-    encoded_length = struct.pack('=I', len(encoded_content))
-    return {'length': encoded_length, 'content': struct.pack(str(len(encoded_content))+"s",encoded_content)}
+    encoded_length = struct.pack("=I", len(encoded_content))
+    return {
+        "length": encoded_length,
+        "content": struct.pack(str(len(encoded_content)) + "s", encoded_content),
+    }
 
 
 # Send an encoded message to stdout.
 def send_message(message):
     encoded_message = encode_message(message)
-    sys.stdout.buffer.write(encoded_message['length'])
-    sys.stdout.buffer.write(encoded_message['content'])
+    sys.stdout.buffer.write(encoded_message["length"])
+    sys.stdout.buffer.write(encoded_message["content"])
     sys.stdout.buffer.flush()
 
+
 def add_jabref_entry(data):
-    cmd = str(JABREF_PATH) + " -importBibtex " + "\"" + data + "\""
-    try: 
+    cmd = f'{str(JABREF_PATH)} --importBibtex """{data}"""'
+    logger.error(f"Try to execute command {cmd}")
+    try:
         response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         logging.error("Failed to call JabRef: %s %s", exc.returncode, exc.output)
     else:
-        logging.info(f'Called JabRef and got: {response}')
+        logging.info(f"Called JabRef and got: {response}")
     return response
 
 
@@ -72,18 +77,17 @@ except Exception as e:
     message = str(e)
 logging.info(str(message))
 
-if 'status' in message and message["status"] == "validate":
+if "status" in message and message["status"] == "validate":
     cmd = str(JABREF_PATH) + " -version"
-    try: 
+    try:
         response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         logging.error("Failed to call JabRef: %s %s", exc.returncode, exc.output)
         send_message({"message": "jarNotFound", "path": JABREF_PATH})
     else:
-        logging.info(f'{response}')
+        logging.info(f"{response}")
         send_message({"message": "jarFound"})
 else:
     entry = message["text"]
     output = add_jabref_entry(entry)
     send_message({"message": "ok", "output": str(output)})
-    


### PR DESCRIPTION
This updates the python script to keep the double quotes
(or to not fail at least) if passed on the cli by the extension.
if i call `jabref --importBibtex """some citation "with quotes" """`
the triple quotes should resolve it properly.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
