### PR TITLE
Update teaching.md : Reference as superscript

### DIFF
--- a/docs/teaching.md
+++ b/docs/teaching.md
@@ -4,7 +4,7 @@ With JabRef students can level-up their coding and GitHub skills. When taking pa
 
 JabRef tries to achieve high code quality. This ultimately leads to improved software engineering knowledge of contributors. After contributing for JabRef, both coding and general software engienering skills will have increased. Our [development strategy](getting-into-the-code/development-strategy.md) provides more details.
 
-We recommend to start early and constantly, since students working earlier and more often produce projects that are more correct and completed earlier at the same overall invested time [1](teaching.md#Ayaankazerouni).
+We recommend to start early and constantly, since students working earlier and more often produce projects that are more correct and completed earlier at the same overall invested time <sup>[1](teaching.md#Ayaankazerouni)</sup>.
 
 ## Notes for instructors
 


### PR DESCRIPTION
Footnote doesn't work in Gitbook, so I at least set the reference of the research as a superscript. 
Here the link to the docs where it is for convenience:
https://devdocs.jabref.org/teaching

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.