### PR TITLE
Remove ampersand escape when writing to bib file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the file extension was missing after downloading a file (we now fall-back to pdf). [#5816](https://github.com/JabRef/jabref/issues/5816)
 
 ### Removed
+- Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action.
 
 
 ## [5.0-beta] – 2019-12-15

--- a/src/main/java/org/jabref/logic/bibtex/FieldContentFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/FieldContentFormatter.java
@@ -15,16 +15,15 @@ import org.jabref.model.strings.StringUtil;
  * in JabRef style. The reformatting must undo all formatting done by JabRef when
  * writing the same fields.
  */
-public class FieldContentParser {
+public class FieldContentFormatter {
 
     // 's' matches a space, tab, new line, carriage return.
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     private final Set<Field> multiLineFields;
 
-
-    public FieldContentParser(FieldContentParserPreferences prefs) {
-        Objects.requireNonNull(prefs);
+    public FieldContentFormatter(FieldContentFormatterPreferences preferences) {
+        Objects.requireNonNull(preferences);
 
         multiLineFields = new HashSet<>();
         // the following two are also coded in org.jabref.logic.bibtex.LatexFieldFormatter.format(String, String)
@@ -32,7 +31,7 @@ public class FieldContentParser {
         multiLineFields.add(StandardField.COMMENT);
         multiLineFields.add(StandardField.REVIEW);
         // the file field should not be formatted, therefore we treat it as a multi line field
-        multiLineFields.addAll(prefs.getNonWrappableFields());
+        multiLineFields.addAll(preferences.getNonWrappableFields());
     }
 
     /**

--- a/src/main/java/org/jabref/logic/bibtex/FieldContentFormatterPreferences.java
+++ b/src/main/java/org/jabref/logic/bibtex/FieldContentFormatterPreferences.java
@@ -5,16 +5,16 @@ import java.util.List;
 
 import org.jabref.model.entry.field.Field;
 
-public class FieldContentParserPreferences {
+public class FieldContentFormatterPreferences {
 
     private final List<Field> nonWrappableFields;
 
-    public FieldContentParserPreferences() {
+    public FieldContentFormatterPreferences() {
         // This constructor is only to allow an empty constructor in SavePreferences
         this.nonWrappableFields = Collections.emptyList();
     }
 
-    public FieldContentParserPreferences(List<Field> nonWrappableFields) {
+    public FieldContentFormatterPreferences(List<Field> nonWrappableFields) {
         this.nonWrappableFields = nonWrappableFields;
     }
 

--- a/src/main/java/org/jabref/logic/bibtex/FieldWriterPreferences.java
+++ b/src/main/java/org/jabref/logic/bibtex/FieldWriterPreferences.java
@@ -10,18 +10,18 @@ public class FieldWriterPreferences {
     private final boolean resolveStringsAllFields;
     private final List<Field> doNotResolveStringsFor;
     private final int lineLength = 65; // Constant
-    private final FieldContentParserPreferences fieldContentParserPreferences;
+    private final FieldContentFormatterPreferences fieldContentFormatterPreferences;
 
     public FieldWriterPreferences(boolean resolveStringsAllFields, List<Field> doNotResolveStringsFor,
-                                  FieldContentParserPreferences fieldContentParserPreferences) {
+                                  FieldContentFormatterPreferences fieldContentFormatterPreferences) {
         this.resolveStringsAllFields = resolveStringsAllFields;
         this.doNotResolveStringsFor = doNotResolveStringsFor;
-        this.fieldContentParserPreferences = fieldContentParserPreferences;
+        this.fieldContentFormatterPreferences = fieldContentFormatterPreferences;
     }
 
     public FieldWriterPreferences() {
         // This constructor is only to allow an empty constructor in SavePreferences
-        this(true, Collections.emptyList(), new FieldContentParserPreferences());
+        this(true, Collections.emptyList(), new FieldContentFormatterPreferences());
     }
 
     public boolean isResolveStringsAllFields() {
@@ -36,7 +36,7 @@ public class FieldWriterPreferences {
         return lineLength;
     }
 
-    public FieldContentParserPreferences getFieldContentParserPreferences() {
-        return fieldContentParserPreferences;
+    public FieldContentFormatterPreferences getFieldContentFormatterPreferences() {
+        return fieldContentFormatterPreferences;
     }
 }

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
+import org.jabref.logic.formatter.bibtexfields.EscapeAmpersandsFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeUnderscoresFormatter;
 import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.HtmlToUnicodeFormatter;
@@ -69,6 +70,7 @@ public class Formatters {
                 new RemoveBracesFormatter(),
                 new UnitsToLatexFormatter(),
                 new EscapeUnderscoresFormatter(),
+                new EscapeAmpersandsFormatter(),
                 new ShortenDOIFormatter()
         );
     }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
@@ -1,0 +1,95 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import java.util.Objects;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.cleanup.Formatter;
+
+public class EscapeAmpersandsFormatter extends Formatter {
+
+    @Override
+    public String getName() {
+        return Localization.lang("Escape ampersands");
+    }
+
+    @Override
+    public String getKey() {
+        return "escapeAmpersands";
+    }
+
+    @Override
+    public String format(String value) {
+        Objects.requireNonNull(value);
+
+        StringBuilder result = new StringBuilder();
+
+        boolean escape = false;
+        boolean inCommandName = false;
+        boolean inCommand = false;
+        boolean inCommandOption = false;
+        int nestedEnvironments = 0;
+        StringBuilder commandName = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+
+            // Track whether we are in a LaTeX command of some sort.
+            if (Character.isLetter(c) && (escape || inCommandName)) {
+                inCommandName = true;
+                if (!inCommandOption) {
+                    commandName.append(c);
+                }
+            } else if (Character.isWhitespace(c) && (inCommand || inCommandOption)) {
+                // Whitespace
+            } else if (inCommandName) {
+                // This means the command name is ended.
+                // Perhaps the beginning of an argument:
+                if (c == '[') {
+                    inCommandOption = true;
+                } else if (inCommandOption && (c == ']')) {
+                    // Or the end of an argument:
+                    inCommandOption = false;
+                } else if (!inCommandOption && (c == '{')) {
+                    inCommandName = false;
+                    inCommand = true;
+                } else {
+                    // Or simply the end of this command alltogether:
+                    commandName.delete(0, commandName.length());
+                    inCommandName = false;
+                }
+            }
+            // If we are in a command body, see if it has ended:
+            if (inCommand && (c == '}')) {
+                if ("begin".equals(commandName.toString())) {
+                    nestedEnvironments++;
+                }
+                if ((nestedEnvironments > 0) && "end".equals(commandName.toString())) {
+                    nestedEnvironments--;
+                }
+
+                commandName.delete(0, commandName.length());
+                inCommand = false;
+            }
+
+            // We add a backslash before any ampersand characters, with one exception: if
+            // we are inside an \\url{...} command, we should write it as it is. Maybe.
+            if ((c == '&') && !escape && !(inCommand && "url".equals(commandName.toString()))
+                    && (nestedEnvironments == 0)) {
+                result.append("\\&");
+            } else {
+                result.append(c);
+            }
+            escape = c == '\\';
+        }
+        return result.toString();
+    }
+
+    @Override
+    public String getDescription() {
+        return Localization.lang("Escape ampersands");
+    }
+
+    @Override
+    public String getExampleInput() {
+        return "Text & with &ampersands";
+    }
+}

--- a/src/main/java/org/jabref/logic/importer/ImportFormatPreferences.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatPreferences.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer;
 import java.nio.charset.Charset;
 import java.util.Set;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.xmp.XmpPreferences;
@@ -14,18 +14,18 @@ public class ImportFormatPreferences {
     private final Charset encoding;
     private final Character keywordSeparator;
     private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;
-    private final FieldContentParserPreferences fieldContentParserPreferences;
+    private final FieldContentFormatterPreferences fieldContentFormatterPreferences;
     private final XmpPreferences xmpPreferences;
     private final boolean keywordSyncEnabled;
 
     public ImportFormatPreferences(Set<CustomImporter> customImportList, Charset encoding, Character keywordSeparator,
-            BibtexKeyPatternPreferences bibtexKeyPatternPreferences,
-                                   FieldContentParserPreferences fieldContentParserPreferences, XmpPreferences xmpPreferences, boolean keywordSyncEnabled) {
+                                   BibtexKeyPatternPreferences bibtexKeyPatternPreferences,
+                                   FieldContentFormatterPreferences fieldContentFormatterPreferences, XmpPreferences xmpPreferences, boolean keywordSyncEnabled) {
         this.customImportList = customImportList;
         this.encoding = encoding;
         this.keywordSeparator = keywordSeparator;
         this.bibtexKeyPatternPreferences = bibtexKeyPatternPreferences;
-        this.fieldContentParserPreferences = fieldContentParserPreferences;
+        this.fieldContentFormatterPreferences = fieldContentFormatterPreferences;
         this.xmpPreferences = xmpPreferences;
         this.keywordSyncEnabled = keywordSyncEnabled;
     }
@@ -50,13 +50,13 @@ public class ImportFormatPreferences {
         return bibtexKeyPatternPreferences;
     }
 
-    public FieldContentParserPreferences getFieldContentParserPreferences() {
-        return fieldContentParserPreferences;
+    public FieldContentFormatterPreferences getFieldContentFormatterPreferences() {
+        return fieldContentFormatterPreferences;
     }
 
     public ImportFormatPreferences withEncoding(Charset newEncoding) {
         return new ImportFormatPreferences(customImportList, newEncoding, keywordSeparator, bibtexKeyPatternPreferences,
-                                           fieldContentParserPreferences, xmpPreferences, keywordSyncEnabled);
+                fieldContentFormatterPreferences, xmpPreferences, keywordSyncEnabled);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.bibtex.FieldContentParser;
+import org.jabref.logic.bibtex.FieldContentFormatter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SavePreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
@@ -65,7 +65,7 @@ public class BibtexParser implements Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(BibtexParser.class);
 
     private static final Integer LOOKAHEAD = 64;
-    private final FieldContentParser fieldContentParser;
+    private final FieldContentFormatter fieldContentFormatter;
     private final Deque<Character> pureTextFromFile = new LinkedList<>();
     private final ImportFormatPreferences importFormatPreferences;
     private PushbackReader pushbackReader;
@@ -78,7 +78,7 @@ public class BibtexParser implements Parser {
 
     public BibtexParser(ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) {
         this.importFormatPreferences = Objects.requireNonNull(importFormatPreferences);
-        fieldContentParser = new FieldContentParser(importFormatPreferences.getFieldContentParserPreferences());
+        fieldContentFormatter = new FieldContentFormatter(importFormatPreferences.getFieldContentFormatterPreferences());
         metaDataParser = new MetaDataParser(fileMonitor);
     }
 
@@ -594,13 +594,13 @@ public class BibtexParser implements Parser {
             }
             if (character == '"') {
                 StringBuilder text = parseQuotedFieldExactly();
-                value.append(fieldContentParser.format(text, field));
+                value.append(fieldContentFormatter.format(text, field));
             } else if (character == '{') {
                 // Value is a string enclosed in brackets. There can be pairs
                 // of brackets inside of a field, so we need to count the
                 // brackets to know when the string is finished.
                 StringBuilder text = parseBracketedTextExactly();
-                value.append(fieldContentParser.format(text, field));
+                value.append(fieldContentFormatter.format(text, field));
             } else if (Character.isDigit((char) character)) { // value is a number
                 String number = parseTextToken();
                 value.append(number);

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -54,7 +54,7 @@ import org.jabref.gui.push.PushToApplication;
 import org.jabref.gui.push.PushToApplicationsManager;
 import org.jabref.gui.specialfields.SpecialFieldsPreferences;
 import org.jabref.gui.util.ThemeLoader;
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtex.FieldWriterPreferences;
 import org.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
 import org.jabref.logic.citationstyle.CitationStyle;
@@ -1440,14 +1440,14 @@ public class JabRefPreferences implements PreferencesService {
                 getFieldContentParserPreferences());
     }
 
-    public FieldContentParserPreferences getFieldContentParserPreferences() {
-        return new FieldContentParserPreferences(getStringList(NON_WRAPPABLE_FIELDS).stream().map(FieldFactory::parseField).collect(Collectors.toList()));
+    public FieldContentFormatterPreferences getFieldContentParserPreferences() {
+        return new FieldContentFormatterPreferences(getStringList(NON_WRAPPABLE_FIELDS).stream().map(FieldFactory::parseField).collect(Collectors.toList()));
     }
 
     @Override
     public boolean isKeywordSyncEnabled() {
         return getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)
-               && getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
+                && getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
     }
 
     @Override

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2103,3 +2103,4 @@ Normalize\ newline\ characters=Normalize newline characters
 Normalizes\ all\ newline\ characters\ in\ the\ field\ content.=Normalizes all newline characters in the field content.
 
 Index=Index
+Escape=ampersands=Escape ampersands

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2103,4 +2103,4 @@ Normalize\ newline\ characters=Normalize newline characters
 Normalizes\ all\ newline\ characters\ in\ the\ field\ content.=Normalizes all newline characters in the field content.
 
 Index=Index
-Escape=ampersands=Escape ampersands
+Escape\ ampersands=Escape ampersands

--- a/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
@@ -13,7 +13,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.util.OptionalObjectProperty;
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtex.FieldWriterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -50,8 +50,8 @@ class SourceTabTest {
         when(stateManager.activeSearchQueryProperty()).thenReturn(OptionalObjectProperty.empty());
         KeyBindingRepository keyBindingRepository = new KeyBindingRepository(Collections.emptyList(), Collections.emptyList());
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences())
-                .thenReturn(mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences())
+                .thenReturn(mock(FieldContentFormatterPreferences.class));
 
         sourceTab = new SourceTab(new BibDatabaseContext(), new CountingUndoManager(), new FieldWriterPreferences(), importFormatPreferences, new DummyFileUpdateMonitor(), mock(DialogService.class), stateManager, keyBindingRepository);
         pane = new TabPane(

--- a/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/SaveDatabaseActionTest.java
@@ -15,7 +15,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.util.FileDialogConfiguration;
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtex.FieldWriterPreferences;
 import org.jabref.logic.exporter.SavePreferences;
 import org.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
@@ -112,7 +112,7 @@ class SaveDatabaseActionTest {
         file.toFile().deleteOnExit();
 
         FieldWriterPreferences fieldWriterPreferences = mock(FieldWriterPreferences.class);
-        when(fieldWriterPreferences.getFieldContentParserPreferences()).thenReturn(mock(FieldContentParserPreferences.class));
+        when(fieldWriterPreferences.getFieldContentFormatterPreferences()).thenReturn(mock(FieldContentFormatterPreferences.class));
         SavePreferences savePreferences = mock(SavePreferences.class);
         // In case a "thenReturn" is modified, the whole mock has to be recreated
         dbContext = mock(BibDatabaseContext.class);
@@ -132,7 +132,7 @@ class SaveDatabaseActionTest {
         when(dbContext.getEntries()).thenReturn(database.getEntries());
         when(preferences.getBoolean(JabRefPreferences.LOCAL_AUTO_SAVE)).thenReturn(false);
         when(preferences.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
-        when(preferences.getFieldContentParserPreferences()).thenReturn(mock(FieldContentParserPreferences.class));
+        when(preferences.getFieldContentParserPreferences()).thenReturn(mock(FieldContentFormatterPreferences.class));
         when(preferences.loadForSaveFromPreferences()).thenReturn(savePreferences);
         when(basePanel.frame()).thenReturn(jabRefFrame);
         when(basePanel.getBibDatabaseContext()).thenReturn(dbContext);

--- a/src/test/java/org/jabref/logic/bibtex/FieldContentFormatterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FieldContentFormatterTest.java
@@ -11,18 +11,18 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FieldContentParserTest {
+class FieldContentFormatterTest {
 
-    private FieldContentParser parser;
+    private FieldContentFormatter parser;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        FieldContentParserPreferences prefs = new FieldContentParserPreferences(Collections.emptyList());
-        parser = new FieldContentParser(prefs);
+    void setUp() throws Exception {
+        FieldContentFormatterPreferences preferences = new FieldContentFormatterPreferences(Collections.emptyList());
+        parser = new FieldContentFormatter(preferences);
     }
 
     @Test
-    public void unifiesLineBreaks() {
+    void unifiesLineBreaks() {
         String original = "I\r\nunify\nline\rbreaks.";
         String expected = "I\nunify\nline\nbreaks.".replace("\n", OS.NEWLINE);
         String processed = parser.format(new StringBuilder(original), StandardField.ABSTRACT);
@@ -31,7 +31,7 @@ public class FieldContentParserTest {
     }
 
     @Test
-    public void retainsWhitespaceForMultiLineFields() {
+    void retainsWhitespaceForMultiLineFields() {
         String original = "I\nkeep\nline\nbreaks\nand\n\ttabs.";
         String formatted = original.replace("\n", OS.NEWLINE);
 
@@ -43,7 +43,7 @@ public class FieldContentParserTest {
     }
 
     @Test
-    public void removeWhitespaceFromNonMultiLineFields() {
+    void removeWhitespaceFromNonMultiLineFields() {
         String original = "I\nshould\nnot\ninclude\nadditional\nwhitespaces  \nor\n\ttabs.";
         String expected = "I should not include additional whitespaces or tabs.";
 

--- a/src/test/java/org/jabref/logic/bibtex/FieldWriterTests.java
+++ b/src/test/java/org/jabref/logic/bibtex/FieldWriterTests.java
@@ -116,7 +116,7 @@ class FieldWriterTests {
     @Test
     void hashEnclosedWordsGetRealStringsInMonthFieldBecauseMonthIsStandardField() throws Exception {
         FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(
-                false, Collections.emptyList(), new FieldContentParserPreferences());
+                false, Collections.emptyList(), new FieldContentFormatterPreferences());
         FieldWriter formatter = new FieldWriter(fieldWriterPreferences);
         String text = "#jan# - #feb#";
         assertEquals("jan #{ - } # feb", formatter.write(StandardField.MONTH, text));

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatterTest.java
@@ -1,0 +1,31 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EscapeAmpersandsFormatterTest {
+
+    private EscapeAmpersandsFormatter formatter;
+
+    @BeforeEach
+    void setUp() {
+        formatter = new EscapeAmpersandsFormatter();
+    }
+
+    @Test
+    void formatReturnsSameTextIfNoAmpersandsPresent() throws Exception {
+        assertEquals("Lorem ipsum", formatter.format("Lorem ipsum"));
+    }
+
+    @Test
+    void formatEscapesAmpersandsIfPresent() throws Exception {
+        assertEquals("Lorem\\&ipsum", formatter.format("Lorem&ipsum"));
+    }
+
+    @Test
+    void formatExample() {
+        assertEquals("Text \\& with \\&ampersands", formatter.format(formatter.getExampleInput()));
+    }
+}

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/EscapeUnderscoresFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/EscapeUnderscoresFormatterTest.java
@@ -5,33 +5,27 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class EscapeUnderscoresFormatterTest {
+class EscapeUnderscoresFormatterTest {
 
     private EscapeUnderscoresFormatter formatter;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         formatter = new EscapeUnderscoresFormatter();
     }
 
-    /**
-     * Check whether the clear formatter really returns the empty string for the empty string
-     */
     @Test
-    public void formatReturnsSameTextIfNoUnderscoresPresent() throws Exception {
+    void formatReturnsSameTextIfNoUnderscoresPresent() throws Exception {
         assertEquals("Lorem ipsum", formatter.format("Lorem ipsum"));
     }
 
-    /**
-     * Check whether the clear formatter really returns the empty string for some string
-     */
     @Test
-    public void formatEscapesUnderscoresIfPresent() throws Exception {
+    void formatEscapesUnderscoresIfPresent() throws Exception {
         assertEquals("Lorem\\_ipsum", formatter.format("Lorem_ipsum"));
     }
 
     @Test
-    public void formatExample() {
+    void formatExample() {
         assertEquals("Text\\_with\\_underscores", formatter.format(formatter.getExampleInput()));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -27,7 +27,7 @@ class ACMPortalFetcherTest {
     @BeforeEach
     void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(mock(FieldContentFormatterPreferences.class));
         fetcher = new ACMPortalFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -28,8 +28,8 @@ public class AstrophysicsDataSystemTest {
     @BeforeEach
     public void setUp() throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(
-                mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+                mock(FieldContentFormatterPreferences.class));
         fetcher = new AstrophysicsDataSystem(importFormatPreferences);
 
         diezSliceTheoremEntry = new BibEntry();

--- a/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
@@ -28,8 +28,8 @@ public class DBLPFetcherTest {
     @BeforeEach
     public void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences())
-                .thenReturn(mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences())
+                .thenReturn(mock(FieldContentFormatterPreferences.class));
         dblpFetcher = new DBLPFetcher(importFormatPreferences);
         entry = new BibEntry();
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
@@ -31,8 +31,8 @@ class GoogleScholarTest {
     @BeforeEach
     void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(
-                mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+                mock(FieldContentFormatterPreferences.class));
         finder = new GoogleScholar(importFormatPreferences);
         entry = new BibEntry();
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -26,7 +26,7 @@ class INSPIREFetcherTest {
     @BeforeEach
     void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(mock(FieldContentFormatterPreferences.class));
         fetcher = new INSPIREFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -29,8 +29,8 @@ class MathSciNetTest {
     @BeforeEach
     void setUp() throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(
-                mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+                mock(FieldContentFormatterPreferences.class));
         fetcher = new MathSciNet(importFormatPreferences);
 
         ratiuEntry = new BibEntry();

--- a/src/test/java/org/jabref/logic/importer/fetcher/ZbMATHTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ZbMATHTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentParserPreferences;
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -27,8 +27,8 @@ class ZbMATHTest {
     @BeforeEach
     void setUp() throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(
-                mock(FieldContentParserPreferences.class));
+        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+                mock(FieldContentFormatterPreferences.class));
         fetcher = new ZbMATH(importFormatPreferences);
 
         donaldsonEntry = new BibEntry();

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1105,7 +1105,7 @@ class BibtexParserTest {
 
     @Test
     void parsePreservesMultipleSpacesInNonWrappableField() throws IOException {
-        when(importFormatPreferences.getFieldContentParserPreferences().getNonWrappableFields())
+        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields())
                 .thenReturn(Collections.singletonList(StandardField.FILE));
         BibtexParser parser = new BibtexParser(importFormatPreferences, fileMonitor);
         ParserResult result = parser
@@ -1140,7 +1140,7 @@ class BibtexParserTest {
     @Test
     void parseHandlesAccentsCorrectly() throws IOException {
         ParserResult result = parser
-                .parse(new StringReader("@article{test,author = {H\'{e}lne Fiaux}}"));
+                .parse(new StringReader("@article{test,author = {H'{e}lne Fiaux}}"));
 
         Collection<BibEntry> parsedEntries = result.getDatabase().getEntries();
         BibEntry parsedEntry = parsedEntries.iterator().next();
@@ -1149,7 +1149,7 @@ class BibtexParserTest {
         assertEquals(1, parsedEntries.size());
         assertEquals(StandardEntryType.Article, parsedEntry.getType());
         assertEquals(Optional.of("test"), parsedEntry.getCiteKeyOptional());
-        assertEquals(Optional.of("H\'{e}lne Fiaux"), parsedEntry.getField(StandardField.AUTHOR));
+        assertEquals(Optional.of("H'{e}lne Fiaux"), parsedEntry.getField(StandardField.AUTHOR));
     }
 
     /**
@@ -1158,7 +1158,7 @@ class BibtexParserTest {
     @Test
     void parsePreambleAndEntryWithoutNewLine() throws IOException {
         ParserResult result = parser
-                .parse(new StringReader("@preamble{some text and \\latex}@article{test,author = {H\'{e}lne Fiaux}}"));
+                .parse(new StringReader("@preamble{some text and \\latex}@article{test,author = {H'{e}lne Fiaux}}"));
 
         Collection<BibEntry> parsedEntries = result.getDatabase().getEntries();
         BibEntry parsedEntry = parsedEntries.iterator().next();
@@ -1168,7 +1168,7 @@ class BibtexParserTest {
         assertEquals(1, parsedEntries.size());
         assertEquals(StandardEntryType.Article, parsedEntry.getType());
         assertEquals(Optional.of("test"), parsedEntry.getCiteKeyOptional());
-        assertEquals(Optional.of("H\'{e}lne Fiaux"), parsedEntry.getField(StandardField.AUTHOR));
+        assertEquals(Optional.of("H'{e}lne Fiaux"), parsedEntry.getField(StandardField.AUTHOR));
     }
 
     @Test


### PR DESCRIPTION
Instead use save action to handle this case. Hopefully fixes the last remaining issue in #4877.


Includes also a bit of refactoring (mostly renames).

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
