### PR TITLE
[WIP] File Magic Wizard Issue #380

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -84,6 +84,7 @@ import org.jabref.gui.externalfiles.AutoLinkFilesAction;
 import org.jabref.gui.externalfiles.DownloadFullTextAction;
 import org.jabref.gui.externalfiles.FindUnlinkedFilesAction;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.gui.filewizard.FileWizardAction;
 import org.jabref.gui.help.AboutAction;
 import org.jabref.gui.help.ErrorConsoleAction;
 import org.jabref.gui.help.HelpAction;
@@ -815,6 +816,8 @@ public class JabRefFrame extends BorderPane {
                 new SeparatorMenuItem(),
 
                 factory.createMenuItem(StandardActions.SEND_AS_EMAIL, new SendAsEMailAction(dialogService, stateManager)),
+                factory.createMenuItem(StandardActions.FILE_WIZARD, new FileWizardAction(dialogService, stateManager)),
+
                 pushToApplicationMenuItem,
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.START_SYSTEMATIC_LITERATURE_REVIEW, new StartLiteratureReviewAction(this, Globals.getFileUpdateMonitor(), Globals.prefs.getWorkingDir(), Globals.TASK_EXECUTOR))

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -157,7 +157,9 @@ public enum StandardActions implements Action {
     OPEN_FORUM(Localization.lang("Online help forum"), Localization.lang("Online help forum"), IconTheme.JabRefIcons.FORUM),
     ERROR_CONSOLE(Localization.lang("View event log"), Localization.lang("Display all error messages")),
     SEARCH_FOR_UPDATES(Localization.lang("Check for updates")),
-    ABOUT(Localization.lang("About JabRef"), Localization.lang("About JabRef"));
+    ABOUT(Localization.lang("About JabRef"), Localization.lang("About JabRef")),
+    FILE_WIZARD(Localization.lang("File Wizard"), Localization.lang("Automatically links BibEntries to their fulltext files"));
+
 
     private final String text;
     private final String description;

--- a/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
+++ b/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
@@ -40,7 +40,7 @@ public class AutoSetFileLinksUtil {
         this(databaseContext.getFileDirectories(filePreferences), autoLinkPreferences, externalFileTypes);
     }
 
-    private AutoSetFileLinksUtil(List<Path> directories, AutoLinkPreferences autoLinkPreferences, ExternalFileTypes externalFileTypes) {
+    public AutoSetFileLinksUtil(List<Path> directories, AutoLinkPreferences autoLinkPreferences, ExternalFileTypes externalFileTypes) {
         this.directories = directories;
         this.autoLinkPreferences = autoLinkPreferences;
         this.externalFileTypes = externalFileTypes;

--- a/src/main/java/org/jabref/gui/filewizard/FileWizard.fxml
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizard.fxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import org.checkerframework.checker.units.qual.A?>
+<?import javafx.scene.text.Text?>
+<?import javafx.geometry.Insets?>
+<DialogPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="org.jabref.gui.filewizard.FileWizardView"
+            prefHeight="100.0" prefWidth="600.0">
+    <buttonTypes>
+        <ButtonType fx:constant="CANCEL"/>
+        <ButtonType fx:id="startButton" buttonData="OK_DONE" text="%Start"/>
+    </buttonTypes>
+    <content>
+        <VBox>
+            <padding>
+                <Insets bottom="4.0" left="4.0" right="4.0" top="4.0"/>
+            </padding>
+            <GridPane hgap="10.0" vgap="4.0">
+                <Label text="%Choose the directory in which the Wizard will expect and into which it will try to download the files:"
+                        GridPane.columnSpan="3" GridPane.rowIndex="1"/>
+                <TextField fx:id="directoryTextField"
+                           GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+                <Button text="%Browse" onAction="#browseDirectory"
+                        GridPane.columnIndex="2" GridPane.rowIndex="2"/>
+                <CheckBox fx:id="openDirectoryCheckbox"
+                          text="%Open the directory after the wizard has terminated."
+                            GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+            </GridPane>
+
+        </VBox>
+    </content>
+
+</DialogPane>

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardAction.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardAction.java
@@ -1,0 +1,36 @@
+package org.jabref.gui.filewizard;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.SimpleCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.jabref.gui.actions.ActionHelper.needsDatabase;
+
+public class FileWizardAction extends SimpleCommand {
+
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+
+    FileWizardView fileWizardView;
+
+    public FileWizardAction(DialogService dialogService, StateManager stateManager) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+
+        this.executable.bind(needsDatabase(stateManager));
+    }
+
+    @Override
+    public void execute() {
+        fileWizardView = new FileWizardView(this,
+                dialogService, stateManager);
+        fileWizardView.showAndWait();
+    }
+
+    public void closeFileWizardControlPanel() {
+        fileWizardView.close();
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardDownloader.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardDownloader.java
@@ -1,0 +1,158 @@
+package org.jabref.gui.filewizard;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.application.Platform;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.externalfiles.DownloadFullTextAction;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.gui.fieldeditors.LinkedFileViewModel;
+import org.jabref.gui.fieldeditors.LinkedFilesEditorViewModel;
+import org.jabref.gui.util.BackgroundTask;
+import org.jabref.gui.Globals;
+import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.importer.FulltextFetchers;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
+import org.jabref.preferences.FilePreferences;
+import org.jabref.preferences.PreferencesService;
+
+import com.sun.star.sdb.DatabaseContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class downloads a PDF-File in a specified directory. It will also connect it to the BibEntry.
+ * There will be more methods implemented, for example one which searches for the DOI of a BibEntry based on the Title.
+ * Also there will be a method which searches for the URL of a file based on the DOI.
+ */
+public class FileWizardDownloader {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileWizardDownloader.class);
+
+    /**
+     * Manages the downloader (which is only called if no linked file for the concerning pdf exists)
+     * @param dialogService     is needed to call the method who downloads the file
+     * @param preferences       is needed to call the method who downloads the file and who searches for teh url
+     * @param databaseContext   is needed to call the method who downloads the file
+     * @param targetDirectory   where the file is safed after download
+     * @param entry             the BibEntry which the pdf is needed
+     * @return                  boolean if a pdf was downloaded or not
+     */
+    public static boolean startDownloader(DialogService dialogService, PreferencesService preferences, BibDatabaseContext databaseContext, Path targetDirectory, BibEntry entry) {
+
+        LOGGER.debug("FW:startDownloader, started");
+        Optional<URL> url;
+        url = fileWizardSearchURL(entry, preferences.getImportFormatPreferences());
+
+        if (url.isPresent()) {
+            LOGGER.debug("url was found, call fw-downloadFromURL");
+
+            // call the method which downloads
+            fileWizardDownloaderFromURL(dialogService, preferences, databaseContext, url.get(), entry, targetDirectory);
+
+            LOGGER.debug("(startDownloader): downloader should end now");
+            return true;
+        } else {
+            LOGGER.info("startDownloader: was not possible to find url");
+            return false;
+            // ToDo: let Report know that it was not possible to download it
+            // add debug logger
+        }
+    }
+
+    /**
+     * attaches a linked file from a url (which is not linked yet) to an entry
+     * and downloads the file into the target directory (also links it afterwards)
+     * @param dialogService     is needed to crate a LinkedFileViewModel, which is needed for the download
+     * @param preferences       is needed to crate a LinkedFileViewModel, which is needed for the download
+     * @param databaseContext   the active database
+     * @param url               the url "key"
+     * @param entry             the entry "value"
+     * @param targetDirectory   the target directory for the downloaded file
+     */
+    public static void fileWizardDownloaderFromURL(DialogService dialogService, PreferencesService preferences, BibDatabaseContext databaseContext, URL url, BibEntry entry, Path targetDirectory) {
+        LOGGER.debug("downloadFromURL started");
+
+        // linked file represents the link to an external file (e.g. associated pdf file)
+        LinkedFile newLinkedFile = new LinkedFile(url, "");
+
+        // new linkedFileViewModel
+        LinkedFileViewModel onlineFile = new LinkedFileViewModel(
+                newLinkedFile,
+                entry,
+                databaseContext,
+                Globals.TASK_EXECUTOR,
+                dialogService,
+                preferences.getXmpPreferences(),
+                preferences.getFilePreferences(),
+                ExternalFileTypes.getInstance());
+
+        try {
+            URLDownload urldownload = new URLDownload(newLinkedFile.getLink());
+
+            // this calls to the download
+            BackgroundTask<Path> downloadTask = onlineFile.prepareDownloadTask(targetDirectory, urldownload);
+            LOGGER.info("dwlFromURL (try), startet downloading");
+
+            // the downloaded file is "linked" to the bibEntry
+            downloadTask.onSuccess(destination -> {
+                LinkedFile downloadedFile = LinkedFilesEditorViewModel.fromFile(
+                        destination,
+                        databaseContext.getFileDirectories(preferences.getFilePreferences()),
+                        ExternalFileTypes.getInstance());
+                entry.addFile(downloadedFile);
+            });
+            LOGGER.info("downloadFromURL(try), file should now be linked");
+
+            downloadTask.titleProperty().set(Localization.lang("Downloading"));
+            downloadTask.messageProperty().set(
+                    Localization.lang("Fulltext for") + ": " + entry.getCitationKey().orElse(Localization.lang("New entry")));
+            downloadTask.showToUser(true);
+
+            // executes the download (was prepared before, without this, the download never starts)
+            // Globals.TASK_EXECUTOR.execute(downloadTask);
+            Platform.runLater(() -> Globals.TASK_EXECUTOR.execute(downloadTask));
+
+        } catch (MalformedURLException exception) {
+            LOGGER.info("DwldFromURL, malformedURLException");
+            dialogService.showErrorDialogAndWait(Localization.lang("Invalid URL"), exception);
+            // ToDo: let report know that this has not been found
+        }
+    }
+
+    /**
+     * calls a method which searches for the url of a bibEntry
+     * @param entry the entry you want to know the url for
+     * @param preferences needed to create FulltextFetchers (which searches for url
+     * @return  the optional url of the entry
+     */
+    public static Optional<URL> fileWizardSearchURL(BibEntry entry, ImportFormatPreferences preferences) {
+        LOGGER.debug("searchURL was startet");
+        FulltextFetchers fetchers = new FulltextFetchers(preferences);
+
+        // searches for url and also doi (but doi is not set as a field, since only a copy of the entry is passed, within the FUlltextFetchers class)
+        Optional<URL> optULR = fetchers.findFullTextPDF(entry);
+        LOGGER.debug("finished looking for ulr");
+
+        // this part is only in during development to see what url is found (not always the same url for the same enry
+        String test2 = optULR.toString();
+        System.out.println("url found in fulltextfetchers: " + test2);
+
+        return optULR;
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardLocal.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardLocal.java
@@ -1,0 +1,150 @@
+package org.jabref.gui.filewizard;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.application.Platform;
+import org.jabref.gui.Globals;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.externalfiles.AutoSetFileLinksUtil;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.preferences.PreferencesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+/**
+ * This class is used to check if an entry has a linked file in the target directory.
+ * If not an attempt is made to copy a file from the default directory to the target directory.
+ * In case no linked file could be found in or copied to the target directory,
+ * the target directory is scanned for a corresponding local file and linked in case of success.
+ */
+
+
+public class FileWizardLocal {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileWizardManager.class);
+
+    /**
+     * Checks if a linked file in target directory exists
+     *
+     * @param entry      the BibEntry to be checked
+     * @param targetDir  the target directory
+     * @param defaultDir the default directory (used for {@code copyFileFromDefaultDirectory} call)
+     * @return true if a linked file exists target directory
+     */
+    public static boolean fileExistsLocally(BibEntry entry, Path targetDir, List<Path> defaultDir) {
+
+        // create list with target directory
+        List<Path> targetDirAsList = new ArrayList<>();
+        targetDirAsList.add(targetDir);
+
+        //return false if entry has no linked files
+        if (entry.getFiles().size() == 0) {
+            return false;
+        }
+
+        //iterate through linked files
+        for (LinkedFile linkedFile : entry.getFiles()) {
+
+            //return true if one linked file is in target directory
+            if (linkedFile.findIn(targetDirAsList).isPresent()) {
+                return true;
+            }
+        }
+
+        //try to copy file from default directory to target diresctory
+        return copyFileFromDefaultDirectory(entry, targetDir, defaultDir);
+    }
+
+    /**
+     * Tries to copy file to target directory from default directory
+     *
+     * @param entry      the BibEntry to check
+     * @param targetDir  the target directory
+     * @param defaultDir the default directory
+     * @return true if file could be copied from default to target directory
+     */
+    public static boolean copyFileFromDefaultDirectory(BibEntry entry, Path targetDir, List<Path> defaultDir) {
+
+        //iterate over linked files
+        Iterator<LinkedFile> linkedFileIterator = entry.getFiles().iterator();
+        while (linkedFileIterator.hasNext()) {
+
+            LinkedFile linkedFile = linkedFileIterator.next();
+
+            try {
+                // path to file in default directory
+                Path oldPath = linkedFile.findIn(defaultDir).get();
+
+                // path to file in target directory
+                Path newPath = targetDir.resolve(oldPath.getFileName());
+
+                // copy file from default to target directory
+                Files.copy(oldPath, newPath, StandardCopyOption.REPLACE_EXISTING);
+
+                // add linked file in target directory to file list and return true
+                entry.addFile(new LinkedFile(linkedFile.getDescription(), newPath, linkedFile.getFileType()));
+                return true;
+
+                // is not able to copy current linked file
+            } catch (Exception e) {
+
+                // delete linked file if local file does not exist
+                if (!new File(linkedFile.getLink()).exists()) {
+                    linkedFileIterator.remove();
+                }
+
+                continue;
+            }
+        }
+
+        //if no file could be copied
+        return false;
+    }
+
+    /**
+     * If the BibEntry doesn't have a file field, then the directory is searched for files whose names
+     * match the pattern defined in the settings, by default starting with the citation key.
+     *
+     * @param entry        the bibEntry to be checked
+     * @param fileLinkUtil AutoSetFileLinksUtil for finding associated files
+     * @return true if a file could be found and linked in target directory
+     * @throws IOException
+     */
+
+    public static boolean mapToFileInDirectory(BibEntry entry, AutoSetFileLinksUtil fileLinkUtil) {
+
+        try {
+            // search for matching local files
+            List<LinkedFile> linkedFiles = fileLinkUtil.findAssociatedNotLinkedFiles(entry);
+
+            // add matching files if present and return true
+            if (!linkedFiles.isEmpty()) {
+                entry.setFiles(linkedFiles);
+                linkedFiles.clear();
+                return true;
+
+                // return false if no matching files were found
+            } else {
+                return false;
+            }
+
+        } catch (IOException ioe) {
+            LOGGER.error("IO exception in mapToFile");
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardManager.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardManager.java
@@ -1,0 +1,158 @@
+package org.jabref.gui.filewizard;
+
+import javafx.application.Platform;
+import javafx.concurrent.Task;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.Globals;
+import org.jabref.gui.externalfiles.AutoSetFileLinksUtil;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntry;
+
+import org.jabref.preferences.PreferencesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.io.*;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.jabref.gui.filewizard.FileWizardLocal.*;
+import static org.jabref.gui.filewizard.FileWizardDownloader.*;
+
+/**
+ * Handles the actual execution of the File Wizard, combining the different functionalities.
+ */
+public class FileWizardManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileWizardManager.class);
+
+    private final File directory;
+    private final List<Path> directoryAsList = new ArrayList<>();
+    private final DialogService dialogService;
+    private final ArrayList<BibEntry> unsuccessfullyLinked;
+    private final File checkedFilesListFile;
+    private List<String> checkedFilesList;
+    private final FileWizardSerializer serializer;
+
+    /**
+     * @param dialogService The dialog service.
+     * @param stateManager The state manager.
+     * @param openDirectory True if the user checked the box to open the directory after the File Wizard has completed.
+     * @param directory The selected target directory in which the File Wizard expects and downloads the fulltexts.
+     * @param preferences The preferences service.
+     */
+    public FileWizardManager(DialogService dialogService, StateManager stateManager,
+                             boolean openDirectory, File directory, PreferencesService preferences) {
+        this.directory = directory;
+        this.directoryAsList.add(directory.toPath());
+        this.dialogService = dialogService;
+        this.unsuccessfullyLinked = new ArrayList<>();
+        this.serializer = new FileWizardSerializer();
+
+        this.checkedFilesListFile = new File(directory, "jabref_info.txt");
+
+        // if the info file for the checked files list doesn't exists (i. e. the file wizard is executed for the first time),
+        // then the info file is created. Otherwise the file is deserialized.
+        if (!checkedFilesListFile.exists()) {
+            try {
+                checkedFilesListFile.createNewFile();
+                checkedFilesList = new ArrayList<>();
+            } catch (IOException ioe) {
+                LOGGER.error("couldn't create info file.");
+            }
+        } else {
+            checkedFilesList = serializer.deserializeCheckedFilesList(checkedFilesListFile);
+        }
+
+        FileWizardProgressDialog progressDialog = new FileWizardProgressDialog(stateManager.getActiveDatabase()
+                .get().getEntries().size() - checkedFilesList.size());
+
+        // The task which actually coordinates the different functionalities.
+        Task<Void> fileWizard = new Task<>() {
+            @Override
+            protected Void call() {
+                List<BibEntry> entriesList = new LinkedList<>(stateManager.getActiveDatabase().get().getEntries());
+
+                // Removes all entries which have previously been successfully linked from the list of BibEntries
+                // to be handled, in order to avoid unnecessary work for the File Wizard. The citation key is used
+                // as an identifier, because serialization doesn't work with BibEntry objects.
+                for(BibEntry entry : entriesList) {
+                    if(checkedFilesList.contains(entry.getCitationKey().get())) {
+                        Platform.runLater(() -> entriesList.remove(entry));
+                    }
+                }
+
+                // Iterates over all entries which haven't already been successfully linked.
+                for(BibEntry entry : entriesList) {
+                    if(!progressDialog.isRunning()) {
+                        for(int i = entriesList.indexOf(entry); i < entriesList.size(); i++) {
+                            unsuccessfullyLinked.add(entriesList.get(i));
+                        }
+                        return null;
+                    }
+
+                    progressDialog.updateProgress(entry, entriesList.indexOf(entry));
+
+                    LOGGER.info("File Wizard is handling " + entry.getCitationKey());
+
+                    // Checks if the linked file exists locally and if it does it copies it into the target directory.
+                    if(!fileExistsLocally(entry, directory.toPath(), stateManager.getActiveDatabase().get().getFileDirectories(preferences.getFilePreferences()))) {
+                        // Checks if the entry can be mapped to an existing file in the target directory based on the
+                        // the file's name and the conventions declared in the settings.
+                        if(!mapToFileInDirectory(entry, new AutoSetFileLinksUtil(directoryAsList, preferences.getAutoLinkPreferences(), ExternalFileTypes.getInstance()))) {
+                            // Tries to download the file based on the entry's DOI.
+                            if(!startDownloader(dialogService, preferences, stateManager.getActiveDatabase().get(), directory.toPath(), entry)) {
+                                // If the entry arrives here, then the File Wizard couldn't link a fulltext file,
+                                // the entry's unsuccessful linking will be displayed in the report window at the end
+                                // and the File Wizard tries to link the next file in the list.
+                                unsuccessfullyLinked.add(entry);
+                                continue;
+                            }
+                        }
+                    }
+                    // If the entry arrives here, it could be successfully linked and is added to the list which will be
+                    // serialized and the entry will never again be iterated over by the File Wizard.
+                    checkedFilesList.add(entry.getCitationKey().get());
+                }
+                return null;
+            }
+        };
+
+        fileWizard.setOnSucceeded((e) -> {
+            if (openDirectory) {
+                openDirectory();
+            }
+            serializer.serializeCheckedFiles(checkedFilesList, checkedFilesListFile);
+            progressDialog.close();
+            if(unsuccessfullyLinked.isEmpty()) {
+                dialogService.showInformationDialogAndWait(Localization.lang("File Wizard"),
+                        Localization.lang("The File Wizard could successfully link all BibEntries to their respective fulltext files."));
+            } else {
+                FileWizardReport fileWizardReport = new FileWizardReport(unsuccessfullyLinked);
+                Platform.runLater(fileWizardReport::showAndWait);
+            }
+        });
+
+        //dialogService.showProgressDialog("File Wizard", "Please wait, the file wizard is working.", fileWizard);
+        Globals.TASK_EXECUTOR.execute(fileWizard);
+        Platform.runLater(progressDialog::showAndWait);
+    }
+
+
+    private void openDirectory() {
+        try {
+            Desktop.getDesktop().open(new File(directory.toURI()));
+        } catch (IOException ioe) {
+            dialogService.showErrorDialogAndWait("An IO error occurred regarding opening the directory");
+            LOGGER.error("An IO error occurred regarding the directory");
+        }
+    }
+
+    public File getDirectory() {
+        return directory;
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardProgressDialog.fxml
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardProgressDialog.fxml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.geometry.Insets?>
+<DialogPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="org.jabref.gui.filewizard.FileWizardProgressDialog"
+            prefHeight="150.0" prefWidth="400.0">
+    <content>
+        <VBox>
+            <GridPane hgap="10.0" vgap="4.0">
+                <Label text="%Please wait for the File Wizard to complete." GridPane.rowIndex="0"
+                       GridPane.columnIndex="0"/>
+                <Label fx:id="progressLabel" GridPane.rowIndex="1"
+                       GridPane.columnIndex="0"/>
+                <ProgressBar fx:id="progressBar" GridPane.rowIndex="2"
+                             GridPane.columnIndex="0" prefWidth="5000.0" progress="0.0"/>
+            </GridPane>
+        </VBox>
+    </content>
+    <ButtonType fx:id="cancelButton" text="%Cancel" />
+</DialogPane>

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardProgressDialog.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardProgressDialog.java
@@ -1,0 +1,63 @@
+package org.jabref.gui.filewizard;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Task;
+import javafx.fxml.FXML;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.ControlHelper;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntry;
+
+/**
+ * Represents the dialog window showing the progress of the running File Wizard.
+ */
+public class FileWizardProgressDialog extends BaseDialog<Void> {
+    @FXML ProgressBar progressBar;
+    @FXML ButtonType cancelButton;
+    @FXML Label progressLabel;
+    int numberOfBibEntries;
+    boolean running;
+
+    public FileWizardProgressDialog(int numberOfBibEntries) {
+        running = true;
+        this.numberOfBibEntries = numberOfBibEntries;
+
+        this.setTitle("File Wizard");
+
+        ViewLoader.view(this)
+                  .load()
+                  .setAsDialogPane(this);
+
+        ControlHelper.setAction(cancelButton, getDialogPane(), event -> stopRunning());
+    }
+
+    public void updateProgress(BibEntry entry, int progress) {
+        double percent;
+        if(progress == 0) {
+            percent = 0;
+        } else {
+            percent = (double) progress / numberOfBibEntries;
+            progressBar.setProgress(percent);
+        }
+        Platform.runLater(() -> progressLabel.setText((int) (percent * 100) + "% complete, currently handling " + entry.getAuthorTitleYear(30)));
+    }
+
+    /**
+     * Quits the File Wizard. The manager reacts to this method being executed and after completing the currently handled
+     * entry, it terminates.
+     */
+    public void stopRunning() {
+        running = false;
+        Platform.runLater(() -> progressLabel.setText(Localization.lang("Cancelling, please wait...")));
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardReport.fxml
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardReport.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.*?>
+<?import java.util.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.geometry.Insets?>
+<DialogPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="org.jabref.gui.filewizard.FileWizardReport"
+            prefHeight="400.0" prefWidth="500.0">
+    <content>
+        <VBox>
+            <GridPane hgap="10.0" vgap="4.0">
+                <Label text="The following BibEntries couldn't be linked:" GridPane.rowIndex="0"
+                       GridPane.columnIndex="0"/>
+                <ListView fx:id="unsuccessfulList" prefHeight="400" prefWidth="400" HBox.hgrow="ALWAYS" maxHeight="500"
+                          GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+            </GridPane>
+        </VBox>
+    </content>
+    <ButtonType fx:constant="CLOSE"/>
+</DialogPane>

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardReport.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardReport.java
@@ -1,0 +1,42 @@
+package org.jabref.gui.filewizard;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListView;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.util.BaseDialog;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileWizardReport extends BaseDialog<Void> {
+
+    @FXML ListView<String> unsuccessfulList;
+
+    public FileWizardReport(List<BibEntry> unsuccessfullyLinked) {
+
+        this.setTitle(Localization.lang("File Wizard"));
+
+        ViewLoader.view(this)
+                .load()
+                .setAsDialogPane(this);
+
+        List<String> list = new ArrayList<>();
+
+        for(int i = 0; i < unsuccessfullyLinked.size(); i++) {
+            list.add(unsuccessfullyLinked.get(i).getAuthorTitleYear(60));
+        }
+
+        ObservableList<String> names = FXCollections.observableArrayList(list);
+        unsuccessfulList.setItems(names);
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardSerializer.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardSerializer.java
@@ -1,0 +1,58 @@
+package org.jabref.gui.filewizard;
+
+import org.jabref.model.entry.BibEntry;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Contains the methods needed for (de-) serializing the list of BibEntries which have already been successfully linked.
+ */
+public class FileWizardSerializer {
+    /**
+     *  Serializes the list of already checked BibEntries, making the information survive past runtime.
+     */
+    public void serializeCheckedFiles(List<String> checkedFilesList, File checkedFilesListFile) {
+        try
+        {
+            FileOutputStream fos = new FileOutputStream(checkedFilesListFile);
+            ObjectOutputStream oos = new ObjectOutputStream(fos);
+            oos.writeObject(checkedFilesList);
+            oos.close();
+            fos.close();
+        } catch (IOException ioe)
+        {
+            ioe.printStackTrace();
+        }
+    }
+
+    /**
+     *  Deserializes the list of already checked BibEntry, minimizing redundant work for the Wizard.
+     */
+    public List<String> deserializeCheckedFilesList(File checkedFilesListFile) {
+        try
+        {
+            FileInputStream fis = new FileInputStream(checkedFilesListFile);
+            ObjectInputStream ois = new ObjectInputStream(fis);
+
+            List<String> result = (ArrayList<String>) ois.readObject();
+
+            ois.close();
+            fis.close();
+
+            return result;
+        }
+        catch (IOException ioe)
+        {
+            ioe.printStackTrace();
+            return null;
+        }
+        catch (ClassNotFoundException c)
+        {
+            System.out.println("Class not found");
+            c.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardView.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardView.java
@@ -1,0 +1,90 @@
+package org.jabref.gui.filewizard;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.control.TextField;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.util.BaseDialog;
+import org.jabref.gui.util.ControlHelper;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.preferences.PreferencesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+
+
+/**
+ * Represents the first window encountered when clicking on "File Wizard" in the Tools section of the toolbar.
+ */
+public class FileWizardView extends BaseDialog<Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileWizardView.class);
+
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private FileWizardViewModel viewModel;
+    private File directory;
+    private final FileWizardAction action;
+
+    @FXML TextField directoryTextField;
+    @FXML CheckBox openDirectoryCheckbox;
+    @FXML ButtonType startButton;
+
+    @Inject private PreferencesService preferencesService;
+
+    public FileWizardView(FileWizardAction action, DialogService dialogService, StateManager stateManager) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.action = action;
+
+        this.setTitle(Localization.lang("File Wizard"));
+
+        ViewLoader.view(this)
+                .load()
+                .setAsDialogPane(this);
+
+        ControlHelper.setAction(startButton, this.getDialogPane(), event -> startWizard());
+    }
+
+    @FXML
+    private void initialize() {
+        viewModel = new FileWizardViewModel(dialogService, preferencesService);
+
+        directoryTextField.textProperty().bindBidirectional(viewModel.getDirectoryProperty());
+    }
+
+    /**
+     * Here the wizard starts working. The method is activated when the "Start" button is pressed in the wizard interface.
+     */
+    private void startWizard() {
+        directory = new File(viewModel.getDirectoryProperty().get());
+
+        if(!directory.exists()) {
+            if(directory.toString().equals("")) {
+                dialogService.showErrorDialogAndWait("Please choose a path");
+                return;
+            }
+            dialogService.showErrorDialogAndWait(directory.toPath() + " is not a valid pathname");
+            LOGGER.error(directory.getPath() + " is not a valid pathname");
+            return;
+        }
+
+
+        action.closeFileWizardControlPanel();
+        // Manages the file wizard's doings.
+        FileWizardManager manager = new FileWizardManager(dialogService, stateManager,
+                openDirectoryCheckbox.isSelected(), directory, preferencesService);
+    }
+
+    @FXML
+    public void browseDirectory(ActionEvent event) {
+        viewModel.browseFileDirectory();
+    }
+}

--- a/src/main/java/org/jabref/gui/filewizard/FileWizardViewModel.java
+++ b/src/main/java/org/jabref/gui/filewizard/FileWizardViewModel.java
@@ -1,0 +1,28 @@
+package org.jabref.gui.filewizard;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.util.DirectoryDialogConfiguration;
+import org.jabref.preferences.PreferencesService;
+
+public class FileWizardViewModel {
+    private final StringProperty directory = new SimpleStringProperty("");
+    private final DialogService dialogService;
+    private final DirectoryDialogConfiguration directoryDialogConfiguration;
+
+    public FileWizardViewModel(DialogService dialogService, PreferencesService preferences) {
+        this.dialogService = dialogService;
+        this.directoryDialogConfiguration = new DirectoryDialogConfiguration.Builder()
+                .withInitialDirectory(preferences.getWorkingDir()).build();
+    }
+
+    public void browseFileDirectory() {
+        dialogService.showDirectorySelectionDialog(directoryDialogConfiguration)
+                .ifPresent(dir -> directory.setValue(dir.toAbsolutePath().toString()));
+    }
+
+    public StringProperty getDirectoryProperty() {
+        return this.directory;
+    }
+}

--- a/src/test/java/org/jabref/gui/filewizard/FileWizardDownloadTest.java
+++ b/src/test/java/org/jabref/gui/filewizard/FileWizardDownloadTest.java
@@ -1,0 +1,196 @@
+package org.jabref.gui.filewizard;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.Globals;
+import org.jabref.gui.util.CurrentThreadTaskExecutor;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.fileformat.medline.URL;
+import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.preferences.FilePreferences;
+import org.jabref.preferences.PreferencesService;
+
+
+import static org.jabref.gui.filewizard.FileWizardDownloader.*;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javafx.application.Platform;
+
+public class FileWizardDownloadTest {
+    // private FileWizardDownloader fwd;
+    private BibDatabaseContext databaseContext = Mockito.mock(BibDatabaseContext.class);
+    private DialogService dialogService = Mockito.mock(DialogService.class);
+    // private Path path = mock(Path.class); //muss noch geändert werden, macht nicht viel sinn path zu mocken
+    private Path targetDirectory;
+    private Path fileA;
+    private Path fileB;
+    private Path fileC;
+
+    private BibEntry entryWithMalformedURL = new BibEntry();
+    private BibEntry entryWithNoURLToBeFound = new BibEntry();
+    private BibEntry entryWithURLToBeFound = new BibEntry();
+
+    private String noSilverBullet;
+    private String malformedURL = "lkdj";
+    // private java.net.URL malformedURLurl = new java.net.URL("http://arxiv.org/pdf/1207.0408v1");
+    private java.net.URL malformedURLurl = null;
+    private java.net.URL noSilverBulletURL = null;
+    private java.net.URL noURLfound = null;
+
+
+    @BeforeEach
+    void setUp(@TempDir Path folder) throws IOException {
+        this.targetDirectory = folder;
+
+        /*
+        fileA = folder.resolve("a.pdf");
+        fileB = folder.resolve("b.pdf");
+        fileC = folder.resolve("c.pdf");
+
+        Files.createFile(fileA);
+        Files.createFile(fileB);
+        Files.createFile(fileC);
+
+        entryWithURLToBeFound.addFile(new LinkedFile("", fileA, "PDF"));
+        entryWithMalformedURL.addFile(new LinkedFile("", fileB, "PDF"));
+        entryWithNoURLToBeFound.addFile(new LinkedFile("", fileC, "PDF"));
+
+         */
+
+        // entryWithURLToBeFound.setField(StandardField.URL, noSilverBullet);
+        entryWithURLToBeFound.setField(StandardField.DOI, "10.1109/MC.1987.1663532");
+        entryWithMalformedURL.setField(StandardField.URL, malformedURL);
+        entryWithNoURLToBeFound.setField(StandardField.DOI, "10.1109/ICDSP.2015.7251883");
+
+
+
+
+
+
+        // fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, path);
+        // fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, targetDirectory);
+        // FileWizardDownloader spyFWD = spy(fwd);
+    }
+
+
+
+    @Test
+    void testFileWizardDownloaderFromUrlCallsPrepareDownloadTask() {
+        /*
+        fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, targetDirectory);
+        FileWizardDownloader spyFWD = spy(fwd);
+        URLDownload urldownload = new URLDownload(noSilverBulletURL);
+
+        spyFWD.startDownloader(entryWithURLToBeFound);
+        spyFWD.fileWizardDownloaderFromURL(databaseContext, noSilverBulletURL, entryWithURLToBeFound, targetDirectory);
+        // verify(spyFWD).prepareDownloadTask(path, urldownload);
+
+         */
+    }
+
+    @Test
+    void testFileWizardDownloaderFromUrlWithMalformedURL() {
+        /*
+        fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, targetDirectory);
+        FileWizardDownloader spyFWD = spy(fwd);
+
+        // fwd.fileWizardDownloaderFromURL(databaseContext, );
+
+         */
+    }
+
+    /**
+     * Tests if startDownloader behaves correctly when URL can be found
+     * If an URL is found, startDownloader should call fileWizardDownloaderFromURL, and should return true
+     */
+    @Test
+    void testStartDownloaderCouldFindURLReturnsTrue() {
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        FilePreferences filePreferences = mock(FilePreferences.class);
+        // when(PreferencesService.getXmpPreferences()).thenReturn(XmpPreferences); // use this variant, as we cannot mock the linkedFileHandler cause it's initialized inside the viewModel
+        // when(PreferencesService.getFilePreferences()).thenReturn(XmpPreferences);
+        when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
+        // when(PreferencesService.getXmpPreferences()).thenReturn(XmpPreferences);
+        when(Globals.TASK_EXECUTOR).thenReturn(new CurrentThreadTaskExecutor());
+
+        System.out.println("hallo");
+
+        // fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, targetDirectory);
+        // FileWizardDownloader spyFWD = spy(fwd);
+
+        // spyFWD.startDownloader(entryWithURLToBeFound);
+        // verify(spyFWD, times(1)).fileWizardSearchURL(entryWithURLToBeFound, Globals.prefs);
+        // verify(spyFWD, times(1)).fileWizardDownloaderFromURL(databaseContext, noSilverBulletURL, entryWithURLToBeFound, targetDirectory);
+        Assertions.assertTrue(startDownloader(mock(DialogService.class), Globals.prefs, mock(BibDatabaseContext.class), targetDirectory, entryWithURLToBeFound));
+
+    }
+
+    /**
+     * Tests if startDownloader behaves correctly when no URL is to be found
+     * If no URL is found, startDownloader should not call fileWizardDownloaderFromURL, and should return false
+     */
+    @Test
+    void testStartDownloaderCouldNotFindURLReturnsFalse() {
+        /*
+        fwd = new FileWizardDownloader(dialogService, Globals.prefs, databaseContext, targetDirectory);
+        FileWizardDownloader spyFWD = spy(fwd);
+
+        spyFWD.startDownloader(entryWithNoURLToBeFound);
+        verify(spyFWD, times(1)).fileWizardSearchURL(entryWithNoURLToBeFound, Globals.prefs);
+        verify(spyFWD, times(0)).fileWizardDownloaderFromURL(databaseContext, noURLfound, entryWithNoURLToBeFound, targetDirectory);
+
+         */
+        Assertions.assertFalse(startDownloader(mock(DialogService.class), Globals.prefs, mock(BibDatabaseContext.class), targetDirectory, entryWithNoURLToBeFound));
+    }
+
+    /**
+     * Tests if after the execution of The downloader an actual file is downloaded
+     */
+    @Test
+    void testStartDownloaderCheckDirectoryForFileWithURLFound() {
+        startDownloader(mock(DialogService.class), Globals.prefs, mock(BibDatabaseContext.class), targetDirectory, entryWithURLToBeFound);
+        Assertions.assertTrue(new File(entryWithURLToBeFound.getFiles().get(0).getLink()).exists());
+    }
+
+    @Test
+    void testFileWizardSearchUrlResultReturnsURLReturnsTrue() {
+        // String urlFoundOn03112020 = "https://dl.acm.org/doi/pdf/10.1145/1297846.1297973";
+        // Assertions.assertEquals(urlFoundOn03112020, fwd.fileWizardSearchURL(entryWithURLToBeFound, Globals.prefs).get());
+        Assertions.assertTrue(fileWizardSearchURL(entryWithURLToBeFound, mock(ImportFormatPreferences.class)).isPresent());
+        //failes, can not find url, maybe add more info to bibentry
+
+    }
+
+    @Test
+    void testFileWizardSearchUrlResultReturnsNoURLReturnsFalse() {
+        /*
+        TaskExecutor taskExecutor = Globals.TASK_EXECUTOR;
+            XmpPreferences xmpPreferences = preferences.getXmpPreferences();
+            FilePreferences filePreferences = preferences.getFilePreferences();
+            ExternalFileTypes externalFileType = ExternalFileTypes.getInstance();
+
+         */
+        Assertions.assertFalse(fileWizardSearchURL(entryWithNoURLToBeFound, mock(ImportFormatPreferences.class)).isPresent());
+    }
+}

--- a/src/test/java/org/jabref/gui/filewizard/FileWizardLocalTest.java
+++ b/src/test/java/org/jabref/gui/filewizard/FileWizardLocalTest.java
@@ -1,0 +1,208 @@
+package org.jabref.gui.filewizard;
+
+import org.jabref.gui.externalfiles.AutoSetFileLinksUtil;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.FilePreferences;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.jabref.gui.filewizard.FileWizardLocal.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FileWizardLocalTest {
+
+    private final FilePreferences fileDirPrefs = mock(FilePreferences.class);
+    private final AutoLinkPreferences autoLinkPrefs =
+            new AutoLinkPreferences(AutoLinkPreferences.CitationKeyDependency.START, "", ';');
+    private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private final ExternalFileTypes externalFileTypes = mock(ExternalFileTypes.class);
+
+    private Path targetDir;
+    private final List<Path> targetDirAsList = new ArrayList<>();
+    private final List<Path> otherDirAsList = new ArrayList<>();
+
+    private Path fileInTarget1;
+    private Path fileInTarget2;
+    private Path fileInOther1;
+    private Path fileInOther2;
+    private Path fileInvalid;
+
+    private BibEntry entryWithOneFileInTarget = new BibEntry();
+    private BibEntry entryWithOneFileInOther = new BibEntry();
+    private BibEntry entryWithOneFileInvalid = new BibEntry();
+    private BibEntry entryWithZeroFiles = new BibEntry();
+    private BibEntry entryWithMultipleFilesOneInOther = new BibEntry();
+    private BibEntry entryWithoutLinkButWithMatchingKey = new BibEntry();
+    private BibEntry entryWithoutLinkAndWithoutMatchingKey = new BibEntry();
+
+    @BeforeEach
+    void setUp(@TempDir Path targetDir, @TempDir Path otherDir) throws IOException {
+
+        this.targetDir = targetDir;
+        targetDirAsList.add(targetDir);
+        otherDirAsList.add(otherDir);
+
+        fileInTarget1 = targetDir.resolve("a.pdf");
+        fileInTarget2 = targetDir.resolve("b.pdf");
+
+        fileInOther1 = otherDir.resolve("c.pdf");
+        fileInOther2 = otherDir.resolve("d.pdf");
+
+        fileInvalid = targetDir.resolve("e.pdf");
+
+        Files.createFile(fileInTarget1);
+        Files.createFile(fileInTarget2);
+        Files.createFile(fileInOther1);
+        Files.createFile(fileInOther2);
+
+        entryWithOneFileInTarget.addFile(new LinkedFile("", fileInTarget1, ""));
+        entryWithOneFileInOther.addFile(new LinkedFile("", fileInOther1, ""));
+        entryWithOneFileInvalid.addFile(new LinkedFile("", fileInvalid, ""));
+
+        entryWithMultipleFilesOneInOther.addFile(0, new LinkedFile("", fileInvalid, ""));
+        entryWithMultipleFilesOneInOther.addFile(1, new LinkedFile("", fileInOther2, ""));
+
+        entryWithoutLinkButWithMatchingKey.setCitationKey("b");
+        entryWithoutLinkAndWithoutMatchingKey.setCitationKey("f");
+
+        when(externalFileTypes.getExternalFileTypeSelection()).thenReturn(new TreeSet<>(ExternalFileTypes.getDefaultExternalFileTypes()));
+        when(databaseContext.getFileDirectories(any())).thenReturn(Collections.singletonList(fileInTarget2.getParent()));
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithOneFileInOtherReturnTrue() {
+
+        assertTrue(copyFileFromDefaultDirectory(entryWithOneFileInOther, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithOneFileInvalidReturnFalse() {
+
+        assertFalse(copyFileFromDefaultDirectory(entryWithOneFileInvalid, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithZeroFilesReturnFalse() {
+
+        assertFalse(copyFileFromDefaultDirectory(entryWithZeroFiles, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithMultipleFilesOneInOtherReturnTrue() {
+
+        assertTrue(copyFileFromDefaultDirectory(entryWithMultipleFilesOneInOther, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testFileExistsLocallyWithEntryWithOneFileInTargetReturnTrue() {
+
+        assertTrue(fileExistsLocally(entryWithOneFileInTarget, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testFileExistsLocallyWithEntryWithOneFileInOtherReturnTrue() {
+
+        assertTrue(fileExistsLocally(entryWithOneFileInOther, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testFileExistsLocallyWithEntryWithOneFileInvalidReturnFalse() {
+
+        assertFalse(fileExistsLocally(entryWithOneFileInvalid, targetDir, otherDirAsList));
+    }
+
+
+    @Test
+    void testFileExistsLocallyWithEntryWithZeroFilesReturnFalse() {
+
+        assertFalse(fileExistsLocally(entryWithZeroFiles, targetDir, otherDirAsList));
+    }
+
+    @Test
+    void testMapToFileInDirWithEntryWithOneFileInTargetReturnFalse() {
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, fileDirPrefs, autoLinkPrefs, externalFileTypes);
+        assertFalse(mapToFileInDirectory(entryWithOneFileInTarget, util));
+    }
+
+    @Test
+    void testMapToFileInDirWithEntryWithoutLinkButWithMatchingKeyReturnTrue() {
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, fileDirPrefs, autoLinkPrefs, externalFileTypes);
+        assertTrue(mapToFileInDirectory(entryWithoutLinkButWithMatchingKey, util));
+    }
+
+    @Test
+    void testMapToFileInDirWithEntryWithoutLinkAndWithoutMatchingKeyReturnFalse() {
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, fileDirPrefs, autoLinkPrefs, externalFileTypes);
+        assertFalse(mapToFileInDirectory(entryWithoutLinkAndWithoutMatchingKey, util));
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithOneFileInOtherDoesCopy() {
+        copyFileFromDefaultDirectory(entryWithOneFileInOther, targetDir, otherDirAsList);
+        Path expectedFile = targetDir.resolve("c.pdf");
+        LinkedFile expectedLinkedFile = new LinkedFile("", expectedFile, "");
+        assertEquals(expectedLinkedFile, entryWithOneFileInOther.getFiles().get(1));
+        assertEquals(entryWithOneFileInOther.getFiles().size(), 2);
+        assertTrue(new File(entryWithOneFileInOther.getFiles().get(1).getLink()).exists());
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithOneFileInvalidDoesNotCopy() {
+        Path expectedFile = targetDir.resolve("e.pdf");
+        copyFileFromDefaultDirectory(entryWithOneFileInvalid, targetDir, otherDirAsList);
+        assertEquals(entryWithOneFileInOther.getFiles().size(), 1);
+        assertFalse(new File(String.valueOf(expectedFile)).exists());
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryZeroFilesDoesNotCopy() {
+        copyFileFromDefaultDirectory(entryWithZeroFiles, targetDir, otherDirAsList);
+        assertEquals(entryWithZeroFiles.getFiles().size(), 0);
+    }
+
+    @Test
+    void testCopyFileFromDefaultDirectoryWithEntryWithMultipleFilesOneInOtherDoesCopy() {
+        copyFileFromDefaultDirectory(entryWithMultipleFilesOneInOther, targetDir, otherDirAsList);
+        Path expectedFile = targetDir.resolve("d.pdf");
+        LinkedFile expectedLinkedFile = new LinkedFile("", expectedFile, "");
+        assertEquals(expectedLinkedFile, entryWithMultipleFilesOneInOther.getFiles().get(2));
+        assertEquals(entryWithMultipleFilesOneInOther.getFiles().size(), 3);
+        assertTrue(new File(entryWithMultipleFilesOneInOther.getFiles().get(2).getLink()).exists());
+    }
+
+    @Test
+    void testMapToFileInDirWithEntryWithoutLinkButWithMatchingKeyDoesLink() {
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, fileDirPrefs, autoLinkPrefs, externalFileTypes);
+        mapToFileInDirectory(entryWithoutLinkButWithMatchingKey, util);
+        LinkedFile expectedLinkedFile = new LinkedFile("", Path.of("b.pdf"), "");
+        assertEquals(expectedLinkedFile, entryWithoutLinkButWithMatchingKey.getFiles().get(0));
+        assertEquals(1, entryWithoutLinkButWithMatchingKey.getFiles().size());
+        assertTrue(new File(String.valueOf(fileInTarget2)).exists());
+    }
+
+    @Test
+    void testMapToFileInDirWithEntryWithoutLinkAndWithoutMatchingKeyDoesNotLink() {
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, fileDirPrefs, autoLinkPrefs, externalFileTypes);
+        mapToFileInDirectory(entryWithoutLinkAndWithoutMatchingKey, util);
+        assertEquals(entryWithoutLinkButWithMatchingKey.getFiles().size(), 0);
+    }
+}

--- a/src/test/java/org/jabref/gui/filewizard/FileWizardManagerTest.java
+++ b/src/test/java/org/jabref/gui/filewizard/FileWizardManagerTest.java
@@ -1,0 +1,52 @@
+package org.jabref.gui.filewizard;
+
+import org.jabref.model.entry.BibEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+
+public class FileWizardManagerTest {
+
+    @Test
+    void testSerializeCheckedFilesAndDeSerializedCheckedFiles() {
+        List<String> entryList = new ArrayList<>();
+        File file;
+
+        try {
+            file = File.createTempFile("tmp", ".txt");
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+
+        BibEntry one = new BibEntry();
+        BibEntry two = new BibEntry();
+        BibEntry three = new BibEntry();
+
+        one.setCitationKey("id1");
+        two.setCitationKey("id2");
+        three.setCitationKey("id3");
+
+        entryList.add(one.getCitationKey().get());
+        entryList.add(two.getCitationKey().get());
+        entryList.add(three.getCitationKey().get());
+
+        FileWizardSerializer serializer = new FileWizardSerializer();
+        serializer.serializeCheckedFiles(entryList, file);
+        List<String> deserializedList = serializer.deserializeCheckedFilesList(file);
+
+        //System.out.println("Original List: " + entryList.size() + ", Deserialized List: " + deserializedList.size());
+
+        file.delete();
+
+        assertEquals(entryList, deserializedList);
+    }
+}


### PR DESCRIPTION
This is the first draft for File Magic Wizard (Issue #380).
The File Wizard should automatically synchronize local files with the corresponding BibEntries of a JabRef Library when executed.
https://github.com/koppor/jabref/issues/380

This project is part of the course "software engineering" at Universität Basel.
@flurfis, @yasminmeier, @maxjappert

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

![Screenshot 2020-12-08 152906](https://user-images.githubusercontent.com/71381124/101496606-41e86d00-396a-11eb-9b93-3225ab0d5651.jpg)
