### PR TITLE
Remove unuseful search syntax feedback

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPane.java
@@ -72,14 +72,6 @@ public class WebSearchPane extends SidePaneComponent {
         // Create text field for query input
         TextField query = SearchTextField.create();
         query.getStyleClass().add("searchBar");
-        query.textProperty().addListener((observable, oldValue, newValue) -> viewModel.validateQueryStringAndGiveColorFeedback(query, newValue));
-        query.focusedProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue) {
-                viewModel.validateQueryStringAndGiveColorFeedback(query, query.getText());
-            } else {
-                viewModel.setPseudoClassToValid(query);
-            }
-        });
 
         viewModel.queryProperty().bind(query.textProperty());
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2264,9 +2264,6 @@ Remove\ redundant\ spaces=Remove redundant spaces
 Replaces\ consecutive\ spaces\ with\ a\ single\ space\ in\ the\ field\ content.=Replaces consecutive spaces with a single space in the field content.
 Remove\ digits=Remove digits
 Removes\ digits.=Removes digits.
-The\ query\ cannot\ contain\ a\ year\ and\ year-range\ field.=The query cannot contain a year and year-range field.
-This\ query\ uses\ unsupported\ fields.=This query uses unsupported fields.
-This\ query\ uses\ unsupported\ syntax.=This query uses unsupported syntax.
 
 Presets=Presets
 


### PR DESCRIPTION
This PR removes unuseful feedback from the web search text field, as it is not necessary and provides no advantage.
With the introduction of transformers in #7350, the syntax feedback will be adapted  and provide adequate and useful feedback.

Fixes #7349, addresses #7277.

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
