### PR TITLE
Fixed invisible file path in the dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the Harvard RTF exporter did not use the new authors formatter and therefore did not export "organization" authors correctly. [4508](https://github.com/JabRef/jabref/issues/4508)
 - We fixed an issue where the field `urldate` was not exported to the corresponding fields `YearAccessed`, `MonthAccessed`, `DayAccessed` in MS Office XML [#7354](https://github.com/JabRef/jabref/issues/7354)
 - We fixed an issue where the password for a shared SQL database was only remembered if it was the same as the username [#6869](https://github.com/JabRef/jabref/issues/6869)
+- We fixed an issue where the file path is invisible in dark theme. [#7382](https://github.com/JabRef/jabref/issues/7382)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -642,6 +642,10 @@
     -fx-background-color: -jr-warn;
 }
 
+.file-row-text{
+    -fx-fill: -jr-search-text;
+}
+
 .combo-box-base {
     -fx-background-color: -fx-outer-border, -fx-control-inner-background;
     -fx-background-insets: 0, 1;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -141,8 +141,10 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         icon.setOnMouseClicked(event -> linkedFile.open());
         Text link = new Text();
         link.textProperty().bind(linkedFile.linkProperty());
+        link.getStyleClass().setAll("file-row-text");
         Text desc = new Text();
         desc.textProperty().bind(linkedFile.descriptionProperty());
+        desc.getStyleClass().setAll("file-row-text");
 
         ProgressBar progressIndicator = new ProgressBar();
         progressIndicator.progressProperty().bind(linkedFile.downloadProgressProperty());


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
In the original version, the file path is not visually good due to its font color. After a hard debuging process, I find that we don't bind the property of text with "css" and then the text color is black by default. Such that, I bind them and change the color the text and it looks wonderful now. Fixes #7382 
<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

**Light Theme**
![image](https://user-images.githubusercontent.com/57991879/106352720-56206900-6320-11eb-93e1-7aa94994cf51.png)

**Dark Theme**
![image](https://user-images.githubusercontent.com/57991879/106352743-8bc55200-6320-11eb-8455-074dd861be0e.png)