### PR TITLE
Rework tools menu

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -712,6 +712,10 @@ public class JabRefFrame extends BorderPane {
 
                 new SeparatorMenuItem(),
 
+                factory.createMenuItem(StandardActions.REPLACE_ALL, new OldDatabaseCommandWrapper(Actions.REPLACE_ALL, this, stateManager)),
+
+                new SeparatorMenuItem(),
+
                 factory.createMenuItem(StandardActions.MANAGE_KEYWORDS, new ManageKeywordsAction(stateManager))
         );
 
@@ -769,7 +773,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.NEW_SUB_LIBRARY_FROM_AUX, new NewSubLibraryAction(this, stateManager)),
 
                 new SeparatorMenuItem(),
-                
+
                 factory.createMenuItem(StandardActions.FIND_UNLINKED_FILES, new FindUnlinkedFilesAction(this, stateManager)),
                 factory.createMenuItem(StandardActions.WRITE_XMP, new OldDatabaseCommandWrapper(Actions.WRITE_XMP, this, stateManager)),
                 factory.createMenuItem(StandardActions.COPY_LINKED_FILES, new CopyFilesAction(stateManager, this.getDialogService())),
@@ -782,7 +786,6 @@ public class JabRefFrame extends BorderPane {
                 new SeparatorMenuItem(),
 
                 factory.createMenuItem(StandardActions.GENERATE_CITE_KEYS, new OldDatabaseCommandWrapper(Actions.MAKE_KEY, this, stateManager)),
-                factory.createMenuItem(StandardActions.REPLACE_ALL, new OldDatabaseCommandWrapper(Actions.REPLACE_ALL, this, stateManager)),
                 factory.createMenuItem(StandardActions.SEND_AS_EMAIL, new OldDatabaseCommandWrapper(Actions.SEND_AS_EMAIL, this, stateManager)),
                 pushToApplicationMenuItem,
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -767,6 +767,9 @@ public class JabRefFrame extends BorderPane {
         tools.getItems().addAll(
                 factory.createMenuItem(StandardActions.PARSE_TEX, new ParseTexAction(stateManager)),
                 factory.createMenuItem(StandardActions.NEW_SUB_LIBRARY_FROM_AUX, new NewSubLibraryAction(this, stateManager)),
+
+                new SeparatorMenuItem(),
+                
                 factory.createMenuItem(StandardActions.FIND_UNLINKED_FILES, new FindUnlinkedFilesAction(this, stateManager)),
                 factory.createMenuItem(StandardActions.WRITE_XMP, new OldDatabaseCommandWrapper(Actions.WRITE_XMP, this, stateManager)),
                 factory.createMenuItem(StandardActions.COPY_LINKED_FILES, new CopyFilesAction(stateManager, this.getDialogService())),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -87,7 +87,7 @@ public enum StandardActions implements Action {
 
     PARSE_TEX(Localization.lang("Search for citations in LaTeX files"), IconTheme.JabRefIcons.LATEX_CITATIONS),
     NEW_SUB_LIBRARY_FROM_AUX(Localization.lang("New sublibrary based on AUX file") + "...", Localization.lang("New BibTeX sublibrary") + Localization.lang("This feature generates a new library based on which entries are needed in an existing LaTeX document."), IconTheme.JabRefIcons.NEW),
-    WRITE_XMP(Localization.lang("Write XMP-metadata to PDFs"), Localization.lang("Will write XMP-metadata to the PDFs linked from selected entries."), KeyBinding.WRITE_XMP),
+    WRITE_XMP(Localization.lang("Write XMP metadata to PDFs"), Localization.lang("Will write XMP metadata to the PDFs linked from selected entries."), KeyBinding.WRITE_XMP),
     OPEN_FOLDER(Localization.lang("Open folder"), Localization.lang("Open folder"), KeyBinding.OPEN_FOLDER),
     OPEN_FILE(Localization.lang("Open file"), Localization.lang("Open file"), IconTheme.JabRefIcons.FILE, KeyBinding.OPEN_FILE),
     OPEN_CONSOLE(Localization.lang("Open terminal here"), Localization.lang("Open terminal here"), IconTheme.JabRefIcons.CONSOLE, KeyBinding.OPEN_CONSOLE),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -85,7 +85,7 @@ public enum StandardActions implements Action {
     TOOGLE_OO(Localization.lang("OpenOffice/LibreOffice"), IconTheme.JabRefIcons.FILE_OPENOFFICE, KeyBinding.OPEN_OPEN_OFFICE_LIBRE_OFFICE_CONNECTION),
     TOGGLE_WEB_SEARCH(Localization.lang("Web search"), Localization.lang("Toggle web search interface"), IconTheme.JabRefIcons.WWW, KeyBinding.WEB_SEARCH),
 
-    PARSE_TEX(Localization.lang("Search for Citations in LaTeX Files"), IconTheme.JabRefIcons.LATEX_CITATIONS),
+    PARSE_TEX(Localization.lang("Search for citations in LaTeX files"), IconTheme.JabRefIcons.LATEX_CITATIONS),
     NEW_SUB_LIBRARY_FROM_AUX(Localization.lang("New sublibrary based on AUX file") + "...", Localization.lang("New BibTeX sublibrary") + Localization.lang("This feature generates a new library based on which entries are needed in an existing LaTeX document."), IconTheme.JabRefIcons.NEW),
     WRITE_XMP(Localization.lang("Write XMP-metadata to PDFs"), Localization.lang("Will write XMP-metadata to the PDFs linked from selected entries."), KeyBinding.WRITE_XMP),
     OPEN_FOLDER(Localization.lang("Open folder"), Localization.lang("Open folder"), KeyBinding.OPEN_FOLDER),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -85,7 +85,7 @@ public enum StandardActions implements Action {
     TOOGLE_OO(Localization.lang("OpenOffice/LibreOffice"), IconTheme.JabRefIcons.FILE_OPENOFFICE, KeyBinding.OPEN_OPEN_OFFICE_LIBRE_OFFICE_CONNECTION),
     TOGGLE_WEB_SEARCH(Localization.lang("Web search"), Localization.lang("Toggle web search interface"), IconTheme.JabRefIcons.WWW, KeyBinding.WEB_SEARCH),
 
-    PARSE_TEX(Localization.lang("Search for citations in LaTeX files"), IconTheme.JabRefIcons.LATEX_CITATIONS),
+    PARSE_TEX(Localization.lang("Search for citations in LaTeX files..."), IconTheme.JabRefIcons.LATEX_CITATIONS),
     NEW_SUB_LIBRARY_FROM_AUX(Localization.lang("New sublibrary based on AUX file") + "...", Localization.lang("New BibTeX sublibrary") + Localization.lang("This feature generates a new library based on which entries are needed in an existing LaTeX document."), IconTheme.JabRefIcons.NEW),
     WRITE_XMP(Localization.lang("Write XMP metadata to PDFs"), Localization.lang("Will write XMP metadata to the PDFs linked from selected entries."), KeyBinding.WRITE_XMP),
     OPEN_FOLDER(Localization.lang("Open folder"), Localization.lang("Open folder"), KeyBinding.OPEN_FOLDER),

--- a/src/main/java/org/jabref/gui/exporter/WriteXMPAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteXMPAction.java
@@ -70,15 +70,15 @@ public class WriteXMPAction extends SimpleCommand {
 
             if (entries.isEmpty()) {
                 dialogService.showErrorDialogAndWait(
-                        Localization.lang("Write XMP-metadata"),
+                        Localization.lang("Write XMP metadata"),
                         Localization.lang("This operation requires one or more entries to be selected."));
                 shouldContinue = false;
                 return;
 
             } else {
                 boolean confirm = dialogService.showConfirmationDialogAndWait(
-                        Localization.lang("Write XMP-metadata"),
-                        Localization.lang("Write XMP-metadata for all PDFs in current library?"));
+                        Localization.lang("Write XMP metadata"),
+                        Localization.lang("Write XMP metadata for all PDFs in current library?"));
                 if (confirm) {
                     shouldContinue = false;
                     return;
@@ -93,7 +93,7 @@ public class WriteXMPAction extends SimpleCommand {
         }
         optionsDialog.open();
 
-        dialogService.notify(Localization.lang("Writing XMP-metadata..."));
+        dialogService.notify(Localization.lang("Writing XMP metadata..."));
     }
 
     private void writeXMP() {
@@ -176,7 +176,7 @@ public class WriteXMPAction extends SimpleCommand {
         private final TextArea progressArea;
 
         public OptionsDialog() {
-            super(AlertType.NONE, Localization.lang("Writing XMP-metadata for selected entries..."), false);
+            super(AlertType.NONE, Localization.lang("Writing XMP metadata for selected entries..."), false);
             okButton.setDisable(true);
             okButton.setOnAction(e -> dispose());
             okButton.setPrefSize(100, 30);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -369,7 +369,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
     }
 
     public void writeXMPMetadata() {
-        // Localization.lang("Writing XMP-metadata...")
+        // Localization.lang("Writing XMP metadata...")
         BackgroundTask<Void> writeTask = BackgroundTask.wrap(() -> {
             Optional<Path> file = linkedFile.findIn(databaseContext, filePreferences);
             if (!file.isPresent()) {
@@ -386,7 +386,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
             return null;
         });
 
-        // Localization.lang("Finished writing XMP-metadata.")
+        // Localization.lang("Finished writing XMP metadata.")
 
         // TODO: Show progress
         taskExecutor.execute(writeTask);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -151,7 +151,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         acceptAutoLinkedFile.getStyleClass().setAll("icon-button");
 
         Button writeXMPMetadata = IconTheme.JabRefIcons.IMPORT.asButton();
-        writeXMPMetadata.setTooltip(new Tooltip(Localization.lang("Write BibTeXEntry as XMP-metadata to PDF.")));
+        writeXMPMetadata.setTooltip(new Tooltip(Localization.lang("Write BibTeXEntry as XMP metadata to PDF.")));
         writeXMPMetadata.visibleProperty().bind(linkedFile.canWriteXMPMetadataProperty());
         writeXMPMetadata.setOnAction(event -> linkedFile.writeXMPMetadata());
         writeXMPMetadata.getStyleClass().setAll("icon-button");

--- a/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabView.java
@@ -42,7 +42,7 @@ public class XmpPrivacyTabView extends AbstractPreferenceTabView<XmpPrivacyTabVi
     }
 
     @Override
-    public String getTabName() { return Localization.lang("XMP-metadata"); }
+    public String getTabName() { return Localization.lang("XMP metadata"); }
 
     public void initialize () {
         this.viewModel = new XmpPrivacyTabViewModel(dialogService, preferences);

--- a/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabViewModel.java
@@ -43,7 +43,7 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
                 xmpFilterListProperty,
                 input -> input.size() > 0,
                 ValidationMessage.error(String.format("%s > %s %n %n %s",
-                        Localization.lang("XMP-metadata"),
+                        Localization.lang("XMP metadata"),
                         Localization.lang("Filter List"),
                         Localization.lang("List must not be empty."))));
     }

--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogView.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogView.java
@@ -50,7 +50,7 @@ public class ParseTexDialogView extends BaseDialog<Void> {
         this.databaseContext = databaseContext;
         this.validationVisualizer = new ControlsFxVisualizer();
 
-        setTitle(Localization.lang("Search for citations in LaTeX files"));
+        setTitle(Localization.lang("Search for citations in LaTeX files..."));
 
         ViewLoader.view(this).load().setAsDialogPane(this);
 

--- a/src/main/java/org/jabref/gui/texparser/ParseTexDialogView.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseTexDialogView.java
@@ -50,7 +50,7 @@ public class ParseTexDialogView extends BaseDialog<Void> {
         this.databaseContext = databaseContext;
         this.validationVisualizer = new ControlsFxVisualizer();
 
-        setTitle(Localization.lang("Search for Citations in LaTeX Files"));
+        setTitle(Localization.lang("Search for citations in LaTeX files"));
 
         ViewLoader.view(this).load().setAsDialogPane(this);
 

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * XMPUtilShared provides support for reading (@link XMPUtilReader) and writing (@link XMPUtilWriter) BibTex data as XMP-Metadata
+ * XMPUtilShared provides support for reading (@link XMPUtilReader) and writing (@link XMPUtilWriter) BibTex data as XMP metadata
  * in PDF-documents.
  */
 public class XmpUtilShared {

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -844,15 +844,15 @@ web\ link=link
 
 What\ do\ you\ want\ to\ do?=Hvad vil du gøre?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Skriver XMP-metadata til PDF-filerne linket fra de valgte poster.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Skriver XMP metadata til PDF-filerne linket fra de valgte poster.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata til PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Skriv BibTeX-posten som XMP metadata til PDF.
 
 Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne library?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte poster...
+Write\ XMP\ metadata=Skriv XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP metadata for alle PDFer i denne library?
+Writing\ XMP\ metadata...=Skriver XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Skriver XMP metadata for de valgte poster...
 
 XMP-annotated\ PDF=XMP-annoteret PDF
 XMP\ export\ privacy\ settings=Indstillinger for XMP-eksport
@@ -1123,7 +1123,7 @@ Check\ integrity=Tjek integritet
 Export\ selected\ entries=Eksporter valgte poster
 Fork\ me\ on\ GitHub=Fork mig på GitHub
 Push\ entries\ to\ external\ application\ (%0)=Send poster til ekstern applikation (%0)
-Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata til PDF-filer
+Write\ XMP\ metadata\ to\ PDFs=Skriv XMP metadata til PDF-filer
 
 Override\ default\ font\ settings=Tilsidesæt standardskrifttyper
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -943,19 +943,17 @@ web\ link=Web-Link
 What\ do\ you\ want\ to\ do?=Was möchten Sie tun?
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=Wie auch immer Sie sich entscheiden, Mr.DLib kann seine Daten mit Forschungspartnern teilen, um die Empfehlungsleistung im Rahmen eines "Reallabors" weiter zu verbessern. Mr.DLib kann auch öffentliche Datensätze veröffentlichen, die anonymisierte Informationen über Sie enthalten können und Empfehlungen (sensible Informationen wie Metadaten Ihrer Artikel werden z.B. durch Hashing anonymisiert) werden. Forschungspartner sind verpflichtet, die gleichen strengen Grundsätze des Datenschutzes zu beachten wie Mr.DLib.
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Schreibe XMP-Metadaten in die PDFs, die mit den ausgewählten Einträgen verlinkt sind.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Schreibe XMP-Metadaten in die PDFs, die mit den ausgewählten Einträgen verlinkt sind.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeX-Eintrag als XMP-Metadaten ins PDF schreiben.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=BibTeX-Eintrag als XMP-Metadaten ins PDF schreiben.
 
 Write\ XMP=XMP schreiben
-Write\ XMP-metadata=Schreibe XMP-Metadaten
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=XMP-Metadaten für alle PDFs der aktuellen Bibliothek schreiben?
-Writing\ XMP-metadata...=XMP-Metadaten werden geschrieben...
-Writing\ XMP-metadata\ for\ selected\ entries...=XMP-Metadaten für ausgewählte Einträge werden geschrieben...
-
+Write\ XMP\ metadata=Schreibe XMP-Metadaten
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=XMP-Metadaten für alle PDFs der aktuellen Bibliothek schreiben?
+Writing\ XMP\ metadata...=XMP-Metadaten werden geschrieben...
 XMP-annotated\ PDF=PDF mit XMP-Anmerkungen
 XMP\ export\ privacy\ settings=Sicherheitseinstellungen für den XMP-Export
-XMP-metadata=XMP-Metadaten
+XMP\ metadata=XMP-Metadaten
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Sie müssen JabRef neu starten, damit diese Änderungen in Kraft treten.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Sie müssen JabRef neu starten, damit die Tastenkürzel funktionieren.
@@ -1840,7 +1838,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Konnte Daten von '%0' nicht abruf
 Entry\ from\ %0\ could\ not\ be\ parsed.=Eintrag von %0 konnte nicht analysiert werden.
 Invalid\ identifier\:\ '%0'.=Ungültige Kennung\: "%0".
 This\ paper\ has\ been\ withdrawn.=Dieses Paper wurde zurückgezogen.
-Finished\ writing\ XMP-metadata.=XMP-Metadaten schreiben abgeschlossen.
+Finished\ writing\ XMP\ metadata.=XMP-Metadaten schreiben abgeschlossen.
 empty\ BibTeX\ key=Leerer BibTeX-Key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Ihre Java Laufzeitumgebung befindet sich in %0.
 Aux\ file=Aux-Datei
@@ -1912,7 +1910,7 @@ Set\ up\ general\ fields=Allgemeine Felder festlegen
 View\ change\ log=Changelog öffnen
 View\ event\ log=Ereignisprotokoll anzeigen
 Website=Webseite
-Write\ XMP-metadata\ to\ PDFs=&XMP-Metadaten in PDFs schreiben
+Write\ XMP\ metadata\ to\ PDFs=&XMP-Metadaten in PDFs schreiben
 
 Override\ default\ font\ settings=Standardschrifteinstellungen überschreiben
 Clear\ search=Suche zurücksetzen

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2017,7 +2017,7 @@ Matching=Passend
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Wie --import, aber wird in den geöffneten Tab importiert
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Ganzzahlen im Feld 'edition' im BibTeX-Modus erlauben
 
-Search\ for\ Citations\ in\ LaTeX\ Files=Suche nach Zitaten in LaTeX Dateien
+Search\ for\ citations\ in\ LaTeX\ files=Suche nach Zitaten in LaTeX Dateien
 LaTeX\ Citations\ Search\ Results=Suchergebnisse der Zitate aus LaTeX
 LaTeX\ files\ directory\:=LaTeX-Dateiverzeichnis\:
 LaTeX\ files\ found\:=LaTeX-Dateien gefunden\:

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2015,7 +2015,7 @@ Matching=Passend
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Wie --import, aber wird in den geöffneten Tab importiert
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Ganzzahlen im Feld 'edition' im BibTeX-Modus erlauben
 
-Search\ for\ citations\ in\ LaTeX\ files=Suche nach Zitaten in LaTeX Dateien
+Search\ for\ citations\ in\ LaTeX\ files...=Suche nach Zitaten in LaTeX Dateien...
 LaTeX\ Citations\ Search\ Results=Suchergebnisse der Zitate aus LaTeX
 LaTeX\ files\ directory\:=LaTeX-Dateiverzeichnis\:
 LaTeX\ files\ found\:=LaTeX-Dateien gefunden\:

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -885,19 +885,19 @@ web\ link=ηλεκτρονικός σύνδεσμος
 
 What\ do\ you\ want\ to\ do?=Τι θέλετε να κάνετε;
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Θα γράψει τα μεταδεδομένα XMP στα αρχεία PDF που έχουν συνδεθεί από τις επιλεγμένες καταχωρήσεις.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Θα γράψει τα μεταδεδομένα XMP στα αρχεία PDF που έχουν συνδεθεί από τις επιλεγμένες καταχωρήσεις.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Εγγραφή των μεταδεδομένων XMP σε αρχείο PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Εγγραφή των μεταδεδομένων XMP σε αρχείο PDF.
 
 Write\ XMP=Εγγραφή XMP
-Write\ XMP-metadata=Εγγραφή μεταδεδομένων XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Εγγραφή μεταδεδομένων XMP για όλα τα αρχεία PDF στην τρέχουσα βιβλιοθήκη;
-Writing\ XMP-metadata...=Πραγματοποιείται εγγραφή μεταδεδομένων XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Πραγματοποιείται εγγραφή μεταδεδομένων XMP για τις επιλεγμένες καταχωρήσεις...
+Write\ XMP\ metadata=Εγγραφή μεταδεδομένων XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Εγγραφή μεταδεδομένων XMP για όλα τα αρχεία PDF στην τρέχουσα βιβλιοθήκη;
+Writing\ XMP\ metadata...=Πραγματοποιείται εγγραφή μεταδεδομένων XMP...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Πραγματοποιείται εγγραφή μεταδεδομένων XMP για τις επιλεγμένες καταχωρήσεις...
 
 XMP-annotated\ PDF=Αρχείο PDF με σχόλια XMP
 XMP\ export\ privacy\ settings=Ρυθμίσεις ιδιωτικότητας εξαγωγής XMP
-XMP-metadata=Μεταδεδομένα XMP
+XMP\ metadata=Μεταδεδομένα XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Πρέπει να επανεκκινήσετε το JabRef για να τεθεί σε λειτουργία αυτό.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Πρέπει να επανεκκινήσετε το JabRef για να λειτουργήσουν σωστά οι νέες συντομεύσεις πληκτρολογίου.
@@ -1741,7 +1741,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Αδυναμία ανάκτηση
 Entry\ from\ %0\ could\ not\ be\ parsed.=Αδυναμία ανάλυσης καταχώρησης από %0.
 Invalid\ identifier\:\ '%0'.=Μη έγκυρο αναγνωριστικό\: '%0'.
 This\ paper\ has\ been\ withdrawn.=Αυτή η εργασία έχει αποσυρθεί.
-Finished\ writing\ XMP-metadata.=Ολοκλήρωση εγγραφής μεταδεδομένων XMP.
+Finished\ writing\ XMP\ metadata.=Ολοκλήρωση εγγραφής μεταδεδομένων XMP.
 empty\ BibTeX\ key=κενό κλειδί BibTeX
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Το Περιβάλλον Λειτουργίας Java βρίσκεται στο %0.
 Aux\ file=Αρχείο AUX
@@ -1809,7 +1809,7 @@ Set\ up\ general\ fields=Ορισμός γενικών πεδίων
 View\ change\ log=Προβολή αρχείου καταγραφής αλλαγών
 View\ event\ log=Προβολή καταγραφής συμβάντων (event log)
 Website=Ιστότοπος
-Write\ XMP-metadata\ to\ PDFs=Εγγραφή XMP-μεταδεδομένων σε PDF
+Write\ XMP\ metadata\ to\ PDFs=Εγγραφή XMP-μεταδεδομένων σε PDF
 
 Override\ default\ font\ settings=Παράκαμψη των προεπιλεγμένων ρυθμίσεων γραμματοσειράς
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -931,7 +931,7 @@ Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research
 
 Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP metadata to the PDFs linked from selected entries.
 
-Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Write BibTeXEntry as XMPmetadata to PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Write BibTeXEntry as XMP metadata to PDF.
 
 Write\ XMP=Write XMP
 Write\ XMP\ metadata=Write XMP metadata

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2000,7 +2000,7 @@ Matching=Matching
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Same as --import, but will be imported to the opened tab
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Allow integers in 'edition' field in BibTeX mode
 
-Search\ for\ Citations\ in\ LaTeX\ Files=Search for Citations in LaTeX Files
+Search\ for\ citations\ in\ LaTeX\ files=Search for citations in LaTeX files
 LaTeX\ Citations\ Search\ Results=LaTeX Citations Search Results
 LaTeX\ files\ directory\:=LaTeX files directory:
 LaTeX\ files\ found\:=LaTeX files found:

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2000,7 +2000,7 @@ Matching=Matching
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Same as --import, but will be imported to the opened tab
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Allow integers in 'edition' field in BibTeX mode
 
-Search\ for\ citations\ in\ LaTeX\ files=Search for citations in LaTeX files
+Search\ for\ citations\ in\ LaTeX\ files...=Search for citations in LaTeX files...
 LaTeX\ Citations\ Search\ Results=LaTeX Citations Search Results
 LaTeX\ files\ directory\:=LaTeX files directory:
 LaTeX\ files\ found\:=LaTeX files found:

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -929,19 +929,19 @@ web\ link=web link
 What\ do\ you\ want\ to\ do?=What do you want to do?
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=Whatever option you choose, Mr. DLib may share its data with research partners to further improve recommendation quality as part of a 'living lab'. Mr. DLib may also release public datasets that may contain anonymized information about you and the recommendations (sensitive information such as metadata of your articles will be anonymised through e.g. hashing). Research partners are obliged to adhere to the same strict data protection policy as Mr. DLib.
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP-metadata to the PDFs linked from selected entries.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP metadata to the PDFs linked from selected entries.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Write BibTeXEntry as XMP-metadata to PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Write BibTeXEntry as XMPmetadata to PDF.
 
 Write\ XMP=Write XMP
-Write\ XMP-metadata=Write XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Write XMP-metadata for all PDFs in current library?
-Writing\ XMP-metadata...=Writing XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Writing XMP-metadata for selected entries...
+Write\ XMP\ metadata=Write XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Write XMP metadata for all PDFs in current library?
+Writing\ XMP\ metadata...=Writing XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Writing XMP metadata for selected entries...
 
 XMP-annotated\ PDF=XMP-annotated PDF
 XMP\ export\ privacy\ settings=XMP export privacy settings
-XMP-metadata=XMP-metadata
+XMP\ metadata=XMP metadata
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=You must restart JabRef for this to come into effect.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=You must restart JabRef for the new key bindings to work properly.
@@ -1829,7 +1829,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Could not retrieve entry data fro
 Entry\ from\ %0\ could\ not\ be\ parsed.=Entry from %0 could not be parsed.
 Invalid\ identifier\:\ '%0'.=Invalid identifier: '%0'.
 This\ paper\ has\ been\ withdrawn.=This paper has been withdrawn.
-Finished\ writing\ XMP-metadata.=Finished writing XMP-metadata.
+Finished\ writing\ XMP\ metadata.=Finished writing XMP metadata.
 empty\ BibTeX\ key=empty BibTeX key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Your Java Runtime Environment is located at %0.
 Aux\ file=Aux file
@@ -1901,7 +1901,7 @@ Set\ up\ general\ fields=Set up general fields
 View\ change\ log=View change log
 View\ event\ log=View event log
 Website=Website
-Write\ XMP-metadata\ to\ PDFs=Write XMP-metadata to PDFs
+Write\ XMP\ metadata\ to\ PDFs=Write XMP metadata to PDFs
 
 Override\ default\ font\ settings=Override default font settings
 Clear\ search=Clear search

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1963,7 +1963,7 @@ Matching=Emparejamiento
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Igual que --import, pero se importará en la pestaña abierta
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Permitir números enteros en el campo 'edition' en modo BibTeX
 
-Search\ for\ Citations\ in\ LaTeX\ Files=Buscar citas en archivos LaTeX
+Search\ for\ citations\ in\ LaTeX\ files=Buscar citas en archivos LaTeX
 LaTeX\ Citations\ Search\ Results=Resultados de búsqueda de citas en los archivos LaTeX
 LaTeX\ files\ directory\:=Directorio de archivos de LaTeX\:
 LaTeX\ files\ found\:=Archivos de LaTeX encontrados\:

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -922,19 +922,19 @@ web\ link=enlace a web
 
 What\ do\ you\ want\ to\ do?=¿Qué desea hacer?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Escribirá metadatos XMP a los PDF's enlazados desde las entradas seleccionadas.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Escribirá metadatos XMP a los PDF's enlazados desde las entradas seleccionadas.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escribir entrada BibTeX como metadatos XMP al PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Escribir entrada BibTeX como metadatos XMP al PDF.
 
 Write\ XMP=Escribir XMP
-Write\ XMP-metadata=Escribir metadatos XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=¿Escribir metadatos XMP para todos los PDF en la biblioteca actual?
-Writing\ XMP-metadata...=Escribiendo metadatos XMP
-Writing\ XMP-metadata\ for\ selected\ entries...=Escribiendo metadatos XMP para las entradas seleccionadas...
+Write\ XMP\ metadata=Escribir metadatos XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=¿Escribir metadatos XMP para todos los PDF en la biblioteca actual?
+Writing\ XMP\ metadata...=Escribiendo metadatos XMP
+Writing\ XMP\ metadata\ for\ selected\ entries...=Escribiendo metadatos XMP para las entradas seleccionadas...
 
 XMP-annotated\ PDF=PDF con anotaciones XMP
 XMP\ export\ privacy\ settings=Ajustes de privacidad en exportación XMP
-XMP-metadata=Metadatos XMP
+XMP\ metadata=Metadatos XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Debe reiniciar JabRef para que los cambios surtan efecto.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Debe reiniciar JabRef para que las nuevas combinaciones de teclas funcionen correctamente.
@@ -1862,7 +1862,7 @@ Set\ up\ general\ fields=Establecer campos generales
 View\ change\ log=Ver registro de cambios
 View\ event\ log=Ver visor de eventos
 Website=Sitio web
-Write\ XMP-metadata\ to\ PDFs=Escribir metadatos XMP a PDF
+Write\ XMP\ metadata\ to\ PDFs=Escribir metadatos XMP a PDF
 
 Override\ default\ font\ settings=Ignorar ajustes de tipo de letra por defecto
 Clear\ search=Limpiar búsqueda

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1963,7 +1963,7 @@ Matching=Emparejamiento
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Igual que --import, pero se importará en la pestaña abierta
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Permitir números enteros en el campo 'edition' en modo BibTeX
 
-Search\ for\ citations\ in\ LaTeX\ files=Buscar citas en archivos LaTeX
+Search\ for\ citations\ in\ LaTeX\ files...=Buscar citas en archivos LaTeX...
 LaTeX\ Citations\ Search\ Results=Resultados de búsqueda de citas en los archivos LaTeX
 LaTeX\ files\ directory\:=Directorio de archivos de LaTeX\:
 LaTeX\ files\ found\:=Archivos de LaTeX encontrados\:

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -570,7 +570,7 @@ Check\ integrity=بررسی بی‌نقصی
 Export\ selected\ entries=فرستادن موارد منتخب
 Fork\ me\ on\ GitHub=مرا در GitHub منشعب کن
 Push\ entries\ to\ external\ application\ (%0)=(نشاندن ورودی‌ها به برنامه‌ی خارجی (%0
-Write\ XMP-metadata\ to\ PDFs=نوشتن XMP-metadata در PDFها
+Write\ XMP\ metadata\ to\ PDFs=نوشتن XMP metadata در PDFها
 
 
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -944,19 +944,19 @@ web\ link=Lien internet
 What\ do\ you\ want\ to\ do?=Que voulez-vous faire ?
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=Quelle que soit l'option choisie, Mr. DLib pourrait partager ses données avec des partenaires de recherche afin d'améliorer la qualité des recommandations dans le cadre d'un « living lab ». Mr. DLib pourrait également rendre public des jeux de données pouvant contenir des informations anonymisées à votre sujet et les recommandations formulées (les informations sensibles telles que les métadonnées de vos articles seront anonymisées par le biais de hachage par exemple). Les partenaires de recherche sont tenus d'adhérer à la même politique de protection stricte des données que Mr. Dlib.
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Écrira les métadonnées XMP dans les PDFs liés aux entrées sélectionnées.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Écrira les métadonnées XMP dans les PDFs liés aux entrées sélectionnées.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Écrire l'entrée BibTeX comme des métadonnées XMP dans un PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Écrire l'entrée BibTeX comme des métadonnées XMP dans un PDF.
 
 Write\ XMP=Écrire XMP
-Write\ XMP-metadata=Écrire les métadonnées XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ecrire les métadonnées XMP pour tous les PDFs dans le fichier courant ?
-Writing\ XMP-metadata...=Ecriture des métadonnées XMP
-Writing\ XMP-metadata\ for\ selected\ entries...=Ecriture des métadonnées XMP pour les entrées sélectionnées
+Write\ XMP\ metadata=Écrire les métadonnées XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Ecrire les métadonnées XMP pour tous les PDFs dans le fichier courant ?
+Writing\ XMP\ metadata...=Ecriture des métadonnées XMP
+Writing\ XMP\ metadata\ for\ selected\ entries...=Ecriture des métadonnées XMP pour les entrées sélectionnées
 
 XMP-annotated\ PDF=PDF avec annotations XMP
 XMP\ export\ privacy\ settings=Paramètres de confidentialité pour l'exportation XMP
-XMP-metadata=Métadonnées XMP
+XMP\ metadata=Métadonnées XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Vous devez redémarrer JabRef pour que ce changement prenne effet.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Vous devez relancer JabRef pour que les nouvelles affectations des touches soient activées.
@@ -1843,7 +1843,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Impossible de récupérer les don
 Entry\ from\ %0\ could\ not\ be\ parsed.=Entrée de %0 n’a pas pu être analysée.
 Invalid\ identifier\:\ '%0'.=Identifiant non valide \: « %0 ».
 This\ paper\ has\ been\ withdrawn.=Cet article a été retiré.
-Finished\ writing\ XMP-metadata.=Écriture des métadonnées XMP terminée.
+Finished\ writing\ XMP\ metadata.=Écriture des métadonnées XMP terminée.
 empty\ BibTeX\ key=Clef BibTeX vide
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Votre environnement d’exécution Java se trouve dans %0.
 Aux\ file=Fichier aux
@@ -1915,7 +1915,7 @@ Set\ up\ general\ fields=Définir les champs généraux
 View\ change\ log=Afficher le fichier des changements
 View\ event\ log=Afficher le journal des évènements
 Website=Site Internet
-Write\ XMP-metadata\ to\ PDFs=Ecrire les métadonnées XMP dans les PDFs
+Write\ XMP\ metadata\ to\ PDFs=Ecrire les métadonnées XMP dans les PDFs
 
 Override\ default\ font\ settings=Remplacer les paramètres de police par défaut
 Clear\ search=Vider la recherche

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2020,7 +2020,7 @@ Matching=Correspondant
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Comme --import, mais sera importé dans l'onglet ouvert
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Autoriser les entiers dans le champ 'edition' en mode BibTeX
 
-Search\ for\ citations\ in\ LaTeX\ files=Rechercher des citations dans les fichiers LaTeX
+Search\ for\ citations\ in\ LaTeX\ files...=Rechercher des citations dans les fichiers LaTeX...
 LaTeX\ Citations\ Search\ Results=Résultats de recherche de citations LaTeX
 LaTeX\ files\ directory\:=Répertoire des fichiers LaTeX \:
 LaTeX\ files\ found\:=Fichiers LaTeX trouvés \:

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2020,7 +2020,7 @@ Matching=Correspondant
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=Comme --import, mais sera importé dans l'onglet ouvert
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=Autoriser les entiers dans le champ 'edition' en mode BibTeX
 
-Search\ for\ Citations\ in\ LaTeX\ Files=Rechercher des citations dans les fichiers LaTeX
+Search\ for\ citations\ in\ LaTeX\ files=Rechercher des citations dans les fichiers LaTeX
 LaTeX\ Citations\ Search\ Results=Résultats de recherche de citations LaTeX
 LaTeX\ files\ directory\:=Répertoire des fichiers LaTeX \:
 LaTeX\ files\ found\:=Fichiers LaTeX trouvés \:

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -875,19 +875,19 @@ web\ link=tautan web
 
 What\ do\ you\ want\ to\ do?=Apa yang anda inginkan?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Akan menulis metadata XMP ke tautan PDF dari entri pilihan.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Akan menulis metadata XMP ke tautan PDF dari entri pilihan.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Menulis BibTeXEntry sebagai XMP-metadata ke PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Menulis BibTeXEntry sebagai XMP metadata ke PDF.
 
 Write\ XMP=Menulis XMP
-Write\ XMP-metadata=Menulis XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Menulis XMP-metadata untuk semua PDF di basisdata sekarang?
-Writing\ XMP-metadata...=Sedang menulis XMP metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Sedang menulis XMP metadata untuk entri pilihan...
+Write\ XMP\ metadata=Menulis XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Menulis XMP metadata untuk semua PDF di basisdata sekarang?
+Writing\ XMP\ metadata...=Sedang menulis XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Sedang menulis XMP metadata untuk entri pilihan...
 
 XMP-annotated\ PDF=Anotasi XMP PDF
 XMP\ export\ privacy\ settings=Pengaturan Info Ekspor XMP
-XMP-metadata=Metadata XMP
+XMP\ metadata=Metadata XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Anda harus menjalankan ulang JabRef agar berfungsi.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Anda harus menjalankan ulang JabRef agar gabungan kunci dapat berfungsi.
@@ -1749,7 +1749,7 @@ Push\ entries\ to\ external\ application\ (%0)=Kirim entri ke program eksternal 
 View\ change\ log=Lihat log perubahan
 View\ event\ log=Lihat log aktivitas
 Website=Situs web
-Write\ XMP-metadata\ to\ PDFs=Tulis metadata XMP ke PSF
+Write\ XMP\ metadata\ to\ PDFs=Tulis metadata XMP ke PSF
 
 Override\ default\ font\ settings=Ganti ukuran huruf bawaan
 

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -885,19 +885,19 @@ web\ link=collegamenti Internet
 
 What\ do\ you\ want\ to\ do?=Cosa vuoi fare?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Scrive i metadati XMP nei file PDF collegati alle voci selezionate
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Scrive i metadati XMP nei file PDF collegati alle voci selezionate
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Scrivi voce BibTeX come metadati XMP in un file PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Scrivi voce BibTeX come metadati XMP in un file PDF.
 
 Write\ XMP=Scrivi XMP
-Write\ XMP-metadata=Scrivi i metadati XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Scrivere i metadati XMP per tutti i file PDF della libreria corrente?
-Writing\ XMP-metadata...=Scrittura dei metadati XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Scrittura dei metadati XMP per le voci selezionate
+Write\ XMP\ metadata=Scrivi i metadati XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Scrivere i metadati XMP per tutti i file PDF della libreria corrente?
+Writing\ XMP\ metadata...=Scrittura dei metadati XMP...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Scrittura dei metadati XMP per le voci selezionate
 
 XMP-annotated\ PDF=PDF con annotazioni XMP
 XMP\ export\ privacy\ settings=Impostazioni per la riservatezza dei dati XMP esportati
-XMP-metadata=Metadati XMP
+XMP\ metadata=Metadati XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Riavviare JabRef per rendere effettiva la modifica.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Riavviare JabRef per rendere operative le nuove assegnazioni di tasti.
@@ -1741,7 +1741,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Impossibile recuperare dati in in
 Entry\ from\ %0\ could\ not\ be\ parsed.=Non è stato possibile analizzare la voce %0.
 Invalid\ identifier\:\ '%0'.=Identificatore non valido\: '%0'.
 This\ paper\ has\ been\ withdrawn.=Questo documento è stato ritirato.
-Finished\ writing\ XMP-metadata.=Finito di trascrivere i metadati XMP.
+Finished\ writing\ XMP\ metadata.=Finito di trascrivere i metadati XMP.
 empty\ BibTeX\ key=chiave BibTeX vuota
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Il tuo ambiente di Runtime di Java si trova in %0.
 Aux\ file=File aux
@@ -1809,7 +1809,7 @@ Set\ up\ general\ fields=Imposta i campi generali
 View\ change\ log=Visualizza la lista delle modifiche
 View\ event\ log=Visualizza il log degli eventi
 Website=Sito web
-Write\ XMP-metadata\ to\ PDFs=Inserisci metadati XMP nei file PDF
+Write\ XMP\ metadata\ to\ PDFs=Inserisci metadati XMP nei file PDF
 
 Override\ default\ font\ settings=Ignora le impostazioni dei font predefinite
 

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2020,7 +2020,7 @@ Matching=一致
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=--importと同じですが，開かれているタブに読み込みます
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=BibTeXモードの「edition」フィールドを整数にすることを許可する
 
-Search\ for\ citations\ in\ LaTeX\ files=LaTeXファイルから引用を検索
+Search\ for\ citations\ in\ LaTeX\ files...=LaTeXファイルから引用を検索...
 LaTeX\ Citations\ Search\ Results=「LaTeXでの引用」の検索結果
 LaTeX\ files\ directory\:=LaTeXファイルディレクトリ：
 LaTeX\ files\ found\:=検出されたLaTeXファイル：

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2020,7 +2020,7 @@ Matching=一致
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=--importと同じですが，開かれているタブに読み込みます
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=BibTeXモードの「edition」フィールドを整数にすることを許可する
 
-Search\ for\ Citations\ in\ LaTeX\ Files=LaTeXファイルから引用を検索
+Search\ for\ citations\ in\ LaTeX\ files=LaTeXファイルから引用を検索
 LaTeX\ Citations\ Search\ Results=「LaTeXでの引用」の検索結果
 LaTeX\ files\ directory\:=LaTeXファイルディレクトリ：
 LaTeX\ files\ found\:=検出されたLaTeXファイル：

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -944,19 +944,19 @@ web\ link=ウェブリンク
 What\ do\ you\ want\ to\ do?=どうしますか？
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=どの選択肢を選んだとしても，Mr. DLibは「活動中の実験室」の一翼を担うものとして，推奨文献をさらに改善するために，データを研究パートナーと共有することがあります．また，Mr. DLibは，あなたと推奨文献についての匿名化された情報が含まれている可能性のあるパブリックデータセットを公開することがあります（あなたの文献のメタデータのようなセンシティブ情報は，ハッシング等を通じて匿名化されます）．研究パートナーは，Mr. DLibと同じ厳格なデータ保護ポリシーに従う義務を負っています．
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
 
 Write\ XMP=XMPを書き込む
-Write\ XMP-metadata=XMPメタデータを書き込む
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=現ライブラリの全PDFにXMPメタデータを書き込みますか？
-Writing\ XMP-metadata...=XMPメタデータを書き込んでいます...
-Writing\ XMP-metadata\ for\ selected\ entries...=選択した項目にXMPメタデータを書き込んでいます...
+Write\ XMP\ metadata=XMPメタデータを書き込む
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=現ライブラリの全PDFにXMPメタデータを書き込みますか？
+Writing\ XMP\ metadata...=XMPメタデータを書き込んでいます...
+Writing\ XMP\ metadata\ for\ selected\ entries...=選択した項目にXMPメタデータを書き込んでいます...
 
 XMP-annotated\ PDF=XMP注釈付きPDF
 XMP\ export\ privacy\ settings=XMP書き出しのプライバシー設定
-XMP-metadata=XMPメタデータ
+XMP\ metadata=XMPメタデータ
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=これを有効にするためにはJabRefを再起動する必要があります．
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=新しいキー割当が正しく機能するようにするためには，JabRefを再起動しなくてはなりません．
@@ -1843,7 +1843,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.='%0' から項目データを取�
 Entry\ from\ %0\ could\ not\ be\ parsed.=%0 からの項目を解析することができませんでした．
 Invalid\ identifier\:\ '%0'.=「%0」は識別子として無効です．
 This\ paper\ has\ been\ withdrawn.=この論文は撤回されました．
-Finished\ writing\ XMP-metadata.=XMPメタデータを書き終えました．
+Finished\ writing\ XMP\ metadata.=XMPメタデータを書き終えました．
 empty\ BibTeX\ key=空のBibTeX鍵
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=お使いのJava Runtime Environmentは%0にあります．
 Aux\ file=auxファイル
@@ -1915,7 +1915,7 @@ Set\ up\ general\ fields=汎用フィールドを設定
 View\ change\ log=変更履歴を閲覧
 View\ event\ log=イベントログを表示
 Website=ウェブサイト
-Write\ XMP-metadata\ to\ PDFs=XMPメタデータをPDFに書き出す
+Write\ XMP\ metadata\ to\ PDFs=XMPメタデータをPDFに書き出す
 
 Override\ default\ font\ settings=既定フォント設定を上書き
 Clear\ search=検索を消去

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -906,19 +906,19 @@ web\ link=web-link
 
 What\ do\ you\ want\ to\ do?=Wat wilt u doen?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Zal XMP metadata naar de PDFs gelinkt vanuit geselecteerde invoergegevens schrijven.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Zal XMP metadata naar de PDFs gelinkt vanuit geselecteerde invoergegevens schrijven.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Schrijf BibTeX-entry als XMP-metadata naar PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Schrijf BibTeX-entry als XMP metadata naar PDF.
 
 Write\ XMP=Schrijf XMP
-Write\ XMP-metadata=Schrijven van XMP-metagegevens
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Schrijf XMP-metagegevens voor alle PDF's in huidige bibliotheek?
-Writing\ XMP-metadata...=XMP metadata aan het schrijven...
-Writing\ XMP-metadata\ for\ selected\ entries...=XMP metadata voor geselecteerde invoergegevens aan het schrijven...
+Write\ XMP\ metadata=Schrijven van XMP-metagegevens
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Schrijf XMP-metagegevens voor alle PDF's in huidige bibliotheek?
+Writing\ XMP\ metadata...=XMP metadata aan het schrijven...
+Writing\ XMP\ metadata\ for\ selected\ entries...=XMP metadata voor geselecteerde invoergegevens aan het schrijven...
 
 XMP-annotated\ PDF=XMP geannoteerde PDF
 XMP\ export\ privacy\ settings=XMP privacy-instellingen exporteren
-XMP-metadata=XMP metadata
+XMP\ metadata=XMP metadata
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=U moet JabRef herstarten om dit toe te passen.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=U moet JabRef herstarten om de nieuwe sneltoetsen naar behoren te laten werken.
@@ -1763,7 +1763,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Kon geen data ophalen van '%0'.
 Entry\ from\ %0\ could\ not\ be\ parsed.=Invoer van %0 kon niet worden geparseerd.
 Invalid\ identifier\:\ '%0'.=Ongeldig Id\: '%0'.
 This\ paper\ has\ been\ withdrawn.=Dit artikel is ingetrokken.
-Finished\ writing\ XMP-metadata.=Klaar met schrijven van XMP-metadata.
+Finished\ writing\ XMP\ metadata.=Klaar met schrijven van XMP metadata.
 empty\ BibTeX\ key=lege BibTeX-sleutel
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Uw Java Runtime Environment bevindt zich op %0.
 Aux\ file=Aux bestand
@@ -1835,7 +1835,7 @@ Set\ up\ general\ fields=Algemene velden instellen
 View\ change\ log=Verandering logboek weergeven
 View\ event\ log=Afspraken logboek weergeven
 Website=Website
-Write\ XMP-metadata\ to\ PDFs=Schrijf XMP metadata naar PDFs
+Write\ XMP\ metadata\ to\ PDFs=Schrijf XMP metadata naar PDFs
 
 Override\ default\ font\ settings=Wijzig standaard lettertypeinstellingen
 Clear\ search=Wis zoekopdracht

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -889,15 +889,15 @@ web\ link=link
 
 What\ do\ you\ want\ to\ do?=Hva vil du gjøre?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Vil skrive XMP-metadata til PDFene linket fra de valgte enhetene.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Vil skrive XMP metadata til PDFene linket fra de valgte enhetene.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-enheten som XMP-metadata til PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Skriv BibTeX-enheten som XMP metadata til PDF.
 
 Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i dette biblioteket?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte enhetene...
+Write\ XMP\ metadata=Skriv XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP metadata for alle PDFer i dette biblioteket?
+Writing\ XMP\ metadata...=Skriver XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Skriver XMP metadata for de valgte enhetene...
 
 XMP-annotated\ PDF=XMP-annotert PDF
 XMP\ export\ privacy\ settings=Innstillinger for XMP-eksport
@@ -1230,7 +1230,7 @@ Quit=Avslutt
 Recent\ libraries=Nylig brukte biblioteker
 View\ change\ log=Vis endringslogg
 Website=Nettsted
-Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata til PDF-filer
+Write\ XMP\ metadata\ to\ PDFs=Skriv XMP metadata til PDF-filer
 
 Override\ default\ font\ settings=Overstyr standardfonter
 Clear\ search=Nullstill søk

--- a/src/main/resources/l10n/JabRef_pt.properties
+++ b/src/main/resources/l10n/JabRef_pt.properties
@@ -902,19 +902,19 @@ web\ link=link web
 
 What\ do\ you\ want\ to\ do?=O que você deseja fazer?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
 
 Write\ XMP=Escrever XMP
-Write\ XMP-metadata=Escrever metadados XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
-Writing\ XMP-metadata...=Escrevendo metadados XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
+Write\ XMP\ metadata=Escrever metadados XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
+Writing\ XMP\ metadata...=Escrevendo metadados XMP...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
 
 XMP-annotated\ PDF=PDF com anotações XMP
 XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP
-XMP-metadata=Metaddos XMP
+XMP\ metadata=Metaddos XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Você deve reiniciar o JabRef para a alteração tenha efeito.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=O JabRef precisa ser reiniciado para que as novas atribuições de chave funcionem corretamente.
@@ -1434,7 +1434,7 @@ Manage\ protected\ terms=Gerenciar palavras reservadas
 New\ %0\ library=%0 novas bases de dados
 Push\ entries\ to\ external\ application\ (%0)=Enviar referências para um aplicativo externo (%0)
 View\ change\ log=Ver changelog
-Write\ XMP-metadata\ to\ PDFs=Escrever metadados XMP para PDFs
+Write\ XMP\ metadata\ to\ PDFs=Escrever metadados XMP para PDFs
 
 Override\ default\ font\ settings=Substituir configurações de fonte padrão
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -932,19 +932,17 @@ web\ link=link web
 
 What\ do\ you\ want\ to\ do?=O que você deseja fazer?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
 
 Write\ XMP=Escrever XMP
-Write\ XMP-metadata=Escrever metadados XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
-Writing\ XMP-metadata...=Escrevendo metadados XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
-
+Write\ XMP\ metadata=Escrever metadados XMP
+Write\ XMP \ metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
+Writing\ XMP\ metadata...=Escrevendo metadados XMP...
 XMP-annotated\ PDF=PDF com anotações XMP
 XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP
-XMP-metadata=Metaddos XMP
+XMP\ metadata=Metaddos XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Você deve reiniciar o JabRef para a alteração tenha efeito.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=O JabRef precisa ser reiniciado para que as novas atribuições de chave funcionem corretamente.
@@ -1469,7 +1467,7 @@ Manage\ protected\ terms=Gerenciar palavras reservadas
 New\ %0\ library=%0 novas bases de dados
 Push\ entries\ to\ external\ application\ (%0)=Enviar referências para um aplicativo externo (%0)
 View\ change\ log=Ver changelog
-Write\ XMP-metadata\ to\ PDFs=Escrever metadados XMP para PDFs
+Write\ XMP\ metadata\ to\ PDFs=Escrever metadados XMP para PDFs
 
 Override\ default\ font\ settings=Substituir configurações de fonte padrão
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -938,7 +938,7 @@ Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Escrever BibTeXEntry como um met
 
 Write\ XMP=Escrever XMP
 Write\ XMP\ metadata=Escrever metadados XMP
-Write\ XMP \ metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
 Writing\ XMP\ metadata...=Escrevendo metadados XMP...
 XMP-annotated\ PDF=PDF com anotações XMP
 XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -898,19 +898,19 @@ web\ link=веб-ссылки
 
 What\ do\ you\ want\ to\ do?=Выберите действие для продолжения.
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Будет выполнена запись метаданных XMP в PDF со ссылками из выбранных записей.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Будет выполнена запись метаданных XMP в PDF со ссылками из выбранных записей.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Запись значения записи BibTeX как метаданных XMP в PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Запись значения записи BibTeX как метаданных XMP в PDF.
 
 Write\ XMP=Запись XMP
-Write\ XMP-metadata=Запись метаданных XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Выполнить запись метаданных XMP для всех PDF текущей БД?
-Writing\ XMP-metadata...=Выполняется запись метаданных XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Выполняется запись метаданных XMPдля выбранных записей...
+Write\ XMP\ metadata=Запись метаданных XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Выполнить запись метаданных XMP для всех PDF текущей БД?
+Writing\ XMP\ metadata...=Выполняется запись метаданных XMP...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Выполняется запись метаданных XMPдля выбранных записей...
 
 XMP-annotated\ PDF=PDF с аннотациями XMP
 XMP\ export\ privacy\ settings=Настройки защиты экспорта XMP
-XMP-metadata=Метаданные XMP
+XMP\ metadata=Метаданные XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Для применения изменений необходимо перезапустить JabRef.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Для правильной работы новых назначений функциональных клавиш необходимо перезапустить JabRef.
@@ -1693,7 +1693,7 @@ Set\ up\ general\ fields=Настроить общие поля
 View\ change\ log=Просмотр журнала изменений
 View\ event\ log=Просмотр журнала событий
 Website=Веб-сайт
-Write\ XMP-metadata\ to\ PDFs=Запись метаданных XMP в PDF-файл
+Write\ XMP\ metadata\ to\ PDFs=Запись метаданных XMP в PDF-файл
 
 Override\ default\ font\ settings=Переопределить настройки шрифта, заданные по умолчанию
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -823,15 +823,15 @@ web\ link=weblänk
 
 What\ do\ you\ want\ to\ do?=Vad vill du göra?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Kommer skriva XMP-metadata till PDFer länkade från valda poster.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Kommer skriva XMP metadata till PDFer länkade från valda poster.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata i PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Skriv BibTeX-posten som XMP metadata i PDF.
 
 Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata för alla PDFer i aktuell databas?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata för valda poster...
+Write\ XMP\ metadata=Skriv XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP metadata för alla PDFer i aktuell databas?
+Writing\ XMP\ metadata...=Skriver XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Skriver XMP metadata för valda poster...
 
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du måste starta om JabRef för att ändringen ska slå igenom.
 
@@ -1493,7 +1493,7 @@ New\ %0\ library=Ny %0-databas
 Push\ entries\ to\ external\ application\ (%0)=Infoga &citeringar i externt program (%0)
 View\ change\ log=Visa ändringar
 Website=Hemsida
-Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata till PDFer
+Write\ XMP\ metadata\ to\ PDFs=Skriv XMP metadata till PDFer
 
 Override\ default\ font\ settings=Ignorera normala typsnittsinställningar
 

--- a/src/main/resources/l10n/JabRef_tl.properties
+++ b/src/main/resources/l10n/JabRef_tl.properties
@@ -876,19 +876,19 @@ web\ link=ang link ng web
 
 What\ do\ you\ want\ to\ do?=Ano ang gusto mong gawin?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ay magsusulat ng XMP-metadata para sa PDFs na linked mula sa napiling mga entries.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ay magsusulat ng XMP metadata para sa PDFs na linked mula sa napiling mga entries.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Isulat ang BibTeXEntry bilang XMP-metadata sa PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Isulat ang BibTeXEntry bilang XMP metadata sa PDF.
 
 Write\ XMP=Isulat ang XMP
-Write\ XMP-metadata=Isulat ang XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Isulat ang XMP-medata para sa lahat na PDF sa kasalukuyang library?
-Writing\ XMP-metadata...=Nagsusulat ng XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Nagsusulat ng XMP-medata para sa mga napiling entries...
+Write\ XMP\ metadata=Isulat ang XMP metadata
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Isulat ang XMP-medata para sa lahat na PDF sa kasalukuyang library?
+Writing\ XMP\ metadata...=Nagsusulat ng XMP metadata...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Nagsusulat ng XMP-medata para sa mga napiling entries...
 
 XMP-annotated\ PDF=Ang XMP-ay nalagyan ng anotasyon sa PDF
 XMP\ export\ privacy\ settings=Ang XMP ay nagpalabas ng mga settings na privacy
-XMP-metadata=Ang XMP-metadata
+XMP\ metadata=Ang XMP metadata
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Dapat mong i-restart ang JabRef para gumana ito.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Dapat mong i-restart ang JabRef para ang bagong susi na bindings para gumana ng maayus.
@@ -1425,7 +1425,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Hindi makuha ang data mula sa ent
 Entry\ from\ %0\ could\ not\ be\ parsed.=Ang entry mula sa %0 ay hindi ma-parse.
 Invalid\ identifier\:\ '%0'.=Di-wastong identifier\: '%0'.
 This\ paper\ has\ been\ withdrawn.=Ang papel na ito ay na-withdraw.
-Finished\ writing\ XMP-metadata.=Tapos na pagsulat ng XMP-metadata.
+Finished\ writing\ XMP\ metadata.=Tapos na pagsulat ng XMP metadata.
 empty\ BibTeX\ key=walang laman na BibTeX key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Ang iyong Java Runtime Environment ay matatagpuan sa %0.
 Aux\ file=Aux file

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2019,7 +2019,7 @@ Matching=Eşleştirme
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=İçe aktarma gibi, fakat açık sekmeye aktarılacak
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=BibTeX kipinin 'sürüm' alanında tam sayılara izin ver
 
-Search\ for\ Citations\ in\ LaTeX\ Files=LaTeX Dosyalarında Alıntıları ara
+Search\ for\ citations\ in\ LaTeX\ files=LaTeX Dosyalarında Alıntıları ara
 LaTeX\ Citations\ Search\ Results=LaTeX Alıntıları Arama Sonuçları
 LaTeX\ files\ directory\:=LaTeX dosyaları dizini\:
 LaTeX\ files\ found\:=Bulunan LaTeX dosyaları\:

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2019,7 +2019,7 @@ Matching=Eşleştirme
 Same\ as\ --import,\ but\ will\ be\ imported\ to\ the\ opened\ tab=İçe aktarma gibi, fakat açık sekmeye aktarılacak
 Allow\ integers\ in\ 'edition'\ field\ in\ BibTeX\ mode=BibTeX kipinin 'sürüm' alanında tam sayılara izin ver
 
-Search\ for\ citations\ in\ LaTeX\ files=LaTeX Dosyalarında Alıntıları ara
+Search\ for\ citations\ in\ LaTeX\ files...=LaTeX Dosyalarında Alıntıları ara...
 LaTeX\ Citations\ Search\ Results=LaTeX Alıntıları Arama Sonuçları
 LaTeX\ files\ directory\:=LaTeX dosyaları dizini\:
 LaTeX\ files\ found\:=Bulunan LaTeX dosyaları\:

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -943,19 +943,19 @@ web\ link=sanaldoku linki
 What\ do\ you\ want\ to\ do?=Ne yapmak istersiniz?
 Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research\ partners\ to\ further\ improve\ recommendation\ quality\ as\ part\ of\ a\ 'living\ lab'.\ Mr.\ DLib\ may\ also\ release\ public\ datasets\ that\ may\ contain\ anonymized\ information\ about\ you\ and\ the\ recommendations\ (sensitive\ information\ such\ as\ metadata\ of\ your\ articles\ will\ be\ anonymised\ through\ e.g.\ hashing).\ Research\ partners\ are\ obliged\ to\ adhere\ to\ the\ same\ strict\ data\ protection\ policy\ as\ Mr.\ DLib.=Hangi seçeneği seçerseniz seçin, Mr. DLib verilerini, 'yaşayan laboratuvar'ın parçası olarak, öneri kalitesini daha da arttırmak amacıyla araştırma ortaklarıyla paylaşabilir. Mr. DLib, hakkınızda anonimleştirilimiş bilgi içeren genel veri kümelerini ve önerileri (makalelerinizin metaverisi gibi duyarlı bilgiler karmaşıklaştırma gibi yöntemlerle anonimleştirilerek) genel kullanıma açabilir. Araştırma ortakları, Mr DLib'in katı veri koruma politikasının aynısına uymak zorundadır.
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Seçili girdilerle bağlantılı PDFlere XMP metaverisi yazılacak.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Seçili girdilerle bağlantılı PDFlere XMP metaverisi yazılacak.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeXGirdisi'ni PDF'ye XMP-metaverisi olarak yaz.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=BibTeXGirdisi'ni PDF'ye XMP-metaverisi olarak yaz.
 
 Write\ XMP=XMP'yi yaz
-Write\ XMP-metadata=XMP-metaverisini yaz
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Mevcut veritabanındaki tüm PFDlere XMP-metaverisi yazılsın mı?
-Writing\ XMP-metadata...=XMP metaverisi yazılıyor...
-Writing\ XMP-metadata\ for\ selected\ entries...=Seçili girdiler için XMP metaverisi yazılıyor...
+Write\ XMP\ metadata=XMP-metaverisini yaz
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Mevcut veritabanındaki tüm PFDlere XMP-metaverisi yazılsın mı?
+Writing\ XMP\ metadata...=XMP metaverisi yazılıyor...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Seçili girdiler için XMP metaverisi yazılıyor...
 
 XMP-annotated\ PDF=XMP-ek notlu PDF
 XMP\ export\ privacy\ settings=Gizlilik Ayarlarını XMP Dışa Aktar
-XMP-metadata=XMP metaverisi
+XMP\ metadata=XMP metaverisi
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bunun etkinleşmesi için JabRefi yeniden başlatmalısınız.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Yeni anahtar demetlerinin düzgün çalışması için JabRef'i yeniden başlatmalısınız.
@@ -1842,7 +1842,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.='%0' dan girdi verileri alınamad
 Entry\ from\ %0\ could\ not\ be\ parsed.=%0'dan girdi çözümlenemedi.
 Invalid\ identifier\:\ '%0'.=Geçersiz tanımlayıcı\: '%0 '.
 This\ paper\ has\ been\ withdrawn.=Bu yayın geri çekildi.
-Finished\ writing\ XMP-metadata.=XMP-meta veri yazımı bitti.
+Finished\ writing\ XMP\ metadata.=XMP-meta veri yazımı bitti.
 empty\ BibTeX\ key=boş BibTeX anahtarı
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Sizin Java Runtime Environment'ınız %0'da yer alır.
 Aux\ file=Aux dosya
@@ -1914,7 +1914,7 @@ Set\ up\ general\ fields=Genel alanları ayarla
 View\ change\ log=Değişiklik kütüğünü göster
 View\ event\ log=Olay kayıt dosyasını göster
 Website=Web sitesi
-Write\ XMP-metadata\ to\ PDFs=XMP-metaverisini PDF'ye yaz
+Write\ XMP\ metadata\ to\ PDFs=XMP-metaverisini PDF'ye yaz
 
 Override\ default\ font\ settings=Öntamınlı yazıtipi ayarlarını geçersiz kıl
 Clear\ search=Aramayı temizle

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -865,19 +865,19 @@ web\ link=liên kết web
 
 What\ do\ you\ want\ to\ do?=Bạn muốn làm gì?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Sẽ ghi đặc tả dữ liệu XMP vào các PDF được liên kết từ các mục đã chọn.
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Sẽ ghi đặc tả dữ liệu XMP vào các PDF được liên kết từ các mục đã chọn.
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ghi mục BibTeX dưới dạng đặc tả dữ liệu XMP vào PDF.
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Ghi mục BibTeX dưới dạng đặc tả dữ liệu XMP vào PDF.
 
 Write\ XMP=Ghi XMP
-Write\ XMP-metadata=Ghi đặc tả dữ liệu XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ghi đặc tả dữ liệu XMP cho tất cả các PDF trong CSDL hiện tại?
-Writing\ XMP-metadata...=Đang ghi đặc tả dữ liệu XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Đang ghi đặc tả dữ liệu XMP cho các mục được chọn...
+Write\ XMP\ metadata=Ghi đặc tả dữ liệu XMP
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=Ghi đặc tả dữ liệu XMP cho tất cả các PDF trong CSDL hiện tại?
+Writing\ XMP\ metadata...=Đang ghi đặc tả dữ liệu XMP...
+Writing\ XMP\ metadata\ for\ selected\ entries...=Đang ghi đặc tả dữ liệu XMP cho các mục được chọn...
 
 XMP-annotated\ PDF=PDF có chú giải XMP
 XMP\ export\ privacy\ settings=Các thiết lập riêng về Xuất XMP
-XMP-metadata=Đặc tả dữ liệu XMP
+XMP\ metadata=Đặc tả dữ liệu XMP
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bạn phải khởi động lại JabRef để thay đổi có hiệu lực.
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Bạn phải khởi động lại JabRef để các tổ hợp phím mới hoạt động được.
@@ -1148,7 +1148,7 @@ New\ %0\ library=CSDL %0 mới
 Push\ entries\ to\ external\ application\ (%0)=Đưa các mục ra ứng dụng ngoài (%0)
 View\ change\ log=Xem nhật kí thay đổi
 Website=Trang web
-Write\ XMP-metadata\ to\ PDFs=Ghi XMP-metadata thành các PDF
+Write\ XMP\ metadata\ to\ PDFs=Ghi XMP metadata thành các PDF
 
 Override\ default\ font\ settings=Ghi đè các thiết lập phông chữ mặc định
 

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -906,19 +906,19 @@ web\ link=web 链接
 
 What\ do\ you\ want\ to\ do?=您希望做什么?
 
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=将写入 XMP 元数据到选中记录链接的 PDF 文件。
+Will\ write\ XMP\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=将写入 XMP 元数据到选中记录链接的 PDF 文件。
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=将 BibTeX 记录作为 XMP 源数据写入到 PDF 中。
+Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=将 BibTeX 记录作为 XMP 源数据写入到 PDF 中。
 
 Write\ XMP=写入 XMP
-Write\ XMP-metadata=写入 XMP 元数据
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=将 XMP 元数据写入到当前文献库中所有 PDF 文件?
-Writing\ XMP-metadata...=正在写入 XMP 元数据...
-Writing\ XMP-metadata\ for\ selected\ entries...=正在为选中记录写入 XMP 元数据...
+Write\ XMP\ metadata=写入 XMP 元数据
+Write\ XMP\ metadata\ for\ all\ PDFs\ in\ current\ library?=将 XMP 元数据写入到当前文献库中所有 PDF 文件?
+Writing\ XMP\ metadata...=正在写入 XMP 元数据...
+Writing\ XMP\ metadata\ for\ selected\ entries...=正在为选中记录写入 XMP 元数据...
 
 XMP-annotated\ PDF=XMP注释的PDF文档
 XMP\ export\ privacy\ settings=XMP 导出隐私设置
-XMP-metadata=XMP 元数据
+XMP\ metadata=XMP 元数据
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=为使这项更改生效，您必须重启 JabRef。
 
 You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=为使热键绑定生效，您必须重启 JabRef。
@@ -1764,7 +1764,7 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=无法从 "%0" 中检索条目数
 Entry\ from\ %0\ could\ not\ be\ parsed.=无法解析 %0 中的条目。
 Invalid\ identifier\:\ '%0'.=无效的标识符：'%0'。
 This\ paper\ has\ been\ withdrawn.=这篇论文已被撤回。
-Finished\ writing\ XMP-metadata.=完成编写 XMP-metadata。
+Finished\ writing\ XMP\ metadata.=完成编写 XMP metadata。
 empty\ BibTeX\ key=空 BibTeX 键
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=您的Java运行环境位于 %0。
 Aux\ file=Aux 文件
@@ -1836,7 +1836,7 @@ Set\ up\ general\ fields=配置通用字段
 View\ change\ log=查看变更记录
 View\ event\ log=查看事件日志
 Website=网站
-Write\ XMP-metadata\ to\ PDFs=将 XMP 元数据写入到 PDF 中
+Write\ XMP\ metadata\ to\ PDFs=将 XMP 元数据写入到 PDF 中
 
 Override\ default\ font\ settings=跳过默认字体设置
 Clear\ search=清除搜索


### PR DESCRIPTION
Formerly:
![image](https://user-images.githubusercontent.com/2141507/74993803-7bd49b00-544c-11ea-8935-f128511017ad.png)

 - 1st entry: alles klein + ... ("Search for citations in LaTeX files..."). ... because it opens a dialog
 - XMP metadata (spelling)
 - Move "Find and replace" to "Edit" (consistency to other tools)
 - Add divider

Closes https://github.com/koppor/jabref/issues/399