### PR TITLE
Add validation of "AUTHORS" file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,7 +231,7 @@ jobs:
         with:
           # full checkout needed for authors generation
           fetch-depth: 0
-      - name: "No new AUTHORS"
+      - name: "Check AUTHORS"
         id: authors_check
         shell: bash
         run: |
@@ -243,11 +243,11 @@ jobs:
             echo "No authors added"
             exit 0
           fi
-          message="When merged, this pull request will introduce additions in the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to appear differently, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git).%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
+          message="When merged, this pull request proposes to manually add the following to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to raise a different proposal, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git).%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
           echo "::set-output name=message::$message"
           echo "::set-output name=newauthor::true"
           echo "New authors found"
-      - name: comment PR
+      - name: Comment PR
         uses: unsplash/comment-on-pr@master
         if: steps.authors_check.outputs.newauthor == 'true'
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
             echo "No authors added"
             exit 0
           fi
-          message="When merged, this pull request proposes to manually add the following to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to raise a different proposal, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git). You will have to [rewrite your git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) and use `git commit --author="John Doe <john@doe.org>"` for each changed commit.%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
+          message="When merged, this pull request proposes to manually add the following to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to raise a different proposal, please comment here (we will adapt our `.mailmap` file then) or [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git). You will have to [rewrite your git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) and use `git commit --author="John Doe <john@doe.org>"` for each changed commit.%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
           echo "::set-output name=message::$message"
           echo "::set-output name=newauthor::true"
           echo "New authors found"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,3 +223,35 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
+  checkauthors:
+    name: "Validate AUTHORS"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # full checkout needed for authors generation
+          fetch-depth: 0
+      - name: "No new AUTHORS"
+        id: authors_check
+        shell: bash
+        run: |
+          ./scripts/generate-authors.sh
+          set +o pipefail
+          added=$(git diff HEAD --no-ext-diff --unified=0 -a --no-prefix | egrep "^\+[^+]" | sed "s/^\+//")
+          if [ -z "$added" ]; then
+            echo "::set-output name=newauthor::false"
+            echo "No authors added"
+            exit 0
+          fi
+          message="When merged, this pull request will introduce additions in the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to appear differently, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git).%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
+          echo "::set-output name=message::$message"
+          echo "::set-output name=newauthor::true"
+          echo "New authors found"
+      - name: comment PR
+        uses: unsplash/comment-on-pr@master
+        if: steps.authors_check.outputs.newauthor == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "${{ steps.authors_check.outputs.message }}"
+          check_for_duplicate_msg: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
             echo "No authors added"
             exit 0
           fi
-          message="When merged, this pull request proposes to manually add the following to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to raise a different proposal, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git).%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
+          message="When merged, this pull request proposes to manually add the following to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to raise a different proposal, please [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git). You will have to [rewrite your git history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) and use `git commit --author="John Doe <john@doe.org>"` for each changed commit.%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
           echo "::set-output name=message::$message"
           echo "::set-output name=newauthor::true"
           echo "New authors found"


### PR DESCRIPTION
Just before a release, I have to check the names of the contributors to be able to add them to `AUHTORS`. This is a good habit, where I received positive feedback for. We outline that in our contribution guide at https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits, but it seems no one reads that far.

The issue is that 80% of the names are wrong. Be it casing errors, misspellings, multiple email adresses with slightly dfferent name, or no name at all.

To redeuce the load on my side, I created a check which comments on the PR if some new names will be added.

Example:

![grafik](https://user-images.githubusercontent.com/1366654/88723257-d3c4ab80-d128-11ea-9f4c-6b139d6298e8.png)

The check renders as follows if no new AUTHOR was found:

![grafik](https://user-images.githubusercontent.com/1366654/88723292-e3dc8b00-d128-11ea-84b5-6029b0915748.png)

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
