### PR TITLE
fix "the handling of illegal file path"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the Harvard RTF exporter did not use the new authors formatter and therefore did not export "organization" authors correctly. [4508](https://github.com/JabRef/jabref/issues/4508)
 - We fixed an issue where the field `urldate` was not exported to the corresponding fields `YearAccessed`, `MonthAccessed`, `DayAccessed` in MS Office XML [#7354](https://github.com/JabRef/jabref/issues/7354)
 - We fixed an issue where the password for a shared SQL database was only remembered if it was the same as the username [#6869](https://github.com/JabRef/jabref/issues/6869)
+- We fixed an issue where the handling of illegal file field. [#6859](https://github.com/JabRef/jabref/issues/6859)
 
 ### Removed
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
If the user open a library including an illegal file path, the application will crash in the original version. In this case, I add an exception handling to deal with this problem and prompt user "the file path is invalid". Fixs #6859

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.


**Testcase**

@InCollection{Favre2004,
  Title                    = {{AVS and AVS/Express}},
  Author                   = {Jean Favre and Mario Valle},
  Booktitle                = {{The Visualization Handbook}},
  Publisher                = {Academic Press},
  Year                     = {2004},
  Editor                   = {Chuck Hansen and Chris Johnson},
  Month                    = dec,
  Pages                    = {655--672},
  File                     = {Paper:file\:///D\:\\Books\\Publications\\ch33%20favre.pdf:PDF},
  Keywords                 = {books},
  Mvpubtype                = {books},
  Langid                   = {english},
  Url                      = {http://www.elsevierdirect.com/product.jsp?isbn=9780123875822}
}