### PR TITLE
Fixes the auto-update problem with TexGroups on Ubuntu Linux and makes the detection of file modifications more reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the file path is invisible in dark theme. [#7382](https://github.com/JabRef/jabref/issues/7382)
 - We fixed an issue where the secondary sorting is not working for some special fields. [#7015](https://github.com/JabRef/jabref/issues/7015)
 - We fixed an issue where changing the font size makes the font size field too small. [#7085](https://github.com/JabRef/jabref/issues/7085)
+- We fixed an issue with TexGroups on Linux systems, where the modification of an aux-file did not trigger an auto-update for TexGroups. Furthermore, the detection of file modifications is now more reliable. [#7412](https://github.com/JabRef/jabref/pull/7412)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -56,8 +56,8 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
                     if (kind == StandardWatchEventKinds.OVERFLOW) {
                         Thread.yield();
                         continue;
-                    } else if (kind == StandardWatchEventKinds.ENTRY_MODIFY) {
-                        // We only handle "ENTRY_MODIFY" here, so the context is always a Path
+                    } else if (kind == StandardWatchEventKinds.ENTRY_CREATE || kind == StandardWatchEventKinds.ENTRY_MODIFY) {
+                        // We only handle "ENTRY_CREATE" and "ENTRY_MODIFY" here, so the context is always a Path
                         @SuppressWarnings("unchecked")
                         WatchEvent<Path> ev = (WatchEvent<Path>) event;
                         Path path = ((Path) key.watchable()).resolve(ev.context());
@@ -88,7 +88,7 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
         if (isActive()) {
             // We can't watch files directly, so monitor their parent directory for updates
             Path directory = file.toAbsolutePath().getParent();
-            directory.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
+            directory.register(watcher, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
             listeners.put(file, listener);
         }
     }

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -1,10 +1,8 @@
 package org.jabref.logic.importer.util;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.auxparser.DefaultAuxParser;
@@ -29,7 +27,6 @@ import org.jabref.model.groups.TexGroup;
 import org.jabref.model.groups.WordKeywordGroup;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.strings.StringUtil;
-import org.jabref.model.util.FileHelper;
 import org.jabref.model.util.FileUpdateMonitor;
 
 import org.slf4j.LoggerFactory;
@@ -129,13 +126,6 @@ public class GroupsParser {
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
         try {
             Path path = Path.of(tok.nextToken());
-
-            String user = System.getProperty("user.name") + '-' + InetAddress.getLocalHost().getHostName();
-            List<Path> fileDirectoriesAsPaths = metaData.getLatexFileDirectory(user)
-                    .map(List::of)
-                    .orElse(Collections.emptyList());
-            path = FileHelper.find(path.toString(), fileDirectoriesAsPaths).orElse(path);
-
             try {
                 TexGroup newGroup = TexGroup.create(name, context, path, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData);
                 addGroupDetails(tok, newGroup);

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -1,8 +1,10 @@
 package org.jabref.logic.importer.util;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.auxparser.DefaultAuxParser;
@@ -27,6 +29,7 @@ import org.jabref.model.groups.TexGroup;
 import org.jabref.model.groups.WordKeywordGroup;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.strings.StringUtil;
+import org.jabref.model.util.FileHelper;
 import org.jabref.model.util.FileUpdateMonitor;
 
 import org.slf4j.LoggerFactory;
@@ -126,6 +129,13 @@ public class GroupsParser {
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
         try {
             Path path = Path.of(tok.nextToken());
+
+            String user = System.getProperty("user.name") + '-' + InetAddress.getLocalHost().getHostName();
+            List<Path> fileDirectoriesAsPaths = metaData.getLatexFileDirectory(user)
+                    .map(List::of)
+                    .orElse(Collections.emptyList());
+            path = FileHelper.find(path.toString(), fileDirectoriesAsPaths).orElse(path);
+
             try {
                 TexGroup newGroup = TexGroup.create(name, context, path, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData);
                 addGroupDetails(tok, newGroup);

--- a/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -47,7 +47,14 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     public static TexGroup create(String name, GroupHierarchyType context, Path filePath, AuxParser auxParser, FileUpdateMonitor fileMonitor, MetaData metaData) throws IOException {
         TexGroup group = new TexGroup(name, context, filePath, auxParser, fileMonitor, metaData);
-        fileMonitor.addListenerForFile(filePath, group);
+
+        String user = System.getProperty("user.name") + '-' + InetAddress.getLocalHost().getHostName();
+        List<Path> fileDirectoriesAsPaths = metaData.getLatexFileDirectory(user)
+                .map(List::of)
+                .orElse(Collections.emptyList());
+        Path expandedFilePath = FileHelper.find(filePath.toString(), fileDirectoriesAsPaths).orElse(filePath);
+
+        fileMonitor.addListenerForFile(expandedFilePath, group);
         return group;
     }
 

--- a/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -47,12 +47,16 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     public static TexGroup create(String name, GroupHierarchyType context, Path filePath, AuxParser auxParser, FileUpdateMonitor fileMonitor, MetaData metaData) throws IOException {
         TexGroup group = new TexGroup(name, context, filePath, auxParser, fileMonitor, metaData);
-        fileMonitor.addListenerForFile(filePath, group);
+        fileMonitor.addListenerForFile(group.getFilePathResolved(), group);
         return group;
     }
 
     public static TexGroup createWithoutFileMonitoring(String name, GroupHierarchyType context, Path filePath, AuxParser auxParser, FileUpdateMonitor fileMonitor, MetaData metaData) throws IOException {
         return new TexGroup(name, context, filePath, auxParser, fileMonitor, metaData);
+    }
+
+    public Path getFilePathResolved() {
+        return this.filePath;
     }
 
     @Override
@@ -134,7 +138,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     private List<Path> getFileDirectoriesAsPaths() {
         return metaData.getLatexFileDirectory(user)
-                .map(List::of)
-                .orElse(Collections.emptyList());
+                       .map(List::of)
+                       .orElse(Collections.emptyList());
     }
 }

--- a/src/main/java/org/jabref/model/groups/TexGroup.java
+++ b/src/main/java/org/jabref/model/groups/TexGroup.java
@@ -47,14 +47,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     public static TexGroup create(String name, GroupHierarchyType context, Path filePath, AuxParser auxParser, FileUpdateMonitor fileMonitor, MetaData metaData) throws IOException {
         TexGroup group = new TexGroup(name, context, filePath, auxParser, fileMonitor, metaData);
-
-        String user = System.getProperty("user.name") + '-' + InetAddress.getLocalHost().getHostName();
-        List<Path> fileDirectoriesAsPaths = metaData.getLatexFileDirectory(user)
-                .map(List::of)
-                .orElse(Collections.emptyList());
-        Path expandedFilePath = FileHelper.find(filePath.toString(), fileDirectoriesAsPaths).orElse(filePath);
-
-        fileMonitor.addListenerForFile(expandedFilePath, group);
+        fileMonitor.addListenerForFile(filePath, group);
         return group;
     }
 
@@ -141,7 +134,7 @@ public class TexGroup extends AbstractGroup implements FileUpdateListener {
 
     private List<Path> getFileDirectoriesAsPaths() {
         return metaData.getLatexFileDirectory(user)
-                       .map(List::of)
-                       .orElse(Collections.emptyList());
+                .map(List::of)
+                .orElse(Collections.emptyList());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/pull/7173#issuecomment-768998167 in #7173.

On Ubuntu Linux the auto-update functionality does not work with `TexGroup`s, when the associated `.aux` file gets updated externally.

<strike>This is a quick fix for this issue, which may still be improved. Only one of both files needs to be changed in order to fix it.</strike>

- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
