### PR TITLE
Fix missing file extension for downloaded files. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the Medline fetcher was only working when JabRef was running from source. [#5645](https://github.com/JabRef/jabref/issues/5645)
 - We fixed some visual issues in the dark theme. [#5764](https://github.com/JabRef/jabref/pull/5764) [#5753](https://github.com/JabRef/jabref/issues/5753)
 - We fixed an issue where non-default previews didn't handle unicode characters. [#5779](https://github.com/JabRef/jabref/issues/5779)
-- We fixed an issue where the ampersand character wasn't rendering correctly on previews.[#3840](https://github.com/JabRef/jabref/issues/3840)
+- We fixed an issue where the ampersand character wasn't rendering correctly on previews. [#3840](https://github.com/JabRef/jabref/issues/3840)
 - We fixed an issue where an erroneous "The library has been modified by another program" message was shown when saving. [#4877](https://github.com/JabRef/jabref/issues/4877)
+- We fixed an issue where the file extension was missing after downloading a file (we now fall-back to pdf). [#5816](https://github.com/JabRef/jabref/issues/5816)
 
 ### Removed
 


### PR DESCRIPTION
Fixes #5816 by falling back to PDF as default file type.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
