### PR TITLE
Modify message at the duplicates found dialog

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -664,7 +664,7 @@ public class LibraryTab extends Tab {
                     message,
                     okButton,
                     cancelButton,
-                    Localization.lang("Disable this confirmation dialog"),
+                    Localization.lang("Do not ask again"),
                     optOut -> preferencesService.storeGeneralPreferences(
                             preferencesService.getGeneralPreferences().withConfirmDelete(!optOut)));
         } else {

--- a/src/main/java/org/jabref/gui/citationkeypattern/GenerateCitationKeyAction.java
+++ b/src/main/java/org/jabref/gui/citationkeypattern/GenerateCitationKeyAction.java
@@ -56,7 +56,7 @@ public class GenerateCitationKeyAction extends SimpleCommand {
                     Localization.lang("One or more keys will be overwritten. Continue?"),
                     Localization.lang("Overwrite keys"),
                     Localization.lang("Cancel"),
-                    Localization.lang("Disable this confirmation dialog"),
+                    Localization.lang("Do not ask again"),
                     optOut -> Globals.prefs.storeCitationKeyPatternPreferences(
                             Globals.prefs.getCitationKeyPatternPreferences().withWarnBeforeOverwriteCiteKey(!optOut)));
         } else {

--- a/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
@@ -67,7 +67,7 @@ public class CleanupAction extends SimpleCommand {
                         Localization.lang("Auto-generating PDF-Names does not support undo. Continue?"),
                         Localization.lang("Autogenerate PDF Names"),
                         Localization.lang("Cancel"),
-                        Localization.lang("Disable this confirmation dialog"),
+                        Localization.lang("Do not ask again"),
                         optOut -> preferences.storeAutoLinkPreferences(preferences.getAutoLinkPreferences()
                                                                                   .withAskAutoNamingPdfs(!optOut)));
                 if (!confirmed) {

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -120,7 +120,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                 if (duplicateFound) {
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
                             Localization.lang("There are possible duplicates that haven't been resolved. Continue?"),
-                            Localization.lang("Auto merge"),
+                            Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),
                             Localization.lang("Do not ask again"),
                             optOut -> preferences.setShouldWarnAboutDuplicatesForImport(!optOut));

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -119,10 +119,10 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
                     boolean continueImport = dialogService.showConfirmationDialogWithOptOutAndWait(Localization.lang("Duplicates found"),
-                            Localization.lang("There are possible duplicates (marked with an icon) that haven't been resolved. Continue?"),
-                            Localization.lang("Continue with import"),
+                            Localization.lang("There are possible duplicates that haven't been resolved. Continue?"),
+                            Localization.lang("Auto merge"),
                             Localization.lang("Cancel import"),
-                            Localization.lang("Disable this confirmation dialog"),
+                            Localization.lang("Do not ask again"),
                             optOut -> preferences.setShouldWarnAboutDuplicatesForImport(!optOut));
 
                     if (!continueImport) {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -841,7 +841,7 @@ The\ search\ is\ case\ insensitive.=The search is case insensitive.
 
 The\ search\ is\ case\ sensitive.=The search is case sensitive.
 
-There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=There are possible duplicates (marked with an icon) that haven't been resolved. Continue?
+There\ are\ possible\ duplicates\ that\ haven't\ been\ resolved.\ Continue?=There are possible duplicates that haven't been resolved. Continue?
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ citation\ keys\ defined.=This operation requires all selected entries to have citation keys defined.
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -231,7 +231,7 @@ Descending=Descending
 
 Description=Description
 
-Disable\ this\ confirmation\ dialog=Disable this confirmation dialog
+Do\ not\ ask\ again=Do not ask again
 
 Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups=Display all entries belonging to one or more of the selected groups
 


### PR DESCRIPTION
### Summary
This pull request is to fix issue #6334 /  Finding duplicates
The previous message at duplicates found dialog was not so descriptive as it is marked at the issue #6334 

### Changes
Modify ImportEntriesViewModel to show a more explicit message when a duplicate is found.

### Demo
![Issue test](https://user-images.githubusercontent.com/32725639/102950254-7f2f1d80-4487-11eb-90c9-ee9c66f04695.png)


- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
