### PR TITLE
Pin application insights

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,10 @@ updates:
   ignore:
   - dependency-name: com.microsoft.azure:applicationinsights-core
     versions:
-    - ">= 2.5.a, <= 2.6.1" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
+    - ">= 2.5.a" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
   - dependency-name: com.microsoft.azure:applicationinsights-logging-log4j2
     versions:
-    - ">= 2.5.a, <= 2.6.1" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
+    - ">= 2.5.a" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
   - dependency-name: de.jensd:fontawesomefx-materialdesignfont
     versions:
     - "> 1.7.22-4" # Strange versioning format


### PR DESCRIPTION
There is too much noise with non-working dependencies (see https://github.com/JabRef/jabref/pull/6952). I would like to pin the version. We can update the dependency as soon as issue https://github.com/microsoft/ApplicationInsights-Java/issues/1155 is closed.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
