### PR TITLE
Remove processResources to speedup build

### DIFF
--- a/.idea/runConfigurations/JabRef_Main.xml
+++ b/.idea/runConfigurations/JabRef_Main.xml
@@ -1,15 +1,13 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="JabRef Main" type="Application" factoryName="Application" singleton="false">
-    <module name="JabRef.main" />
+  <configuration default="false" name="JabRef Main" type="Application" factoryName="Application" singleton="true">
     <option name="MAIN_CLASS_NAME" value="org.jabref.gui.JabRefMain" />
-    <option name="REDIRECT_INPUT" value="true" />
+    <module name="JabRef.main" />
     <option name="VM_PARAMETERS" value="--patch-module test=fastparse_2.12-1.0.0.jar --patch-module test2=fastparse-utils_2.12-1.0.0.jar --patch-module test3=sourcecode_2.12-0.1.4.jar --patch-module org.jabref=build/resources/main --add-exports javafx.controls/com.sun.javafx.scene.control=org.jabref --add-exports org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref --add-opens javafx.controls/javafx.scene.control=org.jabref --add-opens org.controlsfx.controls/org.controlsfx.control.textfield=org.jabref --add-exports javafx.graphics/com.sun.javafx.scene=org.controlsfx.controls --add-exports javafx.graphics/com.sun.javafx.scene.traversal=org.controlsfx.controls --add-exports javafx.graphics/com.sun.javafx.css=org.controlsfx.controls --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=org.controlsfx.controls --add-exports javafx.controls/com.sun.javafx.scene.control=org.controlsfx.controls --add-exports javafx.controls/com.sun.javafx.scene.control.inputmap=org.controlsfx.controls --add-exports javafx.base/com.sun.javafx.event=org.controlsfx.controls --add-exports javafx.base/com.sun.javafx.collections=org.controlsfx.controls --add-exports javafx.base/com.sun.javafx.runtime=org.controlsfx.controls --add-exports javafx.web/com.sun.webkit=org.controlsfx.controls --add-exports javafx.graphics/com.sun.javafx.css=org.controlsfx.controls --add-opens javafx.controls/javafx.scene.control.skin=org.controlsfx.controls --add-opens javafx.graphics/javafx.scene=org.controlsfx.controls --add-exports com.oracle.truffle.regex/com.oracle.truffle.regex=org.graalvm.truffle --add-exports javafx.graphics/com.sun.javafx.stage=com.jfoenix --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=com.jfoenix" />
     <option name="WORKING_DIRECTORY" value="$MODULE_WORKING_DIR$" />
     <RunnerSettings RunnerId="Profile ">
       <option name="myExternalizedOptions" value="additional-options2=onexit\=snapshot,_no_java_version_check&#13;&#10;startup=12" />
     </RunnerSettings>
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="processResources" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="" />
       <option name="Make" enabled="true" />
     </method>
   </configuration>


### PR DESCRIPTION
In `processResoures`, we only copy author information and keys into the build:

https://github.com/JabRef/jabref/blob/86e2c82cbe0eb8ca18f1b80f7b85b375cc316ad7/build.gradle#L263

It taskes a very long time for compilation. With removing that, we should be able to speed-up compilation

![grafik](https://user-images.githubusercontent.com/1366654/102010611-66b05c00-3d3f-11eb-8a13-4d2b205685db.png)

## Before

![grafik](https://user-images.githubusercontent.com/1366654/102010646-b55df600-3d3f-11eb-8bde-858dd3b8a112.png)

## After

![grafik](https://user-images.githubusercontent.com/1366654/102010634-95c6cd80-3d3f-11eb-8d66-c4dd35aaf905.png)

Regarding following, I did not do anyithing in the UI:

```xml
<option name="REDIRECT_INPUT" value="true" />
```

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
