### PR TITLE
Add ADR von JUnit vs. AssertJ

### DIFF
--- a/docs/adr/0009-use-plain-junit5-for-testing.md
+++ b/docs/adr/0009-use-plain-junit5-for-testing.md
@@ -1,0 +1,83 @@
+# Use Plain JUnit5 for advanced test assertions
+
+## Context and Problem Statement
+
+How to write readable test assertions?
+How to write readable test assertions for advanced tests?
+
+## Considered Options
+
+* Plain JUnit5
+* Hamcrest
+* AssertJ
+
+## Decision Outcome
+
+Chosen option: "Plain JUnit5", because comes out best \(see below\).
+
+### Positive Consequences
+
+* Tests are more readable
+* More easy to write tests
+* More readable assertions
+
+### Negative Consequences
+
+* More complicated testing leads to more complicated assertions
+
+## Pros and Cons of the Options
+
+### Plain JUnit5
+
+Homepage: <https://junit.org/junit5/docs/current/user-guide/>
+JabRef testing guidelines: <https://devdocs.jabref.org/getting-into-the-code/code-howtos#test-cases>
+
+Example:
+
+```java
+String actual = markdownFormatter.format(source);
+assertTrue(actual.contains("Markup<br />"));
+assertTrue(actual.contains("<li>list item one</li>"));
+assertTrue(actual.contains("<li>list item 2</li>"));
+assertTrue(actual.contains("> rest"));
+assertFalse(actual.contains("\n"));
+```
+
+* Good, because Junit5 is "common Java knowledge"
+* Bad, because complex assertions tend to get hard to read
+* Bad, because no fluent API
+
+### Hamcrest
+
+Homepage: <http://hamcrest.org/JavaHamcrest/>
+
+* Good, because offers advanced matchers (such as `contains`)
+* Bad, because not full fluent API
+* Bad, because entry barrier is increased
+
+### AssertJ
+
+Homepage: <https://joel-costigliola.github.io/assertj/>
+
+Example:
+
+```java
+assertThat(markdownFormatter.format(source))
+        .contains("Markup<br />")
+        .contains("<li>list item one</li>")
+        .contains("<li>list item 2</li>")
+        .contains("> rest")
+        .doesNotContain("\n");
+```
+
+* Good, because offers fluent assertions
+* Good, because allows partial string testing to focus on important parts
+* Good, because assertions are more readable
+* Bad, because not commonly used
+* Bad, because newcomers have to learn an additional language to express test cases
+* Bad, because entry barrier is increased
+* Bad, because expressions of test cases vary from unit test to unit test
+
+## Links
+
+* German comparison between Hamcrest and AssertJ: <https://www.sigs-datacom.de/uploads/tx_dmjournals/philipp_JS_06_15_gRfN.pdf>

--- a/src/test/java/org/jabref/architecture/MainArchitectureTestsWithArchUnit.java
+++ b/src/test/java/org/jabref/architecture/MainArchitectureTestsWithArchUnit.java
@@ -47,6 +47,11 @@ class MainArchitectureTestsWithArchUnit {
         noClasses().that().resideOutsideOfPackage("org.jabref.gui.icon").should().accessClassesThat().resideInAnyPackage("de.jensd.fx.glyphs", "de.jensd.fx.glyphs.materialdesignicons").check(classes);
     }
 
+    @ArchTest
+    public static void doNotUseAssertJ(JavaClasses classes) {
+        noClasses().should().accessClassesThat().resideInAPackage("org.assertj..").check(classes);
+    }
+
     // "Currently disabled as there is no alternative for the rest of classes who need awt"
     @ArchIgnore
     @ArchTest


### PR DESCRIPTION
When doing #latemob with external contributors, I often get asked, why we don't use [AssertJ](https://joel-costigliola.github.io/assertj/) @AlexanderGirgis @skufer322. This was a result of internal developer discussions, mostly in 2018 and before.

Thus, I thought, it is a good time to add an [ADR](https://adr.github.io/madr/).

Refs https://github.com/JabRef/jabref/pull/6232/commits/b13832575ebfd45df3b5381f5e6e424113bf5714

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
