### PR TITLE
6848 fixed the issue of clicking collapse all expanding tree

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,6 +113,7 @@ Eiswindyeti
 Ellen Reitmayr
 Erdem Derebasoglu
 Erdem Derebaşoğlu
+Eric Lau
 Erik Putrycz
 Ervin Kolenovic
 Escoul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where it was impossible to connect to OpenOffice/LibreOffice on Mac OSX. [#6970](https://github.com/JabRef/jabref/pull/6970)
 - We fixed an issue with the python script used by browser plugins that failed to locate JabRef if not installed in its default location. [#6963](https://github.com/JabRef/jabref/pull/6963/files)
 - We fixed an issue where identity column header had incorrect foreground color in the  Dark theme. [#6796](https://github.com/JabRef/jabref/issues/6796)
+- We fixed an issue where clicking on Collapse All button in the Search for Unlinked Local Files expanded the directory structure erroneously [#6848](https://github.com/JabRef/jabref/issues/6848)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesDialog.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindUnlinkedFilesDialog.java
@@ -165,7 +165,7 @@ public class FindUnlinkedFilesDialog extends BaseDialog<Boolean> {
         buttonOptionCollapseAll.setOnAction(event -> {
             CheckBoxTreeItem<FileNodeWrapper> root = (CheckBoxTreeItem<FileNodeWrapper>) tree.getRoot();
             expandTree(root, false);
-            root.setExpanded(true);
+            root.setExpanded(false);
         });
 
         textfieldDirectoryPath = new TextField();


### PR DESCRIPTION
Fixes #6848 
When clicking Collapse All button in the Search for Unlinked Local Files, it expands the directory structure erroneously.

- Please don't remove any items, just leave them unchecked if they are not applicable.

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
