### PR TITLE
Typos in teaching.md

### DIFF
--- a/docs/teaching.md
+++ b/docs/teaching.md
@@ -4,7 +4,7 @@ With JabRef students can level-up their coding and GitHub skills. When taking pa
 
 JabRef tries to achieve high code quality. This ultimately leads to improved software engineering knowledge of contributors. After contributing for JabRef, both coding and general software engienering skills will have increased. Our [development strategy](getting-into-the-code/development-strategy.md) provides more details.
 
-We recommend to start early and constantly, since students working earlier and more often produce projects that are more correct and completed earlier at the same overall invested time.
+We recommend to start early and constantly, since students working earlier and more often produce projects that are more correct and completed earlier at the same overall invested time [1](teaching.md#Ayaankazerouni).
 
 ## Notes for instructors
 

--- a/docs/teaching.md
+++ b/docs/teaching.md
@@ -4,7 +4,7 @@ With JabRef students can level-up their coding and GitHub skills. When taking pa
 
 JabRef tries to achieve high code quality. This ultimately leads to improved software engineering knowledge of contributors. After contributing for JabRef, both coding and general software engienering skills will have increased. Our [development strategy](getting-into-the-code/development-strategy.md) provides more details.
 
-We recommend to start early and constantly, since students wirking earlier and more often, produce projects that are more correct, completed earlier at the same overall invested time [1](teaching.md#Ayaankazerouni).
+We recommend to start early and constantly, since students working earlier and more often produce projects that are more correct and completed earlier at the same overall invested time.
 
 ## Notes for instructors
 


### PR DESCRIPTION
Removed a link leading to nothing, a comma and replaced "wirking" through "working".

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.