### PR TITLE
Fixed an issue in Group validation: Convert error dialogs to checkers

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -86,6 +86,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         final Button confirmDialogButton = (Button) getDialogPane().lookupButton(ButtonType.OK);
         // handle validation before closing dialog and calling resultConverter
         confirmDialogButton.addEventFilter(ActionEvent.ACTION, viewModel::validationHandler);
+        getDialogPane().lookupButton(ButtonType.OK).setDisable(true);
     }
 
     @FXML
@@ -134,7 +135,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
         validationVisualizer.setDecoration(new IconValidationDecorator());
         Platform.runLater(() -> {
-            validationVisualizer.initVisualization(viewModel.nameValidationStatus(), nameField);
+            validationVisualizer.initVisualization(viewModel.nameValidationStatus(), nameField, true);
             validationVisualizer.initVisualization(viewModel.nameContainsDelimiterValidationStatus(), nameField, false);
             validationVisualizer.initVisualization(viewModel.sameNameValidationStatus(), nameField);
             validationVisualizer.initVisualization(viewModel.searchRegexValidationStatus(), searchGroupSearchTerm);


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes https://github.com/JabRef/jabref/issues/6221

In the Add subgroup Dialog the name field is now mandatory. I also disabled the dialog validation with the error message, because the dialog was duplicate and I tried to kept consistency in the dialogs app (like the SharedDatabaseLogin).
Now the Group Dialog View only activates OK button when the user writes something.



<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
