### PR TITLE
Unmerge LO citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with TexGroups on Linux systems, where the modification of an aux-file did not trigger an auto-update for TexGroups. Furthermore, the detection of file modifications is now more reliable. [#7412](https://github.com/JabRef/jabref/pull/7412)
 - We fixed an issue where the Unicode to Latex formatter produced wrong results for characters with a codepoint higher than Character.MAX_VALUE. [#7387](https://github.com/JabRef/jabref/issues/7387)
 - We fixed an issue where a non valid value as font size results in an uncaught exception. [#7415](https://github.com/JabRef/jabref/issues/7415)
+- We fixed an issue where "Merge citations" in the Openoffice/Libreoffice integration panel did not have a corresponding opposite. [#7454](https://github.com/JabRef/jabref/issues/7454)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1304,8 +1304,8 @@ class OOBibBase {
                 int last = keys.size() - 1;
                 int i = 0;
                 for (String key : keys) {
-                    String bName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
-                    insertReferenceMark(bName, "tmp", textCursor, true, style);
+                    String newName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
+                    insertReferenceMark(newName, "tmp", textCursor, true, style);
                     textCursor.collapseToEnd();
                     if (i != last) {
                         textCursor.setString(" ");

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1278,13 +1278,13 @@ class OOBibBase {
             XTextRange range1 = UnoRuntime.queryInterface(XTextContent.class, nameAccess.getByName(names.get(pivot)))
                 .getAnchor();
 
-            XTextCursor mxDocCursor = range1.getText().createTextCursorByRange(range1);
+            XTextCursor textCursor = range1.getText().createTextCursorByRange(range1);
 
             // If we are supposed to set character format for citations, test this before
             // making any changes. This way we can throw an exception before any reference
             // marks are removed, preventing damage to the user's document:
             if (style.isFormatCitations()) {
-                XPropertySet xCursorProps = UnoRuntime.queryInterface(XPropertySet.class, mxDocCursor);
+                XPropertySet xCursorProps = UnoRuntime.queryInterface(XPropertySet.class, textCursor);
                 String charStyle = style.getCitationCharacterFormat();
                 try {
                     xCursorProps.setPropertyValue(CHAR_STYLE_NAME, charStyle);
@@ -1305,11 +1305,11 @@ class OOBibBase {
                 int i = 0;
                 for (String key : keys) {
                     String bName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
-                    insertReferenceMark(bName, "tmp", mxDocCursor, true, style);
-                    mxDocCursor.collapseToEnd();
+                    insertReferenceMark(bName, "tmp", textCursor, true, style);
+                    textCursor.collapseToEnd();
                     if (i != last) {
-                        mxDocCursor.setString(" ");
-                        mxDocCursor.collapseToEnd();
+                        textCursor.setString(" ");
+                        textCursor.collapseToEnd();
                     }
                     i++;
                 }

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1279,7 +1279,7 @@ class OOBibBase {
                 .getAnchor();
 
             XTextCursor mxDocCursor = range1.getText().createTextCursorByRange(range1);
-            //
+
             // If we are supposed to set character format for citations, test this before
             // making any changes. This way we can throw an exception before any reference
             // marks are removed, preventing damage to the user's document:
@@ -1299,7 +1299,7 @@ class OOBibBase {
             List<String> keys = parseRefMarkName(names.get(piv));
             if (keys.size() > 1) {
                 removeReferenceMark(names.get(piv));
-                //
+
                 // Insert bookmark for each key
                 int last = keys.size() - 1;
                 int i = 0;

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1258,6 +1258,7 @@ class OOBibBase {
             refreshCiteMarkers(databases, style);
         }
     }
+
     /**
      * Do the opposite of combineCiteMarkers.
      * Combined markers are split, with a space inserted between.
@@ -1274,47 +1275,47 @@ class OOBibBase {
 
         int piv = 0;
         boolean madeModifications = false;
-        while (piv < (names.size() )) {
+        while (piv < (names.size())) {
             XTextRange range1 = UnoRuntime.queryInterface(XTextContent.class, nameAccess.getByName(names.get(piv)))
-		.getAnchor();
+                .getAnchor();
 
             XTextCursor mxDocCursor = range1.getText().createTextCursorByRange(range1);
-	    //
-	    // If we are supposed to set character format for citations, test this before
-	    // making any changes. This way we can throw an exception before any reference
-	    // marks are removed, preventing damage to the user's document:
-	    if (style.isFormatCitations()) {
-		XPropertySet xCursorProps = UnoRuntime.queryInterface(XPropertySet.class, mxDocCursor);
-		String charStyle = style.getCitationCharacterFormat();
-		try {
-		    xCursorProps.setPropertyValue(CHAR_STYLE_NAME, charStyle);
-		} catch (UnknownPropertyException | PropertyVetoException | IllegalArgumentException |
-			 WrappedTargetException ex) {
-		    // Setting the character format failed, so we throw an exception that
-		    // will result in an error message for the user:
+            //
+            // If we are supposed to set character format for citations, test this before
+            // making any changes. This way we can throw an exception before any reference
+            // marks are removed, preventing damage to the user's document:
+            if (style.isFormatCitations()) {
+                XPropertySet xCursorProps = UnoRuntime.queryInterface(XPropertySet.class, mxDocCursor);
+                String charStyle = style.getCitationCharacterFormat();
+                try {
+                    xCursorProps.setPropertyValue(CHAR_STYLE_NAME, charStyle);
+                } catch (UnknownPropertyException | PropertyVetoException | IllegalArgumentException |
+                         WrappedTargetException ex) {
+                    // Setting the character format failed, so we throw an exception that
+                    // will result in an error message for the user:
                         throw new UndefinedCharacterFormatException(charStyle);
-		}
-	    }
+                }
+            }
 
-	    List<String> keys = parseRefMarkName(names.get(piv));
-	    if ( keys.size() > 1 ){
-		removeReferenceMark(names.get(piv));
-		//
-		// Insert bookmark for each key
-		int last = keys.size()-1;
-		int i = 0;
-		for (String key : keys) {
-		    String bName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
-		    insertReferenceMark(bName, "tmp", mxDocCursor, true, style);
-		    mxDocCursor.collapseToEnd();
-		    if ( i != last ){
-			mxDocCursor.setString(" ");
-			mxDocCursor.collapseToEnd();
-		    }
-		    i++;
-		}
-		madeModifications = true;
-	    }
+            List<String> keys = parseRefMarkName(names.get(piv));
+            if (keys.size() > 1) {
+                removeReferenceMark(names.get(piv));
+                //
+                // Insert bookmark for each key
+                int last = keys.size() - 1;
+                int i = 0;
+                for (String key : keys) {
+                    String bName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
+                    insertReferenceMark(bName, "tmp", mxDocCursor, true, style);
+                    mxDocCursor.collapseToEnd();
+                    if (i != last){
+                        mxDocCursor.setString(" ");
+                        mxDocCursor.collapseToEnd();
+                    }
+                    i++;
+                }
+                madeModifications = true;
+            }
             piv++;
         }
         if (madeModifications) {

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1308,7 +1308,7 @@ class OOBibBase {
                     String bName = getUniqueReferenceMarkName(key, OOBibBase.AUTHORYEAR_PAR);
                     insertReferenceMark(bName, "tmp", mxDocCursor, true, style);
                     mxDocCursor.collapseToEnd();
-                    if (i != last){
+                    if (i != last) {
                         mxDocCursor.setString(" ");
                         mxDocCursor.collapseToEnd();
                     }

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1268,7 +1268,6 @@ class OOBibBase {
             UndefinedCharacterFormatException, UnknownPropertyException, PropertyVetoException, CreationException,
             BibEntryNotFoundException {
         XNameAccess nameAccess = getReferenceMarks();
-        // TODO: doesn't work for citations in footnotes/tables
         List<String> names = getSortedReferenceMarks(nameAccess);
 
         final XTextRangeCompare compare = UnoRuntime.queryInterface(XTextRangeCompare.class, text);

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -1272,10 +1272,10 @@ class OOBibBase {
 
         final XTextRangeCompare compare = UnoRuntime.queryInterface(XTextRangeCompare.class, text);
 
-        int piv = 0;
+        int pivot = 0;
         boolean madeModifications = false;
-        while (piv < (names.size())) {
-            XTextRange range1 = UnoRuntime.queryInterface(XTextContent.class, nameAccess.getByName(names.get(piv)))
+        while (pivot < (names.size())) {
+            XTextRange range1 = UnoRuntime.queryInterface(XTextContent.class, nameAccess.getByName(names.get(pivot)))
                 .getAnchor();
 
             XTextCursor mxDocCursor = range1.getText().createTextCursorByRange(range1);
@@ -1296,9 +1296,9 @@ class OOBibBase {
                 }
             }
 
-            List<String> keys = parseRefMarkName(names.get(piv));
+            List<String> keys = parseRefMarkName(names.get(pivot));
             if (keys.size() > 1) {
-                removeReferenceMark(names.get(piv));
+                removeReferenceMark(names.get(pivot));
 
                 // Insert bookmark for each key
                 int last = keys.size() - 1;
@@ -1315,7 +1315,7 @@ class OOBibBase {
                 }
                 madeModifications = true;
             }
-            piv++;
+            pivot++;
         }
         if (madeModifications) {
             updateSortedReferenceMarks();

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -242,7 +242,7 @@ public class OpenOfficePanel {
         });
 
         unmerge.setMaxWidth(Double.MAX_VALUE);
-        unmerge.setTooltip(new Tooltip(Localization.lang("UnCombine merged citations")));
+        unmerge.setTooltip(new Tooltip(Localization.lang("Separate merged citations")));
         unmerge.setOnAction(e -> {
             try {
                 ooBase.unCombineCiteMarkers(getBaseList(), style);

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -83,7 +83,7 @@ public class OpenOfficePanel {
     private final Button pushEntriesAdvanced = new Button(Localization.lang("Cite special"));
     private final Button update;
     private final Button merge = new Button(Localization.lang("Merge citations"));
-    private final Button unmerge = new Button(Localization.lang("UnMerge citations"));
+    private final Button unmerge = new Button(Localization.lang("Separate citations"));
     private final Button manageCitations = new Button(Localization.lang("Manage citations"));
     private final Button exportCitations = new Button(Localization.lang("Export cited"));
     private final Button settingsB = new Button(Localization.lang("Settings"));

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -83,6 +83,7 @@ public class OpenOfficePanel {
     private final Button pushEntriesAdvanced = new Button(Localization.lang("Cite special"));
     private final Button update;
     private final Button merge = new Button(Localization.lang("Merge citations"));
+    private final Button unmerge = new Button(Localization.lang("UnMerge citations"));
     private final Button manageCitations = new Button(Localization.lang("Manage citations"));
     private final Button exportCitations = new Button(Localization.lang("Export cited"));
     private final Button settingsB = new Button(Localization.lang("Settings"));
@@ -239,6 +240,21 @@ public class OpenOfficePanel {
                 LOGGER.warn("Problem combining cite markers", ex);
             }
         });
+
+        unmerge.setMaxWidth(Double.MAX_VALUE);
+        unmerge.setTooltip(new Tooltip(Localization.lang("UnCombine merged citations")));
+        unmerge.setOnAction(e -> {
+            try {
+                ooBase.unCombineCiteMarkers(getBaseList(), style);
+            } catch (UndefinedCharacterFormatException ex) {
+                reportUndefinedCharacterFormat(ex);
+            } catch (com.sun.star.lang.IllegalArgumentException | UnknownPropertyException | PropertyVetoException |
+                     CreationException | NoSuchElementException | WrappedTargetException | IOException |
+                     BibEntryNotFoundException ex) {
+                LOGGER.warn("Problem uncombining cite markers", ex);
+            }
+        });
+
         ContextMenu settingsMenu = createSettingsPopup();
         settingsB.setMaxWidth(Double.MAX_VALUE);
         settingsB.setContextMenu(settingsMenu);
@@ -258,6 +274,7 @@ public class OpenOfficePanel {
         pushEntriesAdvanced.setDisable(true);
         update.setDisable(true);
         merge.setDisable(true);
+        unmerge.setDisable(true);
         manageCitations.setDisable(true);
         exportCitations.setDisable(true);
 
@@ -271,7 +288,7 @@ public class OpenOfficePanel {
         flow.setHgap(4);
         flow.setPrefWrapLength(200);
         flow.getChildren().addAll(setStyleFile, pushEntries, pushEntriesInt);
-        flow.getChildren().addAll(pushEntriesAdvanced, pushEntriesEmpty, merge);
+        flow.getChildren().addAll(pushEntriesAdvanced, pushEntriesEmpty, merge, unmerge);
         flow.getChildren().addAll(manageCitations, exportCitations, settingsB);
 
         vbox.setFillWidth(true);
@@ -422,6 +439,7 @@ public class OpenOfficePanel {
             pushEntriesAdvanced.setDisable(false);
             update.setDisable(false);
             merge.setDisable(false);
+            unmerge.setDisable(false);
             manageCitations.setDisable(false);
             exportCitations.setDisable(false);
         });

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2282,6 +2282,9 @@ No\ metadata\ found.\ Creating\ empty\ entry\ with\ file\ link=No metadata found
 Processing\ file\ %0=Processing file %0
 Export\ selected=Export selected
 
+UnCombine\ merged\ citations=UnCombine merged citations
+UnMerge\ citations=UnMerge citations
+
 Unprotect\ terms=Unprotect terms
 Error\ connecting\ to\ Writer\ document=Error connecting to Writer document
 You\ need\ to\ open\ Writer\ with\ a\ document\ before\ connecting=You need to open Writer with a document before connecting

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2282,7 +2282,7 @@ No\ metadata\ found.\ Creating\ empty\ entry\ with\ file\ link=No metadata found
 Processing\ file\ %0=Processing file %0
 Export\ selected=Export selected
 
-UnCombine\ merged\ citations=UnCombine merged citations
+Separate\ merged\ citations=Separate merged citations
 Separate\ citations=Separate citations
 
 Unprotect\ terms=Unprotect terms

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2283,7 +2283,7 @@ Processing\ file\ %0=Processing file %0
 Export\ selected=Export selected
 
 UnCombine\ merged\ citations=UnCombine merged citations
-UnMerge\ citations=UnMerge citations
+Separate\ citations=Separate citations
 
 Unprotect\ terms=Unprotect terms
 Error\ connecting\ to\ Writer\ document=Error connecting to Writer document


### PR DESCRIPTION
Implemented "Unmerge citations" in the Openoffice/Libreoffice
integration panel. 
Fixes #7454(https://github.com/JabRef/jabref/issues/7454)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
      No, tests were not created.  Do you have GUI tests?

      There is a known problem: "Merge citations" does not save the information needed
      to find the optional extra info (like page reference) stored in document properties.
      When reestablishing the individual references in unCombineCiteMarkers,
      getUniqueReferenceMarkName() may or may not return the original name.
      When it does not, the extra info may be lost, or even taken from another entry.

      A solution could be to encode the number making the originals unique
      in the merged name: in stead of  "JR_cite_1_XX2000a,YY2010" it would be e.g.
      "JR_cite_1_XX2000a,1_YY2010". Apart from construction and parsing,
       probably marking (or calulating) the originals as "in use" for getUniqueReferenceMarkName()
       would be needed.

       Another problem: combineCiteMarkers orders the merged entries by year  (I am not sure why).
       The original order is lost.

       In summary, the presented solution, although improves the situation, does not cover
       all aspects.

- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)

![jabref-Unmerge-citations](https://user-images.githubusercontent.com/15824666/108429997-fc390200-7240-11eb-9d4c-2766b8342997.png)

- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

https://docs.jabref.org/cite/openofficeintegration does not mention the "Merge citations" button.
The most appropriate addition would probably go under the "Known issues" section,
describing the two problems above (or the original, if the proposed changes are not applied)

