### PR TITLE
Use env to determine python3 location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where groups generated from authors' last names did not include all entries of the authors' [#5833](https://github.com/JabRef/jabref/issues/5833)
 - The export to MS Office XML now uses the month name for the field `MonthAcessed` instead of the two digit number [#7354](https://github.com/JabRef/jabref/issues/7354)
 - We included some standalone dialogs from the options menu in the main preference dialog and fixed some visual issues in the preferences dialog. [#7384](https://github.com/JabRef/jabref/pull/7384)
+- We improved the linking of the `python3` interpreter via the shebang to dynamically use the systems default Python. Related to [JabRef-Browser-Extension #177](https://github.com/JabRef/JabRef-Browser-Extension/issues/177)
 
 ### Fixed
 

--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import logging

--- a/buildres/mac/jabrefHost.py
+++ b/buildres/mac/jabrefHost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import logging

--- a/buildres/mac/jabrefHost.py
+++ b/buildres/mac/jabrefHost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import json
 import logging


### PR DESCRIPTION
In general, it is recommended to use `#!/usr/bin/env python3` as the shebang instead of the hardcoded `!#/usr/bin/python3`.
See <https://stackoverflow.com/a/5709632> for more information.
Related to [JabRef-Browser-Extension #177](https://github.com/JabRef/JabRef-Browser-Extension/issues/177), especially [this comment](https://github.com/JabRef/JabRef-Browser-Extension/issues/177#issuecomment-640054939).

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
