### PR TITLE
Remove obsolete usage of File in DatabaseContext

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -70,7 +70,6 @@ public class BasePanel extends StackPane {
     private final FileAnnotationCache annotationCache;
 
     private final JabRefFrame frame;
-    // The undo manager.
     private final CountingUndoManager undoManager;
 
     private final SidePaneManager sidePaneManager;
@@ -80,13 +79,10 @@ public class BasePanel extends StackPane {
     private final DialogService dialogService;
     private MainTable mainTable;
     private BasePanelPreferences preferences;
-    // To contain instantiated entry editors. This is to save time
-    // As most enums, this must not be null
     private BasePanelMode mode = BasePanelMode.SHOWING_NOTHING;
     private SplitPane splitPane;
     private DatabaseChangePane changePane;
     private boolean saving;
-    // AutoCompleter used in the search bar
     private PersonNameSuggestionProvider searchAutoCompleter;
     private boolean baseChanged;
     private boolean nonUndoableChange;
@@ -152,10 +148,10 @@ public class BasePanel extends StackPane {
         boolean isAutosaveEnabled = Globals.prefs.getBoolean(JabRefPreferences.LOCAL_AUTO_SAVE);
 
         if (databaseLocation == DatabaseLocation.LOCAL) {
-            if (this.bibDatabaseContext.getDatabaseFile().isPresent()) {
+            if (this.bibDatabaseContext.getDatabasePath().isPresent()) {
                 // check if file is modified
                 String changeFlag = isModified() && !isAutosaveEnabled ? "*" : "";
-                title.append(this.bibDatabaseContext.getDatabaseFile().get().getName()).append(changeFlag);
+                title.append(this.bibDatabaseContext.getDatabasePath().get().getFileName()).append(changeFlag);
             } else {
                 title.append(Localization.lang("untitled"));
 
@@ -558,8 +554,8 @@ public class BasePanel extends StackPane {
             }
         } else if (baseChanged && !nonUndoableChange) {
             baseChanged = false;
-            if (getBibDatabaseContext().getDatabaseFile().isPresent()) {
-                frame.setTabTitle(this, getTabTitle(), getBibDatabaseContext().getDatabaseFile().get().getAbsolutePath());
+            if (getBibDatabaseContext().getDatabasePath().isPresent()) {
+                frame.setTabTitle(this, getTabTitle(), getBibDatabaseContext().getDatabasePath().get().toAbsolutePath().toString());
             } else {
                 frame.setTabTitle(this, Localization.lang("untitled"), null);
             }

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -306,8 +306,8 @@ public class JabRefFrame extends BorderPane {
         if (panel.getBibDatabaseContext().getLocation() == DatabaseLocation.LOCAL) {
             String changeFlag = panel.isModified() && !isAutosaveEnabled ? "*" : "";
             String databaseFile = panel.getBibDatabaseContext()
-                                       .getDatabaseFile()
-                                       .map(File::getPath)
+                                       .getDatabasePath()
+                                       .map(Path::toString)
                                        .orElse(Localization.lang("untitled"));
             //setTitle(FRAME_TITLE + " - " + databaseFile + changeFlag + modeInfo);
         } else if (panel.getBibDatabaseContext().getLocation() == DatabaseLocation.SHARED) {

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1,7 +1,6 @@
 package org.jabref.gui;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -355,7 +355,7 @@ public class JabRefFrame extends BorderPane {
                 prefs.remove(JabRefPreferences.LAST_EDITED);
             } else {
                 prefs.putStringList(JabRefPreferences.LAST_EDITED, filenames);
-                File focusedDatabase = getCurrentBasePanel().getBibDatabaseContext().getDatabaseFile().orElse(null);
+                Path focusedDatabase = getCurrentBasePanel().getBibDatabaseContext().getDatabasePath().orElse(null);
                 new LastFocusedTabPreferences(prefs).setLastFocusedTab(focusedDatabase);
             }
         }
@@ -394,7 +394,7 @@ public class JabRefFrame extends BorderPane {
             }
             AutosaveManager.shutdown(context);
             BackupManager.shutdown(context);
-            context.getDatabaseFile().map(File::getAbsolutePath).ifPresent(filenames::add);
+            context.getDatabasePath().map(Path::toAbsolutePath).map(Path::toString).ifPresent(filenames::add);
         }
 
         WaitForSaveFinishedDialog waitForSaveFinishedDialog = new WaitForSaveFinishedDialog(dialogService);
@@ -953,15 +953,11 @@ public class JabRefFrame extends BorderPane {
         List<String> dbPaths = new ArrayList<>(getBasePanelCount());
 
         for (BasePanel basePanel : getBasePanelList()) {
-            try {
-                // db file exists
-                if (basePanel.getBibDatabaseContext().getDatabaseFile().isPresent()) {
-                    dbPaths.add(basePanel.getBibDatabaseContext().getDatabaseFile().get().getCanonicalPath());
-                } else {
-                    dbPaths.add("");
-                }
-            } catch (IOException ex) {
-                LOGGER.error("Invalid database file path: " + ex.getMessage());
+            // db file exists
+            if (basePanel.getBibDatabaseContext().getDatabasePath().isPresent()) {
+                dbPaths.add(basePanel.getBibDatabaseContext().getDatabasePath().get().toAbsolutePath().toString());
+            } else {
+                dbPaths.add("");
             }
         }
         return dbPaths;
@@ -977,10 +973,10 @@ public class JabRefFrame extends BorderPane {
         List<String> paths = getUniquePathParts();
         for (int i = 0; i < getBasePanelCount(); i++) {
             String uniqPath = paths.get(i);
-            Optional<File> file = getBasePanelAt(i).getBibDatabaseContext().getDatabaseFile();
+            Optional<Path> file = getBasePanelAt(i).getBibDatabaseContext().getDatabasePath();
 
             if (file.isPresent()) {
-                if (!uniqPath.equals(file.get().getName()) && uniqPath.contains(File.separator)) {
+                if (!uniqPath.equals(file.get().getFileName()) && uniqPath.contains(File.separator)) {
                     // remove filename
                     uniqPath = uniqPath.substring(0, uniqPath.lastIndexOf(File.separator));
                     tabbedPane.getTabs().get(i).setText(getBasePanelAt(i).getTabTitle() + " \u2014 " + uniqPath);
@@ -991,7 +987,7 @@ public class JabRefFrame extends BorderPane {
             } else {
                 tabbedPane.getTabs().get(i).setText(getBasePanelAt(i).getTabTitle());
             }
-            tabbedPane.getTabs().get(i).setTooltip(new Tooltip(file.map(File::getAbsolutePath).orElse(null)));
+            tabbedPane.getTabs().get(i).setTooltip(new Tooltip(file.map(Path::toAbsolutePath).map(Path::toString).orElse(null)));
         }
     }
 
@@ -1047,7 +1043,7 @@ public class JabRefFrame extends BorderPane {
         return ((context.getLocation() == DatabaseLocation.SHARED) ||
                 ((context.getLocation() == DatabaseLocation.LOCAL) && Globals.prefs.getBoolean(JabRefPreferences.LOCAL_AUTO_SAVE)))
                 &&
-                context.getDatabaseFile().isPresent();
+                context.getDatabasePath().isPresent();
     }
 
     /**

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.layout;
 
-import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -2,6 +2,7 @@ package org.jabref.logic.layout;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -366,10 +367,8 @@ class LayoutEntry {
                 return encoding.displayName();
 
             case LayoutHelper.IS_FILENAME:
-                return databaseContext.getDatabaseFile().map(File::getName).orElse("");
-
             case LayoutHelper.IS_FILEPATH:
-                return databaseContext.getDatabaseFile().map(File::getPath).orElse("");
+                return databaseContext.getDatabasePath().map(Path::toAbsolutePath).map(Path::toString).orElse("");
 
             default:
                 break;

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -74,21 +74,15 @@ public class BibDatabaseContext {
         metaData.setMode(bibDatabaseMode);
     }
 
-    /**
-     * Get the file where this database was last saved to or loaded from, if any.
-     *
-     * @return Optional of the relevant File, or Optional.empty() if none is defined.
-     * @deprecated use {@link #getDatabasePath()} instead
-     */
-    @Deprecated
-    public Optional<File> getDatabaseFile() {
-        return file.map(Path::toFile);
-    }
-
     public void setDatabasePath(Path file) {
         this.file = Optional.ofNullable(file);
     }
 
+    /**
+     * Get the file where this database was last saved to or loaded from, if any.
+     *
+     * @return Optional of the relevant File, or Optional.empty() if none is defined.
+     */
     public Optional<Path> getDatabasePath() {
         return file;
     }
@@ -195,19 +189,19 @@ public class BibDatabaseContext {
         String dir = directoryName;
         // If this directory is relative, we try to interpret it as relative to
         // the file path of this BIB file:
-        Optional<File> databaseFile = getDatabaseFile();
+        Optional<Path> databaseFile = getDatabasePath();
         if (!new File(dir).isAbsolute() && databaseFile.isPresent()) {
-            String relDir;
+            Path relDir;
             if (".".equals(dir)) {
                 // if dir is only "current" directory, just use its parent (== real current directory) as path
                 relDir = databaseFile.get().getParent();
             } else {
-                relDir = databaseFile.get().getParent() + File.separator + dir;
+                relDir = databaseFile.get().getParent().resolve(dir);
             }
             // If this directory actually exists, it is very likely that the
             // user wants us to use it:
-            if (new File(relDir).exists()) {
-                dir = relDir;
+            if (Files.exists(relDir)) {
+                dir = relDir.toString();
             }
         }
         return dir;

--- a/src/main/java/org/jabref/preferences/LastFocusedTabPreferences.java
+++ b/src/main/java/org/jabref/preferences/LastFocusedTabPreferences.java
@@ -1,6 +1,5 @@
 package org.jabref.preferences;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 

--- a/src/main/java/org/jabref/preferences/LastFocusedTabPreferences.java
+++ b/src/main/java/org/jabref/preferences/LastFocusedTabPreferences.java
@@ -1,6 +1,7 @@
 package org.jabref.preferences;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Objects;
 
 public class LastFocusedTabPreferences {
@@ -11,21 +12,21 @@ public class LastFocusedTabPreferences {
         this.preferences = Objects.requireNonNull(preferences);
     }
 
-    public void setLastFocusedTab(File file) {
-        if (file == null) {
+    public void setLastFocusedTab(Path path) {
+        if (path == null) {
             return;
         }
 
-        String filePath = file.getAbsolutePath();
+        String filePath = path.toAbsolutePath().toString();
         preferences.put(JabRefPreferences.LAST_FOCUSED, filePath);
     }
 
-    public boolean hadLastFocus(File file) {
-        if (file == null) {
+    public boolean hadLastFocus(Path path) {
+        if (path == null) {
             return false;
         }
 
         String lastFocusedDatabase = preferences.get(JabRefPreferences.LAST_FOCUSED);
-        return file.getAbsolutePath().equals(lastFocusedDatabase);
+        return path.toAbsolutePath().toString().equals(lastFocusedDatabase);
     }
 }

--- a/src/test/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/test/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
@@ -1,6 +1,5 @@
 package org.jabref.preferences;
 
-import java.io.File;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/test/java/org/jabref/preferences/LastFocusedTabPreferencesTest.java
@@ -1,6 +1,7 @@
 package org.jabref.preferences;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +28,7 @@ public class LastFocusedTabPreferencesTest {
     @Test
     public void testLastFocusedTab() {
         LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
-        File whatever = new File("whatever");
+        Path whatever = Path.of("whatever");
         prefs.setLastFocusedTab(whatever);
         assertTrue(prefs.hadLastFocus(whatever));
     }
@@ -35,7 +36,7 @@ public class LastFocusedTabPreferencesTest {
     @Test
     public void testLastFocusedTabNull() {
         LastFocusedTabPreferences prefs = new LastFocusedTabPreferences(JabRefPreferences.getInstance());
-        File whatever = new File("whatever");
+        Path whatever = Path.of("whatever");
         prefs.setLastFocusedTab(whatever);
         assertTrue(prefs.hadLastFocus(whatever));
 


### PR DESCRIPTION
Folllow-up to #6117 

Get rid of `File` in `BibDatabaseContext`.

Also removed obsolete comments.