### PR TITLE
Fixed issue in PreviewView for number textfield

### DIFF
--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -669,7 +669,7 @@ public class JabRefPreferences implements PreferencesService {
                         "\\begin{year}<BR>\\year\\end{year}__NEWLINE__" +
                         "\\begin{booktitle}<BR><i>\\format[HTMLChars]{\\booktitle}</i>, \\end{booktitle}__NEWLINE__" +
                         "\\begin{chapter} \\format[HTMLChars]{\\chapter}<BR>\\end{chapter}" +
-                        "\\begin{journal}<BR><BR><i>\\format[HTMLChars]{\\journal}</i> \\end{journal} \\begin{volume}, Vol. \\volume\\end{volume}\\begin{series}<BR> \\format[HTMLChars]{\\series}\\end{series}\\begin{number}, No. \\format[HTMLChars]{number}\\end{number}__NEWLINE__" +
+                        "\\begin{journal}<BR><BR><i>\\format[HTMLChars]{\\journal}</i> \\end{journal} \\begin{volume}, Vol. \\volume\\end{volume}\\begin{series}<BR> \\format[HTMLChars]{\\series}\\end{series}\\begin{number}, No. \\format[HTMLChars]{\\number}\\end{number}__NEWLINE__" +
                         "\\begin{school} \\format[HTMLChars]{\\school}, \\end{school}__NEWLINE__" +
                         "\\begin{institution} <em>\\format[HTMLChars]{\\institution}, </em>\\end{institution}__NEWLINE__" +
                         "\\begin{publisher}<BR><BR>\\format[HTMLChars]{\\publisher}\\end{publisher}\\begin{location}: \\format[HTMLChars]{\\location} \\end{location}__NEWLINE__" +

--- a/src/main/resources/resource/layout/din1505/din1505winword.article.layout
+++ b/src/main/resources/resource/layout/din1505/din1505winword.article.layout
@@ -7,7 +7,7 @@
 \end{volume}
  (\year)
 \begin{number}
-, Nr. {\number}
+, Nr. \number
 \end{number}
 \begin{pages}
 , S. \pages

--- a/src/main/resources/resource/layout/din1505/din1505winword.article.layout
+++ b/src/main/resources/resource/layout/din1505/din1505winword.article.layout
@@ -1,4 +1,4 @@
-{[\Bibtexkey]:}	
+{[\Bibtexkey]:}
 {\\scaps \format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author}}
 : \format[RTFChars]{\title}}
 . In: {\\i \format[RTFChars,RemoveLatexCommands]{\journal}}
@@ -7,7 +7,7 @@
 \end{volume}
  (\year)
 \begin{number}
-, Nr. \number
+, Nr. {\number}
 \end{number}
 \begin{pages}
 , S. \pages


### PR DESCRIPTION
Follow-up to #6901 

<!-- 
Fixed issue in PreviewView in number textfield its displayed 'number', now display an integer instead.
So, I did 2 changes:

1. In **JabRefPreferences.java**. I added the "//" missing in the variable _number_. But this is not where the issue came from.
2. In **din1505winword.article.layout**. I noticed that this file did have the "/" in _number_ but didn't have the curly brackets("{}") so, I added and now the preview for the number file it works.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
