### PR TITLE
Fix XmpExporterTest

### DIFF
--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -119,22 +119,23 @@ public class XmpExporterTest {
 
     @Test
     public void writeMultipleEntriesInDifferentFiles(@TempDir Path testFolder) throws Exception {
-        Path file = testFolder.resolve("split");
+        // set path to the one where the exporter produces several files
+        Path file = testFolder.resolve(XmpExporter.XMP_SPLIT_DIRECTORY_INDICATOR);
         Files.createFile(file);
 
-        BibEntry entryTuring = new BibEntry();
-        entryTuring.setField(StandardField.AUTHOR, "Alan Turing");
+        BibEntry entryTuring = new BibEntry()
+                .withField(StandardField.AUTHOR, "Alan Turing");
 
-        BibEntry entryArmbrust = new BibEntry();
-        entryArmbrust.setField(StandardField.AUTHOR, "Michael Armbrust");
-        entryArmbrust.setCiteKey("Armbrust2010");
+        BibEntry entryArmbrust = new BibEntry()
+                .withField(StandardField.AUTHOR, "Michael Armbrust")
+                .withCiteKey("Armbrust2010");
 
-        exporter.export(databaseContext, file, encoding, Arrays.asList(entryTuring, entryArmbrust));
+        exporter.export(databaseContext, file, encoding, List.of(entryTuring, entryArmbrust));
 
         List<String> lines = Files.readAllLines(file);
         assertEquals(Collections.emptyList(), lines);
 
-        Path fileTuring = Paths.get(file.getParent().toString() + "/" + entryTuring.getId() + "_null.xmp");
+        Path fileTuring = Paths.get(file.getParent().toString(), entryTuring.getId() + "_null.xmp");
         String actualTuring = String.join("\n", Files.readAllLines(fileTuring)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expectedTuring = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
@@ -155,7 +156,7 @@ public class XmpExporterTest {
 
         assertEquals(expectedTuring, actualTuring);
 
-        Path fileArmbrust = Paths.get(file.getParent().toString() + "/" + entryArmbrust.getId() + "_Armbrust2010.xmp");
+        Path fileArmbrust = Paths.get(file.getParent().toString(), entryArmbrust.getId() + "_Armbrust2010.xmp");
         String actualArmbrust = String.join("\n", Files.readAllLines(fileArmbrust)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expectedArmbrust = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +


### PR DESCRIPTION
Hotfix for XmpExporterTest not working.

As soon as PR goes through, I will merge.

Follow up on code-quality will be done at #6237.

The issue was introduced during removing of `@deprected` method in #6283.