### PR TITLE
Added error msg when isbn entry was not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a DOI format and organization check to detect [American Physical Society](https://journals.aps.org/) journals to copy the article ID
 to the page field for cases where the page numbers are missing. [#7019](https://github.com/JabRef/jabref/issues/7019)
 - We added a new fetcher to enable users to search jstor.org [#6627](https://github.com/JabRef/jabref/issues/6627)
+- We added an error message in the EntryTypeViewModel that gets displayed to the user if a fetched entry is empty. [#7000](https://github.com/JabRef/jabref/issues/7000)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a DOI format and organization check to detect [American Physical Society](https://journals.aps.org/) journals to copy the article ID
 to the page field for cases where the page numbers are missing. [#7019](https://github.com/JabRef/jabref/issues/7019)
 - We added a new fetcher to enable users to search jstor.org [#6627](https://github.com/JabRef/jabref/issues/6627)
-- We added an error message in the EntryTypeViewModel that gets displayed to the user if a fetched entry is empty. [#7000](https://github.com/JabRef/jabref/issues/7000)
+- We added an error message in the New Entry dialog that is shown in case the fetcher did not find anything . [#7000](https://github.com/JabRef/jabref/issues/7000)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -176,6 +176,10 @@ public class EntryTypeViewModel {
                 searchSuccesfulProperty.set(true);
             } else if (StringUtil.isBlank(idText.getValue())) {
                 dialogService.showWarningDialogAndWait(Localization.lang("Empty search ID"), Localization.lang("The given search ID was empty."));
+            } else if (result.isEmpty()) {
+                String fetcher = selectedItemProperty().getValue().getName();
+                String searchId = idText.getValue();
+                dialogService.showErrorDialogAndWait(Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId));
             }
             fetcherWorker = new FetcherWorker();
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import javafx.scene.control.Alert.AlertType;
+
+import org.jabref.gui.FXDialog;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.FetcherException;
@@ -57,6 +60,13 @@ public class IsbnFetcher implements EntryBasedFetcher, IdBasedFetcher {
             LOGGER.debug("No entry found at ebook.de; trying ottobib");
             IsbnViaOttoBibFetcher isbnViaOttoBibFetcher = new IsbnViaOttoBibFetcher(importFormatPreferences);
             bibEntry = isbnViaOttoBibFetcher.performSearchById(identifier);
+        }
+
+        // nothing found at ebook.de and ottobib
+        if (!bibEntry.isPresent()) {
+            FXDialog noEntryFoundDialog = new FXDialog(AlertType.ERROR);
+            noEntryFoundDialog.setContentText("No entry found for ISBN: " + identifier + ".");
+            noEntryFoundDialog.show();
         }
 
         return bibEntry;

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnFetcher.java
@@ -5,9 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import javafx.scene.control.Alert.AlertType;
-
-import org.jabref.gui.FXDialog;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.FetcherException;
@@ -60,13 +57,6 @@ public class IsbnFetcher implements EntryBasedFetcher, IdBasedFetcher {
             LOGGER.debug("No entry found at ebook.de; trying ottobib");
             IsbnViaOttoBibFetcher isbnViaOttoBibFetcher = new IsbnViaOttoBibFetcher(importFormatPreferences);
             bibEntry = isbnViaOttoBibFetcher.performSearchById(identifier);
-        }
-
-        // nothing found at ebook.de and ottobib
-        if (!bibEntry.isPresent()) {
-            FXDialog noEntryFoundDialog = new FXDialog(AlertType.ERROR);
-            noEntryFoundDialog.setContentText("No entry found for ISBN: " + identifier + ".");
-            noEntryFoundDialog.show();
         }
 
         return bibEntry;

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
@@ -58,6 +58,13 @@ public class IsbnViaOttoBibFetcher extends AbstractIsbnFetcher {
             throw new FetcherException("Could not ", e);
         }
         Element textArea = html.select("textarea").first();
+
+        // inspect the "no results" error message (if there is one)
+        Element potentialErrorMessageDiv = html.select("div#flash-notice.notice.add-bottom").first();
+        if (potentialErrorMessageDiv.hasText() && potentialErrorMessageDiv.text().contains("No Results")) {
+            LOGGER.error("ISBN " + identifier + " not found at ottobib");
+        }
+
         Optional<BibEntry> entry = Optional.empty();
         try {
             entry = BibtexParser.singleFromString(textArea.text(), importFormatPreferences, new DummyFileUpdateMonitor());

--- a/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcher.java
@@ -60,9 +60,9 @@ public class IsbnViaOttoBibFetcher extends AbstractIsbnFetcher {
         Element textArea = html.select("textarea").first();
 
         // inspect the "no results" error message (if there is one)
-        Element potentialErrorMessageDiv = html.select("div#flash-notice.notice.add-bottom").first();
-        if (potentialErrorMessageDiv.hasText() && potentialErrorMessageDiv.text().contains("No Results")) {
-            LOGGER.error("ISBN " + identifier + " not found at ottobib");
+        Optional<Element> potentialErrorMessageDiv = Optional.ofNullable((html.select("div#flash-notice.notice.add-bottom").first()));
+        if (potentialErrorMessageDiv.isPresent() && potentialErrorMessageDiv.get().text().contains("No Results")) {
+            LOGGER.error("ISBN {} not found at ottobib", identifier);
         }
 
         Optional<BibEntry> entry = Optional.empty();


### PR DESCRIPTION
Fixes #7000 
Added an error message that gets shown when the entered ISBN leads to no results on ebook.de and ottobib.

Screenshot of change:
![errormessage](https://user-images.githubusercontent.com/47194464/96875310-5da9b980-1477-11eb-8aee-5af3cd7c5c95.png)


- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
