### PR TITLE
Replace comment by just a failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           # full checkout needed for authors generation
           fetch-depth: 0
-      - name: "Check AUTHORS"
+      - name: "All authors of this PR listed in AUTHORS"
         id: authors_check
         shell: bash
         run: |
@@ -245,19 +245,16 @@ jobs:
           set +o pipefail
           added=$(git diff HEAD --no-ext-diff --unified=0 -a --no-prefix | egrep "^\+[^+]" | sed "s/^\+//")
           if [ -z "$added" ]; then
-            echo "::set-output name=newauthor::false"
             echo "No authors added"
             exit 0
           fi
-          message="The JabRef maintainers will add the following name to the [AUTHORS file](https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits). In case you want to use a different one, please comment here and [adjust your name in your git configuration](https://docs.github.com/en/github/using-git/setting-your-username-in-git) for future commits.%0A%0A\`\`\`%0A${added//$'\n'/'%0A'}%0A\`\`\`%0A"
-          echo "::set-output name=message::$message"
-          echo "::set-output name=newauthor::true"
-          echo "New authors found"
-      - name: Comment PR
-        uses: unsplash/comment-on-pr@master
-        if: steps.authors_check.outputs.newauthor == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_COMMENT_ON_PR }}
-        with:
-          msg: "${{ steps.authors_check.outputs.message }}"
-          check_for_duplicate_msg: true
+          echo "Authors found in this PR not listed in the AUTHORS file."
+          echo
+          echo "The JabRef maintainers will add the following name to the AUTHORS file"
+          echo
+          echo -e "$added"
+          echo
+          echo "In case you want to use a different one, please comment here and adjust your name in your git configuration for future commits"
+          echo
+          echo "Background: Information about the AUTHORS file can be found at https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md#author-credits"
+          exit 1


### PR DESCRIPTION
The current checker for AUTHORS does not work when a non-JabRef-developer creates a PR. This PR removes the commenting functionality and adds a normal failure.

Reason: consistent to other checkers (e.g., checkstyle)

I'll just go ahead, since I take care about the AUTHORS file. Just want to have the update better referenceable.

Follow up to #6722 

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
