### PR TITLE
Fix binding issue for the regex and case sensitive search buttons

### DIFF
--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -126,13 +126,16 @@ public class GlobalSearchBar extends HBox {
         // searchModeButton = new Button();
         initSearchModifierButtons();
 
-        BooleanBinding focusBinding = searchField.focusedProperty()
-                                                 .or(regularExpressionButton.focusedProperty()
-                                                                            .or(caseSensitiveButton.focusedProperty()));
+        BooleanBinding focusedOrActive = searchField.focusedProperty()
+                                                    .or(regularExpressionButton.focusedProperty())
+                                                    .or(caseSensitiveButton.focusedProperty())
+                                                    .or(searchField.textProperty()
+                                                                   .isNotEmpty());
+
         regularExpressionButton.visibleProperty().unbind();
-        regularExpressionButton.visibleProperty().bind(focusBinding);
+        regularExpressionButton.visibleProperty().bind(focusedOrActive);
         caseSensitiveButton.visibleProperty().unbind();
-        caseSensitiveButton.visibleProperty().bind(focusBinding);
+        caseSensitiveButton.visibleProperty().bind(focusedOrActive);
 
         StackPane modifierButtons = new StackPane(new HBox(regularExpressionButton, caseSensitiveButton));
         modifierButtons.setAlignment(Pos.CENTER);


### PR DESCRIPTION
This PR fixes the issue related to the regex and case sensitive search buttons disappearing if the search bar is not empty. This addresses the issue raised by @k3KAW8Pnf7mkmdSMPHz27 in https://github.com/JabRef/jabref/issues/7123.

Here how it currently looks if something else (WebSearchBar) is focused and the bar is nonempty:
![image](https://user-images.githubusercontent.com/43381984/100270467-68fd7280-2f58-11eb-805e-617529953f28.png)

In case of an empty search bar:
![image](https://user-images.githubusercontent.com/43381984/100270555-892d3180-2f58-11eb-84b6-7b633e3c211a.png)


- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
