### PR TITLE
Remove background command line window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 
+- We fixed an issue where the command line console was always opened in the background. [#5474](https://github.com/JabRef/jabref/issues/5474)
 - We fixed and issue where pdf files will not open under some KDE linux distributions when using okular. [#5253](https://github.com/JabRef/jabref/issues/5253)
 - We fixed an issue where the Medline fetcher was only working when JabRef was running from source. [#5645](https://github.com/JabRef/jabref/issues/5645)
 - We fixed some visual issues in the dark theme. [#5764](https://github.com/JabRef/jabref/pull/5764) [#5753](https://github.com/JabRef/jabref/issues/5753)

--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,7 @@ dependencyUpdates.resolutionStrategy = {
         }
         rules.withModule("de.jensd:fontawesomefx-materialdesignfont") { ComponentSelection selection ->
             if (selection.candidate.version ==~ /2.0.26-9.1.2/
-                || selection.candidate.version ==~ /2.0.26-9.1.1/ 
+                || selection.candidate.version ==~ /2.0.26-9.1.1/
                 || selection.candidate.version ==~ /2.0.26-9.1.0/) {
                 selection.reject('1.7.22-11 is actually newer (strange version system)')
             }
@@ -590,7 +590,7 @@ jlink {
         requires 'java.rmi'
         requires 'java.xml'
         requires 'com.sun.xml.txw2'
-        requires 'com.google.gson';
+        requires 'com.google.gson'
         requires 'java.desktop'
         requires 'java.security.jgss'
         requires 'jdk.jsobject'
@@ -628,7 +628,6 @@ jlink {
             // This requires WiX to be installed: https://github.com/wixtoolset/wix3/releases
             installerType = "msi"
             imageOptions = [
-                    '--win-console',
                     '--icon', "${projectDir}/src/main/resources/icons/jabref.ico",
             ]
             installerOptions = [


### PR DESCRIPTION
Fixes #5474. Apparently, the upstream bug in the jdk concerning cmd line arguments was fixed in the meantime, which makes the `win-console` toggle obsolete.

Only problem I've encountered so far is that no logger output is written to the console. Combined with the Log4j issues we have at the moment, this means that for users it's not possible to report detailed stack traces etc. Workaround: use `.\runtime\bin\JabRef` to start JabRef instead of `JabRef.exe` (I would add this to the release notes under "known issues").

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
