### PR TITLE
Fix for issue 6959

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ## [Unreleased]
 
 ### Added
+
 - We added a validation to check if the current database location is shared, preventing an exception when Pulling Changes From Shared Database. [#6959](https://github.com/JabRef/jabref/issues/6959)
 - We added a query parser and mapping layer to enable conversion of queries formulated in simplified lucene syntax by the user into api queries. [#6799](https://github.com/JabRef/jabref/pull/6799)
 - We added some basic functionality to customise the look of JabRef by importing a css theme file. [#5790](https://github.com/JabRef/jabref/issues/5790)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ## [Unreleased]
 
 ### Added
-
+- We added a Boolean Expression to validate if the current database location is shared, preventing an exception when Pulling Changes From Shared Database. [#6959](https://github.com/JabRef/jabref/issues/6959)
 - We added a query parser and mapping layer to enable conversion of queries formulated in simplified lucene syntax by the user into api queries. [#6799](https://github.com/JabRef/jabref/pull/6799)
 - We added some basic functionality to customise the look of JabRef by importing a css theme file. [#5790](https://github.com/JabRef/jabref/issues/5790)
 - We added connection check function in network preference setting [#6560](https://github.com/JabRef/jabref/issues/6560)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ## [Unreleased]
 
 ### Added
-- We added a Boolean Expression to validate if the current database location is shared, preventing an exception when Pulling Changes From Shared Database. [#6959](https://github.com/JabRef/jabref/issues/6959)
+- We added a validation to check if the current database location is shared, preventing an exception when Pulling Changes From Shared Database. [#6959](https://github.com/JabRef/jabref/issues/6959)
 - We added a query parser and mapping layer to enable conversion of queries formulated in simplified lucene syntax by the user into api queries. [#6799](https://github.com/JabRef/jabref/pull/6799)
 - We added some basic functionality to customise the look of JabRef by importing a css theme file. [#5790](https://github.com/JabRef/jabref/issues/5790)
 - We added connection check function in network preference setting [#6560](https://github.com/JabRef/jabref/issues/6560)

--- a/src/main/java/org/jabref/gui/actions/ActionHelper.java
+++ b/src/main/java/org/jabref/gui/actions/ActionHelper.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import com.tobiasdiez.easybind.EasyBinding;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanExpression;
@@ -19,7 +18,9 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.util.FileHelper;
 import org.jabref.preferences.PreferencesService;
+
 import com.tobiasdiez.easybind.EasyBind;
+import com.tobiasdiez.easybind.EasyBinding;
 
 public class ActionHelper {
 

--- a/src/main/java/org/jabref/gui/actions/ActionHelper.java
+++ b/src/main/java/org/jabref/gui/actions/ActionHelper.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.tobiasdiez.easybind.EasyBinding;
 import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanExpression;
@@ -27,10 +28,9 @@ public class ActionHelper {
         return stateManager.activeDatabaseProperty().isPresent();
     }
 
-    public static BooleanExpression needsSharedDatabase(StateManager stateManager){
-        var binding = Bindings.createBooleanBinding(() ->
-                        stateManager.activeDatabaseProperty().getValue().filter(context -> context.getLocation() == DatabaseLocation.SHARED).isPresent(),
-                stateManager.activeDatabaseProperty());
+    public static BooleanExpression needsSharedDatabase(StateManager stateManager) {
+        EasyBinding<Boolean> binding = EasyBind.map(stateManager.activeDatabaseProperty(), context ->
+                context.filter( c -> c.getLocation() == DatabaseLocation.SHARED).isPresent());
         return BooleanExpression.booleanExpression(binding);
     }
 

--- a/src/main/java/org/jabref/gui/actions/ActionHelper.java
+++ b/src/main/java/org/jabref/gui/actions/ActionHelper.java
@@ -12,6 +12,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.TabPane;
 
 import org.jabref.gui.StateManager;
+import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.Field;
@@ -24,6 +25,13 @@ public class ActionHelper {
 
     public static BooleanExpression needsDatabase(StateManager stateManager) {
         return stateManager.activeDatabaseProperty().isPresent();
+    }
+
+    public static BooleanExpression needsSharedDatabase(StateManager stateManager){
+        var binding = Bindings.createBooleanBinding(() ->
+                        stateManager.activeDatabaseProperty().getValue().filter(context -> context.getLocation() == DatabaseLocation.SHARED).isPresent(),
+                stateManager.activeDatabaseProperty());
+        return BooleanExpression.booleanExpression(binding);
     }
 
     public static BooleanExpression needsEntriesSelected(StateManager stateManager) {

--- a/src/main/java/org/jabref/gui/actions/ActionHelper.java
+++ b/src/main/java/org/jabref/gui/actions/ActionHelper.java
@@ -19,7 +19,6 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.util.FileHelper;
 import org.jabref.preferences.PreferencesService;
-
 import com.tobiasdiez.easybind.EasyBind;
 
 public class ActionHelper {
@@ -29,8 +28,7 @@ public class ActionHelper {
     }
 
     public static BooleanExpression needsSharedDatabase(StateManager stateManager) {
-        EasyBinding<Boolean> binding = EasyBind.map(stateManager.activeDatabaseProperty(), context ->
-                context.filter( c -> c.getLocation() == DatabaseLocation.SHARED).isPresent());
+        EasyBinding<Boolean> binding = EasyBind.map(stateManager.activeDatabaseProperty(), context -> context.filter(c -> c.getLocation() == DatabaseLocation.SHARED).isPresent());
         return BooleanExpression.booleanExpression(binding);
     }
 

--- a/src/main/java/org/jabref/gui/shared/PullChangesFromSharedAction.java
+++ b/src/main/java/org/jabref/gui/shared/PullChangesFromSharedAction.java
@@ -12,7 +12,7 @@ public class PullChangesFromSharedAction extends SimpleCommand {
     public PullChangesFromSharedAction(StateManager stateManager) {
         this.stateManager = stateManager;
 
-        this.executable.bind(ActionHelper.needsDatabase(stateManager));
+        this.executable.bind(ActionHelper.needsDatabase(stateManager).and(ActionHelper.needsSharedDatabase(stateManager)));
     }
 
     public void execute() {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #6959 implementing the method `needsSharedDatabase` in the `ActionHelper` and then binding it in the class `PullChangesFromSharedDatabase`. This solution prevents the user from clicking "Pull changes from database" if a shared database is not present.

When the DatabaseLocation is **local**:
<img width="635" alt="Screen Shot 2020-12-02 at 5 13 49 PM" src="https://user-images.githubusercontent.com/23217708/100947116-31e01180-34c2-11eb-8148-8697adc0227a.png">
 
When the DatabaseLocation is **shared**:
<img width="711" alt="Screen Shot 2020-12-02 at 5 19 30 PM" src="https://user-images.githubusercontent.com/23217708/100947288-969b6c00-34c2-11eb-804e-13a5fb0289c8.png">

When there is **no library open**:
<img width="632" alt="Screen Shot 2020-12-03 at 1 06 53 PM" src="https://user-images.githubusercontent.com/23217708/101082308-7de59180-3568-11eb-865b-1f7d197df4ea.png">

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
