### PR TITLE
Fix updating File annotation tab immediately

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -283,6 +283,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         case MOVE:
                             LOGGER.debug("Mode MOVE"); //alt on win
                             importHandler.getLinker().moveFilesToFileDirAndAddToEntry(entry, files);
+                            panel.getEntryEditor().setEntry(entry);
                             break;
                         case COPY:
                             LOGGER.debug("Mode Copy"); //ctrl on win


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #5633 

Hi, I find a way to fix this bug, that is set the new entry after the file is attach. But don't konw whether it is proper.

Adding one code in **MainTable.java** to set entry, thus it can show **File annotaion** tab immediately after dragging.

Below is an example.

![JabRef-FileAnnotation](https://user-images.githubusercontent.com/49422929/81367514-0c537b00-9120-11ea-9587-f29b62041dc2.gif)

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
