### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,5 +14,13 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180
         days-before-close: 14
-        stale-issue-message: 'The issue was incactive for half a year. Since the JabRef team cannot address all issues, it aims to focus on valid issues. May I ask whether the issue still persists? If yes, can more details be added? In case this issue is not valid anymore, no action is needed: We will auto-close it in two weeks if no action is taken.'
+        stale-issue-message: |
+          This issue has been inactive for half a year. In light of JabRef's rapid development this issue may not be relevant any longer and it will be closed in two weeks if no further activity occurs.
+
+          As part of an effort to ensure that the JabRef team is focusing on important and valid issues, we would like to ask if you could update the issue if it still persists. This could be in the following form:
+          - If there has been a longer discussion, add a short summary of the most important points as a new comment (if not yet existing).
+          - Provide further steps or information on how to reproduce this issue.
+          - Upvote the initial post if you like to see it implemented soon. Votes are not the only metric that we use to determine the requests that are implemented, however they do factor in to our decision making process.
+          - If all information are provided and still up-to-date, then just add a short comment that the issue is still relevant.
+          Thank you for your contribution!
         stale-issue-label: 'status: stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,12 +15,14 @@ jobs:
         days-before-stale: 180
         days-before-close: 14
         stale-issue-message: |
-          This issue has been inactive for half a year. In light of JabRef's rapid development this issue may not be relevant any longer and it will be closed in two weeks if no further activity occurs.
+          This issue has been inactive for half a year. Since JabRef is constantly evolving this issue may not be relevant any longer and it will be closed in two weeks if no further activity occurs.
 
           As part of an effort to ensure that the JabRef team is focusing on important and valid issues, we would like to ask if you could update the issue if it still persists. This could be in the following form:
+
           - If there has been a longer discussion, add a short summary of the most important points as a new comment (if not yet existing).
           - Provide further steps or information on how to reproduce this issue.
           - Upvote the initial post if you like to see it implemented soon. Votes are not the only metric that we use to determine the requests that are implemented, however they do factor in to our decision making process.
           - If all information are provided and still up-to-date, then just add a short comment that the issue is still relevant.
+
           Thank you for your contribution!
         stale-issue-label: 'status: stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
 
           - If there has been a longer discussion, add a short summary of the most important points as a new comment (if not yet existing).
           - Provide further steps or information on how to reproduce this issue.
-          - Upvote the initial post if you like to see it implemented soon. Votes are not the only metric that we use to determine the requests that are implemented, however they do factor in to our decision making process.
-          - If all information are provided and still up-to-date, then just add a short comment that the issue is still relevant.
+          - Upvote the initial post if you like to see it implemented soon. Votes are not the only metric that we use to determine the requests that are implemented, however, they do factor into our decision-making process.
+          - If all information is provided and still up-to-date, then just add a short comment that the issue is still relevant.
 
           Thank you for your contribution!
         stale-issue-label: 'status: stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,17 +2,17 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "0 0 * * *"
+  - cron: "20 19 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@master
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue will be closed in 7 days due to inactivity :zzz: Please provide the requested information if the problem persists.'
+        days-before-stale: 180
+        days-before-close: 14
+        stale-issue-message: 'The issue was incactive for half a year. Since the JabRef team cannot address all issues, it aims to focus on valid issues. May I ask whether the issue still persists? If yes, can more details be added? In case this issue is not valid anymore, no action is needed: We will auto-close it in two weeks if no action is taken.'
         stale-issue-label: 'status: stale'
-        days-before-stale: 30
-        only-labels: 'status: waiting-for-customer-feedback'


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/6282.

We decided on today's dev call that we take the risk to use a stale bot to achieve that *all* opened issues are still valid.

Many issues have been opened years ago and have a huge list of discussions. It is not easy to follow the discussions years later. Thus, we ask for feedback of users. In case, there won't be any feedback, we assume that the issue was not important to many users and that the issue can be closed.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
