### PR TITLE
Prevent download file if it is already attached

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -472,9 +472,11 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     String fulltextDir = FileUtil.createDirNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileDirectoryPattern());
                     String finalName = FileNameUniqueness.getNonOverWritingFileName(targetDirectory.resolve(fulltextDir), suggestedName);
                     if (!suggestedName.equals(finalName)) {
-                        messageError.append("File: \"");
+                        messageError.append(Localization.lang("File"));
+                        messageError.append(": \"");
                         messageError.append(suggestedName);
-                        messageError.append("\" already exists");
+                        messageError.append("\"");
+                        messageError.append(Localization.lang(" already exists"));
                         // return null to stop the download process
                         return null;
                     }


### PR DESCRIPTION
### Summary
This  pull request is to fix issue #6197 
If you try to download a file (Lookup -> Search full text documents online) and you have this file already attached, an alert will be shown and the file will not be downloaded

### Changes
Modify `LinkedFileViewModel` to catch immediately when we know that the file we are trying to download already exists.

### Demo
Lookup -> Search full text documents online -> Try to download -> Throw error because the file already exists
![download issue 1](https://user-images.githubusercontent.com/32725639/102032061-0d631f80-3d75-11eb-92bd-c40c246c0558.png) ![download issue 2](https://user-images.githubusercontent.com/32725639/102032064-0f2ce300-3d75-11eb-93ea-5b8ffb6855a1.png) ![download issue 3](https://user-images.githubusercontent.com/32725639/102032068-10f6a680-3d75-11eb-870b-20909d8e22d1.png)
![download issue 4](https://user-images.githubusercontent.com/32725639/102032071-12c06a00-3d75-11eb-9ee0-c46b5b04c584.png)

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
