### PR TITLE
Merge parsing of bracketed patterns

### DIFF
--- a/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -223,8 +223,9 @@ public class BracketedPattern {
                 case "\\" -> {
                     if (parsedPattern.hasMoreTokens()) {
                         expandedPattern.append(parsedPattern.nextToken());
+                    } else {
+                        LOGGER.warn("Found a \"\\\" that is not part of an escape sequence");
                     }
-                    // FIXME: else -> raise exception or log? (S.G.)
                 }
                 default -> expandedPattern.append(token);
             }

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -107,6 +107,12 @@ public class CitationKeyGenerator extends BracketedPattern {
         return removeUnwantedCharacters(key, unwantedCharacters).replaceAll("\\s", "");
     }
 
+    /**
+     * Generate a citation key for the given {@link BibEntry}.
+     *
+     * @param entry a {@link BibEntry}
+     * @return a citation key based on the user's preferences
+     */
     public String generateKey(BibEntry entry) {
         Objects.requireNonNull(entry);
         String currentKey = entry.getCitationKey().orElse(null);
@@ -118,6 +124,13 @@ public class CitationKeyGenerator extends BracketedPattern {
         return cleanKey(newKey, unwantedCharacters);
     }
 
+    /**
+     * A letter will be appended to the key based on the user's preferences, either always or to prevent duplicated keys.
+     *
+     * @param key    the new key
+     * @param oldKey the old key
+     * @return a key, if needed, with an appended letter
+     */
     private String appendLettersToKey(String key, String oldKey) {
         long occurrences = database.getNumberOfCitationKeyOccurrences(key);
 
@@ -152,6 +165,12 @@ public class CitationKeyGenerator extends BracketedPattern {
         return key;
     }
 
+    /**
+     * Using preferences, replace matches to the provided regex with a string.
+     *
+     * @param key the citation key
+     * @return the citation key where matches to the regex are replaced
+     */
     private String replaceWithRegex(String key) {
         // Remove Regular Expressions while generating Keys
         String regex = citationKeyPatternPreferences.getKeyPatternRegex();
@@ -177,6 +196,12 @@ public class CitationKeyGenerator extends BracketedPattern {
         return expandBrackets(citationKeyPattern.get(0), expandBracketContent(entry));
     }
 
+    /**
+     * A helper method to create a {@link Function} that takes a single bracketed expression, expands it, and cleans the key.
+     *
+     * @param entry the {@link BibEntry} that a citation key is generated for
+     * @return a cleaned citation key for the given {@link BibEntry}
+     */
     private Function<String, String> expandBracketContent(BibEntry entry) {
         Character keywordDelimiter = citationKeyPatternPreferences.getKeywordDelimiter();
 

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -116,7 +116,7 @@ public class CitationKeyGenerator extends BracketedPattern {
         newKey = replaceWithRegex(newKey);
         newKey = appendLettersToKey(newKey, currentKey);
 
-        return newKey;
+        return cleanKey(newKey, unwantedCharacters);
     }
 
     private String appendLettersToKey(String key, String oldKey) {

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -22,12 +22,12 @@ import org.slf4j.LoggerFactory;
  * This is the utility class of the LabelPattern package.
  */
 public class CitationKeyGenerator extends BracketedPattern {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
     /*
      * All single characters that we can use for extending a key to make it unique.
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     public static final String DEFAULT_UNWANTED_CHARACTERS = "-`ʹ:!;?^+";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
     // Source of disallowed characters : https://tex.stackexchange.com/a/408548/9075
     private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
     private final AbstractCitationKeyPattern citeKeyPattern;
@@ -72,8 +72,7 @@ public class CitationKeyGenerator extends BracketedPattern {
     }
 
     /**
-     * Computes an appendix to a citation key that could make it unique. We use a-z for numbers 0-25, and then aa-az,
-     * ba-bz, etc.
+     * Computes an appendix to a citation key that could make it unique. We use a-z for numbers 0-25, and then aa-az, ba-bz, etc.
      *
      * @param number The appendix number.
      * @return The String to append.

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.PatternSyntaxException;
 
 import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabase;
@@ -14,10 +15,14 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.strings.StringUtil;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * This is the utility class of the LabelPattern package.
  */
 public class CitationKeyGenerator extends BracketedPattern {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
     /*
      * All single characters that we can use for extending a key to make it unique.
      */
@@ -153,7 +158,11 @@ public class CitationKeyGenerator extends BracketedPattern {
         String regex = citationKeyPatternPreferences.getKeyPatternRegex();
         if ((regex != null) && !regex.trim().isEmpty()) {
             String replacement = citationKeyPatternPreferences.getKeyPatternReplacement();
-            key = key.replaceAll(regex, replacement);
+            try {
+                key = key.replaceAll(regex, replacement);
+            } catch (PatternSyntaxException e) {
+                LOGGER.warn("There is a syntax error in the regular expression \"{}\" used to generate a citation key", regex, e);
+            }
         }
         return key;
     }

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -14,9 +14,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.strings.StringUtil;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * This is the utility class of the LabelPattern package.
  */
@@ -26,7 +23,6 @@ public class CitationKeyGenerator extends BracketedPattern {
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
     public static final String DEFAULT_UNWANTED_CHARACTERS = "-`ʹ:!;?^+";
-    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
     // Source of disallowed characters : https://tex.stackexchange.com/a/408548/9075
     private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
     private final AbstractCitationKeyPattern citeKeyPattern;
@@ -71,8 +67,8 @@ public class CitationKeyGenerator extends BracketedPattern {
     }
 
     /**
-     * Computes an appendix to a citation key that could make it unique. We use
-     * a-z for numbers 0-25, and then aa-az, ba-bz, etc.
+     * Computes an appendix to a citation key that could make it unique. We use a-z for numbers 0-25, and then aa-az,
+     * ba-bz, etc.
      *
      * @param number The appendix number.
      * @return The String to append.

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -278,4 +278,11 @@ class BracketedPatternTest {
                 .withField(StandardField.AUTHOR, "Patrik {\\v{S}}pan{\\v{e}}l and Kseniya Dryahina and David Smith");
         assertEquals("ŠpanělEtAl", BracketedPattern.expandBrackets("[authEtAl:latex_to_unicode]", null, bibEntry, null));
     }
+
+    @Test
+    void expandBracketsWithModifierContainingRegexCharacterCkass() {
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness:Managing");
+
+        assertEquals("Wickedness.Managing", BracketedPattern.expandBrackets("[title:regex(\"[:]+\",\".\")]", null, bibEntry, null));
+    }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -285,4 +285,11 @@ class BracketedPatternTest {
 
         assertEquals("Wickedness.Managing", BracketedPattern.expandBrackets("[title:regex(\"[:]+\",\".\")]", null, bibEntry, null));
     }
+
+    @Test
+    void expandBracketsEmptyStringFromEmptyBrackets() {
+        BibEntry bibEntry = new BibEntry();
+
+        assertEquals("", BracketedPattern.expandBrackets("[]", null, bibEntry, null));
+    }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1104,8 +1104,8 @@ class CitationKeyGeneratorTest {
 
     @Test
     void generateKeyWithModifierContainingRegexCharacterCkass() {
-        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness:Managing");
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness_Managing");
 
-        assertEquals("Wickedness.Managing", generateKey(bibEntry, "[title:regex(\"[:]+\",\".\")]"));
+        assertEquals("Wickedness.Managing", generateKey(bibEntry, "[title:regex(\"[_]+\",\".\")]"));
     }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -80,8 +80,7 @@ class CitationKeyGeneratorTest {
     }
 
     static String generateKey(BibEntry entry, String pattern, BibDatabase database) {
-        GlobalCitationKeyPattern keyPattern = new GlobalCitationKeyPattern(Collections.emptyList());
-        keyPattern.setDefaultValue(pattern);
+        GlobalCitationKeyPattern keyPattern = GlobalCitationKeyPattern.fromPattern(pattern);
         CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
                 false,
                 false,
@@ -1070,7 +1069,7 @@ class CitationKeyGeneratorTest {
                 .withField(StandardField.AUTHOR, AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1)
                 .withField(StandardField.YEAR, "2019");
 
-        assertEquals("Newton-2019", generateKey(entry, "[auth]-[year]"));
+        assertEquals("Newton2019", generateKey(entry, "[auth]-[year]"));
     }
 
     @Test
@@ -1078,7 +1077,7 @@ class CitationKeyGeneratorTest {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Newton, Isaac")
                                        .withField(StandardField.YEAR, "2019");
 
-        assertEquals("newt-2019", generateKey(entry, "[auth4:lower]-[year]"));
+        assertEquals("newt2019", generateKey(entry, "[auth4:lower]-[year]"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.citationkeypattern;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import org.jabref.logic.importer.ImportFormatPreferences;

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1101,4 +1101,11 @@ class CitationKeyGeneratorTest {
 
         assertEquals("Modele", generateKey(bibEntry, "[veryshorttitle]"));
     }
+
+    @Test
+    void generateKeyWithModifierContainingRegexCharacterCkass() {
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness:Managing");
+
+        assertEquals("Wickedness.Managing", generateKey(bibEntry, "[title:regex(\"[:]+\",\".\")]"));
+    }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1103,9 +1103,9 @@ class CitationKeyGeneratorTest {
     }
 
     @Test
-    void generateKeyWithModifierContainingRegexCharacterCkass() {
-        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness_Managing");
+    void generateKeyWithModifierContainingRegexCharacterClass() {
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness Managing");
 
-        assertEquals("Wickedness.Managing", generateKey(bibEntry, "[title:regex(\"[_]+\",\".\")]"));
+        assertEquals("WM", generateKey(bibEntry, "[title:regex(\"[a-z]+\",\"\")]"));
     }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1106,4 +1106,24 @@ class CitationKeyGeneratorTest {
 
         assertEquals("WM", generateKey(bibEntry, "[title:regex(\"[a-z]+\",\"\")]"));
     }
+
+    @Test
+    void generateKeyDoesNotModifyTheKeyWithIncorrectRegexReplacement() {
+        String pattern = "[title]";
+        GlobalCitationKeyPattern keyPattern = GlobalCitationKeyPattern.fromPattern(pattern);
+        CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
+                false,
+                false,
+                false,
+                CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_A,
+                "[", // Invalid regexp
+                "",
+                DEFAULT_UNWANTED_CHARACTERS,
+                keyPattern,
+                ',');
+
+        BibEntry bibEntry = new BibEntry().withField(StandardField.TITLE, "Wickedness Managing");
+        assertEquals("WickednessManaging",
+                new CitationKeyGenerator(keyPattern, new BibDatabase(), patternPreferences).generateKey(bibEntry));
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #6892.
Character classes (regex expressions in brackets, e.g., `[a-zA-Z]`) should be usable with the regex modifier, but it currently isn't for citation keys.

Bracketed patterns are parsed using several different methods in `CitationKeyGenerator.java`, `BracketedPattern.java` and `AbstractCitationKeyPattern`. This PR aims to merge all parsing code into `BracketedPattern.java` to make it easier to modify bracketed patterns without breaking the citation key generator.

Currently BracketedPattern's parser can parse expressions containing the regex modifier using character classes.

**Todo**
- [x] ~What are `AbstractCitationKeyPattern` and `GlobalCitationKeyPattern` used for, and should they be removed?~
- [x] ~Why are both `GlobalCitationKeyPattern` and `CitationKeyPatternPreferences`  needed to create a `CitationKeyGenerator`?~

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->
**Checklist**
- [x] ~Change in CHANGELOG.md described (if applicable)~
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] ~Screenshots added in PR description (for UI changes)~
- [x] ~[Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.~
