### PR TITLE
Move generate BibTeX keys to Edit menu

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -713,6 +713,7 @@ public class JabRefFrame extends BorderPane {
                 new SeparatorMenuItem(),
 
                 factory.createMenuItem(StandardActions.REPLACE_ALL, new OldDatabaseCommandWrapper(Actions.REPLACE_ALL, this, stateManager)),
+                factory.createMenuItem(StandardActions.GENERATE_CITE_KEYS, new OldDatabaseCommandWrapper(Actions.MAKE_KEY, this, stateManager)),
 
                 new SeparatorMenuItem(),
 
@@ -785,7 +786,6 @@ public class JabRefFrame extends BorderPane {
 
                 new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.GENERATE_CITE_KEYS, new OldDatabaseCommandWrapper(Actions.MAKE_KEY, this, stateManager)),
                 factory.createMenuItem(StandardActions.SEND_AS_EMAIL, new OldDatabaseCommandWrapper(Actions.SEND_AS_EMAIL, this, stateManager)),
                 pushToApplicationMenuItem,
 


### PR DESCRIPTION
Previously:
![image](https://user-images.githubusercontent.com/2141507/75071625-058c7300-54f6-11ea-8e43-bbb75d1c48a6.png)

Now:
![image](https://user-images.githubusercontent.com/2141507/75071733-497f7800-54f6-11ea-9cc3-979b0d53d03b.png)

Assumption: Generate BibTeX keys is a replace action or at least closely related.

Closes https://github.com/koppor/jabref/issues/403