### PR TITLE
Remove the option to configure to create .bib.bak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Removed
 
 - We removed the obsolete `External programs / Open PDF` section in the preferences, as the default application to open PDFs is now set in the `Manage external file types` dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
+- We removed the option to configure whether a `.bib.bak` file should be generated upon save. It is now always enabled. Documentation at <https://docs.jabref.org/general/autosave>. [#6092](https://github.com/JabRef/jabref/issues/6092)
 
 ## [5.0] – 2020-03-06
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -149,9 +149,10 @@ public class BasePanel extends StackPane {
 
         if (databaseLocation == DatabaseLocation.LOCAL) {
             if (this.bibDatabaseContext.getDatabasePath().isPresent()) {
-                // check if file is modified
-                String changeFlag = isModified() && !isAutosaveEnabled ? "*" : "";
-                title.append(this.bibDatabaseContext.getDatabasePath().get().getFileName()).append(changeFlag);
+                title.append(this.bibDatabaseContext.getDatabasePath().get().getFileName());
+                if (isModified() && !isAutosaveEnabled) {
+                    title.append("*");
+                }
             } else {
                 title.append(Localization.lang("untitled"));
 

--- a/src/main/java/org/jabref/gui/preferences/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.fxml
@@ -20,7 +20,6 @@
     <Label styleClass="titleHeader" text="%File"/>
 
     <CheckBox fx:id="openLastStartup" text="%Open last edited libraries at startup"/>
-    <CheckBox fx:id="backupOldFile" text="%Backup old file when saving"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <Label text="%Do not wrap the following fields when saving"/>
         <TextField fx:id="noWrapFiles" HBox.hgrow="ALWAYS"/>

--- a/src/main/java/org/jabref/gui/preferences/FileTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/FileTabView.java
@@ -25,7 +25,6 @@ import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 public class FileTabView extends AbstractPreferenceTabView<FileTabViewModel> implements PreferencesTab {
 
     @FXML private CheckBox openLastStartup;
-    @FXML private CheckBox backupOldFile;
     @FXML private TextField noWrapFiles;
     @FXML private RadioButton resolveStringsBibTex;
     @FXML private RadioButton resolveStringsAll;
@@ -63,7 +62,6 @@ public class FileTabView extends AbstractPreferenceTabView<FileTabViewModel> imp
         this.viewModel = new FileTabViewModel(dialogService, preferences);
 
         openLastStartup.selectedProperty().bindBidirectional(viewModel.openLastStartupProperty());
-        backupOldFile.selectedProperty().bindBidirectional(viewModel.backupOldFileProperty());
         noWrapFiles.textProperty().bindBidirectional(viewModel.noWrapFilesProperty());
         resolveStringsBibTex.selectedProperty().bindBidirectional(viewModel.resolveStringsBibTexProperty());
         resolveStringsAll.selectedProperty().bindBidirectional(viewModel.resolveStringsAllProperty());

--- a/src/main/java/org/jabref/gui/preferences/FileTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/FileTabViewModel.java
@@ -32,7 +32,6 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 public class FileTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty openLastStartupProperty = new SimpleBooleanProperty();
-    private final BooleanProperty backupOldFileProperty = new SimpleBooleanProperty();
     private final StringProperty noWrapFilesProperty = new SimpleStringProperty("");
     private final BooleanProperty resolveStringsBibTexProperty = new SimpleBooleanProperty();
     private final BooleanProperty resolveStringsAllProperty = new SimpleBooleanProperty();
@@ -80,7 +79,6 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     @Override
     public void setValues() {
         openLastStartupProperty.setValue(preferences.getBoolean(JabRefPreferences.OPEN_LAST_EDITED));
-        backupOldFileProperty.setValue(preferences.getBoolean(JabRefPreferences.BACKUP));
         noWrapFilesProperty.setValue(preferences.get(JabRefPreferences.NON_WRAPPABLE_FIELDS));
         resolveStringsAllProperty.setValue(preferences.getBoolean(JabRefPreferences.RESOLVE_STRINGS_ALL_FIELDS)); // Flipped around
         resolveStringsBibTexProperty.setValue(!resolveStringsAllProperty.getValue());
@@ -108,7 +106,6 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     @Override
     public void storeSettings() {
         preferences.putBoolean(JabRefPreferences.OPEN_LAST_EDITED, openLastStartupProperty.getValue());
-        preferences.putBoolean(JabRefPreferences.BACKUP, backupOldFileProperty.getValue());
         if (!noWrapFilesProperty.getValue().trim().equals(preferences.get(JabRefPreferences.NON_WRAPPABLE_FIELDS))) {
             preferences.put(JabRefPreferences.NON_WRAPPABLE_FIELDS, noWrapFilesProperty.getValue());
         }
@@ -159,8 +156,6 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     // General
 
     public BooleanProperty openLastStartupProperty() { return openLastStartupProperty; }
-
-    public BooleanProperty backupOldFileProperty() { return backupOldFileProperty; }
 
     public StringProperty noWrapFilesProperty() { return noWrapFilesProperty; }
 

--- a/src/main/java/org/jabref/logic/exporter/SavePreferences.java
+++ b/src/main/java/org/jabref/logic/exporter/SavePreferences.java
@@ -24,7 +24,7 @@ public class SavePreferences {
     private final Boolean generateBibtexKeysBeforeSaving;
     private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;
 
-    public SavePreferences(Boolean saveInOriginalOrder, SaveOrderConfig saveOrder, Charset encoding, Boolean makeBackup,
+    private SavePreferences(Boolean saveInOriginalOrder, SaveOrderConfig saveOrder, Charset encoding, Boolean makeBackup,
                            DatabaseSaveType saveType, Boolean takeMetadataSaveOrderInAccount, Boolean reformatFile,
                            FieldWriterPreferences fieldWriterPreferences, GlobalBibtexKeyPattern globalCiteKeyPattern,
                            Boolean generateBibtexKeysBeforeSaving, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
@@ -39,6 +39,13 @@ public class SavePreferences {
         this.globalCiteKeyPattern = globalCiteKeyPattern;
         this.generateBibtexKeysBeforeSaving = generateBibtexKeysBeforeSaving;
         this.bibtexKeyPatternPreferences = bibtexKeyPatternPreferences;
+    }
+
+    public SavePreferences(Boolean saveInOriginalOrder, SaveOrderConfig saveOrder, Charset encoding,
+                           DatabaseSaveType saveType, Boolean takeMetadataSaveOrderInAccount, Boolean reformatFile,
+                           FieldWriterPreferences fieldWriterPreferences, GlobalBibtexKeyPattern globalCiteKeyPattern,
+                           Boolean generateBibtexKeysBeforeSaving, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
+        this(saveInOriginalOrder, saveOrder, encoding, true, saveType, takeMetadataSaveOrderInAccount, reformatFile, fieldWriterPreferences, globalCiteKeyPattern, generateBibtexKeysBeforeSaving, bibtexKeyPatternPreferences);
     }
 
     public Boolean takeMetadataSaveOrderInAccount() {
@@ -63,6 +70,11 @@ public class SavePreferences {
         return makeBackup;
     }
 
+    /**
+     * Required by {@link org.jabref.logic.autosaveandbackup.BackupManager}. Should not be used in other settings
+     *
+     * @param newMakeBackup whether a backup (.bak file) should be made
+     */
     public SavePreferences withMakeBackup(Boolean newMakeBackup) {
         return new SavePreferences(this.saveInOriginalOrder, this.saveOrder, this.encoding, newMakeBackup, this.saveType,
                 this.takeMetadataSaveOrderInAccount, this.reformatFile, this.fieldWriterPreferences,
@@ -97,10 +109,6 @@ public class SavePreferences {
         return new SavePreferences(this.saveInOriginalOrder, this.saveOrder, this.encoding, this.makeBackup,
                 this.saveType, this.takeMetadataSaveOrderInAccount, newReformatFile, this.fieldWriterPreferences,
                 this.globalCiteKeyPattern, this.generateBibtexKeysBeforeSaving, this.bibtexKeyPatternPreferences);
-    }
-
-    public Charset getEncodingOrDefault() {
-        return encoding == null ? Charset.defaultCharset() : encoding;
     }
 
     public FieldWriterPreferences getFieldWriterPreferences() {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -165,7 +165,6 @@ public class JabRefPreferences implements PreferencesService {
     public static final String LAST_EDITED = "lastEdited";
     public static final String OPEN_LAST_EDITED = "openLastEdited";
     public static final String LAST_FOCUSED = "lastFocused";
-    public static final String BACKUP = "backup";
     public static final String AUTO_OPEN_FORM = "autoOpenForm";
     public static final String IMPORT_WORKING_DIRECTORY = "importWorkingDirectory";
     public static final String EXPORT_WORKING_DIRECTORY = "exportWorkingDirectory";
@@ -495,7 +494,6 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(IMPORT_WORKING_DIRECTORY, USER_HOME);
         defaults.put(PREFS_EXPORT_PATH, USER_HOME);
         defaults.put(AUTO_OPEN_FORM, Boolean.TRUE);
-        defaults.put(BACKUP, Boolean.TRUE);
         defaults.put(OPEN_LAST_EDITED, Boolean.TRUE);
         defaults.put(LAST_EDITED, "");
         defaults.put(LAST_FOCUSED, "");
@@ -1326,7 +1324,6 @@ public class JabRefPreferences implements PreferencesService {
                 saveInOriginalOrder,
                 saveOrder,
                 this.getDefaultEncoding(),
-                this.getBoolean(JabRefPreferences.BACKUP),
                 SavePreferences.DatabaseSaveType.ALL,
                 false,
                 this.getBoolean(JabRefPreferences.REFORMAT_FILE_ON_SAVE_AND_EXPORT),
@@ -1341,7 +1338,6 @@ public class JabRefPreferences implements PreferencesService {
                 false,
                 null,
                 this.getDefaultEncoding(),
-                this.getBoolean(JabRefPreferences.BACKUP),
                 SavePreferences.DatabaseSaveType.ALL,
                 true,
                 this.getBoolean(JabRefPreferences.REFORMAT_FILE_ON_SAVE_AND_EXPORT),

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -94,8 +94,6 @@ Available\ export\ formats=Available export formats
 
 Available\ import\ formats=Available import formats
 
-Backup\ old\ file\ when\ saving=Backup old file when saving
-
 %0\ source=%0 source
 
 Browse=Browse


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/6092

Additionally:

- remove obsolete method getEncodingOrDefault
- simplify code for adding a "*" for a modified library

![](https://raw.githubusercontent.com/JabRef/user-documentation/master/en/.gitbook/assets/autosave.png)

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for bigger UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? Updated https://docs.jabref.org/general/autosave
