### PR TITLE
Fixing Group color not imported after closing the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We fixed an issue where modifications to the Custom preview layout in the preferences were not saved [#6447](https://github.com/JabRef/jabref/issues/6447)
 - We fixed an issue where errors from imports were not shown to the user [#7084](https://github.com/JabRef/jabref/pull/7084)
 - We fixed an issue where the EndNote XML Import would fail on empty keywords tags [forum#2387](https://discourse.jabref.org/t/importing-in-unknown-format-fails-to-import-xml-library-from-bookends-export/2387)
+- We fixed an issue where the color of groups of type "free search expression" not persisting after restarting the application [#6999](https://github.com/JabRef/jabref/issues/6999)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -84,7 +84,7 @@ public class GroupsParser {
     /**
      * Re-create a group instance from a textual representation.
      *
-     * @param s           The result from the group's toString() method.
+     * @param s The result from the group's toString() method.
      * @return New instance of the encoded group.
      * @throws ParseException If an error occurred and a group could not be created, e.g. due to a malformed regular expression.
      */
@@ -278,9 +278,11 @@ public class GroupsParser {
         boolean regExp = Integer.parseInt(tok.nextToken()) == 1;
         // version 0 contained 4 additional booleans to specify search
         // fields; these are ignored now, all fields are always searched
-        return new SearchGroup(name,
+        SearchGroup searchGroup = new SearchGroup(name,
                 GroupHierarchyType.getByNumberOrDefault(context), expression, caseSensitive, regExp
         );
+        addGroupDetails(tok, searchGroup);
+        return searchGroup;
     }
 
     private static void addGroupDetails(QuotedStringTokenizer tokenizer, AbstractGroup group) {


### PR DESCRIPTION
- Hi, I found the bug #6999, it's caused by `org.jabref.logic.importer.util.GroupParser.searchGroupFromString()`, the problem is when parsing a search group most of the properties gets parsed by `searchGroupFromString()` but some properties like (expanded, color, iconName, description) gets parsed by another method `addGroupDetails()`
- to fix it instead of returning `searchGroup` right away i called `addGroupDetails()` on `searchGroup` to add the missing properties then I returned `searchGroup`
- Fixes #6999 

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
