### PR TITLE
Fixed freeze for few seconds on DNS timeout in MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where application dialogs were opening in the wrong display when using multiple screens [#7273](https://github.com/JabRef/jabref/pull/7273)
 - We fixed an issue where the "Find unlinked files" dialog would freeze JabRef on importing. [#7205](https://github.com/JabRef/jabref/issues/7205)
 - We fixed an issue where the "Find unlinked files" would stop importing when importing a single file failed. [#7206](https://github.com/JabRef/jabref/issues/7206)
+- We fixed an issue where JabRef froze for a few seconds in MacOS when DNS resolution timed out. [#7441](https://github.com/JabRef/jabref/issues/7441)
 - We fixed an issue where an exception would be displayed for previewing and preferences when a custom theme has been configured but is missing [#7177](https://github.com/JabRef/jabref/issues/7177)
 - We fixed an issue where URLs in `file` fields could not be handled on Windows. [#7359](https://github.com/JabRef/jabref/issues/7359)
 - We fixed an issue where the regex based file search miss-interpreted specific symbols. [#4342](https://github.com/JabRef/jabref/issues/4342)

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -765,8 +765,9 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public String getUser() {
-        if (StringUtil.isNotBlank(userName))
+        if (StringUtil.isNotBlank(userName)) {
             return userName;
+        }
 
         try {
             userName = get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -349,7 +349,6 @@ public class JabRefPreferences implements PreferencesService {
     // User
     private static final String USER_ID = "userId";
     private static final String EXTERNAL_JOURNAL_LISTS = "externalJournalLists";
-    private String userName;
 
     // Telemetry collection
     private static final String COLLECT_TELEMETRY = "collectTelemetry";
@@ -408,6 +407,7 @@ public class JabRefPreferences implements PreferencesService {
     private SidePanePreferences sidePanePreferences;
     private Theme globalTheme;
     private Set<CustomImporter> customImporters;
+    private String userName;
 
     // The constructor is made private to enforce this as a singleton class:
     private JabRefPreferences() {
@@ -773,7 +773,8 @@ public class JabRefPreferences implements PreferencesService {
             userName = get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();
             return userName;
         } catch (UnknownHostException ex) {
-            LOGGER.error("Hostname not found.", ex);
+            LOGGER.error("Hostname not found. Please go to https://docs.jabref.org/ to find possible " +
+                    "problem resolution", ex);
             return get(DEFAULT_OWNER);
         }
     }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -349,6 +349,7 @@ public class JabRefPreferences implements PreferencesService {
     // User
     private static final String USER_ID = "userId";
     private static final String EXTERNAL_JOURNAL_LISTS = "externalJournalLists";
+    private final String USER_NAME;
 
     // Telemetry collection
     private static final String COLLECT_TELEMETRY = "collectTelemetry";
@@ -679,6 +680,7 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(FX_THEME, Theme.BASE_CSS);
 
         setLanguageDependentDefaultValues();
+        USER_NAME = getUserName();
     }
 
     /**
@@ -764,12 +766,7 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public String getUser() {
-        try {
-            return get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException ex) {
-            LOGGER.debug("Hostname not found.", ex);
-            return get(DEFAULT_OWNER);
-        }
+        return USER_NAME;
     }
 
     public void setLanguageDependentDefaultValues() {
@@ -787,6 +784,15 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(CUSTOM_TAB_NAME + "_def2", Localization.lang("Comments"));
 
         defaults.put(EMAIL_SUBJECT, Localization.lang("References"));
+    }
+
+    private String getUserName() {
+        try {
+            return get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException ex) {
+            LOGGER.debug("Hostname not found.", ex);
+            return get(DEFAULT_OWNER);
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -349,7 +349,7 @@ public class JabRefPreferences implements PreferencesService {
     // User
     private static final String USER_ID = "userId";
     private static final String EXTERNAL_JOURNAL_LISTS = "externalJournalLists";
-    private final String USER_NAME;
+    private String userName;
 
     // Telemetry collection
     private static final String COLLECT_TELEMETRY = "collectTelemetry";
@@ -680,7 +680,6 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(FX_THEME, Theme.BASE_CSS);
 
         setLanguageDependentDefaultValues();
-        USER_NAME = getUserName();
     }
 
     /**
@@ -766,7 +765,16 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public String getUser() {
-        return USER_NAME;
+        if (StringUtil.isNotBlank(userName))
+            return userName;
+
+        try {
+            userName = get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();
+            return userName;
+        } catch (UnknownHostException ex) {
+            LOGGER.error("Hostname not found.", ex);
+            return get(DEFAULT_OWNER);
+        }
     }
 
     public void setLanguageDependentDefaultValues() {
@@ -784,15 +792,6 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(CUSTOM_TAB_NAME + "_def2", Localization.lang("Comments"));
 
         defaults.put(EMAIL_SUBJECT, Localization.lang("References"));
-    }
-
-    private String getUserName() {
-        try {
-            return get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException ex) {
-            LOGGER.debug("Hostname not found.", ex);
-            return get(DEFAULT_OWNER);
-        }
     }
 
     /**


### PR DESCRIPTION
 #7441 Add user name caching, because on mac `InetAddress.getLocalHost().getHostName()` operation is slow. Problem described [here](https://stackoverflow.com/questions/33289695/inetaddress-getlocalhost-slow-to-run-30-seconds)