### PR TITLE
Change "duplicates" window to recall size/position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the context menu of the column "Linked identifiers" of the main table, by truncating their texts, if they are too long. [#6499](https://github.com/JabRef/jabref/issues/6499)
 - We merged the main table tabs in the preferences dialog. [#6518](https://github.com/JabRef/jabref/pull/6518)
 - We changed the command line option 'generateBibtexKeys' to the more generic term 'generateCitationKeys' while the short option remains 'g'.[#6545](https://github.com/JabRef/jabref/pull/6545)
+- We improved the "Possible duplicate entries" window to remember its size and position throughout a session. [#6582](https://github.com/JabRef/jabref/issues/6582)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -119,7 +119,7 @@ public class EntryTypeView extends BaseDialog<EntryType> {
     @FXML
     public void initialize() {
         visualizer.setDecoration(new IconValidationDecorator());
-        viewModel = new EntryTypeViewModel(prefs, basePanel, dialogService);
+        viewModel = new EntryTypeViewModel(prefs, basePanel, dialogService, stateManager);
 
         idBasedFetchers.itemsProperty().bind(viewModel.fetcherItemsProperty());
         idTextField.textProperty().bindBidirectional(viewModel.idTextProperty());

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -49,11 +49,13 @@ public class EntryTypeViewModel {
     private final BasePanel basePanel;
     private final DialogService dialogService;
     private final Validator idFieldValidator;
+    private final StateManager stateManager;
 
-    public EntryTypeViewModel(JabRefPreferences preferences, BasePanel basePanel, DialogService dialogService) {
+    public EntryTypeViewModel(JabRefPreferences preferences, BasePanel basePanel, DialogService dialogService, StateManager stateManager) {
         this.basePanel = basePanel;
         this.prefs = preferences;
         this.dialogService = dialogService;
+        this.stateManager = stateManager;
         fetchers.addAll(WebFetchers.getIdBasedFetchers(preferences.getImportFormatPreferences()));
         selectedItemProperty.setValue(getLastSelectedFetcher());
         idFieldValidator = new FunctionBasedValidator<>(idText, StringUtil::isNotBlank, ValidationMessage.error(Localization.lang("Required field \"%0\" is empty.", Localization.lang("ID"))));
@@ -147,7 +149,7 @@ public class EntryTypeViewModel {
                 final BibEntry entry = result.get();
                 Optional<BibEntry> duplicate = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(basePanel.getDatabase(), entry, basePanel.getBibDatabaseContext().getMode());
                 if ((duplicate.isPresent())) {
-                    DuplicateResolverDialog dialog = new DuplicateResolverDialog(entry, duplicate.get(), DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK, basePanel.getBibDatabaseContext());
+                    DuplicateResolverDialog dialog = new DuplicateResolverDialog(entry, duplicate.get(), DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK, basePanel.getBibDatabaseContext(), stateManager);
                     switch (dialog.showAndWait().orElse(DuplicateResolverDialog.DuplicateResolverResult.BREAK)) {
                         case KEEP_LEFT:
                             basePanel.getDatabase().removeEntry(duplicate.get());

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -149,11 +149,11 @@ public class StateManager {
         return tasksProgress;
     }
 
-    public DialogWindowState getDialogWindowState(String windowName) {
-        return dialogWindowStates.get(windowName);
+    public DialogWindowState getDialogWindowState(String className) {
+        return dialogWindowStates.get(className);
     }
 
-    public void setDialogWindowState(String windowName, DialogWindowState state) {
-        dialogWindowStates.put(windowName, state);
+    public void setDialogWindowState(String className, DialogWindowState state) {
+        dialogWindowStates.put(className, state);
     }
 }

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -38,6 +38,7 @@ import com.tobiasdiez.easybind.EasyBinding;
  *   <li>active search</li>
  *   <li>active number of search results</li>
  *   <li>focus owner</li>
+ *   <li>dialog window sizes/positions</li>
  * </ul>
  */
 public class StateManager {
@@ -53,12 +54,9 @@ public class StateManager {
     private final ObservableList<Task<?>> backgroundTasks = FXCollections.observableArrayList(task -> {
         return new Observable[]{task.progressProperty(), task.runningProperty()};
     });
-
     private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.anyMatch(Task::isRunning));
-
     private final EasyBinding<Double> tasksProgress = EasyBind.reduce(backgroundTasks, tasks -> tasks.filter(Task::isRunning).mapToDouble(Task::getProgress).average().orElse(1));
-
-    private final DialogWindowState duplicateResolverDialogWindowState = new DialogWindowState();
+    private final ObservableMap<String, DialogWindowState> dialogWindowStates = FXCollections.observableHashMap();
 
     public StateManager() {
         activeGroups.bind(Bindings.valueAt(selectedGroups, activeDatabase.orElse(null)));
@@ -151,7 +149,11 @@ public class StateManager {
         return tasksProgress;
     }
 
-    public DialogWindowState getDuplicateResolverDialogWindowState() {
-        return duplicateResolverDialogWindowState;
+    public DialogWindowState getDialogWindowState(String windowName) {
+        return dialogWindowStates.get(windowName);
+    }
+
+    public void setDialogWindowState(String windowName, DialogWindowState state) {
+        dialogWindowStates.put(windowName, state);
     }
 }

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -18,6 +18,7 @@ import javafx.concurrent.Task;
 import javafx.scene.Node;
 
 import org.jabref.gui.util.CustomLocalDragboard;
+import org.jabref.gui.util.DialogWindowState;
 import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.model.database.BibDatabaseContext;
@@ -56,6 +57,8 @@ public class StateManager {
     private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.anyMatch(Task::isRunning));
 
     private final EasyBinding<Double> tasksProgress = EasyBind.reduce(backgroundTasks, tasks -> tasks.filter(Task::isRunning).mapToDouble(Task::getProgress).average().orElse(1));
+
+    private final DialogWindowState duplicateResolverDialogWindowState = new DialogWindowState();
 
     public StateManager() {
         activeGroups.bind(Bindings.valueAt(selectedGroups, activeDatabase.orElse(null)));
@@ -146,5 +149,9 @@ public class StateManager {
 
     public EasyBinding<Double> getTasksProgress() {
         return tasksProgress;
+    }
+
+    public DialogWindowState getDuplicateResolverDialogWindowState() {
+        return duplicateResolverDialogWindowState;
     }
 }

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
@@ -6,10 +6,12 @@ import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.BorderPane;
 
+import org.jabref.Globals;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolverResult;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.mergeentries.MergeEntries;
 import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.DialogWindowState;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
@@ -95,10 +97,20 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
 
         this.getDialogPane().getButtonTypes().addAll(first, second, both, merge, cancel, help);
 
+        // Retrieves the previous window state and sets the new dialog window size and position to match it
+        DialogWindowState state = Globals.stateManager.getDuplicateResolverDialogWindowState();
+        if (!state.isNull()) {
+            this.getDialogPane().setPrefSize(state.getWidth(), state.getHeight());
+            this.setX(state.getX());
+            this.setY(state.getY());
+        }
+
         BorderPane borderPane = new BorderPane(me);
         borderPane.setBottom(options);
 
         this.setResultConverter(button -> {
+            // Updates the window state on button press
+            state.setAll(this.getX(), this.getY(), this.getDialogPane().getHeight(), this.getDialogPane().getWidth());
 
             if (button.equals(first)) {
                 return DuplicateResolverResult.KEEP_LEFT;

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
@@ -100,7 +100,7 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
         this.getDialogPane().getButtonTypes().addAll(first, second, both, merge, cancel, help);
 
         // Retrieves the previous window state and sets the new dialog window size and position to match it
-        DialogWindowState state = stateManager.getDialogWindowState("DUPLICATE_RESOLVER_DIALOG");
+        DialogWindowState state = stateManager.getDialogWindowState(getClass().getSimpleName());
         if (state != null) {
             this.getDialogPane().setPrefSize(state.getWidth(), state.getHeight());
             this.setX(state.getX());
@@ -112,7 +112,7 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
 
         this.setResultConverter(button -> {
             // Updates the window state on button press
-            stateManager.setDialogWindowState("DUPLICATE_RESOLVER_DIALOG", new DialogWindowState(this.getX(), this.getY(), this.getDialogPane().getHeight(), this.getDialogPane().getWidth()));
+            stateManager.setDialogWindowState(getClass().getSimpleName(), new DialogWindowState(this.getX(), this.getY(), this.getDialogPane().getHeight(), this.getDialogPane().getWidth()));
 
             if (button.equals(first)) {
                 return DuplicateResolverResult.KEEP_LEFT;

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
@@ -6,7 +6,7 @@ import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.BorderPane;
 
-import org.jabref.Globals;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolverResult;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.mergeentries.MergeEntries;
@@ -20,6 +20,7 @@ import org.jabref.model.entry.BibEntry;
 public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult> {
 
     private final BibDatabaseContext database;
+    private final StateManager stateManager;
 
     public enum DuplicateResolverType {
         DUPLICATE_SEARCH,
@@ -39,9 +40,10 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
 
     private MergeEntries me;
 
-    public DuplicateResolverDialog(BibEntry one, BibEntry two, DuplicateResolverType type, BibDatabaseContext database) {
+    public DuplicateResolverDialog(BibEntry one, BibEntry two, DuplicateResolverType type, BibDatabaseContext database, StateManager stateManager) {
         this.setTitle(Localization.lang("Possible duplicate entries"));
         this.database = database;
+        this.stateManager = stateManager;
         init(one, two, type);
     }
 
@@ -98,8 +100,8 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
         this.getDialogPane().getButtonTypes().addAll(first, second, both, merge, cancel, help);
 
         // Retrieves the previous window state and sets the new dialog window size and position to match it
-        DialogWindowState state = Globals.stateManager.getDuplicateResolverDialogWindowState();
-        if (!state.isNull()) {
+        DialogWindowState state = stateManager.getDialogWindowState("DUPLICATE_RESOLVER_DIALOG");
+        if (state != null) {
             this.getDialogPane().setPrefSize(state.getWidth(), state.getHeight());
             this.setX(state.getX());
             this.setY(state.getY());
@@ -110,7 +112,7 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
 
         this.setResultConverter(button -> {
             // Updates the window state on button press
-            state.setAll(this.getX(), this.getY(), this.getDialogPane().getHeight(), this.getDialogPane().getWidth());
+            stateManager.setDialogWindowState("DUPLICATE_RESOLVER_DIALOG", new DialogWindowState(this.getX(), this.getY(), this.getDialogPane().getHeight(), this.getDialogPane().getWidth()));
 
             if (button.equals(first)) {
                 return DuplicateResolverResult.KEEP_LEFT;

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -131,7 +131,7 @@ public class DuplicateSearch extends SimpleCommand {
     }
 
     private void askResolveStrategy(DuplicateSearchResult result, BibEntry first, BibEntry second, DuplicateResolverType resolverType) {
-        DuplicateResolverDialog dialog = new DuplicateResolverDialog(first, second, resolverType, frame.getCurrentBasePanel().getBibDatabaseContext());
+        DuplicateResolverDialog dialog = new DuplicateResolverDialog(first, second, resolverType, frame.getCurrentBasePanel().getBibDatabaseContext(), stateManager);
 
         DuplicateResolverResult resolverResult = dialog.showAndWait().orElse(DuplicateResolverResult.BREAK);
 

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -230,7 +230,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         Optional<BibEntry> other = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
         if (other.isPresent()) {
             DuplicateResolverDialog dialog = new DuplicateResolverDialog(other.get(),
-                    entry, DuplicateResolverDialog.DuplicateResolverType.INSPECTION, databaseContext);
+                    entry, DuplicateResolverDialog.DuplicateResolverType.INSPECTION, databaseContext, stateManager);
 
             DuplicateResolverDialog.DuplicateResolverResult result = dialog.showAndWait().orElse(DuplicateResolverDialog.DuplicateResolverResult.BREAK);
 
@@ -260,7 +260,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         other = findInternalDuplicate(entry);
         if (other.isPresent()) {
             DuplicateResolverDialog diag = new DuplicateResolverDialog(entry,
-                    other.get(), DuplicateResolverDialog.DuplicateResolverType.DUPLICATE_SEARCH, databaseContext);
+                    other.get(), DuplicateResolverDialog.DuplicateResolverType.DUPLICATE_SEARCH, databaseContext, stateManager);
 
             DuplicateResolverDialog.DuplicateResolverResult answer = diag.showAndWait().orElse(DuplicateResolverDialog.DuplicateResolverResult.BREAK);
             if (answer == DuplicateResolverDialog.DuplicateResolverResult.KEEP_LEFT) {

--- a/src/main/java/org/jabref/gui/util/DialogWindowState.java
+++ b/src/main/java/org/jabref/gui/util/DialogWindowState.java
@@ -5,19 +5,12 @@ package org.jabref.gui.util;
  * these properties stay consistent when they are closed and re-opened
  */
 public class DialogWindowState {
-    private double x;
-    private double y;
-    private double height;
-    private double width;
+    private final double x;
+    private final double y;
+    private final double height;
+    private final double width;
 
-    public DialogWindowState() {
-    }
-
-    public boolean isNull() {
-        return this.x == 0 && this.y == 0 && this.height == 0 && this.width == 0;
-    }
-
-    public void setAll(double x, double y, double height, double width) {
+    public DialogWindowState(double x, double y, double height, double width) {
         this.x = x;
         this.y = y;
         this.height = height;
@@ -25,34 +18,18 @@ public class DialogWindowState {
     }
 
     public double getX() {
-        return this.x;
+        return x;
     }
 
     public double getY() {
-        return this.y;
+        return y;
     }
 
     public double getHeight() {
-        return this.height;
+        return height;
     }
 
     public double getWidth() {
-        return this.width;
-    }
-
-    public void setX(double x) {
-        this.x = x;
-    }
-
-    public void setY(double y) {
-        this.y = y;
-    }
-
-    public void setHeight(double height) {
-        this.height = height;
-    }
-
-    public void setWidth(double width) {
-        this.width = width;
+        return width;
     }
 }

--- a/src/main/java/org/jabref/gui/util/DialogWindowState.java
+++ b/src/main/java/org/jabref/gui/util/DialogWindowState.java
@@ -1,0 +1,58 @@
+package org.jabref.gui.util;
+
+/**
+ * This class is used to store the size and position of dialog windows so that
+ * these properties stay consistent when they are closed and re-opened
+ */
+public class DialogWindowState {
+    private double x;
+    private double y;
+    private double height;
+    private double width;
+
+    public DialogWindowState() {
+    }
+
+    public boolean isNull() {
+        return this.x == 0 && this.y == 0 && this.height == 0 && this.width == 0;
+    }
+
+    public void setAll(double x, double y, double height, double width) {
+        this.x = x;
+        this.y = y;
+        this.height = height;
+        this.width = width;
+    }
+
+    public double getX() {
+        return this.x;
+    }
+
+    public double getY() {
+        return this.y;
+    }
+
+    public double getHeight() {
+        return this.height;
+    }
+
+    public double getWidth() {
+        return this.width;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    public void setHeight(double height) {
+        this.height = height;
+    }
+
+    public void setWidth(double width) {
+        this.width = width;
+    }
+}


### PR DESCRIPTION
The "Possible duplicate entries" window now remembers its size and position throughout a session ([#6582](https://github.com/JabRef/jabref/issues/6582)). This was done by adding a DialogWindowState class to the gui utils. This class stores the size and position of the dialog window. The StateManager class was modified to store this object. It is retrieved whenever a new DuplicateResolverDialog object is created to get the previous size and position and is updated whenever the user proceeds through the dialog options. The DialogWindowState class can be re-used if this feature is needed for other dialog windows.

This is my first ever pull request so please let me know what you think or whether I need to re-tool my approach to be more in line with the structure of the rest of the code! I did not include any screenshots as this felt like a sort of awkward fix to try and take screenshots of.

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
