### PR TITLE
Make the DOI Resolution Fetcher return nothing when the DOI leads to a host for which a tailored fetcher exists

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -35,7 +35,7 @@ public class DoiResolution implements FulltextFetcher {
     /**
      * Hosts for which tailored fetchers exist, so this fetcher is not needed.
      */
-    private static final List<String> excludedHosts = Arrays.asList("link.springer.com", "ieeexplore.ieee.org");
+    private final List<String> excludedHosts = Arrays.asList("link.springer.com", "ieeexplore.ieee.org");
 
     @Override
     public Optional<URL> findFullText(BibEntry entry) throws IOException {

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -31,6 +32,11 @@ import org.slf4j.LoggerFactory;
 public class DoiResolution implements FulltextFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(DoiResolution.class);
 
+    /**
+     * Hosts for which tailored fetchers exist, so this fetcher is not needed.
+     */
+    private static final List<String> excludedHosts = Arrays.asList("link.springer.com", "ieeexplore.ieee.org");
+
     @Override
     public Optional<URL> findFullText(BibEntry entry) throws IOException {
         Objects.requireNonNull(entry);
@@ -57,7 +63,12 @@ public class DoiResolution implements FulltextFetcher {
             // some publishers are quite slow (default is 3s)
             connection.timeout(10000);
 
-            Document html = connection.get();
+            Connection.Response response = connection.execute();
+            if (excludedHosts.contains(response.url().getHost())) {
+                return Optional.empty();
+            }
+
+            Document html = response.parse();
             // scan for PDF
             Elements hrefElements = html.body().select("a[href]");
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -3,7 +3,6 @@ package org.jabref.logic.importer.fetcher;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -32,11 +31,6 @@ import org.slf4j.LoggerFactory;
 public class DoiResolution implements FulltextFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(DoiResolution.class);
 
-    /**
-     * Hosts for which tailored fetchers exist, so this fetcher is not needed.
-     */
-    private final List<String> excludedHosts = Arrays.asList("link.springer.com", "ieeexplore.ieee.org");
-
     @Override
     public Optional<URL> findFullText(BibEntry entry) throws IOException {
         Objects.requireNonNull(entry);
@@ -63,12 +57,7 @@ public class DoiResolution implements FulltextFetcher {
             // some publishers are quite slow (default is 3s)
             connection.timeout(10000);
 
-            Connection.Response response = connection.execute();
-            if (excludedHosts.contains(response.url().getHost())) {
-                return Optional.empty();
-            }
-
-            Document html = response.parse();
+            Document html = connection.get();
             // scan for PDF
             Elements hrefElements = html.body().select("a[href]");
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -121,6 +121,6 @@ public class DoiResolution implements FulltextFetcher {
 
     @Override
     public TrustLevel getTrustLevel() {
-        return TrustLevel.SOURCE;
+        return TrustLevel.META_SEARCH;
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -54,6 +54,18 @@ class DoiResolutionTest {
     }
 
     @Test
+    void notReturnAnythingWhenDOILeadsToSpringerLink() throws IOException {
+        entry.setField(StandardField.DOI, "https://doi.org/10.1007/978-3-319-89963-3_28");
+        assertEquals(Optional.empty(), finder.findFullText(entry));
+    }
+
+    @Test
+    void notReturnAnythingWhenDOILeadsToIEEE() throws IOException {
+        entry.setField(StandardField.DOI, "https://doi.org/10.1109/TTS.2020.2992669");
+        assertEquals(Optional.empty(), finder.findFullText(entry));
+    }
+
+    @Test
     void notFoundByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/unknown-doi");
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -54,18 +54,6 @@ class DoiResolutionTest {
     }
 
     @Test
-    void notReturnAnythingWhenDOILeadsToSpringerLink() throws IOException {
-        entry.setField(StandardField.DOI, "https://doi.org/10.1007/978-3-319-89963-3_28");
-        assertEquals(Optional.empty(), finder.findFullText(entry));
-    }
-
-    @Test
-    void notReturnAnythingWhenDOILeadsToIEEE() throws IOException {
-        entry.setField(StandardField.DOI, "https://doi.org/10.1109/TTS.2020.2992669");
-        assertEquals(Optional.empty(), finder.findFullText(entry));
-    }
-
-    @Test
     void notFoundByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/unknown-doi");
 


### PR DESCRIPTION
Fixes #6922

- [ ] Change in CHANGELOG.md described (not applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
