### PR TITLE
Catch correct exception in LO inserter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a linked identifier icon inconsistency. [#6705](https://github.com/JabRef/jabref/issues/6705)
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
 - We fixed an issue where the sort order of the entry table was reset after a restart of JabRef [#6898](https://github.com/JabRef/jabref/pull/6898)
-- We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat" .
+- We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat"[#6907](https://github.com/JabRef/jabref/pull/60907).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a linked identifier icon inconsistency. [#6705](https://github.com/JabRef/jabref/issues/6705)
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
 - We fixed an issue where the sort order of the entry table was reset after a restart of JabRef [#6898](https://github.com/JabRef/jabref/pull/6898)
+- We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat" .
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the `.sav` file was not deleted upon exiting JabRef. [#6109](https://github.com/JabRef/jabref/issues/6109)
 - We fixed a linked identifier icon inconsistency. [#6705](https://github.com/JabRef/jabref/issues/6705)
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
-- We fixed an issue where the sort order of the entry table was reset after a restart of JabRef [#6898](https://github.com/JabRef/jabref/pull/6898)
-- We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat"[#6907](https://github.com/JabRef/jabref/pull/60907).
+- We fixed an issue where the sort order of the entry table was reset after a restart of JabRef. [#6898](https://github.com/JabRef/jabref/pull/6898)
+- We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat". [#6907](https://github.com/JabRef/jabref/pull/60907).
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/openoffice/OOUtil.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOUtil.java
@@ -120,7 +120,7 @@ public class OOUtil {
 
         try {
             props.setPropertyValue(PARA_STYLE_NAME, parStyle);
-        } catch (IllegalArgumentException ex) {
+        } catch (com.sun.star.lang.IllegalArgumentException ex) {
             throw new UndefinedParagraphFormatException(parStyle);
         }
 


### PR DESCRIPTION
Discovered that bug while reproducing #6903 

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
