### PR TITLE
Fix 6488

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,8 +128,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the blue and red text colors in the Merge entries dialog were not quite visible [#6334](https://github.com/JabRef/jabref/issues/6334)
 - We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
 - We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
-- We fixed an issue that showing teh duplicate information more clear [#6488]
-(https://github.com/JabRef/jabref/issues/6488)
 ### Removed
 
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action. [#5869](https://github.com/JabRef/jabref/issues/5869)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the blue and red text colors in the Merge entries dialog were not quite visible [#6334](https://github.com/JabRef/jabref/issues/6334)
 - We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
 - We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
-
+- We fixed an issue that showing the duplicate information more clear [#6488](https://github.com/JabRef/jabref/issues/6488)
 ### Removed
 
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action. [#5869](https://github.com/JabRef/jabref/issues/5869)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the blue and red text colors in the Merge entries dialog were not quite visible [#6334](https://github.com/JabRef/jabref/issues/6334)
 - We fixed an issue where underscore character was removed from the file name in the Recent Libraries list in File menu [#6383](https://github.com/JabRef/jabref/issues/6383)
 - We fixed an issue where few keyboard shortcuts regarding new entries were missing [#6403](https://github.com/JabRef/jabref/issues/6403)
+- We fixed an issue that showing teh duplicate information more clear [#6488]
+(https://github.com/JabRef/jabref/issues/6488)
 ### Removed
 
 - Ampersands are no longer escaped by default in the `bib` file. If you want to keep the current behaviour, you can use the new "Escape Ampersands" formatter as a save action. [#5869](https://github.com/JabRef/jabref/issues/5869)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ## [Unreleased]
 
 ### Added
-
+- We added the Library properties to a context menu on the library tabs [#6485](https://github.com/JabRef/jabref/issues/6485)
 - We added a new field in the preferences in 'BibTeX key generator' for unwanted characters that can be user-specified. [#6295](https://github.com/JabRef/jabref/issues/6295)
 - We added support for searching ShortScience for an entry through the user's browser. [#6018](https://github.com/JabRef/jabref/pull/6018)
 - We updated EditionChecker to permit edition to start with a number. [#6144](https://github.com/JabRef/jabref/issues/6144)

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -22,6 +22,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
@@ -97,6 +98,7 @@ import org.jabref.gui.journals.AbbreviateAction;
 import org.jabref.gui.journals.ManageJournalsAction;
 import org.jabref.gui.keyboard.CustomizeKeyBindingAction;
 import org.jabref.gui.keyboard.KeyBinding;
+import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.libraryproperties.LibraryPropertiesAction;
 import org.jabref.gui.menus.FileHistoryMenu;
 import org.jabref.gui.mergeentries.MergeEntriesAction;
@@ -1077,6 +1079,15 @@ public class JabRefFrame extends BorderPane {
         }
     }
 
+    private static ContextMenu createTabContextMenu(KeyBindingRepository keyBindingRepository, BasePanel panel, StateManager stateManager) {
+        ContextMenu contextMenu = new ContextMenu();
+        ActionFactory factory = new ActionFactory(keyBindingRepository);
+
+        contextMenu.getItems().add(factory.createMenuItem(StandardActions.LIBRARY_PROPERTIES, new LibraryPropertiesAction(panel.frame(), stateManager)));
+
+        return contextMenu;
+    }
+
     public void addTab(BasePanel basePanel, boolean raisePanel) {
         // add tab
         Tab newTab = new Tab(basePanel.getTabTitle(), basePanel);
@@ -1085,6 +1096,9 @@ public class JabRefFrame extends BorderPane {
             closeTab((BasePanel) newTab.getContent());
             event.consume();
         });
+
+        // add tab context menu
+        newTab.setContextMenu(createTabContextMenu(Globals.getKeyPrefs(), basePanel, stateManager));
 
         // update all tab titles
         updateAllTabTitles();

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -33,15 +33,11 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.LinkedFile;
-import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.InternalField;
-import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +56,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private ObservableList<BibEntry> entries;
     private PreferencesService preferences;
 
-    private Optional<BibEntry> internalDuplicate;
-    private Optional<BibEntry> datasetDuplicate;
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
@@ -98,16 +92,10 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         return entries;
     }
 
-    /*public boolean hasDuplicate(BibEntry entry) {
+    public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent()
                 ||
                 new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode()).isPresent();
-    }*/
-    public boolean hasDuplicate(BibEntry entry) {
-
-        this.internalDuplicate = findInternalDuplicate(entry);
-        this.datasetDuplicate = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
-        return this.internalDuplicate.isPresent() || this.datasetDuplicate.isPresent();
     }
 
     /**
@@ -122,21 +110,8 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
-                    StringBuffer duplicateInfo = new StringBuffer("There are possible duplicates (") ;
-                    if (this.datasetDuplicate.isPresent()){
-                        duplicateInfo.append("duplicate to the entry in the database whose Bibtexkey is : ");
-                        duplicateInfo.append(this.datasetDuplicate.get().getField(InternalField.KEY_FIELD).get());
-                    }
-                    else if (this.internalDuplicate.isPresent()){
-                        duplicateInfo.append("duplicate to the entry in the list of entries to be imported whose title is : ");
-                        duplicateInfo.append(this.internalDuplicate.get().getField(StandardField.TITLE).get());
-
-                    }
-                    duplicateInfo.append(") that haven't been resolved. Continue?");
-
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
-                            //Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
-                            Localization.lang(duplicateInfo.toString()),
+                            Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
                             Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),
                             Localization.lang("Disable this confirmation dialog"),

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -62,7 +62,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     private Optional<BibEntry> internalDuplicate;
     private Optional<BibEntry> datasetDuplicate;
-    private List<BibEntry> entriesToImport;
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
@@ -119,7 +118,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean downloadFiles) {
         // Check if we are supposed to warn about duplicates.
         // If so, then see if there are duplicates, and warn if yes.
-        this.entriesToImport = entriesToImport;
         if (preferences.shouldWarnAboutDuplicatesForImport()) {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
@@ -241,7 +239,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
      * @return A possible duplicate, if any, or null if none were found.
      */
     private Optional<BibEntry> findInternalDuplicate(BibEntry entry) {
-        for (BibEntry othEntry : entriesToImport) {
+        for (BibEntry othEntry : entries) {
             if (othEntry.equals(entry)) {
                 continue; // Don't compare the entry to itself
             }

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -33,11 +33,15 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +60,8 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private ObservableList<BibEntry> entries;
     private PreferencesService preferences;
 
+    private Optional<BibEntry> internalDuplicate;
+    private Optional<BibEntry> datasetDuplicate;
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
@@ -92,10 +98,16 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         return entries;
     }
 
-    public boolean hasDuplicate(BibEntry entry) {
+    /*public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent()
                 ||
                 new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode()).isPresent();
+    }*/
+    public boolean hasDuplicate(BibEntry entry) {
+
+        this.internalDuplicate = findInternalDuplicate(entry);
+        this.datasetDuplicate = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
+        return this.internalDuplicate.isPresent() || this.datasetDuplicate.isPresent();
     }
 
     /**
@@ -110,8 +122,21 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
+                    StringBuffer duplicateInfo = new StringBuffer("There are possible duplicates (") ;
+                    if (this.datasetDuplicate.isPresent()){
+                        duplicateInfo.append("duplicate to the entry in the database whose Bibtexkey is : ");
+                        duplicateInfo.append(this.datasetDuplicate.get().getField(InternalField.KEY_FIELD).get());
+                    }
+                    else if (this.internalDuplicate.isPresent()){
+                        duplicateInfo.append("duplicate to the entry in the list of entries to be imported whose title is : ");
+                        duplicateInfo.append(this.internalDuplicate.get().getField(StandardField.TITLE).get());
+
+                    }
+                    duplicateInfo.append(") that haven't been resolved. Continue?");
+
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
-                            Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
+                            //Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
+                            Localization.lang(duplicateInfo.toString()),
                             Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),
                             Localization.lang("Disable this confirmation dialog"),

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -62,6 +62,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     private Optional<BibEntry> internalDuplicate;
     private Optional<BibEntry> datasetDuplicate;
+    private List<BibEntry> entriesToImport;
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
@@ -118,6 +119,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean downloadFiles) {
         // Check if we are supposed to warn about duplicates.
         // If so, then see if there are duplicates, and warn if yes.
+        this.entriesToImport = entriesToImport;
         if (preferences.shouldWarnAboutDuplicatesForImport()) {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
@@ -239,7 +241,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
      * @return A possible duplicate, if any, or null if none were found.
      */
     private Optional<BibEntry> findInternalDuplicate(BibEntry entry) {
-        for (BibEntry othEntry : entries) {
+        for (BibEntry othEntry : entriesToImport) {
             if (othEntry.equals(entry)) {
                 continue; // Don't compare the entry to itself
             }

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -33,7 +33,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.LinkedFile;
-import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.groups.GroupTreeNode;
@@ -41,7 +40,6 @@ import org.jabref.model.metadata.MetaData;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
-import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,11 +97,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         return entries;
     }
 
-    /*public boolean hasDuplicate(BibEntry entry) {
-        return findInternalDuplicate(entry).isPresent()
-                ||
-                new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode()).isPresent();
-    }*/
     public boolean hasDuplicate(BibEntry entry) {
 
         this.internalDuplicate = findInternalDuplicate(entry);
@@ -124,20 +117,17 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
-                    StringBuffer duplicateInfo = new StringBuffer("There are possible duplicates (") ;
-                    if (this.datasetDuplicate.isPresent()){
+                    StringBuffer duplicateInfo = new StringBuffer("There are possible duplicates (");
+                    if (this.datasetDuplicate.isPresent()) {
                         duplicateInfo.append("duplicate to the entry in the database whose Bibtexkey is : ");
                         duplicateInfo.append(this.datasetDuplicate.get().getField(InternalField.KEY_FIELD).get());
-                    }
-                    else if (this.internalDuplicate.isPresent()){
+                    } else if (this.internalDuplicate.isPresent()) {
                         duplicateInfo.append("duplicate to the entry in the list of entries to be imported whose title is : ");
                         duplicateInfo.append(this.internalDuplicate.get().getField(StandardField.TITLE).get());
-
                     }
                     duplicateInfo.append(") that haven't been resolved. Continue?");
 
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
-                            //Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
                             Localization.lang(duplicateInfo.toString()),
                             Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -33,11 +33,15 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
+import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +60,9 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private ObservableList<BibEntry> entries;
     private PreferencesService preferences;
 
+    private Optional<BibEntry> internalDuplicate;
+    private Optional<BibEntry> datasetDuplicate;
+    private List<BibEntry> entriesToImport;
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
@@ -92,10 +99,16 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         return entries;
     }
 
-    public boolean hasDuplicate(BibEntry entry) {
+    /*public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent()
                 ||
                 new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode()).isPresent();
+    }*/
+    public boolean hasDuplicate(BibEntry entry) {
+
+        this.internalDuplicate = findInternalDuplicate(entry);
+        this.datasetDuplicate = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
+        return this.internalDuplicate.isPresent() || this.datasetDuplicate.isPresent();
     }
 
     /**
@@ -106,12 +119,26 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean downloadFiles) {
         // Check if we are supposed to warn about duplicates.
         // If so, then see if there are duplicates, and warn if yes.
+        this.entriesToImport = entriesToImport;
         if (preferences.shouldWarnAboutDuplicatesForImport()) {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
+                    StringBuffer duplicateInfo = new StringBuffer("There are possible duplicates (") ;
+                    if (this.datasetDuplicate.isPresent()){
+                        duplicateInfo.append("duplicate to the entry in the database whose Bibtexkey is : ");
+                        duplicateInfo.append(this.datasetDuplicate.get().getField(InternalField.KEY_FIELD).get());
+                    }
+                    else if (this.internalDuplicate.isPresent()){
+                        duplicateInfo.append("duplicate to the entry in the list of entries to be imported whose title is : ");
+                        duplicateInfo.append(this.internalDuplicate.get().getField(StandardField.TITLE).get());
+
+                    }
+                    duplicateInfo.append(") that haven't been resolved. Continue?");
+
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
-                            Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
+                            //Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
+                            Localization.lang(duplicateInfo.toString()),
                             Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),
                             Localization.lang("Disable this confirmation dialog"),
@@ -214,7 +241,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
      * @return A possible duplicate, if any, or null if none were found.
      */
     private Optional<BibEntry> findInternalDuplicate(BibEntry entry) {
-        for (BibEntry othEntry : entries) {
+        for (BibEntry othEntry : entriesToImport) {
             if (othEntry.equals(entry)) {
                 continue; // Don't compare the entry to itself
             }


### PR DESCRIPTION
Fix #6488
In order to let duplicate information more clear, I hava make some changes.
When user imports some entries to a database:
(1) If these entries are duplicate to the entry in the database, it will shown the Bibtexkey of the duplicate entry in UI.
(2) If there are two entries are duplicate among the imported entries, it will shown the title of the duplicate entry.
![image](https://user-images.githubusercontent.com/50331948/83010987-b81b2700-a04b-11ea-8e91-14ae7101771d.png)



<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
