### PR TITLE
Fix communication with JabFox

### DIFF
--- a/buildres/windows/JabRefHost.ps1
+++ b/buildres/windows/JabRefHost.ps1
@@ -11,7 +11,7 @@ function Respond($response) {
     }
 }
 
-$jabRefExe = [System.IO.Path]::Combine($PSScriptRoot, "JabRef.exe")
+$jabRefExe = [System.IO.Path]::Combine($PSScriptRoot, "runtime\\bin\\JabRef.bat")
 
 try {
     $reader = New-Object System.IO.BinaryReader([System.Console]::OpenStandardInput())
@@ -37,9 +37,10 @@ try {
     #$wshell = New-Object -ComObject Wscript.Shell
     #$wshell.Popup($message.Text,0,"JabRef", 0x0 + 0x30)
 
-    $messageText = $message.Text
-    $output = & $jabRefExe -importBibtex "$messageText" 2>&1
-    #$output = & echoargs -importBibtex $messageText 2>&1
+    $messageText = $message.Text.replace("`n"," ").replace("`r"," ")
+    $output = & $jabRefExe -importBibtex "$messageText" *>&1
+    #$output = "$messageText"
+    #$wshell = New-Object -ComObject Wscript.Shell
     #$wshell.Popup($output,0,"JabRef", 0x0 + 0x30)
     return Respond @{message="ok";output="$output"}
 } finally {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

For some reason, removing `win-console` is still not compatible with JabFox (there are no errors, it simply does nothing). Changing the path to the "real" executable and removing new lines does work.

<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
