### PR TITLE
Fix copy pasting and delete via menu or key

### DIFF
--- a/src/main/java/org/jabref/gui/edit/EditAction.java
+++ b/src/main/java/org/jabref/gui/edit/EditAction.java
@@ -7,12 +7,18 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.gui.maintable.MainTable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class for handling general actions; cut, copy and paste. The focused component is kept track of by
  * Globals.focusListener, and we call the action stored under the relevant name in its action map.
  */
 public class EditAction extends SimpleCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EditAction.class);
 
     private final JabRefFrame frame;
     private final StandardActions action;
@@ -53,6 +59,29 @@ public class EditAction extends SimpleCommand {
                         break;
                     default:
                         throw new IllegalStateException("Only cut/copy/paste supported in TextInputControl but got " + action);
+                }
+
+            } else if (focusOwner instanceof MainTable) {
+
+                LOGGER.debug("I am a Maintable in Edit action");
+                // Not sure what is selected -> copy/paste/cut selected entries
+
+                // ToDo: Should be handled by BibDatabaseContext instead of BasePanel
+                switch (action) {
+                    case COPY:
+                        frame.getCurrentBasePanel().copy();
+                        break;
+                    case CUT:
+                        frame.getCurrentBasePanel().cut();
+                        break;
+                    case PASTE:
+                        frame.getCurrentBasePanel().paste();
+                        break;
+                    case DELETE_ENTRY:
+                        frame.getCurrentBasePanel().delete(false);
+                        break;
+                    default:
+                        throw new IllegalStateException("Only cut/copy/paste supported but got " + action);
                 }
             }
         });

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -37,6 +37,7 @@ import org.jabref.gui.util.CustomLocalDragboard;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.ViewModelTableRowFactory;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.OS;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.event.EntriesAddedEvent;
 import org.jabref.model.entry.BibEntry;
@@ -60,6 +61,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
     private long lastKeyPressTime;
     private String columnSearchTerm;
+
 
     public MainTable(MainTableDataModel model, JabRefFrame frame,
                      BasePanel panel, BibDatabaseContext database,
@@ -220,10 +222,13 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         clearAndSelectLast();
                         event.consume();
                         break;
-                    case PASTE:
-                        paste();
-                        event.consume();
-                        break;
+                    case PASTE: {
+                        if (!OS.OS_X) { //ugly hack, prevents duplicate entries on pasting. Side effect: Prevents pasting using cmd+v on an empty library
+                            paste();
+                            event.consume();
+                            break;
+                        }
+                    }
                     case COPY:
                         copy();
                         event.consume();
@@ -258,6 +263,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         if (!entriesToAdd.isEmpty()) {
             this.requestFocus();
         }
+
     }
 
     private void handleOnDragOver(TableRow<BibEntryTableViewModel> row, BibEntryTableViewModel item, DragEvent event) {

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -62,7 +62,6 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
     private long lastKeyPressTime;
     private String columnSearchTerm;
 
-
     public MainTable(MainTableDataModel model, JabRefFrame frame,
                      BasePanel panel, BibDatabaseContext database,
                      MainTablePreferences preferences, ExternalFileTypes externalFileTypes, KeyBindingRepository keyBindingRepository) {
@@ -222,13 +221,12 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         clearAndSelectLast();
                         event.consume();
                         break;
-                    case PASTE: {
-                        if (!OS.OS_X) { //ugly hack, prevents duplicate entries on pasting. Side effect: Prevents pasting using cmd+v on an empty library
+                    case PASTE:
+                        if (!OS.OS_X) { // ugly hack, prevents duplicate entries on pasting. Side effect: Prevents pasting using cmd+v on an empty library
                             paste();
                             event.consume();
                             break;
                         }
-                    }
                     case COPY:
                         copy();
                         event.consume();


### PR DESCRIPTION
Add hack for OSX.
Caveat: Prevents pasting using Cmd+V on an empty library. Menu pasting however works.

Fixes #6739 
Fixes #6738 
Fixes #6293 

Would be nice if someone could test this for windows/linux as well

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
