### PR TITLE
getAgency moved from DOI to DoiFetcher

### DIFF
--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -1,22 +1,16 @@
 package org.jabref.model.entry.identifier;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.net.URLDownload;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONException;
-import kong.unirest.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,22 +254,4 @@ public class DOI implements Identifier {
         return Objects.hash(doi.toLowerCase(Locale.ENGLISH));
     }
 
-    /**
-     * Returns registration agency. Optional.empty() if no agency is found.
-     */
-    public Optional<String> getAgency() throws IOException {
-        Optional<String> agency = Optional.empty();
-        try {
-            URLDownload download = new URLDownload(new URL(DOI.AGENCY_RESOLVER + "/" + doi));
-            JSONObject response = new JSONArray(download.asString()).getJSONObject(0);
-            if (response != null) {
-                agency = Optional.ofNullable(response.optString("RA"));
-            }
-        } catch (JSONException e) {
-            LOGGER.error("Cannot parse agency fetcher repsonse to JSON");
-            return Optional.empty();
-        }
-
-        return agency;
-    }
 }


### PR DESCRIPTION
The method `getAgency` has been moved from `DOI` back to `DoiFetcher`.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
