### PR TITLE
Correcting file name for groups.uml

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,21 +27,22 @@ Without jlink, it is not possible to generate a fat jar any more. During develop
 ## Groups
 
 
-diagram showing aspects of groups: [Groups.uml](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/Groups.uml).
+diagram showing aspects of groups: [Groups.uml](Groups.uml).
 
 ## Decision Records
 
 This log lists the decisions for JabRef.
 
-* [ADR-0000](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
-* [ADR-0001](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0001-use-crowdin-for-translations.md) - Use Crowdin for translations
-* [ADR-0002](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0002-use-slf4j-for-logging.md) - Use slf4j together with log4j2 for logging
-* [ADR-0003](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0003-use-gradle-as-build-tool.md) - Use Gradle as build tool
-* [ADR-0003](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0003-use-openjson-as-replacement-for-org-json.md) - Use openjson as replacement for org.json
-* [ADR-0004](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0004-use-mariadb-connector.md) - Use MariaDB Connector
-* [ADR-0005](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0005-fully-support-utf8-only-for-latex-files.md) - Fully Support UTF-8 Only For LaTeX Files
-* [ADR-0006](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0006-only-translated-strings-in-language-file.md) - Only translated strings in language file
-* [ADR-0007](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/0007-human-readable-changelog.md) - Provide a human-readable changelog
+* [ADR-0000](adr/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+* [ADR-0001](adr/0001-use-crowdin-for-translations.md) - Use Crowdin for translations
+* [ADR-0002](adr/0002-use-slf4j-for-logging.md) - Use slf4j together with log4j2 for logging
+* [ADR-0003](adr/0003-use-gradle-as-build-tool.md) - Use Gradle as build tool
+* [ADR-0004](adr/0004-use-mariadb-connector.md) - Use MariaDB Connector
+* [ADR-0005](adr/0005-fully-support-utf8-only-for-latex-files.md) - Fully Support UTF-8 Only For LaTeX Files
+* [ADR-0006](adr/0006-only-translated-strings-in-language-file.md) - Only translated strings in language file
+* [ADR-0007](adr/0007-human-readable-changelog.md) - Provide a human-readable changelog
+* [ADR-0008](adr/0008-use-public-final-instead-of-getters.md) - Use public final instead of getters to offer access to immutable variables
+* [ADR-0009](adr/0009-use-plain-junit5-for-testing.md) - Use Plain JUnit5 for advanced test assertions
 
-For new ADRs, please use [docs/template.md](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/docs/template.md) as basis. More information on MADR is available at [https://adr.github.io/madr/](https://adr.github.io/madr/). General information about architectural decision records is available at [https://adr.github.io/](https://adr.github.io/).
+For new ADRs, please use [template.md](adr/template.md) as basis. More information on MADR is available at [https://adr.github.io/madr/](https://adr.github.io/madr/). General information about architectural decision records is available at [https://adr.github.io/](https://adr.github.io/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,8 @@ Without jlink, it is not possible to generate a fat jar any more. During develop
 
 ## Groups
 
-UML diagram showing aspects of groups: [Groups.uml](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/Gropus.uml).
+
+diagram showing aspects of groups: [Groups.uml](https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/Groups.uml).
 
 ## Decision Records
 


### PR DESCRIPTION
Following message at https://discourse.jabref.org/t/github-documentation-uml-diagram-link-broken/2048 , fixing the file name.

Note: several links are in the form https://github.com/JabRef/jabref/tree/ec47f2138b0550a4622872d455902443cd56d9cc/docs/Groups.uml
Why not something like  https://github.com/JabRef/jabref/blob/master/docs/Groups.uml ?
