### PR TITLE
fxdocs changed their URL

### DIFF
--- a/docs/readings-on-coding/javafx.md
+++ b/docs/readings-on-coding/javafx.md
@@ -150,7 +150,7 @@ The view consists a FXML file `MyDialog.fxml` which defines the structure and th
 * [CSS Reference](http://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html)
 * [JFoenix](https://github.com/jfoenixadmin/JFoenix) Material Designs look & feel
 * [FontAwesomeFX](https://bitbucket.org/Jerady/fontawesomefx/overview): supports different icon fonts
-* [JavaFX Documentation project](https://fxdocs.github.io/docs/index.html): Collected information on javafx in a central place
+* [JavaFX Documentation project](https://fxdocs.github.io/docs/html5/index.html): Collected information on JavaFX in a central place
 * [FXExperience](http://fxexperience.com/) JavaFX Links of the week
 
 ## Features missing in JavaFX


### PR DESCRIPTION
Fixes a broken external link

From https://fxdocs.github.io/docs/index.html to https://fxdocs.github.io/docs/html5/index.html

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
