### PR TITLE
Fix for multiple error messages in messed up source editor

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -68,4 +68,5 @@ open module org.jabref {
     requires org.jsoup;
     requires commons.csv;
     requires io.github.javadiffutils;
+    requires flowless;
 }

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -60,7 +60,7 @@
 }
 
 .table-view .groupColumnBackground {
-    -fx-stroke: -jr-gray-4;
+    -fx-stroke: -jr-gray-3;
 }
 
 .code-area .lineno {

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -50,6 +50,7 @@ import org.jabref.model.util.FileUpdateMonitor;
 
 import de.saxsys.mvvmfx.utils.validation.ObservableRuleBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
+import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 import org.slf4j.Logger;
@@ -196,10 +197,10 @@ public class SourceTab extends EntryEditorTab {
         sourceValidator.addRule(sourceIsValid);
 
         sourceValidator.getValidationStatus().getMessages().addListener((InvalidationListener) c -> {
-            if (!sourceValidator.getValidationStatus().isValid()) {
-                sourceValidator.getValidationStatus().getHighestMessage().ifPresent(validationMessage -> {
-                    dialogService.showErrorDialogAndWait(validationMessage.getMessage());
-                });
+            ValidationStatus sourceValidationStatus = sourceValidator.getValidationStatus();
+            if (!sourceValidationStatus.isValid()) {
+                sourceValidationStatus.getHighestMessage().ifPresent(message ->
+                    dialogService.showErrorDialogAndWait(message.getMessage()));
             }
         });
 
@@ -217,6 +218,10 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
+        if (boundEntry != null) {
+            storeSource(boundEntry, codeArea.textProperty().getValue());
+        }
+
         this.boundEntry = entry;
 
         if (entry != null) {

--- a/src/main/java/org/jabref/gui/preferences/AdvancedTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/AdvancedTabViewModel.java
@@ -25,6 +25,7 @@ import de.saxsys.mvvmfx.utils.validation.CompositeValidator;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class AdvancedTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty remoteServerProperty = new SimpleBooleanProperty();
@@ -39,11 +40,11 @@ public class AdvancedTabViewModel implements PreferenceTabViewModel {
     private final StringProperty proxyUsernameProperty = new SimpleStringProperty("");
     private final StringProperty proxyPasswordProperty = new SimpleStringProperty("");
 
-    private FunctionBasedValidator remotePortValidator;
-    private FunctionBasedValidator proxyHostnameValidator;
-    private FunctionBasedValidator proxyPortValidator;
-    private FunctionBasedValidator proxyUsernameValidator;
-    private FunctionBasedValidator proxyPasswordValidator;
+    private Validator remotePortValidator;
+    private Validator proxyHostnameValidator;
+    private Validator proxyPortValidator;
+    private Validator proxyUsernameValidator;
+    private Validator proxyPasswordValidator;
 
     private final DialogService dialogService;
     private final JabRefPreferences preferences;

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTabViewModel.java
@@ -16,6 +16,7 @@ import org.jabref.preferences.JabRefPreferences;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class AppearanceTabViewModel implements PreferenceTabViewModel {
 
@@ -27,7 +28,7 @@ public class AppearanceTabViewModel implements PreferenceTabViewModel {
     private final DialogService dialogService;
     private final JabRefPreferences preferences;
 
-    private FunctionBasedValidator fontSizeValidator;
+    private Validator fontSizeValidator;
 
     private List<String> restartWarnings = new ArrayList<>();
 
@@ -93,12 +94,10 @@ public class AppearanceTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public boolean validateSettings() {
-        if (fontOverrideProperty.getValue()) {
-            if (!fontSizeValidator.getValidationStatus().isValid()) {
-                fontSizeValidator.getValidationStatus().getHighestMessage().ifPresent(message ->
-                        dialogService.showErrorDialogAndWait(message.getMessage()));
-                return false;
-            }
+        if (fontOverrideProperty.getValue() && !fontSizeValidator.getValidationStatus().isValid()) {
+            fontSizeValidator.getValidationStatus().getHighestMessage().ifPresent(message ->
+                    dialogService.showErrorDialogAndWait(message.getMessage()));
+            return false;
         }
         return true;
     }

--- a/src/main/java/org/jabref/gui/preferences/FileTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/FileTabViewModel.java
@@ -27,6 +27,7 @@ import org.jabref.preferences.NewLineSeparator;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class FileTabViewModel implements PreferenceTabViewModel {
 
@@ -51,7 +52,7 @@ public class FileTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty autosaveLocalLibraries = new SimpleBooleanProperty();
 
-    private final FunctionBasedValidator mainFileDirValidator;
+    private final Validator mainFileDirValidator;
 
     private final DialogService dialogService;
     private final JabRefPreferences preferences;
@@ -136,9 +137,10 @@ public class FileTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public boolean validateSettings() {
-        ValidationStatus status = mainFileDirValidationStatus();
-        if (!status.isValid()) {
-            dialogService.showErrorDialogAndWait(status.getHighestMessage().get().getMessage());
+        ValidationStatus validationStatus = mainFileDirValidationStatus();
+        if (!validationStatus.isValid()) {
+            validationStatus.getHighestMessage().ifPresent(message ->
+                    dialogService.showErrorDialogAndWait(message.getMessage()));
             return false;
         }
         return true;

--- a/src/main/java/org/jabref/gui/preferences/GeneralTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTabViewModel.java
@@ -25,6 +25,7 @@ import org.jabref.preferences.JabRefPreferences;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class GeneralTabViewModel implements PreferenceTabViewModel {
     private final ListProperty<Language> languagesListProperty = new SimpleListProperty<>();
@@ -50,7 +51,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
     private final StringProperty markTimeStampFieldNameProperty = new SimpleStringProperty("");
     private final BooleanProperty updateTimeStampProperty = new SimpleBooleanProperty();
 
-    private FunctionBasedValidator markTimeStampFormatValidator;
+    private Validator markTimeStampFormatValidator;
 
     private final DialogService dialogService;
     private final JabRefPreferences preferences;

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
@@ -43,6 +43,7 @@ import org.jabref.preferences.PreviewPreferences;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyleSpansBuilder;
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     private final PreviewPreferences previewPreferences;
     private final TaskExecutor taskExecutor;
     private final CustomLocalDragboard localDragboard = GUIGlobals.localDragboard;
-    private FunctionBasedValidator chosenListValidator;
+    private Validator chosenListValidator;
     private ListProperty<PreviewLayout> dragSourceList = null;
 
     public PreviewTabViewModel(DialogService dialogService, JabRefPreferences preferences, TaskExecutor taskExecutor) {

--- a/src/main/java/org/jabref/gui/preferences/TableColumnsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/TableColumnsTabViewModel.java
@@ -32,6 +32,7 @@ import org.jabref.preferences.JabRefPreferences;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class TableColumnsTabViewModel implements PreferenceTabViewModel {
 
@@ -60,7 +61,7 @@ public class TableColumnsTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty specialFieldsSerializeProperty = new SimpleBooleanProperty();
     private final BooleanProperty extraFileColumnsEnabledProperty = new SimpleBooleanProperty();
 
-    private FunctionBasedValidator<?> columnsNotEmptyValidator;
+    private Validator columnsNotEmptyValidator;
 
     private List<String> restartWarnings = new ArrayList<>();
 
@@ -239,9 +240,10 @@ public class TableColumnsTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public boolean validateSettings() {
-        ValidationStatus status = columnsListValidationStatus();
-        if (!status.isValid() && status.getHighestMessage().isPresent()) {
-            dialogService.showErrorDialogAndWait(status.getHighestMessage().get().getMessage());
+        ValidationStatus validationStatus = columnsListValidationStatus();
+        if (!validationStatus.isValid()) {
+            validationStatus.getHighestMessage().ifPresent(message ->
+                    dialogService.showErrorDialogAndWait(message.getMessage()));
             return false;
         }
         return true;

--- a/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabViewModel.java
@@ -21,6 +21,7 @@ import org.jabref.preferences.JabRefPreferences;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
 
@@ -32,7 +33,7 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
     private final DialogService dialogService;
     private final JabRefPreferences preferences;
 
-    private FunctionBasedValidator xmpFilterListValidator;
+    private Validator xmpFilterListValidator;
 
     XmpPrivacyTabViewModel(DialogService dialogService, JabRefPreferences preferences) {
         this.dialogService = dialogService;

--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogViewModel.java
@@ -37,6 +37,7 @@ import org.jabref.preferences.PreferencesService;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,7 @@ public class ParseTexDialogViewModel extends AbstractViewModel {
     private final PreferencesService preferencesService;
     private final FileUpdateMonitor fileMonitor;
     private final StringProperty texDirectory;
-    private final FunctionBasedValidator<String> texDirectoryValidator;
+    private final Validator texDirectoryValidator;
     private final ObjectProperty<FileNodeViewModel> root;
     private final ObservableList<TreeItem<FileNodeViewModel>> checkedFileList;
     private final BooleanProperty noFilesFound;

--- a/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
@@ -78,7 +78,7 @@ class SourceTabTest {
 
         // Update source editor
         robot.interact(() -> pane.getSelectionModel().select(2));
-        robot.interact(() -> sourceTab.bindToEntry(entry));
+        robot.interact(() -> sourceTab.notifyAboutFocus(entry));
         robot.clickOn(1200, 500);
         robot.interrupt(100);
 


### PR DESCRIPTION
Fixes #5820

JabRef created a new instance of CodeArea everytime an entry was selected and bound multiple listeners to the CodeArea and to the ValidationStatus in bindToEntry. Refactored it a little bit, so the CodeArea stays persistent and the error messages are only displayed once.

Did some minor refactorings to the other Validators and to modules.info too, to avoid warning messages from the IDE, and fixed a minor mistake from a previous PR in dark.css. 

No screenshot, as there is no visual change.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
