### PR TITLE
Improve user friendliness of automatically linked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The export to MS Office XML now uses the month name for the field `MonthAcessed` instead of the two digit number [#7354](https://github.com/JabRef/jabref/issues/7354)
 - We included some standalone dialogs from the options menu in the main preference dialog and fixed some visual issues in the preferences dialog. [#7384](https://github.com/JabRef/jabref/pull/7384)
 - We improved the linking of the `python3` interpreter via the shebang to dynamically use the systems default Python. Related to [JabRef-Browser-Extension #177](https://github.com/JabRef/JabRef-Browser-Extension/issues/177)
+- Automatically found pdf files now have "(Auto)" in front of their names and the linking button now uses the icon LINK_PLUS instead of BRIEFCASE_CHECK [#3607](https://github.com/JabRef/JabRef-Browser-Extension/issues/3607)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -20,7 +20,11 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.text.Text;
 
 import org.jabref.gui.DialogService;
@@ -150,9 +154,17 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         progressIndicator.progressProperty().bind(linkedFile.downloadProgressProperty());
         progressIndicator.visibleProperty().bind(linkedFile.downloadOngoingProperty());
 
+
+        Text auto = new Text();
+        auto.visibleProperty().bind(linkedFile.isAutomaticallyFoundProperty());
+        auto.managedProperty().bind(linkedFile.isAutomaticallyFoundProperty());
+        auto.setText("(Auto)");
+        auto.getStyleClass().setAll("file-row-text");
+
         HBox info = new HBox(8);
         info.setStyle("-fx-padding: 0.5em 0 0.5em 0;"); // To align with buttons below which also have 0.5em padding
-        info.getChildren().setAll(icon, link, desc, progressIndicator);
+        info.getChildren().setAll(icon, auto, link, desc, progressIndicator);
+
 
         Button acceptAutoLinkedFile = IconTheme.JabRefIcons.AUTO_LINKED_FILE.asButton();
         acceptAutoLinkedFile.setTooltip(new Tooltip(Localization.lang("This file was found automatically. Do you want to link it to this entry?")));
@@ -168,6 +180,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
         HBox container = new HBox(10);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);
+
 
         container.getChildren().addAll(info, acceptAutoLinkedFile, writeXMPMetadata);
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -150,7 +150,6 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         progressIndicator.progressProperty().bind(linkedFile.downloadProgressProperty());
         progressIndicator.visibleProperty().bind(linkedFile.downloadOngoingProperty());
 
-
         Text auto = new Text();
         auto.visibleProperty().bind(linkedFile.isAutomaticallyFoundProperty());
         auto.managedProperty().bind(linkedFile.isAutomaticallyFoundProperty());
@@ -160,7 +159,6 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         HBox info = new HBox(8);
         info.setStyle("-fx-padding: 0.5em 0 0.5em 0;"); // To align with buttons below which also have 0.5em padding
         info.getChildren().setAll(icon, auto, link, desc, progressIndicator);
-
 
         Button acceptAutoLinkedFile = IconTheme.JabRefIcons.AUTO_LINKED_FILE.asButton();
         acceptAutoLinkedFile.setTooltip(new Tooltip(Localization.lang("This file was found automatically. Do you want to link it to this entry?")));

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -20,11 +20,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.HBox;
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import javafx.scene.text.Text;
 
 import org.jabref.gui.DialogService;
@@ -180,7 +176,6 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
         HBox container = new HBox(10);
         container.setPrefHeight(Double.NEGATIVE_INFINITY);
-
 
         container.getChildren().addAll(info, acceptAutoLinkedFile, writeXMPMetadata);
 

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -230,7 +230,7 @@ public class IconTheme {
         RENAME(MaterialDesignR.RENAME_BOX),
         DELETE_FILE(MaterialDesignD.DELETE_FOREVER),
         REMOVE_LINK(MaterialDesignL.LINK_OFF),
-        AUTO_LINKED_FILE(MaterialDesignB.BRIEFCASE_CHECK),
+        AUTO_LINKED_FILE(MaterialDesignL.LINK_PLUS),
         QUALITY_ASSURED(MaterialDesignC.CERTIFICATE),
         QUALITY(MaterialDesignC.CERTIFICATE),
         OPEN(MaterialDesignF.FOLDER_OUTLINE),


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
We have implemented a new textfield for files that are automatically detected by JabRef and listed as files in the general tab of the entry editor. We also changed the icon for automatically linked files from a BRIEFCASE_CHECK to LINK_PLUS, since we found it more intuitive. This fixes #3607.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

We thought that creating an issue would be redundant if our changes weren't accepted, so we have not completed the documentation task. The [documentation](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#auto-linking-files) refers to the icon as a "suitcase", which would not be accurate, were these changes to be accepted. Instead it should be referred to as a link with a plus sign.

## Screenshots
### Before changes
#### File not linked
![Before changes, file not added](https://user-images.githubusercontent.com/64270456/109797452-cb31d780-7c19-11eb-9143-c0ab53921b53.png)
#### File linked
![Before changes, file added](https://user-images.githubusercontent.com/64270456/109797517-e0a70180-7c19-11eb-8c1e-bcdf35ceca05.png)

### After changes
#### File not linked
![After changes, file not added](https://user-images.githubusercontent.com/64270456/109797681-0f24dc80-7c1a-11eb-8197-2f3c91235bb6.png)
#### File linked
![After changes, file added](https://user-images.githubusercontent.com/64270456/109797708-18ae4480-7c1a-11eb-9fc7-ae7138b2cba7.png)