### PR TITLE
Fixes Texgroup's "Library has been modified by another program"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where "null" appeared in generated BibTeX keys. [#6459](https://github.com/JabRef/jabref/issues/6459)
 - We fixed an issue where the authors' names were incorrectly displayed in the authors' column when they were bracketed. [#6465](https://github.com/JabRef/jabref/issues/6465) [#6459](https://github.com/JabRef/jabref/issues/6459)
 - We fixed an issue where importing certain unlinked files would result in an exception [#5815](https://github.com/JabRef/jabref/issues/5815)
-- We fixed an issue with creating a group of cited entries, which wrongly triggered that the library had been changed externally. [#6420](https://github.com/JabRef/jabref/issues/6420)
+- We fixed an issue with the creation of a group of cited entries which incorrectly showed the message that the library had been modified externally whenever saving the library. [#6420](https://github.com/JabRef/jabref/issues/6420)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where "null" appeared in generated BibTeX keys. [#6459](https://github.com/JabRef/jabref/issues/6459)
 - We fixed an issue where the authors' names were incorrectly displayed in the authors' column when they were bracketed. [#6465](https://github.com/JabRef/jabref/issues/6465) [#6459](https://github.com/JabRef/jabref/issues/6459)
 - We fixed an issue where importing certain unlinked files would result in an exception [#5815](https://github.com/JabRef/jabref/issues/5815)
+- We fixed an issue with creating a group of cited entries, which wrongly triggered that the library had been changed externally. [#6420](https://github.com/JabRef/jabref/issues/6420)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -73,10 +73,6 @@ public class MetaDataParser {
             }
 
             switch (entry.getKey()) {
-                case MetaData.GROUPSTREE:
-                case MetaData.GROUPSTREE_LEGACY:
-                    metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator, fileMonitor, metaData));
-                    break;
                 case MetaData.SAVE_ACTIONS:
                     metaData.setSaveActions(Cleanups.parse(value));
                     break;
@@ -104,6 +100,19 @@ public class MetaDataParser {
                     metaData.putUnknownMetaDataItem(entry.getKey(), value);
             }
         }
+
+        // process GROUPSTREE and GROUPSTREE_LEGACY at the very end (otherwise it may happen that not all dependent data is set)
+        for (Map.Entry<String, String> entry : data.entrySet()) {
+            List<String> value = getAsList(entry.getValue());
+
+            switch (entry.getKey()) {
+                case MetaData.GROUPSTREE:
+                case MetaData.GROUPSTREE_LEGACY:
+                    metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator, fileMonitor, metaData));
+                    break;
+            }
+        }
+
         if (!defaultCiteKeyPattern.isEmpty() || !nonDefaultCiteKeyPatterns.isEmpty()) {
             metaData.setCiteKeyPattern(defaultCiteKeyPattern, nonDefaultCiteKeyPatterns);
         }

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -55,49 +55,36 @@ public class MetaDataParser {
             if (entry.getKey().startsWith(MetaData.PREFIX_KEYPATTERN)) {
                 EntryType entryType = EntryTypeFactory.parse(entry.getKey().substring(MetaData.PREFIX_KEYPATTERN.length()));
                 nonDefaultCiteKeyPatterns.put(entryType, Collections.singletonList(getSingleItem(value)));
-                continue;
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY + '-')) {
                 // The user name comes directly after "FILE_DIRECTORY-"
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY.length() + 1);
                 metaData.setUserFileDirectory(user, getSingleItem(value));
-                continue;
             } else if (entry.getKey().startsWith(MetaData.SELECTOR_META_PREFIX)) {
                 metaData.addContentSelector(ContentSelectors.parse(FieldFactory.parseField(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length())), StringUtil.unquote(entry.getValue(), MetaData.ESCAPE_CHARACTER)));
-                continue;
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY + "Latex-")) {
                 // The user name comes directly after "FILE_DIRECTORYLatex-"
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY.length() + 6);
                 Path path = Path.of(getSingleItem(value)).normalize();
                 metaData.setLatexFileDirectory(user, path);
-                continue;
-            }
-
-            switch (entry.getKey()) {
-                case MetaData.SAVE_ACTIONS:
-                    metaData.setSaveActions(Cleanups.parse(value));
-                    break;
-                case MetaData.DATABASE_TYPE:
-                    metaData.setMode(BibDatabaseMode.parse(getSingleItem(value)));
-                    break;
-                case MetaData.KEYPATTERNDEFAULT:
-                    defaultCiteKeyPattern = Collections.singletonList(getSingleItem(value));
-                    break;
-                case MetaData.PROTECTED_FLAG_META:
-                    if (Boolean.parseBoolean(getSingleItem(value))) {
-                        metaData.markAsProtected();
-                    } else {
-                        metaData.markAsNotProtected();
-                    }
-                    break;
-                case MetaData.FILE_DIRECTORY:
-                    metaData.setDefaultFileDirectory(getSingleItem(value));
-                    break;
-                case MetaData.SAVE_ORDER_CONFIG:
-                    metaData.setSaveOrderConfig(SaveOrderConfig.parse(value));
-                    break;
-                default:
-                    // Keep meta data items that we do not know in the file
-                    metaData.putUnknownMetaDataItem(entry.getKey(), value);
+            } else if (entry.getKey().equals(MetaData.SAVE_ACTIONS)) {
+                metaData.setSaveActions(Cleanups.parse(value));
+            } else if (entry.getKey().equals(MetaData.DATABASE_TYPE)) {
+                metaData.setMode(BibDatabaseMode.parse(getSingleItem(value)));
+            } else if (entry.getKey().equals(MetaData.KEYPATTERNDEFAULT)) {
+                defaultCiteKeyPattern = Collections.singletonList(getSingleItem(value));
+            } else if (entry.getKey().equals(MetaData.PROTECTED_FLAG_META)) {
+                if (Boolean.parseBoolean(getSingleItem(value))) {
+                    metaData.markAsProtected();
+                } else {
+                    metaData.markAsNotProtected();
+                }
+            } else if (entry.getKey().equals(MetaData.FILE_DIRECTORY)) {
+                metaData.setDefaultFileDirectory(getSingleItem(value));
+            } else if (entry.getKey().equals(MetaData.SAVE_ORDER_CONFIG)) {
+                metaData.setSaveOrderConfig(SaveOrderConfig.parse(value));
+            } else {
+                // Keep meta data items that we do not know in the file
+                metaData.putUnknownMetaDataItem(entry.getKey(), value);
             }
         }
 

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -52,14 +52,14 @@ public class MetaDataParser {
         Map<EntryType, List<String>> nonDefaultCiteKeyPatterns = new HashMap<>();
 
         // process GROUPSTREE and GROUPSTREE_LEGACY at the very end (otherwise it can happen that not all dependent data are set)
-        Stream<Map.Entry<String, String>> stream = data.entrySet().stream().filter(entry -> !entry.getKey().equals(MetaData.GROUPSTREE) && !entry.getKey().equals(MetaData.GROUPSTREE_LEGACY));
-        Stream<Map.Entry<String, String>> streamTail = data.entrySet().stream().filter(entry -> entry.getKey().equals(MetaData.GROUPSTREE) || entry.getKey().equals(MetaData.GROUPSTREE_LEGACY));
-        stream = Stream.concat(stream, streamTail);
+        Stream<Map.Entry<String, String>> entrySetStream = data.entrySet().stream().filter(entry -> !entry.getKey().equals(MetaData.GROUPSTREE) && !entry.getKey().equals(MetaData.GROUPSTREE_LEGACY));
+        Stream<Map.Entry<String, String>> entrySetStreamTail = data.entrySet().stream().filter(entry -> entry.getKey().equals(MetaData.GROUPSTREE) || entry.getKey().equals(MetaData.GROUPSTREE_LEGACY));
+        entrySetStream = Stream.concat(entrySetStream, entrySetStreamTail);
 
-        Iterator<Map.Entry<String, String>> it = stream.iterator();
+        Iterator<Map.Entry<String, String>> entryIterator = entrySetStream.iterator();
 
-        while (it.hasNext()) {
-            Map.Entry<String, String> entry = it.next();
+        while (entryIterator.hasNext()) {
+            Map.Entry<String, String> entry = entryIterator.next();
             List<String> value = getAsList(entry.getValue());
 
             if (entry.getKey().startsWith(MetaData.PREFIX_KEYPATTERN)) {


### PR DESCRIPTION
Fixes #6420.
Partially fixes #6585.

https://github.com/JabRef/jabref/blob/2eac6494de00948e218c29bd22d7eb689c663a58/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java#L67

must be called before calling

https://github.com/JabRef/jabref/blob/2eac6494de00948e218c29bd22d7eb689c663a58/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java#L109

so that the latex file directory is set properly.

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
