### PR TITLE
add concise message when SaveException happen

### DIFF
--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -236,7 +236,7 @@ public class SaveDatabaseAction {
         } catch (UnsupportedCharsetException ex) {
             throw new SaveException(Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()), ex);
         } catch (IOException ex) {
-            throw new SaveException("Problems saving:", ex);
+            throw new SaveException("Problems saving:" + ex, ex);
         }
 
         return true;

--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -236,7 +236,7 @@ public class SaveDatabaseAction {
         } catch (UnsupportedCharsetException ex) {
             throw new SaveException(Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()), ex);
         } catch (IOException ex) {
-            throw new SaveException("Problems saving:" + ex, ex);
+            throw new SaveException("Problems saving: " + ex, ex);
         }
 
         return true;


### PR DESCRIPTION
add concise message when SaveException happen. To fix https://github.com/JabRef/jabref/issues/6127

When SaveException happen (e.g. braces not match in any field) when saving, no consise message about what's wrong, I added the consise message of the SaveException to the popup window. 
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Screenshots:
Before:
![image](https://user-images.githubusercontent.com/898436/76709297-16e42c00-66fe-11ea-9b28-6dba43ce047f.png)
After: 
![image](https://user-images.githubusercontent.com/5562899/81355868-5b8ab300-9102-11ea-9575-b312f3e28523.png)

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
