### PR TITLE
Fix autocomplete thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the Preferences entry preview will be unexpected modified leads to Value too long exception [#6198](https://github.com/JabRef/jabref/issues/6198)
 - We fixed an issue where custom jstyles for Open/LibreOffice would only be valid if a layout line for the entry type `default` was at the end of the layout section [#6303](https://github.com/JabRef/jabref/issues/6303)
 - We fixed an issue where sort on numeric cases was broken. [#6349](https://github.com/JabRef/jabref/issues/6349)
-
+- We fixed an issue where an "Not on FX thread" exception occured when saving on linux [#6453](https://github.com/JabRef/jabref/issues/6453)
 
 ### Removed
 

--- a/build.gradle
+++ b/build.gradle
@@ -543,7 +543,7 @@ task deleteInstallerTemp(type: Delete) {
 
 jpackage.dependsOn deleteInstallerTemp
 jlink {
-    options = ['--strip-debug','--compress', '2', '--no-header-files', '--no-man-pages']
+    options = ['--compress', '2', '--no-header-files', '--no-man-pages']
     launcher {
         name = 'JabRef'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -543,7 +543,7 @@ task deleteInstallerTemp(type: Delete) {
 
 jpackage.dependsOn deleteInstallerTemp
 jlink {
-    options = ['--compress', '2', '--no-header-files', '--no-man-pages']
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
     launcher {
         name = 'JabRef'
     }

--- a/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -33,6 +33,8 @@ import javafx.scene.control.TextInputControl;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
 
+import org.jabref.gui.util.DefaultTaskExecutor;
+
 import org.controlsfx.control.textfield.AutoCompletionBinding;
 
 /**
@@ -98,7 +100,7 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
     }
 
     private static <T> StringConverter<T> defaultStringConverter() {
-        return new StringConverter<T>() {
+        return new StringConverter<>() {
             @Override
             public String toString(T t) {
                 return t == null ? null : t.toString();
@@ -133,7 +135,7 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
             newText = "";
         }
         AutoCompletionInput input = inputAnalyzer.analyze(newText);
-        setUserInput(input.getUnfinishedPart());
+        DefaultTaskExecutor.runInJavaFXThread(() -> setUserInput(input.getUnfinishedPart()));
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -33,10 +33,12 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         ((ContextMenuAddable) textInput).addToContextMenu(EditorMenus.getDefaultMenu(textInput));
         this.getChildren().add(textInput);
 
-        AutoCompletionTextInputBinding<?> autoCompleter = AutoCompletionTextInputBinding.autoComplete(textInput, viewModel::complete, viewModel.getAutoCompletionStrategy());
-        if (suggestionProvider instanceof ContentSelectorSuggestionProvider) {
-            // If content selector values are present, then we want to show the auto complete suggestions immediately on focus
-            autoCompleter.setShowOnFocus(true);
+        if (!isMultiLine) {
+            AutoCompletionTextInputBinding<?> autoCompleter = AutoCompletionTextInputBinding.autoComplete(textInput, viewModel::complete, viewModel.getAutoCompletionStrategy());
+            if (suggestionProvider instanceof ContentSelectorSuggestionProvider) {
+                // If content selector values are present, then we want to show the auto complete suggestions immediately on focus
+                autoCompleter.setShowOnFocus(true);
+            }
         }
 
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textInput);


### PR DESCRIPTION

Fixes #6453
The autcomplete binding was triggered when a cleanup called setBibEntry from a background thread.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
