### PR TITLE
Capitalize path properly

### DIFF
--- a/buildres/linux/native-messaging-host/chromium/org.jabref.jabref.json
+++ b/buildres/linux/native-messaging-host/chromium/org.jabref.jabref.json
@@ -1,7 +1,7 @@
 {
   "name": "org.jabref.jabref",
   "description": "JabRef",
-  "path": "/opt/jabref/lib/jabrefHost.py",
+  "path": "/opt/JabRef/lib/jabrefHost.py",
   "type": "stdio",
   "allowed_origins": [
     "chrome-extension://bifehkofibaamoeaopjglfkddgkijdlh/"

--- a/buildres/linux/native-messaging-host/firefox/org.jabref.jabref.json
+++ b/buildres/linux/native-messaging-host/firefox/org.jabref.jabref.json
@@ -1,7 +1,7 @@
 {
   "name": "org.jabref.jabref",
   "description": "JabRef",
-  "path": "/opt/jabref/lib/jabrefHost.py",
+  "path": "/opt/JabRef/lib/jabrefHost.py",
   "type": "stdio",
   "allowed_extensions": [
     "browserextension@jabref.org",


### PR DESCRIPTION
I installed [jabref-latest](https://aur.archlinux.org/packages/jabref-latest/) via pacman in Arch and then installed the JabFox extension through Mozilla's addon website. The addon would get stuck on `Send to JabRef...` and in Firefox in the JabFox preferences, I would see `Error: Attempt to postMessage on disconnected port`.

I had to make the change indicated in this PR and set executable bit of `/opt/JabRef/lib/jabrefHost.py` manually (I noticed this is already the case in this repo, but it was not in the file installed on my system).

Related to https://github.com/JabRef/JabRef-Browser-Extension/pull/127, https://github.com/JabRef/JabRef-Browser-Extension/issues/110, and https://github.com/JabRef/JabRef-Browser-Extension/issues/75.
