### PR TITLE
Small improvements in preferences dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - We fixed an issue where opening a library from the recent libraries menu was not possible. [#5939](https://github.com/JabRef/jabref/issues/5939)
 - We fixed an issue with inconsistent capitalization of file extensions when downloading files [#6115](https://github.com/JabRef/jabref/issues/6115)
-- We fixed the display of language, encoding and bibliography mode in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
+- We fixed the display of language and encoding in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 
 ### Removed
 
-- We removed the obsolete `External programs -> Open PDF` section in the preferences, as the default application to open PDFs is now set in the `Manage external file types` dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
+- We removed the obsolete `External programs / Open PDF` section in the preferences, as the default application to open PDFs is now set in the `Manage external file types` dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 
 ## [5.0] – 2020-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,17 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - We improved the arXiv fetcher. Now it should find entries even more reliably and does no longer include the version (e.g `v1`) in the `eprint` field. [forum#1941](https://discourse.jabref.org/t/remove-version-in-arxiv-import/1941)
 - We moved the group search bar and the button "New group" from bottom to top position to make it more prominent. [#6112](https://github.com/JabRef/jabref/pull/6112)
-
+- We changed the buttons for import/export/show all/reset of preferences to smaller icon buttons in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 
 ### Fixed
 
 - We fixed an issue where opening a library from the recent libraries menu was not possible. [#5939](https://github.com/JabRef/jabref/issues/5939)
 - We fixed an issue with inconsistent capitalization of file extensions when downloading files [#6115](https://github.com/JabRef/jabref/issues/6115)
+- We fixed the display of language, encoding and bibliography mode in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 
 ### Removed
+
+- We removed the obsolete `External programs -> Open PDF` section in the preferences, as the default application to open PDFs is now set in the `Manage external file types` dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 
 ## [5.0] – 2020-03-06
 

--- a/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
@@ -4,7 +4,6 @@ import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,11 +30,6 @@ public class DefaultDesktop implements NativeDesktop {
     @Override
     public void openConsole(String absolutePath) throws IOException {
         LOGGER.error("This feature is not supported by your Operating System.");
-    }
-
-    @Override
-    public void openPdfWithParameters(String filePath, List<String> parameters) throws IOException {
-        //TODO imlement default
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -6,22 +6,16 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.StringJoiner;
 
 import org.jabref.JabRefExecutorService;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.StreamGobbler;
-import org.jabref.preferences.JabRefPreferences;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.jabref.preferences.JabRefPreferences.ADOBE_ACROBAT_COMMAND;
-import static org.jabref.preferences.JabRefPreferences.USE_PDF_READER;
 
 public class Linux implements NativeDesktop {
 
@@ -105,23 +99,6 @@ public class Linux implements NativeDesktop {
             } else {
                 runtime.exec(emulatorName, null, new File(absolutePath));
             }
-        }
-    }
-
-    @Override
-    public void openPdfWithParameters(String filePath, List<String> parameters) throws IOException {
-
-        String application;
-        if (JabRefPreferences.getInstance().get(USE_PDF_READER).equals(JabRefPreferences.getInstance().get(ADOBE_ACROBAT_COMMAND))) {
-            application = "acroread";
-
-            StringJoiner sj = new StringJoiner(" ");
-            sj.add(application);
-            parameters.forEach((param) -> sj.add(param));
-
-            openFileWithApplication(filePath, sj.toString());
-        } else {
-            openFile(filePath, "PDF");
         }
     }
 

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -3,7 +3,6 @@ package org.jabref.gui.desktop.os;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 public interface NativeDesktop {
     void openFile(String filePath, String fileType) throws IOException;
@@ -20,14 +19,6 @@ public interface NativeDesktop {
     void openFolderAndSelectFile(Path file) throws IOException;
 
     void openConsole(String absolutePath) throws IOException;
-
-    /**
-     * This method opens a pdf using the giving the parameters to the executing pdf reader
-     * @param filePath absolute path to the pdf file to be opened
-     * @param parameters console parameters depending on the pdf reader
-     * @throws IOException
-     */
-    void openPdfWithParameters(String filePath, List<String> parameters) throws  IOException;
 
     String detectProgramPath(String programName, String directoryName);
 

--- a/src/main/java/org/jabref/gui/desktop/os/OSX.java
+++ b/src/main/java/org/jabref/gui/desktop/os/OSX.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Optional;
 
 import org.jabref.gui.externalfiletype.ExternalFileType;
@@ -40,11 +39,6 @@ public class OSX implements NativeDesktop {
     @Override
     public void openConsole(String absolutePath) throws IOException {
         Runtime.getRuntime().exec("open -a Terminal " + absolutePath, null, new File(absolutePath));
-    }
-
-    @Override
-    public void openPdfWithParameters(String filePath, List<String> parameters) throws IOException {
-        //TODO implement
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Windows.java
@@ -4,16 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Optional;
 
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
-import org.jabref.preferences.JabRefPreferences;
-
-import static org.jabref.preferences.JabRefPreferences.ADOBE_ACROBAT_COMMAND;
-import static org.jabref.preferences.JabRefPreferences.SUMATRA_PDF_COMMAND;
-import static org.jabref.preferences.JabRefPreferences.USE_PDF_READER;
 
 public class Windows implements NativeDesktop {
     private static String DEFAULT_EXECUTABLE_EXTENSION = ".exe";
@@ -68,21 +62,5 @@ public class Windows implements NativeDesktop {
         ProcessBuilder process = new ProcessBuilder("cmd.exe", "/c", "start");
         process.directory(new File(absolutePath));
         process.start();
-    }
-
-    @Override
-    public void openPdfWithParameters(String filePath, List<String> parameters) throws IOException {
-        String pdfReaderPath = JabRefPreferences.getInstance().get(USE_PDF_READER);
-        if (pdfReaderPath.equals(SUMATRA_PDF_COMMAND) || pdfReaderPath.equals(ADOBE_ACROBAT_COMMAND)) {
-            String[] command = new String[parameters.size() + 2];
-            command[0] = "\"" + Paths.get(pdfReaderPath).toString() + "\"";
-            for (int i = 1; i < command.length - 1; i++) {
-                command[i] = "\"" + parameters.get(i - 1) + "\"";
-            }
-            command[command.length - 1] = "\"" + filePath + "\"";
-            new ProcessBuilder(command).start();
-        } else {
-            openFile(filePath, "PDF");
-        }
     }
 }

--- a/src/main/java/org/jabref/gui/exporter/SaveAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveAction.java
@@ -11,7 +11,7 @@ import org.jabref.gui.actions.SimpleCommand;
  */
 public class SaveAction extends SimpleCommand {
 
-    public enum SaveMethod {SAVE, SAVE_AS, SAVE_SELECTED}
+    public enum SaveMethod { SAVE, SAVE_AS, SAVE_SELECTED }
 
     private final SaveMethod saveMethod;
     private final JabRefFrame frame;

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -228,6 +228,7 @@ public class IconTheme {
         GITHUB(MaterialDesignIcon.GITHUB_CIRCLE), /*css: github-circle*/
         TOGGLE_ENTRY_PREVIEW(MaterialDesignIcon.LIBRARY_BOOKS), /*css: library-books */
         TOGGLE_GROUPS(MaterialDesignIcon.VIEW_LIST), /*css: view-list */
+        SHOW_PREFERENCES_LIST(MaterialDesignIcon.VIEW_LIST), /*css: view-list */
         WRITE_XMP(MaterialDesignIcon.IMPORT), /* css: import */
         FILE_WORD(MaterialDesignIcon.FILE_WORD), /*css: file-word */
         FILE_EXCEL(MaterialDesignIcon.FILE_EXCEL), /*css: file-excel */

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
@@ -7,8 +7,8 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Spinner?>
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/11.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.AppearanceTabView">
     <fx:define>
@@ -18,9 +18,9 @@
 
     <Label styleClass="sectionHeader" text="%Font"/>
     <CheckBox fx:id="fontOverride" text="%Override default font settings"/>
-    <HBox spacing="4.0" alignment="CENTER_LEFT">
-        <Label text="%Size:" disable="${!fontOverride.selected}"/>
-        <TextField fx:id="fontSize" prefWidth="40" alignment="CENTER_RIGHT" disable="${!fontOverride.selected}"/>
+    <HBox alignment="CENTER_LEFT" spacing="4.0">
+        <Label text="%Size" disable="${!fontOverride.selected}"/>
+        <Spinner fx:id="fontSize" prefWidth="60.0" editable="true"/>
         <padding>
             <Insets left="20.0"/>
         </padding>

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTabView.java
@@ -2,11 +2,11 @@ package org.jabref.gui.preferences;
 
 import javafx.application.Platform;
 import javafx.fxml.FXML;
+import javafx.geometry.Pos;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.RadioButton;
-import javafx.scene.control.TextField;
+import javafx.scene.control.Spinner;
 
-import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
@@ -17,7 +17,7 @@ import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 public class AppearanceTabView extends AbstractPreferenceTabView<AppearanceTabViewModel> implements PreferencesTab {
 
     @FXML public CheckBox fontOverride;
-    @FXML public TextField fontSize;
+    @FXML public Spinner<Integer> fontSize;
     @FXML public RadioButton themeLight;
     @FXML public RadioButton themeDark;
 
@@ -38,8 +38,12 @@ public class AppearanceTabView extends AbstractPreferenceTabView<AppearanceTabVi
         this.viewModel = new AppearanceTabViewModel(dialogService, preferences);
 
         fontOverride.selectedProperty().bindBidirectional(viewModel.fontOverrideProperty());
-        fontSize.setTextFormatter(ControlHelper.getIntegerTextFormatter());
-        fontSize.textProperty().bindBidirectional(viewModel.fontSizeProperty());
+
+        // Spinner does neither support alignment nor disableProperty in FXML
+        fontSize.disableProperty().bind(fontOverride.selectedProperty().not());
+        fontSize.getEditor().setAlignment(Pos.CENTER_RIGHT);
+        fontSize.setValueFactory(AppearanceTabViewModel.fontSizeValueFactory);
+        fontSize.getEditor().textProperty().bindBidirectional(viewModel.fontSizeProperty());
 
         themeLight.selectedProperty().bindBidirectional(viewModel.themeLightProperty());
         themeDark.selectedProperty().bindBidirectional(viewModel.themeDarkProperty());

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTabViewModel.java
@@ -7,6 +7,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.scene.control.SpinnerValueFactory;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.ThemeLoader;
@@ -19,6 +20,9 @@ import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 import de.saxsys.mvvmfx.utils.validation.Validator;
 
 public class AppearanceTabViewModel implements PreferenceTabViewModel {
+
+    public static SpinnerValueFactory<Integer> fontSizeValueFactory =
+            new SpinnerValueFactory.IntegerSpinnerValueFactory(9, Integer.MAX_VALUE);
 
     private final BooleanProperty fontOverrideProperty = new SimpleBooleanProperty();
     private final StringProperty fontSizeProperty = new SimpleStringProperty();

--- a/src/main/java/org/jabref/gui/preferences/ExternalTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTab.fxml
@@ -79,27 +79,6 @@
                 GridPane.columnIndex="2" GridPane.rowIndex="1"/>
     </GridPane>
 
-    <Label styleClass="sectionHeader" text="%Open PDF"/>
-    <GridPane alignment="CENTER_LEFT" hgap="10.0" vgap="4.0">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="200.0"/>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="350.0"/>
-            <ColumnConstraints hgrow="SOMETIMES"/>
-        </columnConstraints>
-        <rowConstraints>
-            <RowConstraints minHeight="30.0" vgrow="SOMETIMES"/>
-            <RowConstraints minHeight="30.0" vgrow="SOMETIMES"/>
-        </rowConstraints>
-        <RadioButton fx:id="usePDFAcrobat" text="%Adobe Acrobat Reader" toggleGroup="$openPDF"/>
-        <TextField fx:id="usePDFAcrobatCommand" prefWidth="350.0" GridPane.columnIndex="1"/>
-        <Button fx:id="usePDFAcrobatBrowse" onAction="#usePDFAcrobatCommandBrowse" text="%Browse"
-                GridPane.columnIndex="2"/>
-        <RadioButton fx:id="usePDFSumatra" text="%Sumatra Reader" toggleGroup="$openPDF" GridPane.rowIndex="1"/>
-        <TextField fx:id="usePDFSumatraCommand" prefWidth="350.0" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
-        <Button fx:id="usePDFSumatraBrowse" onAction="#usePDFSumatraCommandBrowse" text="%Browse"
-                GridPane.columnIndex="2" GridPane.rowIndex="1"/>
-    </GridPane>
-
     <Label styleClass="sectionHeader" text="%Open File Browser"/>
     <GridPane alignment="CENTER_LEFT" hgap="10.0" vgap="4.0">
         <columnConstraints>

--- a/src/main/java/org/jabref/gui/preferences/ExternalTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTabView.java
@@ -28,13 +28,6 @@ public class ExternalTabView extends AbstractPreferenceTabView<ExternalTabViewMo
     @FXML private TextField useTerminalCommand;
     @FXML private Button useTerminalBrowse;
 
-    @FXML private RadioButton usePDFAcrobat;
-    @FXML private TextField usePDFAcrobatCommand;
-    @FXML private Button usePDFAcrobatBrowse;
-    @FXML private RadioButton usePDFSumatra;
-    @FXML private TextField usePDFSumatraCommand;
-    @FXML private Button usePDFSumatraBrowse;
-
     @FXML private RadioButton useFileBrowserDefault;
     @FXML private RadioButton useFileBrowserSpecial;
     @FXML private TextField useFileBrowserSpecialCommand;
@@ -74,16 +67,6 @@ public class ExternalTabView extends AbstractPreferenceTabView<ExternalTabViewMo
         useTerminalCommand.textProperty().bindBidirectional(viewModel.useTerminalCommandProperty());
         useTerminalCommand.disableProperty().bind(useTerminalSpecial.selectedProperty().not());
         useTerminalBrowse.disableProperty().bind(useTerminalSpecial.selectedProperty().not());
-
-        usePDFAcrobat.selectedProperty().bindBidirectional(viewModel.usePDFAcrobatProperty());
-        usePDFAcrobatCommand.textProperty().bindBidirectional(viewModel.usePDFAcrobatCommandProperty());
-        usePDFAcrobatCommand.disableProperty().bind(usePDFAcrobat.selectedProperty().not());
-        usePDFAcrobatBrowse.disableProperty().bind(usePDFAcrobat.selectedProperty().not());
-
-        usePDFSumatra.selectedProperty().bindBidirectional(viewModel.usePDFSumatraProperty());
-        usePDFSumatraCommand.textProperty().bindBidirectional(viewModel.usePDFSumatraCommandProperty());
-        usePDFSumatraCommand.disableProperty().bind(usePDFSumatra.selectedProperty().not());
-        usePDFSumatraBrowse.disableProperty().bind(usePDFSumatra.selectedProperty().not());
 
         useFileBrowserDefault.selectedProperty().bindBidirectional(viewModel.useFileBrowserDefaultProperty());
         useFileBrowserSpecial.selectedProperty().bindBidirectional(viewModel.useFileBrowserSpecialProperty());

--- a/src/main/java/org/jabref/gui/preferences/ExternalTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTabViewModel.java
@@ -23,7 +23,6 @@ import org.jabref.gui.push.PushToApplicationSettings;
 import org.jabref.gui.push.PushToApplicationsManager;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.util.OS;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.preferences.JabRefPreferences;
 
@@ -74,17 +73,6 @@ public class ExternalTabViewModel implements PreferenceTabViewModel {
         useTerminalCommandProperty.setValue(preferences.get(JabRefPreferences.CONSOLE_COMMAND));
         useTerminalSpecialProperty.setValue(!preferences.getBoolean(JabRefPreferences.USE_DEFAULT_CONSOLE_APPLICATION));
 
-        usePDFAcrobatCommandProperty.setValue(preferences.get(JabRefPreferences.ADOBE_ACROBAT_COMMAND));
-        if (OS.WINDOWS) {
-            usePDFSumatraCommandProperty.setValue(preferences.get(JabRefPreferences.SUMATRA_PDF_COMMAND));
-
-            if (preferences.get(JabRefPreferences.USE_PDF_READER).equals(usePDFAcrobatCommandProperty.getValue())) {
-                usePDFAcrobatProperty.setValue(true);
-            } else if (preferences.get(JabRefPreferences.USE_PDF_READER).equals(usePDFSumatraCommandProperty.getValue())) {
-                usePDFSumatraProperty.setValue(true);
-            }
-        }
-
         useFileBrowserDefaultProperty.setValue(preferences.getBoolean(JabRefPreferences.USE_DEFAULT_FILE_BROWSER_APPLICATION));
         useFileBrowserSpecialProperty.setValue(!preferences.getBoolean(JabRefPreferences.USE_DEFAULT_FILE_BROWSER_APPLICATION));
         useFileBrowserSpecialCommandProperty.setValue(preferences.get(JabRefPreferences.FILE_BROWSER_COMMAND));
@@ -99,16 +87,6 @@ public class ExternalTabViewModel implements PreferenceTabViewModel {
 
         preferences.putBoolean(JabRefPreferences.USE_DEFAULT_CONSOLE_APPLICATION, useTerminalDefaultProperty.getValue());
         preferences.put(JabRefPreferences.CONSOLE_COMMAND, useTerminalCommandProperty.getValue());
-
-        preferences.put(JabRefPreferences.ADOBE_ACROBAT_COMMAND, usePDFAcrobatCommandProperty.getValue());
-        if (OS.WINDOWS) {
-            preferences.put(JabRefPreferences.SUMATRA_PDF_COMMAND, usePDFSumatraCommandProperty.getValue());
-        }
-        if (usePDFAcrobatProperty.getValue()) {
-            preferences.put(JabRefPreferences.USE_PDF_READER, usePDFAcrobatCommandProperty.getValue());
-        } else if (usePDFSumatraProperty.getValue()) {
-            preferences.put(JabRefPreferences.USE_PDF_READER, usePDFSumatraCommandProperty.getValue());
-        }
 
         preferences.putBoolean(JabRefPreferences.USE_DEFAULT_FILE_BROWSER_APPLICATION, useFileBrowserDefaultProperty.getValue());
         if (StringUtil.isNotBlank(useFileBrowserSpecialCommandProperty.getValue())) {

--- a/src/main/java/org/jabref/gui/preferences/FileTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/FileTabView.java
@@ -13,6 +13,7 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.util.IconValidationDecorator;
+import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
@@ -68,6 +69,9 @@ public class FileTabView extends AbstractPreferenceTabView<FileTabViewModel> imp
         resolveStringsAll.selectedProperty().bindBidirectional(viewModel.resolveStringsAllProperty());
         resolveStringsExcept.textProperty().bindBidirectional(viewModel.resolvStringsExceptProperty());
         resolveStringsExcept.disableProperty().bind(resolveStringsAll.selectedProperty().not());
+        new ViewModelListCellFactory<NewLineSeparator>()
+                .withText(NewLineSeparator::getDisplayName)
+                .install(newLineSeparator);
         newLineSeparator.itemsProperty().bind(viewModel.newLineSeparatorListProperty());
         newLineSeparator.valueProperty().bindBidirectional(viewModel.selectedNewLineSeparatorProperty());
         alwaysReformatBib.selectedProperty().bindBidirectional(viewModel.alwaysReformatBibProperty());

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
@@ -39,7 +39,7 @@
     <CheckBox fx:id="allowIntegerEdition" text="%Allow integers in 'edition' field in BibTeX mode"/>
     <CheckBox fx:id="memoryStickMode"
               text="%Load and Save preferences from/to jabref.xml on start-up (memory stick mode)"/>
-    <CheckBox fx:id="collectTelemetry" text="%Collect and share telemetry data to help improve JabRef."/>
+    <CheckBox fx:id="collectTelemetry" text="%Collect and share telemetry data to help improve JabRef"/>
     <CheckBox fx:id="showAdvancedHints"
               text="%Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"/>
 

--- a/src/main/java/org/jabref/gui/preferences/GeneralTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTabView.java
@@ -15,6 +15,7 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.util.IconValidationDecorator;
+import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.l10n.Localization;
@@ -65,12 +66,21 @@ public class GeneralTabView extends AbstractPreferenceTabView<GeneralTabViewMode
     public void initialize() {
         this.viewModel = new GeneralTabViewModel(dialogService, preferences);
 
+        new ViewModelListCellFactory<Language>()
+                .withText(Language::getDisplayName)
+                .install(language);
         language.itemsProperty().bind(viewModel.languagesListProperty());
         language.valueProperty().bindBidirectional(viewModel.selectedLanguageProperty());
 
+        new ViewModelListCellFactory<Charset>()
+                .withText(Charset::displayName)
+                .install(defaultEncoding);
         defaultEncoding.itemsProperty().bind(viewModel.encodingsListProperty());
         defaultEncoding.valueProperty().bindBidirectional(viewModel.selectedEncodingProperty());
 
+        new ViewModelListCellFactory<BibDatabaseMode>()
+                .withText(BibDatabaseMode::getFormattedName)
+                .install(biblatexMode);
         biblatexMode.itemsProperty().bind(viewModel.biblatexModeListProperty());
         biblatexMode.valueProperty().bindBidirectional(viewModel.selectedBiblatexModeProperty());
 

--- a/src/main/java/org/jabref/gui/preferences/NameFormatterTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/NameFormatterTab.fxml
@@ -23,7 +23,7 @@
                     <TableColumn fx:id="formatterStringColumn"
                                  minWidth="50.0" prefWidth="368" sortable="false" text="%Format string"/>
                     <TableColumn fx:id="actionsColumn" maxWidth="30.0" minWidth="30.0" prefWidth="30.0"
-                                 editable="false" resizable="false"/>
+                                 editable="false" resizable="false" reorderable="false"/>
                 </columns>
                 <columnResizePolicy>
                     <TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/>
@@ -36,7 +36,7 @@
         </VBox>
         <VBox>
             <Button fx:id="formatterHelp" prefHeight="25.0" prefWidth="25.0"/>
-            <VBox VBox.vgrow="ALWAYS"/>
+            <VBox VBox.vgrow="ALWAYS" />
             <Button styleClass="icon-button,narrow" onAction="#addFormatter"
                     prefHeight="25.0" prefWidth="25.0">
                 <graphic>

--- a/src/main/java/org/jabref/gui/preferences/NameFormatterTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/NameFormatterTabView.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextField;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import org.jabref.Globals;
 import org.jabref.gui.actions.ActionFactory;
@@ -44,8 +45,6 @@ public class NameFormatterTabView extends AbstractPreferenceTabView<NameFormatte
     public void initialize () {
         this.viewModel = new NameFormatterTabViewModel(dialogService, preferences);
 
-        formatterList.setEditable(true);
-
         formatterNameColumn.setSortable(true);
         formatterNameColumn.setReorderable(false);
         formatterNameColumn.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
@@ -69,21 +68,38 @@ public class NameFormatterTabView extends AbstractPreferenceTabView<NameFormatte
         actionsColumn.setCellValueFactory(cellData -> cellData.getValue().nameProperty());
         new ValueTableCellFactory<NameFormatterItemModel, String>()
                 .withGraphic(name -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
-                .withTooltip(name -> Localization.lang("Remove") + " " + name)
+                .withTooltip(name -> Localization.lang("Remove formatter %0", name))
                 .withOnMouseClickedEvent(item -> evt ->
                         viewModel.removeFormatter(formatterList.getFocusModel().getFocusedItem()))
                 .install(actionsColumn);
 
-        formatterList.setOnKeyPressed(event -> {
+        formatterList.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.DELETE) {
                 viewModel.removeFormatter(formatterList.getSelectionModel().getSelectedItem());
+                event.consume();
             }
         });
 
+        formatterList.setEditable(true);
         formatterList.itemsProperty().bindBidirectional(viewModel.formatterListProperty());
 
         addFormatterName.textProperty().bindBidirectional(viewModel.addFormatterNameProperty());
+        addFormatterName.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                addFormatterString.requestFocus();
+                addFormatterString.selectAll();
+                event.consume();
+            }
+        });
+
         addFormatterString.textProperty().bindBidirectional(viewModel.addFormatterStringProperty());
+        addFormatterString.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                viewModel.addFormatter();
+                addFormatterName.requestFocus();
+                event.consume();
+            }
+        });
 
         ActionFactory actionFactory = new ActionFactory(Globals.getKeyPrefs());
         actionFactory.configureIconButton(StandardActions.HELP_NAME_FORMATTER, new HelpAction(HelpFile.CUSTOM_EXPORTS_NAME_FORMATTER), formatterHelp);

--- a/src/main/java/org/jabref/gui/preferences/NameFormatterTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/NameFormatterTabViewModel.java
@@ -61,12 +61,11 @@ public class NameFormatterTabViewModel implements PreferenceTabViewModel {
         if (!StringUtil.isNullOrEmpty(addFormatterNameProperty.getValue()) &&
                 !StringUtil.isNullOrEmpty(addFormatterStringProperty.getValue())) {
 
-            NameFormatterItemModel newFormatter = new NameFormatterItemModel(
-                    addFormatterNameProperty.getValue(), addFormatterStringProperty.getValue());
+            formatterListProperty.add(new NameFormatterItemModel(
+                    addFormatterNameProperty.getValue(), addFormatterStringProperty.getValue()));
 
             addFormatterNameProperty.setValue("");
             addFormatterStringProperty.setValue("");
-            formatterListProperty.add(newFormatter);
         }
     }
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
@@ -10,6 +10,8 @@
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.VBox?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
+<?import org.jabref.gui.icon.JabRefIconView?>
+<?import javafx.scene.layout.HBox?>
 <DialogPane prefHeight="700.0" prefWidth="1100.0" minHeight="400" minWidth="600"
             xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.jabref.gui.preferences.PreferencesDialogView">
@@ -23,23 +25,43 @@
                 </CustomTextField>
                 <ListView fx:id="preferenceTabList" VBox.vgrow="ALWAYS"/>
                 <VBox prefHeight="10.0" VBox.vgrow="SOMETIMES"/>
-                <VBox alignment="BOTTOM_LEFT" spacing="3.0">
+                <HBox alignment="BOTTOM_LEFT" spacing="3.0">
                     <padding>
                         <Insets bottom="3.0" left="3.0" right="3.0" top="3.0"/>
                     </padding>
-                    <Button maxWidth="Infinity" onAction="#importPreferences" text="%Import preferences">
+                    <Button styleClass="icon-button,narrow" maxWidth="Infinity" onAction="#importPreferences" HBox.hgrow="ALWAYS">
+                        <graphic>
+                            <JabRefIconView glyph="IMPORT"/>
+                        </graphic>
                         <tooltip>
                             <Tooltip text="%Import preferences from file"/>
                         </tooltip>
                     </Button>
-                    <Button maxWidth="Infinity" onAction="#exportPreferences" text="%Export preferences">
+                    <Button styleClass="icon-button,narrow" maxWidth="Infinity" onAction="#exportPreferences" HBox.hgrow="ALWAYS">
+                        <graphic>
+                            <JabRefIconView glyph="EXPORT"/>
+                        </graphic>
                         <tooltip>
                             <Tooltip text="%Export preferences to file"/>
                         </tooltip>
                     </Button>
-                    <Button maxWidth="Infinity" onAction="#showAllPreferences" text="%Show preferences"/>
-                    <Button maxWidth="Infinity" onAction="#resetPreferences" text="%Reset preferences"/>
-                </VBox>
+                    <Button styleClass="icon-button,narrow" maxWidth="Infinity" onAction="#showAllPreferences" HBox.hgrow="ALWAYS">
+                        <graphic>
+                            <JabRefIconView glyph="SHOW_PREFERENCES_LIST"/>
+                        </graphic>
+                        <tooltip>
+                            <Tooltip text="%Show preferences"/>
+                        </tooltip>
+                    </Button>
+                    <Button styleClass="icon-button,narrow" maxWidth="Infinity" onAction="#resetPreferences" HBox.hgrow="ALWAYS">
+                        <graphic>
+                            <JabRefIconView glyph="REFRESH"/>
+                        </graphic>
+                        <tooltip>
+                            <Tooltip text="%Reset preferences"/>
+                        </tooltip>
+                    </Button>
+                </HBox>
             </VBox>
             <ScrollPane fx:id="preferencesContainer" maxHeight="Infinity" maxWidth="Infinity"/>
         </SplitPane>

--- a/src/main/java/org/jabref/gui/preferences/TableColumnsTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/TableColumnsTabView.java
@@ -9,6 +9,7 @@ import javafx.scene.control.RadioButton;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
@@ -83,9 +84,10 @@ public class TableColumnsTabView extends AbstractPreferenceTabView<TableColumnsT
                 .install(actionsColumn);
 
         viewModel.selectedColumnModelProperty().setValue(columnsList.getSelectionModel());
-        columnsList.setOnKeyPressed(event -> {
+        columnsList.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.DELETE) {
                 viewModel.removeColumn(columnsList.getSelectionModel().getSelectedItem());
+                event.consume();
             }
         });
 
@@ -97,7 +99,7 @@ public class TableColumnsTabView extends AbstractPreferenceTabView<TableColumnsT
         addColumnName.itemsProperty().bind(viewModel.availableColumnsProperty());
         addColumnName.valueProperty().bindBidirectional(viewModel.addColumnProperty());
         addColumnName.setConverter(TableColumnsTabViewModel.columnNameStringConverter);
-        addColumnName.setOnKeyPressed(event -> {
+        addColumnName.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.ENTER) {
                 viewModel.insertColumnInList();
                 event.consume();

--- a/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/XmpPrivacyTabView.java
@@ -8,6 +8,7 @@ import javafx.scene.control.ComboBox;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.BindingsHelper;
@@ -69,9 +70,10 @@ public class XmpPrivacyTabView extends AbstractPreferenceTabView<XmpPrivacyTabVi
                         item -> evt -> viewModel.removeFilter(filterList.getFocusModel().getFocusedItem()))
                 .install(actionsColumn);
 
-        filterList.setOnKeyPressed(event -> {
+        filterList.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.DELETE) {
                 viewModel.removeFilter(filterList.getSelectionModel().getSelectedItem());
+                event.consume();
             }
         });
 
@@ -84,6 +86,12 @@ public class XmpPrivacyTabView extends AbstractPreferenceTabView<XmpPrivacyTabVi
         addFieldName.itemsProperty().bind(viewModel.availableFieldsProperty());
         addFieldName.valueProperty().bindBidirectional(viewModel.addFieldNameProperty());
         addFieldName.setConverter(FieldsUtil.fieldStringConverter);
+        addFieldName.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                viewModel.addField();
+                event.consume();
+            }
+        });
 
         validationVisualizer.setDecoration(new IconValidationDecorator());
         Platform.runLater(() -> validationVisualizer.initVisualization(viewModel.xmpFilterListValidationStatus(), filterList));

--- a/src/main/java/org/jabref/model/database/BibDatabaseMode.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseMode.java
@@ -17,7 +17,7 @@ public enum BibDatabaseMode {
         if (this == BIBTEX) {
             return "BibTeX";
         } else {
-            return "biblatex";
+            return "BibLaTeX";
         }
     }
 

--- a/src/main/java/org/jabref/model/database/BibDatabaseMode.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseMode.java
@@ -17,7 +17,7 @@ public enum BibDatabaseMode {
         if (this == BIBTEX) {
             return "BibTeX";
         } else {
-            return "BibLaTeX";
+            return "biblatex";
         }
     }
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1997,7 +1997,7 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     public void setActivePushToApplication(PushToApplication application, PushToApplicationsManager manager) {
-        if (application.getApplicationName() != get(PUSH_TO_APPLICATION)) {
+        if (!application.getApplicationName().equals(get(PUSH_TO_APPLICATION))) {
             put(PUSH_TO_APPLICATION, application.getApplicationName());
             manager.updateApplicationAction();
         }
@@ -2008,7 +2008,7 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     public void setNewLineSeparator(NewLineSeparator newLineSeparator) {
-        String escapeChars = newLineSeparator.getEscapeChars();
+        String escapeChars = newLineSeparator.toString();
         put(JabRefPreferences.NEWLINE, escapeChars);
 
         // we also have to change Globals variable as globals is not a getter, but a constant

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -205,9 +205,6 @@ public class JabRefPreferences implements PreferencesService {
     public static final String KEY_PATTERN_REPLACEMENT = "KeyPatternReplacement";
     public static final String CONSOLE_COMMAND = "consoleCommand";
     public static final String USE_DEFAULT_CONSOLE_APPLICATION = "useDefaultConsoleApplication";
-    public static final String ADOBE_ACROBAT_COMMAND = "adobeAcrobatCommand";
-    public static final String SUMATRA_PDF_COMMAND = "sumatraCommand";
-    public static final String USE_PDF_READER = "usePDFReader";
     public static final String USE_DEFAULT_FILE_BROWSER_APPLICATION = "userDefaultFileBrowserApplication";
     public static final String FILE_BROWSER_COMMAND = "fileBrowserCommand";
 
@@ -644,15 +641,9 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(USE_DEFAULT_FILE_BROWSER_APPLICATION, Boolean.TRUE);
         if (OS.WINDOWS) {
             defaults.put(CONSOLE_COMMAND, "C:\\Program Files\\ConEmu\\ConEmu64.exe /single /dir \"%DIR\"");
-            defaults.put(ADOBE_ACROBAT_COMMAND, "C:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader");
-            defaults.put(SUMATRA_PDF_COMMAND, "C:\\Program Files\\SumatraPDF");
-            defaults.put(USE_PDF_READER, ADOBE_ACROBAT_COMMAND);
             defaults.put(FILE_BROWSER_COMMAND, "explorer.exe /select, \"%DIR\"");
         } else {
             defaults.put(CONSOLE_COMMAND, "");
-            defaults.put(ADOBE_ACROBAT_COMMAND, "");
-            defaults.put(SUMATRA_PDF_COMMAND, "");
-            defaults.put(USE_PDF_READER, "");
             defaults.put(FILE_BROWSER_COMMAND, "");
         }
 

--- a/src/main/java/org/jabref/preferences/NewLineSeparator.java
+++ b/src/main/java/org/jabref/preferences/NewLineSeparator.java
@@ -1,16 +1,15 @@
 package org.jabref.preferences;
 
+/**
+ * An enum which contains the possible NewLineSeperators
+ * Possible are CR ("\n"), LF ("\r") and the windows standard CR/LF.
+ */
 public enum NewLineSeparator {
     CR,
     LF,
     CRLF;
 
-    /**
-     * An enum which contains the possible NewLineSeperators
-     * Possible are CR ("\n"), LF ("\r") and the windows standard CR/LF.
-     */
-
-    public String toString() {
+    public String getDisplayName() {
         switch (this) {
             case CR:
                 return "CR (\"\\r\")";
@@ -24,7 +23,7 @@ public enum NewLineSeparator {
     /**
      * @return the name of the current mode as String
      */
-    public String getEscapeChars() {
+    public String toString() {
         switch (this) {
             case CR:
                 return "\r";

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -561,8 +561,6 @@ No\ journal\ names\ could\ be\ abbreviated.=No journal names could be abbreviate
 
 No\ journal\ names\ could\ be\ unabbreviated.=No journal names could be unabbreviated.
 
-Open\ PDF=Open PDF
-
 not=not
 
 not\ found=not found
@@ -1698,8 +1696,6 @@ Author=Author
 Date=Date
 File\ annotations=File annotations
 Show\ file\ annotations=Show file annotations
-Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
-Sumatra\ Reader=Sumatra Reader
 shared=shared
 should\ contain\ an\ integer\ or\ a\ literal=should contain an integer or a literal
 should\ have\ the\ first\ letter\ capitalized=should have the first letter capitalized

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1777,7 +1777,7 @@ Show\ this\ document\ until\ unlocked.=Show this document until unlocked.
 Set\ current\ user\ name\ as\ owner.=Set current user name as owner.
 
 Sort\ all\ subgroups\ (recursively)=Sort all subgroups (recursively)
-Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Collect and share telemetry data to help improve JabRef.
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef=Collect and share telemetry data to help improve JabRef
 Don't\ share=Don't share
 Share\ anonymous\ statistics=Share anonymous statistics
 Telemetry\:\ Help\ make\ JabRef\ better=Telemetry: Help make JabRef better
@@ -2035,7 +2035,6 @@ Light\ theme=Light theme
 Dark\ theme=Dark theme
 Overwrite\ existing\ keys=Overwrite existing keys
 Key\ patterns=Key patterns
-Size\:=Size:
 Font\ settings=Font settings
 Override\ font\ settings=Override font settings
 Override\ font\ size=Override font size
@@ -2116,3 +2115,5 @@ Unable\ to\ open\ ShortScience.=Unable to open ShortScience.
 
 Shared\ database=Shared database
 Lookup=Lookup
+
+Remove\ formatter\ %0=Remove formatter %0


### PR DESCRIPTION
Changes:
- Reduces the size of the rarely used import/export/show/reset-preferences buttons to icon buttons to free space to display all of the tabs in the list ( fixes #6038 )
- The font size is now controlled by a Spinner (a text field with arrows on the right side)
- The ComboBoxes now have ValueFactories to properly display the real name of the languages, the charsets and the BibDatabaseMode which incorrectly displayed `biblatex` instead of `BibLaTeX`.
- Some keyboard events are added to the add-TextFields in NameFormatterTab etc. to make usage more intuitive.
- Removed obsolete and non functional `Open PDF` settings  ( closes #5529 )

![preferences_polish](https://user-images.githubusercontent.com/50491877/76712228-efe62400-6716-11ea-84ad-9b331ea046a4.png)

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.