### PR TITLE
Improved detection of long DOI's within text. fixes #7256.

### DIFF
--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -45,7 +45,7 @@ public class DOI implements Identifier {
             + "10"                              // directory indicator
             + "(?:\\.[0-9]+)+"                  // registrant codes
             + "[/:]"                            // divider
-            + "(?:[^\\s]+)"                     // suffix alphanumeric without space
+            + "(?:[^\\s,;]+[^,;(\\.\\s)])"      // suffix alphanumeric without " "/","/";" and not ending on "."/","/";"
             + ")";                              // end group \1
 
     // Regex (Short DOI)

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -165,12 +165,24 @@ public class DOITest {
                 // findDoiInsideArbitraryText
                 Arguments.of("10.1006/jmbi.1998.2354",
                         DOI.findInText("other stuff 10.1006/jmbi.1998.2354 end").get().getDOI()),
+                Arguments.of("10.1007/s10549-018-4743-9",
+                        DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9. ").get().getDOI()),
+                Arguments.of("10.1007/s10549-018-4743-9",
+                        DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9, ").get().getDOI()),
+                Arguments.of("10.1007/s10549-018-4743-9",
+                        DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9;something else").get().getDOI()),
+                Arguments.of("10.1007/s10549-018-4743-9.1234",
+                        DOI.findInText("bla doi:10.1007/s10549-018-4743-9.1234 with . in doi").get().getDOI()),
+
 
                 // findShortDoiInsideArbitraryText
                 Arguments.of("10/12ab", DOI.findInText("other stuff doi:10/12ab end").get().getDOI()),
                 Arguments.of("10/12ab", DOI.findInText("other stuff /urn:doi:10/12ab end").get().getDOI()),
                 Arguments.of("10%12ab", DOI.findInText("other stuff doi:10%12ab end").get().getDOI()),
                 Arguments.of("10%12ab", DOI.findInText("other stuff /doi:10%12ab end").get().getDOI()),
+                Arguments.of("10%12ab", DOI.findInText("other stuff /doi:10%12ab, end").get().getDOI()),
+                Arguments.of("10%12ab", DOI.findInText("other stuff /doi:10%12ab. end").get().getDOI()),
+                Arguments.of("10%12ab", DOI.findInText("other stuff /doi:10%12ab; end").get().getDOI()),
                 Arguments.of("10/1234", DOI.findInText("10/B(C)/15 \n" +
                         " \n" +
                         "10:51 \n" +


### PR DESCRIPTION
Fixes #7256 

Extraction of long DOI's from within text no longer trips over DOI's placed at the end of sentences or before commata.
E.g. 

_"Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9.  bla blubb"_

is now processed successfully as _10.1007/s10549-018-4743-9_ without the trailing period.

- [ ] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
