### PR TITLE
Fix entry file field issue

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -1,5 +1,8 @@
 package org.jabref.logic.importer.util;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +68,18 @@ public class FileFieldParser {
         while (entry.size() < 3) {
             entry.add("");
         }
-        LinkedFile field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+        LinkedFile field;
+        try {
+            field = new LinkedFile(entry.get(0), Path.of(entry.get(1)), entry.get(2));
+        } catch (InvalidPathException ex) {
+            // Might be a URL not a Path
+            try {
+                field = new LinkedFile(new URL(entry.get(1)), entry.get(2));
+            } catch (MalformedURLException e) {
+                // Otherwise just throw the InvalidPathException
+                throw ex;
+            }
+        }
         // link is only mandatory field
         if (field.getDescription().isEmpty() && field.getLink().isEmpty() && !field.getFileType().isEmpty()) {
             field = new LinkedFile("", Path.of(field.getFileType()), "");


### PR DESCRIPTION
This PR addresses an issue that occurred when an entry was imported that contained an URL in the file field.
This could happen when an entry was imported, e.g. using the WebSearchPane or if a bibliographic database was opened that contains such an entry.

Example of the issue when such an entry was imported over the WebSearchPane:

![image](https://user-images.githubusercontent.com/43381984/97408930-1d29c000-18fd-11eb-9f0d-8dd9a0138ba8.png)


Signed-off-by: Dominik Voigt <dominik.ingo.voigt@gmail.com>


- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
