### PR TITLE
Fix locating jabref in jabrefHost.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where no longer a warning was displayed when inserting references into LibreOffice with an invalid "ReferenceParagraphFormat". [#6907](https://github.com/JabRef/jabref/pull/60907).
 - We fixed an issue where a selected field was not removed after the first click in the custom entry types dialog [#6934](https://github.com/JabRef/jabref/issues/6934)
 - We fixed an issue where a remove icon was shown for standard entry types in the custom entry types dialog [6906](https://github.com/JabRef/jabref/issues/6906)
+- We fixed an issue with the python script used by browser plugins that failed to locate JabRef if not installed in its default location.
 
 ### Removed
 

--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import platform
 import shlex
 import shutil
@@ -16,11 +17,16 @@ from pathlib import Path
 
 # We assume that this python script is located in "jabref/lib" while the executable is "jabref/bin/JabRef"
 script_dir = Path(__file__).resolve().parent.parent
-JABREF_PATH = script_dir / "bin/JabRef"
-if not JABREF_PATH.exists():
-    JABREF_PATH = shutil.which("jabref")
-
-if not JABREF_PATH.exists():
+relpath_path = script_dir / "bin/JabRef"
+lowercase_path = shutil.which("jabref")
+uppercase_path = shutil.which("JabRef")
+if relpath_path.exists():
+    JABREF_PATH = relpath_path
+elif lowercase_path is not None and os.path.exists(lowercase_path):
+    JABREF_PATH = Path(lowercase_path)
+elif uppercase_path is not None and os.path.exists(uppercase_path):
+    JABREF_PATH = Path(uppercase_path)
+else:
     logging.error("Could not determine JABREF_PATH")
     sys.exit(-1)
 


### PR DESCRIPTION
`shutil.which()` returns an `str` and not a `pathlib.Path`. Therefore, we need to check if `which()` actually returns something and if so, we should convert it to a `pathlib.Path` such that `JABREF_PATH` is always of the same type.

I stumbled across this while fixing https://github.com/JabRef/JabRef-Browser-Extension/issues/158 for the unofficial Arch Linux JabRef package in the Arch User Repository (AUR): https://github.com/michaellass/AUR/issues/17

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.