### PR TITLE
Speedup processResources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ clean {
 processResources {
     filteringCharset = 'UTF-8'
 
-    filesMatching("build.properties") {
+    filesMatching("./build.properties") {
         expand(version: project.findProperty('projVersionInfo') ?: '100.0.0',
                 "year": String.valueOf(Calendar.getInstance().get(Calendar.YEAR)),
                 "authors": new File('AUTHORS').readLines().findAll { !it.startsWith("#") }.join(", "),
@@ -279,7 +279,7 @@ processResources {
         filteringCharset = 'UTF-8'
     }
 
-    filesMatching("resource/**/meta.xml") {
+    filesMatching(["resources/resource/ods/meta.xml", "resources/resource/openoffice/meta.xml"]) {
         expand version: project.version
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ clean {
 processResources {
     filteringCharset = 'UTF-8'
 
-    filesMatching("./build.properties") {
+    filesMatching("build.properties") {
         expand(version: project.findProperty('projVersionInfo') ?: '100.0.0',
                 "year": String.valueOf(Calendar.getInstance().get(Calendar.YEAR)),
                 "authors": new File('AUTHORS').readLines().findAll { !it.startsWith("#") }.join(", "),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.vs.watch=true


### PR DESCRIPTION
`processResources` task was very slow:

```terminal
$ gradlew processResources
> Configure project :
Project : => 'org.jabref' Java module

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 49s
1 actionable task: 1 executed
```

Speed up by:

1. Pointing to the files to be modified directly
2. Add [gradle file system watcher](https://blog.gradle.org/introducing-file-system-watching)

```terminal
@ C:\git-repositories\jabref\jabref
$ gradlew --watch-fs -Dorg.gradle.vfs.verbose=true processResources
Watching the file system is an incubating feature.
Received 7 file system events since last build
Virtual file system retained information about 21136 files, 269 directories and 1 missing files since last build

> Configure project :
Project : => 'org.jabref' Java module

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4s
1 actionable task: 1 up-to-date
Received 11 file system events for current build
Virtual file system retains information about 21136 files, 269 directories and 1 missing files till next build
```

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
