### PR TITLE
Snapcraft: set version from new xml file

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Build snap (1) Run build
         uses: snapcore/action-build@v1
         id: snapcraft
+        with:
+          snapcraft-args: "--debug"
       - name: Build snap (2) Upload snap
         if: ${{ steps.checksecrets.outputs.secretspresent }}
         uses: snapcore/action-publish@v1

--- a/build.gradle
+++ b/build.gradle
@@ -674,6 +674,7 @@ jlink {
         if (OperatingSystem.current().isLinux()) {
             imageOptions = [
                     '--icon', "${projectDir}/src/main/resources/icons/JabRef-icon-64.png",
+                    '--app-version', "${project.version}",
             ]
             installerOptions = [
                     '--verbose',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,7 @@ parts:
       - x11-utils
     override-build: |
       snapcraftctl build
-      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/.jpackage.xml | grep "app.version=" | cut -d'=' -f2)"
+      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/.jpackage.xml | grep "app-version" | cut -d">" -f2 | cut -d"<" -f1)"
       sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/native-messaging-host/*/org.jabref.jabref.json
       rm $SNAPCRAFT_PART_INSTALL/bin/JabRef
   jabref-launcher:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,7 @@ parts:
       - x11-utils
     override-build: |
       snapcraftctl build
-      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/JabRef.cfg | grep "app.version=" | cut -d'=' -f2)"
+      snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/.jpackage.xml | grep "app.version=" | cut -d'=' -f2)"
       sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/native-messaging-host/*/org.jabref.jabref.json
       rm $SNAPCRAFT_PART_INSTALL/bin/JabRef
   jabref-launcher:


### PR DESCRIPTION
Fix #7022 
A change in jpackage has moved the version to an xml file.
We can parse that to read the version and set it in the snap package

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
