### PR TITLE
Sorted list of content selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Changed
 
+- The keywords added via "Manage content selectors" are now displayed in alphabetical order. [#3791](https://github.com/JabRef/jabref/issues/3791)
 - We improved the "Find unlinked files" dialog to show import results for each file. [#7209](https://github.com/JabRef/jabref/pull/7209)
 - The content of the field `timestamp` is migrated to `creationdate`. In case one configured "udpate timestampe", it is migrated to `modificationdate`. [koppor#130](https://github.com/koppor/jabref/issues/130)
 - The JabRef specific meta-data content in the main field such as priorities (prio1, prio2, ...) are migrated to their respective fields. They are removed from the keywords. [#6840](https://github.com/jabref/jabref/issues/6840)

--- a/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.contentselector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -153,8 +154,8 @@ class ContentSelectorDialogViewModel extends AbstractViewModel {
 
         List<String> existingKeywords = fieldKeywordsMap.getOrDefault(field, new ArrayList<>());
         existingKeywords.add(keywordToAdd);
+        existingKeywords.sort(Comparator.naturalOrder());
         fieldKeywordsMap.put(field, existingKeywords);
-        keywords.add(keywordToAdd);
         populateKeywords(field);
     }
 

--- a/src/test/java/org/jabref/gui/autocompleter/ContentSelectorSuggestionProviderTest.java
+++ b/src/test/java/org/jabref/gui/autocompleter/ContentSelectorSuggestionProviderTest.java
@@ -1,0 +1,129 @@
+package org.jabref.gui.autocompleter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.Test;
+
+import static org.jabref.gui.autocompleter.AutoCompleterUtil.getRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ContentSelectorSuggestionProviderTest {
+
+    private ContentSelectorSuggestionProvider autoCompleter;
+
+    @Test
+    void completeWithoutAddingAnythingReturnsNothing() {
+        SuggestionProvider<String> suggestionProvider = new EmptySuggestionProvider();
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.emptyList());
+
+        Collection<String> expected = Collections.emptyList();
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("test")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeKeywordReturnsKeyword() {
+        SuggestionProvider<String> suggestionProvider = new EmptySuggestionProvider();
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.singletonList("test"));
+
+        Collection<String> expected = Collections.singletonList("test");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("test")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeBeginningOfKeywordReturnsKeyword() {
+        SuggestionProvider<String> suggestionProvider = new EmptySuggestionProvider();
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.singletonList("test"));
+
+        Collection<String> expected = Collections.singletonList("test");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("te")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeKeywordReturnsKeywordFromDatabase() {
+        BibDatabase database = new BibDatabase();
+        BibEntry bibEntry = new BibEntry();
+        bibEntry.addKeyword("test", ',');
+        database.insertEntry(bibEntry);
+
+        SuggestionProvider<String> suggestionProvider = new WordSuggestionProvider(StandardField.KEYWORDS, database);
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.emptyList());
+
+        Collection<String> expected = Collections.singletonList("test");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("test")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeUppercaseBeginningOfNameReturnsName() {
+        SuggestionProvider<String> suggestionProvider = new EmptySuggestionProvider();
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.singletonList("test"));
+
+        Collection<String> expected = Collections.singletonList("test");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("TE")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeNullThrowsException() {
+        assertThrows(NullPointerException.class, () -> autoCompleter.provideSuggestions(getRequest((null))));
+    }
+
+    @Test
+    void completeEmptyStringReturnsNothing() {
+        SuggestionProvider<String> suggestionProvider = new EmptySuggestionProvider();
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.singletonList("test"));
+
+        Collection<String> expected = Collections.emptyList();
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeReturnsMultipleResults() {
+        BibDatabase database = new BibDatabase();
+        BibEntry bibEntry = new BibEntry();
+        bibEntry.addKeyword("testa", ',');
+        database.insertEntry(bibEntry);
+
+        SuggestionProvider<String> suggestionProvider = new WordSuggestionProvider(StandardField.KEYWORDS, database);
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Collections.singletonList("testb"));
+
+        Collection<String> expected = Arrays.asList("testa", "testb");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("test")));
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void completeReturnsKeywordsInAlphabeticalOrder() {
+        BibDatabase database = new BibDatabase();
+        BibEntry bibEntry = new BibEntry();
+        bibEntry.addKeyword("testd", ',');
+        bibEntry.addKeyword("testc", ',');
+        database.insertEntry(bibEntry);
+
+        SuggestionProvider<String> suggestionProvider = new WordSuggestionProvider(StandardField.KEYWORDS, database);
+        autoCompleter = new ContentSelectorSuggestionProvider(suggestionProvider, Arrays.asList("testb", "testa"));
+
+        Collection<String> expected = Arrays.asList("testa", "testb", "testc", "testd");
+        Collection<String> result = autoCompleter.provideSuggestions(getRequest(("test")));
+
+        assertEquals(expected, result);
+    }
+}

--- a/src/test/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModelTest.java
+++ b/src/test/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModelTest.java
@@ -19,14 +19,13 @@ import org.jabref.model.entry.field.UnknownField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ContentSelectorViewModelTest {
+public class ContentSelectorDialogViewModelTest {
     private ContentSelectorDialogViewModel viewModel;
     private final LibraryTab libraryTab = mock(LibraryTab.class);
     private final DialogService dialogService = mock(DialogService.class);

--- a/src/test/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModelTest.java
+++ b/src/test/java/org/jabref/gui/contentselector/ContentSelectorDialogViewModelTest.java
@@ -19,19 +19,18 @@ import org.jabref.model.entry.field.UnknownField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class ContentSelectorDialogViewModelTest {
-    private ContentSelectorDialogViewModel viewModel;
     private final LibraryTab libraryTab = mock(LibraryTab.class);
     private final DialogService dialogService = mock(DialogService.class);
-    private BibDatabaseContext bibDatabaseContext;
     private final List<StandardField> DEFAULT_FIELDS = Arrays.asList(
             StandardField.AUTHOR, StandardField.JOURNAL, StandardField.KEYWORDS, StandardField.PUBLISHER);
+    private ContentSelectorDialogViewModel viewModel;
+    private BibDatabaseContext bibDatabaseContext;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/jabref/gui/contentselector/ContentSelectorViewModelTest.java
+++ b/src/test/java/org/jabref/gui/contentselector/ContentSelectorViewModelTest.java
@@ -1,0 +1,168 @@
+package org.jabref.gui.contentselector;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.collections.FXCollections;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.LibraryTab;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ContentSelectorViewModelTest {
+    private ContentSelectorDialogViewModel viewModel;
+    private final LibraryTab libraryTab = mock(LibraryTab.class);
+    private final DialogService dialogService = mock(DialogService.class);
+    private BibDatabaseContext bibDatabaseContext;
+    private final List<StandardField> DEFAULT_FIELDS = Arrays.asList(
+            StandardField.AUTHOR, StandardField.JOURNAL, StandardField.KEYWORDS, StandardField.PUBLISHER);
+
+    @BeforeEach
+    void setUp() {
+        bibDatabaseContext = new BibDatabaseContext();
+        when(libraryTab.getBibDatabaseContext()).thenReturn(bibDatabaseContext);
+        viewModel = new ContentSelectorDialogViewModel(libraryTab, dialogService);
+    }
+
+    @Test
+    void initHasDefaultFieldNames() {
+        ListProperty<Field> expected = new SimpleListProperty<>(FXCollections.observableArrayList(DEFAULT_FIELDS));
+        ListProperty<Field> result = viewModel.getFieldNamesBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void addsNewKeyword() {
+        addKeyword(StandardField.KEYWORDS, "test");
+
+        ListProperty<String> expected = new SimpleListProperty<>(
+                FXCollections.observableArrayList("test"));
+        ListProperty<String> result = viewModel.getKeywordsBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void addsKeywordOnlyIfUnique() {
+        addKeyword(StandardField.KEYWORDS, "test");
+        addKeyword(StandardField.KEYWORDS, "test");
+
+        ListProperty<String> expected = new SimpleListProperty<>(
+                FXCollections.observableArrayList("test"));
+        ListProperty<String> result = viewModel.getKeywordsBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void removesKeyword() {
+        addKeyword(StandardField.KEYWORDS, "test");
+        removeKeyword(StandardField.KEYWORDS, "test");
+
+        ListProperty<String> expected = new SimpleListProperty<>(FXCollections.observableArrayList());
+        ListProperty<String> result = viewModel.getKeywordsBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void addsNewField() {
+        UnknownField testField = new UnknownField("Test");
+        addField(testField);
+
+        ListProperty<Field> fields = viewModel.getFieldNamesBackingList();
+        boolean fieldsContainTestValue = fields.stream().anyMatch(field -> field.getDisplayName().equals("Test"));
+
+        assertTrue(fieldsContainTestValue);
+    }
+
+    @Test
+    void removesField() {
+        UnknownField testField = new UnknownField("Test");
+        addField(testField);
+        removeField(testField);
+
+        ListProperty<Field> expected = new SimpleListProperty<>(FXCollections.observableArrayList(DEFAULT_FIELDS));
+        ListProperty<Field> result = viewModel.getFieldNamesBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void displaysKeywordsInAlphabeticalOrder() {
+        addKeyword(StandardField.KEYWORDS, "test1");
+        addKeyword(StandardField.KEYWORDS, "test2");
+
+        ListProperty<String> expected = new SimpleListProperty<>(
+                FXCollections.observableArrayList("test1", "test2"));
+        ListProperty<String> result = viewModel.getKeywordsBackingList();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void savingPersistsDataInDatabase() {
+        UnknownField testField = new UnknownField("Test");
+        addField(testField);
+        addKeyword(testField, "test1");
+        addKeyword(testField, "test2");
+        viewModel.saveChanges();
+
+        List<String> result = bibDatabaseContext.getMetaData()
+                                                .getContentSelectorValuesForField(testField);
+        List<String> expected = Arrays.asList("test1", "test2");
+
+        assertEquals(expected, result);
+    }
+
+    private void addKeyword(Field field, String keyword) {
+        when(dialogService.showInputDialogAndWait(
+                Localization.lang("Add new keyword"), Localization.lang("Keyword:")))
+                .thenReturn(Optional.of(keyword));
+
+        viewModel.showInputKeywordDialog(field);
+    }
+
+    private void removeKeyword(Field field, String keyword) {
+        when(dialogService.showConfirmationDialogAndWait(Localization.lang("Remove keyword"),
+                Localization.lang("Are you sure you want to remove keyword: \"%0\"?", keyword)))
+                .thenReturn(true);
+
+        viewModel.showRemoveKeywordConfirmationDialog(field, keyword);
+    }
+
+    private void addField(Field field) {
+        when(dialogService.showInputDialogAndWait(
+                Localization.lang("Add new field name"), Localization.lang("Field name:")))
+                .thenReturn(Optional.of(field.getDisplayName()));
+
+        viewModel.showInputFieldNameDialog();
+    }
+
+    private void removeField(Field field) {
+        when(dialogService.showConfirmationDialogAndWait(
+                Localization.lang("Remove field name"),
+                Localization.lang("Are you sure you want to remove field name: \"%0\"?", field.getDisplayName())))
+                .thenReturn(true);
+
+        viewModel.showRemoveFieldNameConfirmationDialog(field);
+    }
+}


### PR DESCRIPTION
List of keywords added in "Manage content selectors" is now always displayed in alphabetic order. Also added tests for ContentSelectorSuggestionProvider and ContentSelectorDialogViewModel classes which include asserting alphabetical order in suggestions affected by content selectors as well.
Fixes #3791.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

![mcs_sorted_image](https://user-images.githubusercontent.com/54515221/108607933-c53f2980-73c3-11eb-95a6-5cd1786dfc58.jpg)