### PR TITLE
Fix bracket collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where sort on numeric cases was broken. [#6349](https://github.com/JabRef/jabref/issues/6349)
 - We fixed an issue where an "Not on FX thread" exception occured when saving on linux [#6453](https://github.com/JabRef/jabref/issues/6453)
 - We fixed an issue where the library sort order was lost. [#6091](https://github.com/JabRef/jabref/issues/6091)
+- We fixed an issue where brackets in regular expressions were not working. [6469](https://github.com/JabRef/jabref/pull/6469)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -127,11 +127,15 @@ public class BracketedPattern {
                     // FIXME: else -> raise exception or log? (S.G.)
                 } else {
                     if ("[".equals(token)) {
+                        Boolean foundClosingBracket = false;
                         // Fetch the next token after the '[':
                         token = st.nextToken();
-                        Boolean foundClosingBracket = false;
+                        if ("]".equals(token)) {
+                            LOGGER.warn("Found empty brackets \"[]\" in '" + pattern + "'");
+                            foundClosingBracket = true;
+                        }
                         // make sure to read until the next ']'
-                        while (st.hasMoreTokens()) {
+                        while (st.hasMoreTokens() && !foundClosingBracket) {
                             String subtoken = st.nextToken();
                             // I the beginning of a quote is found, include the content in the original token
                             if ("\"".equals(subtoken)) {

--- a/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
@@ -241,4 +241,10 @@ class BracketedPatternTest {
         assertEquals("2003-JabRef Science",
                 BracketedPattern.expandBrackets("[year]-[journal:regex(\"Organization\",\"JabRef\")]", ';', dbentry, database));
     }
+
+    @Test
+    void regularExpressionWithBrackets() {
+        assertEquals("2003-JabRef Science",
+                BracketedPattern.expandBrackets("[year]-[journal:regex(\"[OX]rganization\",\"JabRef\")]", ';', dbentry, database));
+    }
 }

--- a/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
@@ -247,4 +247,10 @@ class BracketedPatternTest {
         assertEquals("2003-JabRef Science",
                 BracketedPattern.expandBrackets("[year]-[journal:regex(\"[OX]rganization\",\"JabRef\")]", ';', dbentry, database));
     }
+
+    @Test
+    void testEmptyBrackets() {
+        assertEquals("2003-Organization Science",
+                BracketedPattern.expandBrackets("[year][]-[journal]", ';', dbentry, database));
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Brackets in regular expressions were interpreted as brackets for fields. This change allows users to define regular expressions that contain brackets. This led to an exception before.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [X] Change in CHANGELOG.md described (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
