### PR TITLE
Changes string representation when detecting custom entry types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where renaming referenced files for bib entries with long titles was not possible. [#5603](https://github.com/JabRef/jabref/issues/5603)
 - We fixed an issue where a window which is on an external screen gets unreachable when external screen is removed. [#5037](https://github.com/JabRef/jabref/issues/5037)
 - We fixed a bug where the selection of groups was lost after drag and drop. [#2868](https://github.com/JabRef/jabref/issues/2868)
+- We fixed an issue where the custom entry types didn't show the correct display name [#5651](https://github.com/JabRef/jabref/issues/5651)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.fxml
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.fxml
@@ -13,7 +13,6 @@
          <children>
             <Label text="%Custom entry types found in file" />
             <Label text="%Select all customized types to be stored in local preferences:" />
-            <Label text="%Currently unknown:" />
             <CheckListView fx:id="unknownEntryTypesCheckList" />
             <VBox fx:id="boxDifferentCustomization">
                <children>

--- a/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomEntryTypesDialog.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.cell.CheckBoxListCell;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.util.BaseDialog;
@@ -50,10 +51,16 @@ public class ImportCustomEntryTypesDialog extends BaseDialog<Void> {
     @FXML
     public void initialize() {
         viewModel = new ImportCustomEntryTypesDialogViewModel(mode, customEntryTypes, preferencesService);
-
         boxDifferentCustomization.visibleProperty().bind(Bindings.isNotEmpty(viewModel.differentCustomizations()));
         boxDifferentCustomization.managedProperty().bind(Bindings.isNotEmpty(viewModel.differentCustomizations()));
         unknownEntryTypesCheckList.setItems(viewModel.newTypes());
+        unknownEntryTypesCheckList.setCellFactory(listView -> new CheckBoxListCell<>(unknownEntryTypesCheckList::getItemBooleanProperty) {
+            @Override
+            public void updateItem(BibEntryType bibEntryType, boolean empty) {
+                super.updateItem(bibEntryType, empty);
+                setText(bibEntryType == null ? "" : bibEntryType.getType().getDisplayName());
+            }
+        });
         differentCustomizationCheckList.setItems(viewModel.differentCustomizations());
     }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
fixes issue #5651
Adds new CellFactory that changes the way the BibEntryTypes are displayed on the table without changing the `toString()` method on BibEntryType.
It also removes unnecessary label.

Here is a screenshot on how the window looks now.
<img width="566" alt="Screen Shot 2019-12-13 at 9 33 21 AM" src="https://user-images.githubusercontent.com/16848115/70816592-0df55e80-1d8d-11ea-848e-98a795cd9be3.png">
<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
