### PR TITLE
Add the correct path to the native messaging json files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -666,7 +666,7 @@ if (OperatingSystem.current().isLinux()) {
     tasks.jpackageImage.doLast {
         copy {
             from("${projectDir}/buildres/linux") {
-                include "org.jabref.jabref.json", "jabrefHost.py"
+                include "native-messaging-host/**", "jabrefHost.py"
             }
             into "$buildDir/distribution/JabRef/lib"
         }


### PR DESCRIPTION
Add in build.gradle the correct path to the json files needed
for the native-messaging-host functionality.

Fixes #5626 


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
