### PR TITLE
Fix jstyle was invalid with default section at the start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We changed the buttons for import/export/show all/reset of preferences to smaller icon buttons in the preferences dialog. [#6130](https://github.com/JabRef/jabref/pull/6130)
 - We moved the functionality "Manage field names & content" from the "Library" menu to the "Edit" menu, because it affects the selected entries and not the whole library
 - We merged the functionality "Append contents from a BibTeX library into the currently viewed library" into the "Import into database" functionality. Fixes [#6049](https://github.com/JabRef/jabref/issues/6049).
+- We improved the error message for invalid jstyles. [#6303](https://github.com/JabRef/jabref/issues/6303)
 
 ### Fixed
 
@@ -40,12 +41,12 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where custom jstyles for Open/LibreOffice where not saved correctly. [#6170](https://github.com/JabRef/jabref/issues/6170)
 - We fixed an issue where the INSPIRE fetcher was no longer working [#6229](https://github.com/JabRef/jabref/issues/6229)
 - We fixed an issue where custom exports with an uppercase file extension could not be selected for "Copy...-> Export to Clipboard" [#6285](https://github.com/JabRef/jabref/issues/6285)
-
 - We fixed the display of icon both in the main table and linked file editor. [#6169](https://github.com/JabRef/jabref/issues/6169)
 - We fixed the paste entry command in the menu and toolbar, that did not do anything. [#6293](https://github.com/JabRef/jabref/issues/6293)
 - We fixed an issue where the windows installer did not create an entry in the start menu [bug report in the forum](https://discourse.jabref.org/t/error-while-fetching-from-doi/2018/3)
 - We fixed an issue where JabRef switched to discrete graphics under macOS [#5935](https://github.com/JabRef/jabref/issues/5935)
 - We fixed an issue where the Preferences entry preview will be unexpected modified leads to Value too long exception [#6198](https://github.com/JabRef/jabref/issues/6198)
+- We fixed an issue where custom jstyles for Open/LibreOffice would only be valid if a layout line for the entry type `default` was at the end of the layout section [#6303](https://github.com/JabRef/jabref/issues/6303)
 
 ### Removed
 

--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -31,6 +31,9 @@ eclipse {
                 def javafxgraphics = entries.find { isJavafxGraphics(it) };
                 javafxgraphics.entryAttributes['add-opens'] = 'javafx.graphics/javafx.scene=org.controlsfx.controls';
 
+                def javafxfxml = entries.find { isJavafxFXML(it) };
+                javafxfxml.entryAttributes['add-opens'] = 'javafx.fxml/javafx.fxml=org.jabref';
+
                 def graaltruffle = entries.find{ isTruffleGraal(it) } ;
                 graaltruffle.entryAttributes['add-exports'] = 'com.oracle.truffle.regex/com.oracle.truffle.regex=org.graalvm.truffle';
 
@@ -60,6 +63,8 @@ boolean isControlsfx(entry) { return entry.properties.path.contains('controlsfx'
 boolean isJavafxControls(entry) { return entry.properties.path.contains('javafx-controls'); }
 
 boolean isJavafxGraphics(entry) { return entry.properties.path.contains('javafx-graphics'); }
+
+boolean isJavafxFXML(entry) { return entry.properties.path.contains('javafx-fxml'); }
 
 boolean isTruffleGraal(entry)  {return entry.properties.path.contains('org.graalvm.regex'); }
 

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -71,7 +71,7 @@ public class StyleSelectDialogViewModel {
                 styles.setAll(loadStyles());
                 selectedItem.setValue(getStyleOrDefault(stylePath));
             } else {
-                dialogService.showErrorDialogAndWait(Localization.lang("Invalid style selected"), Localization.lang("You must select a valid style file."));
+                dialogService.showErrorDialogAndWait(Localization.lang("Invalid style selected"), Localization.lang("You must select a valid style file. Your style is probably missing a line for the type \"default\"."));
             }
         });
     }

--- a/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOBibStyle.java
@@ -125,7 +125,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private boolean isDefaultLayoutPresent;
 
     public OOBibStyle(File styleFile, LayoutFormatterPreferences prefs,
-            Charset encoding) throws IOException {
+                      Charset encoding) throws IOException {
         this.prefs = Objects.requireNonNull(prefs);
         this.styleFile = Objects.requireNonNull(styleFile);
         this.encoding = Objects.requireNonNull(encoding);
@@ -281,46 +281,46 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
             }
             // Check if we should change mode:
             switch (line) {
-            case NAME_MARK:
-                mode = BibStyleMode.NAME;
-                continue;
-            case LAYOUT_MRK:
-                mode = BibStyleMode.LAYOUT;
-                continue;
-            case PROPERTIES_MARK:
-                mode = BibStyleMode.PROPERTIES;
-                continue;
-            case CITATION_MARK:
-                mode = BibStyleMode.CITATION;
-                continue;
-            case JOURNALS_MARK:
-                mode = BibStyleMode.JOURNALS;
-                continue;
-            default:
-                break;
+                case NAME_MARK:
+                    mode = BibStyleMode.NAME;
+                    continue;
+                case LAYOUT_MRK:
+                    mode = BibStyleMode.LAYOUT;
+                    continue;
+                case PROPERTIES_MARK:
+                    mode = BibStyleMode.PROPERTIES;
+                    continue;
+                case CITATION_MARK:
+                    mode = BibStyleMode.CITATION;
+                    continue;
+                case JOURNALS_MARK:
+                    mode = BibStyleMode.JOURNALS;
+                    continue;
+                default:
+                    break;
 
             }
 
             switch (mode) {
-            case NAME:
-                if (!line.trim().isEmpty()) {
-                    name = line.trim();
-                }
-                break;
-            case LAYOUT:
-                handleStructureLine(line);
-                break;
-            case PROPERTIES:
-                handlePropertiesLine(line, properties);
-                break;
-            case CITATION:
-                handlePropertiesLine(line, citProperties);
-                break;
-            case JOURNALS:
-                handleJournalsLine(line);
-                break;
-            default:
-                break;
+                case NAME:
+                    if (!line.trim().isEmpty()) {
+                        name = line.trim();
+                    }
+                    break;
+                case LAYOUT:
+                    handleStructureLine(line);
+                    break;
+                case PROPERTIES:
+                    handlePropertiesLine(line, properties);
+                    break;
+                case CITATION:
+                    handlePropertiesLine(line, citProperties);
+                    break;
+                case JOURNALS:
+                    handleJournalsLine(line);
+                    break;
+                default:
+                    break;
             }
 
         }
@@ -349,12 +349,14 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private void handleStructureLine(String line) {
         int index = line.indexOf('=');
         if ((index > 0) && (index < (line.length() - 1))) {
-            String formatString = line.substring(index + 1);
-            isDefaultLayoutPresent = line.substring(0, index).equals(OOBibStyle.DEFAULT_MARK);
-            EntryType type = EntryTypeFactory.parse(line.substring(0, index));
+
             try {
+                String formatString = line.substring(index + 1);
                 Layout layout = new LayoutHelper(new StringReader(formatString), this.prefs).getLayoutFromText();
-                if (isDefaultLayoutPresent) {
+                EntryType type = EntryTypeFactory.parse(line.substring(0, index));
+
+                if (!isDefaultLayoutPresent && line.substring(0, index).equals(OOBibStyle.DEFAULT_MARK)) {
+                    isDefaultLayoutPresent = true;
                     defaultBibLayout = layout;
                 } else {
                     bibLayout.put(type, layout);
@@ -493,7 +495,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      * @return The formatted citation.
      */
     public String getCitationMarker(List<BibEntry> entries, Map<BibEntry, BibDatabase> database, boolean inParenthesis,
-            String[] uniquefiers, int[] unlimAuthors) {
+                                    String[] uniquefiers, int[] unlimAuthors) {
         // Look for groups of uniquefied entries that should be combined in the output.
         // E.g. (Olsen, 2005a, b) should be output instead of (Olsen, 2005a; Olsen, 2005b).
         int piv = -1;
@@ -515,20 +517,20 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
                     if (piv == -1) {
                         piv = i;
                         tmpMarker = getAuthorYearParenthesisMarker(Collections.singletonList(currentEntry), database,
-                                null, unlimAuthors);
+                                                                   null, unlimAuthors);
                     } else {
                         // See if this entry can go into a group with the previous one:
                         String thisMarker = getAuthorYearParenthesisMarker(Collections.singletonList(currentEntry),
-                                database, null, unlimAuthors);
+                                                                           database, null, unlimAuthors);
 
                         String authorField = getStringCitProperty(AUTHOR_FIELD);
                         int maxAuthors = getIntCitProperty(MAX_AUTHORS);
                         String author = getCitationMarkerField(currentEntry, database.get(currentEntry),
-                                authorField);
+                                                               authorField);
                         AuthorList al = AuthorList.parse(author);
                         int prevALim = unlimAuthors[i - 1]; // i always at least 1 here
                         if (!thisMarker.equals(tmpMarker)
-                                || ((al.getNumberOfAuthors() > maxAuthors) && (unlimAuthors[i] != prevALim))) {
+                            || ((al.getNumberOfAuthors() > maxAuthors) && (unlimAuthors[i] != prevALim))) {
                             // No match. Update piv to exclude the previous entry. But first check if the
                             // previous entry was part of a group:
                             if ((piv > -1) && (i > (piv + 1))) {
@@ -584,11 +586,11 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      * @return The formatted citation.
      */
     private String getAuthorYearParenthesisMarker(List<BibEntry> entries, Map<BibEntry, BibDatabase> database,
-            String[] uniquifiers, int[] unlimAuthors) {
+                                                  String[] uniquifiers, int[] unlimAuthors) {
 
         String authorField = getStringCitProperty(AUTHOR_FIELD); // The bibtex field providing author names, e.g. "author" or "editor".
         int maxA = getIntCitProperty(MAX_AUTHORS); // The maximum number of authors to write out in full without using etal. Set to
-                                                             // -1 to always write out all authors.
+                                                   // -1 to always write out all authors.
         String yearSep = getStringCitProperty(YEAR_SEPARATOR); // The String to separate authors from year, e.g. "; ".
         String startBrace = getStringCitProperty(BRACKET_BEFORE); // The opening parenthesis.
         String endBrace = getStringCitProperty(BRACKET_AFTER); // The closing parenthesis.
@@ -637,11 +639,11 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      * @return The formatted citation.
      */
     private String getAuthorYearInTextMarker(List<BibEntry> entries, Map<BibEntry, BibDatabase> database,
-            String[] uniquefiers,
-            int[] unlimAuthors) {
+                                             String[] uniquefiers,
+                                             int[] unlimAuthors) {
         String authorField = getStringCitProperty(AUTHOR_FIELD); // The bibtex field providing author names, e.g. "author" or "editor".
         int maxA = getIntCitProperty(MAX_AUTHORS); // The maximum number of authors to write out in full without using etal. Set to
-                                                             // -1 to always write out all authors.
+                                                   // -1 to always write out all authors.
         String yearSep = getStringCitProperty(IN_TEXT_YEAR_SEPARATOR); // The String to separate authors from year, e.g. "; ".
         String startBrace = getStringCitProperty(BRACKET_BEFORE); // The opening parenthesis.
         String endBrace = getStringCitProperty(BRACKET_AFTER); // The closing parenthesis.
@@ -865,9 +867,9 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         if (o instanceof OOBibStyle) {
             OOBibStyle otherStyle = (OOBibStyle) o;
             return Objects.equals(path, otherStyle.path)
-                    && Objects.equals(name, otherStyle.name)
-                    && Objects.equals(citProperties, otherStyle.citProperties)
-                    && Objects.equals(properties, otherStyle.properties);
+                   && Objects.equals(name, otherStyle.name)
+                   && Objects.equals(citProperties, otherStyle.citProperties)
+                   && Objects.equals(properties, otherStyle.properties);
         }
         return false;
     }
@@ -878,7 +880,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     }
 
     private String createAuthorList(String author, int maxAuthors, String andString,
-            String yearSep) {
+                                    String yearSep) {
         Objects.requireNonNull(author);
         String etAlString = getStringCitProperty(ET_AL_STRING); //  The String to represent authors that are not mentioned, e.g. " et al."
         String authorSep = getStringCitProperty(AUTHOR_SEPARATOR); // The String to add between author names except the last two, e.g. ", ".

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1402,7 +1402,7 @@ Internal\ style=Internal style
 Add\ style\ file=Add style file
 Current\ style\ is\ '%0'=Current style is '%0'
 Remove\ style=Remove style
-You\ must\ select\ a\ valid\ style\ file.=You must select a valid style file.
+You\ must\ select\ a\ valid\ style\ file.\ Your\ style\ is\ probably\ missing\ a\ line\ for\ the\ type\ "default".=You must select a valid style file. Your style is probably missing a line for the type "default".
 Invalid\ style\ selected=Invalid style selected
 
 Reload=Reload

--- a/src/test/java/org/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/OOBibStyleTest.java
@@ -490,7 +490,7 @@ class OOBibStyleTest {
     }
 
     @Test
-    void testEmptyStringPropertyAndOxfordComma() throws URISyntaxException, IOException {
+    void testEmptyStringPropertyAndOxfordComma() throws Exception {
         OOBibStyle style = new OOBibStyle("test.jstyle", layoutFormatterPreferences);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -506,5 +506,12 @@ class OOBibStyleTest {
         entryDBMap.put(entry, database);
         assertEquals("von Beta, Epsilon, & Tau, 2016",
                 style.getCitationMarker(entries, entryDBMap, true, null, null));
+    }
+
+    @Test
+    void testIsValidWithDefaultSectionAtTheStart() throws Exception
+    {
+        OOBibStyle style = new OOBibStyle("testWithDefaultAtFirstLIne.jstyle", layoutFormatterPreferences);
+        assertTrue(style.isValid());
     }
 }

--- a/src/test/resources/org/jabref/logic/openoffice/testWithDefaultAtFirstLIne.jstyle
+++ b/src/test/resources/org/jabref/logic/openoffice/testWithDefaultAtFirstLIne.jstyle
@@ -1,0 +1,44 @@
+# Test .jstyle-file
+
+NAME
+Style file for tests.
+
+JOURNALS
+Journal name 1
+Journal name 2
+
+PROPERTIES
+Title="References"
+IsSortByPosition="true"
+IsNumberEntries="true"
+ReferenceParagraphFormat="Text body"
+ReferenceHeaderParagraphFormat="Heading 2"
+
+CITATION
+BracketBefore=""
+BracketAfter=""
+BracketBeforeInList="["
+BracketAfterInList="] "
+CitationSeparator="; "
+UniquefierSeparator=","
+GroupedNumbersSeparator="-"
+MinimumGroupingCount="3"
+FormatCitations="false"
+CitationCharacterFormat="Default"
+PageInfoSeparator="; "
+OxfordComma=","
+
+LAYOUT
+
+default=\format[Authors(LastFirst,Semicolon)]{\author} (<b>\year\uniq</b>). <i>\title</i>, \journal \volume\begin{pages} : \format[FormatPagesForHTML]{\pages}\end{pages}.
+
+article=<b>\format[Authors(LastFirst,Semicolon)]{\author}</b> (<b>\year\uniq</b>). <i>\title</i>, \journal \volume\begin{pages} : \format[FormatPagesForHTML]{\pages}\end{pages}.
+
+book=\format[Authors(LastFirst,Semicolon)]{\author}\begin{editor}\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor} (Ed.)\end{editor}, <b>\year\uniq</b>. <i>\title</i>. \publisher, \address.
+
+incollection=\format[Authors(LastFirst,Semicolon)]{\author} (<b>\year\uniq</b>). <i>\title</i>. In: \format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor} (Ed.), <i>\booktitle</i>, \publisher.
+
+inbook=\format[Authors(LastFirst,Semicolon)]{\author} (<b>\year\uniq</b>). <i>\chapter</i>. In: \format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor} (Ed.), <i>\title</i>, \publisher.
+
+phdthesis=\format[Authors(LastFirst,Semicolon)]{\author} (<b>\year\uniq</b>). <i>\title</i>, \school.
+


### PR DESCRIPTION
Fixes #6303
Adapted the error message to give a hint what is probably missing.

I also noticed a problem in eclipse when executing the L10n test. It was missing an add-opens

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
