### PR TITLE
Fix file not linked after DL from fulltext fetcher

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/DownloadFullTextAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DownloadFullTextAction.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.externalfiles;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
@@ -17,11 +16,8 @@ import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.fieldeditors.LinkedFileViewModel;
-import org.jabref.gui.fieldeditors.LinkedFilesEditorViewModel;
-import org.jabref.gui.util.BackgroundTask;
 import org.jabref.logic.importer.FulltextFetchers;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.net.URLDownload;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
@@ -154,26 +150,7 @@ public class DownloadFullTextAction extends SimpleCommand {
                     preferences.getFilePreferences(),
                     ExternalFileTypes.getInstance());
 
-            try {
-                URLDownload urlDownload = new URLDownload(newLinkedFile.getLink());
-                BackgroundTask<Path> downloadTask = onlineFile.prepareDownloadTask(targetDirectory, urlDownload);
-                downloadTask.onSuccess(destination -> {
-                    LinkedFile downloadedFile = LinkedFilesEditorViewModel.fromFile(
-                            destination,
-                            databaseContext.getFileDirectories(preferences.getFilePreferences()),
-                            ExternalFileTypes.getInstance());
-                    entry.addFile(downloadedFile);
-                    dialogService.notify(Localization.lang("Finished downloading full text document for entry %0.",
-                            entry.getCitationKey().orElse(Localization.lang("undefined"))));
-                });
-                downloadTask.titleProperty().set(Localization.lang("Downloading"));
-                downloadTask.messageProperty().set(
-                        Localization.lang("Fulltext for") + ": " + entry.getCitationKey().orElse(Localization.lang("New entry")));
-                downloadTask.showToUser(true);
-                Globals.TASK_EXECUTOR.execute(downloadTask);
-            } catch (MalformedURLException exception) {
-                dialogService.showErrorDialogAndWait(Localization.lang("Invalid URL"), exception);
-            }
+            onlineFile.download();
         } else {
             dialogService.notify(Localization.lang("Full text document for entry %0 already linked.",
                     entry.getCitationKey().orElse(Localization.lang("undefined"))));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1660,7 +1660,6 @@ Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=O
 See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=See what has been changed in the JabRef versions
 Referenced\ citation\ key\ does\ not\ exist=Referenced citation key does not exist
 Full\ text\ document\ for\ entry\ %0\ already\ linked.=Full text document for entry %0 already linked.
-Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Finished downloading full text document for entry %0.
 Download\ full\ text\ documents=Download full text documents
 You\ are\ about\ to\ download\ full\ text\ documents\ for\ %0\ entries.=You are about to download full text documents for %0 entries.
 last\ four\ nonpunctuation\ characters\ should\ be\ numerals=last four nonpunctuation characters should be numerals


### PR DESCRIPTION
Remove redundant code

While debugging for #7152  I found that the file is downloaded, but not linked to the library afterwards. 
Fortunately I could just replace it with the specific download method already defined.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
