### PR TITLE
Update Codecov yaml with proper indentation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
   - src/gen/.*
   status:
     patch: false
-  project:
-    default:
-      threshold: 0.005
+    project:
+      default:
+        threshold: 0.005
 comment: false


### PR DESCRIPTION
`project` should be a child of `status`, this might be why `comment` isn't being properly handled.
This should help with disabling Codecov comments (https://twitter.com/JabRef_org/status/1241737914205290502)
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues by using the following pattern: #333.
If you fixed a koppor issue, link it with following pattern: [koppor#47](https://github.com/koppor/jabref/issues/47).
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not: Issue created at <https://github.com/JabRef/user-documentation/issues>.
