### PR TITLE
Revert "Fix #5615 side pane not remembering position (#5629)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed visibility issues with the scrollbar and group selection highlight in "Dark" mode, and enabled "Dark" mode for the OpenOffice preview in the style selection window. [#5522](https://github.com/JabRef/jabref/issues/5522)
 - We fixed an issue where the author field was not correctly parsed during bibtex key-generation. [#5551](https://github.com/JabRef/jabref/issues/5551)
 - We fixed an issue where notifications where shown during autosave. [#5555](https://github.com/JabRef/jabref/issues/5555)
-- We fixed an issue where the side pane was not remembering its position. [#5615](https://github.com/JabRef/jabref/issues/5615)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -410,6 +410,7 @@ public class JabRefFrame extends BorderPane {
         head.setCenter(createToolbar());
         setTop(head);
 
+        SplitPane.setResizableWithParent(sidePane, Boolean.FALSE);
         splitPane.getItems().addAll(sidePane, tabbedPane);
 
         // We need to wait with setting the divider since it gets reset a few times during the initial set-up
@@ -422,8 +423,6 @@ public class JabRefFrame extends BorderPane {
 
                     EasyBind.subscribe(sidePane.visibleProperty(), visible -> {
                         if (visible) {
-                            // Run SplitPane.setResizableWithParent later to avoid miscalculation during initial layouting
-                            Platform.runLater(() -> SplitPane.setResizableWithParent(sidePane, Boolean.FALSE));
                             if (!splitPane.getItems().contains(sidePane)) {
                                 splitPane.getItems().add(0, sidePane);
                                 setDividerPosition();


### PR DESCRIPTION
This reverts commit 9ab537ffee59622b45631dab18286b3068edfc9a.

I'm not sure how to proceed with this. Unfortunately, in #5629 (which fixes https://github.com/JabRef/jabref/issues/5615), a UI bug was introduced (at least for MacOs). The two screenshots show the problem:

In the first screenshot everything is as in 5.0-alpha
<img width="1398" alt="Screen Shot 2019-12-03 at 13 54 35" src="https://user-images.githubusercontent.com/1254003/70052984-c9233800-15d4-11ea-9cfc-bc0df749695b.png">

From commit 9ab537ffee59622b45631dab18286b3068edfc9a (PR #5629) on, all the toolbar items are not shown anymore, unless you click on the icon with the two angle brackets (>>)
<img width="1394" alt="Screen Shot 2019-12-03 at 13 51 29" src="https://user-images.githubusercontent.com/1254003/70052985-c9bbce80-15d4-11ea-8368-ac24e8747958.png">

@Ka0o0 Do you have an alternative/better solution to the original problem https://github.com/JabRef/jabref/issues/5615?