### PR TITLE
Create action to automatically close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,18 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@master
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Closing this issue due to inactivity :zzz: Please reopen the issue with additional information if the problem persists.'
+        stale-issue-label: 's: stale'
+        days-before-stale: 30
+        only-labels: 's: waiting-for-customer-feedback'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/stale@master
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Closing this issue due to inactivity :zzz: Please reopen the issue with additional information if the problem persists.'
+        stale-issue-message: 'This issue will be closed in 7 days due to inactivity :zzz: Please provide the requested information if the problem persists.'
         stale-issue-label: 's: stale'
         days-before-stale: 30
         only-labels: 's: waiting-for-customer-feedback'


### PR DESCRIPTION
Uses the [stale action](https://github.com/marketplace/actions/close-stale-issues) to automatically close stale issues. 

With this action, the workflow is as follows:
- Developer marks issue with "s: waiting-for-customer-feedback"
- After 30 days without reaction, the bot marks the issue with "s: stale" and comments on the issue.
- After further 7 days without reaction, the issue is closed.

This only applies to issues with "waiting-for-customer-feedback".

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
