### PR TITLE
Fix overwritting downloaded files with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening a library from the recent libraries menu was not possible. [#5939](https://github.com/JabRef/jabref/issues/5939)
 - We fixed an issue with inconsistent capitalization of file extensions when downloading files [#6115](https://github.com/JabRef/jabref/issues/6115)
 - We fixed the display of language and encoding in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
-
+- We fixed an issue where search full-text documents downloaded files with same name, overwriting existing files. [#6174](https://github.com/JabRef/jabref/pull/6174)
 ### Removed
 
 - We removed the obsolete `External programs / Open PDF` section in the preferences, as the default application to open PDFs is now set in the `Manage external file types` dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -38,6 +38,7 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.externalfiles.LinkedFileHandler;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.util.io.FileNameUniqueness;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.logic.xmp.XmpUtilWriter;
 import org.jabref.model.database.BibDatabaseContext;
@@ -419,6 +420,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     String suggestedTypeName = externalFileType.getName();
                     linkedFile.setFileType(suggestedTypeName);
                     String suggestedName = linkedFileHandler.getSuggestedFileName(externalFileType.getExtension());
+                    suggestedName = FileNameUniqueness.getNonOverWritingFileName(targetDirectory, suggestedName);
                     return targetDirectory.resolve(suggestedName);
                 })
                 .then(destination -> new FileDownloadTask(urlDownload.getSource(), destination))

--- a/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
+++ b/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
@@ -1,0 +1,49 @@
+package org.jabref.logic.util.io;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class FileNameUniqueness {
+
+    /**
+     * Returns an absolute path to a file which does not match with any existing file names
+     *
+     * @param targetDirectory The directory in which file name should be unique
+     * @param fileName Suggested name for the file
+     * @return a file-name such that it does not match any existing files in targetDirectory.
+     * */
+    public static String getNonOverWritingFileName(Path targetDirectory, String fileName) {
+//        String absoluteName = targetDirectory.resolve(fileName)
+//                .toString();
+
+        Optional<String> extensionOptional = FileUtil.getFileExtension(fileName);
+
+        // the suffix include the '.' , if extension is present Eg: ".pdf"
+        String extensionSuffix;
+        String fileNameWithoutExtension;
+
+        if (extensionOptional.isPresent()) {
+            extensionSuffix = '.' + extensionOptional.get();
+            fileNameWithoutExtension = fileName.substring(0, fileName.lastIndexOf('.'));
+        }
+        else {
+            extensionSuffix = "";
+            fileNameWithoutExtension = fileName;
+        }
+
+//        Path absolutePath = Paths.get(absoluteName);
+        String newFileName = fileName;
+
+        int counter = 1;
+        while ( Files.exists(
+                targetDirectory.resolve(newFileName))
+        ) {
+            newFileName = fileNameWithoutExtension +
+                    " (" + counter + ")" +
+                    extensionSuffix;
+            counter++;
+        }
+        return newFileName;
+    }
+}

--- a/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
+++ b/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
@@ -7,15 +7,13 @@ import java.util.Optional;
 public class FileNameUniqueness {
 
     /**
-     * Returns an absolute path to a file which does not match with any existing file names
+     * Returns a file-name such that it does not match any existing files in targetDirectory
      *
      * @param targetDirectory The directory in which file name should be unique
      * @param fileName Suggested name for the file
      * @return a file-name such that it does not match any existing files in targetDirectory.
      * */
     public static String getNonOverWritingFileName(Path targetDirectory, String fileName) {
-//        String absoluteName = targetDirectory.resolve(fileName)
-//                .toString();
 
         Optional<String> extensionOptional = FileUtil.getFileExtension(fileName);
 
@@ -32,7 +30,6 @@ public class FileNameUniqueness {
             fileNameWithoutExtension = fileName;
         }
 
-//        Path absolutePath = Paths.get(absoluteName);
         String newFileName = fileName;
 
         int counter = 1;

--- a/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
@@ -1,15 +1,14 @@
 package org.jabref.logic.util.io;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-
 
 public class FileNameUniquenessTest {
 

--- a/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
@@ -16,15 +16,14 @@ public class FileNameUniquenessTest {
     protected Path tempDir;
 
     @Test
-    public void testGetNonOverWritingFileNameReturnsSameName(@TempDir Path tempDirectory) throws IOException {
+    public void testGetNonOverWritingFileNameReturnsSameName() throws IOException {
 
         assertFalse(
-                Files.exists(tempDirectory.resolve("sameFile.txt"))
+                Files.exists(tempDir.resolve("sameFile.txt"))
         );
 
-        String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDirectory, "sameFile.txt");
+        String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDir, "sameFile.txt");
         assertEquals("sameFile.txt", outputFileName);
-
     }
 
     @Test
@@ -35,8 +34,6 @@ public class FileNameUniquenessTest {
 
         String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDir, "differentFile.txt");
         assertEquals("differentFile (1).txt", outputFileName);
-
-        Files.delete(dummyFilePath1);
     }
 
     @Test
@@ -49,8 +46,5 @@ public class FileNameUniquenessTest {
 
         String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDir, "manyfiles.txt");
         assertEquals("manyfiles (2).txt", outputFileName);
-
-        Files.delete(dummyFilePath1);
-        Files.delete(dummyFilePath2);
     }
 }

--- a/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
@@ -1,0 +1,57 @@
+package org.jabref.logic.util.io;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+
+public class FileNameUniquenessTest {
+
+    @TempDir
+    protected Path tempDir;
+
+    @Test
+    public void testGetNonOverWritingFileNameReturnsSameName(@TempDir Path tempDirectory) throws IOException {
+
+        assertFalse(
+                Files.exists(tempDirectory.resolve("sameFile.txt"))
+        );
+
+        String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDirectory, "sameFile.txt");
+        assertEquals("sameFile.txt", outputFileName);
+
+    }
+
+    @Test
+    public void testGetNonOverWritingFileNameReturnsUniqueNameOver1Conflict() throws IOException {
+        Path dummyFilePath1 = tempDir.resolve("differentFile.txt");
+
+        Files.createFile(dummyFilePath1);
+
+        String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDir, "differentFile.txt");
+        assertEquals("differentFile (1).txt", outputFileName);
+
+        Files.delete(dummyFilePath1);
+    }
+
+    @Test
+    public void testGetNonOverWritingFileNameReturnsUniqueNameOverNConflicts() throws IOException {
+        Path dummyFilePath1 = tempDir.resolve("manyfiles.txt");
+        Path dummyFilePath2 = tempDir.resolve("manyfiles (1).txt");
+
+        Files.createFile(dummyFilePath1);
+        Files.createFile(dummyFilePath2);
+
+        String outputFileName = FileNameUniqueness.getNonOverWritingFileName(tempDir, "manyfiles.txt");
+        assertEquals("manyfiles (2).txt", outputFileName);
+
+        Files.delete(dummyFilePath1);
+        Files.delete(dummyFilePath2);
+    }
+}


### PR DESCRIPTION
Added auto-numbering for downloaded file names, which conflict with file names in the current directory. #6068 


<!-- 
- All items with `[ ]` are still a TODO.
- All items checked with `[x]` are done.
- Remove items not applicable
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
