### PR TITLE
Add latex2unicode formatter for displaying previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 - We fixed an issue where the Medline fetcher was only working when JabRef was running from source [#5645](https://github.com/JabRef/jabref/issues/5645)
 - We fixed some visual issues in the dark theme [#5764](https://github.com/JabRef/jabref/pull/5764) [#5753](https://github.com/JabRef/jabref/issues/5753)
+- We fixed an issue where non-default previews didn't handle unicode characters. [#5779](https://github.com/JabRef/jabref/issues/5779)
+
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -18,6 +18,7 @@ import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
 import de.undercouch.citeproc.output.Bibliography;
+import org.jabref.model.strings.LatexToUnicodeAdapter;
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.DigitStringValue;
 import org.jbibtex.Key;
@@ -97,6 +98,7 @@ public class CSLAdapter {
             for (Field key : bibEntry.getFieldMap().keySet()) {
                 bibEntry.getField(key)
                         .map(removeNewlinesFormatter::format)
+                        .map(LatexToUnicodeAdapter::format)
                         .map(latexToHtmlConverter::format)
                         .ifPresent(value -> {
                             if (StandardField.MONTH.equals(key)) {

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -117,4 +117,17 @@ class CitationStyleGeneratorTest {
         String actualCitation = CitationStyleGenerator.generateCitation(entry, style, format);
         assertEquals(expectedCitation, actualCitation);
     }
+
+    @Test
+    void testHandleDiacritics() {
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.AUTHOR, "L{\"a}st, First and Doe, Jane");
+        // if the default citation style changes this has to be modified.
+        // in this case ä was added to check if it is formatted appropriately
+        String expected = "  <div class=\"csl-entry\">\n" +
+                "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">F. Läst and J. Doe, .</div>\n" +
+                "  </div>\n";
+        String citation = CitationStyleGenerator.generateCitation(entry, CitationStyle.getDefault());
+        assertEquals(expected, citation);
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Bibtex entries with characters with diacritics {"a} were not rendering properly when showing non-default previews (eg: IEEE).

I added a call to the LatexToUnicodeAdapter on the "pipeline" when translating the data from the BibEntry to the HTML format to be displayed by the preview pane. With this change every preview style should always handle special diacritics. check issue #5779 for more details.

Here is a screenshot of the IEEE preview of the following entry
```
@book{Wickman2009non,
author={Wickman, Per-Olof and Persson, Hans},
title={Naturvetenskap och naturorienterande {\"a}mnen i grundskolan: En {\"a}mnesdidaktisk v{\"a}gledning},
publisher={Liber},
address={Stockholm},
year={2009},
ISBN={978-91-47-05333-9},
}
```
![sample](https://user-images.githubusercontent.com/16848115/71424675-27ca5780-2651-11ea-99ce-f4e921617edd.png)

I also added a test to verify this functionality in the future, but the Tests for CitationStyleGenerator are disabled because an unrelated issue, when that issue is fixed the test should work just fine.

<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
