### PR TITLE
Add launcher to fix extension import in snap

### DIFF
--- a/snap/local/JabRef-launcher
+++ b/snap/local/JabRef-launcher
@@ -1,0 +1,3 @@
+#! /bin/sh
+DIR="$SNAP/lib/runtime/bin"
+"$DIR/java"  -p "$DIR/../app" -m org.jabref/org.jabref.JabRefLauncher  "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,3 +57,12 @@ parts:
       snapcraftctl build
       snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/JabRef.cfg | grep "app.version=" | cut -d'=' -f2)"
       sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/native-messaging-host/*/org.jabref.jabref.json
+      rm $SNAPCRAFT_PART_INSTALL/bin/JabRef
+  jabref-launcher:
+    after:
+      - jabref
+    source: snap/local
+    source-type: local
+    plugin: dump
+    organize:
+      JabRef-launcher: bin/JabRef


### PR DESCRIPTION
Fixes #5537 and https://github.com/JabRef/JabRef-Browser-Extension/issues/165
Add a separate launcher to avoid launching another instance of jabref, removing the list of errors that come from parsing the cli options (as viewed on gitter in https://paste.ubuntu.com/p/YXkqWVr9mz/)

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
