### PR TITLE
Fix properly resolves OrFields of required fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where an erroneous "The library has been modified by another program" message was shown when saving. [#4877](https://github.com/JabRef/jabref/issues/4877)
 - We fixed an issue where the file extension was missing after downloading a file (we now fall-back to pdf). [#5816](https://github.com/JabRef/jabref/issues/5816)
 - We fixed an issue where cleaning up entries broke web URLs, if "Make paths of linked files relative (if possible)" was enabled, which resulted in various other issues subsequently. [#5861](https://github.com/JabRef/jabref/issues/5861)
+- We fixed an issue where the tab "Required fields" of the entry editor did not show all required fields, if at least two of the defined required fields are linked with a logical or.
 
 ### Removed
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action.

--- a/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
@@ -4,8 +4,6 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-
 import javax.swing.undo.UndoManager;
 
 import javafx.scene.control.Tooltip;
@@ -43,7 +41,9 @@ public class RequiredFieldsTab extends FieldsEditorTab {
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
         SortedSet<Field> fields = new TreeSet<>(Comparator.comparing(Field::getName));
         if (entryType.isPresent()) {
-            fields.addAll(entryType.get().getRequiredFields().stream().map(OrFields::getPrimary).collect(Collectors.toSet()));
+            for (OrFields orFields : entryType.get().getRequiredFields()) {
+                fields.addAll(orFields);
+            }
             // Add the edit field for Bibtex-key.
             fields.add(InternalField.KEY_FIELD);
         } else {

--- a/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
 import javax.swing.undo.UndoManager;
 
 import javafx.scene.control.Tooltip;


### PR DESCRIPTION
Addresses: #5859 and partially #5853

This fix adds all entries of OrFields of the required fields of EntryTypeDefinitions to the list of required fields for the tab "Required fields" of the entry editor.

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
