### PR TITLE
Add unit tests for org.jabref.gui classes

### DIFF
--- a/src/test/java/org/jabref/gui/autocompleter/AppendPersonNamesStrategyTest.java
+++ b/src/test/java/org/jabref/gui/autocompleter/AppendPersonNamesStrategyTest.java
@@ -1,0 +1,26 @@
+package org.jabref.gui.autocompleter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AppendPersonNamesStrategyTest {
+
+    @Test
+    void testWithoutParam() {
+        AppendPersonNamesStrategy strategy = new AppendPersonNamesStrategy();
+        assertEquals(" and ", strategy.getDelimiter());
+    }
+
+    @ParameterizedTest(name = "separationBySpace={0}, expectedResult={1}")
+    @CsvSource({
+            "TRUE, ' '",
+            "FALSE, ' and '",
+    })
+    void testWithParam(boolean separationBySpace, String expectedResult) {
+        AppendPersonNamesStrategy strategy = new AppendPersonNamesStrategy(separationBySpace);
+        assertEquals(expectedResult, strategy.getDelimiter());
+    }
+}

--- a/src/test/java/org/jabref/gui/autocompleter/PersonNameStringConverterTest.java
+++ b/src/test/java/org/jabref/gui/autocompleter/PersonNameStringConverterTest.java
@@ -1,0 +1,65 @@
+package org.jabref.gui.autocompleter;
+
+import org.jabref.model.entry.Author;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PersonNameStringConverterTest {
+
+    /** The author. **/
+    private Author author;
+
+    @BeforeEach
+    void setUp() {
+        // set up auhtor's name
+        author = new Author("Joseph M.", "J. M.", "", "Reagle", "Jr.");
+    }
+
+    @ParameterizedTest(name = "autoCompFF={0}, autoCompLF={1}, autoCompleteFirstNameMode={2}, expectedResult={3}")
+    @CsvSource({
+            "TRUE, TRUE, ONLY_FULL, 'Reagle, Jr., Joseph M.'",
+            "TRUE, FALSE, ONLY_FULL, 'Joseph M. Reagle, Jr.'",
+            "FALSE, TRUE, ONLY_FULL, 'Reagle, Jr., Joseph M.'",
+            "FALSE, FALSE, ONLY_FULL, 'Reagle'",
+
+            "TRUE, TRUE, ONLY_ABBREVIATED, 'Reagle, Jr., J. M.'",
+            "TRUE, FALSE, ONLY_ABBREVIATED, 'J. M. Reagle, Jr.'",
+            "FALSE, TRUE, ONLY_ABBREVIATED, 'Reagle, Jr., J. M.'",
+            "FALSE, FALSE, ONLY_ABBREVIATED, 'Reagle'",
+
+            "TRUE, TRUE, BOTH, 'Reagle, Jr., J. M.'",
+            "TRUE, FALSE, BOTH, 'J. M. Reagle, Jr.'",
+            "FALSE, TRUE, BOTH, 'Reagle, Jr., J. M.'",
+            "FALSE, FALSE, BOTH, 'Reagle'"
+    })
+    void testToStringWithoutAutoCompletePreferences(boolean autoCompFF, boolean autoCompLF, AutoCompleteFirstNameMode autoCompleteFirstNameMode, String expectedResult) {
+        PersonNameStringConverter converter = new PersonNameStringConverter(autoCompFF, autoCompLF, autoCompleteFirstNameMode);
+        String formattedStr = converter.toString(author);
+        assertEquals(expectedResult, formattedStr);
+    }
+
+    @ParameterizedTest(name = "shouldAutoComplete={0}, firstNameMode={1}, nameFormat={2}, expectedResult={3}")
+    @CsvSource({
+            "TRUE, ONLY_FULL, LAST_FIRST, 'Reagle, Jr., Joseph M.'",
+            "TRUE, ONLY_ABBREVIATED, LAST_FIRST, 'Reagle, Jr., J. M.'",
+            "TRUE, BOTH, LAST_FIRST, 'Reagle, Jr., J. M.'",
+
+            "TRUE, ONLY_FULL, FIRST_LAST, 'Joseph M. Reagle, Jr.'",
+            "TRUE, ONLY_ABBREVIATED, FIRST_LAST, 'J. M. Reagle, Jr.'",
+            "TRUE, BOTH, FIRST_LAST, 'J. M. Reagle, Jr.'",
+
+            "TRUE, ONLY_FULL, BOTH, 'Reagle, Jr., Joseph M.'",
+            "TRUE, ONLY_ABBREVIATED, BOTH, 'Reagle, Jr., J. M.'",
+            "TRUE, BOTH, BOTH, 'Reagle, Jr., J. M.'"
+    })
+    void testToStringWithAutoCompletePreferences(boolean shouldAutoComplete, AutoCompleteFirstNameMode firstNameMode, AutoCompletePreferences.NameFormat nameFormat, String expectedResult) {
+        AutoCompletePreferences preferences = new AutoCompletePreferences(shouldAutoComplete, firstNameMode, nameFormat, null, null);
+        PersonNameStringConverter converter = new PersonNameStringConverter(preferences);
+        String formattedStr = converter.toString(author);
+        assertEquals(expectedResult, formattedStr);
+    }
+}

--- a/src/test/java/org/jabref/gui/edit/ReplaceStringViewModelTest.java
+++ b/src/test/java/org/jabref/gui/edit/ReplaceStringViewModelTest.java
@@ -51,16 +51,20 @@ public class ReplaceStringViewModelTest {
 
     @ParameterizedTest(name = "findString={0}, replaceString={1}, fieldString={2}, selectOnly={3}, allFieldReplace={4}, expectedResult={5}")
     @CsvSource({
-            "RandomText, ReplaceText, author, TRUE, FALSE, 0", // does not replace when findString does not exist in the selected field
-            "Informatics, ReplaceText, journaltitle, TRUE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
-            "Informatics, ReplaceText, journaltitle, TRUE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
-            "Informatics, ReplaceText, journaltitle, FALSE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
-            "Informatics, ReplaceText, journaltitle, FALSE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
+            "randomText, replaceText, author, TRUE, FALSE, 0", // does not replace when findString does not exist in the selected field
+            "Informatics, replaceText, randomField, TRUE, FALSE, 0", // does not replace if the BibEntry does not have selected field
+
+            "Informatics, replaceText, journaltitle, TRUE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "replaceText" in the BibEntry
+            "Informatics, replaceText, journaltitle, TRUE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "replaceText" in the BibEntry
+            "Informatics, replaceText, journaltitle, FALSE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "replaceText" in the BibEntry
+            "Informatics, replaceText, journaltitle, FALSE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "replaceText" in the BibEntry
+
             "2020, 2021, date, TRUE, FALSE, 1", // only replace "2020" in the DATE field to "2021" in the BibEntry
             "2020, 2021, date, FALSE, TRUE, 2", // replace all the "2020"s in the entries
             "2020, 2021, date, FALSE, FALSE, 1", // only replace "2020" in the DATE field to "2021" in the BibEntry
             "2020, 2021, date, TRUE, TRUE, 2", // replace all the "2020"s in the entries
-            "System, ReplaceText, title, FALSE, TRUE, 1", // replace "System" in all entries is case sensitive
+
+            "System, replaceText, title, FALSE, TRUE, 1", // replace "System" in all entries is case sensitive
             "and, '', author, TRUE, FALSE, 2", // replace two "and"s with empty string in the same AUTHOR field
             "' ', ',', date, TRUE, FALSE, 1" // replace space with comma in DATE field
     })

--- a/src/test/java/org/jabref/gui/edit/ReplaceStringViewModelTest.java
+++ b/src/test/java/org/jabref/gui/edit/ReplaceStringViewModelTest.java
@@ -1,0 +1,75 @@
+package org.jabref.gui.edit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+
+import org.jabref.gui.LibraryTab;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReplaceStringViewModelTest {
+
+    private final LibraryTab libraryTab = mock(LibraryTab.class);
+    private ReplaceStringViewModel viewModel;
+
+    @BeforeEach
+    void setUp() {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
+                .withField(StandardField.DATE, "April 2020")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
+                .withField(StandardField.FILE, ":https\\://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912:PDF")
+                .withField(StandardField.ISSUE, "4")
+                .withField(StandardField.ISSN, "1941-0050")
+                .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
+                .withField(StandardField.PAGES, "2346--2356")
+                .withField(StandardField.PUBLISHER, "IEEE")
+                .withField(StandardField.TITLE, "Economic Operation and Quality Control in PV-BES-DG-Based Autonomous System")
+                .withField(StandardField.VOLUME, "16")
+                .withField(StandardField.KEYWORDS, "Batteries, Generators, Economics, Power quality, State of charge, Harmonic analysis, Control systems, Battery, diesel generator (DG), distributed generation, power quality, photovoltaic (PV), voltage source converter (VSC)");
+
+        List<BibEntry> entries = new ArrayList<>();
+        entries.add(entry);
+        when(libraryTab.getSelectedEntries()).thenReturn(entries);
+        when(libraryTab.getDatabase()).thenReturn(new BibDatabase(entries));
+        viewModel = new ReplaceStringViewModel(libraryTab);
+    }
+
+    @ParameterizedTest(name = "findString={0}, replaceString={1}, fieldString={2}, selectOnly={3}, allFieldReplace={4}, expectedResult={5}")
+    @CsvSource({
+            "RandomText, ReplaceText, author, TRUE, FALSE, 0", // does not replace when findString does not exist in the selected field
+            "Informatics, ReplaceText, journaltitle, TRUE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
+            "Informatics, ReplaceText, journaltitle, TRUE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
+            "Informatics, ReplaceText, journaltitle, FALSE, FALSE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
+            "Informatics, ReplaceText, journaltitle, FALSE, TRUE, 1", // replace "Informatics" in the JOURNALTITLE field to "ReplaceText" in the BibEntry
+            "2020, 2021, date, TRUE, FALSE, 1", // only replace "2020" in the DATE field to "2021" in the BibEntry
+            "2020, 2021, date, FALSE, TRUE, 2", // replace all the "2020"s in the entries
+            "2020, 2021, date, FALSE, FALSE, 1", // only replace "2020" in the DATE field to "2021" in the BibEntry
+            "2020, 2021, date, TRUE, TRUE, 2", // replace all the "2020"s in the entries
+            "System, ReplaceText, title, FALSE, TRUE, 1", // replace "System" in all entries is case sensitive
+            "and, '', author, TRUE, FALSE, 2", // replace two "and"s with empty string in the same AUTHOR field
+            "' ', ',', date, TRUE, FALSE, 1" // replace space with comma in DATE field
+    })
+    void testReplace(String findString, String replaceString, String fieldString, boolean selectOnly, boolean allFieldReplace, int expectedResult) {
+        viewModel.findStringProperty().bind(new SimpleStringProperty(findString));
+        viewModel.replaceStringProperty().bind(new SimpleStringProperty(replaceString));
+        viewModel.fieldStringProperty().bind(new SimpleStringProperty(fieldString));
+        viewModel.selectOnlyProperty().bind(new SimpleBooleanProperty(selectOnly));
+        viewModel.allFieldReplaceProperty().bind(new SimpleBooleanProperty(allFieldReplace));
+        assertEquals(expectedResult, viewModel.replace());
+    }
+}


### PR DESCRIPTION
Test coverage for org.jabref.gui package is rather low (8%). This pull request adds unit tests to 3 classes under the gui package, increasing their respective line coverage from 0% to 100%. They contribute to issue #6207.
Tests added:
1. AppendPersonNamesStrategyTest
2. PersonNameStringConverterTest
3. ReplaceStringViewModelTest

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
