### PR TITLE
Added a strong border on hover to the file field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the file path is invisible in dark theme. [#7382](https://github.com/JabRef/jabref/issues/7382)
 - We fixed an issue where the secondary sorting is not working for some special fields. [#7015](https://github.com/JabRef/jabref/issues/7015)
 - We fixed an issue where changing the font size makes the font size field too small. [#7085](https://github.com/JabRef/jabref/issues/7085)
+- We fixed an issue where the buttons are invisible for file field. [#6859](https://github.com/JabRef/jabref/issues/6859)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -600,6 +600,15 @@
     -fx-stroke: -jr-gray-2;
 }
 
+.list-view {
+    -fx-border-color: -fx-outer-border;
+}
+
+.list-view:hover {
+    -fx-border-color: -jr-selected;
+    -fx-border-width: 2;
+}
+
 .scroll-pane:focused,
 .split-pane:focused,
 .list-view:focused,


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Since we do not set the border property for file field, the button are invisible in some cases. Such that, I add the border property in the css file. Now, the file field is invisible. Fixes #6859 

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in CHANGELOG.md described (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

![image](https://user-images.githubusercontent.com/57991879/106567722-3e89f000-656d-11eb-9226-0705b6343e44.png)
![image](https://user-images.githubusercontent.com/57991879/106567751-48135800-656d-11eb-8d27-876cb126c2bd.png)


