### PR TITLE
Switch to our IntelliJ config

### DIFF
--- a/docs/guidelines-for-setting-up-a-local-workspace.md
+++ b/docs/guidelines-for-setting-up-a-local-workspace.md
@@ -79,11 +79,11 @@ Under Ubuntu Linux, you can follow the [documentation from the Ubuntu Community]
    ```
 4. Use IntellJ to build and run (instead of gradle): File -> Settings -> Build, Execution, Deployment ->  Build Tools -> Gradle -> At "Build and run using" and "Run tests using" choose "Intellj IDEA"
 4. Ensure that JDK13 is enabled for Gradle: Use IntellJ to build and run (instead of gradle): File -> Settings -> Build, Execution, Deployment ->  Build Tools -> Gradle -> Gradle -> Gradle JVM
-5. Use the provided code style: 
-   1. Install the [CheckStyle-IDEA plugin](http://plugins.jetbrains.com/plugin/1065?pr=idea), it can be found via plug-in repository (File > Settings > Plugins > Marketplace -> Search for "CHeckstyle" and choose "CheckSTyle-IDEA).
+5. Use the provided code style:
+   1. Install the [CheckStyle-IDEA plugin](http://plugins.jetbrains.com/plugin/1065?pr=idea), it can be found via plug-in repository (File > Settings > Plugins > Marketplace -> Search for "Checkstyle" and choose "CheckStyle-IDEA). Close the settings afterwards and restart IntelliJ.
    2. Go to File > Settings > Editor > Code Style, choose a code style (or create a new one) 
    3. Click on the settings wheel (next to the scheme chooser), then click "Import Scheme" and choose "IntelliJ Code Style xml". Select the IntelliJ configuration file `config/IntelliJ Code Style.xml`. Click OK.
-   4. Go to File -> Settings -> Checkstyle and import the above CheckStyle configuration file. Activate it.
+   4. Go to File -> Settings -> Checkstyle and import the CheckStyle configuration file. Activate it.
 6. Use the provided run configuration: Run -> Run "JabRef Main"
 
 ### Set-up Eclipse

--- a/docs/guidelines-for-setting-up-a-local-workspace.md
+++ b/docs/guidelines-for-setting-up-a-local-workspace.md
@@ -77,11 +77,12 @@ Under Ubuntu Linux, you can follow the [documentation from the Ubuntu Community]
    --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=com.jfoenix
    --patch-module org.jabref=build/resources/main
    ```
-4. Optional: Use IntellJ to build and run (instead of gradle): File -> Settings -> Build, Execution, Deployment ->  Build Tools -> Gradle -> Under "Build and run using" and "Run tests using" choose "Intellj IDEA"
+4. Use IntellJ to build and run (instead of gradle): File -> Settings -> Build, Execution, Deployment ->  Build Tools -> Gradle -> At "Build and run using" and "Run tests using" choose "Intellj IDEA"
+4. Ensure that JDK13 is enabled for Gradle: Use IntellJ to build and run (instead of gradle): File -> Settings -> Build, Execution, Deployment ->  Build Tools -> Gradle -> Gradle -> Gradle JVM
 5. Use the provided code style: 
-   1. Install the [CheckStyle-IDEA plugin](http://plugins.jetbrains.com/plugin/1065?pr=idea), it can be found via plug-in repository (File > Settings > Plugins > Browse repositories).
+   1. Install the [CheckStyle-IDEA plugin](http://plugins.jetbrains.com/plugin/1065?pr=idea), it can be found via plug-in repository (File > Settings > Plugins > Marketplace -> Search for "CHeckstyle" and choose "CheckSTyle-IDEA).
    2. Go to File > Settings > Editor > Code Style, choose a code style (or create a new one) 
-   3. Click on the settings wheel (next to the scheme chooser), then Import scheme and choose "CheckStyle Configuration". Select the CheckStyle configuration file `config\checkstyle\checkstyle.xml`. Click OK and restart IntelliJ.
+   3. Click on the settings wheel (next to the scheme chooser), then click "Import Scheme" and choose "IntelliJ Code Style xml". Select the IntelliJ configuration file `config/IntelliJ Code Style.xml`. Click OK.
    4. Go to File -> Settings -> Checkstyle and import the above CheckStyle configuration file. Activate it.
 6. Use the provided run configuration: Run -> Run "JabRef Main"
 


### PR DESCRIPTION
While checking our IDE setup on ChromeOS, I saw that we stick to checkstyle and are not using our IntelliJ config. Is this intended? I suppose not, so I changed it back.