### PR TITLE
Fixed group drag-n-drop not working after inserting an article into a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the most bottom group in the list got lost, if it was dragged on itself. [#5983](https://github.com/JabRef/jabref/issues/5983)
 - We fixed an issue where changing entry type doesn't always work when biblatex source is shown. [#5905](https://github.com/JabRef/jabref/issues/5905)
 - We fixed an issue where the group and the link column were not updated after changing the entry in the main table. [#5985](https://github.com/JabRef/jabref/issues/5985)
+- We fixed an issue where reordering the groups was not possible after inserting an article. [#6008](https://github.com/JabRef/jabref/issues/6008)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -201,6 +201,10 @@ public class GroupTreeView {
                     }
                 }
 
+                if (groupsToMove.size() > 0) {
+                    localDragboard.clearAll();
+                }
+
                 // Put the group nodes as content
                 Dragboard dragboard = treeTable.startDragAndDrop(TransferMode.MOVE);
                 // Display the group when dragging


### PR DESCRIPTION
fixes #5510 
Credit goes all to @mgroth0, who had Problems with git uploading this fix. Played around a little bit, I don't see any new issue arise from this fix.

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
