### PR TITLE
fix: fix content selector for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a non valid value as font size results in an uncaught exception. [#7415](https://github.com/JabRef/jabref/issues/7415)
 - We fixed an issue where "Merge citations" in the Openoffice/Libreoffice integration panel did not have a corresponding opposite. [#7454](https://github.com/JabRef/jabref/issues/7454)
 - We fixed an issue where drag and drop of bib files for opening resulted in uncaught exceptions [#7464](https://github.com/JabRef/jabref/issues/7464)
+- We fixed an issue where Content selector does not seem to work for custom fields. [#6819](https://github.com/JabRef/jabref/issues/6819)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogView.java
+++ b/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogView.java
@@ -18,7 +18,6 @@ import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;

--- a/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogView.java
+++ b/src/main/java/org/jabref/gui/contentselector/ContentSelectorDialogView.java
@@ -16,7 +16,9 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
+import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
@@ -68,6 +70,9 @@ public class ContentSelectorDialogView extends BaseDialog<Void> {
     private void initFieldNameComponents() {
         initListView(fieldsListView, viewModel::getFieldNamesBackingList);
         viewModel.selectedFieldProperty().bind(fieldsListView.getSelectionModel().selectedItemProperty());
+        new ViewModelListCellFactory<Field>()
+                .withText(Field::getDisplayName)
+                .install(fieldsListView);
         removeFieldNameButton.disableProperty().bind(viewModel.isNoFieldNameSelected());
         EasyBind.subscribe(viewModel.selectedFieldProperty(), viewModel::populateKeywords);
     }

--- a/src/main/java/org/jabref/model/entry/field/UnknownField.java
+++ b/src/main/java/org/jabref/model/entry/field/UnknownField.java
@@ -46,6 +46,8 @@ public class UnknownField implements Field {
 
     @Override
     public String toString() {
-        return name;
+        return "UnknownField{" +
+                "name='" + name + '\'' +
+                '}';
     }
 }

--- a/src/main/java/org/jabref/model/entry/field/UnknownField.java
+++ b/src/main/java/org/jabref/model/entry/field/UnknownField.java
@@ -46,8 +46,6 @@ public class UnknownField implements Field {
 
     @Override
     public String toString() {
-        return "UnknownField{" +
-                "name='" + name + '\'' +
-                '}';
+        return name;
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

We Fix the issue that Content selector does not seem to work for custom fields. This issue actually do not affect the correctness of running and just show a ugly output in the frontend. So I simply change the 'toString()' method in UnkownField class. This method do not make any effect to other functions but the user interface shown in the issue.

fixes #6819 

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

![image](https://user-images.githubusercontent.com/60515999/110461290-34c65000-810a-11eb-881f-aa399e740a93.png)
