### PR TITLE
Multiple messages in the SnackBar

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -72,6 +72,7 @@ public class JabRefDialogService implements DialogService {
 
     private final Window mainWindow;
     private final JFXSnackbar statusLine;
+    private JFXSnackbarLayout currSnackbarLayout;
 
     public JabRefDialogService(Window mainWindow, Pane mainPane, PreferencesService preferences) {
         this.mainWindow = mainWindow;
@@ -336,7 +337,13 @@ public class JabRefDialogService implements DialogService {
     @Override
     public void notify(String message) {
         LOGGER.info(message);
-        statusLine.fireEvent(new SnackbarEvent(new JFXSnackbarLayout(message), TOAST_MESSAGE_DISPLAY_TIME, null));
+        SnackbarEvent currEvent = statusLine.getCurrentEvent();
+        if (currEvent == null) {
+            currSnackbarLayout = new JFXSnackbarLayout(message);
+            statusLine.fireEvent(new SnackbarEvent(currSnackbarLayout, TOAST_MESSAGE_DISPLAY_TIME));
+        } else if (currSnackbarLayout != null) {
+            currSnackbarLayout.setToast(message + "\n\n" + currSnackbarLayout.getToast());
+        }
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -68,7 +68,7 @@ public class CSLAdapter {
         if ((cslInstance == null) || !Objects.equals(newStyle, style)) {
             // lang and forceLang are set to the default values of other CSL constructors
             cslInstance = new CSL(dataProvider, new JabRefLocaleProvider(),
-                    new DefaultAbbreviationProvider(), null, newStyle, "en-US");
+                    new DefaultAbbreviationProvider(), newStyle, "en-US");
             style = newStyle;
         }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Previously, the SnackBar component could only display one message at a time, and messages that were created quickly were displayed in sequence and became obsolete because there was a more recent message waiting to be displayed.
The changes made allow for the SnackBar to display multiple messages in the same component, each in a different line.

![Image](https://user-images.githubusercontent.com/38781152/112718860-a74a7480-8eed-11eb-9a5d-b6289e1a9e5a.png)

Changes that are still to be made in this PR:
- [ ] Increase/Reset SnackBar timeout when a new message is added
- [x] Add a maximum limit for the number of messages displayed at the same time in the SnackBar
- [ ] Gradually remove old messages from the SnackBar as they timeout

Fixes #7340.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

---

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
