### PR TITLE
Update citeproc-java to 2.1.0-SNAPSHOT and enable experimental pure-Java mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
 
-    compile 'de.undercouch:citeproc-java:2.0.0'
+    compile 'de.undercouch:citeproc-java:2.1.0-SNAPSHOT'
 
     compile group: 'jakarta.activation', name: 'jakarta.activation-api', version: '1.2.1'
     compile group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.2'

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -14,6 +14,7 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.strings.LatexToUnicodeAdapter;
 
 import de.undercouch.citeproc.CSL;
+import de.undercouch.citeproc.DefaultAbbreviationProvider;
 import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
@@ -66,7 +67,8 @@ public class CSLAdapter {
     private void initialize(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
         if ((cslInstance == null) || !Objects.equals(newStyle, style)) {
             // lang and forceLang are set to the default values of other CSL constructors
-            cslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), newStyle, "en-US", false);
+            cslInstance = new CSL(dataProvider, new JabRefLocaleProvider(),
+                  new DefaultAbbreviationProvider(), null, newStyle, "en-US", false, true);
             style = newStyle;
         }
 


### PR DESCRIPTION
As discussed in #5622, this pull request updates citeproc-java to version 2.1.0-SNAPSHOT and enables the new experimental pure-Java mode. The entry previews are super fast now and seem to work well. 

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
