### PR TITLE
Docs: For developers: New architectural decision added to list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This page presents all development informatation around JabRef. For users documentation see [https://docs.jabref.org](https://docs.jabref.org).
 
-## Teaching Excersises
+## Teaching Exercises
 
 We are very happy that JabRef is part of [Software Engineering](https://en.wikipedia.org/wiki/Software_engineering) trainings.
 Please head to [Teaching](teaching.md) for more information on using JabRef as teaching object and on previous courses where JabRef was used.
@@ -26,8 +26,7 @@ Without jlink, it is not possible to generate a fat jar any more. During develop
 
 ## Groups
 
-
-diagram showing aspects of groups: [Groups.uml](Groups.uml).
+Diagram showing aspects of groups: [Groups.uml](Groups.uml).
 
 ## Decision Records
 
@@ -43,6 +42,7 @@ This log lists the decisions for JabRef.
 * [ADR-0007](adr/0007-human-readable-changelog.md) - Provide a human-readable changelog
 * [ADR-0008](adr/0008-use-public-final-instead-of-getters.md) - Use public final instead of getters to offer access to immutable variables
 * [ADR-0009](adr/0009-use-plain-junit5-for-testing.md) - Use Plain JUnit5 for advanced test assertions
+* [ADR-0010](0010-use-h2-as-internal-database.md) - Use H2 as Internal SQL Database
 
 For new ADRs, please use [template.md](adr/template.md) as basis. More information on MADR is available at [https://adr.github.io/madr/](https://adr.github.io/madr/). General information about architectural decision records is available at [https://adr.github.io/](https://adr.github.io/).
 


### PR DESCRIPTION
Adding a recent architectural decision added to their list. 

Maybe there is an easy way to have this list being maintained automatically? 
Otherwise, I am afraid the list may be incomplete most of the time (the numbering is designed to go up to 9999 :wink: )

and some typo.
