### PR TITLE
Reenable cleanup

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -15,10 +15,10 @@ jobs:
       run: echo "##[set-output name=branch;](echo{GITHUB_REF#refs/heads/})"
       id: extract_branch
     - name: Delete folder on builds.jabref.org
-      uses: appleboy/ssh-action@v0.0.3
+      uses: appleboy/ssh-action@v0.0.6
       with:
-        script: rm -rf www/${{ steps.extract_branch.outputs.branch }}
+        script: rm -rf /var/www/builds.jabref.org/www/${{ steps.extract_branch.outputs.branch }}
         host: builds.jabref.org
-        username: builds_jabref_org
-        key: ${{ secrets.buildJabRefPrivateKey }}
         port: 9922
+        username: jrrsync
+        key: ${{ secrets.buildJabRefPrivateKey }}

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -1,0 +1,24 @@
+name: Cleanup after PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;](echo{GITHUB_REF#refs/heads/})"
+      id: extract_branch
+    - name: Delete folder on builds.jabref.org
+      uses: appleboy/ssh-action@v0.0.3
+      with:
+        script: rm -rf www/${{ steps.extract_branch.outputs.branch }}
+        host: builds.jabref.org
+        username: builds_jabref_org
+        key: ${{ secrets.buildJabRefPrivateKey }}
+        port: 9922


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/5365.

We need to clean up the builds directly after the merge, because we run out of disk space. This is now enabled, because we switched from scp to rsync (refs https://github.com/JabRef/jabref/pull/5778)

We already reviewed this script. I just opened a PR to check whether the "revert" worked and commits are "OK". Will merge as soon as I feel comfortable. 😇 