### PR TITLE
Fix not escaping special characters in search pattern

### DIFF
--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -85,7 +85,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
     private boolean registered;
 
     private ChangeListener<Optional<SearchQuery>> listener = (queryObservable, queryOldValue, queryNewValue) -> {
-        searchHighlightPattern = queryNewValue.flatMap(SearchQuery::getJsPatternForWords);
+        searchHighlightPattern = queryNewValue.flatMap(SearchQuery::getJavaScriptPatternForWords);
         highlightSearchPattern();
     };
 

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -85,7 +85,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
     private boolean registered;
 
     private ChangeListener<Optional<SearchQuery>> listener = (queryObservable, queryOldValue, queryNewValue) -> {
-        searchHighlightPattern = queryNewValue.flatMap(SearchQuery::getPatternForWords);
+        searchHighlightPattern = queryNewValue.flatMap(SearchQuery::getJsPatternForWords);
         highlightSearchPattern();
     };
 
@@ -131,7 +131,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
 
     private void highlightSearchPattern() {
         if (searchHighlightPattern.isPresent()) {
-            String pattern = searchHighlightPattern.get().pattern().replace("\\Q", "").replace("\\E", "");
+            String pattern = searchHighlightPattern.get().pattern();
 
             previewView.getEngine().executeScript(
                     "var markInstance = new Mark(document.getElementById(\"content\"));" +

--- a/src/main/java/org/jabref/logic/search/SearchQuery.java
+++ b/src/main/java/org/jabref/logic/search/SearchQuery.java
@@ -24,7 +24,7 @@ public class SearchQuery implements SearchMatcher {
     public static final Pattern JAVASCRIPT_ESCAPED_CHARS_PATTERN = Pattern.compile("[\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\/]");
 
     /**
-     * Metod for escaping special characters in regular expressions
+     * The mode of escaping special characters in regular expressions
      */
     private enum EscapeMode {
         /**
@@ -147,12 +147,12 @@ public class SearchQuery implements SearchMatcher {
     }
 
     // Returns a regular expression pattern in the form (w1)|(w2)| ... wi are escaped for javascript if no regular expression search is enabled
-    public Optional<Pattern> getJsPatternForWords() {
+    public Optional<Pattern> getJavaScriptPatternForWords() {
         return joinWordsToPattern(EscapeMode.JAVASCRIPT);
     }
 
     /** Returns a regular expression pattern in the form (w1)|(w2)| ... wi are escaped if no regular expression search is enabled
-     * @param escapeMode method for escaping special characters in wi
+     * @param escapeMode the mode of escaping special characters in wi
      */
     private Optional<Pattern> joinWordsToPattern(EscapeMode escapeMode) {
         List<String> words = getSearchWords();
@@ -166,8 +166,7 @@ public class SearchQuery implements SearchMatcher {
         for (String word : words) {
             if (regularExpression) {
                 joiner.add(word);
-            }
-            else {
+            } else {
                 switch (escapeMode) {
                     case JAVA:
                         joiner.add(Pattern.quote(word));
@@ -176,7 +175,7 @@ public class SearchQuery implements SearchMatcher {
                         joiner.add(JAVASCRIPT_ESCAPED_CHARS_PATTERN.matcher(word).replaceAll("\\\\$0"));
                         break;
                     default:
-                        throw new IllegalArgumentException("Unknown special characters escape method: " + escapeMode);
+                        throw new IllegalArgumentException("Unknown special characters escape mode: " + escapeMode);
                 }
             }
         }

--- a/src/main/java/org/jabref/logic/search/SearchQuery.java
+++ b/src/main/java/org/jabref/logic/search/SearchQuery.java
@@ -164,9 +164,10 @@ public class SearchQuery implements SearchMatcher {
         // compile the words to a regular expression in the form (w1)|(w2)|(w3)
         StringJoiner joiner = new StringJoiner(")|(", "(", ")");
         for (String word : words) {
-            if (regularExpression)
+            if (regularExpression) {
                 joiner.add(word);
-            else
+            }
+            else {
                 switch (escapeMode) {
                     case JAVA:
                         joiner.add(Pattern.quote(word));
@@ -177,6 +178,7 @@ public class SearchQuery implements SearchMatcher {
                     default:
                         throw new IllegalArgumentException("Unknown special characters escape method: " + escapeMode);
                 }
+            }
         }
         String searchPattern = joiner.toString();
 

--- a/src/test/java/org/jabref/logic/search/SearchQueryTest.java
+++ b/src/test/java/org/jabref/logic/search/SearchQueryTest.java
@@ -203,4 +203,38 @@ public class SearchQueryTest {
         //We can't directly compare the pattern objects
         assertEquals(Optional.of(pattern.toString()), result.getPatternForWords().map(Pattern::toString));
     }
+
+    @Test
+    public void testGetRegexpPattern() {
+        String queryText = "[a-c]\\d* \\d*";
+        SearchQuery regexQuery = new SearchQuery(queryText, false, true);
+        Pattern pattern = Pattern.compile("([a-c]\\d* \\d*)");
+        assertEquals(Optional.of(pattern.toString()), regexQuery.getPatternForWords().map(Pattern::toString));
+    }
+
+    @Test
+    public void testGetRegexpJavascriptPattern() {
+        String queryText = "[a-c]\\d* \\d*";
+        SearchQuery regexQuery = new SearchQuery(queryText, false, true);
+        Pattern pattern = Pattern.compile("([a-c]\\d* \\d*)");
+        assertEquals(Optional.of(pattern.toString()), regexQuery.getJavaScriptPatternForWords().map(Pattern::toString));
+    }
+
+    @Test
+    public void testEscapingInPattern() {
+        //first word contain all java special regex characters
+        String queryText = "<([{\\\\^-=$!|]})?*+.> word1 word2.";
+        SearchQuery textQueryWithSpecialChars = new SearchQuery(queryText, false, false);
+        String pattern = "(\\Q<([{\\^-=$!|]})?*+.>\\E)|(\\Qword1\\E)|(\\Qword2.\\E)";
+        assertEquals(Optional.of(pattern), textQueryWithSpecialChars.getPatternForWords().map(Pattern::toString));
+    }
+
+    @Test
+    public void testEscapingInJavascriptPattern() {
+        //first word contain all javascript special regex characters that should be escaped individually in text based search
+        String queryText = "([{\\\\^$|]})?*+./ word1 word2.";
+        SearchQuery textQueryWithSpecialChars = new SearchQuery(queryText, false, false);
+        String pattern = "(\\(\\[\\{\\\\\\^\\$\\|\\]\\}\\)\\?\\*\\+\\.\\/)|(word1)|(word2\\.)";
+        assertEquals(Optional.of(pattern), textQueryWithSpecialChars.getJavaScriptPatternForWords().map(Pattern::toString));
+    }
 }


### PR DESCRIPTION
fixes #5892

The error when searching for "DOI 10.1210/endrev/bnz006" (or any phrases containing special javascript regular expression characters) is caused by not escaping special characters before passing search  pattern to javascript script used for highlighting words in preview view.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
