### PR TITLE
MySQL: Allow public key retrieval

### DIFF
--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
@@ -118,6 +118,8 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
                 .setUser(user.getValue())
                 .setPassword(password.getValue())
                 .setUseSSL(useSSL.getValue())
+                // Authorize client to retrieve RSA server public key when serverRsaPublicKeyFile is not set (for sha256_password and caching_sha2_password authentication password)
+                .setAllowPublicKeyRetrieval(true)
                 .setKeyStore(keystore.getValue())
                 .setServerTimezone(serverTimezone.getValue())
                 .createDBMSConnectionProperties();


### PR DESCRIPTION
Follow up to https://github.com/JabRef/jabref/pull/5676

I could not connect to my MySQL instance without having `.setAllowPublicKeyRetrieval` set to true.

I am aware that this could lead to some security issues. For production use, the users nevertheless should use SSL and a local keystore.

Dialog values allowing me to connect to MySQL 8.0.19.

![grafik](https://user-images.githubusercontent.com/1366654/73614504-f48bc880-45ff-11ea-9604-33103265841c.png)
