### PR TITLE
"Find unlinked files": rename window

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesDialog.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesDialog.java
@@ -57,7 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * GUI Dialog for the feature "Find unlinked files".
+ * GUI Dialog for the feature "Search for unlinked local files".
  */
 public class FindUnlinkedFilesDialog extends BaseDialog<Boolean> {
 
@@ -77,7 +77,7 @@ public class FindUnlinkedFilesDialog extends BaseDialog<Boolean> {
 
     public FindUnlinkedFilesDialog(BibDatabaseContext database, DialogService dialogService, CountingUndoManager undoManager) {
         super();
-        this.setTitle(Localization.lang("Find unlinked files"));
+        this.setTitle(Localization.lang("Search for unlinked local files"));
         this.dialogService = dialogService;
 
         databaseContext = database;


### PR DESCRIPTION
The window "Find unlinked files" should be named "Search for unlinked local files" now (v. 5.2) to be consistent with the menu Lookup.



- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
