### PR TITLE
Mark medra test as fetcher test

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
@@ -7,6 +7,7 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@FetcherTest
 public class MedraTest {
 
     private final Medra fetcher = new Medra();
@@ -32,7 +34,7 @@ public class MedraTest {
                                         .withField(StandardField.TITLE, "Algemene kroniek")
                                         .withField(StandardField.YEAR, "2018")
                                         .withField(StandardField.DOI, "10.2143/TVF.80.3.3285690")
-                                        .withField(StandardField.ISSN, "2031-8952")
+                                        .withField(StandardField.ISSN, "2031-8952, 2031-8952")
                                         .withField(StandardField.JOURNAL, "Tijdschrift voor Filosofie")
                                         .withField(StandardField.PAGES, "625-629")
                         )),
@@ -62,7 +64,7 @@ public class MedraTest {
                                         .withField(StandardField.AUTHOR, "Paola Cisternino")
                                         .withField(StandardField.PUBLISHER, "Edizioni Otto Novecento")
                                         .withField(StandardField.TITLE, "Diagramma semantico dei lemmi : casa, parola, silenzio e attesa in È fatto giorno e Margherite e rosolacci di Rocco Scotellaro")
-                                        .withField(StandardField.ISSN, "0391-2639")
+                                        .withField(StandardField.ISSN, "03912639")
                                         .withField(StandardField.YEAR, "1999")
                                         .withField(StandardField.DOI, "10.1400/115378")
                                         .withField(StandardField.JOURNAL, "Otto/Novecento : rivista quadrimestrale di critica e storia letteraria")


### PR DESCRIPTION
I noticed that the unit tests were failing and that Medra was not categorized as Fetcher
Fix wrong entry 


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
