### PR TITLE
duplicate query parameter removed

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -37,7 +37,7 @@ public class SpringerFetcher implements SearchBasedParserFetcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringerFetcher.class);
 
-    private static final String API_URL = "http://api.springernature.com/meta/v1/json?q=";
+    private static final String API_URL = "http://api.springernature.com/meta/v1/json";
     private static final String API_KEY = "a98b4a55181ffcd27259bea45edad12e";
 
     /**


### PR DESCRIPTION
Calling the Springer web search always throws an exception:
```
java.lang.NullPointerException
	at org.jabref.merged.module/kong.unirest.json.JSONObject.<init>(Unknown Source)
	at org.jabref.merged.module/kong.unirest.json.JSONObject.<init>(Unknown Source)
	at org.jabref/org.jabref.logic.importer.fetcher.SpringerFetcher.lambda$getParser$2(Unknown Source)
	at org.jabref/org.jabref.logic.importer.SearchBasedParserFetcher.performSearch(Unknown Source)
	at org.jabref/org.jabref.gui.importer.fetcher.WebSearchPaneViewModel.lambda$search$1(Unknown Source)
	at org.jabref/org.jabref.gui.util.BackgroundTask$1.call(Unknown Source)
	at org.jabref/org.jabref.gui.util.DefaultTaskExecutor$1.call(Unknown Source)
	at org.jabref.merged.module/javafx.concurrent.Task$TaskCallable.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

```
In the SpringerFetcher class I saw that the `?q=` parameter is added twice to the request url.
Once here https://github.com/JabRef/jabref/blob/a140fcaad69bb5a6883fdde88f46094183634eae/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java#L40
and  the second time in this line: https://github.com/JabRef/jabref/blob/a140fcaad69bb5a6883fdde88f46094183634eae/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java#L159

This PR removes the duplicate search query parameter from the springer api url.
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
