### PR TITLE
add selection copy to preview window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added some symbols and keybindings to the context menu in the entry editor. [#7268](https://github.com/JabRef/jabref/pull/7268)
 - We added keybindings for setting and clearing the read status. [#7264](https://github.com/JabRef/jabref/issues/7264)
 - We added two new fields to track the creation and most recent modification date and time for each entry. [koppor#130](https://github.com/koppor/jabref/issues/130)
+- We added a feature that allows the user to copy highlighted text in the preview window. [#6962](https://github.com/JabRef/jabref/issues/6962)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -145,6 +145,8 @@ public class PreviewPanel extends VBox {
         MenuItem copyPreview = new MenuItem(Localization.lang("Copy preview"), IconTheme.JabRefIcons.COPY.getGraphicNode());
         keyBindingRepository.getKeyCombination(KeyBinding.COPY_PREVIEW).ifPresent(copyPreview::setAccelerator);
         copyPreview.setOnAction(event -> previewView.copyPreviewToClipBoard());
+        MenuItem copySelection = new MenuItem(Localization.lang("Copy selection"));
+        copySelection.setOnAction(event -> previewView.copySelectionToClipBoard());
         MenuItem printEntryPreview = new MenuItem(Localization.lang("Print entry preview"), IconTheme.JabRefIcons.PRINTED.getGraphicNode());
         printEntryPreview.setOnAction(event -> previewView.print());
         MenuItem previousPreviewLayout = new MenuItem(Localization.lang("Previous preview layout"));
@@ -156,6 +158,7 @@ public class PreviewPanel extends VBox {
 
         ContextMenu menu = new ContextMenu();
         menu.getItems().add(copyPreview);
+        menu.getItems().add(copySelection);
         menu.getItems().add(printEntryPreview);
         menu.getItems().add(new SeparatorMenuItem());
         menu.getItems().add(nextPreviewLayout);

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -224,6 +224,13 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
         clipBoardManager.setContent(content);
     }
 
+    public void copySelectionToClipBoard() {
+        ClipboardContent content = new ClipboardContent();
+        content.putString(getSelectionHtmlContent());
+
+        clipBoardManager.setContent(content);
+    }
+
     @Override
     public void invalidated(Observable observable) {
         update();

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -38,6 +38,26 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PreviewViewer.class);
 
+    // https://stackoverflow.com/questions/5669448/get-selected-texts-html-in-div/5670825#5670825
+    private static final String JS_GET_SELECTION_HTML_SCRIPT = "function getSelectionHtml() {" +
+                                                               "    var html = \"\";" +
+                                                               "    if (typeof window.getSelection != \"undefined\") {" +
+                                                               "        var sel = window.getSelection();" +
+                                                               "        if (sel.rangeCount) {" +
+                                                               "            var container = document.createElement(\"div\");" +
+                                                               "            for (var i = 0, len = sel.rangeCount; i < len; ++i) {" +
+                                                               "                container.appendChild(sel.getRangeAt(i).cloneContents());" +
+                                                               "            }" +
+                                                               "            html = container.innerHTML;" +
+                                                               "        }" +
+                                                               "    } else if (typeof document.selection != \"undefined\") {" +
+                                                               "        if (document.selection.type == \"Text\") {" +
+                                                               "            html = document.selection.createRange().htmlText;" +
+                                                               "        }" +
+                                                               "    }" +
+                                                               "    return html;" +
+                                                               "};" +
+                                                               "getSelectionHtml();";
     private static final String JS_HIGHLIGHT_FUNCTION =
             "<head>" +
                     "   <meta charset=\"UTF-8\">" +
@@ -226,7 +246,8 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
 
     public void copySelectionToClipBoard() {
         ClipboardContent content = new ClipboardContent();
-        content.putString(getSelectionHtmlContent());
+        content.putString(getSelectionTextContent());
+        content.putHtml(getSelectionHtmlContent());
 
         clipBoardManager.setContent(content);
     }
@@ -236,7 +257,11 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
         update();
     }
 
-    public String getSelectionHtmlContent() {
+    public String getSelectionTextContent() {
         return (String) previewView.getEngine().executeScript("window.getSelection().toString()");
+    }
+
+    public String getSelectionHtmlContent() {
+        return (String) previewView.getEngine().executeScript(JS_GET_SELECTION_HTML_SCRIPT);
     }
 }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1325,6 +1325,7 @@ Synchronize\ files=Synchronize files
 Unabbreviate=Unabbreviate
 should\ contain\ a\ protocol=should contain a protocol
 Copy\ preview=Copy preview
+Copy\ selection=Copy selection
 Automatically\ setting\ file\ links=Automatically setting file links
 Regenerating\ citation\ keys\ according\ to\ metadata=Regenerating citation keys according to metadata
 Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Regenerate all keys for the entries in a BibTeX file


### PR DESCRIPTION
Fixes #6962 
Added a feature that allows users to copy highlighted text in the preview window

Screenshot:

![100c67ff4e73c1cb3ea8e4385da41cdd](https://user-images.githubusercontent.com/47194464/106947983-7179e280-672b-11eb-8a7c-4eef008ab992.png)


- [x] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
