### PR TITLE
Merge identical group colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
 - We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
 - We fixed an issue that merging idnetical colors. [#6175](https://github.com/JabRef/jabref/issues/6175)
+=======
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where citation styles except the default "Preview" could not be used. [#56220](https://github.com/JabRef/jabref/issues/5622)
 - We fixed an issue where a warning was displayed when the title content is made up of two sentences. [#5832](https://github.com/JabRef/jabref/issues/5832)
 - We fixed an issue where an exception was thrown when adding a save action without a selected formatter in the library properties [#6069](https://github.com/JabRef/jabref/issues/6069)
+- We fixed an issue that merging idnetical colors. [#6175](https://github.com/JabRef/jabref/issues/6175)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
 - We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
 - We fixed an issue that merging idnetical colors. [#6175](https://github.com/JabRef/jabref/issues/6175)
-=======
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where citation styles except the default "Preview" could not be used. [#56220](https://github.com/JabRef/jabref/issues/5622)
 - We fixed an issue where a warning was displayed when the title content is made up of two sentences. [#5832](https://github.com/JabRef/jabref/issues/5832)
 - We fixed an issue where an exception was thrown when adding a save action without a selected formatter in the library properties [#6069](https://github.com/JabRef/jabref/issues/6069)
+- We fixed an issue where JabRef's icon was missing in the Export to clipboard Dialog. [#6286](https://github.com/JabRef/jabref/issues/6286)
+- We fixed an issue when an "Abstract field" was duplicating text, when importing from RIS file (Neurons) [#6065](https://github.com/JabRef/jabref/issues/6065)
+- We fixed an issue where adding the addition of a new entry was not completely validated [#6370](https://github.com/JabRef/jabref/issues/6370)
+- We fixed an issue where the blue and red text colors in the Merge entries dialog were not quite visible [#6334](https://github.com/JabRef/jabref/issues/6334)
+- We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
+- We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
 - We fixed an issue that merging idnetical colors. [#6175](https://github.com/JabRef/jabref/issues/6175)
 
 ### Removed

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -2,10 +2,12 @@ package org.jabref.gui.maintable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
@@ -180,15 +182,40 @@ class MainTableColumnFactory {
             container.setAlignment(Pos.CENTER_LEFT);
             container.setPadding(new Insets(0, 2, 0, 2));
 
-            for (Color groupColor : groupColors) {
+            /*for (Color groupColor : groupColors) {
+                    Rectangle groupRectangle = new Rectangle();
+                    groupRectangle.getStyleClass().add("groupColumnBackground");
+                    groupRectangle.setWidth(3);
+                    groupRectangle.setHeight(18);
+                    groupRectangle.setFill(groupColor);
+                    groupRectangle.setStrokeWidth(1);
+
+                    container.getChildren().add(groupRectangle);
+            }*/
+            if (groupColors.size() == 1) {
                 Rectangle groupRectangle = new Rectangle();
                 groupRectangle.getStyleClass().add("groupColumnBackground");
                 groupRectangle.setWidth(3);
                 groupRectangle.setHeight(18);
-                groupRectangle.setFill(groupColor);
+                groupRectangle.setFill(groupColors.get(0));
                 groupRectangle.setStrokeWidth(1);
 
                 container.getChildren().add(groupRectangle);
+            } else {
+                Set < Color > colorSet = new HashSet<>();
+                for (Color groupColor : groupColors) {
+                    if (!colorSet.contains(groupColor)) {
+                        Rectangle groupRectangle = new Rectangle();
+                        groupRectangle.getStyleClass().add("groupColumnBackground");
+                        groupRectangle.setWidth(3);
+                        groupRectangle.setHeight(18);
+                        groupRectangle.setFill(groupColor);
+                        groupRectangle.setStrokeWidth(1);
+
+                        container.getChildren().add(groupRectangle);
+                        colorSet.add(groupColor);
+                    }
+                }
             }
 
             String matchedGroupsString = matchedGroups.stream()


### PR DESCRIPTION
We fixed an issue that merging identical colors. [#6175](https://github.com/JabRef/jabref/issues/6175)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
