### PR TITLE
add short date formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 to the page field for cases where the page numbers are missing. [#7019](https://github.com/JabRef/jabref/issues/7019)
 - We added a new fetcher to enable users to search jstor.org [#6627](https://github.com/JabRef/jabref/issues/6627)
 - We added an error message in the New Entry dialog that is shown in case the fetcher did not find anything . [#7000](https://github.com/JabRef/jabref/issues/7000)
+- We added a new formatter to output shorthand month format. [#6579](https://github.com/JabRef/jabref/issues/6579)
 
 ### Changed
 

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -74,6 +74,7 @@ import org.jabref.logic.layout.format.Replace;
 import org.jabref.logic.layout.format.RisAuthors;
 import org.jabref.logic.layout.format.RisKeywords;
 import org.jabref.logic.layout.format.RisMonth;
+import org.jabref.logic.layout.format.ShortMonthFormatter;
 import org.jabref.logic.layout.format.ToLowerCase;
 import org.jabref.logic.layout.format.ToUpperCase;
 import org.jabref.logic.layout.format.WrapContent;
@@ -542,6 +543,8 @@ class LayoutEntry {
                 return new MarkdownFormatter();
             case "CSLType":
                 return new CSLType();
+            case "ShortMonth":
+                return new ShortMonthFormatter();
             default:
                 return null;
         }

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -543,11 +543,8 @@ class LayoutEntry {
                 return new MarkdownFormatter();
             case "CSLType":
                 return new CSLType();
-<<<<<<< HEAD
             case "ShortMonth":
                 return new ShortMonthFormatter();
-=======
->>>>>>> a1107ed890bb562ca6f5b64f26ae7aecceb6f92d
             default:
                 return null;
         }

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -543,8 +543,11 @@ class LayoutEntry {
                 return new MarkdownFormatter();
             case "CSLType":
                 return new CSLType();
+<<<<<<< HEAD
             case "ShortMonth":
                 return new ShortMonthFormatter();
+=======
+>>>>>>> a1107ed890bb562ca6f5b64f26ae7aecceb6f92d
             default:
                 return null;
         }

--- a/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
@@ -1,0 +1,20 @@
+package org.jabref.logic.layout.format;
+
+import java.util.Optional;
+
+import org.jabref.logic.layout.ParamLayoutFormatter;
+import org.jabref.model.entry.Month;
+
+public class ShortMonthFormatter implements ParamLayoutFormatter {
+
+    @Override
+    public void setArgument(String arg) {
+        // no effect
+    }
+
+    @Override
+    public String format(String fieldText) {
+        Optional<Month> month = Month.parse(fieldText);
+        return month.map(Month::getShortName).orElse("");
+    }
+}

--- a/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.layout.format;
 
 import java.util.Optional;
 
-import org.jabref.logic.layout.ParamLayoutFormatter;
+import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.entry.Month;
 
 public class ShortMonthFormatter implements LayoutFormatter {

--- a/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.jabref.logic.layout.ParamLayoutFormatter;
 import org.jabref.model.entry.Month;
 
-public class ShortMonthFormatter implements ParamLayoutFormatter {
+public class ShortMonthFormatter implements LayoutFormatter {
 
     @Override
     public void setArgument(String arg) {

--- a/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/ShortMonthFormatter.java
@@ -8,11 +8,6 @@ import org.jabref.model.entry.Month;
 public class ShortMonthFormatter implements LayoutFormatter {
 
     @Override
-    public void setArgument(String arg) {
-        // no effect
-    }
-
-    @Override
     public String format(String fieldText) {
         Optional<Month> month = Month.parse(fieldText);
         return month.map(Month::getShortName).orElse("");

--- a/src/test/java/org/jabref/logic/layout/format/ShortMonthFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/ShortMonthFormatterTest.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.layout.format;
 
-import org.jabref.logic.layout.ParamLayoutFormatter;
+import org.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ShortMonthFormatterTest {
 
-    private ParamLayoutFormatter formatter;
+    private LayoutFormatter formatter;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/jabref/logic/layout/format/ShortMonthFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/ShortMonthFormatterTest.java
@@ -1,0 +1,24 @@
+package org.jabref.logic.layout.format;
+
+import org.jabref.logic.layout.ParamLayoutFormatter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ShortMonthFormatterTest {
+
+    private ParamLayoutFormatter formatter;
+
+    @BeforeEach
+    public void setUp() {
+        formatter = new ShortMonthFormatter();
+    }
+
+    @Test
+    public void testFormat() {
+        assertEquals("jan", formatter.format("01"));
+        assertEquals("jan", formatter.format("Januar"));
+    }
+}


### PR DESCRIPTION
Add formatter that can format the month field to use the shorthand abbreviation .
fixes #6579



- [X] Change in CHANGELOG.md described (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
