### PR TITLE
Snap GitHub actions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -101,9 +101,11 @@ jobs:
       - name: Package application image
         run: ${{ matrix.archivePortable }}
         shell: bash
-      - name: Build and publish snap
+      - name: Build snap
         uses: jhenstridge/snapcraft-build-action@v1
         id: snapcraft
+        if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
+      - name: Upload snap
         if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -101,14 +101,15 @@ jobs:
       - name: Package application image
         run: ${{ matrix.archivePortable }}
         shell: bash
-      - name: Build snap
+      - name: Build snap (1) Setup snapcraft
         uses: jhenstridge/snapcraft-build-action@v1
         id: snapcraft
         if: matrix.displayName == 'linux'
-      - run: |
+      - name: Build snap (2) Run build
+        run: |
           mv ${{ steps.snapcraft.outputs.snap }} build/distribution/
         if: matrix.displayName == 'linux'
-      - name: Upload snap
+      - name: Build snap (3) Upload snap
         if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -104,14 +104,17 @@ jobs:
       - name: Build snap
         uses: jhenstridge/snapcraft-build-action@v1
         id: snapcraft
-        if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
+        if: matrix.displayName == 'linux'
+      - run: |
+          mv ${{ steps.snapcraft.outputs.snap }} build/distribution/
+        if: matrix.displayName == 'linux'
       - name: Upload snap
         if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}
         run: |
             mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
-            mv ${{ steps.snapcraft.outputs.snap }} build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
+            snapcraft push build/distribution/jabref*.snap --release edge || true"
         shell: bash
       - name: Rename files
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -102,12 +102,14 @@ jobs:
         run: ${{ matrix.archivePortable }}
         shell: bash
       - name: Build and publish snap
+        uses: jhenstridge/snapcraft-build-action@v1
+        id: snapcraft
         if: matrix.displayName == 'linux' && github.ref == 'refs/heads/master'
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}
         run: |
             mkdir .snapcraft && echo ${SNAPCRAFT_LOGIN_FILE} | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
-            docker run -v $(pwd):$(pwd) -t lyzardking/snapcraft-bionic sh -c "apt update -qq && cd $(pwd) && snapcraft && mv jabref*.snap build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
+            mv ${{ steps.snapcraft.outputs.snap }} build/distribution/ && snapcraft push build/distribution/jabref*.snap --release edge || true"
         shell: bash
       - name: Rename files
         run: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,13 +31,19 @@ plugs:
   opengl:
   network-bind:
   removable-media:
-  browser-extension:
-    interface: system-files
-    read:
-      - /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts
-    write:
+  plugs:
+    hostfs-mozilla-native-messaging-jabref:
+      interface: system-files
+      write:
       - /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts/org.jabref.jabref.json
-
+    hostfs-chrome-native-messaging-jabref:
+      interface: system-files
+      write:
+      - /var/lib/snapd/hostfs/etc/opt/chrome/native-messaging-hosts/org.jabref.jabref.json
+    hostfs-chromium-native-messaging-jabref:
+      interface: system-files
+      write:
+      - /var/lib/snapd/hostfs/etc/chromium/native-messaging-hosts/org.jabref.jabref.json
 parts:
   jabref:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,4 +55,4 @@ parts:
     override-build: |
       snapcraftctl build
       snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/JabRef.cfg | grep "app.version=" | cut -d'=' -f2)"
-      sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/org.jabref.jabref.json
+      sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/native-messaging-host/*/org.jabref.jabref.json


### PR DESCRIPTION
This PR uses a github action to build the snap.
The parts(build and push) need to be split, because there cannot be a uses and a run command on the same step.
It seems to work, since it uploads the snap on the pr.
I set the upload to the store to only run if building from master
But the .snap file is uploaded to builds.jabref.org on the PR as well, like the other builds

It might need checking still


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
