### PR TITLE
Fixes making paths of linked files relative (web urls will not be touched anymore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the ampersand character wasn't rendering correctly on previews. [#3840](https://github.com/JabRef/jabref/issues/3840)
 - We fixed an issue where an erroneous "The library has been modified by another program" message was shown when saving. [#4877](https://github.com/JabRef/jabref/issues/4877)
 - We fixed an issue where the file extension was missing after downloading a file (we now fall-back to pdf). [#5816](https://github.com/JabRef/jabref/issues/5816)
+- We fixed an issue where cleaning up entries broke web URLs, if "Make paths of linked files relative (if possible)" was enabled, which resulted in various other issues subsequently. [#5861](https://github.com/JabRef/jabref/issues/5861)
 
 ### Removed
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action.

--- a/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -34,8 +34,8 @@ public class RelativePathsCleanup implements CleanupJob {
         for (LinkedFile fileEntry : fileList) {
             String oldFileName = fileEntry.getLink();
             String newFileName = null;
-            if (isWebUrl(oldFileName)) {
-                // let web url untouched
+            if (fileEntry.isOnlineLink()) {
+                // keep online link untouched
                 newFileName = oldFileName;
             }
             else {
@@ -62,23 +62,5 @@ public class RelativePathsCleanup implements CleanupJob {
         }
 
         return Collections.emptyList();
-    }
-
-    /**
-     * Checks, if the given file path is a well-formed web url
-     *
-     * @param filePath file path to check
-     * @return <code>true</code>, if the given file path is a web url, <code>false</code> otherwise
-     */
-    private static boolean isWebUrl(String filePath)
-    {
-        if (filePath == null) {
-            return false;
-        }
-        String normalizedFilePath = filePath.trim().toLowerCase();
-        if (normalizedFilePath.startsWith("http://") || normalizedFilePath.startsWith("https://")) { // INFO: can be extended, if needed
-            return true;
-        }
-        return false;
     }
 }

--- a/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -33,10 +33,17 @@ public class RelativePathsCleanup implements CleanupJob {
 
         for (LinkedFile fileEntry : fileList) {
             String oldFileName = fileEntry.getLink();
-            String newFileName = FileUtil
-                    .relativize(Paths.get(oldFileName), databaseContext.getFileDirectoriesAsPaths(filePreferences))
-                    .toString();
-
+            String newFileName = null;
+            if (isWebUrl(oldFileName)) {
+                // let web url untouched
+                newFileName = oldFileName;
+            }
+            else {
+                // only try to transform local file path to relative one
+                newFileName = FileUtil
+                        .relativize(Paths.get(oldFileName), databaseContext.getFileDirectoriesAsPaths(filePreferences))
+                        .toString();
+            }
             LinkedFile newFileEntry = fileEntry;
             if (!oldFileName.equals(newFileName)) {
                 newFileEntry = new LinkedFile(fileEntry.getDescription(), newFileName, fileEntry.getFileType());
@@ -57,4 +64,21 @@ public class RelativePathsCleanup implements CleanupJob {
         return Collections.emptyList();
     }
 
+    /**
+     * Checks, if the given file path is a well-formed web url
+     *
+     * @param filePath file path to check
+     * @return <code>true</code>, if the given file path is a web url, <code>false</code> otherwise
+     */
+    private static boolean isWebUrl(String filePath)
+    {
+        if (filePath == null) {
+            return false;
+        }
+        String normalizedFilePath = filePath.trim().toLowerCase();
+        if (normalizedFilePath.startsWith("http://") || normalizedFilePath.startsWith("https://")) { // INFO: can be extended, if needed
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -135,10 +135,11 @@ public class LinkedFile implements Serializable {
     /**
      * Checks if the given String is an online link
      * @param toCheck The String to check
-     * @return True if it starts with http://, https:// or contains www; false otherwise
+     * @return <code>true</code>, if it starts with "http://", "https://" or contains "www."; <code>false</code> otherwise
      */
     private boolean isOnlineLink(String toCheck) {
-        return toCheck.startsWith("http://") || toCheck.startsWith("https://") || toCheck.contains("www.");
+        String normalizedFilePath = toCheck.trim().toLowerCase();
+        return normalizedFilePath.startsWith("http://") || normalizedFilePath.startsWith("https://") || normalizedFilePath.contains("www.");
     }
 
     @Override


### PR DESCRIPTION
Fixes #5861
Description:
- Cleaning up entries with "Make paths of linked files relative (if possible)" broke web URLs and resulted in various other issues subsequently. This PR fixes this issue.
It has been tested for local files and web urls.

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
