### PR TITLE
Use letters to acess recent libraries in menu

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -182,6 +182,13 @@ public class JabRefFrame extends BorderPane {
         this.undoManager = Globals.undoManager;
         this.fileHistory = new FileHistoryMenu(prefs, dialogService, getOpenDatabaseAction());
         this.executorService = JabRefExecutorService.INSTANCE;
+        this.setOnKeyTyped(key -> {
+            if (this.fileHistory.isShowing()) {
+                if (this.fileHistory.openFileByKey(key)) {
+                    this.fileHistory.getParentMenu().hide();
+                }
+            }
+        });
     }
 
     private static BasePanel getBasePanel(Tab tab) {

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.input.KeyEvent;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.importer.actions.OpenDatabaseAction;
@@ -31,6 +32,22 @@ public class FileHistoryMenu extends Menu {
         } else {
             setItems();
         }
+    }
+
+    public boolean openFileByKey(KeyEvent keyEvent) {
+        if (keyEvent.getCharacter() == null) {
+            return false;
+        }
+        char key = keyEvent.getCharacter().charAt(0);
+        if (!Character.isDigit(key)) {
+            return false;
+        }
+        int num = Integer.parseInt(String.valueOf(key));
+        if (num > history.getHistory().size()) {
+            return false;
+        }
+        this.openFile(history.getFileAt(Integer.parseInt(keyEvent.getCharacter()) - 1));
+        return true;
     }
 
     /**

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -37,7 +37,7 @@ public class FileHistoryMenu extends Menu {
     /**
      * This method is to use typed letters to access recent libraries in menu.
      * @param keyEvent a KeyEvent.
-     * @return false if typed letter is invalid.
+     * @return false if typed char is invalid or not a number.
      */
     public boolean openFileByKey(KeyEvent keyEvent) {
         if (keyEvent.getCharacter() == null) {

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -34,16 +34,18 @@ public class FileHistoryMenu extends Menu {
         }
     }
 
+    /**
+     * This method is to use typed letters to access recent libraries in menu.
+     * @param keyEvent a KeyEvent.
+     * @return false if typed letter is invalid.
+     */
     public boolean openFileByKey(KeyEvent keyEvent) {
         if (keyEvent.getCharacter() == null) {
             return false;
         }
         char key = keyEvent.getCharacter().charAt(0);
-        if (!Character.isDigit(key)) {
-            return false;
-        }
-        int num = Integer.parseInt(String.valueOf(key));
-        if (num > history.getHistory().size()) {
+        int num = Character.getNumericValue(key);
+        if (num <= 0 || num > history.getHistory().size()) {
             return false;
         }
         this.openFile(history.getFileAt(Integer.parseInt(keyEvent.getCharacter()) - 1));


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #6529 

After fix the issue: (I typed 1, then 2, then 2)

![K8XVNKFj8t](https://user-images.githubusercontent.com/55199983/83321605-57762f00-a283-11ea-8050-bbf5079d5ed4.gif)

It can open a database relative to typed key. And I also checked that when typing a letter not a num(eg, 'a'), there will be nothing to happen. And if type a num larger than the max index of history record, nothing will happen as well.


The main idea to solve this issue is to add key event listener in `JabRefFrame.java` and design relative handle function `openFileByKey()`.

![image](https://user-images.githubusercontent.com/55199983/83321745-4f6abf00-a284-11ea-838f-a73e34e7672d.png)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
