### PR TITLE
Fix style of highlighted checkboxes while searching in preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Changed
 
 ### Fixed
+- We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Changed
 
 ### Fixed
+
 - We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)
 
 ### Removed

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -427,8 +427,11 @@
 }
 
 .check-box > .box > .mark {
-    -fx-background-color: -fx-control-inner-background;
     -fx-padding: 0.2em 0.2em 0.2em 0.2em;
+}
+
+.check-box:selected > .box > .mark {
+    -fx-background-color: -fx-control-inner-background;
     -fx-shape: "M6.61 11.89L3.5 8.78 2.44 9.84 6.61 14l8.95-8.95L14.5 4z";
     -fx-stroke-width: 5;
 }


### PR DESCRIPTION
<!--
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support auto-linking there.
-->
What:
- Fix style of checkboxes while searching in preferences

Why:
- The "unchecked" behaviour, while distinct from the "checked", is confusing since it still has a checkmark in it. This is a visual bug, the behaviour is still correct.

Fixes #7226 

<img width="1104" alt="Screenshot 2020-12-28 at 12 24 14" src="https://user-images.githubusercontent.com/17176053/103214862-9055af80-4909-11eb-8baf-f2bd3a389a42.png">

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
