### PR TITLE
Fix APS and ScienceDirect fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue about duplicated group color indicators [#6175](https://github.com/JabRef/jabref/issues/6175)
 - We fixed an issue where entries with the entry type Misc from an imported aux file would not be saved correctly to the bib file on disk [#6405](https://github.com/JabRef/jabref/issues/6405)
 - We fixed an issue where percent sign ('%') was not formatted properly by the HTML formatter [#6753](https://github.com/JabRef/jabref/issues/6753)
+- We fixed an issue with the [SAO/NASA Astrophysics Data System](https://docs.jabref.org/collect/import-using-online-bibliographic-database/ads) fetcher where `\textbackslash` appeared at the end of the abstract.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where entries with the entry type Misc from an imported aux file would not be saved correctly to the bib file on disk [#6405](https://github.com/JabRef/jabref/issues/6405)
 - We fixed an issue where percent sign ('%') was not formatted properly by the HTML formatter [#6753](https://github.com/JabRef/jabref/issues/6753)
 - We fixed an issue with the [SAO/NASA Astrophysics Data System](https://docs.jabref.org/collect/import-using-online-bibliographic-database/ads) fetcher where `\textbackslash` appeared at the end of the abstract.
+- We fixed an issue with the Science Direct fetcher where PDFs could not be downloaded. Fixes [#5860](https://github.com/JabRef/jabref/issues/5860)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -156,7 +156,9 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
              .ifPresent(abstractText -> entry.clearField(StandardField.ABSTRACT));
 
         entry.getField(StandardField.ABSTRACT)
-             .map(abstractText -> abstractText.replace("<P />", "").trim())
+             .map(abstractText -> abstractText.replace("<P />", ""))
+             .map(abstractText -> abstractText.replace("\\textbackslash", ""))
+             .map(abstractText -> abstractText.trim())
              .ifPresent(abstractText -> entry.setField(StandardField.ABSTRACT, abstractText));
         // The fetcher adds some garbage (number of found entries etc before)
         entry.setCommentsBeforeEntry("");

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -2,19 +2,15 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jabref.logic.importer.FulltextFetcher;
-import org.jabref.logic.importer.util.JsonReader;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
-import com.google.gson.Gson;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
@@ -24,9 +20,7 @@ import kong.unirest.json.JSONException;
 import kong.unirest.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.jsoup.select.NodeFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/GrobidCitationFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GrobidCitationFetcherTest.java
@@ -34,12 +34,14 @@ public class GrobidCitationFetcherTest {
                 .withField(StandardField.PAGES, "245--259")
                 .withField(StandardField.VOLUME, "23")
                 .withField(StandardField.NUMBER, "4");
+
     static String example2 = "Thomas, H. K. (2004). Training strategies for improving listeners' comprehension of foreign-accented speech (Doctoral dissertation). University of Colorado, Boulder.";
     static BibEntry example2AsBibEntry = new BibEntry(BibEntry.DEFAULT_TYPE).withCiteKey("-1")
             .withField(StandardField.AUTHOR, "Thomas, H")
             .withField(StandardField.TITLE, "Training strategies for improving listeners' comprehension of foreign-accented speech (Doctoral dissertation)")
             .withField(StandardField.YEAR, "2004")
             .withField(StandardField.ADDRESS, "Boulder");
+
     static String example3 = "Turk, J., Graham, P., & Verhulst, F. (2007). Child and adolescent psychiatry : A developmental approach. Oxford, England: Oxford University Press.";
     static BibEntry example3AsBibEntry = new BibEntry(BibEntry.DEFAULT_TYPE).withCiteKey("-1")
             .withField(StandardField.AUTHOR, "Turk, J and Graham, P and Verhulst, F")
@@ -47,6 +49,7 @@ public class GrobidCitationFetcherTest {
             .withField(StandardField.PUBLISHER, "Oxford University Press")
             .withField(StandardField.YEAR, "2007")
             .withField(StandardField.ADDRESS, "Oxford, England");
+
     static String example4 = "Carr, I., & Kidner, R. (2003). Statutes and conventions on international trade law (4th ed.). London, England: Cavendish.";
     static BibEntry example4AsBibEntry = new BibEntry(StandardEntryType.InBook).withCiteKey("-1")
             .withField(StandardField.AUTHOR, "Carr, I and Kidner, R")
@@ -54,9 +57,6 @@ public class GrobidCitationFetcherTest {
             .withField(StandardField.PUBLISHER, "Cavendish")
             .withField(StandardField.YEAR, "2003")
             .withField(StandardField.ADDRESS, "London, England");
-    static String invalidInput1 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx________________________________";
-    static String invalidInput2 = "¦@#¦@#¦@#¦@#¦@#¦@#¦@°#¦@¦°¦@°";
-
 
     public static Stream<Arguments> provideExamplesForCorrectResultTest() {
         return Stream.of(
@@ -64,6 +64,13 @@ public class GrobidCitationFetcherTest {
                 Arguments.of("example2", example2AsBibEntry, example2),
                 Arguments.of("example3", example3AsBibEntry, example3),
                 Arguments.of("example4", example4AsBibEntry, example4)
+        );
+    }
+
+    public static Stream<Arguments> provideInvalidInput() {
+        return Stream.of(
+                Arguments.of("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx________________________________"),
+                Arguments.of("¦@#¦@#¦@#¦@#¦@#¦@#¦@°#¦@¦°¦@°")
         );
     }
 
@@ -86,11 +93,10 @@ public class GrobidCitationFetcherTest {
         assertEquals(Collections.emptyList(), entries);
     }
 
-    @Test
-    public void grobidPerformSearchWithInvalidDataTest() {
-        List<BibEntry> entries = grobidCitationFetcher.performSearch(invalidInput1);
-        assertEquals(Collections.emptyList(), entries);
-        entries = grobidCitationFetcher.performSearch(invalidInput2);
+    @ParameterizedTest
+    @MethodSource("provideInvalidInput")
+    public void grobidPerformSearchWithInvalidDataTest(String invalidInput) {
+        List<BibEntry> entries = grobidCitationFetcher.performSearch(invalidInput);
         assertEquals(Collections.emptyList(), entries);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/GrobidCitationFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GrobidCitationFetcherTest.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
@@ -10,6 +11,9 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,16 +57,21 @@ public class GrobidCitationFetcherTest {
     static String invalidInput1 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx________________________________";
     static String invalidInput2 = "¦@#¦@#¦@#¦@#¦@#¦@#¦@°#¦@¦°¦@°";
 
-    @Test
-    public void grobidPerformSearchCorrectResultTest() {
-        List<BibEntry> entries = grobidCitationFetcher.performSearch(example1);
-        assertEquals(List.of(example1AsBibEntry), entries);
-        entries = grobidCitationFetcher.performSearch(example2);
-        assertEquals(List.of(example2AsBibEntry), entries);
-        entries = grobidCitationFetcher.performSearch(example3);
-        assertEquals(List.of(example3AsBibEntry), entries);
-        entries = grobidCitationFetcher.performSearch(example4);
-        assertEquals(List.of(example4AsBibEntry), entries);
+
+    public static Stream<Arguments> provideExamplesForCorrectResultTest() {
+        return Stream.of(
+                Arguments.of("example1", example1AsBibEntry, example1),
+                Arguments.of("example2", example2AsBibEntry, example2),
+                Arguments.of("example3", example3AsBibEntry, example3),
+                Arguments.of("example4", example4AsBibEntry, example4)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideExamplesForCorrectResultTest")
+    public void grobidPerformSearchCorrectResultTest(String testName, BibEntry expectedBibEntry, String searchQuery) {
+        List<BibEntry> entries = grobidCitationFetcher.performSearch(searchQuery);
+        assertEquals(List.of(expectedBibEntry), entries);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
@@ -50,6 +50,18 @@ class ScienceDirectTest {
 
     @Test
     @DisabledOnCIServer("CI server is blocked")
+    void findByDoiWorksForBoneArticle() throws IOException {
+        // The DOI is an example by a user taken from https://github.com/JabRef/jabref/issues/5860
+        entry.setField(StandardField.DOI, "https://doi.org/10.1016/j.bone.2020.115226");
+
+        assertEquals(
+                Optional.of(new URL("https://www.sciencedirect.com/science/article/pii/S8756328220300065/pdfft?md5=0ad75ff155637dec358e5c9fb8b90afd&pid=1-s2.0-S8756328220300065-main.pdf")),
+                finder.findFullText(entry)
+        );
+    }
+
+    @Test
+    @DisabledOnCIServer("CI server is blocked")
     void notFoundByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1016/j.aasri.2014.0559.002");
 


### PR DESCRIPTION
This PR fixes two fetchers (refs https://github.com/JabRef/jabref/issues/6369):

- APS fetcher: `\textbackslash` is added server side --> removed at cleanup-phase
- ScienceDirect: location of PDF link changed --> rewrote code to extract the PDF url - fixes https://github.com/JabRef/jabref/issues/5860

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
