### PR TITLE
Fix snapcraft upload

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,7 @@
 name: Snap
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - snapcraft

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -28,12 +28,12 @@ jobs:
         uses: actions/checkout@v2
       # The image relies on https://builds.jabref.org/master/JabRef-5.0-portable_linux.tar.gz^
       # See snap/snapcraft.yml for details
-      - name: Build snap (1) Run build
+      - name: Run snapcraft build
         uses: snapcore/action-build@v1
         id: snapcraft
         with:
           snapcraft-args: "--debug"
-      - name: Build snap (2) Upload snap
+      - name: Upload snap
         if: ${{ steps.checksecrets.outputs.secretspresent }}
         uses: snapcore/action-publish@v1
         with:


### PR DESCRIPTION
This PR tries to fix upload to snapcraft.

Before this PR:

```
Run snapcore/action-publish@v1
  with:
    store_login: ***
    snap: jabref_5.2.376_amd64.snap
    release: edge
Publishing snap "jabref_5.2.376_amd64.snap"...
/snap/bin/snapcraft login --with /tmp/login-data-37F4mR/login.txt
Unexpected error when obtaining your account information.
Login failed.
Error: The process '/snap/bin/snapcraft' failed with exit code 1
```

See https://github.com/JabRef/jabref/runs/1605853743

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
