### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,7 +237,7 @@ dependencyUpdates.resolutionStrategy = {
             }
         }
         rules.withModule("org.python:jython-standalone") { ComponentSelection selection ->
-            if (selection.candidate.version ==~ /2.7.2b\d/) {
+            if (selection.candidate.version ==~ /2.7.2b\d/ || selection.candidate.version ==~ /2.7.2rc\d/) {
                 selection.reject('Release candidate')
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ configurations {
 }
 
 javafx {
-    version = "13.0.2"
+    version = "14"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web', 'javafx.swing' ]
 }
 


### PR DESCRIPTION
Can we actually ramp up to JavaFX 14?

fixes #6136 

- [x] Manually tested on MacOS