### PR TITLE
Improve change scanner

### DIFF
--- a/src/main/java/org/jabref/gui/collab/ChangeScanner.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeScanner.java
@@ -30,30 +30,30 @@ public class ChangeScanner {
     public List<DatabaseChangeViewModel> scanForChanges() {
         if (database.getDatabasePath().isEmpty()) {
             return Collections.emptyList();
-        } else {
-            try {
-                List<DatabaseChangeViewModel> changes = new ArrayList<>();
+        }
 
-                // Parse the modified file
-                ImportFormatPreferences importFormatPreferences = Globals.prefs.getImportFormatPreferences();
-                ParserResult result = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor())
-                        .importDatabase(database.getDatabasePath().get(), importFormatPreferences.getEncoding());
-                BibDatabaseContext databaseOnDisk = result.getDatabaseContext();
+        try {
+            List<DatabaseChangeViewModel> changes = new ArrayList<>();
 
-                // Start looking at changes.
-                BibDatabaseDiff differences = BibDatabaseDiff.compare(database, databaseOnDisk);
-                differences.getMetaDataDifferences().ifPresent(diff -> {
-                    changes.add(new MetaDataChangeViewModel(diff));
-                    diff.getGroupDifferences().ifPresent(groupDiff -> changes.add(new GroupChangeViewModel(groupDiff)));
-                });
-                differences.getPreambleDifferences().ifPresent(diff -> changes.add(new PreambleChangeViewModel(diff)));
-                differences.getBibStringDifferences().forEach(diff -> changes.add(createBibStringDiff(diff)));
-                differences.getEntryDifferences().forEach(diff -> changes.add(createBibEntryDiff(diff)));
-                return changes;
-            } catch (IOException e) {
-                LOGGER.warn("Error while parsing changed file.", e);
-                return Collections.emptyList();
-            }
+            // Parse the modified file
+            ImportFormatPreferences importFormatPreferences = Globals.prefs.getImportFormatPreferences();
+            ParserResult result = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor())
+                    .importDatabase(database.getDatabasePath().get(), importFormatPreferences.getEncoding());
+            BibDatabaseContext databaseOnDisk = result.getDatabaseContext();
+
+            // Start looking at changes.
+            BibDatabaseDiff differences = BibDatabaseDiff.compare(database, databaseOnDisk);
+            differences.getMetaDataDifferences().ifPresent(diff -> {
+                changes.add(new MetaDataChangeViewModel(diff));
+                diff.getGroupDifferences().ifPresent(groupDiff -> changes.add(new GroupChangeViewModel(groupDiff)));
+            });
+            differences.getPreambleDifferences().ifPresent(diff -> changes.add(new PreambleChangeViewModel(diff)));
+            differences.getBibStringDifferences().forEach(diff -> changes.add(createBibStringDiff(diff)));
+            differences.getEntryDifferences().forEach(diff -> changes.add(createBibEntryDiff(diff)));
+            return changes;
+        } catch (IOException e) {
+            LOGGER.warn("Error while parsing changed file.", e);
+            return Collections.emptyList();
         }
     }
 

--- a/src/main/java/org/jabref/gui/collab/ChangeScanner.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeScanner.java
@@ -1,67 +1,60 @@
 package org.jabref.gui.collab;
 
-import java.nio.file.Path;
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.jabref.Globals;
-import org.jabref.logic.bibtex.DuplicateCheck;
 import org.jabref.logic.bibtex.comparator.BibDatabaseDiff;
 import org.jabref.logic.bibtex.comparator.BibEntryDiff;
 import org.jabref.logic.bibtex.comparator.BibStringDiff;
 import org.jabref.logic.importer.ImportFormatPreferences;
-import org.jabref.logic.importer.OpenDatabase;
 import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibtexString;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ChangeScanner {
 
-    private final Path referenceFile;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeScanner.class);
     private final BibDatabaseContext database;
-    private final List<DatabaseChangeViewModel> changes = new ArrayList<>();
-    private BibDatabaseContext referenceDatabase;
 
-    public ChangeScanner(BibDatabaseContext database, Path referenceFile) {
+    public ChangeScanner(BibDatabaseContext database) {
         this.database = database;
-        this.referenceFile = referenceFile;
-    }
-
-    /**
-     * Finds the entry in the list best fitting the specified entry. Even if no entries get a score above zero, an entry
-     * is still returned.
-     */
-    private static BibEntry bestFit(BibEntry targetEntry, List<BibEntry> entries) {
-        return entries.stream()
-                      .max(Comparator.comparingDouble(candidate -> DuplicateCheck.compareEntriesStrictly(targetEntry, candidate)))
-                      .orElse(null);
     }
 
     public List<DatabaseChangeViewModel> scanForChanges() {
-        database.getDatabasePath().ifPresent(diskdb -> {
-            // Parse the temporary file.
-            ImportFormatPreferences importFormatPreferences = Globals.prefs.getImportFormatPreferences();
-            ParserResult result = OpenDatabase.loadDatabase(referenceFile.toAbsolutePath().toString(), importFormatPreferences, Globals.getFileUpdateMonitor());
-            referenceDatabase = result.getDatabaseContext();
+        if (database.getDatabasePath().isEmpty()) {
+            return Collections.emptyList();
+        } else {
+            try {
+                List<DatabaseChangeViewModel> changes = new ArrayList<>();
 
-            // Parse the modified file.
-            result = OpenDatabase.loadDatabase(diskdb.toAbsolutePath().toString(), importFormatPreferences, Globals.getFileUpdateMonitor());
-            BibDatabaseContext databaseOnDisk = result.getDatabaseContext();
+                // Parse the modified file
+                ImportFormatPreferences importFormatPreferences = Globals.prefs.getImportFormatPreferences();
+                ParserResult result = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor())
+                        .importDatabase(database.getDatabasePath().get(), importFormatPreferences.getEncoding());
+                BibDatabaseContext databaseOnDisk = result.getDatabaseContext();
 
-            // Start looking at changes.
-            BibDatabaseDiff differences = BibDatabaseDiff.compare(referenceDatabase, databaseOnDisk);
-            differences.getMetaDataDifferences().ifPresent(diff -> {
-                changes.add(new MetaDataChangeViewModel(diff));
-                diff.getGroupDifferences().ifPresent(groupDiff -> changes.add(new GroupChangeViewModel(groupDiff)));
-            });
-            differences.getPreambleDifferences().ifPresent(diff -> changes.add(new PreambleChangeViewModel(diff)));
-            differences.getBibStringDifferences().forEach(diff -> changes.add(createBibStringDiff(diff)));
-            differences.getEntryDifferences().forEach(diff -> changes.add(createBibEntryDiff(diff)));
-        });
-        return changes;
+                // Start looking at changes.
+                BibDatabaseDiff differences = BibDatabaseDiff.compare(database, databaseOnDisk);
+                differences.getMetaDataDifferences().ifPresent(diff -> {
+                    changes.add(new MetaDataChangeViewModel(diff));
+                    diff.getGroupDifferences().ifPresent(groupDiff -> changes.add(new GroupChangeViewModel(groupDiff)));
+                });
+                differences.getPreambleDifferences().ifPresent(diff -> changes.add(new PreambleChangeViewModel(diff)));
+                differences.getBibStringDifferences().forEach(diff -> changes.add(createBibStringDiff(diff)));
+                differences.getEntryDifferences().forEach(diff -> changes.add(createBibEntryDiff(diff)));
+                return changes;
+            } catch (IOException e) {
+                LOGGER.warn("Error while parsing changed file.", e);
+                return Collections.emptyList();
+            }
+        }
     }
 
     private DatabaseChangeViewModel createBibStringDiff(BibStringDiff diff) {
@@ -70,17 +63,14 @@ public class ChangeScanner {
         }
 
         if (diff.getNewString() == null) {
-            Optional<BibtexString> current = database.getDatabase().getStringByName(diff.getOriginalString().getName());
-            return new StringRemoveChangeViewModel(diff.getOriginalString(), current.orElse(null));
+            return new StringRemoveChangeViewModel(diff.getOriginalString());
         }
 
         if (diff.getOriginalString().getName().equals(diff.getNewString().getName())) {
-            Optional<BibtexString> current = database.getDatabase().getStringByName(diff.getOriginalString().getName());
-            return new StringChangeViewModel(current.orElse(null), diff.getOriginalString(), diff.getNewString().getContent());
+            return new StringChangeViewModel(diff.getOriginalString(), diff.getNewString());
         }
 
-        Optional<BibtexString> current = database.getDatabase().getStringByName(diff.getOriginalString().getName());
-        return new StringNameChangeViewModel(current.orElse(null), diff.getOriginalString(), current.map(BibtexString::getName).orElse(""), diff.getNewString().getName());
+        return new StringNameChangeViewModel(diff.getOriginalString(), diff.getNewString());
     }
 
     private DatabaseChangeViewModel createBibEntryDiff(BibEntryDiff diff) {
@@ -89,9 +79,9 @@ public class ChangeScanner {
         }
 
         if (diff.getNewEntry() == null) {
-            return new EntryDeleteChangeViewModel(bestFit(diff.getOriginalEntry(), database.getEntries()), diff.getOriginalEntry());
+            return new EntryDeleteChangeViewModel(diff.getOriginalEntry());
         }
 
-        return new EntryChangeViewModel(bestFit(diff.getOriginalEntry(), database.getEntries()), diff.getOriginalEntry(), diff.getNewEntry());
+        return new EntryChangeViewModel(diff.getOriginalEntry(), diff.getNewEntry());
     }
 }

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -46,7 +46,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     @Override
     public void fileUpdated() {
         // File on disk has changed, thus look for notable changes and notify listeners in case there are such changes
-        ChangeScanner scanner = new ChangeScanner(database, referenceFile);
+        ChangeScanner scanner = new ChangeScanner(database);
         BackgroundTask.wrap(scanner::scanForChanges)
                       .onSuccess(changes -> {
                           if (!changes.isEmpty()) {

--- a/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
@@ -13,11 +13,12 @@ import javafx.scene.layout.VBox;
 
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableFieldChange;
-import org.jabref.logic.bibtex.DuplicateCheck;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.strings.StringUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,43 +29,28 @@ class EntryChangeViewModel extends DatabaseChangeViewModel {
 
     private final List<FieldChangeViewModel> fieldChanges = new ArrayList<>();
 
-    public EntryChangeViewModel(BibEntry memEntry, BibEntry tmpEntry, BibEntry diskEntry) {
+    public EntryChangeViewModel(BibEntry entry, BibEntry newEntry) {
         super();
-        name = tmpEntry.getCiteKeyOptional()
-                       .map(key -> Localization.lang("Modified entry") + ": '" + key + '\'')
-                       .orElse(Localization.lang("Modified entry"));
-
-        // We know that tmpEntry is not equal to diskEntry. Check if it has been modified
-        // locally as well, since last tempfile was saved.
-        boolean isModifiedLocally = (DuplicateCheck.compareEntriesStrictly(memEntry, tmpEntry) <= 1);
-
-        // Another (unlikely?) possibility is that both disk and mem version has been modified
-        // in the same way. Check for this, too.
-        boolean modificationsAgree = (DuplicateCheck.compareEntriesStrictly(memEntry, diskEntry) > 1);
-
-        LOGGER.debug("Modified entry: " + memEntry.getCiteKeyOptional().orElse("<no BibTeX key set>")
-                + "\n Modified locally: " + isModifiedLocally + " Modifications agree: " + modificationsAgree);
+        name = entry.getCiteKeyOptional()
+                    .map(key -> Localization.lang("Modified entry") + ": '" + key + '\'')
+                    .orElse(Localization.lang("Modified entry"));
 
         Set<Field> allFields = new TreeSet<>(Comparator.comparing(Field::getName));
-        allFields.addAll(memEntry.getFields());
-        allFields.addAll(tmpEntry.getFields());
-        allFields.addAll(diskEntry.getFields());
+        allFields.addAll(entry.getFields());
+        allFields.addAll(newEntry.getFields());
 
         for (Field field : allFields) {
-            Optional<String> mem = memEntry.getField(field);
-            Optional<String> tmp = tmpEntry.getField(field);
-            Optional<String> disk = diskEntry.getField(field);
+            Optional<String> value = entry.getField(field);
+            Optional<String> newValue = newEntry.getField(field);
 
-            if ((tmp.isPresent()) && (disk.isPresent())) {
-                if (!tmp.equals(disk)) {
+            if (value.isPresent() && newValue.isPresent()) {
+                if (!value.equals(newValue)) {
                     // Modified externally.
-                    fieldChanges.add(new FieldChangeViewModel(field, memEntry, tmpEntry, mem.orElse(null), tmp.get(), disk.get()));
+                    fieldChanges.add(new FieldChangeViewModel(entry, field, value.get(), newValue.get()));
                 }
-            } else if (((!tmp.isPresent()) && (disk.isPresent()) && !disk.get().isEmpty())
-                    || ((!disk.isPresent()) && (tmp.isPresent()) && !tmp.get().isEmpty()
-                            && (mem.isPresent()) && !mem.get().isEmpty())) {
-                // Added externally.
-                fieldChanges.add(new FieldChangeViewModel(field, memEntry, tmpEntry, mem.orElse(null), tmp.orElse(null), disk.orElse(null)));
+            } else {
+                // Added/removed externally.
+                fieldChanges.add(new FieldChangeViewModel(entry, field, value.orElse(null), newValue.orElse(null)));
             }
         }
     }
@@ -80,7 +66,7 @@ class EntryChangeViewModel extends DatabaseChangeViewModel {
 
     @Override
     public Node description() {
-        VBox container = new VBox();
+        VBox container = new VBox(10);
         Label header = new Label(name);
         header.getStyleClass().add("sectionHeader");
         container.getChildren().add(header);
@@ -95,49 +81,42 @@ class EntryChangeViewModel extends DatabaseChangeViewModel {
     static class FieldChangeViewModel extends DatabaseChangeViewModel {
 
         private final BibEntry entry;
-        private final BibEntry tmpEntry;
         private final Field field;
-        private final String inMem;
-        private final String onTmp;
-        private final String onDisk;
+        private final String value;
+        private final String newValue;
 
-        public FieldChangeViewModel(Field field, BibEntry memEntry, BibEntry tmpEntry, String inMem, String onTmp, String onDisk) {
+        public FieldChangeViewModel(BibEntry entry, Field field, String value, String newValue) {
             super(field.getName());
-            entry = memEntry;
-            this.tmpEntry = tmpEntry;
+            this.entry = entry;
             this.field = field;
-            this.inMem = inMem;
-            this.onTmp = onTmp;
-            this.onDisk = onDisk;
+            this.value = value;
+            this.newValue = newValue;
         }
 
         @Override
         public void makeChange(BibDatabaseContext database, NamedCompound undoEdit) {
-            if (onDisk == null) {
-                entry.clearField(field);
+            Optional<FieldChange> change;
+            if (StringUtil.isBlank(newValue)) {
+                change = entry.clearField(field);
             } else {
-                entry.setField(field, onDisk);
+                change = entry.setField(field, newValue);
             }
-            undoEdit.addEdit(new UndoableFieldChange(entry, field, inMem, onDisk));
+
+            change.map(UndoableFieldChange::new).ifPresent(undoEdit::addEdit);
         }
 
         @Override
         public Node description() {
             VBox container = new VBox();
-            container.getChildren().add(new Label(Localization.lang("Modification of field") + " " + field));
+            container.getChildren().add(new Label(Localization.lang("Modification of field") + " " + field.getDisplayName()));
 
-            if ((onDisk != null) && !onDisk.isEmpty()) {
-                container.getChildren().add(new Label(Localization.lang("Value set externally") + ": " + onDisk));
+            if (StringUtil.isNotBlank(newValue)) {
+                container.getChildren().add(new Label(Localization.lang("Value set externally") + ": " + newValue));
             } else {
                 container.getChildren().add(new Label(Localization.lang("Value cleared externally")));
             }
 
-            if ((inMem != null) && !inMem.isEmpty()) {
-                container.getChildren().add(new Label(Localization.lang("Current value") + ": " + inMem));
-            }
-            if ((onTmp != null) && !onTmp.isEmpty()) {
-                container.getChildren().add(new Label(Localization.lang("Current tmp value") + ": " + onTmp));
-            }
+            container.getChildren().add(new Label(Localization.lang("Current value") + ": " + value));
 
             return container;
         }

--- a/src/main/java/org/jabref/gui/collab/EntryDeleteChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryDeleteChangeViewModel.java
@@ -7,7 +7,6 @@ import org.jabref.JabRefGUI;
 import org.jabref.gui.preview.PreviewViewer;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableRemoveEntries;
-import org.jabref.logic.bibtex.DuplicateCheck;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -18,35 +17,23 @@ import org.slf4j.LoggerFactory;
 class EntryDeleteChangeViewModel extends DatabaseChangeViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EntryDeleteChangeViewModel.class);
-    private final BibEntry memEntry;
-    private final BibEntry tmpEntry;
+    private final BibEntry entry;
 
-    public EntryDeleteChangeViewModel(BibEntry memEntry, BibEntry tmpEntry) {
+    public EntryDeleteChangeViewModel(BibEntry entry) {
         super(Localization.lang("Deleted entry"));
-        this.memEntry = memEntry;
-        this.tmpEntry = tmpEntry;
-
-        // Compare the deleted entry in memory with the one in the tmpfile. The
-        // entry could have been removed in memory.
-        double matchWithTmp = DuplicateCheck.compareEntriesStrictly(memEntry, tmpEntry);
-
-        // Check if it has been modified locally, since last tempfile was saved.
-        boolean isModifiedLocally = (matchWithTmp <= 1);
-
-        LOGGER.debug("Modified entry: " + memEntry.getCiteKeyOptional().orElse("<no BibTeX key set>")
-                + "\n Modified locally: " + isModifiedLocally);
+        this.entry = entry;
     }
 
     @Override
     public void makeChange(BibDatabaseContext database, NamedCompound undoEdit) {
-        database.getDatabase().removeEntry(memEntry);
-        undoEdit.addEdit(new UndoableRemoveEntries(database.getDatabase(), memEntry));
+        database.getDatabase().removeEntry(entry);
+        undoEdit.addEdit(new UndoableRemoveEntries(database.getDatabase(), entry));
     }
 
     @Override
     public Node description() {
         PreviewViewer previewViewer = new PreviewViewer(new BibDatabaseContext(), JabRefGUI.getMainFrame().getDialogService(), Globals.stateManager);
-        previewViewer.setEntry(memEntry);
+        previewViewer.setEntry(entry);
         return previewViewer;
     }
 }

--- a/src/main/java/org/jabref/gui/collab/StringChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/StringChangeViewModel.java
@@ -1,15 +1,15 @@
 package org.jabref.gui.collab;
 
+import java.util.Objects;
+
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.undo.NamedCompound;
-import org.jabref.gui.undo.UndoableInsertString;
 import org.jabref.gui.undo.UndoableStringChange;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.KeyCollisionException;
 import org.jabref.model.entry.BibtexString;
 
 import org.slf4j.Logger;
@@ -19,32 +19,20 @@ class StringChangeViewModel extends DatabaseChangeViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StringChangeViewModel.class);
     private final BibtexString string;
-    private final String disk;
-    private final String label;
+    private final BibtexString newString;
 
-    public StringChangeViewModel(BibtexString string, BibtexString tmpString, String disk) {
-        super(Localization.lang("Modified string") + ": '" + tmpString.getName() + '\'');
-        this.string = string;
-        this.label = tmpString.getName();
-        this.disk = disk;
+    public StringChangeViewModel(BibtexString string, BibtexString newString) {
+        super(Localization.lang("Modified string") + ": '" + string.getName() + '\'');
+        this.string = Objects.requireNonNull(string);
+        this.newString = Objects.requireNonNull(newString);
     }
 
     @Override
     public void makeChange(BibDatabaseContext database, NamedCompound undoEdit) {
-        if (string == null) {
-            // The string was removed or renamed locally. We guess that it was removed.
-            BibtexString bs = new BibtexString(label, disk);
-            try {
-                database.getDatabase().addString(bs);
-                undoEdit.addEdit(new UndoableInsertString(database.getDatabase(), bs));
-            } catch (KeyCollisionException ex) {
-                LOGGER.warn("Error: could not add string '" + bs.getName() + "': " + ex.getMessage(), ex);
-            }
-        } else {
-            String mem = string.getContent();
-            string.setContent(disk);
-            undoEdit.addEdit(new UndoableStringChange(string, false, mem, disk));
-        }
+        String currentValue = string.getContent();
+        String newValue = newString.getContent();
+        string.setContent(newValue);
+        undoEdit.addEdit(new UndoableStringChange(string, false, currentValue, newValue));
     }
 
     @Override
@@ -54,15 +42,11 @@ class StringChangeViewModel extends DatabaseChangeViewModel {
         header.getStyleClass().add("sectionHeader");
         container.getChildren().addAll(
                 header,
-                new Label(Localization.lang("Label") + ": " + label),
-                new Label(Localization.lang("Content") + ": " + disk)
+                new Label(Localization.lang("Label") + ": " + newString.getName()),
+                new Label(Localization.lang("Content") + ": " + newString.getContent())
         );
 
-        if (string == null) {
-            container.getChildren().add(new Label(Localization.lang("Cannot merge this change") + ": " + Localization.lang("The string has been removed locally")));
-        } else {
-            container.getChildren().add(new Label(Localization.lang("Current content") + ": " + string.getContent()));
-        }
+        container.getChildren().add(new Label(Localization.lang("Current content") + ": " + string.getContent()));
 
         return container;
     }

--- a/src/main/java/org/jabref/gui/collab/StringRemoveChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/StringRemoveChangeViewModel.java
@@ -17,18 +17,15 @@ class StringRemoveChangeViewModel extends DatabaseChangeViewModel {
     private static final Logger LOGGER = LoggerFactory.getLogger(StringRemoveChangeViewModel.class);
     private final BibtexString string;
 
-    private final BibtexString inMem;
-
-    public StringRemoveChangeViewModel(BibtexString string, BibtexString inMem) {
+    public StringRemoveChangeViewModel(BibtexString string) {
         super(Localization.lang("Removed string") + ": '" + string.getName() + '\'');
         this.string = string;
-        this.inMem = inMem; // Holds the version in memory. Check if it has been modified...?
     }
 
     @Override
     public void makeChange(BibDatabaseContext database, NamedCompound undoEdit) {
         try {
-            database.getDatabase().removeString(inMem.getId());
+            database.getDatabase().removeString(string.getId());
             undoEdit.addEdit(new UndoableRemoveString(database.getDatabase(), string));
         } catch (Exception ex) {
             LOGGER.warn("Error: could not add string '" + string.getName() + "': " + ex.getMessage(), ex);

--- a/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -83,7 +83,7 @@ public class AppendDatabaseAction implements BaseAction {
 
         if (importStrings) {
             for (BibtexString bs : fromDatabase.getStringValues()) {
-                if (!database.hasStringLabel(bs.getName())) {
+                if (!database.hasStringByName(bs.getName())) {
                     database.addString(bs);
                     ce.addEdit(new UndoableInsertString(database, bs));
                 }
@@ -170,7 +170,7 @@ public class AppendDatabaseAction implements BaseAction {
                               .onFailure(exception -> {
                                   LOGGER.warn("Could not open database", exception);
                                   dialogService.showErrorDialogAndWait(Localization.lang("Open library"), exception);})
-                              .executeWith(Globals.TASK_EXECUTOR);;
+                              .executeWith(Globals.TASK_EXECUTOR);
             }
         }
     }

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class OpenDatabase {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger(OpenDatabase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenDatabase.class);
 
     private OpenDatabase() {
     }

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -309,7 +309,7 @@ public class BibDatabase {
      * Inserts a Bibtex String.
      */
     public synchronized void addString(BibtexString string) throws KeyCollisionException {
-        if (hasStringLabel(string.getName())) {
+        if (hasStringByName(string.getName())) {
             throw new KeyCollisionException("A string with that label already exists");
         }
 
@@ -393,7 +393,7 @@ public class BibDatabase {
     /**
      * Returns true if a string with the given label already exists.
      */
-    public synchronized boolean hasStringLabel(String label) {
+    public synchronized boolean hasStringByName(String label) {
         return bibtexStrings.values().stream().anyMatch(value -> value.getName().equals(label));
     }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -111,8 +111,6 @@ Cannot\ create\ group=Cannot create group
 
 Cannot\ create\ group.\ Please\ create\ a\ library\ first.=Cannot create group. Please create a library first.
 
-Cannot\ merge\ this\ change=Cannot merge this change
-
 case\ insensitive=case insensitive
 
 case\ sensitive=case sensitive
@@ -882,8 +880,6 @@ The\ search\ is\ case\ insensitive.=The search is case insensitive.
 
 The\ search\ is\ case\ sensitive.=The search is case sensitive.
 
-The\ string\ has\ been\ removed\ locally=The string has been removed locally
-
 There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=There are possible duplicates (marked with an icon) that haven't been resolved. Continue?
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=This group contains entries based on manual assignment. Entries can be assigned to this group by selecting them then using either drag and drop or the context menu. Entries can be removed from this group by selecting them then using the context menu.
@@ -1028,7 +1024,6 @@ Error\ opening\ file\ '%0'.=Error opening file '%0'.
 Formatter\ not\ found\:\ %0=Formatter not found: %0
 
 Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Could not save, file locked by another JabRef instance.
-Current\ tmp\ value=Current tmp value
 Metadata\ change=Metadata change
 Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Changes have been made to the following metadata elements
 

--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
@@ -3,20 +3,47 @@ package org.jabref.logic.bibtex.comparator;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BibDatabaseDiffTest {
+class BibDatabaseDiffTest {
 
     @Test
-    public void compareOfEmptyDatabasesReportsNoDifferences() throws Exception {
+    void compareOfEmptyDatabasesReportsNoDifferences() throws Exception {
         BibDatabaseDiff diff = BibDatabaseDiff.compare(new BibDatabaseContext(), new BibDatabaseContext());
+
         assertEquals(Optional.empty(), diff.getPreambleDifferences());
         assertEquals(Optional.empty(), diff.getMetaDataDifferences());
         assertEquals(Collections.emptyList(), diff.getBibStringDifferences());
+        assertEquals(Collections.emptyList(), diff.getEntryDifferences());
+    }
+
+    @Test
+    void compareOfSameEntryReportsNoDifferences() throws Exception {
+        BibEntry entry = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entry)));
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entry)));
+
+        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+
+        assertEquals(Collections.emptyList(), diff.getEntryDifferences());
+    }
+
+    @Test
+    void compareOfDifferentEntriesWithSameDataReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
+        BibEntry entryTwo = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
+
+        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
 }

--- a/src/test/java/org/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseTest.java
@@ -149,8 +149,8 @@ public class BibDatabaseTest {
     public void hasStringLabelFindsString() {
         BibtexString string = new BibtexString("DSP", "Digital Signal Processing");
         database.addString(string);
-        assertTrue(database.hasStringLabel("DSP"));
-        assertFalse(database.hasStringLabel("VLSI"));
+        assertTrue(database.hasStringByName("DSP"));
+        assertFalse(database.hasStringByName("VLSI"));
     }
 
     @Test


### PR DESCRIPTION
If a file is changed externally, JabRef is doing a 3-way merge between the last saved value vs current value in JabRef vs new value in file.
The way this is done is by first comparing the last saved file with the current (changed) file, and then trying to find additional/other changes in the currently open database. This is really complex and I believe there is some subtle bug in the logic leading to #5257.

With this PR, the change scanner is changed to a to simple 2-way merge between the current value in JabRef vs new value in file. This is way simpler and I hope this PR fixes #5257.
In a few edge cases, the 2-way merge has a small disadvantage. For example, consider the following steps:
- User A opens file
- User A changes field `Author` to `User A` and adds field `Title` with value `new`
- User B opens file
- User B changes field `Author` to `User B`
- User B saves file

At this point, User A gets a message that the file changed with the following changes:
- field `Author` changed from `User A` to `User B`
- field `Title` was removed

The 3-way merge could detect that `Title` was newly added, and thus could automatically reapply this change.  This is no longer possible with the simple 2-way merge.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
