### PR TITLE
Improve things arround change detection

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -991,10 +991,6 @@ public class BasePanel extends StackPane {
         return this.bibDatabaseContext;
     }
 
-    public void markExternalChangesAsResolved() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::markExternalChangesAsResolved);
-    }
-
     public SidePaneManager getSidePaneManager() {
         return sidePaneManager;
     }
@@ -1057,10 +1053,6 @@ public class BasePanel extends StackPane {
         changePane = new DatabaseChangePane(splitPane, bibDatabaseContext, changeMonitor.get());
 
         this.getChildren().setAll(changePane);
-    }
-
-    public void updateTimeStamp() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::markAsSaved);
     }
 
     public void copy() {

--- a/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
@@ -42,13 +42,14 @@ class ChangeDisplayDialog extends BaseDialog<Boolean> {
         Label rootInfo = new Label(Localization.lang("Select the tree nodes to view and accept or reject changes") + '.');
         infoPanel.setCenter(rootInfo);
 
+        ButtonType dismissChanges = new ButtonType(Localization.lang("Dismiss changes"), ButtonBar.ButtonData.CANCEL_CLOSE);
         getDialogPane().getButtonTypes().setAll(
                 new ButtonType(Localization.lang("Accept changes"), ButtonBar.ButtonData.APPLY),
-                ButtonType.CANCEL
+                dismissChanges
         );
 
         setResultConverter(button -> {
-            if (button == ButtonType.CANCEL) {
+            if (button == dismissChanges) {
                 return false;
             } else {
                 // Perform all accepted changes

--- a/src/main/java/org/jabref/gui/collab/ChangeScanner.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeScanner.java
@@ -10,8 +10,8 @@ import org.jabref.logic.bibtex.comparator.BibDatabaseDiff;
 import org.jabref.logic.bibtex.comparator.BibEntryDiff;
 import org.jabref.logic.bibtex.comparator.BibStringDiff;
 import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.OpenDatabase;
 import org.jabref.logic.importer.ParserResult;
-import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
@@ -36,9 +36,9 @@ public class ChangeScanner {
             List<DatabaseChangeViewModel> changes = new ArrayList<>();
 
             // Parse the modified file
+            // Important: apply all post-load actions
             ImportFormatPreferences importFormatPreferences = Globals.prefs.getImportFormatPreferences();
-            ParserResult result = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor())
-                    .importDatabase(database.getDatabasePath().get(), importFormatPreferences.getEncoding());
+            ParserResult result = OpenDatabase.loadDatabase(database.getDatabasePath().get(), importFormatPreferences, new DummyFileUpdateMonitor());
             BibDatabaseContext databaseOnDisk = result.getDatabaseContext();
 
             // Start looking at changes.

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -1,14 +1,11 @@
 package org.jabref.gui.collab;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
-import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -22,7 +19,6 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private final BibDatabaseContext database;
     private final FileUpdateMonitor fileMonitor;
     private final List<DatabaseChangeListener> listeners;
-    private Path referenceFile;
     private TaskExecutor taskExecutor;
 
     public DatabaseChangeMonitor(BibDatabaseContext database, FileUpdateMonitor fileMonitor, TaskExecutor taskExecutor) {
@@ -34,9 +30,6 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
         this.database.getDatabasePath().ifPresent(path -> {
             try {
                 fileMonitor.addListenerForFile(path, this);
-                referenceFile = Files.createTempFile("jabref", ".bib");
-                referenceFile.toFile().deleteOnExit();
-                setAsReference(path);
             } catch (IOException e) {
                 LOGGER.error("Error while trying to monitor " + path, e);
             }
@@ -64,15 +57,4 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
         database.getDatabasePath().ifPresent(file -> fileMonitor.removeListener(file, this));
     }
 
-    public void markExternalChangesAsResolved() {
-        markAsSaved();
-    }
-
-    public void markAsSaved() {
-        database.getDatabasePath().ifPresent(this::setAsReference);
-    }
-
-    private void setAsReference(Path file) {
-        FileUtil.copyFile(file, referenceFile, true);
-    }
 }

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangePane.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangePane.java
@@ -30,14 +30,12 @@ public class DatabaseChangePane extends NotificationPane {
     private void onDatabaseChanged(List<DatabaseChangeViewModel> changes) {
         this.getActions().setAll(
                 new Action(Localization.lang("Dismiss changes"), event -> {
-                    monitor.markExternalChangesAsResolved();
                     this.hide();
                 }),
                 new Action(Localization.lang("Review changes"), event -> {
                     ChangeDisplayDialog changeDialog = new ChangeDisplayDialog(database, changes);
                     changeDialog.showAndWait();
 
-                    monitor.markExternalChangesAsResolved();
                     this.hide();
                 }));
         this.show();

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangePane.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangePane.java
@@ -35,11 +35,10 @@ public class DatabaseChangePane extends NotificationPane {
                 }),
                 new Action(Localization.lang("Review changes"), event -> {
                     ChangeDisplayDialog changeDialog = new ChangeDisplayDialog(database, changes);
-                    boolean changesHandled = changeDialog.showAndWait().orElse(false);
-                    if (changesHandled) {
-                        monitor.markExternalChangesAsResolved();
-                        this.hide();
-                    }
+                    changeDialog.showAndWait();
+
+                    monitor.markExternalChangesAsResolved();
+                    this.hide();
                 }));
         this.show();
     }

--- a/src/main/java/org/jabref/gui/collab/EntryAddChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryAddChangeViewModel.java
@@ -13,23 +13,27 @@ import org.jabref.model.entry.BibEntry;
 
 class EntryAddChangeViewModel extends DatabaseChangeViewModel {
 
-    private final BibEntry diskEntry;
+    private final BibEntry entry;
 
-    public EntryAddChangeViewModel(BibEntry diskEntry) {
-        super(Localization.lang("Added entry"));
-        this.diskEntry = diskEntry;
+    public EntryAddChangeViewModel(BibEntry entry) {
+        super();
+        this.name = entry.getCiteKeyOptional()
+                         .map(key -> Localization.lang("Added entry") + ": '" + key + '\'')
+                         .orElse(Localization.lang("Added entry"));
+        this.entry = entry;
     }
 
     @Override
     public void makeChange(BibDatabaseContext database, NamedCompound undoEdit) {
-        database.getDatabase().insertEntry(diskEntry);
-        undoEdit.addEdit(new UndoableInsertEntry(database.getDatabase(), diskEntry));
+        database.getDatabase().insertEntry(entry);
+        undoEdit.addEdit(new UndoableInsertEntry(database.getDatabase(), entry));
     }
 
     @Override
     public Node description() {
         PreviewViewer previewViewer = new PreviewViewer(new BibDatabaseContext(), JabRefGUI.getMainFrame().getDialogService(), Globals.stateManager);
-        previewViewer.setEntry(diskEntry);
+        previewViewer.setLayout(Globals.prefs.getPreviewPreferences().getCurrentPreviewStyle());
+        previewViewer.setEntry(entry);
         return previewViewer;
     }
 }

--- a/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/EntryChangeViewModel.java
@@ -116,7 +116,11 @@ class EntryChangeViewModel extends DatabaseChangeViewModel {
                 container.getChildren().add(new Label(Localization.lang("Value cleared externally")));
             }
 
-            container.getChildren().add(new Label(Localization.lang("Current value") + ": " + value));
+            if (StringUtil.isNotBlank(value)) {
+                container.getChildren().add(new Label(Localization.lang("Current value") + ": " + value));
+            } else {
+                container.getChildren().add(new Label(Localization.lang("Current value") + ": " + Localization.lang("empty")));
+            }
 
             return container;
         }

--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -135,14 +135,12 @@ public class SaveDatabaseAction {
                     SavePreferences.DatabaseSaveType.ALL);
 
             if (success) {
-                panel.updateTimeStamp();
                 panel.getUndoManager().markUnchanged();
                 // (Only) after a successful save the following
                 // statement marks that the base is unchanged
                 // since last save:
                 panel.setNonUndoableChange(false);
                 panel.setBaseChanged(false);
-                panel.markExternalChangesAsResolved();
 
                 // Reset title of tab
                 frame.setTabTitle(panel, panel.getTabTitle(),

--- a/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -179,7 +179,7 @@ public class AppendDatabaseAction implements BaseAction {
                         boolean importSelectorWords) throws IOException, KeyCollisionException {
             Globals.prefs.put(JabRefPreferences.WORKING_DIRECTORY, file.getParent().toString());
             // Should this be done _after_ we know it was successfully opened?
-            ParserResult parserResult = OpenDatabase.loadDatabase(file.toFile(),
+        ParserResult parserResult = OpenDatabase.loadDatabase(file,
                     Globals.prefs.getImportFormatPreferences(), Globals.getFileUpdateMonitor());
             AppendDatabaseAction.mergeFromBibtex(panel, parserResult, importEntries, importStrings, importGroups,
                     importSelectorWords);

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -173,7 +173,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
     }
 
     private void update() {
-        if (!entry.isPresent() || layout == null) {
+        if (entry.isEmpty() || layout == null) {
             // Nothing to do
             return;
         }

--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -170,7 +170,7 @@ public class ImportFormatReader {
 
         // First, see if it is a BibTeX file:
         try {
-            ParserResult parserResult = OpenDatabase.loadDatabase(filePath.toFile(), importFormatPreferences, fileMonitor);
+            ParserResult parserResult = OpenDatabase.loadDatabase(filePath, importFormatPreferences, fileMonitor);
             if (parserResult.getDatabase().hasEntries() || !parserResult.getDatabase().hasNoStrings()) {
                 parserResult.setFile(filePath.toFile());
                 return new UnknownFormatImport(ImportFormatReader.BIBTEX_FORMAT, parserResult);

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -1,7 +1,9 @@
 package org.jabref.logic.importer;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,31 +31,26 @@ public class OpenDatabase {
      *
      * @param name Name of the BIB-file to open
      * @return ParserResult which never is null
+     * @deprecated use {@link #loadDatabase(Path, ImportFormatPreferences, FileUpdateMonitor)} instead
      */
+    @Deprecated
     public static ParserResult loadDatabase(String name, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) {
-        File file = new File(name);
-        LOGGER.info("Opening: " + name);
+        LOGGER.debug("Opening: " + name);
+        Path file = Paths.get(name);
 
-        if (!file.exists()) {
+        if (!Files.exists(file)) {
             ParserResult pr = ParserResult.fromErrorMessage(Localization.lang("File not found"));
-            pr.setFile(file);
+            pr.setFile(file.toFile());
 
             LOGGER.error(Localization.lang("Error") + ": " + Localization.lang("File not found"));
             return pr;
         }
 
         try {
-            ParserResult pr = OpenDatabase.loadDatabase(file, importFormatPreferences, fileMonitor);
-            pr.setFile(file);
-            if (pr.hasWarnings()) {
-                for (String aWarn : pr.warnings()) {
-                    LOGGER.warn(aWarn);
-                }
-            }
-            return pr;
+            return OpenDatabase.loadDatabase(file, importFormatPreferences, fileMonitor);
         } catch (IOException ex) {
             ParserResult pr = ParserResult.fromError(ex);
-            pr.setFile(file);
+            pr.setFile(file.toFile());
             LOGGER.error("Problem opening .bib-file", ex);
             return pr;
         }
@@ -62,9 +59,9 @@ public class OpenDatabase {
     /**
      * Opens a new database.
      */
-    public static ParserResult loadDatabase(File fileToOpen, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor)
+    public static ParserResult loadDatabase(Path fileToOpen, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor)
         throws IOException {
-        ParserResult result = new BibtexImporter(importFormatPreferences, fileMonitor).importDatabase(fileToOpen.toPath(),
+        ParserResult result = new BibtexImporter(importFormatPreferences, fileMonitor).importDatabase(fileToOpen,
                 importFormatPreferences.getEncoding());
 
         if (importFormatPreferences.isKeywordSyncEnabled()) {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2094,4 +2094,4 @@ Reset\ All=Reset All
 Column\ type\ %0\ is\ unknown.=Column type %0 is unknown.
 Linked\ identifiers=Linked identifiers
 Special\ field\ type\ %0\ is\ unknown.\ Using\ normal\ column\ type.=Special field type %0 is unknown. Using normal column type.
-
+empty=empty

--- a/src/test/java/org/jabref/logic/importer/OpenDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/importer/OpenDatabaseTest.java
@@ -1,10 +1,10 @@
 package org.jabref.logic.importer;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Optional;
@@ -23,61 +23,60 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class OpenDatabaseTest {
+class OpenDatabaseTest {
 
     private final Charset defaultEncoding = StandardCharsets.UTF_8;
     private ImportFormatPreferences importFormatPreferences;
-    private final File bibNoHeader;
-    private final File bibWrongHeader;
-    private final File bibHeader;
-    private final File bibHeaderAndSignature;
-    private final File bibEncodingWithoutNewline;
+    private final Path bibNoHeader;
+    private final Path bibWrongHeader;
+    private final Path bibHeader;
+    private final Path bibHeaderAndSignature;
+    private final Path bibEncodingWithoutNewline;
     private final FileUpdateMonitor fileMonitor = new DummyFileUpdateMonitor();
 
-    public OpenDatabaseTest() throws URISyntaxException {
-        bibNoHeader = Paths.get(OpenDatabaseTest.class.getResource("headerless.bib").toURI()).toFile();
-        bibWrongHeader = Paths.get(OpenDatabaseTest.class.getResource("wrong-header.bib").toURI()).toFile();
-        bibHeader = Paths.get(OpenDatabaseTest.class.getResource("encoding-header.bib").toURI()).toFile();
-        bibHeaderAndSignature = Paths.get(OpenDatabaseTest.class.getResource("jabref-header.bib").toURI())
-                                     .toFile();
+    OpenDatabaseTest() throws URISyntaxException {
+        bibNoHeader = Paths.get(OpenDatabaseTest.class.getResource("headerless.bib").toURI());
+        bibWrongHeader = Paths.get(OpenDatabaseTest.class.getResource("wrong-header.bib").toURI());
+        bibHeader = Paths.get(OpenDatabaseTest.class.getResource("encoding-header.bib").toURI());
+        bibHeaderAndSignature = Paths.get(OpenDatabaseTest.class.getResource("jabref-header.bib").toURI());
         bibEncodingWithoutNewline = Paths
-                .get(OpenDatabaseTest.class.getResource("encodingWithoutNewline.bib").toURI()).toFile();
+                .get(OpenDatabaseTest.class.getResource("encodingWithoutNewline.bib").toURI());
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         when(importFormatPreferences.getEncoding()).thenReturn(StandardCharsets.UTF_8);
     }
 
     @Test
-    public void useFallbackEncodingIfNoHeader() throws IOException {
+    void useFallbackEncodingIfNoHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibNoHeader, importFormatPreferences, fileMonitor);
         assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
-    public void useFallbackEncodingIfUnknownHeader() throws IOException {
+    void useFallbackEncodingIfUnknownHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibWrongHeader, importFormatPreferences, fileMonitor);
         assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
-    public void useSpecifiedEncoding() throws IOException {
+    void useSpecifiedEncoding() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeader,
                 importFormatPreferences.withEncoding(StandardCharsets.US_ASCII), fileMonitor);
         assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
-    public void useSpecifiedEncodingWithSignature() throws IOException {
+    void useSpecifiedEncodingWithSignature() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeaderAndSignature,
                 importFormatPreferences.withEncoding(StandardCharsets.US_ASCII), fileMonitor);
         assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
-    public void entriesAreParsedNoHeader() throws IOException {
+    void entriesAreParsedNoHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibNoHeader, importFormatPreferences, fileMonitor);
         BibDatabase db = result.getDatabase();
 
@@ -87,7 +86,7 @@ public class OpenDatabaseTest {
     }
 
     @Test
-    public void entriesAreParsedHeader() throws IOException {
+    void entriesAreParsedHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeader, importFormatPreferences, fileMonitor);
         BibDatabase db = result.getDatabase();
 
@@ -97,7 +96,7 @@ public class OpenDatabaseTest {
     }
 
     @Test
-    public void entriesAreParsedHeaderAndSignature() throws IOException {
+    void entriesAreParsedHeaderAndSignature() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeaderAndSignature, importFormatPreferences, fileMonitor);
         BibDatabase db = result.getDatabase();
 
@@ -110,7 +109,7 @@ public class OpenDatabaseTest {
      * Test for #669
      */
     @Test
-    public void correctlyParseEncodingWithoutNewline() throws IOException {
+    void correctlyParseEncodingWithoutNewline() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibEncodingWithoutNewline, importFormatPreferences, fileMonitor);
         assertEquals(StandardCharsets.US_ASCII, result.getMetaData().getEncoding().get());
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Another shot at fixing https://github.com/JabRef/jabref/issues/4877. The changes in this PR might be already sufficient, let's see...

No time for extended PR description, see commit messages for changes. Last commit contains the actual "fix", the other ones are cosmetic changes.

<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
