### PR TITLE
Change blue and red colors in Merge entries dialog in Dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was thrown when adding a save action without a selected formatter in the library properties [#6069](https://github.com/JabRef/jabref/issues/6069)
 - We fixed an issue where JabRef's icon was missing in the Export to clipboard Dialog. [#6286](https://github.com/JabRef/jabref/issues/6286)
 - We fixed an issue when an "Abstract field" was duplicating text, when importing from RIS file (Neurons) [#6065](https://github.com/JabRef/jabref/issues/6065)
-
+- We fixed an issue where the blue and red text colors in the Merge entries dialog were not quite visible [#6334](https://github.com/JabRef/jabref/issues/6334)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
@@ -3,10 +3,10 @@
 }
 
 .text-added {
-    -fx-fill: #4281be;
+    -fx-fill: #54A3F2;
 }
 
 .text-removed {
-    -fx-fill: #fa4251;
+    -fx-fill: #FA5B68;
 }
 

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.css
@@ -3,10 +3,10 @@
 }
 
 .text-added {
-    -fx-fill: blue;
+    -fx-fill: #4281be;
 }
 
 .text-removed {
-    -fx-fill: red;
+    -fx-fill: #fa4251;
 }
 


### PR DESCRIPTION
This PR is related to #6334 (blue text color in the Merge entries dialog in dark theme).
After modifications, the dialog looks like this
![image](https://user-images.githubusercontent.com/34676841/80314055-31c2b980-87ef-11ea-9cef-fc8822993b0d.png)

I have also tried to replace the red color upon @koppor 's comment (located in the aforementioned issue)

- [X] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [X] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
