### PR TITLE
Fix typo logger to logging in python host script

### DIFF
--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -13,7 +13,7 @@ import logging
 import shutil
 from pathlib import Path
 
-# We assume that this python script is located in 'jabref/lib' while the executable is 'jabref/bin/JabRef'
+# We assume that this python script is located in "jabref/lib" while the executable is "jabref/bin/JabRef"
 script_dir = Path(__file__).resolve().parent.parent
 JABREF_PATH = script_dir / "bin/JabRef"
 if not JABREF_PATH.exists():
@@ -59,7 +59,7 @@ def send_message(message):
 
 def add_jabref_entry(data):
     cmd = f'{str(JABREF_PATH)} --importBibtex """{data}"""'
-    logger.error(f"Try to execute command {cmd}")
+    logging.info(f"Try to execute command {cmd}")
     try:
         response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
in the host file logger is not set
so we need to use logging instead.
I didn't set it properly so there's an error with a log command...
This PR fixes the typo

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
