### PR TITLE
Window "Manage field names & content": make title consistent with menu (+ localization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We completed the rebranding of `bibtexkey` as `citationkey` which was started in JabRef 5.1.
 - JabRef no longer opens the entry editor with the first entry on startup [#6855](https://github.com/JabRef/jabref/issues/6855)
 - Fetch by ID: (long) "SAO/NASA Astrophysics Data System" replaced by (short) "SAO/NASA ADS" [#6876](https://github.com/JabRef/jabref/pull/6876)
+- Window "Manage field names and content": same title as the menu (+ localization)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/edit/MassSetFieldsDialog.java
+++ b/src/main/java/org/jabref/gui/edit/MassSetFieldsDialog.java
@@ -62,7 +62,7 @@ public class MassSetFieldsDialog extends BaseDialog<Void> {
         this.undoManager = undoManager;
 
         init();
-        this.setTitle("Set/clear/append/rename fields");
+        this.setTitle(Localization.lang("Manage field names & content"));
         this.getDialogPane().getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
         this.setResultConverter(button -> {
             if (button == ButtonType.OK) {


### PR DESCRIPTION
With Edit -> Manage field names & content, a window opened, with the title "Set/clear/append/rename".
Window title updated to match the menu.
The window title was not translated ==> Localization instruction added.

Please alter as needed (I am no Java programmer).


- [X] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
