### PR TITLE
Fix preview settings not saved due to l10n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We fixed an issue, when pulling changes from shared database via shortcut caused creation of a new tech report [6867](https://github.com/JabRef/jabref/issues/6867)
 - We fixed an issue where the JabRef GUI does not highlight the "All entries" group on start-up [#6691](https://github.com/JabRef/jabref/issues/6691)
 - We fixed an issue where a custom dark theme was not applied to the entry preview tab [7068](https://github.com/JabRef/jabref/issues/7068)
+- We fixed an issue where modifications to the Custom preview layout in the preferences were not saved [#6447](https://github.com/JabRef/jabref/issues/6447)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabView.java
@@ -118,7 +118,7 @@ public class PreviewTabView extends AbstractPreferenceTabView<PreviewTabViewMode
         availableListView.itemsProperty().bindBidirectional(viewModel.availableListProperty());
         viewModel.availableSelectionModelProperty().setValue(availableListView.getSelectionModel());
         new ViewModelListCellFactory<PreviewLayout>()
-                .withText(PreviewLayout::getName)
+                .withText(PreviewLayout::getDisplayName)
                 .install(availableListView);
         availableListView.setOnDragOver(this::dragOver);
         availableListView.setOnDragDetected(this::dragDetectedInAvailable);
@@ -129,7 +129,7 @@ public class PreviewTabView extends AbstractPreferenceTabView<PreviewTabViewMode
         chosenListView.itemsProperty().bindBidirectional(viewModel.chosenListProperty());
         viewModel.chosenSelectionModelProperty().setValue(chosenListView.getSelectionModel());
         new ViewModelListCellFactory<PreviewLayout>()
-                .withText(PreviewLayout::getName)
+                .withText(PreviewLayout::getDisplayName)
                 .setOnDragDropped(this::dragDroppedInChosenCell)
                 .install(chosenListView);
         chosenListView.setOnDragOver(this::dragOver);
@@ -197,7 +197,7 @@ public class PreviewTabView extends AbstractPreferenceTabView<PreviewTabViewMode
 
         lastKeyPressTime = System.currentTimeMillis();
 
-        list.getItems().stream().filter(item -> item.getName().toLowerCase().startsWith(listSearchTerm))
+        list.getItems().stream().filter(item -> item.getDisplayName().toLowerCase().startsWith(listSearchTerm))
             .findFirst().ifPresent(list::scrollTo);
     }
 

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
@@ -166,9 +166,9 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     }
 
     private PreviewLayout findLayoutByName(String name) {
-        return availableListProperty.getValue().stream().filter(layout -> layout.getInternalName().equals(name))
+        return availableListProperty.getValue().stream().filter(layout -> layout.getName().equals(name))
                                     .findAny()
-                                    .orElse(chosenListProperty.getValue().stream().filter(layout -> layout.getInternalName().equals(name))
+                                    .orElse(chosenListProperty.getValue().stream().filter(layout -> layout.getName().equals(name))
                                                               .findAny()
                                                               .orElse(null));
     }
@@ -260,7 +260,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         chosenSelectionModelProperty.getValue().clearSelection();
         chosenListProperty.removeAll(selected);
         availableListProperty.addAll(selected);
-        availableListProperty.sort((a, b) -> a.getName().compareToIgnoreCase(b.getName()));
+        availableListProperty.sort((a, b) -> a.getDisplayName().compareToIgnoreCase(b.getDisplayName()));
     }
 
     public void selectedInChosenUp() {
@@ -416,7 +416,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
                 success = true;
 
                 if (targetList == availableListProperty) {
-                    targetList.getValue().sort((a, b) -> a.getName().compareToIgnoreCase(b.getName()));
+                    targetList.getValue().sort((a, b) -> a.getDisplayName().compareToIgnoreCase(b.getDisplayName()));
                 }
             }
         }

--- a/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreviewTabViewModel.java
@@ -91,8 +91,9 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         initialPreviewPreferences = preferences.getPreviewPreferences();
 
         sourceTextProperty.addListener((observable, oldValue, newValue) -> {
-            if (getCurrentLayout() instanceof TextBasedPreviewLayout) {
-                ((TextBasedPreviewLayout) getCurrentLayout()).setText(sourceTextProperty.getValue().replace("\n", "__NEWLINE__"));
+            var currentLayout = getCurrentLayout();
+            if (currentLayout instanceof TextBasedPreviewLayout) {
+                ((TextBasedPreviewLayout) currentLayout).setText(sourceTextProperty.getValue().replace("\n", "__NEWLINE__"));
             }
         });
 
@@ -112,6 +113,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         return showAsExtraTab;
     }
 
+    @Override
     public void setValues() {
         showAsExtraTab.set(initialPreviewPreferences.showPreviewAsExtraTab());
         chosenListProperty().getValue().clear();
@@ -164,9 +166,9 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     }
 
     private PreviewLayout findLayoutByName(String name) {
-        return availableListProperty.getValue().stream().filter(layout -> layout.getName().equals(name))
+        return availableListProperty.getValue().stream().filter(layout -> layout.getInternalName().equals(name))
                                     .findAny()
-                                    .orElse(chosenListProperty.getValue().stream().filter(layout -> layout.getName().equals(name))
+                                    .orElse(chosenListProperty.getValue().stream().filter(layout -> layout.getInternalName().equals(name))
                                                               .findAny()
                                                               .orElse(null));
     }
@@ -174,13 +176,14 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     private PreviewLayout getCurrentLayout() {
         if (!chosenSelectionModelProperty.getValue().getSelectedItems().isEmpty()) {
             return chosenSelectionModelProperty.getValue().getSelectedItems().get(0);
+
         }
 
         if (!chosenListProperty.getValue().isEmpty()) {
             return chosenListProperty.getValue().get(0);
         }
 
-        PreviewLayout layout = findLayoutByName("Preview");
+        PreviewLayout layout = findLayoutByName(TextBasedPreviewLayout.NAME);
         if (layout == null) {
             layout = initialPreviewPreferences.getTextBasedPreviewLayout();
         }
@@ -196,7 +199,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             chosenListProperty.add(previewPreferences.getTextBasedPreviewLayout());
         }
 
-        PreviewLayout previewStyle = findLayoutByName("Preview");
+        PreviewLayout previewStyle = findLayoutByName(TextBasedPreviewLayout.NAME);
         if (previewStyle == null) {
             previewStyle = previewPreferences.getTextBasedPreviewLayout();
         }

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -111,7 +111,7 @@ public class PreviewPanel extends VBox {
         previewView.setLayout(currentPreviewStyle);
         preferences.storePreviewPreferences(previewPreferences);
         if (!init) {
-            dialogService.notify(Localization.lang("Preview style changed to: %0", currentPreviewStyle.getName()));
+            dialogService.notify(Localization.lang("Preview style changed to: %0", currentPreviewStyle.getDisplayName()));
         }
     }
 

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -188,7 +188,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
 
         BackgroundTask
                 .wrap(() -> layout.generatePreview(entry.get(), database.getDatabase()))
-                .onRunning(() -> setPreviewText("<i>" + Localization.lang("Processing %0", Localization.lang("Citation Style")) + ": " + layout.getName() + " ..." + "</i>"))
+                .onRunning(() -> setPreviewText("<i>" + Localization.lang("Processing %0", Localization.lang("Citation Style")) + ": " + layout.getDisplayName() + " ..." + "</i>"))
                 .onSuccess(this::setPreviewText)
                 .onFailure(exception -> {
                     LOGGER.error("Error while generating citation style", exception);

--- a/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
@@ -80,4 +80,9 @@ public class BstPreviewLayout implements PreviewLayout {
     public String getName() {
         return name;
     }
+
+    @Override
+    public String getInternalName() {
+        return name;
+    }
 }

--- a/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
@@ -77,12 +77,12 @@ public class BstPreviewLayout implements PreviewLayout {
     }
 
     @Override
-    public String getName() {
+    public String getDisplayName() {
         return name;
     }
 
     @Override
-    public String getInternalName() {
+    public String getName() {
         return name;
     }
 }

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStylePreviewLayout.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStylePreviewLayout.java
@@ -5,7 +5,7 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 
 public class CitationStylePreviewLayout implements PreviewLayout {
-    private CitationStyle citationStyle;
+    private final CitationStyle citationStyle;
 
     public CitationStylePreviewLayout(CitationStyle citationStyle) {
         this.citationStyle = citationStyle;
@@ -27,5 +27,10 @@ public class CitationStylePreviewLayout implements PreviewLayout {
 
     public String getFilePath() {
         return citationStyle.getFilePath();
+    }
+
+    @Override
+    public String getInternalName() {
+        return citationStyle.getTitle();
     }
 }

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStylePreviewLayout.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStylePreviewLayout.java
@@ -17,7 +17,7 @@ public class CitationStylePreviewLayout implements PreviewLayout {
     }
 
     @Override
-    public String getName() {
+    public String getDisplayName() {
         return citationStyle.getTitle();
     }
 
@@ -30,7 +30,7 @@ public class CitationStylePreviewLayout implements PreviewLayout {
     }
 
     @Override
-    public String getInternalName() {
+    public String getName() {
         return citationStyle.getTitle();
     }
 }

--- a/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
@@ -56,12 +56,12 @@ public class TextBasedPreviewLayout implements PreviewLayout {
     }
 
     @Override
-    public String getInternalName() {
+    public String getName() {
         return NAME;
     }
 
     @Override
-    public String getName() {
+    public String getDisplayName() {
         return Localization.lang("Customized preview style");
     }
 }

--- a/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
@@ -15,8 +15,9 @@ import org.slf4j.LoggerFactory;
  * Implements the preview based JabRef's <a href="https://docs.jabref.org/import-export/export/customexports">Custom export fitlters</a>.
  */
 public class TextBasedPreviewLayout implements PreviewLayout {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TextBasedPreviewLayout.class);
+    public static final String NAME = "PREVIEW";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TextBasedPreviewLayout.class);
     private Layout layout;
     private String text;
     private LayoutFormatterPreferences layoutFormatterPreferences;
@@ -52,6 +53,11 @@ public class TextBasedPreviewLayout implements PreviewLayout {
 
     public String getText() {
         return text;
+    }
+
+    @Override
+    public String getInternalName() {
+        return NAME;
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/preview/PreviewLayout.java
+++ b/src/main/java/org/jabref/logic/preview/PreviewLayout.java
@@ -11,4 +11,6 @@ public interface PreviewLayout {
     String generatePreview(BibEntry entry, BibDatabase database);
 
     String getName();
+
+    String getInternalName();
 }

--- a/src/main/java/org/jabref/logic/preview/PreviewLayout.java
+++ b/src/main/java/org/jabref/logic/preview/PreviewLayout.java
@@ -10,7 +10,7 @@ public interface PreviewLayout {
 
     String generatePreview(BibEntry entry, BibDatabase database);
 
-    String getName();
+    String getDisplayName();
 
-    String getInternalName();
+    String getName();
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2409,7 +2409,7 @@ public class JabRefPreferences implements PreferencesService {
             if (layout instanceof CitationStylePreviewLayout) {
                 return ((CitationStylePreviewLayout) layout).getFilePath();
             } else {
-                return layout.getName();
+                return layout.getDisplayName();
             }
         }).collect(Collectors.toList()));
         putDouble(PREVIEW_PANEL_HEIGHT, previewPreferences.getPreviewPanelDividerPosition().doubleValue());


### PR DESCRIPTION
Introduce internal name for finding layout
Fixes #6447

The problem was that the getName method returned a l10n name for Custom Preview layout.....

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
