### PR TITLE
Fixfetcher

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
  * FulltextFetcher implementation that follows the DOI resolution redirects and scans for a full-text PDF URL.
  */
 public class DoiResolution implements FulltextFetcher {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DoiResolution.class);
 
     @Override
@@ -63,7 +64,11 @@ public class DoiResolution implements FulltextFetcher {
                         // Only check if pdf is included in the link or inside the text
                         // ACM uses tokens without PDF inside the link
                         // See https://github.com/lehner/LocalCopy for more scrape ideas
-                        if ((href.contains("pdf") || hrefText.contains("pdf")) && new URLDownload(href).isPdf()) {
+                        if (element.attr("title").toLowerCase(Locale.ENGLISH).contains("pdf") && new URLDownload(href).isPdf()) {
+                            return Optional.of(new URL(href));
+                        }
+
+                        if (href.contains("pdf") || hrefText.contains("pdf") && new URLDownload(href).isPdf()) {
                             links.add(Optional.of(new URL(href)));
                         }
                     }

--- a/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import org.jabref.logic.importer.fetcher.TrustLevel;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@FetcherTest
 public class FulltextFetchersTest {
     private BibEntry entry;
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
@@ -44,7 +44,7 @@ public class DBLPFetcherTest {
         entry.setField(StandardField.YEAR, "2016");
         entry.setField(StandardField.URL,
                 "http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf");
-        entry.setField(new UnknownField("biburl"), "https://dblp.org/rec/bib/journals/stt/GeigerHL16");
+        entry.setField(new UnknownField("biburl"), "{https://dblp.org/rec/journals/stt/GeigerHL16.bib");
         entry.setField(new UnknownField("bibsource"), "dblp computer science bibliography, https://dblp.org");
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -77,6 +77,6 @@ class GoogleScholarTest {
     void findManyEntries() throws FetcherException {
         List<BibEntry> foundEntries = finder.performSearch("random test string");
 
-        assertEquals(10, foundEntries.size());
+        assertEquals(20, foundEntries.size());
     }
 }


### PR DESCRIPTION
Added another possible option for checking fulltexts


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
