### PR TITLE
Adapt the short DOI regex 

### DIFF
--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -64,7 +64,7 @@ public class DOI implements Identifier {
             + "("                               // begin group \1
             + "10"                              // directory indicator
             + "[/%:]"                           // divider
-            + "[a-zA-Z0-9]{4,}"                 // at least 4 characters
+            + "[a-zA-Z0-9]{3,}"                 // at least 3 characters
             + ")"                               // end group  \1
             + "\\s*$";                          // must be the end
     private static final String FIND_SHORT_DOI_EXP = ""

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -25,6 +25,7 @@ public class DOITest {
         assertEquals("10/gf4gqc", new DOI("10/gf4gqc").getDOI());
         assertEquals("10/1000", new DOI("10/1000").getDOI());
         assertEquals("10/aaaa", new DOI("10/aaaa").getDOI());
+        assertEquals("10/adc", new DOI("10/adc").getDOI());
     }
 
     @Test


### PR DESCRIPTION
It now accepts DOIs with only three characters. This fixes an error in the ShortenDOIFormatterTest as run by the CI (see #6369), for example [here](https://github.com/JabRef/jabref/runs/1185667289?check_suite_focus=true#step:6:426).
