### PR TITLE
Fix the paths in chrome snap hooks

### DIFF
--- a/snap/hooks/connect-plug-etc-chromium-native-messaging-jabref
+++ b/snap/hooks/connect-plug-etc-chromium-native-messaging-jabref
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -d /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts ]; then
+if [ ! -d /etc/chromium/native-messaging-hosts ]; then
     echo "Missing directory, create it manually then try again:"
     echo "sudo mkdir -p /etc/chromium/native-messaging-hosts"
     exit 1

--- a/snap/hooks/connect-plug-etc-opt-chrome-native-messaging-jabref
+++ b/snap/hooks/connect-plug-etc-opt-chrome-native-messaging-jabref
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -d /var/lib/snapd/hostfs/usr/lib/mozilla/native-messaging-hosts ]; then
+if [ ! -d /etc/opt/chrome/native-messaging-hosts ]; then
     echo "Missing directory, create it manually then try again:"
     echo "sudo mkdir -p /etc/opt/chrome/native-messaging-hosts"
     exit 1


### PR DESCRIPTION
This PR changes reverts the paths in the snap hooks to the correct one for chrome/chromium.
They were set to look at the mozilla dir for chrome as well, but it's not correct

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
