### PR TITLE
Fix INSPIRE fetcher and short doi fetcher tests

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
@@ -15,6 +15,7 @@ import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.importer.util.MediaTypes;
+import org.jabref.logic.layout.format.LatexToUnicodeFormatter;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -67,6 +68,8 @@ public class INSPIREFetcher implements SearchBasedParserFetcher {
 
         // Remove braces around content of "title" field
         new FieldFormatterCleanup(StandardField.TITLE, new RemoveBracesFormatter()).cleanup(entry);
+
+        new FieldFormatterCleanup(StandardField.TITLE, new LatexToUnicodeFormatter()).cleanup(entry);
     }
 
     @Override

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -64,7 +64,7 @@ public class DOI implements Identifier {
             + "("                               // begin group \1
             + "10"                              // directory indicator
             + "[/%:]"                           // divider
-            + "[a-zA-Z0-9]{4,}"                 // at least 4 characters
+            + "[a-zA-Z0-9]{3,}"                 // at least 3 characters
             + ")"                               // end group  \1
             + "\\s*$";                          // must be the end
     private static final String FIND_SHORT_DOI_EXP = ""


### PR DESCRIPTION
Arxiv Test is failing with the search phrase, because both queries return the same result.

@DominikVoigt  In ArxivTest supportsPhraseSearch(), both queries return the same result.  Maybe you can take a look at that
```
      List<BibEntry> resultWithPhraseSearch = fetcher.performSearch("au:\"Tobias Diez\"");
        List<BibEntry> resultWithOutPhraseSearch = fetcher.performSearch("au:Tobias Diez");
```

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
