### PR TITLE
When using the builder of BibEntry, the entry should not be mod…

### DIFF
--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -41,27 +41,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A bibliography database.
+ * A bibliography database. This is the "bib" file (or the library stored in a shared SQL database)
  */
 public class BibDatabase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BibDatabase.class);
     private static final Pattern RESOLVE_CONTENT_PATTERN = Pattern.compile(".*#[^#]+#.*");
+
     /**
      * State attributes
      */
     private final ObservableList<BibEntry> entries = FXCollections.synchronizedObservableList(FXCollections.observableArrayList(BibEntry::getObservables));
     private Map<String, BibtexString> bibtexStrings = new ConcurrentHashMap<>();
+
     /**
      * this is kept in sync with the database (upon adding/removing an entry, it is updated as well)
      */
     private final DuplicationChecker duplicationChecker = new DuplicationChecker();
+
     /**
      * contains all entry.getID() of the current database
      */
     private final Set<String> internalIDs = new HashSet<>();
+
     private final EventBus eventBus = new EventBus();
+
     private String preamble;
+
     // All file contents below the last entry in the file
     private String epilog = "";
     private String sharedDatabaseID;

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -317,6 +317,7 @@ public class BibEntry implements Cloneable {
 
     public BibEntry withCiteKey(String newCiteKey) {
         setCiteKey(newCiteKey);
+        this.setChanged(false);
         return this;
     }
 
@@ -797,6 +798,7 @@ public class BibEntry implements Cloneable {
 
     public BibEntry withField(Field field, String value) {
         setField(field, value);
+        this.setChanged(false);
         return this;
     }
 

--- a/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.exporter;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -27,9 +26,8 @@ import static org.mockito.Mockito.when;
 
 class SaveDatabaseActionTest {
 
-    private static final String TEST_FILE_PATH = "C:\\Users\\John_Doe\\Jabref";
-    private final File file = new File(TEST_FILE_PATH);
-    private Optional<Path> path = Optional.of(file.toPath());
+    private static final String TEST_BIBTEX_LIBRARY_LOCATION = "C:\\Users\\John_Doe\\Jabref\\literature.bib";
+    private final Path file = Path.of(TEST_BIBTEX_LIBRARY_LOCATION);
 
     private DialogService dialogService = mock(DialogService.class);
     private JabRefPreferences preferences = mock(JabRefPreferences.class);
@@ -49,24 +47,24 @@ class SaveDatabaseActionTest {
 
     @Test
     public void saveAsShouldSetWorkingDirectory() {
-        when(preferences.get(JabRefPreferences.WORKING_DIRECTORY)).thenReturn(TEST_FILE_PATH);
-        when(dialogService.showFileSaveDialog(any(FileDialogConfiguration.class))).thenReturn(path);
+        when(preferences.get(JabRefPreferences.WORKING_DIRECTORY)).thenReturn(TEST_BIBTEX_LIBRARY_LOCATION);
+        when(dialogService.showFileSaveDialog(any(FileDialogConfiguration.class))).thenReturn(Optional.of(file));
         doNothing().when(saveDatabaseAction).saveAs(any());
 
         saveDatabaseAction.saveAs();
 
-        verify(preferences, times(1)).setWorkingDir(path.get().getParent());
+        verify(preferences, times(1)).setWorkingDir(file.getParent());
     }
 
     @Test
     public void saveAsShouldNotSetWorkingDirectoryIfNotSelected() {
-        when(preferences.get(JabRefPreferences.WORKING_DIRECTORY)).thenReturn(TEST_FILE_PATH);
+        when(preferences.get(JabRefPreferences.WORKING_DIRECTORY)).thenReturn(TEST_BIBTEX_LIBRARY_LOCATION);
         when(dialogService.showFileSaveDialog(any(FileDialogConfiguration.class))).thenReturn(Optional.empty());
         doNothing().when(saveDatabaseAction).saveAs(any());
 
         saveDatabaseAction.saveAs();
 
-        verify(preferences, times(0)).setWorkingDir(path.get().getParent());
+        verify(preferences, times(0)).setWorkingDir(file.getParent());
     }
 
     @Test
@@ -75,9 +73,9 @@ class SaveDatabaseActionTest {
         when(dbContext.getLocation()).thenReturn(DatabaseLocation.LOCAL);
         when(preferences.getBoolean(JabRefPreferences.LOCAL_AUTO_SAVE)).thenReturn(false);
 
-        saveDatabaseAction.saveAs(file.toPath());
+        saveDatabaseAction.saveAs(file);
 
-        verify(dbContext, times(1)).setDatabaseFile(file.toPath());
+        verify(dbContext, times(1)).setDatabaseFile(file);
     }
 
     @Test
@@ -85,12 +83,12 @@ class SaveDatabaseActionTest {
         when(dbContext.getDatabasePath()).thenReturn(Optional.empty());
         when(dbContext.getLocation()).thenReturn(DatabaseLocation.LOCAL);
         when(preferences.getBoolean(JabRefPreferences.LOCAL_AUTO_SAVE)).thenReturn(false);
-        when(dialogService.showFileSaveDialog(any())).thenReturn(path);
-        doNothing().when(saveDatabaseAction).saveAs(file.toPath());
+        when(dialogService.showFileSaveDialog(any())).thenReturn(Optional.of(file));
+        doNothing().when(saveDatabaseAction).saveAs(file);
 
         saveDatabaseAction.save();
 
-        verify(saveDatabaseAction, times(1)).saveAs(file.toPath());
+        verify(saveDatabaseAction, times(1)).saveAs(file);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -175,7 +175,7 @@ class BibEntryWriterTest {
         entry.setField(StandardField.COMMENT, "testentry");
         entry.setCiteKey("test");
 
-        //write out bibtex string
+        // write out bibtex string
         StringWriter stringWriter = new StringWriter();
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
@@ -430,6 +430,8 @@ class BibEntryWriterTest {
     void constantMonthApril() throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.MONTH, "#apr#");
+        // enable writing
+        entry.setChanged(true);
 
         StringWriter stringWriter = new StringWriter();
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
@@ -445,6 +447,8 @@ class BibEntryWriterTest {
     void monthApril() throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.MONTH, "apr");
+        // enable writing
+        entry.setChanged(true);
 
         StringWriter stringWriter = new StringWriter();
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -28,7 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
+@Execution(CONCURRENT)
 class BibEntryTest {
     private BibEntry entry;
 
@@ -615,5 +618,17 @@ class BibEntryTest {
         KeywordList actual = entry.getResolvedKeywords(',', database);
 
         assertEquals(new KeywordList(new Keyword("kw"), new Keyword("kw2"), new Keyword("kw3")), actual);
+    }
+
+    @Test
+    public void settingTitleFieldsLeadsToChangeFlagged() {
+        entry.setField(StandardField.AUTHOR, "value");
+        assertTrue(entry.hasChanged());
+    }
+
+    @Test
+    public void builderReturnsABibEntryNotChangedFlagged() {
+        entry = new BibEntry().withField(StandardField.AUTHOR, "value");
+        assertFalse(entry.hasChanged());
     }
 }


### PR DESCRIPTION
Minor code quality things.

- Ensure that `BibEntry#withField` keeps `hasChanged() == false`
- Refine comment and add empty lines in BibDatabase.java
- Fix semantic of variable in SaveDatabaseActionTest (it really points to a file, not to a directory)
