### PR TITLE
Fix Medline tests

### DIFF
--- a/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/IdBasedParserFetcher.java
@@ -81,7 +81,7 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
         } catch (URISyntaxException e) {
             throw new FetcherException("Search URI is malformed", e);
         } catch (IOException e) {
-            // TODO: Catch HTTP Response 401 errors and report that user has no rights to access resource
+            // TODO: Catch HTTP Response 401 errors and report that user has no rights to access resource. It might be that there is an UnknownHostException (eutils.ncbi.nlm.nih.gov cannot be resolved).
             throw new FetcherException("A network error occurred", e);
         } catch (ParseException e) {
             throw new FetcherException("An internal parser error occurred", e);

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -25,8 +25,8 @@ public class MedlineFetcherTest {
 
     @BeforeEach
     public void setUp() throws InterruptedException {
-        // pause between runs to avoid 403 at Medline
-        Thread.sleep(470);
+        // pause between runs to avoid 403 and 429 at Medline
+        Thread.sleep(1000);
 
         fetcher = new MedlineFetcher();
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -24,7 +24,10 @@ public class MedlineFetcherTest {
     private BibEntry entryWijedasa, entryEndharti, bibEntryIchikawa, bibEntrySari;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws InterruptedException {
+        // pause between runs to avoid 403 at Medline
+        Thread.sleep(470);
+
         fetcher = new MedlineFetcher();
 
         entryWijedasa = new BibEntry();
@@ -167,7 +170,6 @@ public class MedlineFetcherTest {
         entryList.forEach(entry -> entry.clearField(StandardField.ABSTRACT)); //Remove abstract due to copyright);
         assertEquals(50, entryList.size());
         assertTrue(entryList.contains(bibEntryIchikawa));
-        assertTrue(entryList.contains(bibEntrySari));
     }
 
     @Test


### PR DESCRIPTION
- wait between calls to avoid 403
- remove assertion of entry not returned anymore

Follow up to https://github.com/JabRef/jabref/pull/5773, where the Springer tests are fixed. Here, the Medline tests are fixed.
