### PR TITLE
Fix opening pdf with okular in linux (#5253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 
+- We fixed and issue where pdf files will not open under some KDE linux distributions when using okular. [#5253](https://github.com/JabRef/jabref/issues/5253)
 - We fixed an issue where the Medline fetcher was only working when JabRef was running from source. [#5645](https://github.com/JabRef/jabref/issues/5645)
 - We fixed some visual issues in the dark theme. [#5764](https://github.com/JabRef/jabref/pull/5764) [#5753](https://github.com/JabRef/jabref/issues/5753)
 - We fixed an issue where non-default previews didn't handle unicode characters. [#5779](https://github.com/JabRef/jabref/issues/5779)

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -18,7 +18,12 @@ import org.jabref.preferences.JabRefPreferences;
 import static org.jabref.preferences.JabRefPreferences.ADOBE_ACROBAT_COMMAND;
 import static org.jabref.preferences.JabRefPreferences.USE_PDF_READER;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class Linux implements NativeDesktop {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);
+
     @Override
     public void openFile(String filePath, String fileType) throws IOException {
         Optional<ExternalFileType> type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(fileType);
@@ -30,11 +35,13 @@ public class Linux implements NativeDesktop {
             viewer = "xdg-open";
         }
         String[] cmdArray = { viewer, filePath };
-        Process p;
-        p = Runtime.getRuntime().exec(cmdArray);
+        Process p = Runtime.getRuntime().exec(cmdArray);
+        // When the stream is full at some point, then blocks the execution of the program
+        // See https://stackoverflow.com/questions/10981969/why-is-going-through-geterrorstream-necessary-to-run-a-process.
         BufferedReader in = new BufferedReader(new InputStreamReader(p.getErrorStream()));
         String line;
         line = in.readLine();
+        LOGGER.debug("Received output: " + line);
     }
 
     @Override
@@ -50,11 +57,13 @@ public class Linux implements NativeDesktop {
         String[] cmdArray = new String[openWith.length + 1];
         System.arraycopy(openWith, 0, cmdArray, 0, openWith.length);
         cmdArray[cmdArray.length - 1] = filePath;
-        Process p;
-        p = Runtime.getRuntime().exec(cmdArray);
+        Process p = Runtime.getRuntime().exec(cmdArray);
+        // When the stream is full at some point, then blocks the execution of the program
+        // See https://stackoverflow.com/questions/10981969/why-is-going-through-geterrorstream-necessary-to-run-a-process.
         BufferedReader in = new BufferedReader(new InputStreamReader(p.getErrorStream()));
         String line;
         line = in.readLine();
+        LOGGER.debug("Received output: " + line);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -15,11 +15,11 @@ import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.preferences.JabRefPreferences;
 
-import static org.jabref.preferences.JabRefPreferences.ADOBE_ACROBAT_COMMAND;
-import static org.jabref.preferences.JabRefPreferences.USE_PDF_READER;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.jabref.preferences.JabRefPreferences.ADOBE_ACROBAT_COMMAND;
+import static org.jabref.preferences.JabRefPreferences.USE_PDF_READER;
 
 public class Linux implements NativeDesktop {
     private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -30,7 +30,11 @@ public class Linux implements NativeDesktop {
             viewer = "xdg-open";
         }
         String[] cmdArray = { viewer, filePath };
-        Runtime.getRuntime().exec(cmdArray);
+        Process p;
+        p = Runtime.getRuntime().exec(cmdArray);
+        BufferedReader in = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+        String line;
+        line = in.readLine();
     }
 
     @Override
@@ -46,7 +50,11 @@ public class Linux implements NativeDesktop {
         String[] cmdArray = new String[openWith.length + 1];
         System.arraycopy(openWith, 0, cmdArray, 0, openWith.length);
         cmdArray[cmdArray.length - 1] = filePath;
-        Runtime.getRuntime().exec(cmdArray);
+        Process p;
+        p = Runtime.getRuntime().exec(cmdArray);
+        BufferedReader in = new BufferedReader(new InputStreamReader(p.getErrorStream()));
+        String line;
+        line = in.readLine();
     }
 
     @Override


### PR DESCRIPTION
<!-- 
Possible fix for issue #5253
Clicking on a document icon does not open the associated PDF.  The PDF viewer opens and closes immediately. 
This seems to be related to KDE desktop with okular as default pdf reader. When okulas gives an error/warning message 
discarding "Send SMS via KDE Connect." ("ShareUrl")
it is not correctly handled and the program closes.
One possible solution is to read the buffer in some way when xdg-open is called by Runtime.getRuntime().exec()
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
