### PR TITLE
Run fetcher tests on a weekly basis

### DIFF
--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -1,0 +1,53 @@
+name: Fetcher Tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/main/java/org/jabref/logic/importer/fetcher/**'
+      - 'src/test/java/org/jabref/logic/importer/fetcher/**'
+      - '.github/workflows/tests-fetchers.yml'
+      - 'build.gradle'
+  pull_request:
+    paths:
+      - 'src/main/java/org/jabref/logic/importer/fetcher/**'
+      - 'src/test/java/org/jabref/logic/importer/fetcher/**'
+      - '.github/workflows/tests-fetchers.yml'
+      - 'build.gradle'
+  schedule:
+    # run on each Wednesday
+    - cron: '2 3 * * 3'
+
+jobs:
+  fetchertests:
+    name: Fetcher tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v1
+        with:
+          depth: 1
+          submodules: false
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 13
+      - uses: actions/cache@v1
+        name: Restore gradle chache
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-${{ env.cache-name }}-
+            ${{ runner.OS }}-gradle-
+            ${{ runner.OS }}-
+      - uses: actions/cache@v1
+        name: Restore gradle wrapper
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Run fetcher tests
+        run: ./gradlew fetcherTest
+        env:
+          CI: "true"

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -11,8 +11,10 @@ on:
       - 'build.gradle'
   pull_request:
     paths:
-      - 'src/main/java/org/jabref/logic/importer/fetcher/**'
-      - 'src/test/java/org/jabref/logic/importer/fetcher/**'
+      - 'src/main/java/org/jabref/logic/**'
+      - 'src/test/java/org/jabref/logic/**'
+      - 'src/main/java/org/jabref/model/**'
+      - 'src/test/java/org/jabref/model/**'
       - '.github/workflows/tests-fetchers.yml'
       - 'build.gradle'
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,37 +133,6 @@ jobs:
         env:
           CI: "true"
           DBMS: "mysql"
-  fetchertests:
-    name: Fetcher tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v1
-        with:
-          depth: 1
-          submodules: false
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 13
-      - uses: actions/cache@v1
-        name: Restore gradle chache
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.OS }}-gradle-${{ env.cache-name }}-
-            ${{ runner.OS }}-gradle-
-            ${{ runner.OS }}-
-      - uses: actions/cache@v1
-        name: Restore gradle wrapper
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-      - name: Run fetcher tests
-        run: ./gradlew fetcherTest
-        env:
-          CI: "true"
   guitests:
     name: GUI tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes, our fetchers break (see e.g. https://github.com/JabRef/jabref/issues/5804) or an endpoint being down (e.g., ottobib this night).

```
  Test searchForIsbnAvailableAtOttoBibButNonOnEbookDe() FAILED (31.4s)

  org.jabref.logic.importer.FetcherException: A network error occurred
      at org.jabref.logic.importer.fetcher.IsbnFetcherTest.searchForIsbnAvailableAtOttoBibButNonOnEbookDe(IsbnFetcherTest.java:104)
  Caused by: java.net.ConnectException: Connection timed out
      at org.jabref.logic.importer.fetcher.IsbnFetcherTest.searchForIsbnAvailableAtOttoBibButNonOnEbookDe(IsbnFetcherTest.java:104)
```

This proposal triggers fetcher tests a) only of fetchers code changes and b) once a week (to check for general issues such as changed endpoints at the provider's side)

It is accepted that refactorings in the internal data model (where fetchers rely on) are not tested any more.

