### PR TITLE
Various fixes to the dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 
 - We fixed an issue where the Medline fetcher was only working when JabRef was running from source [#5645](https://github.com/JabRef/jabref/issues/5645)
-
+- We fixed some visual issues in the dark theme [#5764](https://github.com/JabRef/jabref/pull/5764) [#5753](https://github.com/JabRef/jabref/issues/5753)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -573,7 +573,7 @@
 }
 
 .table-view .groupColumnBackground {
-    -fx-stroke: -fx-mid-text-color;
+    -fx-stroke: -jr-gray-2;
 }
 
 .scroll-pane:focused,

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -211,6 +211,7 @@
 
     /* The small thin light "shadow" for mark-like objects. Typically used in
      * conjunction with -fx-mark-color with an insets of 1 0 -1 0. */
+    -fx-mark-color: -fx-text-base-color;
     -fx-mark-highlight-color: transparent;
     /*-fx-mark-highlight-color: derive(-fx-color,80%);*/
 
@@ -235,10 +236,14 @@
     /** Focus line for keyboard focus traversal on cell based controls */
     -fx-cell-focus-inner-border: derive(-fx-selection-bar,30%);
 
-    -fx-focused-mark-color : -fx-focused-text-base-color;
+    -fx-focused-mark-color: -fx-focused-text-base-color;
 
     /* Consistent size for headers of tab-pane and side-panels*/
     -jr-header-height: 3em;
+}
+
+#frame {
+    -fx-background-color: -jr-background-alt;
 }
 
 /*
@@ -262,6 +267,9 @@
        the text is always vertically centered within the bounds. Based on
        the cap height of the text. */
     -fx-bounds-type: logical_vertical_center;
+
+    /* The base color of icons should always be the same as the text. */
+    -fx-fill: -fx-text-base-color;
 }
 
 .tooltip {
@@ -385,7 +393,7 @@
 }
 
 .check-box > .box {
-    -fx-border-color: rgba(0, 0, 0, 0.54);
+    -fx-border-color: -fx-outer-border; /* rgba(0, 0, 0, 0.54); */
     -fx-border-width: 2px;
     -fx-border-radius: 1px;
     -fx-padding: 0.1em 0.1em 0.2em 0.2em;
@@ -562,6 +570,10 @@
 .tree-table-view > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell .tree-table-cell:selected {
     -fx-border-color: transparent;
     -fx-background-insets: 0;
+}
+
+.table-view .groupColumnBackground {
+    -fx-stroke: -fx-mid-text-color;
 }
 
 .scroll-pane:focused,
@@ -1070,4 +1082,42 @@ We want to have a look that matches our icons in the tool-bar */
 
 .dialog-pane {
     -fx-background-color: -fx-control-inner-background;
+}
+
+.code-area .text {
+    -fx-fill: -fx-text-background-color;
+}
+
+.code-area .selection {
+    -fx-fill: -jr-accent;
+}
+
+.code-area .caret {
+    -fx-stroke: -fx-text-background-color;
+}
+
+.code-area .context-menu {
+    -fx-font-family: sans-serif;
+}
+
+.citationsList {
+    -fx-text-fill: -fx-text-base-color;
+}
+
+.citationsList .contextBox {
+    -fx-border-color: -fx-outer-border;
+    -fx-border-insets: 5;
+    -fx-border-style: dashed;
+    -fx-border-width: 2;
+    -fx-padding: 12;
+}
+
+.citationsList .contextBox * {
+    -fx-fill: -fx-text-base-color;
+}
+
+.citationsList .label {
+    -fx-font-family: monospace;
+    -fx-font-weight: bold;
+    -fx-label-padding: 5 0 10 10;
 }

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -59,6 +59,10 @@
     color : #7d8591; /* -fx-mid-text-color*/
 }
 
+.table-view .groupColumnBackground {
+    -fx-stroke: -jr-gray-4;
+}
+
 .code-area .lineno {
     -fx-background-color: -jr-background-alt;
     -fx-text-fill: -fx-mid-text-color;

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -47,7 +47,7 @@
     -jr-menu-forground-active: derive(-fx-light-text-color, 50%);
 
     -jr-scrollbar-thumb: derive(-fx-outer-border, -30%);
-    -jr-scrollbar-track: derive(-fx-control-inner-background, -90%); 
+    -jr-scrollbar-track: derive(-fx-control-inner-background, -90%);
 
     -fx-focused-text-base-color: -fx-dark-text-color;
 
@@ -57,6 +57,11 @@
 #previewBody{
     background-color: #272b38; /* -fx-control-inner-background*/
     color : #7d8591; /* -fx-mid-text-color*/
+}
+
+.code-area .lineno {
+    -fx-background-color: -jr-background-alt;
+    -fx-text-fill: -fx-mid-text-color;
 }
 
 .text-unchanged {
@@ -73,4 +78,8 @@
 
 .numberColumn > .hits:all-selected {
     -fx-background-color: -jr-gray-3;
+}
+
+#preferencesContainer .tab-pane > .tab-header-area > .tab-header-background {
+    -fx-background-color: -jr-background;
 }

--- a/src/main/java/org/jabref/gui/FXDialog.java
+++ b/src/main/java/org/jabref/gui/FXDialog.java
@@ -64,6 +64,8 @@ public class FXDialog extends Alert {
                 dialogWindow.close();
             }
         });
+
+        getDialogPane().getStyleClass().add("dialog-pane");
     }
 
     public FXDialog(AlertType type) {

--- a/src/main/java/org/jabref/gui/FXDialog.java
+++ b/src/main/java/org/jabref/gui/FXDialog.java
@@ -64,8 +64,6 @@ public class FXDialog extends Alert {
                 dialogWindow.close();
             }
         });
-
-        getDialogPane().getStyleClass().add("dialog-pane");
     }
 
     public FXDialog(AlertType type) {

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -40,6 +40,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 import org.jabref.Globals;
@@ -405,9 +406,10 @@ public class JabRefFrame extends BorderPane {
     private void initLayout() {
         setProgressBarVisible(false);
 
-        BorderPane head = new BorderPane();
-        head.setTop(createMenu());
-        head.setCenter(createToolbar());
+        setId("frame");
+
+        VBox head = new VBox(createMenu(),createToolbar());
+        head.setSpacing(0d);
         setTop(head);
 
         splitPane.getItems().addAll(sidePane, tabbedPane);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -41,10 +41,6 @@
     -fx-font-weight: normal;
 }
 
-.code-area .context-menu {
-    -fx-font-family: sans-serif;
-}
-
 .icon-button.narrow {
     -fx-padding: 0.1em;
 }
@@ -90,35 +86,59 @@
     -fx-background-color: -jr-error;
 }
 
-.code-area .text {
+.code-area .context-menu {
+    -fx-font-family: sans-serif;
+}
+
+#related-articles-tab {
+    -fx-padding: 20 20 20 20;
+    -fx-background-color: -fx-control-inner-background;
+}
+
+#related-articles-tab * {
     -fx-fill: -fx-text-background-color;
 }
 
-.gdpr-dialog {
-    -fx-font-size: 14pt;
+#gdpr-dialog {
+    -fx-border-color: -jr-warn;
+    -fx-border-insets: 5;
+    -fx-border-style: dashed;
+    -fx-border-width: 2;
+    -fx-padding: 12;
+    -fx-font-size: 1.3em;
 }
 
-.related-articles-tab {
-    -fx-padding: 20 20 20 20;
-}
-
-.recommendation-heading {
-    -fx-font-size: 14pt;
-    -fx-font-weight: bold;
-}
-
-.recommendation-description {
-    -fx-font-style: italic;
+#gdpr-dialog * {
+    -fx-fill: -fx-text-background-color;
 }
 
 .recommendation-item {
     -fx-padding: 0 0 0 20;
 }
 
+#bibtexSourceCodeArea {
+    -fx-padding: 4 4 4 4;
+    -fx-background-color: -fx-control-inner-background;
+}
+
 #bibtexSourceCodeArea .search {
     -fx-fill: red;
 }
 
-.bibtexSourceCodeArea .text {
+#citationsPane {
+    -fx-padding: 0;
+    -fx-background-color: -fx-control-inner-background;
+}
+
+#citationsPane * {
     -fx-fill: -fx-text-background-color;
+}
+
+.heading {
+    -fx-font-size: 1.5em;
+    -fx-font-weight: bold;
+}
+
+.description {
+    -fx-font-style: italic;
 }

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -62,6 +62,7 @@ public class LatexCitationsTab extends EntryEditorTab {
 
         searchPane.getColumnConstraints().setAll(column);
         searchPane.getRowConstraints().setAll(mainRow, bottomRow);
+        searchPane.setId("citationsPane");
         setContent(searchPane);
 
         EasyBind.subscribe(viewModel.statusProperty(), status -> {
@@ -86,11 +87,9 @@ public class LatexCitationsTab extends EntryEditorTab {
 
     private HBox getLatexDirectoryBox() {
         Text latexDirectoryText = new Text(Localization.lang("Current search directory:"));
-        latexDirectoryText.setStyle("-fx-font-size: 0.9em;-fx-padding: 0;");
         Text latexDirectoryPath = new Text(viewModel.directoryProperty().get().toString());
-        latexDirectoryPath.setStyle("-fx-font-family: 'Courier New', Courier, monospace;-fx-font-size: 0.9em;-fx-font-weight: bold;");
+        latexDirectoryPath.setStyle("-fx-font-family:monospace;-fx-font-weight: bold;");
         Button latexDirectoryButton = new Button(Localization.lang("Set LaTeX file directory"));
-        latexDirectoryButton.setStyle("-fx-border-width: 1;-fx-font-size: 0.85em;-fx-padding: 0.2em;");
         latexDirectoryButton.setGraphic(IconTheme.JabRefIcons.LATEX_FILE_DIRECTORY.getGraphicNode());
         latexDirectoryButton.setOnAction(event -> viewModel.setLatexDirectory());
         HBox latexDirectoryBox = new HBox(10, latexDirectoryText, latexDirectoryPath, latexDirectoryButton);
@@ -106,8 +105,11 @@ public class LatexCitationsTab extends EntryEditorTab {
 
     private VBox getNotFoundPane() {
         Label titleLabel = new Label(Localization.lang("No citations found"));
-        titleLabel.setStyle("-fx-font-size: 1.5em;-fx-font-weight: bold;-fx-text-fill: -jr-theme-text;");
+        titleLabel.getStyleClass().add("heading");
+
         Text notFoundText = new Text(Localization.lang("No LaTeX files containing this entry were found."));
+        notFoundText.getStyleClass().add("description");
+
         VBox notFoundBox = new VBox(30, titleLabel, notFoundText);
         notFoundBox.setStyle("-fx-padding: 30 0 0 30;");
         return notFoundBox;

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -3,6 +3,8 @@ package org.jabref.gui.entryeditor;
 import java.io.IOException;
 import java.util.List;
 
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.DoubleBinding;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Hyperlink;
@@ -54,7 +56,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
      */
     private StackPane getRelatedArticlesPane(BibEntry entry) {
         StackPane root = new StackPane();
-        root.getStyleClass().add("related-articles-tab");
+        root.setId("related-articles-tab");
         ProgressIndicator progress = new ProgressIndicator();
         progress.setMaxSize(100, 100);
 
@@ -92,10 +94,10 @@ public class RelatedArticlesTab extends EntryEditorTab {
 
         String heading = fetcher.getHeading();
         Text headingText = new Text(heading);
-        headingText.getStyleClass().add("recommendation-heading");
+        headingText.getStyleClass().add("heading");
         String description = fetcher.getDescription();
         Text descriptionText = new Text(description);
-        descriptionText.getStyleClass().add("recommendation-description");
+        descriptionText.getStyleClass().add("description");
         vBox.getChildren().add(headingText);
         vBox.getChildren().add(descriptionText);
 
@@ -143,7 +145,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
         vBox.setSpacing(20.0);
 
         Text descriptionText = new Text(Localization.lang("No recommendations received from Mr. DLib for this entry."));
-        descriptionText.getStyleClass().add("recommendation-description");
+        descriptionText.getStyleClass().add("description");
         vBox.getChildren().add(descriptionText);
         scrollPane.setContent(vBox);
 
@@ -157,20 +159,26 @@ public class RelatedArticlesTab extends EntryEditorTab {
      */
     private ScrollPane getPrivacyDialog(BibEntry entry) {
         ScrollPane root = new ScrollPane();
-        root.getStyleClass().add("related-articles-tab");
+        root.setId("related-articles-tab");
         VBox vbox = new VBox();
-        vbox.getStyleClass().add("gdpr-dialog");
+        vbox.setId("gdpr-dialog");
         vbox.setSpacing(20.0);
+
+        Text title = new Text(Localization.lang("Mr. DLib Privacy settings"));
+        title.getStyleClass().add("heading");
 
         Button button = new Button(Localization.lang("I Agree"));
         button.setDefaultButton(true);
 
+        DoubleBinding rootWidth = Bindings.subtract(root.widthProperty(),88d);
+
         Text line1 = new Text(Localization.lang("JabRef requests recommendations from Mr. DLib, which is an external service. To enable Mr. DLib to calculate recommendations, some of your data must be shared with Mr. DLib. Generally, the more data is shared the better recommendations can be calculated. However, we understand that some of your data in JabRef is sensitive, and you may not want to share it. Therefore, Mr. DLib offers a choice of which data you would like to share."));
-        line1.setWrappingWidth(1300.0);
+        line1.wrappingWidthProperty().bind(rootWidth);
         Text line2 = new Text(Localization.lang("Whatever option you choose, Mr. DLib may share its data with research partners to further improve recommendation quality as part of a 'living lab'. Mr. DLib may also release public datasets that may contain anonymized information about you and the recommendations (sensitive information such as metadata of your articles will be anonymised through e.g. hashing). Research partners are obliged to adhere to the same strict data protection policy as Mr. DLib."));
-        line2.setWrappingWidth(1300.0);
+        line2.wrappingWidthProperty().bind(rootWidth);
         Text line3 = new Text(Localization.lang("This setting may be changed in preferences at any time."));
-        Hyperlink mdlLink = new Hyperlink(Localization.lang("Further information about Mr DLib. for JabRef users."));
+        line3.wrappingWidthProperty().bind(rootWidth);
+        Hyperlink mdlLink = new Hyperlink(Localization.lang("Further information about Mr. DLib for JabRef users."));
         mdlLink.setOnAction(event -> {
             try {
                 JabRefDesktop.openBrowser("http://mr-dlib.org/information-for-users/information-about-mr-dlib-for-jabref-users/");
@@ -202,7 +210,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
             setContent(getRelatedArticlesPane(entry));
         });
 
-        vbox.getChildren().addAll(line1, line2, mdlLink, line3, vb, button);
+        vbox.getChildren().addAll(title, line1, line2, mdlLink, line3, vb, button);
         root.setContent(vbox);
 
         return root;

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -159,10 +159,10 @@ class MainTableColumnFactory {
 
             for (Color groupColor : groupColors) {
                 Rectangle groupRectangle = new Rectangle();
+                groupRectangle.getStyleClass().add("groupColumnBackground");
                 groupRectangle.setWidth(3);
                 groupRectangle.setHeight(18);
                 groupRectangle.setFill(groupColor);
-                groupRectangle.setStroke(Color.DARKGRAY);
                 groupRectangle.setStrokeWidth(1);
 
                 container.getChildren().add(groupRectangle);

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.css
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.css
@@ -26,7 +26,7 @@
     -fx-background-color: transparent;
 }
 
-#container {
+#preferencesContainer {
     -fx-padding: 0.5em;
 }
 
@@ -38,7 +38,10 @@
     -fx-padding: 0;
     -fx-border-width: 1;
     -fx-background-color: transparent;
-    -fx-border-color: -fx-outer-border;
+}
+
+.code-area .text {
+    -fx-fill: -fx-text-background-color;
 }
 
 .code-area .tagmark {
@@ -59,7 +62,7 @@
 }
 
 .code-area .avalue {
-    -fx-fill: black;
+    -fx-fill: green;
 }
 
 .code-area .comment {
@@ -68,10 +71,6 @@
 
 .code-area .highlight-keyword {
     -fx-text-fill: -jr-purple;
-}
-
-.code-area .context-menu {
-    -fx-font-family: sans-serif;
 }
 
 .code-area .context-menu .menu-item .label {

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
@@ -41,7 +41,7 @@
                     <Button maxWidth="Infinity" onAction="#resetPreferences" text="%Reset preferences"/>
                 </VBox>
             </VBox>
-            <ScrollPane fx:id="container" maxHeight="Infinity" maxWidth="Infinity"/>
+            <ScrollPane fx:id="preferencesContainer" maxHeight="Infinity" maxWidth="Infinity"/>
         </SplitPane>
     </content>
     <ButtonType fx:id="saveButton" text="%Save" buttonData="OK_DONE"/>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -30,7 +30,7 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
 
     @FXML private CustomTextField searchBox;
     @FXML private ListView<PreferencesTab> preferenceTabList;
-    @FXML private ScrollPane container;
+    @FXML private ScrollPane preferencesContainer;
     @FXML private ButtonType saveButton;
 
     @Inject private DialogService dialogService;
@@ -76,9 +76,9 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
 
         EasyBind.subscribe(preferenceTabList.getSelectionModel().selectedItemProperty(), tab -> {
             if (tab == null) {
-                container.setContent(null);
+                preferencesContainer.setContent(null);
             } else {
-                container.setContent(tab.getBuilder());
+                preferencesContainer.setContent(tab.getBuilder());
             }
         });
 

--- a/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
+++ b/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
@@ -30,6 +30,8 @@ public class CitationsDisplay extends ListView<Citation> {
         new ViewModelListCellFactory<Citation>().withGraphic(this::getDisplayGraphic)
                                                 .withTooltip(this::getDisplayTooltip)
                                                 .install(this);
+
+        this.getStyleClass().add("citationsList");
     }
 
     public ObjectProperty<Path> basePathProperty() {
@@ -45,13 +47,11 @@ public class CitationsDisplay extends ListView<Citation> {
         Text contextText = new Text(LatexToUnicodeAdapter.format(item.getContext()));
         contextText.wrappingWidthProperty().bind(this.widthProperty().subtract(85));
         HBox contextBox = new HBox(8, citationIcon, contextText);
-        contextBox.setStyle("-fx-border-color: grey;-fx-border-insets: 5;-fx-border-style: dashed;-fx-border-width: 2;-fx-padding: 12;");
+        contextBox.getStyleClass().add("contextBox");
 
         Label fileNameLabel = new Label(String.format("%s", basePath.get().relativize(item.getPath())));
-        fileNameLabel.setStyle("-fx-font-family: 'Courier New', Courier, monospace;-fx-font-weight: bold;-fx-label-padding: 5 0 10 10;");
         fileNameLabel.setGraphic(IconTheme.JabRefIcons.LATEX_FILE.getGraphicNode());
         Label positionLabel = new Label(String.format("(%s:%s-%s)", item.getLine(), item.getColStart(), item.getColEnd()));
-        positionLabel.setStyle("-fx-font-family: 'Courier New', Courier, monospace;-fx-font-weight: bold;-fx-label-padding: 5 0 10 10;");
         positionLabel.setGraphic(IconTheme.JabRefIcons.LATEX_LINE.getGraphicNode());
         HBox dataBox = new HBox(5, fileNameLabel, positionLabel);
 

--- a/src/main/java/org/jabref/gui/texparser/ParseTexResult.css
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexResult.css
@@ -1,0 +1,25 @@
+#referenceListView {
+    -fx-background-color: -jr-sidepane-background;
+}
+
+#referenceListView > .virtual-flow > .clipped-container > .sheet > .list-cell {
+    -fx-padding: 4 4 4 4;
+    -fx-background: transparent;
+    -fx-text-fill: -fx-text-base-color;
+}
+
+#referenceListView > .virtual-flow > .clipped-container > .sheet > .list-cell * {
+    -fx-text-fill: -fx-text-base-color;
+}
+
+.split-pane > .split-pane-divider {
+    -fx-padding: 0 4 0 4;
+    -fx-background-color: transparent;
+}
+
+.button-bar > .container {
+    -fx-border-width: 1 0 0 0;
+    -fx-border-color: -jr-sidepane-background;
+}
+
+

--- a/src/main/java/org/jabref/gui/texparser/ParseTexResult.fxml
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexResult.fxml
@@ -6,16 +6,16 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.texparser.CitationsDisplay?>
+<?import javafx.scene.control.SplitPane?>
+
 <DialogPane xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.jabref.gui.texparser.ParseTexResultView"
             prefWidth="900.0" prefHeight="600.0">
     <content>
-        <VBox spacing="10.0">
-            <HBox spacing="10.0" VBox.vgrow="ALWAYS">
-                <ListView fx:id="referenceListView" prefWidth="200.0"/>
-                <CitationsDisplay fx:id="citationsDisplay" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS"/>
-            </HBox>
-        </VBox>
+        <SplitPane dividerPositions="0.2">
+            <ListView fx:id="referenceListView" prefWidth="200.0"/>
+            <CitationsDisplay fx:id="citationsDisplay" HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS"/>
+        </SplitPane>
     </content>
     <ButtonType fx:id="importButtonType" text="%Import new entries" buttonData="OK_DONE"/>
     <ButtonType fx:constant="CLOSE"/>

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -382,7 +382,7 @@ Formatter\ name=Formatter name
 
 found\ in\ AUX\ file=found in AUX file
 
-Further\ information\ about\ Mr\ DLib.\ for\ JabRef\ users.=Further information about Mr DLib. for JabRef users.
+Further\ information\ about\ Mr.\ DLib\ for\ JabRef\ users.=Further information about Mr. DLib for JabRef users.
 
 General=General
 
@@ -539,6 +539,8 @@ Modify=Modify
 move\ group=move group
 
 Moved\ group\ "%0".=Moved group "%0".
+
+Mr.\ DLib\ Privacy\ settings=Mr. DLib Privacy settings
 
 No\ recommendations\ received\ from\ Mr.\ DLib\ for\ this\ entry.=No recommendations received from Mr. DLib for this entry.
 


### PR DESCRIPTION
Some visual bugs were still in the dark theme present. This is a quick fix:

+ Many icons where dark black. They use the standard text color now.
+ Wrong highlight color of the mark symbol in menus is now highlight text color.
+ The thin white line between the menubar and the toolbar is gone. ( fixes #5753 )
+ The background on starting up JabRef was white until a library was loaded.
+ The unselected checkbox border was black, only while the unselected radio-buttons were grey. Now they are all grey in various shades. (less then 50)
+ The group color indicator was unreadable, as the grey border was too ... grey. It's more lightweight now.
+ The CodeArea in the in the entry source editor and in the preview preferences had the wrong background color, caret color, selection background color, line number colors and some highlights were unreadable. They use the common color scheme now. ( refs [#5522-comment](https://github.com/JabRef/jabref/issues/5522#issuecomment-548920940) )
+ The citations tab was bright white, had some windows specific fonts encoded and some obscure font size settings. It uses the common color scheme now and the font settings are a bit equalized.
+ The dark tab header bar in the preview preferences was too heavy. It uses the common background color now.
+ The related articles tab in the entry editor presents the gdpr warning some smaller font size, it wraps according to the window width, shows a heading and has a fancy yellow border around it.
+ Fixed a typo ("Mr DLib." instead of "Mr. DLib")
+ The TexParserResult dialog is now presented in a SplitPane.

Except the Mr. DLib tab, the light theme should not be affected.

Some screenshots before:
<img width="39" alt="bright checks" src="https://user-images.githubusercontent.com/50491877/71040657-675fe380-2127-11ea-9a09-b62636f5891f.png"> <img width="498" alt="dark tabbar" src="https://user-images.githubusercontent.com/50491877/71040806-c3c30300-2127-11ea-8211-8ea997b1f8cc.png">
<img width="90" alt="indist group indicator" src="https://user-images.githubusercontent.com/50491877/71040747-9e35f980-2127-11ea-9e36-6c322a927a9d.png"> <img width="502" alt="inconsistent control colors" src="https://user-images.githubusercontent.com/50491877/71040766-aa21bb80-2127-11ea-8bcb-035a7496b02d.png">
<img width="159" alt="search icon" src="https://user-images.githubusercontent.com/50491877/71040811-c6bdf380-2127-11ea-8815-b24dc66285f1.png">

And after:
<img width="47" alt="better group bars" src="https://user-images.githubusercontent.com/50491877/71041367-2e287300-2129-11ea-9f3c-59d5df5f35a3.png"> <img width="139" alt="source editor" src="https://user-images.githubusercontent.com/50491877/71041381-3385bd80-2129-11ea-99ad-e9f55f7f4c3b.png"> <img width="176" alt="icons" src="https://user-images.githubusercontent.com/50491877/71041504-89f2fc00-2129-11ea-903a-af4c77bd06cf.png"> <img width="346" alt="mrdlib" src="https://user-images.githubusercontent.com/50491877/71041386-37b1db00-2129-11ea-921b-d8e0c7dba484.png">
<img width="499" alt="previewprefs" src="https://user-images.githubusercontent.com/50491877/71041389-3a143500-2129-11ea-8cc9-c3dfe64132db.png">
<img width="515" alt="checkboxes and icons" src="https://user-images.githubusercontent.com/50491877/71041742-17cee700-212a-11ea-845a-cd5675eddc7c.png">

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
