### PR TITLE
Enable auto labeling of PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+fetcher:
+  - 'src/main/java/org/jabref/logic/importer/fetcher/**'
+  - 'src/test/java/org/jabref/logic/importer/fetcher/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+
+on:
+  - pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
We have some labels to categorize our issues. Sometimes, we forget about them. With an auto labeler, some of them should be added automatically.

Issue: Works only for PRs created by contributors having write access to the repository (see https://github.com/actions/labeler/issues/12). The workaround is https://github.com/paulfantom/periodic-labeler. I checked the code (https://github.com/paulfantom/periodic-labeler/blob/master/main.go): If a label exited before but was removed, the label will be readded. Since I dislike false positives, I stick with the original GitHub action.