### PR TITLE
Extends dark theme to group custom-color-picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- Fixed an issue where dark theme did not extend to a group's custom color picker. The background was white now it is dark and matches dark theme. [#7481](https://github.com/JabRef/jabref/issues/7481)
 - We fixed an issue where choosing the fields on which autocompletion should not work in "Entry editor" preferences had no effect. [#7320](https://github.com/JabRef/jabref/issues/7320)
 - We fixed an issue where the "Normalize page numbers" formatter did not replace en-dashes or em-dashes with a hyphen-minus sign. [#7239](https://github.com/JabRef/jabref/issues/7239)
 - We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
-- Fixed an issue where dark theme did not extend to a group's custom color picker. The background was white now it is dark and matches dark theme. [#7481](https://github.com/JabRef/jabref/issues/7481)
+- We fixed an issue where the dark theme did not extend to a group's custom color picker. [#7481](https://github.com/JabRef/jabref/issues/7481)
 - We fixed an issue where choosing the fields on which autocompletion should not work in "Entry editor" preferences had no effect. [#7320](https://github.com/JabRef/jabref/issues/7320)
 - We fixed an issue where the "Normalize page numbers" formatter did not replace en-dashes or em-dashes with a hyphen-minus sign. [#7239](https://github.com/JabRef/jabref/issues/7239)
 - We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -62,6 +62,10 @@
     color: #7d8591; /* -fx-mid-text-color*/
 }
 
+.custom-color-dialog {
+    -fx-background-color: -fx-control-inner-background;
+}
+
 .table-view .groupColumnBackground {
     -fx-stroke: -jr-gray-3;
 }


### PR DESCRIPTION
fixes  #7481
Color fix

Dark.css update to extend to the custom color picker
Custom-color-picker background was white instead of dark

Custom-color-picker background is now dark and matches dark theme


- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

<img width="625" alt="Screen Shot 2021-03-12 at 1 49 24 PM" src="https://user-images.githubusercontent.com/56512349/110991076-c2d44d80-8339-11eb-80bb-9979d7b53387.png">