### PR TITLE
Fix "irregularly losing ability to edit data in biblatex source tab"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -232,6 +232,7 @@ Malte Deiseroth
 Manuel Siebeneicher
 Manuel Wtfjoke
 Marcel Luethi
+Marco Aurélio Graciotto Silva
 Marco Konersmann
 Mariana Prudencio
 Marius Kleiner

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -133,7 +133,7 @@ public class SourceTab extends EntryEditorTab {
         }
     }
 
-    private static String getSourceString(BibEntry entry, BibDatabaseMode type, FieldWriterPreferences fieldWriterPreferences) throws IOException {
+    private String getSourceString(BibEntry entry, BibDatabaseMode type, FieldWriterPreferences fieldWriterPreferences) throws IOException {
         StringWriter stringWriter = new StringWriter(200);
         FieldWriter fieldWriter = FieldWriter.buildIgnoreHashes(fieldWriterPreferences);
         new BibEntryWriter(fieldWriter, Globals.entryTypesManager).writeWithoutPrependedNewlines(entry, stringWriter, type);
@@ -224,6 +224,7 @@ public class SourceTab extends EntryEditorTab {
             codeArea.clear();
             try {
                 codeArea.appendText(getSourceString(currentEntry, mode, fieldWriterPreferences));
+                codeArea.setEditable(true);
                 highlightSearchPattern();
             } catch (IOException ex) {
                 codeArea.setEditable(false);
@@ -231,6 +232,7 @@ public class SourceTab extends EntryEditorTab {
                         Localization.lang("Correct the entry, and reopen editor to display/edit source."));
                 LOGGER.debug("Incorrect entry", ex);
             }
+
         });
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -232,7 +232,6 @@ public class SourceTab extends EntryEditorTab {
                         Localization.lang("Correct the entry, and reopen editor to display/edit source."));
                 LOGGER.debug("Incorrect entry", ex);
             }
-
         });
     }
 


### PR DESCRIPTION
Issue #6936 is about the source tab (BibTeX source) losing the ability to be editable (https://github.com/JabRef/jabref/issues/6936#issuecomment-703110024). This happens because `codeArea` can be disabled, but there is no code path that re-enables it.

This patch re-enables `codeArea` as editable if the BibTeX entry's source code is correct. Although the source tab cannot be used by the user to fix any syntax error in BibTeX fields (source tab will be disabled if there are syntactic errors introduced by editing the fields in the other tabs), such error can be fixed by editing the field, which will trigger `SourceTab`'s listener and call the `updateCodeArea()` method, which will enable codeArea if the source of the BibTeX entry is syntactically correct.


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
