### PR TITLE
Raise codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,7 @@ coverage:
   - src/gen/.*
   status:
     patch: false
+  project:
+    default:
+      threshold: 1%
 comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,5 @@ coverage:
     patch: false
   project:
     default:
-      threshold: 0.05
+      threshold: 0.005
 comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,5 @@ coverage:
     patch: false
   project:
     default:
-      threshold: 1%
+      threshold: 0.05
 comment: off


### PR DESCRIPTION
Often PRs are red because of minimal threshold changes below 1 percent

![image](https://user-images.githubusercontent.com/2141507/75387797-26810980-58e4-11ea-91c2-909ad09bab86.png)
