### PR TITLE
Move "Manage field names & content" to "Edit"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the arXiv fetcher. Now it should find entries even more reliably and does no longer include the version (e.g `v1`) in the `eprint` field. [forum#1941](https://discourse.jabref.org/t/remove-version-in-arxiv-import/1941)
 - We moved the group search bar and the button "New group" from bottom to top position to make it more prominent. [#6112](https://github.com/JabRef/jabref/pull/6112)
 - We changed the buttons for import/export/show all/reset of preferences to smaller icon buttons in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
+- We moved the functionality "Manage field names & content" from the "Library" menu to the "Edit" menu, because it affects the selected entries and not the whole library
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -728,7 +728,8 @@ public class JabRefFrame extends BorderPane {
 
                 new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.MANAGE_KEYWORDS, new ManageKeywordsAction(stateManager))
+                factory.createMenuItem(StandardActions.MANAGE_KEYWORDS, new ManageKeywordsAction(stateManager)),
+                factory.createMenuItem(StandardActions.MASS_SET_FIELDS, new MassSetFieldsAction(stateManager, dialogService, undoManager))
         );
 
         if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
@@ -756,8 +757,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createMenuItem(StandardActions.LIBRARY_PROPERTIES, new LibraryPropertiesAction(this, dialogService, stateManager)),
                 factory.createMenuItem(StandardActions.EDIT_PREAMBLE, new PreambleEditor(stateManager, undoManager, this.getDialogService())),
                 factory.createMenuItem(StandardActions.EDIT_STRINGS, new BibtexStringEditorAction(stateManager)),
-                factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this, stateManager)),
-                factory.createMenuItem(StandardActions.MASS_SET_FIELDS, new MassSetFieldsAction(stateManager, dialogService, undoManager))
+                factory.createMenuItem(StandardActions.MANAGE_CITE_KEY_PATTERNS, new BibtexKeyPatternAction(this, stateManager))
         );
 
         quality.getItems().addAll(


### PR DESCRIPTION
Background: <blockquote class="twitter-tweet"><p lang="en" dir="ltr">Oh bummer, did the new Jabref remove the &quot;Clear field&quot; feature?</p>&mdash; LianTze Lim (@liantze) <a href="https://twitter.com/liantze/status/1239401355573202944?ref_src=twsrc%5Etfw">March 16, 2020</a></blockquote>

Refs https://github.com/koppor/jabref/issues/410

# This proposal

![grafik](https://user-images.githubusercontent.com/1366654/76824406-489ce600-6817-11ea-8490-ad2da4195018.png)

# JabRef 4.3.1

![grafik](https://user-images.githubusercontent.com/1366654/76824350-2a36ea80-6817-11ea-978e-1e73f858671e.png)

# JabRef 5.0

![grafik](https://user-images.githubusercontent.com/1366654/76824358-31f68f00-6817-11ea-81be-3548c30506b3.png)

![grafik](https://user-images.githubusercontent.com/1366654/76824369-3753d980-6817-11ea-8991-ee65e7a39762.png)

![grafik](https://user-images.githubusercontent.com/1366654/76824376-3ae76080-6817-11ea-89b5-757d81ab2086.png)


