### PR TITLE
Disable automatic build on PRs

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,11 +10,6 @@ on:
       - 'docs/**'
       - 'src/test/**'
       - 'README.md'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'src/test/**'
-      - 'README.md'
 
 env:
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}


### PR DESCRIPTION
We often run out-of-space on our server hosting the builds. We have tests running in any case. The builds itself are only for users.

Two options:

- automatically delete old builds ofter two weeks (or one month)
- manually trigger builds requried for testing by users

This PR implements the second one as we think that a) we developers know how to trigger a build b) we safe traffic (and thus engery)

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
