### PR TITLE
Fix typo in conversion for small pi

### DIFF
--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -270,7 +270,7 @@ public class HTMLUnicodeConversionMaps {
             {"957", "nu", "$\\nu$"}, // greek small letter nu, U+03BD ISOgrk3
             {"958", "xi", "$\\xi$"}, // greek small letter xi, U+03BE ISOgrk3
             {"959", "omicron", "$\\omicron$"}, // greek small letter omicron, U+03BF NEW
-            {"960", "pi", "$\\phi$"}, // greek small letter pi, U+03C0 ISOgrk3
+            {"960", "pi", "$\\pi$"}, // greek small letter pi, U+03C0 ISOgrk3
             {"961", "rho", "$\\rho$"}, // greek small letter rho, U+03C1 ISOgrk3
             {"962", "sigmaf", "$\\varsigma$"}, // greek small letter final sigma,
             //                                   U+03C2 ISOgrk3


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #7291. There is a typo in the unicode <-> latex <-> HTML conversion.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] ~Change in CHANGELOG.md described (if applicable)~
- [x] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
    - [x] Enter "$\pi$ in Abstract field.
    - [x] Convert -> "Unicode to LaTeX" in context menu
- [x] ~Screenshots added in PR description (for UI changes)~
- [x] ~[Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.~
