### PR TITLE
Revert env path in snap python

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,7 @@ parts:
       snapcraftctl build
       snapcraftctl set-version "$(cat $SNAPCRAFT_PART_INSTALL/lib/app/.jpackage.xml | grep "app-version" | cut -d">" -f2 | cut -d"<" -f1)"
       sed -i 's|/opt/jabref/lib/jabrefHost.py|/snap/bin/jabref.browser-proxy|g' $SNAPCRAFT_PART_INSTALL/lib/native-messaging-host/*/org.jabref.jabref.json
+      sed -i 's/usr\/bin\/env python3/usr\/bin\/python3/g' $SNAPCRAFT_PART_INSTALL/lib/jabrefHost.py
       rm $SNAPCRAFT_PART_INSTALL/bin/JabRef
   jabref-launcher:
     after:


### PR DESCRIPTION
Fixes #7515 
The snap cannot correctly unpack the env declaration, since python is not contained in the snap but is in a base snap (core18)
This fix reverts only the version in the snap, so the other builds still work with the env variables.

The flatpak needs checking.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
