### PR TITLE
Fix: in entry types editor selected field is not removed after first click 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the wrong behavior that font size changes are not reflected in dialogs. [#6039](https://github.com/JabRef/jabref/issues/6039)
 - We fixed an issue where the sort order of the entry table was reset after a restart of JabRef. [#6898](https://github.com/JabRef/jabref/pull/6898)
 - We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat". [#6907](https://github.com/JabRef/jabref/pull/60907).
+- We fixed an issue where in entry types editor selected field was not removed after first click [#6934](https://github.com/JabRef/jabref/issues/6934)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
@@ -141,6 +141,7 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
 
         fieldTypeActionColumn.setSortable(false);
         fieldTypeActionColumn.setReorderable(false);
+        fieldTypeActionColumn.setEditable(false);
         fieldTypeActionColumn.setCellValueFactory(cellData -> cellData.getValue().fieldName());
 
         new ValueTableCellFactory<FieldViewModel, String>()


### PR DESCRIPTION
fixes #6934

The issue is happening because cells with delete icon are set editable (because the whole table is set editable).

https://github.com/JabRef/jabref/blob/129c36e24bbd3332832728124ebf27d2462a0300/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java#L111-L112

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
