### PR TITLE
Fix cleanup Field formatters not working when enabled

### DIFF
--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -128,7 +128,7 @@ public class CleanupPresetPanel extends VBox {
         activeJobs.add(CleanupPreset.CleanupStep.FIX_FILE_LINKS);
 
         return new CleanupPreset(activeJobs, new FieldFormatterCleanups(
-                formatterCleanupsPanel.cleanupsDisableProperty().getValue(),
+                !formatterCleanupsPanel.cleanupsDisableProperty().not().getValue(), //We have to use the not here as bindBidrectional can't be bound to a BooleanBinding
                 formatterCleanupsPanel.cleanupsProperty()));
     }
 }

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -128,7 +128,7 @@ public class CleanupPresetPanel extends VBox {
         activeJobs.add(CleanupPreset.CleanupStep.FIX_FILE_LINKS);
 
         return new CleanupPreset(activeJobs, new FieldFormatterCleanups(
-                !formatterCleanupsPanel.cleanupsDisableProperty().not().getValue(), //We have to use the not here as bindBidrectional can't be bound to a BooleanBinding
+                !formatterCleanupsPanel.cleanupsDisableProperty().not().getValue(), // We have to use the not here as bindBidrectional can't be bound to a BooleanBinding
                 formatterCleanupsPanel.cleanupsProperty()));
     }
 }

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -128,7 +128,7 @@ public class CleanupPresetPanel extends VBox {
         activeJobs.add(CleanupPreset.CleanupStep.FIX_FILE_LINKS);
 
         return new CleanupPreset(activeJobs, new FieldFormatterCleanups(
-                !formatterCleanupsPanel.cleanupsDisableProperty().getValue(),
+                formatterCleanupsPanel.cleanupsDisableProperty().getValue(),
                 formatterCleanupsPanel.cleanupsProperty()));
     }
 }

--- a/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -128,7 +128,7 @@ public class CleanupPresetPanel extends VBox {
         activeJobs.add(CleanupPreset.CleanupStep.FIX_FILE_LINKS);
 
         return new CleanupPreset(activeJobs, new FieldFormatterCleanups(
-                !formatterCleanupsPanel.cleanupsDisableProperty().not().getValue(), // We have to use the not here as bindBidrectional can't be bound to a BooleanBinding
+                !formatterCleanupsPanel.cleanupsDisableProperty().getValue(),
                 formatterCleanupsPanel.cleanupsProperty()));
     }
 }

--- a/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
@@ -22,6 +22,7 @@ import org.jabref.model.cleanup.Formatter;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
+import com.tobiasdiez.easybind.EasyBind;
 
 public class FieldFormatterCleanupsPanel extends VBox {
 
@@ -106,7 +107,13 @@ public class FieldFormatterCleanupsPanel extends VBox {
     }
 
     private void setupBindings() {
-        cleanupsEnabled.selectedProperty().bindBidirectional(cleanupsDisableProperty());
+        // cannot bindBidirectional, because viewModel.cleanupsDisableProperty().not() provides a read only
+        // BooleanBinding, but bindBidirectional requires a simple BooleanProperty
+        cleanupsEnabled.selectedProperty().addListener((observableValue, oldValue, newValue) ->
+                viewModel.cleanupsDisableProperty().setValue(!observableValue.getValue()));
+        viewModel.cleanupsDisableProperty().addListener((observableValue, oldValue, newValue) ->
+                cleanupsEnabled.setSelected(!observableValue.getValue()));
+
         cleanupsList.itemsProperty().bind(viewModel.cleanupsListProperty());
         addableFields.itemsProperty().bind(viewModel.availableFieldsProperty());
         addableFields.valueProperty().bindBidirectional(viewModel.selectedFieldProperty());

--- a/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
@@ -22,7 +22,6 @@ import org.jabref.model.cleanup.Formatter;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import com.tobiasdiez.easybind.EasyBind;
 
 public class FieldFormatterCleanupsPanel extends VBox {
 


### PR DESCRIPTION
Fixes #6787

The problem orginally comes from here:
https://github.com/JabRef/jabref/blob/4e220f618a755cb7dc18882653ea46e3ed049c9e/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java#L109

Unfortuantely it's not possible to add a not() there directly
The method bindBidirectional(Property<Boolean>) in the type BooleanProperty is not applicable for the arguments (BooleanBinding)



<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
