### PR TITLE
Fix library sort order get lost

### DIFF
--- a/src/main/java/org/jabref/model/metadata/SaveOrderConfig.java
+++ b/src/main/java/org/jabref/model/metadata/SaveOrderConfig.java
@@ -81,7 +81,9 @@ public class SaveOrderConfig {
         }
         if (o instanceof SaveOrderConfig) {
             SaveOrderConfig that = (SaveOrderConfig) o;
-            return Objects.equals(sortCriteria, that.sortCriteria) && Objects.equals(saveInOriginalOrder, that.saveInOriginalOrder);
+            return Objects.equals(sortCriteria, that.sortCriteria) && 
+            Objects.equals(saveInOriginalOrder, that.saveInOriginalOrder) && 
+            Objects.equals(saveInSpecifiedOrder, that.saveInSpecifiedOrder);
         }
         return false;
     }


### PR DESCRIPTION
This PR fixes #6091

Co-authored-by: Heriniaina Randrianasolo <hjsrandrianasolo@gmail.com>
Co-authored-by: Omar Tachour <omar.tchr@hotmail.com>
Co-authored-by: Sadji Micipsa <micipsasadji@gmail.com>

This error is due to the absence of an object equality test for the saveInSpecifiedOrder attribute. 
So we have  handled this error by correcting the equals function in the SaveOrderConfig class. 

- [ ] Change in CHANGELOG.md described (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
