### PR TITLE
Solve Wrong saving status problem when opening Library properties

### DIFF
--- a/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -141,7 +141,6 @@ public class MetaData {
 
     public void setSaveActions(FieldFormatterCleanups saveActions) {
         this.saveActions = Objects.requireNonNull(saveActions);
-        postChange();
     }
 
     public Optional<BibDatabaseMode> getMode() {


### PR DESCRIPTION
Fix #6541, Hide Event Trigger when open `Library > Library Properties`

We noticed that a comment field looks like this will be added into .bib and .sav file:
```
@Comment{jabref-meta: saveActions:disabled;
all-text-fields[remove_unicode_ligatures]
date[normalize_date]
month[normalize_month]
pages[normalize_page_numbers]
;}
```
It seems that this context will trigger `postChange` method in `setSaveActions` function inside `src/main/java/org/jabref/model/metadata/MetaData.java` file, so I simply remove this line. I am wondering if such simple removal have any harmful action to the program, but at present it works fine for me. 

<img width="358" alt="demo" src="https://user-images.githubusercontent.com/18418456/83353852-cd63be80-a387-11ea-8eb0-cfa6ae625a83.png">

Maybe I would like to write some test function but seems such tests would be hard to be written...
 
- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
