### PR TITLE
Disable CSL refresh on push

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -1,10 +1,6 @@
 name: Refresh Citation Style Language Files
 
 on:
-  push:
-    paths:
-      - '.github/workflows/refresh-csl-subtrees.yml'
-      - 'src/main/resources/csl-locales/**'
   schedule:
     # run on 1st and 15th of each month
     - cron: '1 2 1,15 * *'


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

I've just noticed that the Update CSL workflow is invoked on every push, see e.g. https://github.com/JabRef/jabref/actions?query=workflow%3A%22Refresh+Citation+Style+Language+Files%22. This is fixed. 

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
