### PR TITLE
Allow addition of an entry by its Id (e.g., DOI, ISBN) - fixes #4183 #550

### DIFF
--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -63,6 +63,7 @@ public class Globals {
     public static ExporterFactory exportFactory;
     public static CountingUndoManager undoManager = new CountingUndoManager();
     public static BibEntryTypesManager entryTypesManager = new BibEntryTypesManager();
+
     // Key binding preferences
     private static KeyBindingRepository keyBindingRepository;
     private static DefaultFileUpdateMonitor fileUpdateMonitor;

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -41,12 +42,10 @@ public class JabRefGUI {
     private final boolean isBlank;
     private final List<ParserResult> failed = new ArrayList<>();
     private final List<ParserResult> toOpenTab = new ArrayList<>();
-    private final JabRefExecutorService executorService;
 
     public JabRefGUI(Stage mainStage, List<ParserResult> databases, boolean isBlank) {
         this.bibDatabases = databases;
         this.isBlank = isBlank;
-        executorService = JabRefExecutorService.INSTANCE;
         mainFrame = new JabRefFrame(mainStage);
 
         openWindow(mainStage);
@@ -89,8 +88,7 @@ public class JabRefGUI {
                 event.consume();
             }
         });
-
-        executorService.execute(this::openDatabases);
+        Platform.runLater(this::openDatabases);
     }
 
     private void openDatabases() {
@@ -176,6 +174,7 @@ public class JabRefGUI {
         for (int i = 0; (i < bibDatabases.size()) && (i < mainFrame.getBasePanelCount()); i++) {
             ParserResult pr = bibDatabases.get(i);
             BasePanel panel = mainFrame.getBasePanelAt(i);
+
             OpenDatabaseAction.performPostOpenActions(panel, pr);
         }
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -244,6 +244,7 @@ public class BasePanel extends StackPane {
 
     private void setupActions() {
         SaveDatabaseAction saveAction = new SaveDatabaseAction(this, Globals.prefs, Globals.entryTypesManager);
+
         CleanupAction cleanUpAction = new CleanupAction(this, Globals.prefs, Globals.TASK_EXECUTOR);
 
         actions.put(Actions.UNDO, undoAction);
@@ -258,6 +259,7 @@ public class BasePanel extends StackPane {
         actions.put(Actions.SAVE_AS, saveAction::saveAs);
 
         actions.put(Actions.SAVE_SELECTED_AS_PLAIN, saveAction::saveSelectedAsPlain);
+
 
         // The action for copying selected entries.
         actions.put(Actions.COPY, this::copy);

--- a/src/main/java/org/jabref/gui/EntryFromID.fxml
+++ b/src/main/java/org/jabref/gui/EntryFromID.fxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.ButtonType?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.DialogPane?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+
+
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefWidth="476.0" xmlns="http://javafx.com/javafx/8.0.171" fx:controller="org.jabref.gui.EntryFromIDView">
+
+    <buttonTypes>
+        <ButtonType fx:id="lookupButton" buttonData="OK_DONE" text="%LookUp"/>
+        <ButtonType fx:id="generateButton" buttonData="OK_DONE" text="%Generate"/>
+        <ButtonType fx:constant="CANCEL"/>
+    </buttonTypes>
+
+    <content>
+        <VBox prefHeight="200.0" prefWidth="400.0">
+
+                <GridPane alignment="CENTER">
+                    <children>
+                        <Label text="%FromID" GridPane.rowIndex="1" />
+                        <TextField fx:id="idTextField" onAction="#runFetcherWorker" prefHeight="30.0" prefWidth="300.0"
+                                   GridPane.rowIndex="2"/>
+
+                        <Label text="%LookUp" GridPane.rowIndex="3" />
+
+                        <TextArea fx:id="lookUpField"
+                              GridPane.rowIndex="4"/>
+
+                    </children>
+
+                </GridPane>
+        </VBox>
+    </content>
+</DialogPane>
+

--- a/src/main/java/org/jabref/gui/EntryFromID.fxml
+++ b/src/main/java/org/jabref/gui/EntryFromID.fxml
@@ -19,7 +19,8 @@
 <?import javafx.scene.layout.VBox?>
 
 
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefWidth="476.0" xmlns="http://javafx.com/javafx/8.0.171" fx:controller="org.jabref.gui.EntryFromIDView">
+<?import javafx.geometry.Insets?>
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefWidth="900.0" xmlns="http://javafx.com/javafx/8.0.171" fx:controller="org.jabref.gui.EntryFromIDView">
 
     <buttonTypes>
         <ButtonType fx:id="lookupButton" buttonData="OK_DONE" text="%LookUp"/>
@@ -28,22 +29,35 @@
     </buttonTypes>
 
     <content>
-        <VBox prefHeight="200.0" prefWidth="400.0">
-
+        <VBox prefHeight="400.0" prefWidth="850.0">
+            <children>
                 <GridPane alignment="CENTER">
                     <children>
                         <Label text="%FromID" GridPane.rowIndex="1" />
-                        <TextField fx:id="idTextField" onAction="#runFetcherWorker" prefHeight="30.0" prefWidth="300.0"
+                        <TextField fx:id="idTextField" onAction="#runFetcherWorker" prefHeight="30.0" prefWidth="400.0"
                                    GridPane.rowIndex="2"/>
 
                         <Label text="%LookUp" GridPane.rowIndex="3" />
 
-                        <TextArea fx:id="lookUpField"
+                        <Label fx:id="lookUpField"
                               GridPane.rowIndex="4"/>
 
                     </children>
 
+                    <columnConstraints>
+                        <ColumnConstraints hgrow="SOMETIMES" maxWidth="850.0" minWidth="10.0" prefWidth="850.0" />
+                        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="10.0" prefWidth="150.0" />
+                    </columnConstraints>
+                    <opaqueInsets>
+                        <Insets bottom="4.0" left="4.0" right="4.0" top="4.0" />
+                    </opaqueInsets>
+                    <rowConstraints>
+                        <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+                        <RowConstraints minHeight="30.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+                    </rowConstraints>
+
                 </GridPane>
+            </children>
         </VBox>
     </content>
 </DialogPane>

--- a/src/main/java/org/jabref/gui/EntryFromIDView.java
+++ b/src/main/java/org/jabref/gui/EntryFromIDView.java
@@ -1,0 +1,86 @@
+package org.jabref.gui;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.layout.FlowPane;
+import org.fxmisc.easybind.EasyBind;
+import org.jabref.Globals;
+import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.ControlHelper;
+import org.jabref.gui.util.ViewModelListCellFactory;
+import org.jabref.logic.importer.IdBasedFetcher;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.BibEntryType;
+import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
+import org.jabref.model.entry.types.BibtexEntryTypeDefinitions;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.IEEETranEntryTypeDefinitions;
+import org.jabref.preferences.JabRefPreferences;
+
+public class EntryFromIDView extends BaseDialog<EntryType> {
+
+    @FXML private ButtonType generateButton;
+    @FXML private ButtonType lookupButton;
+    @FXML private TextField idTextField;
+    @FXML private TextArea lookUpField;
+
+    private final BasePanel basePanel;
+    private final DialogService dialogService;
+    private final JabRefPreferences prefs;
+
+    private EntryFromIDViewModel viewModel;
+
+    public EntryFromIDView(BasePanel basePanel, DialogService dialogService, JabRefPreferences preferences) {
+        this.basePanel = basePanel;
+        this.dialogService = dialogService;
+        this.prefs = preferences;
+
+        this.setTitle(Localization.lang("Select entry type from ID"));
+        ViewLoader.view(this).load().setAsDialogPane(this);
+
+        ControlHelper.setAction(lookupButton, this.getDialogPane(), event -> viewModel.runFetcherWorkerForLookUp(lookUpField));
+
+        Button btnLookUp = (Button) this.getDialogPane().lookupButton(lookupButton);
+        btnLookUp.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> (searching) ? Localization.lang("Searching...") : Localization.lang("LookUp")));
+        btnLookUp.disableProperty().bind(viewModel.searchingProperty());
+
+        ControlHelper.setAction(generateButton, this.getDialogPane(), event -> viewModel.runFetcherWorker());
+
+        Button btnGenerate = (Button) this.getDialogPane().lookupButton(generateButton);
+        btnGenerate.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> (searching) ? Localization.lang("Adding...") : Localization.lang("Generate")));
+        btnGenerate.disableProperty().bind(viewModel.searchingProperty());
+
+    }
+
+    @FXML
+    public void initialize() {
+        viewModel = new EntryFromIDViewModel(prefs, basePanel, dialogService);
+
+        idTextField.textProperty().bindBidirectional(viewModel.idTextProperty());
+
+        EasyBind.subscribe(viewModel.getFocusAndSelectAllProperty(), evt -> {
+            if (evt) {
+                idTextField.requestFocus();
+                idTextField.selectAll();
+            }
+        });
+
+        Platform.runLater(() -> idTextField.requestFocus());
+    }
+
+    @FXML
+    private void runFetcherWorker(Event event) {
+        viewModel.runFetcherWorker();
+    }
+
+    @FXML
+    private void focusTextField(Event event) {
+        idTextField.requestFocus();
+        idTextField.selectAll();
+    }
+
+}

--- a/src/main/java/org/jabref/gui/EntryFromIDView.java
+++ b/src/main/java/org/jabref/gui/EntryFromIDView.java
@@ -21,17 +21,22 @@ import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.entry.types.IEEETranEntryTypeDefinitions;
 import org.jabref.preferences.JabRefPreferences;
 
+/**
+ * Dialog that prompts the user to enter an id for an entry.
+ * Returns null if canceled.
+ */
 public class EntryFromIDView extends BaseDialog<EntryType> {
 
     @FXML private ButtonType generateButton;
     @FXML private ButtonType lookupButton;
     @FXML private TextField idTextField;
-    @FXML private TextArea lookUpField;
+    @FXML private Label lookUpField;
 
     private final BasePanel basePanel;
     private final DialogService dialogService;
     private final JabRefPreferences prefs;
 
+    private EntryType type;
     private EntryFromIDViewModel viewModel;
 
     public EntryFromIDView(BasePanel basePanel, DialogService dialogService, JabRefPreferences preferences) {
@@ -40,7 +45,14 @@ public class EntryFromIDView extends BaseDialog<EntryType> {
         this.prefs = preferences;
 
         this.setTitle(Localization.lang("Select entry type from ID"));
-        ViewLoader.view(this).load().setAsDialogPane(this);
+        ViewLoader.view(this)
+                .load()
+                .setAsDialogPane(this);
+
+        setResultConverter(button -> {
+            //The buttonType will always be cancel, even if we pressed one of the entry type buttons
+            return type;
+        });
 
         ControlHelper.setAction(lookupButton, this.getDialogPane(), event -> viewModel.runFetcherWorkerForLookUp(lookUpField));
 

--- a/src/main/java/org/jabref/gui/EntryFromIDViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryFromIDViewModel.java
@@ -14,14 +14,20 @@ import javafx.collections.FXCollections;
 import javafx.concurrent.Task;
 import javafx.concurrent.Worker;
 
+import java.util.regex.Pattern;
+import java.util.HashMap;
+import  java.util.function.Predicate;
+
+import javafx.scene.control.TextArea;
 import org.jabref.Globals;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.logic.bibtex.DuplicateCheck;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyGenerator;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedFetcher;
+import org.jabref.logic.importer.NoFetcherFoundException;
 import org.jabref.logic.importer.WebFetchers;
-import org.jabref.logic.importer.fetcher.DoiFetcher;
+import org.jabref.logic.importer.fetcher.*;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.strings.StringUtil;
@@ -30,27 +36,74 @@ import org.jabref.preferences.JabRefPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EntryTypeViewModel {
+public class EntryFromIDViewModel {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EntryTypeViewModel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntryFromIDViewModel.class);
 
     private final JabRefPreferences prefs;
     private final BooleanProperty searchingProperty = new SimpleBooleanProperty();
     private final BooleanProperty searchSuccesfulProperty = new SimpleBooleanProperty();
-    private final ObjectProperty<IdBasedFetcher> selectedItemProperty = new SimpleObjectProperty<>();
-    private final ListProperty<IdBasedFetcher> fetchers = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final StringProperty idText = new SimpleStringProperty();
+    private  String fetcherName;
     private final BooleanProperty focusAndSelectAllProperty = new SimpleBooleanProperty();
     private Task<Optional<BibEntry>> fetcherWorker = new FetcherWorker();
+    private HashMap <Predicate<String>,IdBasedFetcher> fetcherMatchPattern = new HashMap<>();
     private final BasePanel basePanel;
     private final DialogService dialogService;
 
-    public EntryTypeViewModel(JabRefPreferences preferences, BasePanel basePanel, DialogService dialogService) {
+    public EntryFromIDViewModel(JabRefPreferences preferences, BasePanel basePanel, DialogService dialogService) {
         this.basePanel = basePanel;
         this.prefs = preferences;
         this.dialogService = dialogService;
-        fetchers.addAll(WebFetchers.getIdBasedFetchers(preferences.getImportFormatPreferences()));
-        selectedItemProperty.setValue(getLastSelectedFetcher());
+
+        //DOI validate hors http
+        Pattern pdoi = Pattern.compile("10\\.[0-9]{4}/([0-9]{13}|[a-zA-Z]+\\.[0-9]{4}\\.[0-9]{2}|[-_0-9]+)");
+        fetcherMatchPattern.put(pdoi.asPredicate(),new DoiFetcher(preferences.getImportFormatPreferences()));
+
+        //HTTPDOI
+        Pattern pHTTPdoi = Pattern.compile("10\\.[0-9]{4}/([0-9]{13}|[a-zA-Z]+\\.[0-9]{4}\\.[0-9]{2}|[-_0-9]+)");
+        fetcherMatchPattern.put(pHTTPdoi.asPredicate(),new DoiFetcher(preferences.getImportFormatPreferences()));
+
+        //ISBN validate
+        Pattern pisbn = Pattern.compile("^(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$");
+        fetcherMatchPattern.put(pisbn.asPredicate(),new IsbnFetcher(preferences.getImportFormatPreferences()));
+        //Rajouter pour long isbn
+
+        //DIVA Validate
+        Pattern pdiva = Pattern.compile("diva2:[0-9]{6}");
+        fetcherMatchPattern.put(pdiva.asPredicate(), new DiVA(preferences.getImportFormatPreferences()));
+
+        //MedlineFetcher Validate
+        Pattern pmd = Pattern.compile("[0-9]{8}");
+        fetcherMatchPattern.put(pmd.asPredicate(), new MedlineFetcher());
+
+        //MathSciNetId validate
+        Pattern pMathSciNetId = Pattern.compile("[0-9]{7}");
+        fetcherMatchPattern.put(pMathSciNetId.asPredicate(), new MathSciNet(preferences.getImportFormatPreferences()));
+
+        //LibraryOfCongress validate
+        Pattern pLibraryOfCongress= Pattern.compile("[0-9]{10}");
+        fetcherMatchPattern.put(pLibraryOfCongress.asPredicate(), new LibraryOfCongress(preferences.getImportFormatPreferences()));
+
+        //RfcFetcher validate
+        Pattern pRfcFetcher = Pattern.compile("[rR]*[fF]*[cC]*[0-9]{4}");
+        fetcherMatchPattern.put(pRfcFetcher.asPredicate(),new RfcFetcher(preferences.getImportFormatPreferences()));
+
+        //Arxiv
+        Pattern parxiv = Pattern.compile("[arXiv:]*[0-9][0-9](0[1-9]|1[0-2])\\.[0-9]{4}([v][0-9]+)*");
+        fetcherMatchPattern.put(parxiv.asPredicate(), new ArXiv(preferences.getImportFormatPreferences()));
+
+        //AstrophysicsDataSystem
+        Pattern pads = Pattern.compile("10\\.[0-9]{5}/([0-9]{13}|[a-zA-Z]+\\.[0-9]{4}\\.[0-9]{2}|[-_0-9]+)");
+        fetcherMatchPattern.put(pads.asPredicate(),new AstrophysicsDataSystem(preferences.getImportFormatPreferences()));
+
+        //TitleFetcher
+        //CrossRef -> DOI
+
+        //IacrEprintFetcher "Report 2017/1118 "
+        Pattern pIacr = Pattern.compile("[a-zA-Z]*\\s*[0-9]{4}/[0-9]{4}");
+        fetcherMatchPattern.put(pIacr.asPredicate(),new IacrEprintFetcher(preferences.getImportFormatPreferences()));
+
 
     }
 
@@ -62,10 +115,6 @@ public class EntryTypeViewModel {
         return searchingProperty;
     }
 
-    public ObjectProperty<IdBasedFetcher> selectedItemProperty() {
-        return selectedItemProperty;
-    }
-
     public StringProperty idTextProperty() {
         return idText;
     }
@@ -74,18 +123,6 @@ public class EntryTypeViewModel {
         return focusAndSelectAllProperty;
     }
 
-    public void storeSelectedFetcher() {
-        prefs.setIdBasedFetcherForEntryGenerator(selectedItemProperty.getValue().getName());
-    }
-
-    private IdBasedFetcher getLastSelectedFetcher() {
-        return fetchers.stream().filter(fetcher -> fetcher.getName().equals(prefs.getIdBasedFetcherForEntryGenerator()))
-                .findFirst().orElse(new DoiFetcher(prefs.getImportFormatPreferences()));
-    }
-
-    public ListProperty<IdBasedFetcher> fetcherItemsProperty() {
-        return fetchers;
-    }
 
     public void stopFetching() {
         if (fetcherWorker.getState() == Worker.State.RUNNING) {
@@ -98,20 +135,36 @@ public class EntryTypeViewModel {
         private IdBasedFetcher fetcher = null;
         private String searchID = "";
 
+        public IdBasedFetcher findFetcher (String id) {
+
+            return fetcherMatchPattern.entrySet().stream()
+                    .filter(e -> e.getKey().test(id))
+                    .map(e -> e.getValue())
+                    .findFirst()
+                    .orElseThrow(()-> new NoFetcherFoundException("Can't find fetcher for this id :" + id));
+
+        }
+
         @Override
         protected Optional<BibEntry> call() throws InterruptedException, FetcherException {
             Optional<BibEntry> bibEntry = Optional.empty();
 
             searchingProperty().setValue(true);
-            storeSelectedFetcher();
-            fetcher = selectedItemProperty().getValue();
+
             searchID = idText.getValue();
+
             if (!searchID.isEmpty()) {
-                bibEntry = fetcher.performSearchById(searchID);
+                try {
+                    fetcher = this.findFetcher(searchID);
+                    fetcherName=fetcher.getName();
+                    bibEntry = fetcher.performSearchById(searchID);
+                } catch (NoFetcherFoundException e) {
+                    dialogService.showErrorDialogAndWait(Localization.lang("No fetcher found."), Localization.lang("Error while searching fetcher from %0", searchID));
+                }
+
             }
             return bibEntry;
         }
-
     }
 
     public void runFetcherWorker() {
@@ -120,7 +173,7 @@ public class EntryTypeViewModel {
         fetcherWorker.setOnFailed(event -> {
             Throwable exception = fetcherWorker.getException();
             String fetcherExceptionMessage = exception.getMessage();
-            String fetcher = selectedItemProperty().getValue().getName();
+            String fetcher = fetcherName;
             String searchId = idText.getValue();
             if (exception instanceof FetcherException) {
                 dialogService.showErrorDialogAndWait(Localization.lang("Error"), Localization.lang("Error while fetching from %0", fetcher + "." + "\n" + fetcherExceptionMessage));
@@ -168,6 +221,51 @@ public class EntryTypeViewModel {
             } else if (StringUtil.isBlank(idText.getValue())) {
                 dialogService.showWarningDialogAndWait(Localization.lang("Empty search ID"), Localization.lang("The given search ID was empty."));
             }
+            fetcherWorker = new FetcherWorker();
+
+            focusAndSelectAllProperty.set(true);
+            searchingProperty().setValue(false);
+
+        });
+    }
+
+    public void runFetcherWorkerForLookUp(TextArea lookUpField) {
+        searchSuccesfulProperty.set(false);
+        fetcherWorker.run();
+        fetcherWorker.setOnFailed(event -> {
+            Throwable exception = fetcherWorker.getException();
+            String fetcherExceptionMessage = exception.getMessage();
+            String fetcher = fetcherName;
+            String searchId = idText.getValue();
+            if (exception instanceof FetcherException) {
+                dialogService.showErrorDialogAndWait(Localization.lang("Error"), Localization.lang("Error while fetching from %0", fetcher + "." + "\n" + fetcherExceptionMessage));
+            } else {
+                dialogService.showErrorDialogAndWait(Localization.lang("No files found.", Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId) + "\n" + fetcherExceptionMessage));
+            }
+            LOGGER.error(String.format("Exception during fetching when using fetcher '%s' with entry id '%s'.", searchId, fetcher), exception);
+
+            searchingProperty.set(false);
+
+            fetcherWorker = new FetcherWorker();
+
+        });
+
+        fetcherWorker.setOnSucceeded(evt -> {
+            Optional<BibEntry> result = fetcherWorker.getValue();
+
+            if (result.isPresent()) {
+
+                final BibEntry entry = result.get();
+
+                String entryString = "Found with : " + fetcherName + " Title : " + entry.getTitle();
+                lookUpField.setText(entryString);
+
+                searchSuccesfulProperty.set(true);
+
+            } else if (StringUtil.isBlank(idText.getValue())) {
+                dialogService.showWarningDialogAndWait(Localization.lang("Empty search ID"), Localization.lang("The given search ID was empty."));
+            }
+
             fetcherWorker = new FetcherWorker();
 
             focusAndSelectAllProperty.set(true);

--- a/src/main/java/org/jabref/gui/EntryType.fxml
+++ b/src/main/java/org/jabref/gui/EntryType.fxml
@@ -12,35 +12,43 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+
 <DialogPane xmlns:fx="http://javafx.com/fxml/1" prefWidth="476.0" xmlns="http://javafx.com/javafx/8.0.171"
             fx:controller="org.jabref.gui.EntryTypeView">
+
     <buttonTypes>
         <ButtonType fx:constant="CANCEL"/>
         <ButtonType fx:id="generateButton" buttonData="OK_DONE" text="%Generate"/>
     </buttonTypes>
+
    <content>
        <VBox prefHeight="200.0" prefWidth="400.0">
            <children>
+
                <TitledPane fx:id="biblatexTitlePane" animated="false" collapsible="false" text="Biblatex">
                    <content>
                        <FlowPane fx:id="biblatexPane" prefHeight="200.0" prefWidth="200.0"/>
                    </content>
                </TitledPane>
+
                <TitledPane fx:id="bibTexTitlePane" animated="false" collapsible="false" text="BibTeX">
                    <content>
                        <FlowPane fx:id="bibTexPane" prefHeight="200.0" prefWidth="200.0"/>
                    </content>
                </TitledPane>
+
                <TitledPane fx:id="ieeeTranTitlePane" animated="false" collapsible="false" text="IEEETran">
                    <content>
                        <FlowPane fx:id="ieeetranPane" prefHeight="200.0" prefWidth="200.0"/>
                    </content>
                </TitledPane>
+
                <TitledPane fx:id="customTitlePane" animated="false" collapsible="false" text="%Custom">
                    <content>
                        <FlowPane fx:id="customPane" prefHeight="200.0" prefWidth="200.0"/>
                    </content>
                </TitledPane>
+
                <GridPane alignment="CENTER">
                <children>
                    <Label text="%ID type"/>
@@ -50,6 +58,7 @@
                    <TextField fx:id="idTextField" onAction="#runFetcherWorker" prefHeight="30.0" prefWidth="300.0"
                               GridPane.columnIndex="1" GridPane.rowIndex="1"/>
                </children>
+
                <columnConstraints>
                   <ColumnConstraints hgrow="SOMETIMES" maxWidth="122.0" minWidth="10.0" prefWidth="100.0" />
                   <ColumnConstraints hgrow="SOMETIMES" maxWidth="146.0" minWidth="10.0" prefWidth="300.0" />

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -74,11 +74,7 @@ import org.jabref.gui.help.AboutAction;
 import org.jabref.gui.help.ErrorConsoleAction;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.help.SearchForUpdateAction;
-import org.jabref.gui.importer.ImportCommand;
-import org.jabref.gui.importer.ImportEntriesDialog;
-import org.jabref.gui.importer.ManageCustomImportsAction;
-import org.jabref.gui.importer.NewDatabaseAction;
-import org.jabref.gui.importer.NewEntryAction;
+import org.jabref.gui.importer.*;
 import org.jabref.gui.importer.actions.OpenDatabaseAction;
 import org.jabref.gui.importer.fetcher.LookupIdentifierAction;
 import org.jabref.gui.integrity.IntegrityCheckAction;
@@ -481,6 +477,10 @@ public class JabRefFrame extends BorderPane {
         HBox rightSide = new HBox(
                 factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(this, StandardEntryType.Article, dialogService, Globals.prefs, stateManager)),
                 factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(this, dialogService, Globals.prefs, stateManager)),
+
+                //AJOUT_ICI
+                factory.createIconButton(StandardActions.NEW_ENTRY_FROM_ID, new NewEntryAction(this, true,  dialogService, Globals.prefs, stateManager)),
+
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
                 new Separator(Orientation.VERTICAL),
                 factory.createIconButton(StandardActions.UNDO, new OldDatabaseCommandWrapper(Actions.UNDO, this, stateManager)),
@@ -729,6 +729,10 @@ public class JabRefFrame extends BorderPane {
         //@formatter:off
         library.getItems().addAll(
                 factory.createMenuItem(StandardActions.NEW_ENTRY, new NewEntryAction(this, dialogService, Globals.prefs, stateManager)),
+
+                //AJOUT_ICI
+                factory.createMenuItem(StandardActions.NEW_ENTRY_FROM_ID, new NewEntryAction(this, true, dialogService, Globals.prefs, stateManager)),
+
                 factory.createMenuItem(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, stateManager)),
 
                 new SeparatorMenuItem(),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -118,6 +118,9 @@ public enum StandardActions implements Action {
     SELECT_ALL(Localization.lang("Select all"), KeyBinding.SELECT_ALL),
 
     NEW_ENTRY(Localization.lang("New entry"), IconTheme.JabRefIcons.ADD_ENTRY, KeyBinding.NEW_ENTRY),
+
+    NEW_ENTRY_FROM_ID(Localization.lang("New entry From ID"), IconTheme.JabRefIcons.ADD_ENTRY_FROM_ID, KeyBinding.NEW_ENTRY_FROM_ID),
+
     NEW_ARTICLE(Localization.lang("New article"), IconTheme.JabRefIcons.ADD_ARTICLE),
     NEW_ENTRY_FROM_PLAINTEX(Localization.lang("New entry from plain text"), KeyBinding.NEW_FROM_PLAIN_TEXT),
     LIBRARY_PROPERTIES(Localization.lang("Library properties")),

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -148,6 +148,7 @@ public class IconTheme {
         ADD_NOBOX(MaterialDesignIcon.PLUS),
         ADD_ARTICLE(MaterialDesignIcon.PLUS),
         ADD_ENTRY(MaterialDesignIcon.PLAYLIST_PLUS),
+        ADD_ENTRY_FROM_ID(MaterialDesignIcon.NEWSPAPER),
         EDIT_ENTRY(MaterialDesignIcon.TOOLTIP_EDIT),
         EDIT_STRINGS(MaterialDesignIcon.TOOLTIP_TEXT),
         FOLDER(MaterialDesignIcon.FOOD_FORK_DRINK),

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -48,6 +48,7 @@ public enum KeyBinding {
     NEW_ARTICLE("New article", Localization.lang("New article"), "ctrl+shift+A", KeyBindingCategory.BIBTEX),
     NEW_BOOK("New book", Localization.lang("New book"), "ctrl+shift+B", KeyBindingCategory.BIBTEX),
     NEW_ENTRY("New entry", Localization.lang("New entry"), "ctrl+N", KeyBindingCategory.BIBTEX),
+    NEW_ENTRY_FROM_ID("New entry From ID", Localization.lang("New entry From ID"), "ctrl+D", KeyBindingCategory.BIBTEX),
     NEW_FROM_PLAIN_TEXT("New from plain text", Localization.lang("New from plain text"), "ctrl+shift+N", KeyBindingCategory.BIBTEX),
     NEW_INBOOK("New inbook", Localization.lang("New inbook"), "ctrl+shift+I", KeyBindingCategory.BIBTEX),
     NEW_MASTERSTHESIS("New mastersthesis", Localization.lang("New mastersthesis"), "ctrl+shift+M", KeyBindingCategory.BIBTEX),

--- a/src/main/java/org/jabref/logic/importer/FetcherException.java
+++ b/src/main/java/org/jabref/logic/importer/FetcherException.java
@@ -4,7 +4,6 @@ import org.jabref.JabRefException;
 
 public class FetcherException extends JabRefException {
 
-
     public FetcherException(String errorMessage, Throwable cause) {
         super(errorMessage, cause);
     }

--- a/src/main/java/org/jabref/logic/importer/NoFetcherFoundException.java
+++ b/src/main/java/org/jabref/logic/importer/NoFetcherFoundException.java
@@ -1,0 +1,15 @@
+package org.jabref.logic.importer;
+
+import org.jabref.JabRefException;
+
+public class NoFetcherFoundException extends RuntimeException {
+
+    public NoFetcherFoundException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+
+    public NoFetcherFoundException(String errorMessage) {
+        super(errorMessage);
+    }
+
+}

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -7,6 +7,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import java.util.regex.Pattern;
+import java.util.HashMap;
+import  java.util.function.Predicate;
+
 import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
 import org.jabref.logic.importer.fetcher.ACS;
 import org.jabref.logic.importer.fetcher.ArXiv;
@@ -122,8 +126,65 @@ public class WebFetchers {
     }
 
     /**
-     * @return sorted set containing entry based fetchers
+     * @return an Hashmap containing predicate from id type and their id based fetchers
      */
+    public static HashMap<Predicate<String>,IdBasedFetcher> getHashMapPredicateIdBasedFetchers(ImportFormatPreferences importFormatPreferences) {
+
+        HashMap <Predicate<String>,IdBasedFetcher> fetcherMatchPattern = new HashMap<Predicate<String>,IdBasedFetcher>();
+
+        //DOI validate
+        Pattern pdoi = Pattern.compile("(https://doi\\.org/)?10\\.[0-9]{4}/([0-9]{13}|[a-zA-Z]+\\.[0-9]{4}\\.[0-9]{2}|[-_0-9]+)");
+        fetcherMatchPattern.put(pdoi.asPredicate(), new DoiFetcher(importFormatPreferences));
+
+        //ISBN validate
+        Pattern pisbn = Pattern.compile("^(?:ISBN(?:-1[03])?:? )?(?=[0-9X]{10}$|(?=(?:[0-9]+[- ]){3})[- 0-9X]{13}$|97[89][0-9]{10}$|(?=(?:[0-9]+[- ]){4})[- 0-9]{17}$)(?:97[89][- ]?)?[0-9]{1,5}[- ]?[0-9]+[- ]?[0-9]+[- ]?[0-9X]$");
+        fetcherMatchPattern.put(pisbn.asPredicate(), new IsbnFetcher(importFormatPreferences));
+        //Rajouter pour long isbn
+
+        //DIVA Validate
+        Pattern pdiva = Pattern.compile("diva2:[0-9]{6}");
+        fetcherMatchPattern.put(pdiva.asPredicate(), new DiVA(importFormatPreferences));
+
+        //MedlineFetcher Validate
+        Pattern pmd = Pattern.compile("[0-9]{8}");
+        fetcherMatchPattern.put(pmd.asPredicate(), new MedlineFetcher());
+
+        //MathSciNetId validate
+        Pattern pMathSciNetId = Pattern.compile("[0-9]{7}");
+        fetcherMatchPattern.put(pMathSciNetId.asPredicate(), new MathSciNet(importFormatPreferences));
+
+        //LibraryOfCongress validate
+        Pattern pLibraryOfCongress = Pattern.compile("[0-9]{10}");
+        fetcherMatchPattern.put(pLibraryOfCongress.asPredicate(), new LibraryOfCongress(importFormatPreferences));
+
+        //RfcFetcher validate
+        Pattern pRfcFetcher = Pattern.compile("([rR][fF][cC])?[0-9]{4}");
+        fetcherMatchPattern.put(pRfcFetcher.asPredicate(), new RfcFetcher(importFormatPreferences));
+
+        //IacrEprintFetcher validate
+        Pattern pIacr = Pattern.compile("[a-zA-Z]*[0-9]{4}/[0-9]{4}");
+        fetcherMatchPattern.put(pIacr.asPredicate(), new IacrEprintFetcher(importFormatPreferences));
+
+        //Arxiv validate
+        Pattern parxiv = Pattern.compile("(http[s]?://arxiv\\.org/(abs/)?)?(arXiv:)?[0-9][0-9](0[1-9]|1[0-2])\\.[0-9]{4,5}([v][0-9]+)?");
+        fetcherMatchPattern.put(parxiv.asPredicate(), new ArXiv(importFormatPreferences));
+
+        //AstrophysicsDataSystem
+        Pattern pads = Pattern.compile("10\\.[0-9]{4,5}/[-)(.a-zA-Z_0-9]+");
+        fetcherMatchPattern.put(pads.asPredicate(), new AstrophysicsDataSystem(importFormatPreferences));
+
+        //TitleFetcher
+        Pattern pTitleFetcher = Pattern.compile("[-)(.a-zA-Z_0-9]+");
+        fetcherMatchPattern.put(pTitleFetcher.asPredicate(), new TitleFetcher(importFormatPreferences));
+
+        //CrossRef -> DOI
+
+        return fetcherMatchPattern;
+    }
+
+        /**
+         * @return sorted set containing entry based fetchers
+         */
     public static SortedSet<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         SortedSet<EntryBasedFetcher> set = new TreeSet<>(Comparator.comparing(WebFetcher::getName));
         set.add(new AstrophysicsDataSystem(importFormatPreferences));

--- a/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CrossRef.java
@@ -51,7 +51,7 @@ public class CrossRef implements IdParserFetcher<DOI>, EntryBasedParserFetcher, 
     @Override
     public URL getURLForEntry(BibEntry entry) throws URISyntaxException, MalformedURLException, FetcherException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
-        entry.getLatexFreeField(StandardField.TITLE).ifPresent(title -> uriBuilder.addParameter("query.title", title));
+        entry.getLatexFreeField(StandardField.TITLE).ifPresent(title -> uriBuilder.addParameter("query.bibliographic", title));
         entry.getLatexFreeField(StandardField.AUTHOR).ifPresent(author -> uriBuilder.addParameter("query.author", author));
         entry.getLatexFreeField(StandardField.YEAR).ifPresent(year ->
                 uriBuilder.addParameter("filter", "from-pub-date:" + year)

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -5,3 +5,4 @@ developers=${developers}
 azureInstrumentationKey=${azureInstrumentationKey}
 minRequiredJavaVersion = ${minRequiredJavaVersion}
 allowJava9 = ${allowJava9}
+

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -93,6 +93,8 @@ Automatically\ remove\ exact\ duplicates=Automatically remove exact duplicates
 
 AUX\ file\ import=AUX file import
 
+author = Author
+
 Available\ export\ formats=Available export formats
 
 Available\ import\ formats=Available import formats
@@ -391,6 +393,8 @@ Formatter\ name=Formatter name
 
 found\ in\ AUX\ file=found in AUX file
 
+FromID = Enter the identifier like ISBN, DOI, or Arxiv  in the field below
+
 Further\ information\ about\ Mr\ DLib.\ for\ JabRef\ users.=Further information about Mr DLib. for JabRef users.
 
 General=General
@@ -517,6 +521,8 @@ Link=Link
 Listen\ for\ remote\ operation\ on\ port=Listen for remote operation on port
 Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Load and Save preferences from/to jabref.xml on start-up (memory stick mode)
 
+LookUp = Look Up
+
 Show\ advanced\ hints\ (i.e.\ helpful\ tooltips,\ suggestions\ and\ explanation)=Show advanced hints (i.e. helpful tooltips, suggestions and explanation)
 
 Main\ file\ directory=Main file directory
@@ -575,6 +581,8 @@ no\ library\ generated=no library generated
 
 No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=No entries found. Please make sure you are using the correct import filter.
 No\ files\ found.=No files found.
+
+No\ fetcher\ found.=No fetcher found.
 
 No\ GUI.\ Only\ process\ command\ line\ options=No GUI. Only process command line options
 
@@ -921,6 +929,8 @@ Timezone\ (Provides\ for\ better\ recommendations\ by\ indicating\ the\ time\ of
 Time\ stamp=Time stamp
 Toggle\ groups\ interface=Toggle groups interface
 
+title = Title
+
 Trim\ all\ whitespace\ characters\ in\ the\ field\ content.=Trim all whitespace characters in the field content.
 
 Trim\ whitespace\ characters=Trim whitespace characters
@@ -1007,6 +1017,7 @@ Could\ not\ move\ file\ '%0'.=Could not move file '%0'.
 Could\ not\ find\ file\ '%0'.=Could not find file '%0'.
 Number\ of\ entries\ successfully\ imported=Number of entries successfully imported
 Error\ while\ fetching\ from\ %0=Error while fetching from %0
+Error\ while\ searching\ fetcher\ from\ %0 = Error while searching fetcher from %0
 
 Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refuse to save the library before external changes have been reviewed.
 Library\ protection=Library protection
@@ -1258,6 +1269,7 @@ Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefine
 Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Your style file specifies the paragraph format '%0', which is undefined in your current OpenOffice/LibreOffice document.
 
 Searching...=Searching...
+Adding... = Adding ...
 Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Add {} to specified title words on search to keep the correct case
 Import\ conversions=Import conversions
 Please\ enter\ a\ search\ string=Please enter a search string

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -93,7 +93,7 @@ Automatically\ remove\ exact\ duplicates=Automatically remove exact duplicates
 
 AUX\ file\ import=AUX file import
 
-author = Author
+author= Author
 
 Available\ export\ formats=Available export formats
 
@@ -393,7 +393,7 @@ Formatter\ name=Formatter name
 
 found\ in\ AUX\ file=found in AUX file
 
-FromID = Enter the identifier like ISBN, DOI, or Arxiv  in the field below
+FromID= Enter the identifier like ISBN, DOI, or Arxiv  in the field below
 
 Further\ information\ about\ Mr\ DLib.\ for\ JabRef\ users.=Further information about Mr DLib. for JabRef users.
 
@@ -521,7 +521,7 @@ Link=Link
 Listen\ for\ remote\ operation\ on\ port=Listen for remote operation on port
 Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Load and Save preferences from/to jabref.xml on start-up (memory stick mode)
 
-LookUp = Look Up
+LookUp= Look Up
 
 Show\ advanced\ hints\ (i.e.\ helpful\ tooltips,\ suggestions\ and\ explanation)=Show advanced hints (i.e. helpful tooltips, suggestions and explanation)
 
@@ -929,7 +929,7 @@ Timezone\ (Provides\ for\ better\ recommendations\ by\ indicating\ the\ time\ of
 Time\ stamp=Time stamp
 Toggle\ groups\ interface=Toggle groups interface
 
-title = Title
+title= Title
 
 Trim\ all\ whitespace\ characters\ in\ the\ field\ content.=Trim all whitespace characters in the field content.
 
@@ -1017,7 +1017,7 @@ Could\ not\ move\ file\ '%0'.=Could not move file '%0'.
 Could\ not\ find\ file\ '%0'.=Could not find file '%0'.
 Number\ of\ entries\ successfully\ imported=Number of entries successfully imported
 Error\ while\ fetching\ from\ %0=Error while fetching from %0
-Error\ while\ searching\ fetcher\ from\ %0 = Error while searching fetcher from %0
+Error\ while\ searching\ fetcher\ from\ %0= Error while searching fetcher from %0
 
 Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refuse to save the library before external changes have been reviewed.
 Library\ protection=Library protection
@@ -1269,7 +1269,7 @@ Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefine
 Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Your style file specifies the paragraph format '%0', which is undefined in your current OpenOffice/LibreOffice document.
 
 Searching...=Searching...
-Adding... = Adding ...
+Adding...= Adding ...
 Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Add {} to specified title words on search to keep the correct case
 Import\ conversions=Import conversions
 Please\ enter\ a\ search\ string=Please enter a search string

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -91,6 +91,8 @@ Automatically\ remove\ exact\ duplicates=Supprimer automatiquement les doublons 
 
 AUX\ file\ import=Importation de fichier AUX
 
+author = Auteur
+
 Available\ export\ formats=Formats d'exportation disponibles
 
 Available\ import\ formats=Formats d'importation disponibles
@@ -394,6 +396,8 @@ Formatter\ name=Nom de formateur
 
 found\ in\ AUX\ file=trouvées dans le fichier AUX
 
+FromID = Entrez l'identifiant comme un ISBN, DOI, ou Arxiv  dans le champ ci-dessous
+
 Further\ information\ about\ Mr\ DLib.\ for\ JabRef\ users.=Informations supplémentaires à propos de Mr. Dlib pour les utilisateurs de JabRef.
 
 General=Général
@@ -523,6 +527,8 @@ Link=Lien
 Listen\ for\ remote\ operation\ on\ port=Écouter le port pour des opérations à distance
 Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Charger et enregistrer les préférences de/vers jabref.xml au démarrage (mode clef-mémoire)
 
+LookUp = Aperçu
+
 Show\ advanced\ hints\ (i.e.\ helpful\ tooltips,\ suggestions\ and\ explanation)=Afficher les astuces avancées (c'est-à-dire les astuces utiles, les suggestions et l'explication)
 
 Main\ file\ directory=Répertoire de fichiers principal
@@ -580,6 +586,8 @@ no\ library\ generated=pas de fichier créé
 
 No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Pas d'entrées trouvées. Veuillez vous assurez que vous utilisez le filtre d'importation approprié.
 No\ files\ found.=Fichiers non trouvés.
+
+No\ fetcher\ found.= Outil de recherche non trouvé.
 
 No\ GUI.\ Only\ process\ command\ line\ options=Pas d'interface graphique. Traitement limité aux options de la ligne de commande
 
@@ -929,6 +937,8 @@ Timezone\ (Provides\ for\ better\ recommendations\ by\ indicating\ the\ time\ of
 Time\ stamp=Horodatage
 Toggle\ groups\ interface=Afficher/Masquer l'interface des groupes
 
+title = Titre
+
 Trim\ all\ whitespace\ characters\ in\ the\ field\ content.=Supprime tous les caractères d’espacement du contenu du champ.
 
 Trim\ whitespace\ characters=Supprimez les caractères d’espacement
@@ -1018,6 +1028,7 @@ Could\ not\ move\ file\ '%0'.=Le fichier « %0 » n'a pas pu être déplacé.
 Could\ not\ find\ file\ '%0'.=Le fichier « %0 » n'a pas pu être trouvé.
 Number\ of\ entries\ successfully\ imported=Nombre d'entrées importées avec succès
 Error\ while\ fetching\ from\ %0=Erreur au cours de la recherche %0
+Error\ while\ searching\ fetcher\ from\ %0 = Erreur pour trouver un outil de recherche depuis %0
 
 Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refus d'enregistrement du fichier tant que les changements externes ne sont pas vérifiés.
 Library\ protection=Protection du fichier
@@ -1279,6 +1290,7 @@ Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefine
 Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Votre fichier de style spécifie le format de paragraphe « %0 », qui n'est pas défini dans votre document OpenOffice/LibreOffice actuel.
 
 Searching...=Recherche...
+Adding... = Ajout ...
 Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Ajouter {} aux mots du titre spécifiés lors d'une recherche pour préserver la casse correcte
 Import\ conversions=Importer les conversions
 Please\ enter\ a\ search\ string=Veuillez entrer une chaîne de recherche

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -91,7 +91,7 @@ Automatically\ remove\ exact\ duplicates=Supprimer automatiquement les doublons 
 
 AUX\ file\ import=Importation de fichier AUX
 
-author = Auteur
+author= Auteur
 
 Available\ export\ formats=Formats d'exportation disponibles
 
@@ -396,7 +396,7 @@ Formatter\ name=Nom de formateur
 
 found\ in\ AUX\ file=trouvées dans le fichier AUX
 
-FromID = Entrez l'identifiant comme un ISBN, DOI, ou Arxiv  dans le champ ci-dessous
+FromID= Entrez l'identifiant comme un ISBN, DOI, ou Arxiv  dans le champ ci-dessous
 
 Further\ information\ about\ Mr\ DLib.\ for\ JabRef\ users.=Informations supplémentaires à propos de Mr. Dlib pour les utilisateurs de JabRef.
 
@@ -527,7 +527,7 @@ Link=Lien
 Listen\ for\ remote\ operation\ on\ port=Écouter le port pour des opérations à distance
 Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Charger et enregistrer les préférences de/vers jabref.xml au démarrage (mode clef-mémoire)
 
-LookUp = Aperçu
+LookUp= Aperçu
 
 Show\ advanced\ hints\ (i.e.\ helpful\ tooltips,\ suggestions\ and\ explanation)=Afficher les astuces avancées (c'est-à-dire les astuces utiles, les suggestions et l'explication)
 
@@ -937,7 +937,7 @@ Timezone\ (Provides\ for\ better\ recommendations\ by\ indicating\ the\ time\ of
 Time\ stamp=Horodatage
 Toggle\ groups\ interface=Afficher/Masquer l'interface des groupes
 
-title = Titre
+title= Titre
 
 Trim\ all\ whitespace\ characters\ in\ the\ field\ content.=Supprime tous les caractères d’espacement du contenu du champ.
 
@@ -1028,7 +1028,7 @@ Could\ not\ move\ file\ '%0'.=Le fichier « %0 » n'a pas pu être déplacé.
 Could\ not\ find\ file\ '%0'.=Le fichier « %0 » n'a pas pu être trouvé.
 Number\ of\ entries\ successfully\ imported=Nombre d'entrées importées avec succès
 Error\ while\ fetching\ from\ %0=Erreur au cours de la recherche %0
-Error\ while\ searching\ fetcher\ from\ %0 = Erreur pour trouver un outil de recherche depuis %0
+Error\ while\ searching\ fetcher\ from\ %0= Erreur pour trouver un outil de recherche depuis %0
 
 Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refus d'enregistrement du fichier tant que les changements externes ne sont pas vérifiés.
 Library\ protection=Protection du fichier
@@ -1290,7 +1290,7 @@ Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefine
 Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Votre fichier de style spécifie le format de paragraphe « %0 », qui n'est pas défini dans votre document OpenOffice/LibreOffice actuel.
 
 Searching...=Recherche...
-Adding... = Ajout ...
+Adding...= Ajout ...
 Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Ajouter {} aux mots du titre spécifiés lors d'une recherche pour préserver la casse correcte
 Import\ conversions=Importer les conversions
 Please\ enter\ a\ search\ string=Veuillez entrer une chaîne de recherche


### PR DESCRIPTION
Creation of a button which opens a dialog.
Only one textfield for an id
Regex on the id to know the fetcher
3 buttons : cancel,  look the source and generate
#4183 #550 
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
