### PR TITLE
Build binaries only when src/main changes

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,6 +1,18 @@
-name: Deployment
+name: Create and deploy binaries on builds.jabref.org
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/deployment.yml'
+      - 'build.gradle'
+      - 'src/main/**'
+  pull_request:
+    paths:
+      - '.github/workflows/deployment.yml'
+      - 'build.gradle'
+      - 'src/main/**'
 
 jobs:
   build:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,18 +1,18 @@
-name: Create and deploy binaries on builds.jabref.org
+name: Deployment
 
 on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/deployment.yml'
-      - 'build.gradle'
-      - 'src/main/**'
+    paths-ignore:
+      - 'docs/**'
+      - 'src/test/**'
+      - 'README.md'
   pull_request:
-    paths:
-      - '.github/workflows/deployment.yml'
-      - 'build.gradle'
-      - 'src/main/**'
+    paths-ignore:
+      - 'docs/**'
+      - 'src/test/**'
+      - 'README.md'
 
 jobs:
   build:


### PR DESCRIPTION
IMHO we need new binaries on builds.jabref.org only if src/main/** changes. Not if we work on tests.