### PR TITLE
Logg errors at the Google Scholar fetcher and hide them from the UI

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
@@ -220,7 +220,7 @@ public class GoogleScholar implements FulltextFetcher, PagedSearchBasedFetcher {
                     throw new FetcherException("Fetching from Google Scholar failed.",
                             Localization.lang("This might be caused by reaching the traffic limitation of Google Scholar (see 'Help' for details)."), e);
                 } else {
-                    //throw new FetcherException("Error while fetching from " + getName(), e);
+                    // throw new FetcherException("Error while fetching from " + getName(), e);
                     LOGGER.warn("Error while fetching from " + getName(), e);
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
@@ -220,7 +220,8 @@ public class GoogleScholar implements FulltextFetcher, PagedSearchBasedFetcher {
                     throw new FetcherException("Fetching from Google Scholar failed.",
                             Localization.lang("This might be caused by reaching the traffic limitation of Google Scholar (see 'Help' for details)."), e);
                 } else {
-                    throw new FetcherException("Error while fetching from " + getName(), e);
+                    //throw new FetcherException("Error while fetching from " + getName(), e);
+                    LOGGER.warn("Error while fetching from " + getName(), e);
                 }
             }
             return new Page<>(complexQueryString, pageNumber, foundEntries);

--- a/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
@@ -1,2 +1,4 @@
-package org.jabref.logic.importer.fileformat;public class ACMPortalParser {
+package org.jabref.logic.importer.fileformat;
+
+public class ACMPortalParser {
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
@@ -1,0 +1,2 @@
+package org.jabref.logic.importer.fileformat;public class ACMPortalParser {
+}


### PR DESCRIPTION

### Summary
This  pull request is related to #6334
This pull request is to resolve the exception raised at the UI when you make a search at Google Scholar.

### Changes
Move the error thrown to the logger as is recommended.

### Demo
No UI error through when you make a search at Google Scholar
![google issie](https://user-images.githubusercontent.com/32725639/102001550-c7448800-3cb0-11eb-806b-038e6487f709.png)

Error show at the log as a warning
![google issue](https://user-images.githubusercontent.com/32725639/102001590-01158e80-3cb1-11eb-9081-47cf400351f9.png)



<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
