### PR TITLE
Output java error on console, too

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,10 +267,7 @@ processResources {
                 "azureInstrumentationKey": System.getenv('AzureInstrumentationKey'),
                 "springerNatureAPIKey": System.getenv('SpringerNatureAPIKey'),
                 "astrophysicsDataSystemAPIKey": System.getenv('AstrophysicsDataSystemAPIKey'),
-                "ieeeAPIKey": System.getenv('IEEEAPIKey'),
-                "minRequiredJavaVersion": minRequiredJavaVersion,
-                "allowJava9": allowJava9
-
+                "ieeeAPIKey": System.getenv('IEEEAPIKey')
         )
         filteringCharset = 'UTF-8'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,6 @@ modularity.patchModule("test", "fastparse_2.12-1.0.0.jar")
 modularity.patchModule("test2", "fastparse-utils_2.12-1.0.0.jar")
 modularity.patchModule("test3", "sourcecode_2.12-0.1.4.jar")
 
-// These are the Java version requirements we will check on each start of JabRef
-ext.minRequiredJavaVersion = "1.8.0_171"
-ext.allowJava9 = true
-
 sourceSets {
     main {
         java {

--- a/src/main/java/org/jabref/gui/JabRefMain.java
+++ b/src/main/java/org/jabref/gui/JabRefMain.java
@@ -4,7 +4,6 @@ import java.net.Authenticator;
 
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.scene.control.Alert;
 import javafx.stage.Stage;
 
 import org.jabref.cli.ArgumentProcessor;
@@ -19,8 +18,6 @@ import org.jabref.logic.net.ProxyRegisterer;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
-import org.jabref.logic.util.BuildInfo;
-import org.jabref.logic.util.JavaVersion;
 import org.jabref.logic.util.OS;
 import org.jabref.migrations.PreferencesMigrations;
 import org.jabref.model.database.BibDatabaseMode;
@@ -48,8 +45,6 @@ public class JabRefMain extends Application {
     @Override
     public void start(Stage mainStage) {
         try {
-            // Fail on unsupported Java versions
-            ensureCorrectJavaVersion();
             FallbackExceptionHandler.installExceptionHandler();
 
             // Init preferences
@@ -91,53 +86,6 @@ public class JabRefMain extends Application {
     public void stop() {
         Globals.stopBackgroundTasks();
         Globals.shutdownThreadPools();
-    }
-
-    /**
-     * Tests if we are running an acceptable Java and terminates JabRef when we are sure the version is not supported.
-     * This test uses the requirements for the Java version as specified in <code>gradle.build</code>. It is possible to
-     * define a minimum version including the built number and to indicate whether Java 9 can be used (which it currently
-     * can't). It tries to compare this version number to the version of the currently running JVM. The check is
-     * optimistic and will rather return true even if we could not exactly determine the version.
-     * <p>
-     * Note: Users with a very old version like 1.6 will not profit from this since class versions are incompatible and
-     * JabRef won't even start. Currently, JabRef won't start with Java 9 either, but the warning that it cannot be used
-     * with this version is helpful anyway to prevent users to update from an old 1.8 directly to version 9. Additionally,
-     * we soon might have a JabRef that does start with Java 9 but is not perfectly compatible. Therefore, we should leave
-     * the Java 9 check alive.
-     */
-    private static void ensureCorrectJavaVersion() {
-        // Check if we are running an acceptable version of Java
-        final BuildInfo buildInfo = Globals.BUILD_INFO;
-        JavaVersion checker = new JavaVersion();
-        final boolean java9Fail = !buildInfo.allowJava9 && checker.isJava9();
-        final boolean versionFail = !checker.isAtLeast(buildInfo.minRequiredJavaVersion);
-
-        if (java9Fail || versionFail) {
-            StringBuilder versionError = new StringBuilder(
-                    Localization.lang("Your current Java version (%0) is not supported. Please install version %1 or higher.",
-                            checker.getJavaVersion(),
-                            buildInfo.minRequiredJavaVersion));
-
-            versionError.append("\n");
-            versionError.append(Localization.lang("Your Java Runtime Environment is located at %0.", checker.getJavaInstallationDirectory()));
-
-            if (!buildInfo.allowJava9) {
-                versionError.append("\n");
-                versionError.append(Localization.lang("Note that currently, JabRef does not run with Java 9."));
-            }
-
-            LOGGER.error(versionError.toString());
-
-            FXDialog alert = new FXDialog(Alert.AlertType.ERROR, Localization.lang("Error"), true);
-            alert.setHeaderText(null);
-            alert.setContentText(versionError.toString());
-
-            // We exit on Java 9 error since this will definitely not work
-            if (java9Fail) {
-                System.exit(0);
-            }
-        }
     }
 
     private static boolean handleMultipleAppInstances(String[] args) {

--- a/src/main/java/org/jabref/gui/JabRefMain.java
+++ b/src/main/java/org/jabref/gui/JabRefMain.java
@@ -127,7 +127,7 @@ public class JabRefMain extends Application {
                 versionError.append(Localization.lang("Note that currently, JabRef does not run with Java 9."));
             }
 
-            System.err.println(versionError.toString());
+            LOGGER.error(versionError.toString());
 
             FXDialog alert = new FXDialog(Alert.AlertType.ERROR, Localization.lang("Error"), true);
             alert.setHeaderText(null);

--- a/src/main/java/org/jabref/gui/JabRefMain.java
+++ b/src/main/java/org/jabref/gui/JabRefMain.java
@@ -127,6 +127,8 @@ public class JabRefMain extends Application {
                 versionError.append(Localization.lang("Note that currently, JabRef does not run with Java 9."));
             }
 
+            System.err.println(versionError.toString());
+
             FXDialog alert = new FXDialog(Alert.AlertType.ERROR, Localization.lang("Error"), true);
             alert.setHeaderText(null);
             alert.setContentText(versionError.toString());

--- a/src/main/java/org/jabref/logic/l10n/Localization.java
+++ b/src/main/java/org/jabref/logic/l10n/Localization.java
@@ -51,7 +51,7 @@ public class Localization {
     public static String lang(String key, String... params) {
         if (localizedMessages == null) {
             // I'm logging this because it should never happen
-            LOGGER.error("Messages are not initialized before accessing key: " + key);
+            LOGGER.error("Messages are not initialized before accessing key: {}", key);
             setLanguage(Language.ENGLISH);
         }
         return lookup(localizedMessages, key, params);
@@ -67,7 +67,7 @@ public class Localization {
         Optional<Locale> knownLanguage = Language.convertToSupportedLocale(language);
         final Locale defaultLocale = Locale.getDefault();
         if (knownLanguage.isEmpty()) {
-            LOGGER.warn("Language " + language + " is not supported by JabRef (Default:" + defaultLocale + ")");
+            LOGGER.warn("Language {} is not supported by JabRef (Default: {})", language, defaultLocale);
             setLanguage(Language.ENGLISH);
             return;
         }
@@ -143,7 +143,7 @@ public class Localization {
 
         String translation = bundle.containsKey(key) ? bundle.getString(key) : "";
         if (translation.isEmpty()) {
-            LOGGER.warn("Warning: could not get translation for \"" + key + "\" for locale " + Locale.getDefault());
+            LOGGER.warn("Warning: could not get translation for \"{}\" for locale {}", key, Locale.getDefault());
             translation = key;
         }
         return new LocalizationKeyParams(translation, params).replacePlaceholders();

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -6,5 +6,3 @@ azureInstrumentationKey=${azureInstrumentationKey}
 springerNatureAPIKey=${springerNatureAPIKey}
 astrophysicsDataSystemAPIKey=${astrophysicsDataSystemAPIKey}
 ieeeAPIKey=${ieeeAPIKey}
-minRequiredJavaVersion = ${minRequiredJavaVersion}
-allowJava9 = ${allowJava9}

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1779,8 +1779,6 @@ Checking\ integrity...=Checking integrity...
 
 Remove\ hyphenated\ line\ breaks=Remove hyphenated line breaks
 Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=Removes all hyphenated line breaks in the field content.
-Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=Note that currently, JabRef does not run with Java 9.
-Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=Your current Java version (%0) is not supported. Please install version %1 or higher.
 
 Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Could not retrieve entry data from '%0'.
 Entry\ from\ %0\ could\ not\ be\ parsed.=Entry from %0 could not be parsed.
@@ -1788,7 +1786,6 @@ Invalid\ identifier\:\ '%0'.=Invalid identifier: '%0'.
 This\ paper\ has\ been\ withdrawn.=This paper has been withdrawn.
 Finished\ writing\ XMP\ metadata.=Finished writing XMP metadata.
 empty\ citation\ key=empty citation key
-Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Your Java Runtime Environment is located at %0.
 Aux\ file=Aux file
 Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Group containing entries cited in a given TeX file
 


### PR DESCRIPTION
Before:

```
Skipped patching sourcecode_2.12-0.1.4.jar into test3
19:45:34.512 [JavaFX Application Thread] ERROR org.jabref.logic.l10n.Localization - Messages are not initialized before accessing key: Your current Java version (%0) is not supported. Please install version %1 or higher.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 38s
```

After:

Output on console reporting Java version errors.

```
20:11:40.714 [JavaFX Application Thread] ERROR org.jabref.logic.l10n.Localization - Messages are not initialized before accessing key: Your current Java version (%0) is not supported. Please install version %1 or higher.
20:11:40.780 [JavaFX Application Thread] ERROR org.jabref.gui.JabRefMain - Your current Java version (15.0.1) is not supported. Please install version ${minRequiredJavaVersion} or higher.
```

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
