### PR TITLE
Remove checkstyle hack. 8.36 got released

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -10,13 +10,6 @@
         <property name="header" value=""/>
     </module>
 
-    <!-- BeforeExecutionFileFilters is required for sources that are based on java14 -->
-    <module name="BeforeExecutionExclusionFileFilter">
-        <property
-                name="fileNamePattern"
-                value="AuthorAndsReplacer.java|EntryTypeView.java|IEEE.java|MainTableFieldValueFormatter.java|Ordinal.java"/>
-    </module>
-
     <module name="SuppressionFilter">
         <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
@@ -167,7 +167,7 @@ Contributions to JabRef's source code need to have a code formatting that is con
    3. Click "Browse" and choose `config/checkstyle/checkstyle.xml`
    4. Click "Next" and "Finish"
    5. Activate the CheckStyle configuration file by ticking it in the list
-   6. Ensure that the latest CheckStyle version is selected \(8.32 or higher\)
+   6. Ensure that the [latest CheckStyle version](https://checkstyle.org/releasenotes.html) is selected \(8.36 or higher\). 8.36 is required for Java 14.
    7. Set the "Scan Scope" to "Only Java sources \(including tests\)
    8. Save settings by clicking "OK"
    9. Your configuration should now look like this:

--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -4,12 +4,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import javax.inject.Inject;
+
 import javafx.application.Platform;
 import javafx.event.Event;
 import javafx.fxml.FXML;
-
-import javax.inject.Inject;
-
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
@@ -43,10 +42,10 @@ import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 /**
  * Dialog that prompts the user to choose a type for an entry.
- *
- * @return null if canceled
  */
 public class EntryTypeView extends BaseDialog<EntryType> {
+
+    @Inject StateManager stateManager;
 
     @FXML private ButtonType generateButton;
     @FXML private TextField idTextField;
@@ -61,8 +60,6 @@ public class EntryTypeView extends BaseDialog<EntryType> {
     @FXML private TitledPane ieeeTranTitlePane;
     @FXML private TitledPane customTitlePane;
     @FXML private TitledPane biblatexSoftwareTitlePane;
-
-    @Inject StateManager stateManager;
 
     private final BasePanel basePanel;
     private final DialogService dialogService;
@@ -202,11 +199,12 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         this.close();
     }
 
-    //The description is coming from biblatex manual chapter 2
-    //Biblatex documentation is favored over the bibtex,
-    //since bibtex is a subset of biblatex and biblatex is better documented.
+    /**
+     * The description is originating from biblatex manual chapter 2
+     * Biblatex documentation is favored over the bibtex,
+     * since bibtex is a subset of biblatex and biblatex is better documented.
+     */
     public static String getDescription(EntryType selectedType) {
-        //CHECKSTYLE:OFF
         if (selectedType instanceof StandardEntryType) {
             switch ((StandardEntryType) selectedType) {
                 case Article -> {
@@ -312,7 +310,5 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         } else {
             return "";
         }
-        //CHECKSTYLE:ON
-
     }
 }


### PR DESCRIPTION
Checkstyle 8.36 was released - including Java14 support: https://checkstyle.org/releasenotes.html. Thus, no hack necessary any more.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
