### PR TITLE
Fetch by ID: SAO/NASA Astrophysics Data System -> SAO/NASA ADS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We removed two useless preferences in the groups preferences dialog. [#6836](https://github.com/JabRef/jabref/pull/6836)
 - Synchronization of SpecialFields to keywords is now disabled by default. [#6621](https://github.com/JabRef/jabref/issues/6621)
 - JabRef no longer opens the entry editor with the first entry on startup [6855](https://github.com/JabRef/jabref/issues/6855)
+- Fetch by ID: (long) "SAO/NASA Astrophysics Data System" replaced by (short) "SAO/NASA ADS" [6876]{https://github.com/JabRef/jabref/pull/6876}
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -74,7 +74,7 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
 
     @Override
     public String getName() {
-        return "SAO/NASA Astrophysics Data System";
+        return "SAO/NASA ADS";
     }
 
     /**

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -136,7 +136,7 @@ public class AstrophysicsDataSystemTest {
 
     @Test
     public void testGetName() {
-        assertEquals("SAO/NASA Astrophysics Data System", fetcher.getName());
+        assertEquals("SAO/NASA ADS", fetcher.getName());
     }
 
     @Test


### PR DESCRIPTION
In drop-down menu for fetching by ID of the window "Select entry type", "SAO/NASA Astrophysics Data System" is quite long.
Replacement by SAO/NASA ADS (people knowing it will recognized it).

- [X] Change in CHANGELOG.md described (if applicable)

None of these items...:
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
