### PR TITLE
Fix javadoc plugin complaining about missing exports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,6 +424,10 @@ javadoc {
         encoding = 'UTF-8'
         version = true
         author = true
+         addMultilineStringsOption("-add-exports").setValue([
+            'javafx.controls/com.sun.javafx.scene.control=org.jabref',
+            'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref'
+        ])
     }
 }
 


### PR DESCRIPTION
Refs https://github.com/java9-modularity/gradle-modules-plugin/issues/170

This only fixes the plugin. Not the errors in the javadoc
For fixing the javadoc https://github.com/koppor/jabref/issues/475


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
