### PR TITLE
Add stable extension id to json

### DIFF
--- a/buildres/linux/org.jabref.jabref.json
+++ b/buildres/linux/org.jabref.jabref.json
@@ -4,6 +4,7 @@
   "path": "/opt/jabref/lib/jabrefHost.py",
   "type": "stdio",
   "allowed_extensions": [
-    "browserextension@jabref.org"
+    "browserextension@jabref.org",
+    "@jabfox"
   ]
 }

--- a/buildres/windows/jabref.json
+++ b/buildres/windows/jabref.json
@@ -4,6 +4,7 @@
   "path": "JabRefHost.bat",
   "type": "stdio",
   "allowed_extensions": [
-    "browserextension@jabref.org"
+    "browserextension@jabref.org",
+    "@jabfox"
   ]
 }


### PR DESCRIPTION
This adds the id for the stable version of jabref to the Firefox extension.
As discussed in the JabRef issues..
Solves https://github.com/JabRef/JabRef-Browser-Extension/issues/89 https://github.com/JabRef/JabRef-Browser-Extension/issues/88

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
