### PR TITLE
Add some javadoc and fix the preview update issue

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -73,11 +73,22 @@ public class EntryEditor extends BorderPane {
     private final BibDatabaseContext databaseContext;
     private final EntryEditorPreferences entryEditorPreferences;
     private final ExternalFilesEntryLinker fileLinker;
+    /*
+    * Tabs which can apply filter, but seems non-sense
+    * */
     private final List<EntryEditorTab> tabs;
     private Subscription typeSubscription;
-    private BibEntry entry;  // A reference to the entry this editor works on.
+    /*
+    * A reference to the entry this editor works on.
+    * */
+    private BibEntry entry;
     private SourceTab sourceTab;
+
+    /*
+    * tabs to be showed in GUI
+    * */
     @FXML private TabPane tabbed;
+
     @FXML private Button typeChangeButton;
     @FXML private Button fetcherButton;
     @FXML private Label typeLabel;

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
@@ -49,6 +49,13 @@ import org.fxmisc.richtext.model.StyleSpansBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class is Preferences -> Entry Preview tab model
+ * <p>
+ *     {@link PreviewTabView} is the controller of Entry Preview tab
+ * </p>
+ * @see PreviewTabView
+ * */
 public class PreviewTabViewModel implements PreferenceTabViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PreviewTabViewModel.class);
@@ -60,6 +67,9 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty showAsExtraTab = new SimpleBooleanProperty(false);
     private final BooleanProperty selectedIsEditableProperty = new SimpleBooleanProperty(false);
     private final ObjectProperty<PreviewLayout> layoutProperty = new SimpleObjectProperty<>();
+    /*
+    * A local variable to store the preview text in \n format instead of _NEWLINE_
+    * */
     private final StringProperty sourceTextProperty = new SimpleStringProperty("");
 
     private final DialogService dialogService;

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -115,6 +115,10 @@ public class PreviewPanel extends VBox {
         }
     }
 
+    private void updateLayoutByPreferences(JabRefPreferences preferences) {
+        previewView.setLayout(preferences.getPreviewPreferences().getCurrentPreviewStyle());
+    }
+
     private void createKeyBindings() {
         previewView.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             Optional<KeyBinding> keyBinding = keyBindingRepository.mapToKeyBinding(event);
@@ -153,6 +157,7 @@ public class PreviewPanel extends VBox {
     }
 
     public void setEntry(BibEntry entry) {
+        updateLayoutByPreferences(preferences);
         this.entry = entry;
         previewView.setEntry(entry);
     }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #6447 

I have taken a long time considering how to update the preview when preference change. After I found that the PreviewPanel will be bind to entry in FieldsEditorTab.java, then we can just update the layout in PreviewPanel.java#setEntry()

Some ideas:
Can we using observer pattern to refactor the code: JabRefPreferences as Observable object and component need preferences can register as Observer. If the preferences were changed, we can notify the affected component to do an update?

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
