### PR TITLE
Fix one Google Scholar test

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -51,7 +51,7 @@ class GoogleScholarTest {
     @Test
     @DisabledOnCIServer("CI server is blocked by Google")
     void noLinkFound() throws IOException, FetcherException {
-        entry.setField(StandardField.TITLE, "Pro WF: Windows Workflow in NET 3.5");
+        entry.setField(StandardField.TITLE, "Curriculum programme of career-oriented java specialty guided by principles of software engineering");
 
         assertEquals(Optional.empty(), finder.findFullText(entry));
     }


### PR DESCRIPTION
The PDF has a title - try another publication without an available PDF

When fetching the old title, a PDF returned now. This PR fixes it.