### PR TITLE
combine_journal_lists_dots

### DIFF
--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -20,7 +20,8 @@ jobs:
           cd /tmp
           git clone --depth=1 https://github.com/JabRef/abbrv.jabref.org.git
           cd abbrv.jabref.org
-          ./combine_journal_lists.py $GITHUB_WORKSPACE/src/main/resources/journals/journalList.csv journals/*.csv
+          ./combine_journal_lists_dots.py $GITHUB_WORKSPACE/src/main/resources/journals/journalList.csv
+          ./combine_journal_lists_dotless.py $GITHUB_WORKSPACE/src/main/resources/journals/journalList_dotless.csv
           cd $GITHUB_WORKSPACE
           git add .
           git config user.email "jabrefmail+webfeedback@gmail.com"


### PR DESCRIPTION
Use selective list combine script for dot-abbrevations and create extra file for dotless abbreviations

Uses the new scripts from https://github.com/JabRef/abbrv.jabref.org/pull/54/ modified in https://github.com/JabRef/abbrv.jabref.org/pull/57/