### PR TITLE
New menu "Lookup"

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -653,6 +653,7 @@ public class JabRefFrame extends BorderPane {
         Menu edit = new Menu(Localization.lang("Edit"));
         Menu library = new Menu(Localization.lang("Library"));
         Menu quality = new Menu(Localization.lang("Quality"));
+        Menu lookup = new Menu(Localization.lang("Lookup"));
         Menu view = new Menu(Localization.lang("View"));
         Menu tools = new Menu(Localization.lang("Tools"));
         Menu options = new Menu(Localization.lang("Options"));
@@ -763,6 +764,10 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.SET_FILE_LINKS, new AutoLinkFilesAction(this, prefs, stateManager, undoManager, Globals.TASK_EXECUTOR))
         );
 
+        lookup.getItems().addAll(
+                factory.createMenuItem(StandardActions.FIND_DUPLICATES, new DuplicateSearch(this, dialogService, stateManager))
+        );
+        
         // PushToApplication
         final PushToApplicationAction pushToApplicationAction = pushToApplicationsManager.getPushToApplicationAction();
         final MenuItem pushToApplicationMenuItem = factory.createMenuItem(pushToApplicationAction.getActionInformation(), pushToApplicationAction);

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2115,3 +2115,4 @@ Optional=Optional
 Required=Required
 Entry\ type\ cannot\ be\ empty.\ Please\ enter\ a\ name.=Entry type cannot be empty. Please enter a name.
 Field\ cannot\ be\ empty.\ Please\ enter\ a\ name.=Field cannot be empty. Please enter a name.
+Lookup=Lookup


### PR DESCRIPTION
"Lookup" is a core feature of JabRef and should be made more prominent.
"Tools" is away from library/bibtex context --> external, integration, ...

Content:

Search identifiers online
Search fulltext
unlinked lokal files
Automatically set file links

Previously:
![image](https://user-images.githubusercontent.com/2141507/75073072-02df4d00-54f9-11ea-942c-0f3704fe62d8.png)

Now:
![image](https://user-images.githubusercontent.com/2141507/75073612-19d26f00-54fa-11ea-87ab-dfa1f468e04c.png)


Closes https://github.com/koppor/jabref/issues/404