### PR TITLE
downgrade richtextfx to fix entering of curly braces in mac in code area

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
   - dependency-name: de.jensd:fontawesomefx-materialdesignfont
     versions:
     - "> 1.7.22-4" # Strange versioning format
+  - dependency-name: org.fxmisc.richtext:richtextfx
+    versions:
+    - "> 0.10.4" # Blocked by https://github.com/FXMisc/RichTextFX/issues/967
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ dependencies {
     implementation 'de.saxsys:mvvmfx:1.8.0'
     implementation 'com.tobiasdiez:easybind:2.1.0'
     implementation 'org.fxmisc.flowless:flowless:0.6.1'
-    implementation 'org.fxmisc.richtext:richtextfx:0.10.5'
+    implementation 'org.fxmisc.richtext:richtextfx:0.10.4'
     implementation group: 'org.glassfish.hk2.external', name: 'jakarta.inject', version: '2.6.1'
     implementation 'com.jfoenix:jfoenix:9.0.10'
     implementation 'org.controlsfx:controlsfx:11.0.2'


### PR DESCRIPTION
Fixes #6964 

Refs: https://github.com/FXMisc/RichTextFX/issues/967

TODO: Investigate/report bug
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
