### PR TITLE
Fixes issue where Unix crashes when inotify is full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where downloaded files would be moved to a directory named after the citationkey when no file directory pattern is specified [#6589](https://github.com/JabRef/jabref/issues/6589)
 - We fixed an issue with the creation of a group of cited entries which incorrectly showed the message that the library had been modified externally whenever saving the library. [#6420](https://github.com/JabRef/jabref/issues/6420)
 - We fixed an issue with the creation of a group of cited entries. Now the file path to an aux file gets validated. [#6585](https://github.com/JabRef/jabref/issues/6585)
+- We fixed an issue on Linux systems where the application would crash upon inotify failure. Now, the user is prompted with a warning, and given the choice to continue the session. [#6073](https://github.com/JabRef/jabref/issues/6073)
 
 ### Removed
 

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -105,7 +105,7 @@ public class JabRefGUI {
         });
         Platform.runLater(this::openDatabases);
 
-        if(!(Globals.getFileUpdateMonitor().active())) {
+        if(!(Globals.getFileUpdateMonitor().isActive())) {
             this.getMainFrame().getDialogService()
                     .showErrorDialogAndWait("Unable to monitor file changes. Please close files " +
                             "and processes and restart. You may encounter errors if you continue " +

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -104,6 +104,13 @@ public class JabRefGUI {
             }
         });
         Platform.runLater(this::openDatabases);
+
+        if(!(Globals.getFileUpdateMonitor().active())) {
+            this.getMainFrame().getDialogService()
+                    .showErrorDialogAndWait("Unable to monitor file changes. Please close files " +
+                            "and processes and restart. You may encounter errors if you continue " +
+                            "with this session.");
+        }
     }
 
     private void openDatabases() {

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -107,9 +107,9 @@ public class JabRefGUI {
 
         if (!(Globals.getFileUpdateMonitor().isActive())) {
             this.getMainFrame().getDialogService()
-                    .showErrorDialogAndWait("Unable to monitor file changes. Please close files " +
+                    .showErrorDialogAndWait(Localization.lang("Unable to monitor file changes. Please close files " +
                             "and processes and restart. You may encounter errors if you continue " +
-                            "with this session.");
+                            "with this session."));
         }
     }
 

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -105,7 +105,7 @@ public class JabRefGUI {
         });
         Platform.runLater(this::openDatabases);
 
-        if(!(Globals.getFileUpdateMonitor().isActive())) {
+        if (!(Globals.getFileUpdateMonitor().isActive())) {
             this.getMainFrame().getDialogService()
                     .showErrorDialogAndWait("Unable to monitor file changes. Please close files " +
                             "and processes and restart. You may encounter errors if you continue " +

--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -12,10 +12,10 @@ import java.util.Optional;
 import org.jabref.JabRefException;
 import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
+import org.jabref.model.util.WatchServiceUnavailableException;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import org.jabref.model.util.WatchServiceUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -7,11 +7,9 @@ import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.jabref.JabRefException;
-import org.jabref.logic.layout.format.Default;
 import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
 
@@ -73,7 +71,7 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
         }
     }
 
-    public boolean active() {
+    public boolean isActive() {
         return filesystemMonitorFailure.isEmpty();
     }
 
@@ -83,7 +81,7 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
 
     @Override
     public void addListenerForFile(Path file, FileUpdateListener listener) throws IOException {
-        if (active()) {
+        if (isActive()) {
             // We can't watch files directly, so monitor their parent directory for updates
             Path directory = file.toAbsolutePath().getParent();
             directory.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);

--- a/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
@@ -1,6 +1,5 @@
 package org.jabref.model.util;
 
-import java.io.IOException;
 import java.nio.file.Path;
 
 /**

--- a/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
@@ -19,7 +19,7 @@ public class DummyFileUpdateMonitor implements FileUpdateMonitor {
     }
 
     @Override
-    public boolean active() {
+    public boolean isActive() {
         return false;
     }
 }

--- a/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/DummyFileUpdateMonitor.java
@@ -9,12 +9,17 @@ import java.nio.file.Path;
  */
 public class DummyFileUpdateMonitor implements FileUpdateMonitor {
     @Override
-    public void addListenerForFile(Path file, FileUpdateListener listener) throws IOException {
+    public void addListenerForFile(Path file, FileUpdateListener listener) {
 
     }
 
     @Override
     public void removeListener(Path path, FileUpdateListener listener) {
 
+    }
+
+    @Override
+    public boolean active() {
+        return false;
     }
 }

--- a/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
@@ -21,7 +21,7 @@ public interface FileUpdateMonitor {
 
     /**
      * Indicates whether or not the native system's file monitor has successfully started.
-     * @return True is process is running; false otherwise.
+     * @return true is process is running; false otherwise.
      */
     boolean isActive();
 }

--- a/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
@@ -23,5 +23,5 @@ public interface FileUpdateMonitor {
      * Indicates whether or not the native system's file monitor has successfully started.
      * @return True is process is running; false otherwise.
      */
-    boolean active();
+    boolean isActive();
 }

--- a/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
+++ b/src/main/java/org/jabref/model/util/FileUpdateMonitor.java
@@ -18,4 +18,10 @@ public interface FileUpdateMonitor {
      * @param path The path to remove.
      */
     void removeListener(Path path, FileUpdateListener listener);
+
+    /**
+     * Indicates whether or not the native system's file monitor has successfully started.
+     * @return True is process is running; false otherwise.
+     */
+    boolean active();
 }

--- a/src/main/java/org/jabref/model/util/WatchServiceUnavailableException.java
+++ b/src/main/java/org/jabref/model/util/WatchServiceUnavailableException.java
@@ -1,0 +1,9 @@
+package org.jabref.model.util;
+
+import org.jabref.JabRefException;
+
+public class WatchServiceUnavailableException extends JabRefException {
+    public WatchServiceUnavailableException(final String message, final String localizedMessage, final Throwable cause) {
+        super(message, localizedMessage, cause);
+    }
+}

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1,3 +1,4 @@
+Unable\ to\ monitor\ file\ changes.\ Please\ close\ files\ and\ processes\ and\ restart.\ You\ may\ encounter\ errors\ if\ you\ continue\ with\ this\ session.=Unable to monitor file changes. Please close files and processes and restart. You may encounter errors if you continue with this session.
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contains the regular expression <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 contains the term <b>%1</b>


### PR DESCRIPTION
Previously, the program was crashing for Unix users when inotify had reached its max file limit. Since the only way to fix this seems to be to close applications or to edit privileged system files, the proposed solution is to notify the user of the issue and give them the option of continuing usage of the application. Fixes #6073

