### PR TITLE
Disable certain fetcher tests on CI

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
+@DisabledOnCIServer("CI server is blocked by Google")
 class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTest {
 
     private GoogleScholar finder;

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -41,7 +41,6 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
     }
 
     @Test
-    @DisabledOnCIServer("CI server is blocked by Google")
     void linkFound() throws IOException, FetcherException {
         entry.setField(StandardField.TITLE, "Towards Application Portability in Platform as a Service");
 
@@ -52,7 +51,6 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
     }
 
     @Test
-    @DisabledOnCIServer("CI server is blocked by Google")
     void noLinkFound() throws IOException, FetcherException {
         entry.setField(StandardField.TITLE, "Curriculum programme of career-oriented java specialty guided by principles of software engineering");
 
@@ -60,7 +58,6 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
     }
 
     @Test
-    @DisabledOnCIServer("CI server is blocked by Google")
     void findSingleEntry() throws FetcherException {
         entry.setType(StandardEntryType.InProceedings);
         entry.setCitationKey("geiger2013detecting");
@@ -76,7 +73,6 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
     }
 
     @Test
-    @DisabledOnCIServer("CI server is blocked by Google")
     void findManyEntries() throws FetcherException {
         List<BibEntry> foundEntries = finder.performSearch("random test string");
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
@@ -12,6 +12,7 @@ import org.jabref.logic.importer.SearchBasedFetcher;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.support.DisabledOnCIServer;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.Disabled;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 @FetcherTest
+@DisabledOnCIServer("CI server is blocked by JSTOR")
 public class JstorFetcherTest implements SearchBasedFetcherCapabilityTest {
 
     private final JstorFetcher fetcher = new JstorFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));


### PR DESCRIPTION
Disable GoogleScholar and JSTOR. (Refs #7229)

Other fetchers will be fixed later.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
