### PR TITLE
RIS import takes the wrong date and duplicates abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where citation styles except the default "Preview" could not be used. [#56220](https://github.com/JabRef/jabref/issues/5622)
 - We fixed an issue where a warning was displayed when the title content is made up of two sentences. [#5832](https://github.com/JabRef/jabref/issues/5832)
 - We fixed an issue where an exception was thrown when adding a save action without a selected formatter in the library properties [#6069](https://github.com/JabRef/jabref/issues/6069)
+- We fixed an issue when an "Abstract field" was duplicating text, when importing from RIS file (Neurons) [#6065](https://github.com/JabRef/jabref/issues/6065)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
@@ -199,7 +199,7 @@ public class RisImporter extends Importer {
                         String oldAb = fields.get(StandardField.ABSTRACT);
                         if (oldAb == null) {
                             fields.put(StandardField.ABSTRACT, value);
-                        } else {
+                        } else if (!oldAb.equals(value) && !value.isEmpty()) {
                             fields.put(StandardField.ABSTRACT, oldAb + OS.NEWLINE + value);
                         }
                     } else if ("UR".equals(tag) || "L2".equals(tag) || "LK".equals(tag)) {

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -1,12 +1,18 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,4 +54,15 @@ public class RISImporterTest {
         Path file = Paths.get(RISImporterTest.class.getResource("RisImporterCorrupted.ris").toURI());
         assertFalse(importer.isRecognizedFormat(file, StandardCharsets.UTF_8));
     }
+
+    @Test
+    public void testDuplicatesInAbstractField() throws URISyntaxException, IOException {
+        Path file = Paths.get(RISImporterTest.class.getResource("RisImporterTest9.ris").toURI());
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(file.toAbsolutePath().toString()));
+        List<BibEntry> allEntries = importer.importDatabase(bufferedReader).getDatabase().getEntries();
+        BibEntry firstEntry = allEntries.get(0);
+        assertEquals(394, firstEntry.getField(StandardField.ABSTRACT).get().length());
+    }
+
+
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -1,18 +1,12 @@
 package org.jabref.logic.importer.fileformat;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 
 import org.jabref.logic.util.StandardFileType;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.StandardField;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -54,15 +54,4 @@ public class RISImporterTest {
         Path file = Paths.get(RISImporterTest.class.getResource("RisImporterCorrupted.ris").toURI());
         assertFalse(importer.isRecognizedFormat(file, StandardCharsets.UTF_8));
     }
-
-    @Test
-    public void testDuplicatesInAbstractField() throws URISyntaxException, IOException {
-        Path file = Paths.get(RISImporterTest.class.getResource("RisImporterTest9.ris").toURI());
-        BufferedReader bufferedReader = new BufferedReader(new FileReader(file.toAbsolutePath().toString()));
-        List<BibEntry> allEntries = importer.importDatabase(bufferedReader).getDatabase().getEntries();
-        BibEntry firstEntry = allEntries.get(0);
-        assertEquals(394, firstEntry.getField(StandardField.ABSTRACT).get().length());
-    }
-
-
 }

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.bib
@@ -1,7 +1,18 @@
-@book{,
-author = {Smith, Bob and Doe, Jan and Brown, Judy and Martin, Steve and Clark, Joe},
-publisher = {Test Publisher},
-title = {Testing Book Title},
-volume = {1},
-year = {2015}
+% Encoding: UTF-8
+
+@Article{,
+  author    = {Kriegeskorte, Nikolaus and Storrs, Katherine R.},
+  title     = {Grid Cells for Conceptual Spaces?},
+  doi       = {10.1016/j.neuron.2016.10.006},
+  issn      = {0896-6273},
+  number    = {2},
+  pages     = {280--284},
+  url       = {https://doi.org/10.1016/j.neuron.2016.10.006},
+  volume    = {92},
+  abstract  = {location and direction of movement in 2D physical environments via regularly repeating receptive fields.},
+  comment   = {doi: 10.1016/j.neuron.2016.10.006},
+  journal   = {Neuron},
+  month     = oct,
+  publisher = {Elsevier},
+  year      = {2016},
 }

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.bib
@@ -1,0 +1,7 @@
+@book{,
+author = {Smith, Bob and Doe, Jan and Brown, Judy and Martin, Steve and Clark, Joe},
+publisher = {Test Publisher},
+title = {Testing Book Title},
+volume = {1},
+year = {2015}
+}

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.ris
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.ris
@@ -1,7 +1,7 @@
 TY  - JOUR
 T1  - Grid Cells for Conceptual Spaces?
 AU  - Kriegeskorte, Nikolaus
-AU  - Storrs, Katherine R.
+AU  - Storrs, Katherine R.
 Y1  - 2016/10/19
 PY  - 2016
 N1  - doi: 10.1016/j.neuron.2016.10.006
@@ -13,8 +13,8 @@ EP  - 284
 VL  - 92
 IS  - 2
 PB  - Elsevier
-N2  - ?Grid cells? encode an animal?s location and direction of movement in 2D physical environments via regularly repeating receptive fields. Constantinescu et al. (2016) report the first evidence of grid cells for 2D conceptual spaces. The work has exciting implications for mental representation and shows how detailed neural-coding hypotheses can be tested with bulk population-activity measures.
-AB  - ?Grid cells? encode an animal?s location and direction of movement in 2D physical environments via regularly repeating receptive fields. Constantinescu et al. (2016) report the first evidence of grid cells for 2D conceptual spaces. The work has exciting implications for mental representation and shows how detailed neural-coding hypotheses can be tested with bulk population-activity measures.
+N2  - location and direction of movement in 2D physical environments via regularly repeating receptive fields.
+AB  - location and direction of movement in 2D physical environments via regularly repeating receptive fields.
 SN  - 0896-6273
 M3  - doi: 10.1016/j.neuron.2016.10.006
 UR  - https://doi.org/10.1016/j.neuron.2016.10.006

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.ris
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTest9.ris
@@ -1,0 +1,23 @@
+TY  - JOUR
+T1  - Grid Cells for Conceptual Spaces?
+AU  - Kriegeskorte, Nikolaus
+AU  - Storrs, Katherine R.
+Y1  - 2016/10/19
+PY  - 2016
+N1  - doi: 10.1016/j.neuron.2016.10.006
+DO  - 10.1016/j.neuron.2016.10.006
+T2  - Neuron
+JF  - Neuron
+SP  - 280
+EP  - 284
+VL  - 92
+IS  - 2
+PB  - Elsevier
+N2  - ?Grid cells? encode an animal?s location and direction of movement in 2D physical environments via regularly repeating receptive fields. Constantinescu et al. (2016) report the first evidence of grid cells for 2D conceptual spaces. The work has exciting implications for mental representation and shows how detailed neural-coding hypotheses can be tested with bulk population-activity measures.
+AB  - ?Grid cells? encode an animal?s location and direction of movement in 2D physical environments via regularly repeating receptive fields. Constantinescu et al. (2016) report the first evidence of grid cells for 2D conceptual spaces. The work has exciting implications for mental representation and shows how detailed neural-coding hypotheses can be tested with bulk population-activity measures.
+SN  - 0896-6273
+M3  - doi: 10.1016/j.neuron.2016.10.006
+UR  - https://doi.org/10.1016/j.neuron.2016.10.006
+Y2  - 2020/03/04
+ER  -
+


### PR DESCRIPTION
Fixes #6065 

1. Fixed an issue with "duplicate values in 'Abstract field';
2. Checked code and couldn't reproduce second error: "publication date is taken from the Y2 field, not from the correct Y1"
See lines 207-220 of `RisImporter.java`. It works fine and importing publication date as expected. Tested on file from @crystalfp (see file, attached to issue).

Kind regards,
Gennadiy

- [X] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
