### PR TITLE
Fix dependency updates workflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     testImplementation 'net.bytebuddy:byte-buddy-parent:1.10.8'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '3.0.0-SNAPSHOT'
-    testImplementation 'org.mockito:mockito-core:3.3.0'
+    testImplementation 'org.mockito:mockito-core:3.3.1'
     testImplementation 'org.xmlunit:xmlunit-core:2.6.3'
     testImplementation 'org.xmlunit:xmlunit-matchers:2.6.3'
     testImplementation 'com.tngtech.archunit:archunit-junit5-api:0.13.1'

--- a/build.gradle
+++ b/build.gradle
@@ -243,9 +243,7 @@ dependencyUpdates.resolutionStrategy = {
             }
         }
         rules.withModule("de.jensd:fontawesomefx-materialdesignfont") { ComponentSelection selection ->
-            if (selection.candidate.version ==~ /2.0.26-9.1.2/
-                || selection.candidate.version ==~ /2.0.26-9.1.1/
-                || selection.candidate.version ==~ /2.0.26-9.1.0/) {
+            if (selection.candidate.version ==~ /2.0.26.*/) {
                 selection.reject('1.7.22-11 is actually newer (strange version system)')
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ dependencyUpdates.resolutionStrategy = {
             }
         }
         rules.withModule("org.python:jython-standalone") { ComponentSelection selection ->
-            if (selection.candidate.version ==~ /2.7.2b2/) {
+            if (selection.candidate.version ==~ /2.7.2b\d/) {
                 selection.reject('Release candidate')
             }
         }


### PR DESCRIPTION
As discussed in the devcall, the automatic checker for outdated dependencies needs to be maintained as well.
Now the workflow runs through, but of course, if it fails again, we need to look at it again. 