### PR TITLE
Fix harvard exporter by changing AuthorsFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the option "Move file to file directory" was disabled in the entry editor for all files [#7194](https://github.com/JabRef/jabref/issues/7194)
 - We fixed an issue where application dialogs were opening in the wrong display when using multiple screens [#7273](https://github.com/JabRef/jabref/pull/7273)
 - We fixed an issue where an exception would be displayed for previewing and preferences when a custom theme has been configured but is missing [#7177](https://github.com/JabRef/jabref/issues/7177)
+- We fixed an issue where the Harvard RTF exporter used the wrong default file extension. [4508](https://github.com/JabRef/jabref/issues/4508)
+- We fixed an issue where the Harvard RTF exporter did not use the new authors formatter and therefore did not export "organization" authors correctly. [4508](https://github.com/JabRef/jabref/issues/4508)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -44,7 +44,7 @@ public class ExporterFactory {
         exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, savePreferences));
-        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RDF, layoutPreferences, savePreferences));
+        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter("Endnote", "endnote", "EndNote", "endnote", StandardFileType.TXT, layoutPreferences, savePreferences));

--- a/src/main/resources/resource/layout/harvard/harvard.article.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.article.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And),RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And),RTFChars]{\author} (\year), 
 '\format[RTFChars]{\title}', }{\\i \format[RTFChars]{\journal}}{
 \begin{volume}
  }{\\b \volume}{

--- a/src/main/resources/resource/layout/harvard/harvard.article.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.article.layout
@@ -1,4 +1,4 @@
-\format[AuthorLastFirst,AuthorAbbreviator,RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And),RTFChars]{\author} (\year),
 '\format[RTFChars]{\title}', }{\\i \format[RTFChars]{\journal}}{
 \begin{volume}
  }{\\b \volume}{

--- a/src/main/resources/resource/layout/harvard/harvard.article.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.article.layout
@@ -1,4 +1,4 @@
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author} (\year), 
+\format[AuthorLastFirst,AuthorAbbreviator,RTFChars]{\author} (\year),
 '\format[RTFChars]{\title}', }{\\i \format[RTFChars]{\journal}}{
 \begin{volume}
  }{\\b \volume}{

--- a/src/main/resources/resource/layout/harvard/harvard.book.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.book.layout
@@ -3,7 +3,7 @@
 \end{author}
 \begin{editor}
 \format[FirstFirst,FullName,NoPunc,And,RTFChars]{\editor}, ed., \end{editor}
- (\year),
+ (\year), 
 }{\\i \format[RTFChars]{\title}}{
 \begin{volume}
 , Vol. \volume

--- a/src/main/resources/resource/layout/harvard/harvard.book.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.book.layout
@@ -1,8 +1,8 @@
 \begin{author}
-\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer,RTFChars]{\author}
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author}
 \end{author}
 \begin{editor}
-\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer,RTFChars]{\editor}, ed. \end{editor}
+\format[FirstFirst,FullName,NoPunc,And,RTFChars]{\editor}, ed., \end{editor}
  (\year),
 }{\\i \format[RTFChars]{\title}}{
 \begin{volume}

--- a/src/main/resources/resource/layout/harvard/harvard.book.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.book.layout
@@ -1,9 +1,9 @@
 \begin{author}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author}
+\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer,RTFChars]{\author}
 \end{author}
 \begin{editor}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor}, ed. \end{editor}
- (\year), 
+\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer,RTFChars]{\editor}, ed. \end{editor}
+ (\year),
 }{\\i \format[RTFChars]{\title}}{
 \begin{volume}
 , Vol. \volume

--- a/src/main/resources/resource/layout/harvard/harvard.inbook.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inbook.layout
@@ -1,9 +1,9 @@
 \begin{author}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author}
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author}
 \end{author}
 \begin{editor}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor}, ed., \end{editor}
- (\year), 
+\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
+ (\year),
 }{\\i \format[RTFChars]{\title}}{
 \begin{publisher}
 , \format[RTFChars]{\publisher}

--- a/src/main/resources/resource/layout/harvard/harvard.inbook.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inbook.layout
@@ -3,7 +3,7 @@
 \end{author}
 \begin{editor}
 \format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
- (\year),
+ (\year), 
 }{\\i \format[RTFChars]{\title}}{
 \begin{publisher}
 , \format[RTFChars]{\publisher}

--- a/src/main/resources/resource/layout/harvard/harvard.incollection.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.incollection.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year), 
 }{\format[RTFChars]{\title}}{
 \begin{editor}
 , }{\\i in }{\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}

--- a/src/main/resources/resource/layout/harvard/harvard.incollection.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.incollection.layout
@@ -1,7 +1,7 @@
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author} (\year), 
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
 }{\format[RTFChars]{\title}}{
 \begin{editor}
-, }{\\i in }{\format[RTFChars,AuthorFirstFirst,AuthorAndsReplacer]{\editor}, ed., \end{editor}
+, }{\\i in }{\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
 \begin{booktitle}
 '\format[RTFChars]{\booktitle}'
 \end{booktitle}

--- a/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} {\year}
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year)
 \format[RTFChars]{\title}
 , }{\\i in }{
 \begin{editor}

--- a/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author}
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} {\year}
 \format[RTFChars]{\title}
 , }{\\i in }{
 \begin{editor}

--- a/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
@@ -1,8 +1,8 @@
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author} (\year), 
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author}
 \format[RTFChars]{\title}
 , }{\\i in }{
 \begin{editor}
-\format[RTFChars,AuthorFirstFirst,AuthorAndsReplacer]{\editor}, ed., \end{editor}
+\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
 \begin{booktitle}
 '\format[RTFChars]{\booktitle}'
 \end{booktitle}

--- a/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.inproceedings.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year)
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year), 
 \format[RTFChars]{\title}
 , }{\\i in }{
 \begin{editor}

--- a/src/main/resources/resource/layout/harvard/harvard.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.layout
@@ -1,4 +1,4 @@
-\format[AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer,RTFChars]{\author} (\year), 
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
 '\format[RTFChars]{\title}'
 \begin{journal}
 , }{\\i \format[RTFChars]{\journal}} {\\b \volume}{
@@ -7,7 +7,7 @@
 (\number)
 \end{number}
 \begin{editor}
-, }{\\i in }{\format[AuthorFirstFirst,AuthorAndsReplacer,RTFChars]{\editor}, ed., \end{editor}
+, }{\\i in }{\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars)]{\editor}, ed., \end{editor}
 \begin{booktitle}
 '\format[RTFChars]{\booktitle}'
 \end{booktitle}

--- a/src/main/resources/resource/layout/harvard/harvard.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year), 
 '\format[RTFChars]{\title}'
 \begin{journal}
 , }{\\i \format[RTFChars]{\journal}} {\\b \volume}{

--- a/src/main/resources/resource/layout/harvard/harvard.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.layout
@@ -7,7 +7,7 @@
 (\number)
 \end{number}
 \begin{editor}
-, }{\\i in }{\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars)]{\editor}, ed., \end{editor}
+, }{\\i in }{\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
 \begin{booktitle}
 '\format[RTFChars]{\booktitle}'
 \end{booktitle}

--- a/src/main/resources/resource/layout/harvard/harvard.mastersthesis.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.mastersthesis.layout
@@ -1,4 +1,4 @@
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author} (\year), 
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
 '\format[RTFChars]{\title}'
 \begin{school}
 , Master's thesis, \format[RTFChars]{\school}

--- a/src/main/resources/resource/layout/harvard/harvard.mastersthesis.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.mastersthesis.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year), 
 '\format[RTFChars]{\title}'
 \begin{school}
 , Master's thesis, \format[RTFChars]{\school}

--- a/src/main/resources/resource/layout/harvard/harvard.phdthesis.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.phdthesis.layout
@@ -1,4 +1,4 @@
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author} (\year), 
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
 '\format[RTFChars]{\title}'
 \begin{school}
 , PhD thesis, \format[RTFChars]{\school}

--- a/src/main/resources/resource/layout/harvard/harvard.phdthesis.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.phdthesis.layout
@@ -1,4 +1,4 @@
-\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year),
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author} (\year), 
 '\format[RTFChars]{\title}'
 \begin{school}
 , PhD thesis, \format[RTFChars]{\school}

--- a/src/main/resources/resource/layout/harvard/harvard.proceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.proceedings.layout
@@ -3,7 +3,7 @@
 \end{author}
 \begin{editor}
 \format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
- (\year),
+ (\year), 
 }{\\i \format[RTFChars]{\title}}{
 \begin{volume}
 , Vol. \volume

--- a/src/main/resources/resource/layout/harvard/harvard.proceedings.layout
+++ b/src/main/resources/resource/layout/harvard/harvard.proceedings.layout
@@ -1,9 +1,9 @@
 \begin{author}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\author}
+\format[Authors(LastFirst,Initials,FullPunc,Comma,And,inf),RTFChars]{\author}
 \end{author}
 \begin{editor}
-\format[RTFChars,AuthorLastFirst,AuthorAbbreviator,AuthorAndsReplacer]{\editor}, ed., \end{editor}
- (\year), 
+\format[Authors(FirstFirst,FullName,NoPunc,And),RTFChars]{\editor}, ed., \end{editor}
+ (\year),
 }{\\i \format[RTFChars]{\title}}{
 \begin{volume}
 , Vol. \volume

--- a/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -185,9 +185,4 @@ class RTFCharsTest {
         assertEquals("\\'d6", formatter.format("\\\"O"));
         assertEquals("\\'dc", formatter.format("\\\"U"));
     }
-
-    @Test
-    void keepBraces() {
-        assertEquals("{Organization and JabRef}", formatter.format("{Organization and Jabef}"));
-    }
 }

--- a/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -185,4 +185,9 @@ class RTFCharsTest {
         assertEquals("\\'d6", formatter.format("\\\"O"));
         assertEquals("\\'dc", formatter.format("\\\"U"));
     }
+
+    @Test
+    void keepBraces() {
+        assertEquals("{Organization and JabRef}", formatter.format("{Organization and Jabef}"));
+    }
 }


### PR DESCRIPTION
The layout files were still using the old formatter chaining for authors and therefore were responsible for removing braces 
Also fix extension.

Fixes #4508 

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
