### PR TITLE
Fix document viewer not showing first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ inserting new citations in a OpenOffic/LibreOffice document. [#6957](https://git
 - We fixed an issue where the EndNote XML Import would fail on empty keywords tags [forum#2387](https://discourse.jabref.org/t/importing-in-unknown-format-fails-to-import-xml-library-from-bookends-export/2387)
 - We fixed an issue where the color of groups of type "free search expression" not persisting after restarting the application [#6999](https://github.com/JabRef/jabref/issues/6999)
 - We fixed an issue where modifications in the source tab where not saved without switching to another field before saving the library [#6622](https://github.com/JabRef/jabref/issues/6622)
+- We fixed an issue where the "Document Viewer" did not show the first page of the opened pdf document and did not show the correct total number of pages [#7108](https://github.com/JabRef/jabref/issues/7108)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerViewModel.java
@@ -61,8 +61,6 @@ public class DocumentViewerViewModel extends AbstractViewModel {
             maxPages.bindBidirectional(
                 EasyBind.wrapNullable(currentDocument).selectProperty(DocumentViewModel::maxPagesProperty));
         });
-
-
         setCurrentEntries(this.stateManager.getSelectedEntries());
     }
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerViewModel.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
+import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ListProperty;
@@ -55,8 +56,12 @@ public class DocumentViewerViewModel extends AbstractViewModel {
             }
         });
 
-        maxPages.bindBidirectional(
+        // we need to wrap this in run later so that the max pages number is correctly shown
+        Platform.runLater(() -> {
+            maxPages.bindBidirectional(
                 EasyBind.wrapNullable(currentDocument).selectProperty(DocumentViewModel::maxPagesProperty));
+        });
+
 
         setCurrentEntries(this.stateManager.getSelectedEntries());
     }

--- a/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
@@ -60,7 +60,7 @@ public class PdfDocumentPageViewModel extends DocumentPageViewModel {
 
     @Override
     public int getPageNumber() {
-        return pageNumber;
+        return pageNumber +1;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
@@ -60,7 +60,7 @@ public class PdfDocumentPageViewModel extends DocumentPageViewModel {
 
     @Override
     public int getPageNumber() {
-        return pageNumber +1;
+        return pageNumber + 1;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/documentviewer/PdfDocumentViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/PdfDocumentViewModel.java
@@ -26,7 +26,7 @@ public class PdfDocumentViewModel extends DocumentViewModel {
         List<PdfDocumentPageViewModel> pdfPages = new ArrayList<>();
         // There is apparently no neat way to get the page number from a PDPage...thus this old-style for loop
         for (int i = 0; i < pages.getCount(); i++) {
-            pdfPages.add(new PdfDocumentPageViewModel(pages.get(i), i + 1, document));
+            pdfPages.add(new PdfDocumentPageViewModel(pages.get(i), i, document));
         }
         return FXCollections.observableArrayList(pdfPages);
     }


### PR DESCRIPTION
Turned out it was an off by one error.

<img width="746" alt="Bildschirmfoto 2020-11-27 um 20 43 23" src="https://user-images.githubusercontent.com/320228/100480364-4ce10900-30f1-11eb-8061-65fbd688e9f7.png">


Fixes #7108 

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
