### PR TITLE
PDF Downloader downloads HTML source code instead if no access 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the Unicode to Latex formatter produced wrong results for characters with a codepoint higher than Character.MAX_VALUE. [#7387](https://github.com/JabRef/jabref/issues/7387)
 - We fixed an issue where a non valid value as font size results in an uncaught exception. [#7415](https://github.com/JabRef/jabref/issues/7415)
 - We fixed an issue where drag and drop of bib files for opening resulted in uncaught exceptions [#7464](https://github.com/JabRef/jabref/issues/7464)
-- We fixed an issue in which a linked online file consisting of a web page was saved as an invalid pdf file upon being downloaded. [#7452](https://github.com/JabRef/jabref/issues/7452)
 - We fixed an issue in which a linked online file consisting of a web page was saved as an invalid pdf file upon being downloaded. The user is now notified when downloading a linked file results in an HTML file. [#7452](https://github.com/JabRef/jabref/issues/7452)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the Unicode to Latex formatter produced wrong results for characters with a codepoint higher than Character.MAX_VALUE. [#7387](https://github.com/JabRef/jabref/issues/7387)
 - We fixed an issue where a non valid value as font size results in an uncaught exception. [#7415](https://github.com/JabRef/jabref/issues/7415)
 - We fixed an issue where drag and drop of bib files for opening resulted in uncaught exceptions [#7464](https://github.com/JabRef/jabref/issues/7464)
+- We fixed an issue in which a linked online file consisting of a web page was saved as an invalid pdf file upon being downloaded. [#7452](https://github.com/JabRef/jabref/issues/7452)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a non valid value as font size results in an uncaught exception. [#7415](https://github.com/JabRef/jabref/issues/7415)
 - We fixed an issue where drag and drop of bib files for opening resulted in uncaught exceptions [#7464](https://github.com/JabRef/jabref/issues/7464)
 - We fixed an issue in which a linked online file consisting of a web page was saved as an invalid pdf file upon being downloaded. [#7452](https://github.com/JabRef/jabref/issues/7452)
+- We fixed an issue in which a linked online file consisting of a web page was saved as an invalid pdf file upon being downloaded. The user is now notified when downloading a linked file results in an HTML file. [#7452](https://github.com/JabRef/jabref/issues/7452)
 
 ### Removed
 

--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ dependencies {
     testImplementation "org.testfx:testfx-junit5:4.0.17-alpha-SNAPSHOT"
     testImplementation "org.hamcrest:hamcrest-library:2.2"
 
-    checkstyle 'com.puppycrawl.tools:checkstyle:8.40'
+    checkstyle 'com.puppycrawl.tools:checkstyle:8.41'
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '2.3.3'
 }
 

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jabref.gui.Globals;
 import org.jabref.logic.bibtex.FileFieldWriter;
 import org.jabref.model.entry.LinkedFile;
@@ -111,6 +112,8 @@ public class ExternalFileTypes {
      *         guaranteed to be returned.
      */
     public Optional<ExternalFileType> getExternalFileTypeByMimeType(String mimeType) {
+        // Ignores parameters according to link: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
+        mimeType=StringUtils.substringBefore(mimeType,";").trim();
         for (ExternalFileType type : externalFileTypes) {
             if (type.getMimeType().equalsIgnoreCase(mimeType)) {
                 return Optional.of(type);

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jabref.gui.Globals;
 import org.jabref.logic.bibtex.FileFieldWriter;
 import org.jabref.model.entry.LinkedFile;
@@ -113,8 +112,9 @@ public class ExternalFileTypes {
      */
     public Optional<ExternalFileType> getExternalFileTypeByMimeType(String mimeType) {
         // Ignores parameters according to link: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
-        if(mimeType.indexOf(';') != -1)
+        if (mimeType.indexOf(';') != -1) {
             mimeType = mimeType.substring(0, mimeType.indexOf(';')).trim();
+        }
         for (ExternalFileType type : externalFileTypes) {
             if (type.getMimeType().equalsIgnoreCase(mimeType)) {
                 return Optional.of(type);

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
@@ -113,7 +113,7 @@ public class ExternalFileTypes {
      */
     public Optional<ExternalFileType> getExternalFileTypeByMimeType(String mimeType) {
         // Ignores parameters according to link: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
-        mimeType=StringUtils.substringBefore(mimeType,";").trim();
+        mimeType = mimeType.substring(0, mimeType.indexOf(';')).trim();
         for (ExternalFileType type : externalFileTypes) {
             if (type.getMimeType().equalsIgnoreCase(mimeType)) {
                 return Optional.of(type);

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
@@ -113,7 +113,8 @@ public class ExternalFileTypes {
      */
     public Optional<ExternalFileType> getExternalFileTypeByMimeType(String mimeType) {
         // Ignores parameters according to link: (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
-        mimeType = mimeType.substring(0, mimeType.indexOf(';')).trim();
+        if(mimeType.indexOf(';') != -1)
+            mimeType = mimeType.substring(0, mimeType.indexOf(';')).trim();
         for (ExternalFileType type : externalFileTypes) {
             if (type.getMimeType().equalsIgnoreCase(mimeType)) {
                 return Optional.of(type);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -449,6 +449,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                 // Notify in bar when the file type is HTML.
                 if (newLinkedFile.getFileType().equals(StandardExternalFileType.URL.getName())) {
                     dialogService.notify(Localization.lang("Downloaded website as an HTML file."));
+                    LOGGER.debug("Downloaded website {} as an HTML file at {}", linkedFile.getLink(), destination);
                 }
             });
             downloadProgress.bind(downloadTask.workDonePercentageProperty());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -446,9 +446,9 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     linkedFiles.set(oldFileIndex, newLinkedFile);
                 }
                 entry.setFiles(linkedFiles);
-                // Notify in bar when the filetype is HTML.
+                // Notify in bar when the file type is HTML.
                 if (newLinkedFile.getFileType().equals(StandardExternalFileType.URL.getName())) {
-                    dialogService.notify("Downloaded a linked HTML file.");
+                    dialogService.notify(Localization.lang("Downloaded website as an HTML file."));
                 }
             });
             downloadProgress.bind(downloadTask.workDonePercentageProperty());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -446,6 +446,10 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     linkedFiles.set(oldFileIndex, newLinkedFile);
                 }
                 entry.setFiles(linkedFiles);
+                // Notify in bar when the filetype is HTML.
+                if (newLinkedFile.getFileType().equals(StandardExternalFileType.URL.getName())) {
+                    dialogService.notify("Downloaded a linked HTML file.");
+                }
             });
             downloadProgress.bind(downloadTask.workDonePercentageProperty());
             downloadTask.titleProperty().set(Localization.lang("Downloading"));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -252,6 +252,9 @@ Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata=Do not write the follo
 Donate\ to\ JabRef=Donate to JabRef
 
 Download\ file=Download file
+
+Downloaded\ website\ as\ an\ HTML\ file.=Downloaded website as an HTML file.
+
 duplicate\ removal=duplicate removal
 
 Duplicate\ string\ name=Duplicate string name

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -7,11 +7,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Pattern;
-import java.util.List;
 
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
@@ -280,4 +277,32 @@ class LinkedFileViewModelTest {
         String actual = test.get().toString();
         assertEquals("URL",actual);
     }
+
+    @Test
+    void downloadPdfFileWhenLinkedFilePointsToPdfUrl() throws MalformedURLException {
+        Globals.prefs = JabRefPreferences.getInstance();
+        linkedFile = new LinkedFile(new URL("http://arxiv.org/pdf/1207.0408v1"), "pdf");
+
+        //Needed Mockito stubbing methods to run test
+        when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
+        when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
+        when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
+
+        databaseContext.setDatabasePath(tempFile);
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, new CurrentThreadTaskExecutor(), dialogService, xmpPreferences, filePreferences, externalFileType);
+        viewModel.download();
+
+        //Loop through downloaded files to check for filetype='pdf'
+        List<LinkedFile> linkedFiles = entry.getFiles();
+        for(LinkedFile files : linkedFiles){
+            if(files.getLink().equalsIgnoreCase("Misc/asdf.pdf")){
+                assertEquals("pdf" , files.getFileType().toLowerCase());
+                return;
+            }
+        }
+        //Assert fail if no PDF type was found
+        fail();
+    }
+
 }

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -65,6 +65,7 @@ class LinkedFileViewModelTest {
     private final ExternalFileTypes externalFileType = mock(ExternalFileTypes.class);
     private final FilePreferences filePreferences = mock(FilePreferences.class);
     private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+    private final JabRefPreferences jabRefPreferences = mock(JabRefPreferences.class);
     private CookieManager cookieManager;
 
     @BeforeEach
@@ -185,7 +186,7 @@ class LinkedFileViewModelTest {
     // Structure taken from deleteWhenDialogCancelledReturnsFalseAndDoesNotRemoveFile method
     @Test
     void downloadHtmlFileCausesWarningDisplay() throws MalformedURLException {
-        Globals.prefs = JabRefPreferences.getInstance(); // required for task execution
+        Globals.prefs = jabRefPreferences.getInstance(); // required for task execution
 
         // From BibDatabaseContextTest::setUp
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
@@ -232,7 +233,7 @@ class LinkedFileViewModelTest {
         String fileType = StandardExternalFileType.URL.getName();
         linkedFile = new LinkedFile(new URL(url), fileType);
 
-        Globals.prefs = JabRefPreferences.getInstance();
+        Globals.prefs = jabRefPreferences.getInstance();
 
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
 
@@ -283,16 +284,16 @@ class LinkedFileViewModelTest {
     // Tests if added parameters to mimeType gets parsed to correct format.
     @Test
     void mimeTypeStringWithParameterIsReturnedAsWithoutParameter() {
-        Globals.prefs = JabRefPreferences.getInstance(); // required for task execution
-        ExternalFileTypes externalFileTypes = ExternalFileTypes.getInstance();
-        Optional<ExternalFileType> test = externalFileTypes.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
+        Globals.prefs = jabRefPreferences.getInstance(); // required for task execution
+        ExternalFileTypes externalFileTypesInstance = externalFileType.getInstance();
+        Optional<ExternalFileType> test = externalFileTypesInstance.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
         String actual = test.get().toString();
         assertEquals("URL", actual);
     }
 
     @Test
     void downloadPdfFileWhenLinkedFilePointsToPdfUrl() throws MalformedURLException {
-        Globals.prefs = JabRefPreferences.getInstance();
+        Globals.prefs = jabRefPreferences.getInstance();
         linkedFile = new LinkedFile(new URL("http://arxiv.org/pdf/1207.0408v1"), "pdf");
 
         // Needed Mockito stubbing methods to run test

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -7,7 +7,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import javafx.scene.control.Alert.AlertType;
@@ -27,20 +30,29 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.preferences.FilePreferences;
-
 import org.jabref.preferences.JabRefPreferences;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class LinkedFileViewModelTest {
 
@@ -183,7 +195,7 @@ class LinkedFileViewModelTest {
 
         databaseContext.setDatabasePath(tempFile);
 
-        URL url = new URL( "https://www.google.com/");
+        URL url = new URL("https://www.google.com/");
         String fileType = StandardExternalFileType.URL.getName();
         linkedFile = new LinkedFile(url, fileType);
 
@@ -214,7 +226,7 @@ class LinkedFileViewModelTest {
     }
 
     @Test
-    void downloadHtmlWhenLinkedFilePointsToHtml() throws MalformedURLException{
+    void downloadHtmlWhenLinkedFilePointsToHtml() throws MalformedURLException {
         // the link mentioned in issue #7452
         String url = "https://onlinelibrary.wiley.com/doi/abs/10.1002/0470862106.ia615";
         String fileType = StandardExternalFileType.URL.getName();
@@ -235,7 +247,7 @@ class LinkedFileViewModelTest {
 
         List<LinkedFile> linkedFiles = entry.getFiles();
 
-        for(LinkedFile file: linkedFiles) {
+        for (LinkedFile file: linkedFiles) {
             if (file.getLink().equalsIgnoreCase("Misc/asdf.html")) {
                 assertEquals("URL", file.getFileType());
                 return;
@@ -273,9 +285,9 @@ class LinkedFileViewModelTest {
     void mimeTypeStringWithParameterIsReturnedAsWithoutParameter() {
         Globals.prefs = JabRefPreferences.getInstance(); // required for task execution
         ExternalFileTypes externalFileTypes = ExternalFileTypes.getInstance();
-        Optional<ExternalFileType> test =  externalFileTypes.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
+        Optional<ExternalFileType> test = externalFileTypes.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
         String actual = test.get().toString();
-        assertEquals("URL",actual);
+        assertEquals("URL", actual);
     }
 
     @Test
@@ -283,7 +295,7 @@ class LinkedFileViewModelTest {
         Globals.prefs = JabRefPreferences.getInstance();
         linkedFile = new LinkedFile(new URL("http://arxiv.org/pdf/1207.0408v1"), "pdf");
 
-        //Needed Mockito stubbing methods to run test
+        // Needed Mockito stubbing methods to run test
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
@@ -293,15 +305,15 @@ class LinkedFileViewModelTest {
         LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, new CurrentThreadTaskExecutor(), dialogService, xmpPreferences, filePreferences, externalFileType);
         viewModel.download();
 
-        //Loop through downloaded files to check for filetype='pdf'
+        // Loop through downloaded files to check for filetype='pdf'
         List<LinkedFile> linkedFiles = entry.getFiles();
-        for(LinkedFile files : linkedFiles){
-            if(files.getLink().equalsIgnoreCase("Misc/asdf.pdf")){
-                assertEquals("pdf" , files.getFileType().toLowerCase());
+        for (LinkedFile files : linkedFiles) {
+            if (files.getLink().equalsIgnoreCase("Misc/asdf.pdf")) {
+                assertEquals("pdf", files.getFileType().toLowerCase());
                 return;
             }
         }
-        //Assert fail if no PDF type was found
+        // Assert fail if no PDF type was found
         fail();
     }
 

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -17,7 +17,6 @@ import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.externalfiletype.StandardExternalFileType;
@@ -30,7 +29,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.preferences.FilePreferences;
-import org.jabref.preferences.JabRefPreferences;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -65,7 +63,6 @@ class LinkedFileViewModelTest {
     private final ExternalFileTypes externalFileType = mock(ExternalFileTypes.class);
     private final FilePreferences filePreferences = mock(FilePreferences.class);
     private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
-    private final JabRefPreferences jabRefPreferences = mock(JabRefPreferences.class);
     private CookieManager cookieManager;
 
     @BeforeEach
@@ -186,11 +183,8 @@ class LinkedFileViewModelTest {
     // Structure taken from deleteWhenDialogCancelledReturnsFalseAndDoesNotRemoveFile method
     @Test
     void downloadHtmlFileCausesWarningDisplay() throws MalformedURLException {
-        Globals.prefs = jabRefPreferences.getInstance(); // required for task execution
-
         // From BibDatabaseContextTest::setUp
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
-
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]"); // used in other tests in this class
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]"); // used in movesFileWithFileDirPattern at MoveFilesCleanupTest.java
 
@@ -233,10 +227,7 @@ class LinkedFileViewModelTest {
         String fileType = StandardExternalFileType.URL.getName();
         linkedFile = new LinkedFile(new URL(url), fileType);
 
-        Globals.prefs = jabRefPreferences.getInstance();
-
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
-
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
 
@@ -284,18 +275,14 @@ class LinkedFileViewModelTest {
     // Tests if added parameters to mimeType gets parsed to correct format.
     @Test
     void mimeTypeStringWithParameterIsReturnedAsWithoutParameter() {
-        Globals.prefs = jabRefPreferences.getInstance(); // required for task execution
-        ExternalFileTypes externalFileTypesInstance = externalFileType.getInstance();
-        Optional<ExternalFileType> test = externalFileTypesInstance.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
+        Optional<ExternalFileType> test = externalFileType.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
         String actual = test.get().toString();
         assertEquals("URL", actual);
     }
 
     @Test
     void downloadPdfFileWhenLinkedFilePointsToPdfUrl() throws MalformedURLException {
-        Globals.prefs = jabRefPreferences.getInstance();
         linkedFile = new LinkedFile(new URL("http://arxiv.org/pdf/1207.0408v1"), "pdf");
-
         // Needed Mockito stubbing methods to run test
         when(filePreferences.shouldStoreFilesRelativeToBib()).thenReturn(true);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -56,6 +56,7 @@ class LinkedFileViewModelTest {
     private final ExternalFileTypes externalFileType = mock(ExternalFileTypes.class);
     private final FilePreferences filePreferences = mock(FilePreferences.class);
     private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+    private CookieManager cookieManager;
 
     @BeforeEach
     void setUp(@TempDir Path tempFolder) throws Exception {
@@ -73,14 +74,19 @@ class LinkedFileViewModelTest {
         tempFile = tempFolder.resolve("temporaryFile");
         Files.createFile(tempFile);
 
-        CookieManager cookieManager = new CookieManager();
-        CookieHandler.setDefault(cookieManager);
+        // Check if there exists a system wide cookie handler
+        if (CookieHandler.getDefault() == null) {
+            cookieManager = new CookieManager();
+            CookieHandler.setDefault(cookieManager);
+        } else {
+            cookieManager = (CookieManager) CookieHandler.getDefault();
+        }
         cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
     }
 
     @AfterEach
     void tearDown() {
-        CookieManager.setDefault(null);
+        cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_NONE);
     }
 
     @Test
@@ -211,7 +217,7 @@ class LinkedFileViewModelTest {
     }
 
     @Test
-    void downloadHtmlWhenLinkedFilePointsToHtml(@TempDir Path tempDir) throws MalformedURLException{
+    void downloadHtmlWhenLinkedFilePointsToHtml() throws MalformedURLException{
         // the link mentioned in issue #7452
         String url = "https://onlinelibrary.wiley.com/doi/abs/10.1002/0470862106.ia615";
         String fileType = StandardExternalFileType.URL.getName();

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -18,6 +18,7 @@ import javafx.scene.control.ButtonType;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
+import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.externalfiletype.StandardExternalFileType;
 import org.jabref.gui.util.BackgroundTask;
@@ -261,5 +262,16 @@ class LinkedFileViewModelTest {
 
         LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, xmpPreferences, filePreferences, externalFileType);
         assertTrue(viewModel.isGeneratedPathSameAsOriginal());
+    }
+
+
+    // Tests if added parameters to mimeType gets parsed to correct format.
+    @Test
+    void mimeTypeStringWithParameterIsReturnedAsWithoutParameter() {
+        Globals.prefs = JabRefPreferences.getInstance(); // required for task execution
+        ExternalFileTypes externalFileTypes = ExternalFileTypes.getInstance();
+        Optional<ExternalFileType> test =  externalFileTypes.getExternalFileTypeByMimeType("text/html; charset=UTF-8");
+        String actual = test.get().toString();
+        assertEquals("URL",actual);
     }
 }


### PR DESCRIPTION
Adds ignore parameter to `mimeType` and notify the user if the downloaded file is of HTML type, fixes #7452.
  
In the method `ExternalFileTypes::getExternalFileTypeByMimeType`, we added a feature to remove the parameters part
of the `mimeType`, this is allowed in mimeType-specification [link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types). The previous code didn't consider the parameter part of the mimeType, thus not conforming to the correct enum type in `StandardExternalFileType.java`.

We also added a feature to notify the user if the downloaded link is a HTML file, via the "status bar", because the user might think they have downloaded a PDF while this isn't the case.


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

### Screenshot 1: The downloaded file from the issue example is downloaded as a HTML file instead of a HTML-file disguised as a PDF-file.
![image](https://user-images.githubusercontent.com/78534231/109424586-6e011080-79e4-11eb-89e3-6eb25bb6e150.png)

#### Screenshot of importing the article in the issue
![Screenshot from 2021-03-03 14-57-15](https://user-images.githubusercontent.com/37085022/109816481-13102900-7c31-11eb-82da-3db82fcd434e.png)

#### Screenshot of notification/warning that the link is downloaded as an HTML file after the import is complete
![Screenshot from 2021-03-03 14-57-25](https://user-images.githubusercontent.com/37085022/109816546-291de980-7c31-11eb-8e97-f5981e84b3d9.png)

#### Screenshot showing that the file downloaded is now a local HTML file
![Screenshot from 2021-03-03 14-58-34](https://user-images.githubusercontent.com/37085022/109816678-494da880-7c31-11eb-95d1-05f744383372.png)