### PR TITLE
Fix #5615 side pane not remembering position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the merge dialog showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
 - We fixed an issue where the author field was not correctly parsed during bibtex key-generation. [#5551](https://github.com/JabRef/jabref/issues/5551)
 - We fixed an issue where notifications where shown during autosave. [#5555](https://github.com/JabRef/jabref/issues/5555)
+- We fixed an issue where the side pane was not remembering its position. [#5615](https://github.com/JabRef/jabref/issues/5615)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -410,7 +410,6 @@ public class JabRefFrame extends BorderPane {
         head.setCenter(createToolbar());
         setTop(head);
 
-        SplitPane.setResizableWithParent(sidePane, Boolean.FALSE);
         splitPane.getItems().addAll(sidePane, tabbedPane);
 
         // We need to wait with setting the divider since it gets reset a few times during the initial set-up
@@ -423,6 +422,8 @@ public class JabRefFrame extends BorderPane {
 
                     EasyBind.subscribe(sidePane.visibleProperty(), visible -> {
                         if (visible) {
+                            // Run SplitPane.setResizableWithParent later to avoid miscalculation during initial layouting
+                            Platform.runLater(() -> SplitPane.setResizableWithParent(sidePane, Boolean.FALSE));
                             if (!splitPane.getItems().contains(sidePane)) {
                                 splitPane.getItems().add(0, sidePane);
                                 setDividerPosition();


### PR DESCRIPTION
Hi,
I found a bug where JavaFx was doing some recalculations during the initial layouting. 
Setting `setResizableWithParent` before initial layouting was finished resulted in JavaFx assuming a wrong fixed width.
I changed that by adding the code to a run later block.

It works good for me on Mac. Are there any concerns with that?

Best regards
Kai

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
