### PR TITLE
Update the templates for opening a new issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Help
+    url: https://discourse.jabref.org/c/help/
+    about: Questions and requests for help are handled at https://discourse.jabref.org
+  - name: Feature requests
+    url: https://discourse.jabref.org/c/features/
+    about: If you are missing an important feature? Let us know!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,0 @@
----
-name: Feature request
-about: Suggest an idea for this project
-
----
-
-Please use the GitHub issue tracker only for bug reports and suggestions for improvements.
-Feature requests, questions and general feedback is now handled at http://discourse.jabref.org.
-Thanks!

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,0 @@
----
-name: Question
-about: Ask a question about JabRef
-
----
-
-Please use the GitHub issue tracker only for bug reports and suggestions for improvements.
-Feature requests, questions and general feedback is now handled at http://discourse.jabref.org.
-Thanks!


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Add links to the discourse forum. When you are attempting to open an issue to JabRef,

---

<img width="754" alt="Skärmavbild 2021-01-08 kl  13 19 06" src="https://user-images.githubusercontent.com/2598631/104050281-637c8480-51b4-11eb-91eb-1cdea39c6bc0.png">

---

 **this is what is shown right now**,

---

<img width="613" alt="Skärmavbild 2021-01-08 kl  13 04 34" src="https://user-images.githubusercontent.com/2598631/104049006-2dd69c00-51b2-11eb-87ac-8ccda2622ce5.png">

---

and with the current version of GitHub, **this is what I want to change it to**,

---

<img width="612" alt="Skärmavbild 2021-01-08 kl  13 04 09" src="https://user-images.githubusercontent.com/2598631/104048995-28795180-51b2-11eb-9f2a-c91f14b16df0.png">

---

Clicking the links will open https://discourse.jabref.org/c/help/ or https://discourse.jabref.org/c/features/ .
This relates to a recent issue since neither I nor the creator of the issue ticket appear to have noticed/known that it should have been in the discourse and not it in issue tracker (sorry :flushed:)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] ~Change in CHANGELOG.md described (if applicable)~
- [x] ~Tests created for changes (if applicable)~
- [x] ~Manually tested changed features in running JabRef (always required)~
- [x] Screenshots added in PR description (for UI changes)
- [ ] ~[Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.~
