### PR TITLE
Fixes bugs in the `regex` cite key pattern modifier

### DIFF
--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -29,7 +29,7 @@ public class RegexFormatter extends Formatter {
      * RegexFormatter#regex} and {@link RegexFormatter#replacement} used in {@link RegexFormatter#format(String)}
      */
     private static final Pattern CONSTRUCTOR_ARGUMENT = Pattern.compile(
-            "^\\(\"(?<" + REGEX_CAPTURING_GROUP + ">.*?)\" *?, *?\"(?<" + REPLACEMENT_CAPTURING_GROUP + ">.*?)\"\\)$");
+            "^\\(\"(?<" + REGEX_CAPTURING_GROUP + ">.*?)\" *?, *?\"(?<" + REPLACEMENT_CAPTURING_GROUP + ">.*)\"\\)$");
     // Magic arbitrary unicode char, which will never appear in bibtex files
     private static final String PLACEHOLDER_FOR_PROTECTED_GROUP = Character.toString('\u0A14');
     private static final String PLACEHOLDER_FOR_OPENING_CURLY_BRACE = Character.toString('\u0A15');

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -5,13 +5,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
 
-public class RegexFormatter extends Formatter {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+public class RegexFormatter extends Formatter {
     public static final String KEY = "regex";
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegexFormatter.class);
     private static final Pattern PATTERN_ESCAPED_OPENING_CURLY_BRACE = Pattern.compile("\\\\\\{");
     private static final Pattern PATTERN_ESCAPED_CLOSING_CURLY_BRACE = Pattern.compile("\\\\\\}");
     // RegEx to match {...}
@@ -49,6 +53,7 @@ public class RegexFormatter extends Formatter {
         } else {
             regex = null;
             replacement = null;
+            LOGGER.warn("RegexFormatter could not parse the input: " + input);
         }
     }
 
@@ -70,7 +75,13 @@ public class RegexFormatter extends Formatter {
             replaced.add(matcher.group(1));
         }
         String workingString = matcher.replaceAll(PLACEHOLDER_FOR_PROTECTED_GROUP);
-        workingString = workingString.replaceAll(regex, replacement);
+        try {
+            workingString = workingString.replaceAll(regex, replacement);
+        } catch (PatternSyntaxException e) {
+            LOGGER.warn("There is a syntax error in the regular expression, " +
+                    regex + ", used by the regex modifier", e);
+            return input;
+        }
 
         for (String r : replaced) {
             workingString = workingString.replaceFirst(PLACEHOLDER_FOR_PROTECTED_GROUP, r);

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -53,7 +53,7 @@ public class RegexFormatter extends Formatter {
         } else {
             regex = null;
             replacement = null;
-            LOGGER.warn("RegexFormatter could not parse the input: " + input);
+            LOGGER.warn("RegexFormatter could not parse the input: {}", input);
         }
     }
 

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -36,7 +36,8 @@ public class RegexFormatter extends Formatter {
     /**
      * Constructs a new regular expression-based formatter with the given RegEx.
      *
-     * @param input the regular expressions for matching and replacing given in the form {@code (<regex>, <replace>)}.
+     * @param input the regular expressions for matching and replacing given in the form {@code ("<regex>",
+     *              "<replace>")}.
      */
     public RegexFormatter(String input) {
         Objects.requireNonNull(input);

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -78,8 +78,7 @@ public class RegexFormatter extends Formatter {
         try {
             workingString = workingString.replaceAll(regex, replacement);
         } catch (PatternSyntaxException e) {
-            LOGGER.warn("There is a syntax error in the regular expression, " +
-                    regex + ", used by the regex modifier", e);
+            LOGGER.warn("There is a syntax error in the regular expression \"{}\" used by the regex modifier", regex, e);
             return input;
         }
 

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -73,4 +73,10 @@ class RegexFormatterTest {
         formatter = new RegexFormatter("(\"[A-Z]\", \"\")");
         assertEquals("abc", formatter.format("AaBbCc"));
     }
+
+    @Test
+    void formatWithSyntaxErrorReturnUnchangedString() {
+        formatter = new RegexFormatter("(\"(\", \"\")");
+        assertEquals("AaBbCc", formatter.format("AaBbCc"));
+    }
 }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -4,9 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Tests in addition to the general tests from {@link org.jabref.logic.formatter.FormatterTest}
- */
 class RegexFormatterTest {
 
     private RegexFormatter formatter;
@@ -51,5 +48,23 @@ class RegexFormatterTest {
     void formatExample() {
         formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("Please-replace-the-spaces", formatter.format(formatter.getExampleInput()));
+    }
+
+    @Test
+    void formatCanRemoveMatchesWithEmptyReplacement() {
+        formatter = new RegexFormatter("(\"[A-Z]\",\"\")");
+        assertEquals("abc", formatter.format("AaBbCc"));
+    }
+
+    @Test
+    void constructorWithInvalidConstructorArgumentReturnUnchangedString() {
+        formatter = new RegexFormatter("(\"\",\"\"");
+        assertEquals("AaBbCc", formatter.format("AaBbCc"));
+    }
+
+    @Test
+    void constructorAllowsSpacesBetweenQuotes() {
+        formatter = new RegexFormatter("(\"[A-Z]\", \"\")");
+        assertEquals("abc", formatter.format("AaBbCc"));
     }
 }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -63,6 +63,12 @@ class RegexFormatterTest {
     }
 
     @Test
+    void constructorWithEmptyStringArgumentReturnUnchangedString() {
+        formatter = new RegexFormatter("");
+        assertEquals("AaBbCc", formatter.format("AaBbCc"));
+    }
+
+    @Test
     void constructorAllowsSpacesBetweenQuotes() {
         formatter = new RegexFormatter("(\"[A-Z]\", \"\")");
         assertEquals("abc", formatter.format("AaBbCc"));


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
There are some bugs in the `regex` modifier. The following change-list is preliminary,

- [x] Formatting with invalid or missing arguments will now return an unmodified `String`
- [x] A space between the regex and the replacement will be allowed (both `(".", "")` and `(".","")` will be considered valid)
- [x] The modifier can replace with an empty string (i.e., remove things)

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] ~Change in CHANGELOG.md described (if applicable)~
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] ~Screenshots added in PR description (for UI changes)~
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
