### PR TITLE
Switch to upstream version of markdow-lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
       - name: Run markdown-lint
-        uses: avto-dev/markdown-lint@master
+        uses: avto-dev/markdown-lint@v1.2.0
         with:
           args: CHANGELOG.md README.md docs/
           config: '.markdownlint.yml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
       - name: Run markdown-lint
-        uses: avto-dev/markdown-lint@v1.2.0
+        uses: avto-dev/markdown-lint@v1
         with:
           args: CHANGELOG.md README.md docs/
           config: '.markdownlint.yml'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run checkstyle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
       - name: Run markdown-lint
-        uses: koppor/markdown-lint@master
+        uses: avto-dev/markdown-lint@master
         with:
           args: CHANGELOG.md README.md docs/
           config: '.markdownlint.yml'


### PR DESCRIPTION
I created a fork of markdown-lint. The upstream author quickly merged my changes back. Trying whether everything works fine. If yes, I'll merge.

No need to review.