### PR TITLE
Adds progress count to Possible Duplicates dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Added
 
+- We added a progress counter to the title bar in Possible Duplicates dialog window. [#7366](https://github.com/JabRef/jabref/issues/7366)
 - We added new "Customization" tab to the preferences which includes option to choose a custom address for DOI access. [#7337](https://github.com/JabRef/jabref/issues/7337)
 - We added zbmath to the public databases from which the bibliographic information of an existing entry can be updated. [#7437](https://github.com/JabRef/jabref/issues/7437)
 - We added the possibility to add a new entry via its zbMath ID (zbMATH can be chosen as ID type in the "Select entry type" window). [#7202](https://github.com/JabRef/jabref/issues/7202)

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -11,6 +11,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefExecutorService;
@@ -41,6 +45,9 @@ public class DuplicateSearch extends SimpleCommand {
     private final AtomicBoolean libraryAnalyzed = new AtomicBoolean();
     private final AtomicBoolean autoRemoveExactDuplicates = new AtomicBoolean();
     private final AtomicInteger duplicateCount = new AtomicInteger();
+    private final SimpleStringProperty duplicateCountObservable = new SimpleStringProperty();
+    private final SimpleStringProperty duplicateTotal = new SimpleStringProperty();
+    private final SimpleIntegerProperty duplicateProgress = new SimpleIntegerProperty(0);
     private final DialogService dialogService;
     private final StateManager stateManager;
 
@@ -67,6 +74,8 @@ public class DuplicateSearch extends SimpleCommand {
             return;
         }
 
+        duplicateCountObservable.addListener((obj, oldValue, newValue) -> DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> duplicateTotal.set(newValue)));
+
         JabRefExecutorService.INSTANCE.executeInterruptableTask(() -> searchPossibleDuplicates(entries, database.getMode()), "DuplicateSearcher");
         BackgroundTask.wrap(this::verifyDuplicates)
                       .onSuccess(this::handleDuplicates)
@@ -85,7 +94,7 @@ public class DuplicateSearch extends SimpleCommand {
 
                 if (new DuplicateCheck(Globals.entryTypesManager).isDuplicate(first, second, databaseMode)) {
                     duplicates.add(Arrays.asList(first, second));
-                    duplicateCount.getAndIncrement();
+                    duplicateCountObservable.set(String.valueOf(duplicateCount.incrementAndGet()));
                 }
             }
         }
@@ -96,6 +105,8 @@ public class DuplicateSearch extends SimpleCommand {
         DuplicateSearchResult result = new DuplicateSearchResult();
 
         while (!libraryAnalyzed.get() || !duplicates.isEmpty()) {
+            duplicateProgress.set(duplicateProgress.getValue() + 1);
+
             List<BibEntry> dups;
             try {
                 // poll with timeout in case the library is not analyzed completely, but contains no more duplicates
@@ -132,6 +143,8 @@ public class DuplicateSearch extends SimpleCommand {
 
     private void askResolveStrategy(DuplicateSearchResult result, BibEntry first, BibEntry second, DuplicateResolverType resolverType) {
         DuplicateResolverDialog dialog = new DuplicateResolverDialog(first, second, resolverType, frame.getCurrentLibraryTab().getBibDatabaseContext(), stateManager);
+
+        dialog.titleProperty().bind(Bindings.concat(dialog.getTitle()).concat(" (").concat(duplicateProgress.getValue()).concat("/").concat(duplicateTotal).concat(")"));
 
         DuplicateResolverResult resolverResult = dialogService.showCustomDialogAndWait(dialog)
                                                               .orElse(DuplicateResolverResult.BREAK);
@@ -171,6 +184,8 @@ public class DuplicateSearch extends SimpleCommand {
             libraryTab.getDatabase().insertEntries(result.getToAdd());
             libraryTab.markBaseChanged();
         }
+
+        duplicateProgress.set(0);
 
         dialogService.notify(Localization.lang("Duplicates found") + ": " + duplicateCount.get() + ' '
                 + Localization.lang("pairs processed") + ": " + result.getDuplicateCount());


### PR DESCRIPTION
resolves #7366

When processing duplicate entries,
Possible Duplicates dialog gave no indication as to progress.

To address this lack of feedback,
a progress counter was added to the title bar.

The title property now contains two updatable properties:
1) A total count of all duplicates
2) a count of how many duplicates have already been addressed

They are updated with listeners and bindings to
provide real time feedback.

--- 

Note: because of the use of different threads, the total-count could not be directly bound so an extra variable and listener are required. Also line 88 was removed and `duplicateCount.getAndIncrement()` was changed from `getAndIncrement()` to `incrementAndGet()` so returned value could be used.

--- 
<img width="675" alt="Screen Shot 2021-03-30 at 4 16 45 PM" src="https://user-images.githubusercontent.com/56512349/113058351-a32f8880-9173-11eb-826d-760170b39a67.png">



- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
