### PR TITLE
JDK14 switch - and checkstyle skipping

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -8,8 +8,10 @@
         <property name="header" value=""/>
     </module>
 
-    <!-- Don't stop on exceptions - enables checking Java 14 syntax in checkstyle 8.31 -->
-    <property name="haltOnException" value="false"/>
+    <!-- BeforeExecutionFileFilters is required for sources that are based on java14 -->
+    <module name="BeforeExecutionExclusionFileFilter">
+      <property name="fileNamePattern" value="AuthorAndsReplacer.java|Ordinal.java" />
+    </module>
 
     <module name="SuppressionFilter">
         <property name="file" value="${config_loc}/suppressions.xml"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -8,6 +8,9 @@
         <property name="header" value=""/>
     </module>
 
+    <!-- Don't stop on exceptions - enables checking Java 14 syntax in checkstyle 8.31 -->
+    <property name="haltOnException" value="false"/>
+
     <module name="SuppressionFilter">
         <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
@@ -18,6 +18,7 @@ public class AuthorAndsReplacer implements LayoutFormatter {
             return null;
         }
         String[] authors = fieldText.split(" and ");
+        //CHECKSTYLE:OFF
         String s = switch (authors.length) {
             case 1 -> authors[0]; // just no action
             case 2 ->  authors[0] + " & " + authors[1];
@@ -32,6 +33,7 @@ public class AuthorAndsReplacer implements LayoutFormatter {
                 yield sb.toString();
             }
         };
+        //CHECKSTYLE:ON
 
         return s;
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
@@ -18,28 +18,20 @@ public class AuthorAndsReplacer implements LayoutFormatter {
             return null;
         }
         String[] authors = fieldText.split(" and ");
-        String s;
-
-        switch (authors.length) {
-        case 1:
-            //Does nothing;
-            s = authors[0];
-            break;
-        case 2:
-            s = authors[0] + " & " + authors[1];
-            break;
-        default:
-            int i;
-            int x = authors.length;
-            StringBuilder sb = new StringBuilder();
-
-            for (i = 0; i < (x - 2); i++) {
-                sb.append(authors[i]).append("; ");
+        String s = switch (authors.length) {
+            case 1 -> authors[0]; // just no action
+            case 2 ->  authors[0] + " & " + authors[1];
+            default -> {
+                int i;
+                int x = authors.length;
+                StringBuilder sb = new StringBuilder();
+                for (i = 0; i < (x - 2); i++) {
+                    sb.append(authors[i]).append("; ");
+                }
+                sb.append(authors[i]).append(" & ").append(authors[i + 1]);
+                yield sb.toString();
             }
-            sb.append(authors[i]).append(" & ").append(authors[i + 1]);
-            s = sb.toString();
-            break;
-        }
+        };
 
         return s;
 

--- a/src/main/java/org/jabref/logic/layout/format/Ordinal.java
+++ b/src/main/java/org/jabref/logic/layout/format/Ordinal.java
@@ -23,21 +23,12 @@ public class Ordinal implements LayoutFormatter {
         while (m.find()) {
             String result = m.group(1);
             int value = Integer.parseInt(result);
-            String ordinalString;
-            switch (value) {
-            case 1:
-                ordinalString = "st";
-                break;
-            case 2:
-                ordinalString = "nd";
-                break;
-            case 3:
-                ordinalString = "rd";
-                break;
-            default:
-                ordinalString = "th";
-                break;
-            }
+            String ordinalString = switch (value) {
+                case 1 -> "st";
+                case 2 -> "nd";
+                case 3 -> "rd";
+                default -> "th";
+            };
             m.appendReplacement(sb, result + ordinalString);
         }
         m.appendTail(sb);

--- a/src/main/java/org/jabref/logic/layout/format/Ordinal.java
+++ b/src/main/java/org/jabref/logic/layout/format/Ordinal.java
@@ -23,12 +23,14 @@ public class Ordinal implements LayoutFormatter {
         while (m.find()) {
             String result = m.group(1);
             int value = Integer.parseInt(result);
+            //CHECKSTYLE:OFF
             String ordinalString = switch (value) {
                 case 1 -> "st";
                 case 2 -> "nd";
                 case 3 -> "rd";
                 default -> "th";
             };
+            //CHECKSTYLE:ON
             m.appendReplacement(sb, result + ordinalString);
         }
         m.appendTail(sb);


### PR DESCRIPTION
Follow up on https://github.com/JabRef/jabref/pull/6202. Had to do it, because @Siedlerchr recommended to use JDK14 switch expressions at https://github.com/JabRef/jabref/pull/6203#discussion_r399826927 - and the PR of the contributor breaks the checkstyle task.

Could not reopen #6202, thus a new PR.

<s>The changes were approved by @tobiasdiez, so I will merge if the building succeeds. This will enable https://github.com/JabRef/jabref/pull/6203 to move forward.</s>

Does not work as expected. Created a StackOverflow question: https://stackoverflow.com/q/61050165/873282

I think, the first step could be to patch checkstyle's Java grammar: <https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java.g>