### PR TITLE
Fix #5939 by creating a mutable list in OpenDatabaseAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where entries containing Unicode charaters were not parsed correctly [#5899](https://github.com/JabRef/jabref/issues/5899)
 - We fixed an issue where an entry containing an external filename with curly braces could not be saved. Curly braces are now longer allowed in filenames. [#5899](https://github.com/JabRef/jabref/issues/5899)
 - We fixed an issue where changing the type of an entry did not update the main table [#5906](https://github.com/JabRef/jabref/issues/5906)
+- We fixed an issue where opening a library from the recent libraries menu was not possible [#5939](https://github.com/JabRef/jabref/issues/5939)
 
 
 ### Removed

--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -102,7 +102,7 @@ public class OpenDatabaseAction extends SimpleCommand {
      * @param file the file, may be null or not existing
      */
     public void openFile(Path file, boolean raisePanel) {
-        openFiles(Collections.singletonList(file), raisePanel);
+        openFiles(Arrays.asList(file), raisePanel);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the problem when opening a library from the recent libraries menu. fixes #5939 

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
