### PR TITLE
Trigger websearch using enter

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
@@ -5,6 +5,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
@@ -82,6 +83,13 @@ public class WebSearchPane extends SidePaneComponent {
         });
 
         viewModel.queryProperty().bind(query.textProperty());
+
+        // Allows to trigger search on pressing enter
+        query.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                viewModel.search();
+            }
+        });
 
         // Create button that triggers search
         Button search = new Button(Localization.lang("Search"));


### PR DESCRIPTION
Improves the UX of the web search by triggering it if the enter key is pressed while the search field is focused.
Refs a [user issue](https://discourse.jabref.org/t/web-search-doesnt-start-with-pressing-enter-key/2513/2).

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
