### PR TITLE
Icons from Material design icons not recognized

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -39,6 +39,7 @@ import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.strings.StringUtil;
 
 import com.google.common.base.Enums;
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 import org.fxmisc.easybind.EasyBind;
 
 public class GroupNodeViewModel {
@@ -204,7 +205,7 @@ public class GroupNodeViewModel {
     }
 
     private Optional<JabRefIcon> parseIcon(String iconCode) {
-        return Enums.getIfPresent(IconTheme.JabRefIcons.class, iconCode.toUpperCase(Locale.ENGLISH))
+        return Enums.getIfPresent(MaterialDesignIcon.class, iconCode.toUpperCase(Locale.ENGLISH))
                     .toJavaUtil()
                     .map(icon -> new InternalMaterialDesignIcon(getColor(), icon));
     }


### PR DESCRIPTION
Fixes #6078
Related #5245

@JabRef/developers  2b760cddf53cceae54fd149774226461f5290daa caused this issue.
https://github.com/JabRef/jabref/issues/5245
Obviously only icons contained inside JabRefIcons are available now.

The question is - do we really want this feature? Not sure if changing the line back to 
```
        return Enums.getIfPresent(MaterialDesignIcon.class, iconCode.toUpperCase(Locale.ENGLISH))
                    .toJavaUtil()
                    .map(icon -> new InternalMaterialDesignIcon(getColor(), icon));
```
 will reintroduce the referenced issue (https://github.com/JabRef/jabref/issues/5245).
This feature also only makes sense, if we have a dropdown with all available icons inside the new/edit group dialog IMHO.

![image](https://user-images.githubusercontent.com/2141507/76682572-845c6380-65fd-11ea-9384-8b105d66bd76.png)