### PR TITLE
Fix endnote importer when keyword style is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We fixed an issue where the JabRef GUI does not highlight the "All entries" group on start-up [#6691](https://github.com/JabRef/jabref/issues/6691)
 - We fixed an issue where a custom dark theme was not applied to the entry preview tab [7068](https://github.com/JabRef/jabref/issues/7068)
 - We fixed an issue where modifications to the Custom preview layout in the preferences were not saved [#6447](https://github.com/JabRef/jabref/issues/6447)
+- We fixed an issue where errors from imports were not shown to the user [#7084](https://github.com/JabRef/jabref/pull/7084)
+- We fixed an issue where the EndNote XML Import would fail on empty keywords tags [forum#2387](https://discourse.jabref.org/t/importing-in-unknown-format-fails-to-import-xml-library-from-bookends-export/2387)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/DefaultInjector.java
+++ b/src/main/java/org/jabref/gui/DefaultInjector.java
@@ -8,6 +8,7 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
@@ -46,6 +47,8 @@ public class DefaultInjector implements PresenterFactory {
             return Globals.clipboardManager;
         } else if (clazz == UndoManager.class) {
             return Globals.undoManager;
+        } else if (clazz == BibEntryTypesManager.class) {
+            return Globals.entryTypesManager;
         } else {
             try {
                 return clazz.newInstance();

--- a/src/main/java/org/jabref/gui/importer/ImportAction.java
+++ b/src/main/java/org/jabref/gui/importer/ImportAction.java
@@ -85,7 +85,7 @@ public class ImportAction {
             })
            .onFailure(ex-> {
                LOGGER.error("Error importing", ex);
-               dialogService.notify(Localization.lang("Error importing. See the error log for details"));
+               dialogService.notify(Localization.lang("Error importing. See the error log for details."));
            })
            .executeWith(taskExecutor);
         } else {

--- a/src/main/java/org/jabref/gui/importer/ImportAction.java
+++ b/src/main/java/org/jabref/gui/importer/ImportAction.java
@@ -83,7 +83,11 @@ public class ImportAction {
                 frame.addTab(parserResult.getDatabaseContext(), true);
                 dialogService.notify(Localization.lang("Imported entries") + ": " + parserResult.getDatabase().getEntries().size());
             })
-                .executeWith(taskExecutor);
+           .onFailure(ex-> {
+               LOGGER.error("Error importing", ex);
+               dialogService.notify(Localization.lang("Error importing. See the error log for details"));
+           })
+           .executeWith(taskExecutor);
         } else {
             final LibraryTab libraryTab = frame.getCurrentLibraryTab();
 

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -35,6 +35,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -59,6 +60,7 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
     @Inject private UndoManager undoManager;
     @Inject private PreferencesService preferences;
     @Inject private StateManager stateManager;
+    @Inject private BibEntryTypesManager entryTypesManager;
     @Inject private FileUpdateMonitor fileUpdateMonitor;
     private final BibDatabaseContext database;
 
@@ -94,7 +96,7 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
 
     @FXML
     private void initialize() {
-        viewModel = new ImportEntriesViewModel(task, taskExecutor, database, dialogService, undoManager, preferences, stateManager, fileUpdateMonitor);
+        viewModel = new ImportEntriesViewModel(task, taskExecutor, database, dialogService, undoManager, preferences, stateManager, entryTypesManager, fileUpdateMonitor);
         Label placeholder = new Label();
         placeholder.textProperty().bind(viewModel.messageProperty());
         entriesListView.setPlaceholder(placeholder);

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -13,7 +13,6 @@ import javafx.collections.ObservableList;
 
 import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefGUI;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
@@ -28,6 +27,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.FilePreferences;
@@ -50,6 +50,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private ParserResult parserResult = null;
     private final ObservableList<BibEntry> entries;
     private final PreferencesService preferences;
+    private final BibEntryTypesManager entryTypesManager;
 
     /**
      * @param databaseContext the database to import into
@@ -62,6 +63,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                                   UndoManager undoManager,
                                   PreferencesService preferences,
                                   StateManager stateManager,
+                                  BibEntryTypesManager entryTypesManager,
                                   FileUpdateMonitor fileUpdateMonitor) {
         this.taskExecutor = taskExecutor;
         this.databaseContext = databaseContext;
@@ -69,6 +71,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         this.undoManager = undoManager;
         this.preferences = preferences;
         this.stateManager = stateManager;
+        this.entryTypesManager = entryTypesManager;
         this.fileUpdateMonitor = fileUpdateMonitor;
         this.entries = FXCollections.observableArrayList();
         this.message = new SimpleStringProperty();
@@ -79,11 +82,10 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             this.parserResult = parserResult;
             // fill in the list for the user, where one can select the entries to import
             entries.addAll(parserResult.getDatabase().getEntries());
-        }).onFailure(ex->{
+        }).onFailure(ex -> {
             LOGGER.error("Error importing", ex);
             dialogService.showErrorDialogAndWait(ex);
-        })
-        .executeWith(taskExecutor);
+        }).executeWith(taskExecutor);
     }
 
     public String getMessage() {
@@ -100,7 +102,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent() ||
-                new DuplicateCheck(Globals.entryTypesManager)
+                new DuplicateCheck(entryTypesManager)
                 .containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode()).isPresent();
     }
 
@@ -131,7 +133,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                 } else {
                     buildImportHandlerThenImportEntries(entriesToImport);
                 }
-            }).executeWith(Globals.TASK_EXECUTOR);
+            }).executeWith(taskExecutor);
         } else {
             buildImportHandlerThenImportEntries(entriesToImport);
         }
@@ -191,7 +193,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             if (othEntry.equals(entry)) {
                 continue; // Don't compare the entry to itself
             }
-            if (new DuplicateCheck(Globals.entryTypesManager).isDuplicate(entry, othEntry, databaseContext.getMode())) {
+            if (new DuplicateCheck(entryTypesManager).isDuplicate(entry, othEntry, databaseContext.getMode())) {
                 return Optional.of(othEntry);
             }
         }
@@ -200,7 +202,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     public void resolveDuplicate(BibEntry entry) {
         // First, try to find duplicate in the existing library
-        Optional<BibEntry> other = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
+        Optional<BibEntry> other = new DuplicateCheck(entryTypesManager).containsDuplicate(databaseContext.getDatabase(), entry, databaseContext.getMode());
         if (other.isPresent()) {
             DuplicateResolverDialog dialog = new DuplicateResolverDialog(other.get(),
                     entry, DuplicateResolverDialog.DuplicateResolverType.INSPECTION, databaseContext, stateManager);

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -33,7 +33,12 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.FilePreferences;
 import org.jabref.preferences.PreferencesService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ImportEntriesViewModel extends AbstractViewModel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImportAction.class);
 
     private final StringProperty message;
     private final TaskExecutor taskExecutor;
@@ -74,7 +79,11 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             this.parserResult = parserResult;
             // fill in the list for the user, where one can select the entries to import
             entries.addAll(parserResult.getDatabase().getEntries());
-        }).executeWith(taskExecutor);
+        }).onFailure(ex->{
+            LOGGER.error("Error importing", ex);
+            dialogService.showErrorDialogAndWait(ex);
+        })
+        .executeWith(taskExecutor);
     }
 
     public String getMessage() {

--- a/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
@@ -269,9 +269,12 @@ public class EndnoteXmlImporter extends Importer implements Parser {
     private List<String> getKeywords(Record record) {
         Keywords keywords = record.getKeywords();
         if (keywords != null) {
+
             return keywords.getKeyword()
                            .stream()
-                           .map(keyword -> keyword.getStyle().getContent())
+                           .map(keyword -> keyword.getStyle())
+                           .filter(Objects::nonNull)
+                           .map(style->style.getContent())
                            .collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2278,3 +2278,5 @@ Connection\ successful\!=Connection successful\!
 Generate\ groups\ from\ keywords\ in\ the\ following\ field=Generate groups from keywords in the following field
 Generate\ groups\ for\ author\ last\ names=Generate groups for author last names
 Regular\ expression=Regular expression
+
+Error\ importing.\ See\ the\ error\ log\ for\ details.=Error importing. See the error log for details.

--- a/src/test/resources/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTest_EmptyKeywordStyle.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTest_EmptyKeywordStyle.bib
@@ -1,0 +1,16 @@
+% Encoding: UTF-8
+
+@Article{,
+  author   = {Lim, RCH},
+  title    = {Painless Laser Acupuncture for Smoking Cessation.},
+  doi      = {10.1089/acu.2018.1295},
+  note     = {FFT available, not read on 7/2/18},
+  number   = {3},
+  pages    = {159-162},
+  url      = {https://www.ncbi.nlm.nih.gov/pubmed/29937971},
+  volume   = {30},
+  isbn     = {1933-6586},
+  journal  = {Med Acupunct},
+  keywords = {anxiety; craving; dependency; destress; health restoration; },
+  year     = {2018},
+}

--- a/src/test/resources/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTest_EmptyKeywordStyle.xml
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTest_EmptyKeywordStyle.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xml>
+    <records>
+        <record>
+            <database name="Some databases" path="/test/asdf">LASER Acu.1281 mapping conv .bdb</database>
+            <source-app name="Bookends" version="12.8.5">Bookends</source-app>
+            <rec-number>55549</rec-number>
+            <ref-type name="Journal Article">17</ref-type>
+            <contributors>
+                <authors>
+                    <author>
+                        <style face="normal" size="100%">Lim, RCH</style>
+                    </author>
+                </authors>
+            </contributors>
+            <auth-address>
+                <style face="normal" size="100%">Laser Acupuncture Centre, Singapore.</style>
+            </auth-address>
+            <titles>
+                <title>
+                    <style face="normal" size="100%">Painless Laser Acupuncture for Smoking Cessation.</style>
+                </title>
+                <secondary-title>
+                    <style face="normal" size="100%">Med Acupunct</style>
+                </secondary-title>
+            </titles>
+            <pages>
+                <style face="normal" size="100%">159-162</style>
+            </pages>
+            <number>
+                <style face="normal" size="100%">3</style>
+            </number>
+            <volume>
+                <style face="normal" size="100%">30</style>
+            </volume>
+            <dates>
+                <year>
+                    <style face="normal" size="100%">2018</style>
+                </year>
+                <pub-dates>
+                    <date>
+                        <style face="normal" size="100%">Jun 01</style>
+                    </date>
+                </pub-dates>
+            </dates>
+            <keywords>
+                <keyword />
+                <keyword>
+                    <style face="bold" size="12" />
+                    <style face="normal" size="12">anxiety; craving; dependency; destress; health restoration</style>
+                </keyword>
+                <keyword>
+                    <style face="normal" size="12" />
+                </keyword>
+            </keywords>
+            <notes>
+                <style face="normal" size="100%">FFT available, not read on 7/2/18</style>
+            </notes>
+            <label>
+                <style face="normal" size="12">29937971</style>
+            </label>
+            <urls>
+                <related-urls>
+                    <url>
+                        <style face="normal" size="100%">https://www.ncbi.nlm.nih.gov/pubmed/29937971</style>
+                    </url>
+                </related-urls>
+                <pdf-urls />
+            </urls>
+            <isbn>
+                <style face="normal" size="100%">1933-6586</style>
+            </isbn>
+            <user16>
+                <style face="normal" size="100%">PMC6011367</style>
+            </user16>
+            <electronic-resource-num>
+                <style face="normal" size="100%">10.1089/acu.2018.1295</style>
+            </electronic-resource-num>
+            <accession-num>
+                <style face="normal" size="100%">29937971</style>
+            </accession-num>
+        </record>
+    </records>
+</xml>


### PR DESCRIPTION
Display error messages/notifications for exceptions

I used the endnote xml the user provided via mail.

I will add tests later.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
