### PR TITLE
Dark Theme Visibility Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an exception which occurred when an invalid jstyle was loaded. [#5452](https://github.com/JabRef/jabref/issues/5452)
 - We fixed an error where the preview theme did not adapt to the "Dark" mode [#5463](https://github.com/JabRef/jabref/issues/5463)
 - We fixed an issue where the merge dialog showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
-- We fixed visibility issues with the scrollbar and group selection highlight in "Dark" mode, and enabled "Dark" mode for the OpenOffice preview in the style selection window. [#5522] (https://github.com/JabRef/jabref/issues/5522)
+- We fixed visibility issues with the scrollbar and group selection highlight in "Dark" mode, and enabled "Dark" mode for the OpenOffice preview in the style selection window. [#5522](https://github.com/JabRef/jabref/issues/5522)
 - We fixed an issue where the author field was not correctly parsed during bibtex key-generation. [#5551](https://github.com/JabRef/jabref/issues/5551)
 - We fixed an issue where notifications where shown during autosave. [#5555](https://github.com/JabRef/jabref/issues/5555)
 - We fixed an issue where the side pane was not remembering its position. [#5615](https://github.com/JabRef/jabref/issues/5615)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an exception which occurred when an invalid jstyle was loaded. [#5452](https://github.com/JabRef/jabref/issues/5452)
 - We fixed an error where the preview theme did not adapt to the "Dark" mode [#5463](https://github.com/JabRef/jabref/issues/5463)
 - We fixed an issue where the merge dialog showed the wrong text colour in "Dark" mode [#5516](https://github.com/JabRef/jabref/issues/5516)
+- We fixed visibility issues with the scrollbar and group selection highlight in "Dark" mode, and enabled "Dark" mode for the OpenOffice preview in the style selection window. [#5522] (https://github.com/JabRef/jabref/issues/5522)
 - We fixed an issue where the author field was not correctly parsed during bibtex key-generation. [#5551](https://github.com/JabRef/jabref/issues/5551)
 - We fixed an issue where notifications where shown during autosave. [#5555](https://github.com/JabRef/jabref/issues/5555)
 - We fixed an issue where the side pane was not remembering its position. [#5615](https://github.com/JabRef/jabref/issues/5615)

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -523,6 +523,14 @@
     -fx-padding: 0 0 0 0;
 }
 
+.numberColumn > .hits:any-selected {
+    -fx-background-color: derive(-jr-green, 70%);
+}
+
+.numberColumn > .hits:all-selected {
+    -fx-background-color: -jr-green;
+}
+
 .table-view {
     -fx-background-insets: 0;
     -fx-padding: 0;

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -46,6 +46,9 @@
     -jr-menu-item-foreground: -fx-light-text-color;
     -jr-menu-forground-active: derive(-fx-light-text-color, 50%);
 
+    -jr-scrollbar-thumb: derive(-fx-outer-border, -30%);
+    -jr-scrollbar-track: derive(-fx-control-inner-background, -90%); 
+
     -fx-focused-text-base-color: -fx-dark-text-color;
 
     -jr-tooltip-fg: derive(-fx-light-text-color, 50%);
@@ -64,3 +67,10 @@
     -fx-background-color: -fx-light-text-color, -fx-control-inner-background;
 }
 
+.numberColumn > .hits:any-selected {
+    -fx-background-color: derive(-jr-gray-3, 70%);
+}
+
+.numberColumn > .hits:all-selected {
+    -fx-background-color: -jr-gray-3;
+}

--- a/src/main/java/org/jabref/gui/groups/GroupTree.css
+++ b/src/main/java/org/jabref/gui/groups/GroupTree.css
@@ -29,14 +29,6 @@
     -fx-fill: -jr-group-hits-fg;
 }
 
-.numberColumn > .hits:any-selected {
-    -fx-background-color: derive(-jr-green, 70%);
-}
-
-.numberColumn > .hits:all-selected {
-    -fx-background-color: -jr-green;
-}
-
 .disclosureNodeColumn {
     -fx-alignment: top-right;
 }

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -26,7 +26,6 @@ import org.jabref.logic.util.TestEntry;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.preferences.PreferencesService;
-import org.jabref.preferences.JabRefPreferences;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import org.fxmisc.easybind.EasyBind;
@@ -48,7 +47,6 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
     private StyleSelectDialogViewModel viewModel;
     private PreviewViewer previewArticle;
     private PreviewViewer previewBook;
-    JabRefPreferences prefs = JabRefPreferences.getInstance();
 
     public StyleSelectDialogView(StyleLoader loader) {
 

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -26,7 +26,6 @@ import org.jabref.logic.util.TestEntry;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.preferences.PreferencesService;
-import org.jabref.preferences.JabRefPreferences;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import org.fxmisc.easybind.EasyBind;
@@ -48,7 +47,6 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
     private StyleSelectDialogViewModel viewModel;
     private PreviewViewer previewArticle;
     private PreviewViewer previewBook;
-    JabRefPreferences prefs = JabRefPreferences.getInstance();
 
     public StyleSelectDialogView(StyleLoader loader) {
 
@@ -80,8 +78,8 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
         previewBook.setEntry(TestEntry.getTestEntryBook());
         vbox.getChildren().add(previewBook);
 
-        previewArticle.setTheme(prefs.get(JabRefPreferences.FX_THEME));
-        previewBook.setTheme(prefs.get(JabRefPreferences.FX_THEME));
+        previewArticle.setTheme(preferencesService.getTheme());
+        previewBook.setTheme(preferencesService.getTheme());
 
         colName.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
         colJournals.setCellValueFactory(cellData -> cellData.getValue().journalsProperty());

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -26,6 +26,7 @@ import org.jabref.logic.util.TestEntry;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.preferences.PreferencesService;
+import org.jabref.preferences.JabRefPreferences;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import org.fxmisc.easybind.EasyBind;
@@ -47,6 +48,7 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
     private StyleSelectDialogViewModel viewModel;
     private PreviewViewer previewArticle;
     private PreviewViewer previewBook;
+    JabRefPreferences prefs = JabRefPreferences.getInstance();
 
     public StyleSelectDialogView(StyleLoader loader) {
 

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -26,6 +26,7 @@ import org.jabref.logic.util.TestEntry;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.preferences.PreferencesService;
+import org.jabref.preferences.JabRefPreferences;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import org.fxmisc.easybind.EasyBind;
@@ -47,6 +48,7 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
     private StyleSelectDialogViewModel viewModel;
     private PreviewViewer previewArticle;
     private PreviewViewer previewBook;
+    JabRefPreferences prefs = JabRefPreferences.getInstance();
 
     public StyleSelectDialogView(StyleLoader loader) {
 
@@ -77,6 +79,9 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
         previewBook = new PreviewViewer(new BibDatabaseContext(), dialogService, Globals.stateManager);
         previewBook.setEntry(TestEntry.getTestEntryBook());
         vbox.getChildren().add(previewBook);
+
+        previewArticle.setTheme(prefs.get(JabRefPreferences.FX_THEME));
+        previewBook.setTheme(prefs.get(JabRefPreferences.FX_THEME));
 
         colName.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
         colJournals.setCellValueFactory(cellData -> cellData.getValue().journalsProperty());

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -916,8 +916,8 @@ public class JabRefPreferences implements PreferencesService {
             return get(DEFAULT_OWNER);
         }
     }
-
-   public String getTheme() {
+    @Override
+    public String getTheme() {
         return get(FX_THEME);
     }
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -917,6 +917,10 @@ public class JabRefPreferences implements PreferencesService {
         }
     }
 
+   public String getTheme() {
+        return get(FX_THEME);
+    }
+
     /**
      * Get a Map of default tab names to deafult tab fields.
      * The fields are returned as a String with fields separated by ;

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -916,6 +916,7 @@ public class JabRefPreferences implements PreferencesService {
             return get(DEFAULT_OWNER);
         }
     }
+
     @Override
     public String getTheme() {
         return get(FX_THEME);

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -90,6 +90,8 @@ public interface PreferencesService {
 
     String getUser();
 
+    String getTheme();
+
     SaveOrderConfig loadExportSaveOrder();
 
     void storeExportSaveOrder(SaveOrderConfig config);


### PR DESCRIPTION
There had been some visibility issues with the interface when in dark theme.

- Changed the color of the vertical scroll bar in dark mode to allow it to be more visible against the other colors.

- Changed the color of the accent behind the number selected which appears in the group tree when an item in a group is selected to allow for the number inside to be more readable.

fixes [#5522](https://github.com/JabRef/jabref/issues/5522)


Then:
![](https://user-images.githubusercontent.com/12767489/67626176-9cdf0380-f83f-11e9-9a23-a89a80dac849.png)

Now:
![Screen Shot 2019-11-19 at 5 44 54 PM](https://user-images.githubusercontent.com/20655124/69198088-2b6e3a00-0af9-11ea-9f9d-bb15896b3623.png)
----

- [x ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
