### PR TITLE
Cancel Previous Workflow Runs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -40,6 +40,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Create installer and portable version for ${{ matrix.displayName }}
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Create snapcraft image
-
     steps:
       - name: Check secrets presence
         id: checksecrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
     name: Checkstyle
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout source
         uses: actions/checkout@v2
       - name: Set up JDK


### PR DESCRIPTION
We need to cancel previous running workflows in case a new one starts. This is not suppored by GitHub (https://github.community/t/github-actions-cancel-redundant-builds-not-solved/16025?u=koppor), but there is an action implementing it: https://github.com/marketplace/actions/cancel-workflow-action

This PR adds that action.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
