### PR TITLE
Fix library access error at BasePanelTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,8 +218,9 @@ dependencies {
     testCompile 'com.tngtech.archunit:archunit-junit5-api:0.12.0'
     //testRuntime 'com.tngtech.archunit:archunit-junit5-engine:0.11.0'
     testCompile 'com.tngtech.archunit:archunit-junit5-api:0.12.0'
-    testCompile "org.testfx:testfx-core:4.0.15-alpha"
-    testCompile "org.testfx:testfx-junit5:4.0.15-alpha"
+    testCompile "org.testfx:testfx-core:4.0.17-alpha-SNAPSHOT"
+    testCompile "org.testfx:testfx-junit5:4.0.17-alpha-SNAPSHOT"
+    testCompile "org.hamcrest:hamcrest-library:2.2"
 
     checkstyle 'com.puppycrawl.tools:checkstyle:8.26'
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '2.3.2'

--- a/src/main/java/org/jabref/JabRefLauncher.java
+++ b/src/main/java/org/jabref/JabRefLauncher.java
@@ -1,7 +1,7 @@
 package org.jabref;
 
 /**
- * JabRef Launcher
+ * JabRef launcher: This just starts JabRefMain. It is there because to have the name consistent to other Java applications.
  */
 public class JabRefLauncher {
     public static void main(String[] args) {

--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * JabRef MainClass
+ * JabRef's main class to process command line options and to start the UI
  */
 public class JabRefMain extends Application {
 
@@ -45,7 +45,7 @@ public class JabRefMain extends Application {
     }
 
     @Override
-    public void start(Stage mainStage) throws Exception {
+    public void start(Stage mainStage) {
         try {
             // Fail on unsupported Java versions
             ensureCorrectJavaVersion();


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/issues/5602

- hamcrest wasn't visible --> add it to the test dependencies
- refine comments on JabRefLauncher and JabRefMain

I could not fix following issue when executing the test in IntelliJ

```text
ARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by net.bytebuddy.description.annotation.AnnotationDescription$ForLoadedAnnotation (file:/C:/Users/olive/.gradle/caches/modules-2/files-2.1/net.bytebuddy/byte-buddy/1.9.10/211a2b4d3df1eeef2a6cacf78d74a1f725e7a840/byte-buddy-1.9.10.jar) to method com.sun.javafx.beans.IDProperty.value()
WARNING: Please consider reporting this to the maintainers of net.bytebuddy.description.annotation.AnnotationDescription$ForLoadedAnnotation
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
--- Exception in Async Thread ---
java.lang.reflect.InvocationTargetException: null
	java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	java.base/java.lang.reflect.Method.invoke(Method.java:567)
	org.testfx.framework.junit5.ApplicationExtension$AnnotationBasedApplicationFixture.start(ApplicationExtension.java:158)
	org.testfx.framework.junit5.ApplicationAdapter.start(ApplicationAdapter.java:37)
```