### PR TITLE
Fix remove actions for entry types in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
 - We fixed an issue where the sort order of the entry table was reset after a restart of JabRef. [#6898](https://github.com/JabRef/jabref/pull/6898)
 - We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat". [#6907](https://github.com/JabRef/jabref/pull/60907).
-- We fixed an issue where remove icon was shown for custom entry types in th editor
+- We fixed an issue where a remove icon was shown for standard entry types in the custom entry types dialog [6906](https://github.com/JabRef/jabref/issues/6906)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
 - We fixed an issue where the sort order of the entry table was reset after a restart of JabRef. [#6898](https://github.com/JabRef/jabref/pull/6898)
 - We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat". [#6907](https://github.com/JabRef/jabref/pull/60907).
+- We fixed an issue where remove icon was shown for custom entry types in th editor
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
@@ -87,10 +87,11 @@ public class CustomEntryTypeDialogViewModel {
 
         for (BibEntryType entryType : allTypes) {
             EntryTypeViewModel viewModel;
-            if (entryTypesManager.isCustomType(entryType.getType(), mode))
+            if (entryTypesManager.isCustomType(entryType.getType(), mode)) {
                 viewModel = new CustomEntryTypeViewModel(entryType);
-            else
+            } else {
                 viewModel = new StandardEntryTypeViewModel(entryType);
+            }
             this.entryTypesWithFields.add(viewModel);
         }
     }

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
@@ -51,12 +51,12 @@ public class CustomEntryTypeDialogViewModel {
     };
 
     private final ObservableList<Field> fieldsForAdding = FXCollections.observableArrayList(FieldFactory.getStandardFieldsWithCitationKey());
-    private final ObjectProperty<CustomEntryTypeViewModel> selectedEntryType = new SimpleObjectProperty<>();
+    private final ObjectProperty<EntryTypeViewModel> selectedEntryType = new SimpleObjectProperty<>();
     private final ObjectProperty<Field> selectedFieldToAdd = new SimpleObjectProperty<>();
     private final StringProperty entryTypeToAdd = new SimpleStringProperty("");
     private final ObjectProperty<Field> newFieldToAdd = new SimpleObjectProperty<>();
     private final BibDatabaseMode mode;
-    private final ObservableList<CustomEntryTypeViewModel> entryTypesWithFields = FXCollections.observableArrayList(extractor -> new Observable[] {extractor.entryType(), extractor.fields()});
+    private final ObservableList<EntryTypeViewModel> entryTypesWithFields = FXCollections.observableArrayList(extractor -> new Observable[] {extractor.entryType(), extractor.fields()});
     private final List<BibEntryType> entryTypesToDelete = new ArrayList<>();
 
     private final PreferencesService preferencesService;
@@ -86,12 +86,16 @@ public class CustomEntryTypeDialogViewModel {
         Collection<BibEntryType> allTypes = entryTypesManager.getAllTypes(mode);
 
         for (BibEntryType entryType : allTypes) {
-            CustomEntryTypeViewModel viewModel = new CustomEntryTypeViewModel(entryType);
+            EntryTypeViewModel viewModel;
+            if (entryTypesManager.isCustomType(entryType.getType(), mode))
+                viewModel = new CustomEntryTypeViewModel(entryType);
+            else
+                viewModel = new StandardEntryTypeViewModel(entryType);
             this.entryTypesWithFields.add(viewModel);
         }
     }
 
-    public ObservableList<CustomEntryTypeViewModel> entryTypes() {
+    public ObservableList<EntryTypeViewModel> entryTypes() {
         return this.entryTypesWithFields;
     }
 
@@ -127,17 +131,17 @@ public class CustomEntryTypeDialogViewModel {
         newFieldToAddProperty().setValue(null);
     }
 
-    public CustomEntryTypeViewModel addNewCustomEntryType() {
+    public EntryTypeViewModel addNewCustomEntryType() {
         EntryType newentryType = new UnknownEntryType(entryTypeToAdd.getValue());
         BibEntryType type = new BibEntryType(newentryType, new ArrayList<>(), Collections.emptyList());
-        CustomEntryTypeViewModel viewModel = new CustomEntryTypeViewModel(type);
+        EntryTypeViewModel viewModel = new CustomEntryTypeViewModel(type);
         this.entryTypesWithFields.add(viewModel);
         this.entryTypeToAdd.setValue("");
 
         return viewModel;
     }
 
-    public ObjectProperty<CustomEntryTypeViewModel> selectedEntryTypeProperty() {
+    public ObjectProperty<EntryTypeViewModel> selectedEntryTypeProperty() {
         return this.selectedEntryType;
     }
 
@@ -161,7 +165,7 @@ public class CustomEntryTypeDialogViewModel {
         return fieldValidator.getValidationStatus();
     }
 
-    public void removeEntryType(CustomEntryTypeViewModel focusedItem) {
+    public void removeEntryType(EntryTypeViewModel focusedItem) {
         entryTypesWithFields.remove(focusedItem);
         entryTypesToDelete.add(focusedItem.entryType().getValue());
     }

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
@@ -90,7 +90,7 @@ public class CustomEntryTypeDialogViewModel {
             if (entryTypesManager.isCustomType(entryType.getType(), mode)) {
                 viewModel = new CustomEntryTypeViewModel(entryType);
             } else {
-                viewModel = new StandardEntryTypeViewModel(entryType);
+                viewModel = new EntryTypeViewModel(entryType);
             }
             this.entryTypesWithFields.add(viewModel);
         }

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeViewModel.java
@@ -1,64 +1,9 @@
 package org.jabref.gui.customentrytypes;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-
 import org.jabref.model.entry.BibEntryType;
 
-public class CustomEntryTypeViewModel {
-
-    private final ObjectProperty<BibEntryType> entryType = new SimpleObjectProperty<>();
-    private final ObservableList<FieldViewModel> fields;
-
+public class CustomEntryTypeViewModel extends EntryTypeViewModel {
     public CustomEntryTypeViewModel(BibEntryType entryType) {
-        this.entryType.set(entryType);
-
-        List<FieldViewModel> allFieldsForType = entryType.getAllBibFields().stream().map(bibField -> new FieldViewModel(bibField.getField(), entryType.isRequired(bibField.getField()), bibField.getPriority())).collect(Collectors.toList());
-        fields = FXCollections.observableArrayList((allFieldsForType));
+        super(entryType);
     }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(entryType, fields);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof CustomEntryTypeViewModel)) {
-            return false;
-        }
-        CustomEntryTypeViewModel other = (CustomEntryTypeViewModel) obj;
-        return Objects.equals(entryType, other.entryType) && Objects.equals(fields, other.fields);
-    }
-
-    public void addField(FieldViewModel field) {
-        this.fields.add(field);
-    }
-
-    public ObservableList<FieldViewModel> fields() {
-        return this.fields;
-    }
-
-    public ObjectProperty<BibEntryType> entryType() {
-        return this.entryType;
-    }
-
-    public void removeField(FieldViewModel focusedItem) {
-        this.fields.remove(focusedItem);
-    }
-
-    @Override
-    public String toString() {
-        return "CustomEntryTypeViewModel [entryType=" + entryType + ", fields=" + fields + "]";
-    }
-
 }

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar.ButtonData;
@@ -49,9 +50,9 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
     private final BibDatabaseMode mode;
     private final BibEntryTypesManager entryTypesManager;
 
-    @FXML private TableView<CustomEntryTypeViewModel> entryTypes;
-    @FXML private TableColumn<CustomEntryTypeViewModel, String> entryTypColumn;
-    @FXML private TableColumn<CustomEntryTypeViewModel, String> entryTypeActionsColumn;
+    @FXML private TableView<EntryTypeViewModel> entryTypes;
+    @FXML private TableColumn<EntryTypeViewModel, String> entryTypColumn;
+    @FXML private TableColumn<EntryTypeViewModel, String> entryTypeActionsColumn;
     @FXML private TextField addNewEntryType;
     @FXML private TableView<FieldViewModel> fields;
     @FXML private TableColumn<FieldViewModel, String> fieldNameColumn;
@@ -117,10 +118,25 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
         entryTypeActionsColumn.setSortable(false);
         entryTypeActionsColumn.setReorderable(false);
         entryTypeActionsColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue().entryType().get().getType().getDisplayName()));
-        new ValueTableCellFactory<CustomEntryTypeViewModel, String>()
-                .withGraphic(item -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
-                .withTooltip(name -> Localization.lang("Remove entry type") + " " + name)
-                .withOnMouseClickedEvent(item -> evt -> viewModel.removeEntryType(entryTypes.getSelectionModel().getSelectedItem()))
+        new ValueTableCellFactory<EntryTypeViewModel, String>()
+                .withGraphic((type, name) -> {
+                    if (type instanceof CustomEntryTypeViewModel)
+                        return IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode();
+                    else
+                        return null;
+                })
+                .withTooltip((type, name) -> {
+                    if (type instanceof CustomEntryTypeViewModel)
+                        return (Localization.lang("Remove entry type") + " " + name);
+                    else
+                        return null;
+                })
+                .withOnMouseClickedEvent((type, name) -> {
+                    if (type instanceof CustomEntryTypeViewModel)
+                        return evt -> viewModel.removeEntryType(entryTypes.getSelectionModel().getSelectedItem());
+                    else
+                        return evt -> {};
+                })
                 .install(entryTypeActionsColumn);
 
         fieldTypeColumn.setCellFactory(cellData -> new RadioButtonCell<>(EnumSet.allOf(FieldType.class)));
@@ -210,7 +226,7 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
 
     @FXML
     void addEntryType() {
-        CustomEntryTypeViewModel newlyAdded = viewModel.addNewCustomEntryType();
+        EntryTypeViewModel newlyAdded = viewModel.addNewCustomEntryType();
         this.entryTypes.getSelectionModel().select(newlyAdded);
         this.entryTypes.scrollTo(newlyAdded);
     }

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
@@ -7,7 +7,6 @@ import javax.inject.Inject;
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.ObservableList;
-import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar.ButtonData;
@@ -120,22 +119,26 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
         entryTypeActionsColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue().entryType().get().getType().getDisplayName()));
         new ValueTableCellFactory<EntryTypeViewModel, String>()
                 .withGraphic((type, name) -> {
-                    if (type instanceof CustomEntryTypeViewModel)
+                    if (type instanceof CustomEntryTypeViewModel) {
                         return IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode();
-                    else
+                    } else {
                         return null;
+                    }
                 })
                 .withTooltip((type, name) -> {
-                    if (type instanceof CustomEntryTypeViewModel)
+                    if (type instanceof CustomEntryTypeViewModel) {
                         return (Localization.lang("Remove entry type") + " " + name);
-                    else
+                    } else {
                         return null;
+                    }
                 })
                 .withOnMouseClickedEvent((type, name) -> {
-                    if (type instanceof CustomEntryTypeViewModel)
+                    if (type instanceof CustomEntryTypeViewModel) {
                         return evt -> viewModel.removeEntryType(entryTypes.getSelectionModel().getSelectedItem());
-                    else
-                        return evt -> {};
+                    } else {
+                        return evt -> {
+                        };
+                    }
                 })
                 .install(entryTypeActionsColumn);
 
@@ -162,7 +165,9 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
         new ValueTableCellFactory<FieldViewModel, String>()
                 .withGraphic(item -> IconTheme.JabRefIcons.DELETE_ENTRY.getGraphicNode())
                 .withTooltip(name -> Localization.lang("Remove field %0 from currently selected entry type", name))
-                .withOnMouseClickedEvent(item -> evt -> viewModel.removeField(fields.getSelectionModel().getSelectedItem()))
+                .withOnMouseClickedEvent(item -> evt -> {
+                    viewModel.removeField(fields.getSelectionModel().getSelectedItem());
+                })
                 .install(fieldTypeActionColumn);
 
         viewModel.newFieldToAddProperty().bindBidirectional(addNewField.valueProperty());

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
@@ -1,0 +1,64 @@
+package org.jabref.gui.customentrytypes;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.jabref.model.entry.BibEntryType;
+
+public abstract class EntryTypeViewModel {
+
+    private final ObjectProperty<BibEntryType> entryType = new SimpleObjectProperty<>();
+    private final ObservableList<FieldViewModel> fields;
+
+    protected EntryTypeViewModel(BibEntryType entryType) {
+        this.entryType.set(entryType);
+
+        List<FieldViewModel> allFieldsForType = entryType.getAllBibFields().stream().map(bibField -> new FieldViewModel(bibField.getField(), entryType.isRequired(bibField.getField()), bibField.getPriority())).collect(Collectors.toList());
+        fields = FXCollections.observableArrayList((allFieldsForType));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entryType, fields);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof EntryTypeViewModel)) {
+            return false;
+        }
+        EntryTypeViewModel other = (EntryTypeViewModel) obj;
+        return Objects.equals(entryType, other.entryType) && Objects.equals(fields, other.fields);
+    }
+
+    public void addField(FieldViewModel field) {
+        this.fields.add(field);
+    }
+
+    public ObservableList<FieldViewModel> fields() {
+        return this.fields;
+    }
+
+    public ObjectProperty<BibEntryType> entryType() {
+        return this.entryType;
+    }
+
+    public void removeField(FieldViewModel focusedItem) {
+        this.fields.remove(focusedItem);
+    }
+
+    @Override
+    public String toString() {
+        return "CustomEntryTypeViewModel [entryType=" + entryType + ", fields=" + fields + "]";
+    }
+
+}

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
@@ -11,12 +11,12 @@ import javafx.collections.ObservableList;
 
 import org.jabref.model.entry.BibEntryType;
 
-public abstract class EntryTypeViewModel {
+public class EntryTypeViewModel {
 
     private final ObjectProperty<BibEntryType> entryType = new SimpleObjectProperty<>();
     private final ObservableList<FieldViewModel> fields;
 
-    protected EntryTypeViewModel(BibEntryType entryType) {
+    public EntryTypeViewModel(BibEntryType entryType) {
         this.entryType.set(entryType);
 
         List<FieldViewModel> allFieldsForType = entryType.getAllBibFields().stream().map(bibField -> new FieldViewModel(bibField.getField(), entryType.isRequired(bibField.getField()), bibField.getPriority())).collect(Collectors.toList());

--- a/src/main/java/org/jabref/gui/customentrytypes/StandardEntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/StandardEntryTypeViewModel.java
@@ -1,0 +1,9 @@
+package org.jabref.gui.customentrytypes;
+
+import org.jabref.model.entry.BibEntryType;
+
+public class StandardEntryTypeViewModel extends EntryTypeViewModel {
+    public StandardEntryTypeViewModel(BibEntryType entryType) {
+        super(entryType);
+    }
+}

--- a/src/main/java/org/jabref/gui/customentrytypes/StandardEntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/StandardEntryTypeViewModel.java
@@ -1,9 +1,0 @@
-package org.jabref.gui.customentrytypes;
-
-import org.jabref.model.entry.BibEntryType;
-
-public class StandardEntryTypeViewModel extends EntryTypeViewModel {
-    public StandardEntryTypeViewModel(BibEntryType entryType) {
-        super(entryType);
-    }
-}


### PR DESCRIPTION
fixes #6906
* Created separate view models for standard and custom entry types, adding remove icon only for the custom ones
* Updated CHANGELOG.md

It's working solution, but please take a look whether the implementation is good. I will modify the user doc if it's accepted.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
