### PR TITLE
Fix #2868 - keep source groups selected after drag and drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where JabRef could not interact with [Oracle XE](https://www.oracle.com/de/database/technologies/appdev/xe.html) in the [shared SQL database setup](https://docs.jabref.org/collaborative-work/sqldatabase).
 - We fixed an issue where the toolbar icons were hidden on smaller screens.
 - We fixed an issue where renaming referenced files for bib entries with long titles was not possible. [#5603](https://github.com/JabRef/jabref/issues/5603)
+- We fixed a bug where the selection of groups was lost after drag and drop.[#2868](https://github.com/JabRef/jabref/issues/2868)
 
 ### Removed
 


### PR DESCRIPTION
This PR fixes a bug where the selection of the source groups was lost after drag and drop (#2868). I noticed a bug in the mapping from `GroupNodeViewModel` to the corresponding `TreeItem`.
The bug might also have caused other selection related bugs.

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
