### PR TITLE
Fix Springer fetcher tests

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
@@ -20,14 +20,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * FulltextFetcher implementation that attempts to find a PDF URL at SpringerLink.
- *
+ * <p>
  * Uses Springer API, see @link{https://dev.springer.com}
  */
 public class SpringerLink implements FulltextFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringerLink.class);
 
     private static final String API_URL = "https://api.springer.com/meta/v1/json";
-    private static final String API_KEY = "b0c7151179b3d9c1119cf325bca8460d";
+    private static final String API_KEY = "a98b4a55181ffcd27259bea45edad12e";
     private static final String CONTENT_HOST = "link.springer.com";
 
     @Override
@@ -45,13 +45,14 @@ public class SpringerLink implements FulltextFetcher {
                                                              .queryString("api_key", API_KEY)
                                                              .queryString("q", String.format("doi:%s", doi.get().getDOI()))
                                                              .asJson();
+                if (jsonResponse.getBody() != null) {
+                    JSONObject json = jsonResponse.getBody().getObject();
+                    int results = json.getJSONArray("result").getJSONObject(0).getInt("total");
 
-                JSONObject json = jsonResponse.getBody().getObject();
-                int results = json.getJSONArray("result").getJSONObject(0).getInt("total");
-
-                if (results > 0) {
-                    LOGGER.info("Fulltext PDF found @ Springer.");
-                    pdfLink = Optional.of(new URL("http", CONTENT_HOST, String.format("/content/pdf/%s.pdf", doi.get().getDOI())));
+                    if (results > 0) {
+                        LOGGER.info("Fulltext PDF found @ Springer.");
+                        pdfLink = Optional.of(new URL("http", CONTENT_HOST, String.format("/content/pdf/%s.pdf", doi.get().getDOI())));
+                    }
                 }
             } catch (UnirestException e) {
                 LOGGER.warn("SpringerLink API request failed", e);

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.support.DisabledOnCIServer;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ public class SpringerLinkTest {
         assertEquals(Optional.empty(), finder.findFullText(entry));
     }
 
+    @DisabledOnCIServer("Disable on CI Server to not hit the API call limit")
     @Test
     public void findByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/s13677-015-0042-8");
@@ -44,6 +46,7 @@ public class SpringerLinkTest {
                 finder.findFullText(entry));
     }
 
+    @DisabledOnCIServer("Disable on CI Server to not hit the API call limit")
     @Test
     public void notFoundByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/unknown-doi");


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/5715/files.

In case the key does not work, a 403 Forbidden was returned and `getBody()` returned null. Therefore the check.