### PR TITLE
Fixes problems with managing external file types (issue 5846)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ Admir Obralija
 Adrian Daerr
 Akash Deep
 Alain Vaucher
+alauber
 Aleksandrs Gusevs
 Alessio Pollero
 Alex Montgomery
@@ -127,6 +128,7 @@ Hannes Restel
 Harinda Samarasekara
 Igor Chernyavsky
 Igor Steinmacher
+igorsteinmacher
 Illes Solt
 Ingvar Jackal
 Jackson Ryan
@@ -153,6 +155,7 @@ josephshin93
 Joshua Ramon Enslin
 José Jesús Sinohui Fernández
 Julian Pfeifer
+Julien29121998
 Jure Slak
 József Pallagi
 Jörg Lenhard
@@ -203,6 +206,7 @@ Mattia Bunel
 Mattias Ulbrich
 mcmoody
 Meltem Demirköprü
+MhhhxX
 Michael Beckmann
 Michael Falkenthal
 Michael Lass
@@ -239,6 +243,7 @@ Oliver Beckmann
 Oliver Kopp
 omer-rotem1
 Oscar Gustafsson
+oscargus
 Owen Huang
 P4trice
 Param Mittal
@@ -301,8 +306,10 @@ Stephen Beitzel
 Stéphane Curet
 Super-Tang
 Sven Jäger
+systemoperator
 Thiago Toledo
 Thomas Arildsen
+Thomas F. Duellmann
 Thomas Ilsche
 Thorsten Dahlheimer
 Tim Kilian
@@ -312,6 +319,7 @@ Tobias Boceck
 Tobias Bouschen
 Tobias Denkinger
 Tobias Diez
+Tomás Morales de Luna
 Tony K
 Toralf Senger
 uid112001

--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,6 @@ Admir Obralija
 Adrian Daerr
 Akash Deep
 Alain Vaucher
-alauber
 Aleksandrs Gusevs
 Alessio Pollero
 Alex Montgomery
@@ -128,7 +127,6 @@ Hannes Restel
 Harinda Samarasekara
 Igor Chernyavsky
 Igor Steinmacher
-igorsteinmacher
 Illes Solt
 Ingvar Jackal
 Jackson Ryan
@@ -155,7 +153,6 @@ josephshin93
 Joshua Ramon Enslin
 José Jesús Sinohui Fernández
 Julian Pfeifer
-Julien29121998
 Jure Slak
 József Pallagi
 Jörg Lenhard
@@ -206,7 +203,6 @@ Mattia Bunel
 Mattias Ulbrich
 mcmoody
 Meltem Demirköprü
-MhhhxX
 Michael Beckmann
 Michael Falkenthal
 Michael Lass
@@ -243,7 +239,6 @@ Oliver Beckmann
 Oliver Kopp
 omer-rotem1
 Oscar Gustafsson
-oscargus
 Owen Huang
 P4trice
 Param Mittal
@@ -309,7 +304,6 @@ Sven Jäger
 systemoperator
 Thiago Toledo
 Thomas Arildsen
-Thomas F. Duellmann
 Thomas Ilsche
 Thorsten Dahlheimer
 Tim Kilian
@@ -319,7 +313,6 @@ Tobias Boceck
 Tobias Bouschen
 Tobias Denkinger
 Tobias Diez
-Tomás Morales de Luna
 Tony K
 Toralf Senger
 uid112001

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where an erroneous "The library has been modified by another program" message was shown when saving. [#4877](https://github.com/JabRef/jabref/issues/4877)
 - We fixed an issue where the file extension was missing after downloading a file (we now fall-back to pdf). [#5816](https://github.com/JabRef/jabref/issues/5816)
 - We fixed an issue where cleaning up entries broke web URLs, if "Make paths of linked files relative (if possible)" was enabled, which resulted in various other issues subsequently. [#5861](https://github.com/JabRef/jabref/issues/5861)
+- We fixed several issues concerning managing external file types: Now everything is usable and fully functional. Previously, there were problems with the radio buttons, with saving the settings and with loading an input field value. Furthermore, different behavior for Windows and other operating systems was given, which was unified as well. [#5846](https://github.com/JabRef/jabref/issues/5846)
 
 ### Removed
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action.

--- a/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesDialog.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesDialog.java
@@ -40,7 +40,6 @@ public class CustomizeExternalFileTypesDialog extends BaseDialog<Void> {
         this.setResultConverter(button -> {
             if (button == ButtonType.OK) {
                 viewModel.storeSettings();
-                fileTypesTable.refresh();
             }
             return null;
         });

--- a/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesDialog.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesDialog.java
@@ -40,6 +40,7 @@ public class CustomizeExternalFileTypesDialog extends BaseDialog<Void> {
         this.setResultConverter(button -> {
             if (button == ButtonType.OK) {
                 viewModel.storeSettings();
+                fileTypesTable.refresh();
             }
             return null;
         });

--- a/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/CustomizeExternalFileTypesViewModel.java
@@ -49,6 +49,8 @@ public class CustomizeExternalFileTypesViewModel {
             typeForEdit = (CustomExternalFileType) type;
         } else {
             typeForEdit = new CustomExternalFileType(type);
+            fileTypes.add(fileTypes.indexOf(type), typeForEdit);
+            fileTypes.remove(type);
         }
 
         EditExternalFileTypeEntryDialog dlg = new EditExternalFileTypeEntryDialog(typeForEdit, dialogTitle);

--- a/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeEntryDialog.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeEntryDialog.java
@@ -62,6 +62,7 @@ public class EditExternalFileTypeEntryDialog extends BaseDialog<Void> {
         icon.setGraphic(viewModel.getIcon());
 
         defaultApplication.selectedProperty().bindBidirectional(viewModel.defaultApplicationSelectedProperty());
+        customApplication.selectedProperty().bindBidirectional(viewModel.customApplicationSelectedProperty());
         selectedApplication.disableProperty().bind(viewModel.defaultApplicationSelectedProperty());
         btnBrowse.disableProperty().bind(viewModel.defaultApplicationSelectedProperty());
 

--- a/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
@@ -15,19 +15,25 @@ public class EditExternalFileTypeViewModel {
     private final StringProperty mimeTypeProperty = new SimpleStringProperty("");
     private final StringProperty selectedApplicationProperty = new SimpleStringProperty("");
     private final BooleanProperty defaultApplicationSelectedProperty = new SimpleBooleanProperty(false);
+    private final BooleanProperty customApplicationSelectedProperty = new SimpleBooleanProperty(false);
     private final Node icon;
     private final CustomExternalFileType fileType;
 
     public EditExternalFileTypeViewModel(CustomExternalFileType fileType) {
         this.fileType = fileType;
         extensionProperty.setValue(fileType.getExtension());
-        nameProperty.setValue(fileType.getField().getDisplayName());
+        nameProperty.setValue(fileType.getName());
         mimeTypeProperty.setValue(fileType.getMimeType());
         selectedApplicationProperty.setValue(fileType.getOpenWithApplication());
         icon = fileType.getIcon().getGraphicNode();
 
         if (fileType.getOpenWithApplication().isEmpty()) {
             defaultApplicationSelectedProperty.setValue(true);
+            customApplicationSelectedProperty.setValue(false);
+        }
+        else {
+            defaultApplicationSelectedProperty.setValue(false);
+            customApplicationSelectedProperty.setValue(true);
         }
 
     }
@@ -52,6 +58,10 @@ public class EditExternalFileTypeViewModel {
         return defaultApplicationSelectedProperty;
     }
 
+    public BooleanProperty customApplicationSelectedProperty() {
+        return customApplicationSelectedProperty;
+    }
+
     public Node getIcon() {
         return icon;
     }
@@ -69,20 +79,14 @@ public class EditExternalFileTypeViewModel {
         }
 
         String application = selectedApplicationProperty.getValue().trim();
-        if (OS.WINDOWS) {
-            // On Windows, store application as empty if the "Default" option is selected,
-            // or if the application name is empty:
-            if (defaultApplicationSelectedProperty.getValue() || application.isEmpty()) {
-                fileType.setOpenWith("");
-                selectedApplicationProperty.setValue("");
 
-            } else {
-                fileType.setOpenWith(application);
-            }
+        // store application as empty if the "Default" option is selected, or if the application name is empty:
+        if (defaultApplicationSelectedProperty.getValue() || application.isEmpty()) {
+            fileType.setOpenWith("");
+            selectedApplicationProperty.setValue("");
         } else {
             fileType.setOpenWith(application);
         }
-
     }
 
 }

--- a/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
@@ -6,8 +6,6 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.scene.Node;
 
-import org.jabref.logic.util.OS;
-
 public class EditExternalFileTypeViewModel {
 
     private final StringProperty extensionProperty = new SimpleStringProperty("");
@@ -29,10 +27,8 @@ public class EditExternalFileTypeViewModel {
 
         if (fileType.getOpenWithApplication().isEmpty()) {
             defaultApplicationSelectedProperty.setValue(true);
-            customApplicationSelectedProperty.setValue(false);
         }
         else {
-            defaultApplicationSelectedProperty.setValue(false);
             customApplicationSelectedProperty.setValue(true);
         }
 


### PR DESCRIPTION
Fixes #5846

**Changed:**
- edit/customize external file types: radio button for "default program"/"custom program" fixed: They now get updated and set properly (binding added and setting values).
- "Edit file type" dialog: correct value gets loaded now for the input field "Name"
- when updating an external file type entry: no differentiation will be made anymore whether the program runs on Windows or somewhere else
- Everything concerning the type `CustomExternalFileType` is now working properly as well.
  - Settings will also be saved to JabRef's `config.xml` file.
- Editing an entry with type `ExternalFileType` works now as well. (changes are not lost anymore)
  - Settings will also be saved to JabRef's `config.xml` file.

**Remarks:**
- Table in "Manage external file types" dialog is "lazily" updated when a table entry has been updated. (But this seems to be a Linux issue anyway, since other tables behave the same way.)

**Tasks:**
- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef (always required)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date?
