### PR TITLE
Fix wrong button order (Apply and Cancel) in ManageProtectedTermsDialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed wrong button order (Apply and Cancel) in ManageProtectedTermsDialog.
 - We greatly improved the performance of the overall application and many operations. [#5071](https://github.com/JabRef/jabref/issues/5071)
 - We fixed an issue where sort by priority was broken. [#6222](https://github.com/JabRef/jabref/issues/6222)
 - We fixed an issue where opening a library from the recent libraries menu was not possible. [#5939](https://github.com/JabRef/jabref/issues/5939)

--- a/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.fxml
+++ b/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.fxml
@@ -31,6 +31,6 @@
             </HBox>
         </VBox>
     </content>
-    <ButtonType fx:id="applyButton" buttonData="OK_DONE" text="%Apply" />
+    <ButtonType buttonData="OK_DONE" text="%Save" />
     <ButtonType fx:constant="CANCEL"/>
 </DialogPane>

--- a/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.fxml
+++ b/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.fxml
@@ -31,6 +31,6 @@
             </HBox>
         </VBox>
     </content>
+    <ButtonType fx:id="applyButton" buttonData="OK_DONE" text="%Apply" />
     <ButtonType fx:constant="CANCEL"/>
-    <ButtonType fx:constant="APPLY"/>
 </DialogPane>

--- a/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.java
@@ -3,12 +3,9 @@ package org.jabref.gui.protectedterms;
 import javax.inject.Inject;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
+import javafx.scene.control.*;
 import javafx.scene.control.cell.CheckBoxTableCell;
+import javafx.scene.control.ButtonBar.ButtonData;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.icon.IconTheme;
@@ -48,7 +45,7 @@ public class ManageProtectedTermsDialog extends BaseDialog<Void> {
                   .setAsDialogPane(this);
 
         setResultConverter(button -> {
-            if (button == ButtonType.APPLY) {
+            if (button.getButtonData() == ButtonData.OK_DONE) {
                 viewModel.save();
             }
             return null;

--- a/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/ManageProtectedTermsDialog.java
@@ -3,9 +3,12 @@ package org.jabref.gui.protectedterms;
 import javax.inject.Inject;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.*;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
 import javafx.scene.control.cell.CheckBoxTableCell;
-import javafx.scene.control.ButtonBar.ButtonData;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.icon.IconTheme;
@@ -45,7 +48,7 @@ public class ManageProtectedTermsDialog extends BaseDialog<Void> {
                   .setAsDialogPane(this);
 
         setResultConverter(button -> {
-            if (button.getButtonData() == ButtonData.OK_DONE) {
+            if (button.getButtonData() == ButtonBar.ButtonData.OK_DONE) {
                 viewModel.save();
             }
             return null;


### PR DESCRIPTION
Hi, I noticed that 'manage protected terms files' dialog button order was wrong - 'Apply' was on right side.

![image](https://user-images.githubusercontent.com/20928760/80317348-9be55980-8803-11ea-9ad1-bacb5087c4c6.png)


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
