### PR TITLE
Fix for some Unicode characters in citation keys

### DIFF
--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -588,6 +588,11 @@ public class StringUtil {
      * accept. The basis for replacement is the HashMap UnicodeToReadableCharMap.
      */
     public static String replaceSpecialCharacters(String s) {
+        /* Some unicode characters can be encoded in multiple ways. This uses <a href="https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/text/Normalizer.Form.html#NFC">NFC</a>
+         * to re-encode the characters so that these characters can be found.
+         * Most people expect Unicode to work similar to NFC, i.e., if characters looks the same, it is likely that they are equivalent.
+         * Hence, if someone debugs issues in the `UNICODE_CHAR_MAP`, they will expect NFC.
+         * A more holistic approach should likely start with the <a href="http://unicode.org/reports/tr15/#Compatibility_Equivalence_Figure">compatibility equivalence</a>. */
         String result = Normalizer.normalize(s, Normalizer.Form.NFC);
         for (Map.Entry<String, String> chrAndReplace : UNICODE_CHAR_MAP.entrySet()) {
             result = result.replace(chrAndReplace.getKey(), chrAndReplace.getValue());

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -587,7 +588,7 @@ public class StringUtil {
      * accept. The basis for replacement is the HashMap UnicodeToReadableCharMap.
      */
     public static String replaceSpecialCharacters(String s) {
-        String result = s;
+        String result = Normalizer.normalize(s, Normalizer.Form.NFC);
         for (Map.Entry<String, String> chrAndReplace : UNICODE_CHAR_MAP.entrySet()) {
             result = result.replace(chrAndReplace.getKey(), chrAndReplace.getValue());
         }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1097,7 +1097,6 @@ class CitationKeyGeneratorTest {
 
     @Test
     void generateKeyWithNonNormalizedUnicode() {
-        // https://github.com/JabRef/jabref/issues/6583
         BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Modèle et outil pour soutenir la scénarisation pédagogique de MOOC connectivistes");
 
         assertEquals("Modele", generateKey(bibEntry, "[veryshorttitle]"));

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1094,4 +1094,12 @@ class CitationKeyGeneratorTest {
 
         assertEquals(4, generateKey(bibEntry, "[auth4_1]").length());
     }
+
+    @Test
+    void generateKeyWithNonNormalizedUnicode() {
+        // https://github.com/JabRef/jabref/issues/6583
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Modèle et outil pour soutenir la scénarisation pédagogique de MOOC connectivistes");
+
+        assertEquals("Modele", generateKey(bibEntry, "[veryshorttitle]"));
+    }
 }

--- a/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -297,7 +297,10 @@ class StringUtilTest {
     void testReplaceSpecialCharacters() {
         assertEquals("Hallo Arger", StringUtil.replaceSpecialCharacters("Hallo Arger"));
         assertEquals("aaAeoeeee", StringUtil.replaceSpecialCharacters("åÄöéèë"));
-        // https://github.com/JabRef/jabref/issues/6583
+    }
+
+    @Test
+    void replaceSpecialCharactersWithNonNormalizedUnicode() {
         assertEquals("Modele", StringUtil.replaceSpecialCharacters("Modèle"));
     }
 

--- a/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -297,6 +297,8 @@ class StringUtilTest {
     void testReplaceSpecialCharacters() {
         assertEquals("Hallo Arger", StringUtil.replaceSpecialCharacters("Hallo Arger"));
         assertEquals("aaAeoeeee", StringUtil.replaceSpecialCharacters("åÄöéèë"));
+        // https://github.com/JabRef/jabref/issues/6583
+        assertEquals("Modele", StringUtil.replaceSpecialCharacters("Modèle"));
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #6583 . Some unicode characters can be encoded in multiple ways, and the mapping that `StringUtil#replaceSpecialCharacters` relies on does not contain all cases. The proposed solution uses [NFC](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/text/Normalizer.Form.html#NFC) to re-encode the characters so that these characters can be found.
There exists more information on [Unicode normalization in the Java API](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/text/Normalizer.Form.html#NFC).

My subjective opinion is that most people expect Unicode to work similar to NFC, i.e., if characters looks the same, it is likely that they are equivalent. Hence, if someone debugs issues in the `UNICODE_CHAR_MAP`, they will expect NFC.
A more holistic approach should likely start with the [compatibility equivalence](http://unicode.org/reports/tr15/#Compatibility_Equivalence_Figure), which will require larger changes, and there does not seem to be any bugs/issues that requires these larger changes.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] ~Change in CHANGELOG.md described (if applicable)~
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
