### PR TITLE
Fixed an issue where entry preview in preferences has white theme.

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreviewTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabView.java
@@ -157,6 +157,7 @@ public class PreviewTabView extends AbstractPreferenceTabView<PreviewTabViewMode
         ((PreviewViewer) previewTab.getContent()).setEntry(TestEntry.getTestEntry());
         EasyBind.subscribe(viewModel.layoutProperty(), value -> ((PreviewViewer) previewTab.getContent()).setLayout(value));
         previewTab.getContent().visibleProperty().bind(viewModel.chosenSelectionModelProperty().getValue().selectedItemProperty().isNotNull());
+        ((PreviewViewer) previewTab.getContent()).setTheme(preferences.getTheme());
 
         editArea.clear();
         editArea.setParagraphGraphicFactory(LineNumberFactory.get(editArea));


### PR DESCRIPTION
Related to #5522

Fixed an issue where entry preview in preferences has white theme.

![image](https://user-images.githubusercontent.com/20928760/84541335-7ea71480-acf7-11ea-81a8-98fd9aa65d94.png)


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
