### PR TITLE
Add online-link detection to FileFieldParser

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -67,14 +67,16 @@ public class FileFieldParser {
         while (entry.size() < 3) {
             entry.add("");
         }
-        LinkedFile field;
+
+        LinkedFile field = null;
         if (LinkedFile.isOnlineLink(entry.get(1))) {
             try {
                 field = new LinkedFile(new URL(entry.get(1)), entry.get(2));
-            } catch (MalformedURLException e) {
-                field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+            } catch (MalformedURLException ignored) {
             }
-        } else {
+        }
+
+        if (field == null){
             field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
         }
 

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.importer.util;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +67,17 @@ public class FileFieldParser {
         while (entry.size() < 3) {
             entry.add("");
         }
-        LinkedFile field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+        LinkedFile field;
+        if (LinkedFile.isOnlineLink(entry.get(1))) {
+            try {
+                field = new LinkedFile(new URL(entry.get(1)), entry.get(2));
+            } catch (MalformedURLException e) {
+                field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+            }
+        } else {
+            field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+        }
+
         // link is only mandatory field
         if (field.getDescription().isEmpty() && field.getLink().isEmpty() && !field.getFileType().isEmpty()) {
             field = new LinkedFile("", Path.of(field.getFileType()), "");

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -73,10 +73,11 @@ public class FileFieldParser {
             try {
                 field = new LinkedFile(new URL(entry.get(1)), entry.get(2));
             } catch (MalformedURLException ignored) {
+                // ignored
             }
         }
 
-        if (field == null){
+        if (field == null) {
             field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
         }
 

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -133,7 +133,7 @@ public class LinkedFile implements Serializable {
      * @param toCheck The String to check
      * @return <code>true</code>, if it starts with "http://", "https://" or contains "www."; <code>false</code> otherwise
      */
-    private boolean isOnlineLink(String toCheck) {
+    public static boolean isOnlineLink(String toCheck) {
         String normalizedFilePath = toCheck.trim().toLowerCase();
         return normalizedFilePath.startsWith("http://") || normalizedFilePath.startsWith("https://") || normalizedFilePath.contains("www.");
     }

--- a/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -44,6 +44,15 @@ public class FileFieldWriterTest {
     }
 
     @Test
+    public void parseFaultyOnlineInput(){
+        String input = ":htt\\://arxiv.org/pdf/2010.08497v1:PDF";
+        String inputURL = "htt://arxiv.org/pdf/2010.08497v1";
+        List<LinkedFile> expected = Collections.singletonList(new LinkedFile("", Path.of(inputURL), "PDF"));
+
+        assertEquals(expected, FileFieldParser.parse(input));
+    }
+
+    @Test
     public void ingoreMissingDescription() {
         String input = ":wei2005ahp.pdf:PDF";
 

--- a/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -44,7 +44,7 @@ public class FileFieldWriterTest {
     }
 
     @Test
-    public void parseFaultyOnlineInput(){
+    public void parseFaultyOnlineInput() {
         String input = ":htt\\://arxiv.org/pdf/2010.08497v1:PDF";
         String inputURL = "htt://arxiv.org/pdf/2010.08497v1";
         List<LinkedFile> expected = Collections.singletonList(new LinkedFile("", Path.of(inputURL), "PDF"));

--- a/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -38,7 +38,7 @@ public class FileFieldWriterTest {
     public void parseCorrectOnlineInput() throws MalformedURLException {
         String input = ":http\\://arxiv.org/pdf/2010.08497v1:PDF";
         String inputURL = "http://arxiv.org/pdf/2010.08497v1";
-        List<LinkedFile> expected =  Collections.singletonList(new LinkedFile(new URL(inputURL), "PDF"));
+        List<LinkedFile> expected = Collections.singletonList(new LinkedFile(new URL(inputURL), "PDF"));
 
         assertEquals(expected, FileFieldParser.parse(input));
     }

--- a/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -1,8 +1,11 @@
 package org.jabref.logic.bibtex;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.jabref.logic.importer.util.FileFieldParser;
 import org.jabref.model.entry.LinkedFile;
@@ -29,6 +32,15 @@ public class FileFieldWriterTest {
         assertEquals(
                 Collections.singletonList(new LinkedFile("Desc", Path.of("File.PDF"), "PDF")),
                 FileFieldParser.parse(input));
+    }
+
+    @Test
+    public void parseCorrectOnlineInput() throws MalformedURLException {
+        String input = ":http\\://arxiv.org/pdf/2010.08497v1:PDF";
+        String inputURL = "http://arxiv.org/pdf/2010.08497v1";
+        List<LinkedFile> expected =  Collections.singletonList(new LinkedFile(new URL(inputURL), "PDF"));
+
+        assertEquals(expected, FileFieldParser.parse(input));
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #7032. The FileFieldParser did not detect an URL and created a LinkedFile object with the URL as a local file path, which caused an error when running "Check integrity".

I'm not sure if the unit test is in the right class.
If this change requires a changelog entry, I'm happy to add one.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
