### PR TITLE
Double-click onto PDF in file list just open the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We simplified the select entry type form by splitting it into two parts ("Recommended" and "Others") based on internal usage data. [#6730](https://github.com/JabRef/jabref/issues/6730)
 
 ### Fixed
-- We fixed an issue where Double-click onto PDF in file list should just open the file. [#7465](https://github.com/JabRef/jabref/issues/7465)
+- We fixed an issue where Double-click onto PDF in file list open the file associated to an entry under the 'General' tab. [#7465](https://github.com/JabRef/jabref/issues/7465)
 - We fixed an issue where choosing the fields on which autocompletion should not work in "Entry editor" preferences had no effect. [#7320](https://github.com/JabRef/jabref/issues/7320)
 - We fixed an issue where the "Normalize page numbers" formatter did not replace en-dashes or em-dashes with a hyphen-minus sign. [#7239](https://github.com/JabRef/jabref/issues/7239)
 - We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We simplified the select entry type form by splitting it into two parts ("Recommended" and "Others") based on internal usage data. [#6730](https://github.com/JabRef/jabref/issues/6730)
 
 ### Fixed
-
+- We fixed an issue where Double-click onto PDF in file list should just open the file. [#7465](https://github.com/JabRef/jabref/issues/7465)
 - We fixed an issue where choosing the fields on which autocompletion should not work in "Entry editor" preferences had no effect. [#7320](https://github.com/JabRef/jabref/issues/7320)
 - We fixed an issue where the "Normalize page numbers" formatter did not replace en-dashes or em-dashes with a hyphen-minus sign. [#7239](https://github.com/JabRef/jabref/issues/7239)
 - We fixed an issue with the style of highlighted check boxes while searching in preferences. [#7226](https://github.com/JabRef/jabref/issues/7226)

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -234,7 +234,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
         if (event.getButton().equals(MouseButton.PRIMARY) && (event.getClickCount() == 2)) {
             // Double click -> edit
-            linkedFile.edit();
+            linkedFile.open();
         }
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -233,7 +233,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     private void handleItemMouseClick(LinkedFileViewModel linkedFile, MouseEvent event) {
 
         if (event.getButton().equals(MouseButton.PRIMARY) && (event.getClickCount() == 2)) {
-            // Double click -> edit
+            // Double click -> open
             linkedFile.open();
         }
     }


### PR DESCRIPTION
Fixes #7465

when a file associated to an entry under the 'General' tab is double-clicked, a prompt opens which asks for changing the file location, description or type.

In this fix,When a file is double-clicked, it just open the file.
User can now access that prompt through a new right-click > Edit option.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
