### PR TITLE
Add awt native open commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We changed the name of a group type from "Searching for keywords" to "Searching for a keyword". [6995](https://github.com/JabRef/jabref/pull/6995)
 - We changed the way JabRef displays the title of a tab and of the window. [4161](https://github.com/JabRef/jabref/issues/4161)
 - We changed connect timeouts for server requests to 30 seconds in general and 5 seconds for GROBID server (special) and improved user notifications on connection issues. [7026](https://github.com/JabRef/jabref/pull/7026)
+- We changed the way linked files are opened on Linux to use the native openFile method, compatible with confined packages. [7037](https://github.com/JabRef/jabref/pull/7037)
 
 ### Fixed
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,11 +15,8 @@ architectures:
   - build-on: amd64
 
 plugs:
-  desktop:
-  desktop-legacy:
-  wayland:
-  unity7:
   home:
+  unity7:
   opengl:
   network-bind:
   removable-media:
@@ -46,6 +43,7 @@ apps:
 
 environment:
   _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"
+  GTK_USE_PORTAL: "1"
 
 parts:
   jabref:

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -9,8 +9,6 @@ import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Optional;
 
-import javax.swing.SwingUtilities;
-
 import org.jabref.architecture.AllowedToUseAwt;
 import org.jabref.gui.JabRefExecutorService;
 import org.jabref.gui.externalfiletype.ExternalFileType;
@@ -26,7 +24,7 @@ public class Linux implements NativeDesktop {
     private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);
 
     private void nativeOpenFile(String filePath) {
-        SwingUtilities.invokeLater(() -> {
+        new Thread(() -> {
             try {
                 File file = new File(filePath);
                 Desktop.getDesktop().open(file);
@@ -42,7 +40,7 @@ public class Linux implements NativeDesktop {
             } catch (IOException e) {
                 System.out.println("Native open operation not successful: " + e);
             }
-        });
+        }).start();
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -24,7 +24,7 @@ public class Linux implements NativeDesktop {
     private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);
 
     private void nativeOpenFile(String filePath) {
-        new Thread(() -> {
+        JabRefExecutorService.INSTANCE.execute(() -> {
             try {
                 File file = new File(filePath);
                 Desktop.getDesktop().open(file);
@@ -32,7 +32,7 @@ public class Linux implements NativeDesktop {
             } catch (IllegalArgumentException e) {
                 System.out.println("Fail back to xdg-open");
                 try {
-                    String cmd = "xdg-open " + filePath;
+                    String[] cmd = {"xdg-open", filePath};
                     Runtime.getRuntime().exec(cmd);
                 } catch (Exception e2) {
                     System.out.println("Open operation not successful: " + e2);
@@ -40,7 +40,7 @@ public class Linux implements NativeDesktop {
             } catch (IOException e) {
                 System.out.println("Native open operation not successful: " + e);
             }
-        }).start();
+        });
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -20,11 +20,11 @@ import org.jabref.gui.util.StreamGobbler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@AllowedToUseAwt("Requires AWT to open a file with the native method")
 public class Linux implements NativeDesktop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);
 
-    @AllowedToUseAwt("")
     private void nativeOpenFile(String filePath) {
         SwingUtilities.invokeLater(() -> {
             try {


### PR DESCRIPTION
Fixes https://github.com/flathub/org.jabref.jabref/issues/3
As discussed in gitter the confined releases do not play nicely with xdg-open.
The flatpak fails directly, and the snap asks for confirmation every time.
If we introduce awt.open it works as intended with native commands/windows.
It works in confined and unconfined releases.

At the moment this is a draft pending further tests


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
