### PR TITLE
Fix eclipse classpath build file

### DIFF
--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -28,6 +28,9 @@ eclipse {
                 javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref';
                 javafxcontrols.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref';
 
+                def javafxgraphics = entries.find { isJavafxGraphics(it) };
+                javafxgraphics.entryAttributes['add-opens'] = 'javafx.graphics/javafx.scene=org.controlsfx.controls';
+
                 def graaltruffle = entries.find{ isTruffleGraal(it) } ;
                 graaltruffle.entryAttributes['add-exports'] = 'com.oracle.truffle.regex/com.oracle.truffle.regex=org.graalvm.truffle';
 
@@ -55,6 +58,8 @@ boolean isSource(entry) { return entry.properties.kind.equals('src'); }
 boolean isControlsfx(entry) { return entry.properties.path.contains('controlsfx'); }
 
 boolean isJavafxControls(entry) { return entry.properties.path.contains('javafx-controls'); }
+
+boolean isJavafxGraphics(entry) { return entry.properties.path.contains('javafx-graphics'); }
 
 boolean isTruffleGraal(entry)  {return entry.properties.path.contains('org.graalvm.regex'); }
 


### PR DESCRIPTION
Add missing --add opens for controlsfx in eclipse classpath

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
