### PR TITLE
Add initial section on code quality

### DIFF
--- a/docs/code-quality.md
+++ b/docs/code-quality.md
@@ -1,0 +1,12 @@
+# Code Quality
+
+We monitor the general source code quality at three places:
+
+* [Teamscale](https://www.cqse.eu/de/produkte/teamscale/landing/) is a popular German product analyzing code quality. The analysis results are available at <https://demo.teamscale.com/dashboard.html#show//?id=kinnen%2FJabref%20Overview>.
+* [codacy](https://www.codacy.com/) is a hosted service to monitor code quality. The code quality analysis for JabRef is available at <https://www.codacy.com/app/simonharrer/jabref/dashboard>.
+* [codecov](https://codecov.io/) is a solution to check code coverage of test cases. The code coverage metrics for JabRef are available at <https://codecov.io/github/JabRef/jabref>.
+
+We strongly recommend to read following two books on code quality:
+
+* [Java by Comparison](java.by-comparison.com/) is a book by three JabRef developers which focuses on code improvements close to single statements. It is fast to read and one gains much information from each recommendation discussed in the book.
+* [Effective Java](https://www.oreilly.com/library/view/effective-java-3rd/9780134686097/) is the standard book for advanced Java programming. Did you know that `enum` is the [recommended way to enforce a singleton instance of a class](https://learning.oreilly.com/library/view/effective-java-3rd/9780134686097/ch2.xhtml#lev3)? Did you know that one should [refer to objects by their interfaces](https://learning.oreilly.com/library/view/effective-java-3rd/9780134686097/ch9.xhtml#lev64)?


### PR DESCRIPTION
This adds a section on our used code quality tools. Makes it explicit which tools are in place.

(Yes, I asked @cqse to check the job of Teamscale's JabRef analysis)