### PR TITLE
Switch to Eclipse OpenJ9 JDK v15

### DIFF
--- a/.github/workflows/check-outdated-dependencies.yml
+++ b/.github/workflows/check-outdated-dependencies.yml
@@ -11,10 +11,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - name: Look for outdated dependencies
         run: ./gradlew -q checkOutdatedDependencies
       - name: Report issues

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -56,16 +56,30 @@ jobs:
       - name: Run GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.7
-      - name: Set up JDK 15 for linux and mac
-        uses: actions/setup-java@v1
-        with:
-          java-version: 15
+      - uses: sdkman/sdkman-action@master
         if: matrix.os != 'windows-latest'
-      - name: Set up JDK 14 for windows
-        uses: actions/setup-java@v1
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        if: matrix.os != 'windows-latest'
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
+      - uses: sdkman/sdkman-action@master
         if: matrix.os == 'windows-latest'
+        id: sdkman14
+        with:
+          candidate: java
+          version: 14.0.2.j9-adpt
+      - uses: actions/setup-java@v1
+        if: matrix.os == 'windows-latest'
+        id: setup-java
+        with:
+          java-version: 14.0.2
+          jdkFile: ${{ steps.sdkman14.outputs.file }}
       - name: Restore gradle cache
         uses: actions/cache@master
         with:

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -15,10 +15,16 @@ jobs:
           ref: master
           persist-credentials: false
           fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle wrapper
         with:

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -33,10 +33,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+          id: setup-java
+          with:
+            java-version: 15.0.1
+            jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle chache
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,16 @@ jobs:
           access_token: ${{ github.token }}
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle cache
         with:
@@ -59,10 +65,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle chache
         with:
@@ -103,10 +115,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle chache
         with:
@@ -149,10 +167,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle chache
         with:
@@ -199,10 +223,16 @@ jobs:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.CODECOV_TOKEN }}
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: sdkman/sdkman-action@master
+        id: sdkman
         with:
-          java-version: 14
+          candidate: java
+          version: 15.0.1.j9-adpt
+      - uses: actions/setup-java@v1
+        id: setup-java
+        with:
+          java-version: 15.0.1
+          jdkFile: ${{ steps.sdkman.outputs.file }}
       - uses: actions/cache@v1
         name: Restore gradle chache
         with:


### PR DESCRIPTION
[Eclipse OpenJ9](https://www.eclipse.org/openj9/) is a JVM developed by IBM since the 90s. It has superior performance compared to Oracle's JVM: https://www.eclipse.org/openj9/performance/

We should give it a try in  JabRef, too. This PR switchtes to OpenJ9 by using [SDKMAN!](https://sdkman.io/).

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
