### PR TITLE
Add githandler mock to crawler test to fix NPE

### DIFF
--- a/src/main/java/org/jabref/gui/StartLiteratureReviewAction.java
+++ b/src/main/java/org/jabref/gui/StartLiteratureReviewAction.java
@@ -10,6 +10,7 @@ import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.crawler.Crawler;
+import org.jabref.logic.crawler.git.GitHandler;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntryTypesManager;
@@ -49,7 +50,7 @@ public class StartLiteratureReviewAction extends SimpleCommand {
         }
         final Crawler crawler;
         try {
-            crawler = new Crawler(studyDefinitionFile.get(), fileUpdateMonitor, JabRefPreferences.getInstance().getImportFormatPreferences(), JabRefPreferences.getInstance().getSavePreferences(), new BibEntryTypesManager());
+            crawler = new Crawler(studyDefinitionFile.get(), new GitHandler(studyDefinitionFile.get().getParent()), fileUpdateMonitor, JabRefPreferences.getInstance().getImportFormatPreferences(), JabRefPreferences.getInstance().getSavePreferences(), new BibEntryTypesManager());
         } catch (IOException | ParseException | GitAPIException e) {
             LOGGER.error("Error during reading of study definition file.", e);
             dialogService.showErrorDialogAndWait(Localization.lang("Error during reading of study definition file."), e);

--- a/src/main/java/org/jabref/logic/crawler/Crawler.java
+++ b/src/main/java/org/jabref/logic/crawler/Crawler.java
@@ -31,9 +31,9 @@ public class Crawler {
      *
      * @param studyDefinitionFile The path to the study definition file that contains the list of targeted E-Libraries and used cross-library queries
      */
-    public Crawler(Path studyDefinitionFile, FileUpdateMonitor fileUpdateMonitor, ImportFormatPreferences importFormatPreferences, SavePreferences savePreferences, BibEntryTypesManager bibEntryTypesManager) throws IllegalArgumentException, IOException, ParseException, GitAPIException {
+    public Crawler(Path studyDefinitionFile, GitHandler gitHandler, FileUpdateMonitor fileUpdateMonitor, ImportFormatPreferences importFormatPreferences, SavePreferences savePreferences, BibEntryTypesManager bibEntryTypesManager) throws IllegalArgumentException, IOException, ParseException, GitAPIException {
         Path studyRepositoryRoot = studyDefinitionFile.getParent();
-        studyRepository = new StudyRepository(studyRepositoryRoot, new GitHandler(studyRepositoryRoot), importFormatPreferences, fileUpdateMonitor, savePreferences, bibEntryTypesManager);
+        studyRepository = new StudyRepository(studyRepositoryRoot, gitHandler, importFormatPreferences, fileUpdateMonitor, savePreferences, bibEntryTypesManager);
         Study study = studyRepository.getStudy();
         LibraryEntryToFetcherConverter libraryEntryToFetcherConverter = new LibraryEntryToFetcherConverter(study.getActiveLibraryEntries(), importFormatPreferences);
         this.studyFetcher = new StudyFetcher(libraryEntryToFetcherConverter.getActiveFetchers(), study.getSearchQueryStrings());

--- a/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
+++ b/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
+import org.jabref.logic.crawler.git.GitHandler;
 import org.jabref.logic.exporter.SavePreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.util.io.FileUtil;
@@ -31,11 +32,13 @@ class CrawlerTest {
     ImportFormatPreferences importFormatPreferences;
     SavePreferences savePreferences;
     BibEntryTypesManager entryTypesManager;
+    GitHandler gitHandler = mock(GitHandler.class, Answers.RETURNS_DEFAULTS);
 
     @Test
     public void testWhetherAllFilesAreCreated() throws Exception {
         setUp();
         Crawler testCrawler = new Crawler(getPathToStudyDefinitionFile(),
+                gitHandler,
                 new DummyFileUpdateMonitor(),
                 importFormatPreferences,
                 savePreferences,


### PR DESCRIPTION
This PR fixes the issue with the githandler NPE for the CrawlerTest.java on the CI server that does not have any git credentials configured

Signed-off-by: Dominik Voigt <dominik.ingo.voigt@gmail.com>

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
