### PR TITLE
Hotfix: Fix compilation error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,8 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
 
+    // SNAPSHOT is required because of plain-java support
+    // See https://github.com/michel-kraemer/citeproc-java/issues/92 for details
     implementation 'de.undercouch:citeproc-java:3.0.0-SNAPSHOT'
 
     implementation group: 'jakarta.activation', name: 'jakarta.activation-api', version: '1.2.1'

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -68,7 +68,7 @@ public class CSLAdapter {
         if ((cslInstance == null) || !Objects.equals(newStyle, style)) {
             // lang and forceLang are set to the default values of other CSL constructors
             cslInstance = new CSL(dataProvider, new JabRefLocaleProvider(),
-                    new DefaultAbbreviationProvider(), null, newStyle, "en-US");
+                    new DefaultAbbreviationProvider(), newStyle, "en-US");
             style = newStyle;
         }
 


### PR DESCRIPTION
The `SNAPSHOT` version of citeproc-java changed the constructor. Thus, JabRef did not compile when fetching the latest SNAPSHOT from maven central.

This PR fixes the constructor.

It also changed build.gradle to trigger a refetch of all dependencies in our CI.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
