### PR TITLE
Remember last choice of download files in import dialog

### DIFF
--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -79,7 +79,7 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
         Button btn = (Button) this.getDialogPane().lookupButton(importButton);
         btn.disableProperty().bind(booleanBind);
 
-        downloadLinkedOnlineFiles.setSelected(preferences.getFilePreferences().getDownloadLinkedFiles());
+        downloadLinkedOnlineFiles.setSelected(preferences.getFilePreferences().shouldDownloadLinkedFiles());
 
         setResultConverter(button -> {
             if (button == importButton) {

--- a/src/main/java/org/jabref/gui/preferences/ImportTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ImportTab.fxml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
@@ -28,8 +27,7 @@
                   prefWidth="300" minWidth="300" maxWidth="300"/>
 
         <Label text="%File directory pattern" GridPane.rowIndex="1"/>
-        <TextField fx:id="fileDirPattern" GridPane.columnIndex="1" GridPane.rowIndex="1"
+        <TextField fx:id="fileDirectoryPattern" GridPane.columnIndex="1" GridPane.rowIndex="1"
                    prefWidth="300" minWidth="300" maxWidth="300"/>
-        <CheckBox fx:id="downloadLinkedFiles" text="%Download linked online files" GridPane.rowIndex="2"/>
     </GridPane>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/ImportTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/ImportTabView.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.preferences;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 
@@ -13,8 +12,7 @@ import com.airhacks.afterburner.views.ViewLoader;
 public class ImportTabView extends AbstractPreferenceTabView<ImportTabViewModel> implements PreferencesTab {
 
     @FXML private ComboBox<String> fileNamePattern;
-    @FXML private TextField fileDirPattern;
-    @FXML private CheckBox downloadLinkedFiles;
+    @FXML private TextField fileDirectoryPattern;
 
     public ImportTabView(JabRefPreferences preferences) {
         this.preferences = preferences;
@@ -25,12 +23,11 @@ public class ImportTabView extends AbstractPreferenceTabView<ImportTabViewModel>
     }
 
     public void initialize() {
-        this.viewModel = new ImportTabViewModel(dialogService, preferences);
+        this.viewModel = new ImportTabViewModel(preferences);
 
         fileNamePattern.valueProperty().bindBidirectional(viewModel.fileNamePatternProperty());
         fileNamePattern.itemsProperty().bind(viewModel.defaultFileNamePatternsProperty());
-        fileDirPattern.textProperty().bindBidirectional(viewModel.fileDirPatternProperty());
-        downloadLinkedFiles.selectedProperty().bindBidirectional(viewModel.downloadLinkedFilesProperty());
+        fileDirectoryPattern.textProperty().bindBidirectional(viewModel.fileDirPatternProperty());
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/preferences/ImportTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/ImportTabViewModel.java
@@ -3,15 +3,12 @@ package org.jabref.gui.preferences;
 import java.util.ArrayList;
 import java.util.List;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 
-import org.jabref.gui.DialogService;
 import org.jabref.preferences.JabRefPreferences;
 
 public class ImportTabViewModel implements PreferenceTabViewModel {
@@ -21,13 +18,10 @@ public class ImportTabViewModel implements PreferenceTabViewModel {
     private final ListProperty<String> defaultFileNamePatternsProperty = new SimpleListProperty<>(FXCollections.observableArrayList(DEFAULT_FILENAME_PATTERNS));
     private final StringProperty fileNamePatternProperty = new SimpleStringProperty();
     private final StringProperty fileDirPatternProperty = new SimpleStringProperty();
-    private final BooleanProperty downloadLinkedFilesProperty = new SimpleBooleanProperty();
 
-    private final DialogService dialogService;
     private final JabRefPreferences preferences;
 
-    public ImportTabViewModel(DialogService dialogService, JabRefPreferences preferences) {
-        this.dialogService = dialogService;
+    public ImportTabViewModel(JabRefPreferences preferences) {
         this.preferences = preferences;
     }
 
@@ -35,14 +29,12 @@ public class ImportTabViewModel implements PreferenceTabViewModel {
     public void setValues() {
         fileNamePatternProperty.setValue(preferences.get(JabRefPreferences.IMPORT_FILENAMEPATTERN));
         fileDirPatternProperty.setValue(preferences.get(JabRefPreferences.IMPORT_FILEDIRPATTERN));
-        downloadLinkedFilesProperty.setValue(preferences.getBoolean(JabRefPreferences.DOWNLOAD_LINKED_FILES));
     }
 
     @Override
     public void storeSettings() {
         preferences.put(JabRefPreferences.IMPORT_FILENAMEPATTERN, fileNamePatternProperty.getValue());
         preferences.put(JabRefPreferences.IMPORT_FILEDIRPATTERN, fileDirPatternProperty.getValue());
-        preferences.putBoolean(JabRefPreferences.DOWNLOAD_LINKED_FILES, downloadLinkedFilesProperty.getValue());
     }
 
     @Override
@@ -65,9 +57,5 @@ public class ImportTabViewModel implements PreferenceTabViewModel {
 
     public StringProperty fileDirPatternProperty() {
         return fileDirPatternProperty;
-    }
-
-    public BooleanProperty downloadLinkedFilesProperty() {
-        return downloadLinkedFilesProperty;
     }
 }

--- a/src/main/java/org/jabref/model/metadata/FilePreferences.java
+++ b/src/main/java/org/jabref/model/metadata/FilePreferences.java
@@ -12,20 +12,20 @@ public class FilePreferences {
     private final boolean bibLocationAsPrimary;
     private final String fileNamePattern;
     private final String fileDirPattern;
-    private final boolean downloadLinkedFiles;
+    private boolean shouldDownloadLinkedFiles;
 
     public FilePreferences(String user,
                            String mainFileDirectory,
                            boolean bibLocationAsPrimary,
                            String fileNamePattern,
                            String fileDirPattern,
-                           boolean downloadLinkedFiles) {
+                           boolean shouldDownloadLinkedFiles) {
         this.user = user;
         this.mainFileDirectory = mainFileDirectory;
         this.bibLocationAsPrimary = bibLocationAsPrimary;
         this.fileNamePattern = fileNamePattern;
         this.fileDirPattern = fileDirPattern;
-        this.downloadLinkedFiles = downloadLinkedFiles;
+        this.shouldDownloadLinkedFiles = shouldDownloadLinkedFiles;
     }
 
     public String getUser() {
@@ -52,7 +52,11 @@ public class FilePreferences {
         return fileDirPattern;
     }
 
-    public boolean getDownloadLinkedFiles() {
-        return downloadLinkedFiles;
+    public boolean shouldDownloadLinkedFiles() {
+        return shouldDownloadLinkedFiles;
+    }
+
+    public void setShouldDownloadLinkedFiles(boolean shouldDownloadLinkedFiles) {
+        this.shouldDownloadLinkedFiles = shouldDownloadLinkedFiles;
     }
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -252,7 +252,6 @@ public class JabRefPreferences implements PreferencesService {
     public static final String CLEANUP_FORMATTERS = "CleanUpFormatters";
     public static final String IMPORT_FILENAMEPATTERN = "importFileNamePattern";
     public static final String IMPORT_FILEDIRPATTERN = "importFileDirPattern";
-    private static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
     public static final String NAME_FORMATTER_VALUE = "nameFormatterFormats";
     public static final String NAME_FORMATER_KEY = "nameFormatterNames";
     public static final String PUSH_TO_APPLICATION = "pushToApplication";
@@ -358,6 +357,7 @@ public class JabRefPreferences implements PreferencesService {
 
     // Dialog states
     private static final String PREFS_EXPORT_PATH = "prefsExportPath";
+    private static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
 
     // Helper string
     private static final String USER_HOME = System.getProperty("user.home");

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -252,7 +252,7 @@ public class JabRefPreferences implements PreferencesService {
     public static final String CLEANUP_FORMATTERS = "CleanUpFormatters";
     public static final String IMPORT_FILENAMEPATTERN = "importFileNamePattern";
     public static final String IMPORT_FILEDIRPATTERN = "importFileDirPattern";
-    public static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
+    private static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
     public static final String NAME_FORMATTER_VALUE = "nameFormatterFormats";
     public static final String NAME_FORMATER_KEY = "nameFormatterNames";
     public static final String PUSH_TO_APPLICATION = "pushToApplication";
@@ -647,8 +647,8 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(IMPORT_FILENAMEPATTERN, ImportTabViewModel.DEFAULT_FILENAME_PATTERNS[1]);
         // Default empty String to be backwards compatible
         defaults.put(IMPORT_FILEDIRPATTERN, "");
-        // Don't download files by default
-        defaults.put(DOWNLOAD_LINKED_FILES, false);
+        // Download files by default
+        defaults.put(DOWNLOAD_LINKED_FILES, true);
 
         customImports = new CustomImportList(this);
 
@@ -1180,6 +1180,15 @@ public class JabRefPreferences implements PreferencesService {
                 get(IMPORT_FILENAMEPATTERN),
                 get(IMPORT_FILEDIRPATTERN),
                 getBoolean(DOWNLOAD_LINKED_FILES));
+    }
+
+    @Override
+    public void storeFilePreferences(FilePreferences filePreferences) {
+        put(JabRefPreferences.MAIN_FILE_DIRECTORY, filePreferences.getFileDirectory().map(Path::toString).orElse(""));
+        putBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR, filePreferences.isBibLocationAsPrimary());
+        put(JabRefPreferences.IMPORT_FILENAMEPATTERN, filePreferences.getFileNamePattern());
+        put(JabRefPreferences.IMPORT_FILEDIRPATTERN, filePreferences.getFileDirPattern());
+        putBoolean(JabRefPreferences.DOWNLOAD_LINKED_FILES, filePreferences.shouldDownloadLinkedFiles());
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -58,6 +58,8 @@ public interface PreferencesService {
 
     FilePreferences getFilePreferences();
 
+    void storeFilePreferences(FilePreferences filePreferences);
+
     FieldWriterPreferences getFieldWriterPreferences();
 
     FieldContentFormatterPreferences getFieldContentParserPreferences();


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

The choice to download linked files in the import dialog is now remembered, and automatically restored. So if you downloaded the files the last time, the option is selected on the next import. This made the corresponding option in the preference dialog obsolete.

Rest is a bit of code cleanup.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
