### PR TITLE
Make sure that current database is "shared"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We fixed an issue where clicking on Collapse All button in the Search for Unlinked Local Files expanded the directory structure erroneously [#6848](https://github.com/JabRef/jabref/issues/6848)
 - We fixed an issue, when pulling changes from shared database via shortcut caused creation a new new tech report [6867](https://github.com/JabRef/jabref/issues/6867)
 - We fixed an issue where the JabRef GUI does not highlight the "All entries" group on start-up [#6691](https://github.com/JabRef/jabref/issues/6691)
+- We fixed an issue, when JabRef tried to pull changes from shared database, when you are connected to local db [#6959](https://github.com/JabRef/jabref/issues/6959)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/shared/PullChangesFromSharedAction.java
+++ b/src/main/java/org/jabref/gui/shared/PullChangesFromSharedAction.java
@@ -3,6 +3,7 @@ package org.jabref.gui.shared;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.shared.DatabaseSynchronizer;
 
 public class PullChangesFromSharedAction extends SimpleCommand {
@@ -16,7 +17,9 @@ public class PullChangesFromSharedAction extends SimpleCommand {
     }
 
     public void execute() {
-        stateManager.getActiveDatabase().ifPresent(databaseContext -> {
+        stateManager.getActiveDatabase()
+                    .filter(databaseContext->databaseContext.getLocation() == DatabaseLocation.SHARED)
+                    .ifPresent(databaseContext -> {
             DatabaseSynchronizer dbmsSynchronizer = databaseContext.getDBMSSynchronizer();
             dbmsSynchronizer.pullChanges();
         });


### PR DESCRIPTION
Fixes #6959 
JabRef always tries to pull changes from shared database, even if current database is not shared.
Added filter to ensure that current db is shared.

- [X] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
