### PR TITLE
Group entries number background fix

### DIFF
--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -84,7 +84,7 @@
 }
 
 .numberColumn > .hits:any-selected {
-    -fx-background-color: derive(-jr-gray-3, 70%);
+    -fx-background-color: derive(-jr-gray-3, 25%);
 }
 
 .numberColumn > .hits:all-selected {


### PR DESCRIPTION
Fixes #5522 

Fix for the group colouration (indicating that the selected item was assigned to the coloured group).

<img width="929" alt="Screenshot 2021-03-16 at 7 03 31 PM" src="https://user-images.githubusercontent.com/62339705/111317688-613e1700-868a-11eb-954f-9bf961c94316.png">




- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
