### PR TITLE
Snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,11 +8,9 @@ description: |
   The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.
   To access files in external media (i.e. usb drives) you must run:
   `snap connect jabref:removable-media`
-
 grade: stable
 confinement: strict
 base: core18
-license: MIT
 architectures:
   - build-on: amd64
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,10 +39,10 @@ plugs:
 apps:
   jabref:
     command: bin/JabRef
-    extensions: [gnome-3-28]
+    extensions: [gnome-3-34]
   browser-proxy:
     command: lib/jabrefHost.py
-    extensions: [gnome-3-28]
+    extensions: [gnome-3-34]
 
 environment:
   _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"


### PR DESCRIPTION
Our beta snapcraft image does not start. Reason: No Java 14 available.

I updated the gnome base image. We need to stay "core18". - Gnome 3.34 is not available for core20 --> https://forum.snapcraft.io/t/gnome-3-34-extension-for-core20/18590/3?u=koppor

@LyzardKing Can you take over?

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
