### PR TITLE
Allow entrytype as sorting criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the bug when strike the delete key in the text field. [#6421](https://github.com/JabRef/jabref/issues/6421)
 - We added a BibTex key modifier for truncating strings. [#3915](https://github.com/JabRef/jabref/issues/3915)
 - We added support for jumping to target entry when typing letter/digit after sorting a column in maintable [#6146](https://github.com/JabRef/jabref/issues/6146)
-- We added the field "entrytype" to the export sort criteria 
+- We added the field "entrytype" to the export sort criteria [#6531](https://github.com/JabRef/jabref/pull/6531)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the bug when strike the delete key in the text field. [#6421](https://github.com/JabRef/jabref/issues/6421)
 - We added a BibTex key modifier for truncating strings. [#3915](https://github.com/JabRef/jabref/issues/3915)
 - We added support for jumping to target entry when typing letter/digit after sorting a column in maintable [#6146](https://github.com/JabRef/jabref/issues/6146)
+- We added the field "entrytype" to the export sort criteria 
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
@@ -26,6 +26,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.database.shared.DatabaseLocation;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
+import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.metadata.SaveOrderConfig;
 import org.jabref.preferences.PreferencesService;
@@ -106,6 +107,8 @@ public class LibraryPropertiesDialogViewModel {
         }
 
         Set<Field> fieldNames = FieldFactory.getCommonFields();
+        //allow entrytype field as sort criterion
+        fieldNames.add(InternalField.TYPE_HEADER);
         primarySortFieldsProperty.addAll(fieldNames);
         secondarySortFieldsProperty.addAll(fieldNames);
         tertiarySortFieldsProperty.addAll(fieldNames);

--- a/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
@@ -107,7 +107,7 @@ public class LibraryPropertiesDialogViewModel {
         }
 
         Set<Field> fieldNames = FieldFactory.getCommonFields();
-        //allow entrytype field as sort criterion
+        // allow entrytype field as sort criterion
         fieldNames.add(InternalField.TYPE_HEADER);
         primarySortFieldsProperty.addAll(fieldNames);
         secondarySortFieldsProperty.addAll(fieldNames);


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/export-sort-by-entry-type/2122/1

Entrytype was missing in sort criterion.
I did not add it to the common fields, because the common fields are also used for the customize entrytype

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
