### PR TITLE
Custom DOI base address fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
-- We fixed an issue where accessing DOI via Library Tab did not use custom DOI address. [#7337] (https://github.com/JabRef/jabref/issues/7337)
 - We fixed an issue preventing files from being dragged & dropped into an empty library. [#6851](https://github.com/JabRef/jabref/issues/6851)
 - We fixed an issue where double-click onto PDF in file list under the 'General' tab section should just open the file. [#7465](https://github.com/JabRef/jabref/issues/7465)
 - We fixed an issue where the dark theme did not extend to a group's custom color picker. [#7481](https://github.com/JabRef/jabref/issues/7481)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where accessing DOI via Library Tab did not use custom DOI address. [#7337] (https://github.com/JabRef/jabref/issues/7337)
 - We fixed an issue preventing files from being dragged & dropped into an empty library. [#6851](https://github.com/JabRef/jabref/issues/6851)
 - We fixed an issue where double-click onto PDF in file list under the 'General' tab section should just open the file. [#7465](https://github.com/JabRef/jabref/issues/7465)
 - We fixed an issue where the dark theme did not extend to a group's custom color picker. [#7481](https://github.com/JabRef/jabref/issues/7481)

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
@@ -36,7 +36,7 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
     private final TaskExecutor taskExecutor;
     private final DialogService dialogService;
     private final Field field;
-    private PreferencesService preferences;
+    private final PreferencesService preferences;
 
     public IdentifierEditorViewModel(Field field, SuggestionProvider<?> suggestionProvider, TaskExecutor taskExecutor, DialogService dialogService, FieldCheckers fieldCheckers, PreferencesService preferences) {
         super(field, suggestionProvider, fieldCheckers);
@@ -75,8 +75,8 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
 
     public void openExternalLink() {
         if (field.equals(StandardField.DOI) && preferences.getDOIPreferences().isUseCustom()) {
-            String baseURI = preferences.getDOIPreferences().getDefaultBaseURI();
-            openDOIWithCustomBase(baseURI);
+            identifier.get().map(identifier -> (DOI) identifier).map(DOI::getDOI)
+                      .ifPresent(s -> JabRefDesktop.openCustomDoi(s, preferences, dialogService));
         } else {
             openExternalLinkDefault();
         }
@@ -87,18 +87,6 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
                 url -> {
                     try {
                         JabRefDesktop.openBrowser(url);
-                    } catch (IOException ex) {
-                        dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), ex);
-                    }
-                }
-        );
-    }
-
-    public void openDOIWithCustomBase(String baseURI) {
-        identifier.get().map(identifier -> (DOI) identifier).flatMap(doi -> doi.getExternalURIWithCustomBase(baseURI)).ifPresent(
-                uri -> {
-                    try {
-                        JabRefDesktop.openBrowser(uri);
                     } catch (IOException ex) {
                         dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), ex);
                     }

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -103,7 +103,8 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         preferencesService,
                         externalFileTypes,
                         libraryTab.getUndoManager(),
-                        dialogService).createColumns());
+                        dialogService,
+                        stateManager).createColumns());
 
         new ViewModelTableRowFactory<BibEntryTableViewModel>()
                 .withOnMouseClickedEvent((entry, event) -> {

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -22,6 +22,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.maintable.columns.FieldColumn;
@@ -57,12 +58,14 @@ public class MainTableColumnFactory {
     private final CellFactory cellFactory;
     private final UndoManager undoManager;
     private final DialogService dialogService;
+    private final StateManager stateManager;
 
     public MainTableColumnFactory(BibDatabaseContext database,
                                   PreferencesService preferencesService,
                                   ExternalFileTypes externalFileTypes,
                                   UndoManager undoManager,
-                                  DialogService dialogService) {
+                                  DialogService dialogService,
+                                  StateManager stateManager) {
         this.database = Objects.requireNonNull(database);
         this.preferencesService = Objects.requireNonNull(preferencesService);
         this.columnPreferences = preferencesService.getColumnPreferences();
@@ -70,6 +73,7 @@ public class MainTableColumnFactory {
         this.dialogService = dialogService;
         this.cellFactory = new CellFactory(externalFileTypes, preferencesService, undoManager);
         this.undoManager = undoManager;
+        this.stateManager = stateManager;
     }
 
     public List<TableColumn<BibEntryTableViewModel, ?>> createColumns() {
@@ -207,7 +211,7 @@ public class MainTableColumnFactory {
      * Creates a clickable icons column for DOIs, URLs, URIs and EPrints.
      */
     private TableColumn<BibEntryTableViewModel, Map<Field, String>> createIdentifierColumn(MainTableColumnModel columnModel) {
-        return new LinkedIdentifierColumn(columnModel, cellFactory, database, dialogService);
+        return new LinkedIdentifierColumn(columnModel, cellFactory, database, dialogService, preferencesService, stateManager);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/maintable/OpenUrlAction.java
+++ b/src/main/java/org/jabref/gui/maintable/OpenUrlAction.java
@@ -11,19 +11,24 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.desktop.JabRefDesktop;
+import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
+import org.jabref.preferences.PreferencesService;
 
 public class OpenUrlAction extends SimpleCommand {
 
     private final DialogService dialogService;
     private final StateManager stateManager;
+    private final PreferencesService preferences;
 
-    public OpenUrlAction(DialogService dialogService, StateManager stateManager) {
+    public OpenUrlAction(DialogService dialogService, StateManager stateManager, PreferencesService preferences) {
         this.dialogService = dialogService;
         this.stateManager = stateManager;
+        this.preferences = preferences;
 
         BooleanExpression fieldIsSet = ActionHelper.isAnyFieldSetForSelectedEntry(
                 List.of(StandardField.URL, StandardField.DOI, StandardField.URI, StandardField.EPRINT),
@@ -62,11 +67,28 @@ public class OpenUrlAction extends SimpleCommand {
 
             if (link.isPresent()) {
                 try {
-                    JabRefDesktop.openExternalViewer(databaseContext, link.get(), field);
+                    if (field.equals(StandardField.DOI) && preferences.getDOIPreferences().isUseCustom()) {
+                        openCustomDOI(link.get());
+                    } else {
+                        JabRefDesktop.openExternalViewer(databaseContext, link.get(), field);
+                    }
                 } catch (IOException e) {
                     dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), e);
                 }
             }
         });
+    }
+
+    private void openCustomDOI(String link) {
+        IdentifierParser.parse(StandardField.DOI, link)
+                        .map(identifier -> (DOI) identifier)
+                        .flatMap(doi -> doi.getExternalURIWithCustomBase(preferences.getDOIPreferences().getDefaultBaseURI()))
+                        .ifPresent(uri -> {
+                            try {
+                                JabRefDesktop.openBrowser(uri);
+                            } catch (IOException e) {
+                                dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), e);
+                            }
+                        });
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/OpenUrlAction.java
+++ b/src/main/java/org/jabref/gui/maintable/OpenUrlAction.java
@@ -11,12 +11,10 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.desktop.JabRefDesktop;
-import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.entry.identifier.DOI;
 import org.jabref.preferences.PreferencesService;
 
 public class OpenUrlAction extends SimpleCommand {
@@ -68,7 +66,7 @@ public class OpenUrlAction extends SimpleCommand {
             if (link.isPresent()) {
                 try {
                     if (field.equals(StandardField.DOI) && preferences.getDOIPreferences().isUseCustom()) {
-                        openCustomDOI(link.get());
+                        JabRefDesktop.openCustomDoi(link.get(), preferences, dialogService);
                     } else {
                         JabRefDesktop.openExternalViewer(databaseContext, link.get(), field);
                     }
@@ -77,18 +75,5 @@ public class OpenUrlAction extends SimpleCommand {
                 }
             }
         });
-    }
-
-    private void openCustomDOI(String link) {
-        IdentifierParser.parse(StandardField.DOI, link)
-                        .map(identifier -> (DOI) identifier)
-                        .flatMap(doi -> doi.getExternalURIWithCustomBase(preferences.getDOIPreferences().getDefaultBaseURI()))
-                        .ifPresent(uri -> {
-                            try {
-                                JabRefDesktop.openBrowser(uri);
-                            } catch (IOException e) {
-                                dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), e);
-                            }
-                        });
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -69,7 +69,7 @@ public class RightClickMenu {
 
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_FOLDER, new OpenFolderAction(dialogService, stateManager, preferencesService)));
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_EXTERNAL_FILE, new OpenExternalFileAction(dialogService, stateManager, preferencesService)));
-        contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_URL, new OpenUrlAction(dialogService, stateManager)));
+        contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_URL, new OpenUrlAction(dialogService, stateManager, preferencesService)));
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.SEARCH_SHORTSCIENCE, new SearchShortScienceAction(dialogService, stateManager)));
 
         contextMenu.getItems().add(new SeparatorMenuItem());

--- a/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
@@ -10,6 +10,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.input.MouseButton;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.maintable.BibEntryTableViewModel;
@@ -17,11 +18,13 @@ import org.jabref.gui.maintable.CellFactory;
 import org.jabref.gui.maintable.ColumnPreferences;
 import org.jabref.gui.maintable.MainTableColumnFactory;
 import org.jabref.gui.maintable.MainTableColumnModel;
+import org.jabref.gui.maintable.OpenUrlAction;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.field.Field;
+import org.jabref.preferences.PreferencesService;
 
 /**
  * A clickable icons column for DOIs, URLs, URIs and EPrints.
@@ -31,15 +34,21 @@ public class LinkedIdentifierColumn extends MainTableColumn<Map<Field, String>> 
     private final BibDatabaseContext database;
     private final CellFactory cellFactory;
     private final DialogService dialogService;
+    private final PreferencesService preferences;
+    private final StateManager stateManager;
 
     public LinkedIdentifierColumn(MainTableColumnModel model,
                                   CellFactory cellFactory,
                                   BibDatabaseContext database,
-                                  DialogService dialogService) {
+                                  DialogService dialogService,
+                                  PreferencesService preferences,
+                                  StateManager stateManager) {
         super(model);
         this.database = database;
         this.cellFactory = cellFactory;
         this.dialogService = dialogService;
+        this.preferences = preferences;
+        this.stateManager = stateManager;
 
         Node headerGraphic = IconTheme.JabRefIcons.WWW.getGraphicNode();
         Tooltip.install(headerGraphic, new Tooltip(Localization.lang("Linked identifiers")));
@@ -55,12 +64,8 @@ public class LinkedIdentifierColumn extends MainTableColumn<Map<Field, String>> 
                 .withOnMouseClickedEvent((entry, linkedFiles) -> event -> {
                     if ((event.getButton() == MouseButton.PRIMARY) && (linkedFiles.size() == 1)) {
                         // Open linked identifier directly only if 1 entry is preset
-                        try {
-                            for (Field field : linkedFiles.keySet()) {
-                                JabRefDesktop.openExternalViewer(database, linkedFiles.get(field), field);
-                            }
-                        } catch (IOException e) {
-                            dialogService.showErrorDialogAndWait(Localization.lang("Unable to open link."), e);
+                        for (Field field : linkedFiles.keySet()) {
+                            new OpenUrlAction(dialogService, stateManager, preferences).execute();
                         }
                     }
                 })

--- a/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
@@ -62,11 +62,8 @@ public class LinkedIdentifierColumn extends MainTableColumn<Map<Field, String>> 
                 .withTooltip(this::createIdentifierTooltip)
                 .withMenu(this::createIdentifierMenu)
                 .withOnMouseClickedEvent((entry, linkedFiles) -> event -> {
-                    if ((event.getButton() == MouseButton.PRIMARY) && (linkedFiles.size() == 1)) {
-                        // Open linked identifier directly only if 1 entry is preset
-                        for (Field field : linkedFiles.keySet()) {
-                            new OpenUrlAction(dialogService, stateManager, preferences).execute();
-                        }
+                    if ((event.getButton() == MouseButton.PRIMARY)) {
+                        new OpenUrlAction(dialogService, stateManager, preferences).execute();
                     }
                 })
                 .install(this);


### PR DESCRIPTION
As mentioned in 
Fixes #7337 the option to choose custom DOI base address did not propagate to `LibraryTab` and this PR aims to solve exactly that. In the process I refactored `LinkedIdentifierColumn` so that it uses `OpenUrlAction` as well.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
