### PR TITLE
Fixes issue of Changing font size makes font size field too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the field `urldate` was not exported to the corresponding fields `YearAccessed`, `MonthAccessed`, `DayAccessed` in MS Office XML [#7354](https://github.com/JabRef/jabref/issues/7354)
 - We fixed an issue where the password for a shared SQL database was only remembered if it was the same as the username [#6869](https://github.com/JabRef/jabref/issues/6869)
 - We fixed an issue where the file path is invisible in dark theme. [#7382](https://github.com/JabRef/jabref/issues/7382)
-
+- We fixed an issue where changing the font size makes the font size field too small. [#7085](https://github.com/JabRef/jabref/issues/7085)
 ### Removed
 
 ## [5.2] – 2020-12-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the password for a shared SQL database was only remembered if it was the same as the username [#6869](https://github.com/JabRef/jabref/issues/6869)
 - We fixed an issue where the file path is invisible in dark theme. [#7382](https://github.com/JabRef/jabref/issues/7382)
 - We fixed an issue where changing the font size makes the font size field too small. [#7085](https://github.com/JabRef/jabref/issues/7085)
+
 ### Removed
 
 ## [5.2] – 2020-12-24

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -1225,6 +1225,6 @@ TextFlow * {
     -fx-fill: -fx-mid-text-color;
 }
 
-.prefSpinner{
+.fontsizeSpinner{
     -fx-pref-width: 5em;
 }

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -1224,3 +1224,7 @@ TextFlow * {
 .mainTable-header {
     -fx-fill: -fx-mid-text-color;
 }
+
+.prefSpinner{
+    -fx-pref-width: 5em;
+}

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
@@ -25,7 +25,7 @@
     <CheckBox fx:id="fontOverride" text="%Override default font settings"/>
     <HBox alignment="CENTER_LEFT" spacing="4.0">
         <Label text="%Size" disable="${!fontOverride.selected}"/>
-        <Spinner fx:id="fontSize" prefWidth="60.0" editable="true"/>
+        <Spinner fx:id="fontSize" styleClass="prefSpinner" editable="true"/>
         <padding>
             <Insets left="20.0"/>
         </padding>

--- a/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/AppearanceTab.fxml
@@ -25,7 +25,7 @@
     <CheckBox fx:id="fontOverride" text="%Override default font settings"/>
     <HBox alignment="CENTER_LEFT" spacing="4.0">
         <Label text="%Size" disable="${!fontOverride.selected}"/>
-        <Spinner fx:id="fontSize" styleClass="prefSpinner" editable="true"/>
+        <Spinner fx:id="fontSize" styleClass="fontsizeSpinner" editable="true"/>
         <padding>
             <Insets left="20.0"/>
         </padding>


### PR DESCRIPTION
# Description:
As the preferred width for the fontsize spinner under prefrences/appearence was set to a fixed pixel size, I changed it to use the `em` measure instead. A style class called `fontsizeSpinner` was added to `Base.css` with this change. 
Fixes #7085.


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

# Screenshots:
![Skærmbillede fra 2021-01-31 02-33-56](https://user-images.githubusercontent.com/25526684/106372153-19c72a00-636d-11eb-9c4f-e2e0441c55b9.png)
