### PR TITLE
Fix Preferences Search

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
@@ -34,8 +34,8 @@
     <Label styleClass="sectionHeader" text="%Visual theme"/>
     <RadioButton fx:id="themeLight" text="%Light theme" toggleGroup="$theme"/>
     <RadioButton fx:id="themeDark" text="%Dark theme" toggleGroup="$theme"/>
-    <RadioButton fx:id="customTheme" text="%Custom theme" toggleGroup="$theme"/>
     <HBox alignment="CENTER_LEFT" spacing="4.0">
+        <RadioButton fx:id="customTheme" text="%Custom theme" toggleGroup="$theme"/>
         <TextField fx:id="customThemePath" prefWidth="350.0" disable="${!customTheme.selected}"/>
         <Button onAction="#importTheme" disable="${!customTheme.selected}"
                 styleClass="icon-button,narrow"

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
@@ -11,7 +11,9 @@
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+
 <?import org.jabref.gui.icon.JabRefIconView?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/11.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.AppearanceTabView">
     <fx:define>
@@ -32,8 +34,8 @@
     <Label styleClass="sectionHeader" text="%Visual theme"/>
     <RadioButton fx:id="themeLight" text="%Light theme" toggleGroup="$theme"/>
     <RadioButton fx:id="themeDark" text="%Dark theme" toggleGroup="$theme"/>
+    <RadioButton fx:id="customTheme" text="%Custom theme" toggleGroup="$theme"/>
     <HBox alignment="CENTER_LEFT" spacing="4.0">
-        <RadioButton fx:id="customTheme" text="%Custom theme" toggleGroup="$theme"/>
         <TextField fx:id="customThemePath" prefWidth="350.0" disable="${!customTheme.selected}"/>
         <Button onAction="#importTheme" disable="${!customTheme.selected}"
                 styleClass="icon-button,narrow"

--- a/src/main/java/org/jabref/gui/preferences/CitationKeyPatternTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/CitationKeyPatternTab.fxml
@@ -10,6 +10,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/11.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.CitationKeyPatternTabView">
     <fx:define>
@@ -45,14 +46,13 @@
             <Insets left="20.0"/>
         </padding>
     </HBox>
-
+    <Label text="%Remove the following characters:"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label text="%Remove the following characters:"/>
         <TextField fx:id="unwantedCharacters" HBox.hgrow="ALWAYS"/>
     </HBox>
 
+    <Label styleClass="sectionHeader" text="%Key patterns"/>
     <HBox prefWidth="650.0">
-        <Label styleClass="sectionHeader" text="%Key patterns"/>
         <HBox HBox.hgrow="ALWAYS"/>
         <Button fx:id="keyPatternHelp" prefWidth="20.0"/>
     </HBox>

--- a/src/main/java/org/jabref/gui/preferences/CitationKeyPatternTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/CitationKeyPatternTab.fxml
@@ -46,13 +46,14 @@
             <Insets left="20.0"/>
         </padding>
     </HBox>
-    <Label text="%Remove the following characters:"/>
+
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <Label text="%Remove the following characters:"/>
         <TextField fx:id="unwantedCharacters" HBox.hgrow="ALWAYS"/>
     </HBox>
 
-    <Label styleClass="sectionHeader" text="%Key patterns"/>
     <HBox prefWidth="650.0">
+        <Label styleClass="sectionHeader" text="%Key patterns"/>
         <HBox HBox.hgrow="ALWAYS"/>
         <Button fx:id="keyPatternHelp" prefWidth="20.0"/>
     </HBox>

--- a/src/main/java/org/jabref/gui/preferences/ExternalTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ExternalTab.fxml
@@ -11,7 +11,9 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+
 <?import org.jabref.gui.icon.JabRefIconView?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.preferences.ExternalTabView">

--- a/src/main/java/org/jabref/gui/preferences/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.fxml
@@ -4,9 +4,9 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
-<?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 

--- a/src/main/java/org/jabref/gui/preferences/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.fxml
@@ -19,19 +19,19 @@
     </fx:define>
 
     <CheckBox fx:id="openLastStartup" text="%Open last edited libraries at startup"/>
-    <Label text="%Do not wrap the following fields when saving"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <Label text="%Do not wrap the following fields when saving"/>
         <TextField fx:id="noWrapFiles" HBox.hgrow="ALWAYS"/>
     </HBox>
     <RadioButton fx:id="resolveStringsBibTex" text="%Resolve strings for standard BibTeX fields only"
                  toggleGroup="$stringsResolveToggleGroup"/>
-    <RadioButton fx:id="resolveStringsAll" text="%Resolve strings for all fields except"
-                 toggleGroup="$stringsResolveToggleGroup"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-         <TextField fx:id="resolveStringsExcept" HBox.hgrow="ALWAYS"/>
+        <RadioButton fx:id="resolveStringsAll" text="%Resolve strings for all fields except"
+                     toggleGroup="$stringsResolveToggleGroup"/>
+        <TextField fx:id="resolveStringsExcept" HBox.hgrow="ALWAYS"/>
     </HBox>
-    <Label alignment="TOP_LEFT" text="%Newline separator"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <Label alignment="TOP_LEFT" text="%Newline separator"/>
         <ComboBox fx:id="newLineSeparator" prefWidth="120.0"/>
     </HBox>
     <CheckBox fx:id="alwaysReformatBib" text="%Always reformat BIB file on save and export"/>

--- a/src/main/java/org/jabref/gui/preferences/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.fxml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.VBox?>
-<?import org.jabref.gui.commonfxcontrols.SaveOrderConfigPanel?>
-<?import javafx.scene.control.ToggleGroup?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<?import org.jabref.gui.commonfxcontrols.SaveOrderConfigPanel?>
+
 
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/11.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.FileTabView">

--- a/src/main/java/org/jabref/gui/preferences/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/FileTab.fxml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.ToggleGroup?>
-<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.commonfxcontrols.SaveOrderConfigPanel?>
+<?import javafx.scene.control.ToggleGroup?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Button?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/11.0.1"
          xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.FileTabView">
     <Label text="%File" styleClass="titleHeader"/>
@@ -18,19 +19,19 @@
     </fx:define>
 
     <CheckBox fx:id="openLastStartup" text="%Open last edited libraries at startup"/>
+    <Label text="%Do not wrap the following fields when saving"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label text="%Do not wrap the following fields when saving"/>
         <TextField fx:id="noWrapFiles" HBox.hgrow="ALWAYS"/>
     </HBox>
     <RadioButton fx:id="resolveStringsBibTex" text="%Resolve strings for standard BibTeX fields only"
                  toggleGroup="$stringsResolveToggleGroup"/>
+    <RadioButton fx:id="resolveStringsAll" text="%Resolve strings for all fields except"
+                 toggleGroup="$stringsResolveToggleGroup"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <RadioButton fx:id="resolveStringsAll" text="%Resolve strings for all fields except"
-                     toggleGroup="$stringsResolveToggleGroup"/>
-        <TextField fx:id="resolveStringsExcept" HBox.hgrow="ALWAYS"/>
+         <TextField fx:id="resolveStringsExcept" HBox.hgrow="ALWAYS"/>
     </HBox>
+    <Label alignment="TOP_LEFT" text="%Newline separator"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label alignment="TOP_LEFT" text="%Newline separator"/>
         <ComboBox fx:id="newLineSeparator" prefWidth="120.0"/>
     </HBox>
     <CheckBox fx:id="alwaysReformatBib" text="%Always reformat BIB file on save and export"/>

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
@@ -11,6 +11,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.preferences.GeneralTabView">

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
@@ -43,8 +43,8 @@
               text="%Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"/>
 
     <Label styleClass="sectionHeader" text="%Entry owner"/>
+    <CheckBox fx:id="markOwner" text="%Mark new entries with owner name"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <CheckBox fx:id="markOwner" text="%Mark new entries with owner name"/>
         <TextField fx:id="markOwnerName" HBox.hgrow="ALWAYS"/>
         <CheckBox fx:id="markOwnerOverwrite" text="%Overwrite">
             <tooltip>

--- a/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GeneralTab.fxml
@@ -43,8 +43,8 @@
               text="%Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"/>
 
     <Label styleClass="sectionHeader" text="%Entry owner"/>
-    <CheckBox fx:id="markOwner" text="%Mark new entries with owner name"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <CheckBox fx:id="markOwner" text="%Mark new entries with owner name"/>
         <TextField fx:id="markOwnerName" HBox.hgrow="ALWAYS"/>
         <CheckBox fx:id="markOwnerOverwrite" text="%Overwrite">
             <tooltip>

--- a/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.preferences.GroupsTabView">

--- a/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
@@ -23,8 +23,8 @@
     <CheckBox fx:id="autoAssignGroup" text="%Automatically assign new entry to selected groups"/>
     <CheckBox fx:id="displayGroupCount" text="%Display count of items in group"/>
 
+    <Label text="%Keyword seperator"/>
     <HBox spacing="4" alignment="CENTER_LEFT">
-        <Label text="%Keyword separator"/>
         <TextField fx:id="keywordSeparator" minWidth="30.0" maxWidth="30.0"/>
     </HBox>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
@@ -24,7 +24,7 @@
     <CheckBox fx:id="displayGroupCount" text="%Display count of items in group"/>
 
     <HBox spacing="4" alignment="CENTER_LEFT">
-        <Label text="%Keyword seperator"/>
+        <Label text="%Keyword separator"/>
         <TextField fx:id="keywordSeparator" minWidth="30.0" maxWidth="30.0"/>
     </HBox>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/GroupsTab.fxml
@@ -23,8 +23,8 @@
     <CheckBox fx:id="autoAssignGroup" text="%Automatically assign new entry to selected groups"/>
     <CheckBox fx:id="displayGroupCount" text="%Display count of items in group"/>
 
-    <Label text="%Keyword seperator"/>
     <HBox spacing="4" alignment="CENTER_LEFT">
+        <Label text="%Keyword seperator"/>
         <TextField fx:id="keywordSeparator" minWidth="30.0" maxWidth="30.0"/>
     </HBox>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
@@ -20,8 +20,9 @@
         <ToggleGroup fx:id="autolinkToggleGroup"/>
     </fx:define>
     <Label styleClass="titleHeader" text="%Linked files"/>
-    <Label text="%Main file directory"/>
+
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <Label text="%Main file directory"/>
         <TextField fx:id="mainFileDirectory" HBox.hgrow="ALWAYS"/>
         <Button onAction="#mainFileDirBrowse" text="%Browse"/>
     </HBox>
@@ -38,9 +39,9 @@
                  toggleGroup="$autolinkToggleGroup"/>
     <RadioButton fx:id="autolinkFileExactBibtex" text="%Autolink only files that match the citation key"
                  toggleGroup="$autolinkToggleGroup"/>
-    <RadioButton fx:id="autolinkUseRegex" text="%Use regular expression search"
-                 toggleGroup="$autolinkToggleGroup"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <RadioButton fx:id="autolinkUseRegex" text="%Use regular expression search"
+                     toggleGroup="$autolinkToggleGroup"/>
         <TextField fx:id="autolinkRegexKey" HBox.hgrow="ALWAYS"/>
         <Button fx:id="autolinkRegexHelp"/>
     </HBox>

--- a/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
@@ -8,11 +8,12 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.preferences.LinkedFilesTabView">

--- a/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/LinkedFilesTab.fxml
@@ -8,11 +8,11 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.RowConstraints?>
 <fx:root prefWidth="650.0" spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
          fx:controller="org.jabref.gui.preferences.LinkedFilesTabView">
@@ -20,9 +20,8 @@
         <ToggleGroup fx:id="autolinkToggleGroup"/>
     </fx:define>
     <Label styleClass="titleHeader" text="%Linked files"/>
-
+    <Label text="%Main file directory"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label text="%Main file directory"/>
         <TextField fx:id="mainFileDirectory" HBox.hgrow="ALWAYS"/>
         <Button onAction="#mainFileDirBrowse" text="%Browse"/>
     </HBox>
@@ -39,9 +38,9 @@
                  toggleGroup="$autolinkToggleGroup"/>
     <RadioButton fx:id="autolinkFileExactBibtex" text="%Autolink only files that match the citation key"
                  toggleGroup="$autolinkToggleGroup"/>
+    <RadioButton fx:id="autolinkUseRegex" text="%Use regular expression search"
+                 toggleGroup="$autolinkToggleGroup"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <RadioButton fx:id="autolinkUseRegex" text="%Use regular expression search"
-                     toggleGroup="$autolinkToggleGroup"/>
         <TextField fx:id="autolinkRegexKey" HBox.hgrow="ALWAYS"/>
         <Button fx:id="autolinkRegexHelp"/>
     </HBox>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -79,7 +79,7 @@ class PreferencesSearchHandler {
             if (builder instanceof Parent) {
                 Parent parentBuilder = (Parent) builder;
                 scanInputControls(parentBuilder, prefsTabLabelMap, preferencesTab);
-                
+
             }
         }
         return prefsTabLabelMap;
@@ -89,7 +89,7 @@ class PreferencesSearchHandler {
         return filteredPreferenceTabs;
     }
 
-    private void scanInputControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
+    private static void scanInputControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
         for (Node child : parent.getChildrenUnmodifiable()) {
             if (!(child instanceof Labeled)) {
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -78,7 +78,7 @@ class PreferencesSearchHandler {
             Node builder = preferencesTab.getBuilder();
             if (builder instanceof Parent) {
                 Parent parentBuilder = (Parent) builder;
-                scanInputControls(parentBuilder, prefsTabLabelMap, preferencesTab);
+                scanLabeledControls(parentBuilder, prefsTabLabelMap, preferencesTab);
 
             }
         }
@@ -89,11 +89,11 @@ class PreferencesSearchHandler {
         return filteredPreferenceTabs;
     }
 
-    private static void scanInputControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
+    private static void scanLabeledControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
         for (Node child : parent.getChildrenUnmodifiable()) {
             if (!(child instanceof Labeled)) {
 
-                scanInputControls((Parent) child, prefsTabLabelMap, preferencesTab);
+                scanLabeledControls((Parent) child, prefsTabLabelMap, preferencesTab);
             } else {
 
                 Labeled labeled = (Labeled) child;

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -78,14 +78,8 @@ class PreferencesSearchHandler {
             Node builder = preferencesTab.getBuilder();
             if (builder instanceof Parent) {
                 Parent parentBuilder = (Parent) builder;
-                for (Node child : parentBuilder.getChildrenUnmodifiable()) {
-                    if (child instanceof Labeled) {
-                        Labeled labeled = (Labeled) child;
-                        if (!labeled.getText().isEmpty()) {
-                            prefsTabLabelMap.put(preferencesTab, labeled);
-                        }
-                    }
-                }
+                scanInputControls(parentBuilder, prefsTabLabelMap, preferencesTab);
+                
             }
         }
         return prefsTabLabelMap;
@@ -93,5 +87,20 @@ class PreferencesSearchHandler {
 
     protected ListProperty<PreferencesTab> filteredPreferenceTabsProperty() {
         return filteredPreferenceTabs;
+    }
+
+    private void scanInputControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
+        for (Node child : parent.getChildrenUnmodifiable()) {
+            if (!(child instanceof Labeled)) {
+
+                scanInputControls((Parent) child, prefsTabLabelMap, preferencesTab);
+            } else {
+
+                Labeled labeled = (Labeled) child;
+                if (!labeled.getText().isEmpty()) {
+                    prefsTabLabelMap.put(preferencesTab, labeled);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Updated fxml files from the preferences package to appear in preference search.

The preferences search was unable to find some visual components because they are not a direct child from one of the preferences tab. 
So, the method getPrefsTabLabelMap in PreferencesSearchHandler cannot find them. I moved some components that were inside  <HBox> tags to let them "visible" to their parents in the mentioned method. It does not change the UI. Most of the components could be moved. Some could not because they have many parents until the tab and it could impact the UI. 

Fixes #6866


- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

![image](https://user-images.githubusercontent.com/34105280/94328986-0bef3b80-ff6c-11ea-9b03-be3ac24c3638.png)
