### PR TITLE
Update JDK14 from EA 30 to EA 34

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         include:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         include:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,17 +23,17 @@ jobs:
         include:
          - os: ubuntu-latest
            displayName: linux
-           jpackageDownload: https://download.java.net/java/early_access/jdk14/30/GPL/openjdk-14-ea+30_linux-x64_bin.tar.gz
+           jpackageDownload: https://download.java.net/java/early_access/jdk14/34/GPL/openjdk-14-ea+34_linux-x64_bin.tar.gz
            jdk14Path: /jdk-14
            archivePortable: tar -c -C build/distribution JabRef | pigz --rsyncable > build/distribution/JabRef-portable_linux.tar.gz && rm -R build/distribution/JabRef
          - os: windows-latest
            displayName: windows
-           jpackageDownload: https://download.java.net/java/early_access/jdk14/30/GPL/openjdk-14-ea+30_windows-x64_bin.zip
+           jpackageDownload: https://download.java.net/java/early_access/jdk14/34/GPL/openjdk-14-ea+34_windows-x64_bin.zip
            jdk14Path: /jdk-14
            archivePortable: 7z a -r build/distribution/JabRef-portable_windows.zip ./build/distribution/JabRef && rm -R build/distribution/JabRef
          - os: macOS-latest
            displayName: macOS
-           jpackageDownload: https://download.java.net/java/early_access/jdk14/30/GPL/openjdk-14-ea+30_osx-x64_bin.tar.gz
+           jpackageDownload: https://download.java.net/java/early_access/jdk14/34/GPL/openjdk-14-ea+34_osx-x64_bin.tar.gz
            jdk14Path: /jdk-14.jdk/Contents/Home
            archivePortable: brew install pigz && tar -c -C build/distribution JabRef.app | pigz --rsyncable > build/distribution/JabRef-portable_macos.tar.gz && rm -R build/distribution/JabRef.app
 


### PR DESCRIPTION
We rely on JDK14 to build the binary distribution of JabRef. It is not released yet. The final release candidate will be available on 2020-02-20: https://openjdk.java.net/projects/jdk/14/. Meanwhile, we have to stick to the early access builds.

This PR updates to Build 34 (2020/1/29)

See https://jdk.java.net/14/ for more details.

Refs https://github.com/JabRef/jabref/issues/5591, https://github.com/JabRef/jabref/issues/5474, https://github.com/JabRef/jabref/issues/5079