### PR TITLE
Use python raw string to preserve all special characters

### DIFF
--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -58,10 +58,11 @@ def send_message(message):
 
 
 def add_jabref_entry(data):
-    cmd = f'{str(JABREF_PATH)} --importBibtex """{data}"""'
+    """Send string via cli as literal to preserve special characters"""
+    cmd = [str(JABREF_PATH), "--importBibtex", r"{}".format(data)]
     logging.info(f"Try to execute command {cmd}")
     try:
-        response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
+        response = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         logging.error(f"Failed to call JabRef: {exc.returncode} {exc.output}")
     else:
@@ -78,9 +79,9 @@ except Exception as e:
 logging.info(str(message))
 
 if "status" in message and message["status"] == "validate":
-    cmd = str(JABREF_PATH) + " -version"
+    cmd = [str(JABREF_PATH), "--version"]
     try:
-        response = subprocess.check_output(shlex.split(cmd), stderr=subprocess.STDOUT)
+        response = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         logging.error(f"Failed to call JabRef: {exc.returncode} {exc.output}")
         send_message({"message": "jarNotFound", "path": JABREF_PATH})


### PR DESCRIPTION
in bibtex json when importing from web extension.

This is a more complete fix that should support all escape characters.
The parsing works for `\` based characters, (tab, newline, ..)
and quotes.
It's been manually tested on the snap.


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
