### PR TITLE
Use GitVersion to increment build numbers

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,8 +35,8 @@ jobs:
         fetch-depth: 0
     - name: Fetch tags and master for GitVersion
       run: |
-        git branch --create-reflog master origin/master
         git fetch --tags origin
+        git branch --create-reflog master origin/master
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -47,12 +47,12 @@ jobs:
           git fetch --tags
           git branch --create-reflog master origin/master
     - name: Install GitVersion
-      uses: gittools/use-gitversion/setup@v0.2
+      uses: gittools/actions/setup-gitversion@v0.3
       with:
           versionSpec: '5.1.x'
     - name: Run GitVersion
       id: gitversion
-      uses: gittools/use-gitversion/execute@v0.2
+      uses: gittools/actions/execute-gitversion@v0.3
     - name: Test GitVersion
       run: |
         echo "Major: ${{ steps.gitversion.outputs.Major }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -44,7 +44,7 @@ jobs:
       id: extract_branch
     - name: Reattach head, fetch tags and master for GitVersion
       run: |
-          git checkout "${GITHUB_REF:11}"
+          git checkout "${{ steps.extract_branch.outputs.branch }}"
           git branch --create-reflog master origin/master
           git fetch --tags origin
     - name: Install GitVersion
@@ -121,11 +121,11 @@ jobs:
           zip.close()
       shell: python
     - name: Build runtime image
-      run: ./gradlew -Pdev=true jlinkZip
+      run: ./gradlew -Pdev=true -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
     - name: Build installer
       run: |
         export BADASS_JLINK_JPACKAGE_HOME="${GITHUB_WORKSPACE}${{ matrix.jdk14Path }}"
-        ./gradlew -Pdev=true jpackage
+        ./gradlew -Pdev=true -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
       shell: bash
     - name: Add installer as artifact
       uses: actions/upload-artifact@master

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -55,9 +55,36 @@ jobs:
       uses: gittools/use-gitversion/execute@v0.2
     - name: Test GitVersion
       run: |
-        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+        echo "Major: ${{ steps.gitversion.outputs.Major }}"
+        echo "Minor: ${{ steps.gitversion.outputs.Minor }}"
+        echo "Patch: ${{ steps.gitversion.outputs.Patch }}"
+        echo "PreReleaseTag: ${{ steps.gitversion.outputs.PreReleaseTag }}"
+        echo "PreReleaseTagWithDash: ${{ steps.gitversion.outputs.PreReleaseTagWithDash }}"
+        echo "PreReleaseLabel: ${{ steps.gitversion.outputs.PreReleaseLabel }}"
+        echo "PreReleaseNumber: ${{ steps.gitversion.outputs.PreReleaseNumber }}"
+        echo "WeightedPreReleaseNumber: ${{ steps.gitversion.outputs.WeightedPreReleaseNumber }}"
+        echo "BuildMetaData: ${{ steps.gitversion.outputs.BuildMetaData }}"
+        echo "BuildMetaDataPadded: ${{ steps.gitversion.outputs.BuildMetaDataPadded }}"
+        echo "FullBuildMetaData: ${{ steps.gitversion.outputs.FullBuildMetaData }}"
+        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.MajorMinorPatch }}"
+        echo "SemVer: ${{ steps.gitversion.outputs.SemVer }}"
+        echo "LegacySemVer: ${{ steps.gitversion.outputs.LegacySemVer }}"
+        echo "LegacySemVerPadded: ${{ steps.gitversion.outputs.LegacySemVerPadded }}"
         echo "AssemblySemVer: ${{ steps.gitversion.outputs.AssemblySemVer }}"
-        echo "AssemblySemVer: ${{ steps.gitversion.outputs.assemblySemVer }}"
+        echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.AssemblySemFileVer }}"
+        echo "FullSemVer: ${{ steps.gitversion.outputs.FullSemVer }}"
+        echo "InformationalVersion: ${{ steps.gitversion.outputs.InformationalVersion }}"
+        echo "BranchName: ${{ steps.gitversion.outputs.BranchName }}"
+        echo "Sha: ${{ steps.gitversion.outputs.Sha }}"
+        echo "ShortSha: ${{ steps.gitversion.outputs.ShortSha }}"
+        echo "NuGetVersionV2: ${{ steps.gitversion.outputs.NuGetVersionV2 }}"
+        echo "NuGetVersion: ${{ steps.gitversion.outputs.NuGetVersion }}"
+        echo "NuGetPreReleaseTagV2: ${{ steps.gitversion.outputs.NuGetPreReleaseTagV2 }}"
+        echo "NuGetPreReleaseTag: ${{ steps.gitversion.outputs.NuGetPreReleaseTag }}"
+        echo "VersionSourceSha: ${{ steps.gitversion.outputs.VersionSourceSha }}"
+        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}"
+        echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.CommitsSinceVersionSourcePadded }}"
+        echo "CommitDate: ${{ steps.gitversion.outputs.CommitDate }}"
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2-beta
     - name: Fetch tags for GitVersion
-      run: git fetch --tags origin
+      run: |
+        git fetch --unshallow
+        git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -30,23 +30,12 @@ jobs:
 
     steps:
     - name: Checkout source
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2-beta
       with:
         depth: 1
         submodules: false
-    - name: Extract branch name
-      shell: bash
-      run: |
-         ref=${GITHUB_REF#refs/heads/}
-         ref=${ref#refs/pull/}
-         ref=${ref%/merge}
-         echo "##[set-output name=branch;]${ref}"
-      id: extract_branch
-    - name: Reattach head, fetch tags and master for GitVersion
-      run: |
-          git checkout "${{ steps.extract_branch.outputs.branch }}"
-          git branch --create-reflog master origin/master
-          git fetch --tags origin
+    - name: Fetch tags for GitVersion
+      run: git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:
@@ -104,7 +93,7 @@ jobs:
       run: ${{ matrix.archivePortable }}
       shell: bash
     - name: Build and publish snap
-      if: matrix.os == 'ubuntu-latest' && steps.extract_branch.outputs.branch == 'master'
+      if: matrix.os == 'ubuntu-latest' && steps.gitversion.outputs.branchName == 'master'
       env:
         SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}
       run: |
@@ -120,7 +109,7 @@ jobs:
       uses: garygrossgarten/github-action-scp@release
       with:
         local: build/distribution
-        remote: www/${{ steps.extract_branch.outputs.branch }}
+        remote: www/${{ steps.gitversion.outputs.branchName }}
         host: builds.jabref.org
         username: builds_jabref_org
         privateKey: ${{ secrets.buildJabRefPrivateKey }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,13 +46,9 @@ jobs:
       run: |
           git fetch --tags
           git branch --create-reflog master origin/master
-    - name: Install GitVersion
-      uses: gittools/use-gitversion/setup@v0.2
-      with:
-          versionSpec: '5.1.x'
     - name: Run GitVersion
       id: gitversion
-      uses: gittools/use-gitversion/execute@v0.2
+      uses: roryprimrose/rungitversion@v1.0.0
     - name: Test GitVersion
       run: |
         echo "Major: ${{ steps.gitversion.outputs.Major }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -121,11 +121,11 @@ jobs:
           zip.close()
       shell: python
     - name: Build runtime image
-      run: ./gradlew -Pdev=true -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
+      run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
     - name: Build installer
       run: |
         export BADASS_JLINK_JPACKAGE_HOME="${GITHUB_WORKSPACE}${{ matrix.jdk14Path }}"
-        ./gradlew -Pdev=true -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
+        ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
       shell: bash
     - name: Add installer as artifact
       uses: actions/upload-artifact@master

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,6 +35,7 @@ jobs:
         fetch-depth: 0
     - name: Fetch tags and master for GitVersion
       run: |
+        git branch --create-reflog master origin/master
         git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -44,8 +44,8 @@ jobs:
       id: extract_branch
     - name: Fetch tags and master for GitVersion
       run: |
-          git fetch --tags
-          git branch --create-reflog master origin/master
+          git fetch --tags origin
+          git remote -v
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -111,18 +111,11 @@ jobs:
           mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
           docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "apt update -qq && cd $(pwd) && snapcraft && mv jabref*.snap build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
       shell: bash
-    - name: Rename files (Linux & MacOS)
-      if: matrix.os != 'windows-latest'
-      run: |
-        sudo apt-get install rename
-        rename 's/${{ steps.gitversion.outputs.AssemblySemVer }}/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}/' build/distribution/*
-        rename 's/portable/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-portable/' build/distribution/*
-    - name: Rename files (Windows)
-      if: matrix.os == 'windows-latest'
+    - name: Rename files
       run: |
         get-childitem -Path build/distribution/* | rename-item -NewName {$_.name -replace "${{ steps.gitversion.outputs.AssemblySemVer }}","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}"}
         get-childitem -Path build/distribution/* | rename-item -NewName {$_.name -replace "portable","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-portable"}
-      shell: powershell
+      shell: pwsh
     - name: Upload to builds.jabref.org
       uses: garygrossgarten/github-action-scp@release
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Fetch tags for GitVersion
       run: |
         git fetch --unshallow
+        git branch --create-reflog master origin/master
         git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,10 +42,10 @@ jobs:
          ref=${ref%/merge}
          echo "##[set-output name=branch;]${ref}"
       id: extract_branch
-    - name: Fetch tags and master for GitVersion
+    - name: Reattach head, fetch tags and master for GitVersion
       run: |
+          git checkout "${GITHUB_REF:11}"
           git fetch --tags origin
-          git remote -v
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -111,11 +111,18 @@ jobs:
           mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
           docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "apt update -qq && cd $(pwd) && snapcraft && mv jabref*.snap build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
       shell: bash
-    - name: Rename files
+    - name: Rename files (Linux & MacOS)
+      if: matrix.os != 'windows-latest'
       run: |
+        sudo apt-get install rename
         rename 's/${{ steps.gitversion.outputs.AssemblySemVer }}/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}/' build/distribution/*
         rename 's/portable/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-portable/' build/distribution/*
-      shell: bash
+    - name: Rename files (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        get-childitem -Path build/distribution/* | rename-item -NewName {$_.name -replace "${{ steps.gitversion.outputs.AssemblySemVer }}","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}"}
+        get-childitem -Path build/distribution/* | rename-item -NewName {$_.name -replace "portable","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-portable"}
+      shell: powershell
     - name: Upload to builds.jabref.org
       uses: garygrossgarten/github-action-scp@release
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,9 +31,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 0
     - name: Fetch tags and master for GitVersion
       run: |
-        git branch --create-reflog master origin/master
         git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -56,7 +56,8 @@ jobs:
     - name: Test GitVersion
       run: |
         echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
-        echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
+        echo "AssemblySemVer: ${{ steps.gitversion.outputs.AssemblySemVer }}"
+        echo "AssemblySemVer: ${{ steps.gitversion.outputs.assemblySemVer }}"
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,9 +46,13 @@ jobs:
       run: |
           git fetch --tags
           git branch --create-reflog master origin/master
+    - name: Install GitVersion
+      uses: gittools/use-gitversion/setup@v0.2
+      with:
+          versionSpec: '5.1.x'
     - name: Run GitVersion
       id: gitversion
-      uses: roryprimrose/rungitversion@v1.0.0
+      uses: gittools/use-gitversion/execute@v0.2
     - name: Test GitVersion
       run: |
         echo "Major: ${{ steps.gitversion.outputs.Major }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,9 +31,8 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2-beta
-    - name: Fetch tags for GitVersion
+    - name: Fetch tags and master for GitVersion
       run: |
-        git fetch --unshallow
         git branch --create-reflog master origin/master
         git fetch --tags origin
     - name: Install GitVersion

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,6 +42,21 @@ jobs:
          ref=${ref%/merge}
          echo "##[set-output name=branch;]${ref}"
       id: extract_branch
+    - name: Fetch tags and master for GitVersion
+      run: |
+          git fetch --tags
+          git branch --create-reflog master origin/master
+    - name: Install GitVersion
+      uses: gittools/use-gitversion/setup@v0.2
+      with:
+          versionSpec: '5.1.x'
+    - name: Run GitVersion
+      id: gitversion
+      uses: gittools/use-gitversion/execute@v0.2
+    - name: Test GitVersion
+      run: |
+        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+        echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Reattach head, fetch tags and master for GitVersion
       run: |
           git checkout "${GITHUB_REF:11}"
+          git branch --create-reflog master origin/master
           git fetch --tags origin
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,38 +54,6 @@ jobs:
     - name: Run GitVersion
       id: gitversion
       uses: gittools/actions/execute-gitversion@v0.3
-    - name: Test GitVersion
-      run: |
-        echo "Major: ${{ steps.gitversion.outputs.Major }}"
-        echo "Minor: ${{ steps.gitversion.outputs.Minor }}"
-        echo "Patch: ${{ steps.gitversion.outputs.Patch }}"
-        echo "PreReleaseTag: ${{ steps.gitversion.outputs.PreReleaseTag }}"
-        echo "PreReleaseTagWithDash: ${{ steps.gitversion.outputs.PreReleaseTagWithDash }}"
-        echo "PreReleaseLabel: ${{ steps.gitversion.outputs.PreReleaseLabel }}"
-        echo "PreReleaseNumber: ${{ steps.gitversion.outputs.PreReleaseNumber }}"
-        echo "WeightedPreReleaseNumber: ${{ steps.gitversion.outputs.WeightedPreReleaseNumber }}"
-        echo "BuildMetaData: ${{ steps.gitversion.outputs.BuildMetaData }}"
-        echo "BuildMetaDataPadded: ${{ steps.gitversion.outputs.BuildMetaDataPadded }}"
-        echo "FullBuildMetaData: ${{ steps.gitversion.outputs.FullBuildMetaData }}"
-        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.MajorMinorPatch }}"
-        echo "SemVer: ${{ steps.gitversion.outputs.SemVer }}"
-        echo "LegacySemVer: ${{ steps.gitversion.outputs.LegacySemVer }}"
-        echo "LegacySemVerPadded: ${{ steps.gitversion.outputs.LegacySemVerPadded }}"
-        echo "AssemblySemVer: ${{ steps.gitversion.outputs.AssemblySemVer }}"
-        echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.AssemblySemFileVer }}"
-        echo "FullSemVer: ${{ steps.gitversion.outputs.FullSemVer }}"
-        echo "InformationalVersion: ${{ steps.gitversion.outputs.InformationalVersion }}"
-        echo "BranchName: ${{ steps.gitversion.outputs.BranchName }}"
-        echo "Sha: ${{ steps.gitversion.outputs.Sha }}"
-        echo "ShortSha: ${{ steps.gitversion.outputs.ShortSha }}"
-        echo "NuGetVersionV2: ${{ steps.gitversion.outputs.NuGetVersionV2 }}"
-        echo "NuGetVersion: ${{ steps.gitversion.outputs.NuGetVersion }}"
-        echo "NuGetPreReleaseTagV2: ${{ steps.gitversion.outputs.NuGetPreReleaseTagV2 }}"
-        echo "NuGetPreReleaseTag: ${{ steps.gitversion.outputs.NuGetPreReleaseTag }}"
-        echo "VersionSourceSha: ${{ steps.gitversion.outputs.VersionSourceSha }}"
-        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.CommitsSinceVersionSource }}"
-        echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.CommitsSinceVersionSourcePadded }}"
-        echo "CommitDate: ${{ steps.gitversion.outputs.CommitDate }}"
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -142,6 +110,11 @@ jobs:
       run: |
           mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
           docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "apt update -qq && cd $(pwd) && snapcraft && mv jabref*.snap build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
+      shell: bash
+    - name: Rename files
+      run: |
+        rename 's/${{ steps.gitversion.outputs.AssemblySemVer }}/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}/' build/distribution/*
+        rename 's/portable/${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-portable/' build/distribution/*
       shell: bash
     - name: Upload to builds.jabref.org
       uses: garygrossgarten/github-action-scp@release

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,9 +31,6 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v2-beta
-      with:
-        depth: 1
-        submodules: false
     - name: Fetch tags for GitVersion
       run: git fetch --tags origin
     - name: Install GitVersion

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/setup-gitversion@v0.3
       with:
-          versionSpec: '5.1.x'
+          versionSpec: '5.1.2'
     - name: Run GitVersion
       id: gitversion
       uses: gittools/actions/execute-gitversion@v0.3

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,1 @@
+assembly-versioning-format: '{major}.{minor}.{patch}.{buildmetadata}'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,2 @@
-assembly-versioning-format: '{major}.{minor}.{patch}.{buildmetadata}'
+assembly-versioning-format: '{major}.{minor}.{buildmetadata}'
+assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{BranchName}--{ShortSha}'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
 assembly-versioning-format: '{major}.{minor}.{buildmetadata}'
-assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{BranchName}--{ShortSha}'
+assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,2 @@
 assembly-versioning-format: '{major}.{minor}.{buildmetadata}'
-assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}'
+assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{CommitDate}--{ShortSha}'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: LocalizationPlugin
 apply from: 'eclipse.gradle'
 
 group = "org.jabref"
-version = project.findProperty('projVersion') ?: '0.0.1'
+version = project.findProperty('projVersion') ?: '100.0.0'
 
 sourceCompatibility = 13
 targetCompatibility = 13
@@ -280,7 +280,7 @@ processResources {
     filteringCharset = 'UTF-8'
 
     filesMatching("build.properties") {
-        expand(version: project.findProperty('projVersionInfo') ?: '0.0.1',
+        expand(version: project.findProperty('projVersionInfo') ?: '100.0.0',
                 "year": String.valueOf(Calendar.getInstance().get(Calendar.YEAR)),
                 "authors": new File('AUTHORS').readLines().findAll { !it.startsWith("#") }.join(", "),
                 "developers": new File('DEVELOPERS').readLines().findAll { !it.startsWith("#") }.join(", "),

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ apply plugin: LocalizationPlugin
 apply from: 'eclipse.gradle'
 
 group = "org.jabref"
-version = "5.0.0"
+version = project.findProperty('projVersion') ?: '0.0.1'
 
 sourceCompatibility = 13
 targetCompatibility = 13
@@ -280,7 +280,7 @@ processResources {
     filteringCharset = 'UTF-8'
 
     filesMatching("build.properties") {
-        expand(version: createVersionString(),
+        expand(version: project.findProperty('projVersionInfo') ?: '0.0.1',
                 "year": String.valueOf(Calendar.getInstance().get(Calendar.YEAR)),
                 "authors": new File('AUTHORS').readLines().findAll { !it.startsWith("#") }.join(", "),
                 "developers": new File('DEVELOPERS').readLines().findAll { !it.startsWith("#") }.join(", "),
@@ -715,36 +715,4 @@ task bundleLibreOffice(type: Jar) {
 
     destinationDir = file('lib')
     archiveName = 'libreoffice.jar'
-}
-
-// Returns the value of project.version in production and a string of the format VERSION-dev--DATE--BRANCH--GIT_HASH for development versions
-def createVersionString() {
-    if (hasProperty('dev')) {
-        String command = "git log --pretty=format:%cd--%h -n 1 --date=short"
-        String commitInfo
-        if (OperatingSystem.current().isWindows()) {
-            commitInfo = "cmd /c $command".execute().in.text
-        } else {
-            commitInfo = command.execute().in.text
-        }
-
-        // determine branch
-        command = "git symbolic-ref -q --short HEAD"
-        String branchName
-        if (OperatingSystem.current().isWindows()) {
-            branchName = "cmd /c $command".execute().in.text
-        } else {
-            branchName = command.execute().in.text
-        }
-        // A newline is returned. Remove it. (trim())
-        // In the context of github, the branch name could be something like "pull/277"
-        // "/" is an illegal character. To be safe, all illegal filename characters are replaced by "_"
-        // http://stackoverflow.com/a/15075907/873282 describes the used pattern.
-        branchName = branchName.trim().replaceAll("[^a-zA-Z0-9.-]", "_")
-
-        // first the date (%cd), then the branch name, and finally the commit id (%h)
-        return project.version + "-dev--" + commitInfo.substring(0, 10) + "--" + branchName + "--" + commitInfo.substring(12)
-    } else {
-        return project.version
-    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes https://github.com/JabRef/jabref/issues/5399 and fixes https://github.com/JabRef/jabref/issues/5657.
The following version information is automatically determined by GitVersion based on the current tags.

|  Context      | Build version |  Build information |
|---------------|---------------|--------------------|
| PR            | 5.0.X         | 5.0-branch.Y       |
| Master        | 5.0.X         |  5.0               |
| After tag 5.1 | 5.1.X         |  5.1               |

Here, `X` is the number of commits since the last tag; and `Y is the number of commits on this branch; and `branch` is the branch name. Build version is the version used in gradle, i.e. the one used to generate the installer. Build information is what is displayed in the about dialog.
(Not sure if it really works on the master as it should; couldn't test it so far).

It should also work with tags of the form `5.0-beta` (which have `build version = 5.0.X` and `build information = 5.0-beta`). Thus, this PR hopefully also solves the problems of  https://github.com/JabRef/jabref/pull/5684.

<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
