### PR TITLE
Unconfigure buttons first before reconficuring them

### DIFF
--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -140,6 +140,7 @@ public class ActionFactory {
     }
 
     public ButtonBase configureIconButton(Action action, Command command, ButtonBase button) {
+        ActionUtils.unconfigureButton(button);
         ActionUtils.configureButton(
                 new JabRefAction(action, command, keyBindingRepository, Sources.FromButton),
                 button,


### PR DESCRIPTION
The last update to controlsfx seems to have introduced the requirement of unconfiguring buttons first before reconfiguring them.
In consequence, the user could not save any preferences anymore. This should fix it.
Please test it. I did, but i'm a bit cautious about unforseen consequences.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
