### PR TITLE
Add more unit tests to three gui classes

### DIFF
--- a/buildres/csl/csl-styles/ageing-and-society.csl
+++ b/buildres/csl/csl-styles/ageing-and-society.csl
@@ -14,7 +14,7 @@
     <category field="biology"/>
     <issn>0144-686X</issn>
     <eissn>1469-1779</eissn>
-    <updated>2017-06-04T17:19:24+00:00</updated>
+    <updated>2021-04-10T17:19:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -107,7 +107,7 @@
   <macro name="pages">
     <text variable="page"/>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true">
     <sort>
       <key variable="author"/>
       <key macro="year-date"/>

--- a/buildres/csl/csl-styles/catholic-biblical-association.csl
+++ b/buildres/csl/csl-styles/catholic-biblical-association.csl
@@ -1,24 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
     <title>Catholic Biblical Association (full note)</title>
     <id>http://www.zotero.org/styles/catholic-biblical-association</id>
     <link href="http://www.zotero.org/styles/catholic-biblical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>
-    <link href="http://cba.cua.edu/instruct2%5Ccbqinstr%5Cinstrcbq.pdf" rel="documentation"/>
+    <link href="https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf" rel="documentation"/>
+    <link href="https://www.catholicbiblical.org/cbq-instructions-for-contributors" rel="documentation"/>
     <author>
       <name>Nathan LaMontagne</name>
       <email>nathan.lamontagne@gmail.com</email>
     </author>
+    <contributor>
+      <name>J. David Stark</name>
+      <email>david@jdavidstark.com</email>
+      <uri>https://www.jdavidstark.com</uri>
+    </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2019-11-05T09:18:20+00:00</updated>
+    <updated>2021-03-31T17:57:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+      <!-- Overrides the defaulte en dash delimiter with the hyphen delimiter required by CBA sec. 23. -->
+      <term name="page-range-delimiter">-</term>
+      <!-- Allow for section-based citations per CBA's fallback to CMS. -->
+      <term name="section" form="short">
+        <single>§</single>
+        <multiple>§§</multiple>
+      </term>
     </terms>
   </locale>
   <!--
@@ -152,11 +165,12 @@
           </else-if>
         </choose>
       </if>
+      <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
-        <text variable="title" form="short" font-style="italic"/>
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
       </else-if>
       <else>
-        <text variable="title" form="short" quotes="true"/>
+        <text variable="title" form="short" quotes="true" text-case="title"/>
       </else>
     </choose>
   </macro>
@@ -178,11 +192,12 @@
           </if>
         </choose>
       </if>
+      <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
       <else>
-        <text variable="title" quotes="true"/>
+        <text variable="title" quotes="true" text-case="title"/>
       </else>
     </choose>
   </macro>
@@ -208,9 +223,10 @@
     </names>
   </macro>
   <macro name="editor">
+    <!-- Outputs citation of a work with only editors per CMS with "[name], ed." or "[names], eds." -->
     <names variable="editor">
-      <label form="verb-short" prefix=", " suffix="."/>
       <name and="text" sort-separator=", " delimiter=", "/>
+      <label form="short" prefix=", " suffix="."/>
     </names>
   </macro>
   <macro name="volumes">
@@ -246,7 +262,15 @@
     </group>
   </macro>
   <macro name="collection">
-    <text variable="collection-title"/>
+    <!-- CBQ uses a series abbreviation scheme that resembles but is not identical to that of the SBL Handbook of Style. See CBQ's guidelines, sec. 43, https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf. The macro below allows for a collection-title-short form to be stored and used if it is available. If it does not exist, the style uses the full series name. -->
+    <choose>
+      <if variable="collection-title">
+        <text variable="collection-title" form="short"/>
+      </if>
+      <else>
+        <text variable="collection-title"/>
+      </else>
+    </choose>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="edition">
@@ -260,7 +284,8 @@
             </group>
           </if>
           <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
+            <!-- Removes an initial capital on text-based editions like rev. ed. -->
+            <text variable="edition" suffix="."/>
           </else>
         </choose>
       </if>
@@ -346,18 +371,29 @@
       <if variable="locator" match="none">
         <text macro="pages" prefix=" "/>
       </if>
-      <else-if type="article-journal chapter" match="any">
-        <text macro="pages"/>
+      <!-- Adds support for section-based citations. -->
+      <else-if locator="section">
+        <text term="section" form="short" prefix=" "/>
+        <text variable="locator"/>
+      </else-if>
+      <else-if type="article-journal chapter" locator="page">
+        <text macro="pages" prefix=" "/>
         <text variable="locator" prefix=", here "/>
       </else-if>
-      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+      <else-if type="entry-dictionary entry-encyclopedia" locator="page">
         <text macro="pages"/>
         <text variable="locator" prefix=", esp. "/>
       </else-if>
+      <!-- Corrects improper spacing and delimitation with volume-page citations. See CBA sec. 24. -->
+      <else-if variable="volume">
+        <number variable="volume" form="numeric" prefix=" " suffix=":"/>
+        <text variable="locator"/>
+      </else-if>
       <else>
+        <!-- Adds sub verbo to an initial citation where it had previously been left out. -->
         <choose>
-          <if variable="volume">
-            <number variable="volume" form="numeric" prefix=" " suffix="."/>
+          <if locator="sub-verbo" match="any">
+            <text term="sub verbo" form="short" prefix=" "/>
           </if>
         </choose>
         <text variable="locator" prefix=" "/>
@@ -369,13 +405,14 @@
       <if type="article-journal">
         <text variable="page" prefix=" "/>
       </if>
+      <!-- Corrects the dictionary entry total page range output when a volume is cited. -->
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="volume">
-            <number variable="volume" form="numeric" suffix="."/>
+            <number variable="volume" form="numeric" suffix=":"/>
           </if>
         </choose>
-        <text variable="page" prefix=" "/>
+        <text variable="page"/>
       </else-if>
     </choose>
   </macro>
@@ -404,59 +441,91 @@
       </date>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
-    <layout delimiter="; ">
+  <macro name="custom">
+    <!-- Add support for custom citations specified via annote. -->
+    <group>
+      <text variable="annote"/>
       <choose>
+        <if locator="sub-verbo" match="any">
+          <text term="sub verbo" form="short" prefix=" "/>
+          <text variable="locator" prefix=" "/>
+        </if>
+        <else>
+          <text variable="locator" prefix=" "/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <!-- Adds a period at the end of a citation per current CBA guidelines (deference to CMS, examples in sec. 24). -->
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <!-- Eliminates the spurious uppercasing of ibid. if it appears mid-note. -->
         <if position="ibid-with-locator">
           <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first" suffix="."/>
+            <text term="ibid"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first" suffix="."/>
+          <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <text macro="title-short"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
+          <choose>
+            <!-- Add support for custom citations specified via annote. -->
+            <if variable="annote">
+              <text macro="custom"/>
+            </if>
+            <else>
+              <group delimiter=", ">
+                <text macro="contributors-short"/>
+                <text macro="title-short"/>
+                <text macro="point-locators-subsequent"/>
+              </group>
+            </else>
+          </choose>
         </else-if>
         <else>
           <choose>
-            <if type="book chapter article-journal thesis paper-conference speech" match="any">
-              <group delimiter=", " suffix=" ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="container-title"/>
-              </group>
-              <group delimiter="; " prefix="(" suffix=")">
-                <text macro="translator"/>
-                <text macro="volumes"/>
-                <text macro="secondary-contributors"/>
-                <text macro="collection"/>
-                <text macro="edition"/>
-                <text macro="issue-note"/>
-              </group>
-              <text macro="point-locators"/>
+            <if variable="annote">
+              <text macro="custom"/>
             </if>
-            <else-if type="entry-encyclopedia entry-dictionary" match="any">
-              <group delimiter=", ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="container-title"/>
-                <text macro="point-locators"/>
-              </group>
-            </else-if>
-            <else-if type="webpage post" match="any">
-              <group delimiter=", ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="webpage-title"/>
-                <text macro="webpage-information"/>
-              </group>
-            </else-if>
+            <else>
+              <choose>
+                <if type="book chapter article-journal thesis paper-conference speech" match="any">
+                  <group delimiter=", " suffix=" ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="container-title"/>
+                  </group>
+                  <group delimiter="; " prefix="(" suffix=")">
+                    <text macro="translator"/>
+                    <text macro="volumes"/>
+                    <text macro="secondary-contributors"/>
+                    <text macro="collection"/>
+                    <text macro="edition"/>
+                    <text macro="issue-note"/>
+                  </group>
+                  <text macro="point-locators"/>
+                </if>
+                <else-if type="entry-encyclopedia entry-dictionary" match="any">
+                  <group delimiter=", ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="container-title"/>
+                    <text macro="point-locators"/>
+                  </group>
+                </else-if>
+                <else-if type="webpage post" match="any">
+                  <group delimiter=", ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="webpage-title"/>
+                    <text macro="webpage-information"/>
+                  </group>
+                </else-if>
+              </choose>
+            </else>
           </choose>
         </else>
       </choose>

--- a/buildres/csl/csl-styles/harvard-cite-them-right-no-et-al.csl
+++ b/buildres/csl/csl-styles/harvard-cite-them-right-no-et-al.csl
@@ -156,7 +156,7 @@
           </group>
         </group>
       </else-if>
-      <else-if type="article-newspaper article-magazine" match="none">
+      <else-if type="article-journal article-newspaper article-magazine" match="none">
         <group delimiter=" ">
           <group delimiter=", ">
             <choose>

--- a/buildres/csl/csl-styles/journal-of-consumer-research.csl
+++ b/buildres/csl/csl-styles/journal-of-consumer-research.csl
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" page-range-format="chicago">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
     <title>Journal of Consumer Research</title>
+    <title-short>JCR</title-short>
     <id>http://www.zotero.org/styles/journal-of-consumer-research</id>
     <link href="http://www.zotero.org/styles/journal-of-consumer-research" rel="self"/>
     <link href="http://www.zotero.org/styles/international-studies-association" rel="template"/>
-    <link href="http://www.ejcr.org/newstylesheet.pdf" rel="documentation"/>
+    <link href="https://consumerresearcher.com/manuscript-preparation" rel="documentation"/>
+    <link href="https://consumerresearcher.com/wp-content/uploads/2021/01/stylesheet.pdf" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <issn>0093-5301</issn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <eissn>1537-5277</eissn>
+    <updated>2021-04-01T06:57:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -33,7 +36,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". " sort-separator=", "/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -148,6 +151,7 @@
   <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="author"/>
+      <key macro="year-date"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">

--- a/buildres/csl/csl-styles/methods-of-information-in-medicine.csl
+++ b/buildres/csl/csl-styles/methods-of-information-in-medicine.csl
@@ -19,7 +19,7 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0026-1270</issn>
-    <updated>2020-06-05T09:29:34+00:00</updated>
+    <updated>2021-04-08T14:57:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -41,7 +41,7 @@
   <macro name="editor">
     <names variable="editor">
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " suffix=". "/>
+      <label form="short" prefix=", "/>
     </names>
   </macro>
   <macro name="publisher">
@@ -140,9 +140,11 @@
             </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
-            <group prefix=" ">
-              <text term="in" suffix=": " text-case="capitalize-first"/>
-              <text macro="editor"/>
+            <group delimiter=". " prefix=" ">
+              <group delimiter=": ">
+                <text term="in" text-case="capitalize-first"/>
+                <text macro="editor"/>
+              </group>
               <text variable="container-title"/>
               <group delimiter=":">
                 <group delimiter="; ">

--- a/buildres/csl/csl-styles/presses-universitaires-de-paris-nanterre.csl
+++ b/buildres/csl/csl-styles/presses-universitaires-de-paris-nanterre.csl
@@ -197,6 +197,12 @@
       </else-if>
     </choose>
   </macro>
+  <macro name="locators">
+    <group delimiter=".&#160;">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
   <macro name="yearpage-bib">
     <choose>
       <if type="bill book graphic legal_case motion_picture paper-conference report song speech thesis" match="any">
@@ -212,10 +218,7 @@
             </group>
             <text variable="number-of-pages" suffix="&#160;p"/>
           </group>
-          <group>
-            <label variable="locator" form="short"/>
-            <text variable="locator"/>
-          </group>
+          <text macro="locators"/>
         </group>
       </if>
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
@@ -349,7 +352,7 @@
         <if position="ibid-with-locator">
           <group delimiter=", ">
             <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-            <text variable="locator" prefix="p. "/>
+            <text macro="locators"/>
           </group>
         </if>
         <else-if position="ibid">
@@ -368,7 +371,7 @@
                 <text value="art cit"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text macro="locators"/>
           </group>
         </else-if>
         <else>

--- a/buildres/csl/csl-styles/refugee-survey-quarterly.csl
+++ b/buildres/csl/csl-styles/refugee-survey-quarterly.csl
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="symbol" page-range-format="minimal" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Refugee Survey Quarterly</title>
+    <id>http://www.zotero.org/styles/refugee-survey-quarterly</id>
+    <link href="http://www.zotero.org/styles/refugee-survey-quarterly" rel="self"/>
+    <link href="http://www.zotero.org/styles/henoch" rel="template"/>
+    <link href="https://academic.oup.com/rsq/pages/information_for_authors" rel="documentation"/>
+    <link href="https://static.primary.prod.gcms.the-infra.com/static/site/rsq/document/rsq-style-sheet-for-authors.pdf?node=9f756c3cee0c555986ff&amp;version=78284:309db0246a9285b2f409" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien</name>
+    </author>
+    <category citation-format="note"/>
+    <category field="history"/>
+    <issn>1020-4067</issn>
+    <eissn>1471-695X</eissn>
+    <updated>2021-03-28T08:30:53+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
+      <term name="open-quote">"</term>
+      <term name="close-quote">"</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author" suffix=", ">
+      <name initialize-with="."/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
+      <substitute>
+        <names variable="translator"/>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", "/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
+      <substitute>
+        <names variable="translator"/>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor-translator">
+    <choose>
+      <if variable="editor translator" match="any">
+        <names variable="editor translator">
+          <label form="short" suffix=". " strip-periods="false"/>
+          <name and="text" initialize-with="."/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-editor">
+    <group delimiter=" ">
+      <text term="in" suffix=" "/>
+      <names variable="editor">
+        <name initialize-with="."/>
+        <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <names variable="container-author"/>
+          <text macro="title"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song" match="any">
+        <text variable="title" form="short" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" form="short" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <text variable="collection-title"/>
+    <text variable="collection-number" prefix=" "/>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="paper-conference">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+        <text variable="event-place" prefix=", "/>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="article-newspaper" match="any">
+        <date form="text" date-parts="year-month-day" variable="issued"/>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volumes">
+    <group delimiter=" ">
+      <text variable="number-of-volumes"/>
+      <text term="volume" form="short" plural="true" strip-periods="true"/>
+    </group>
+  </macro>
+  <macro name="pageno">
+    <choose>
+      <if variable="locator" match="none">
+        <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pageref">
+    <choose>
+      <if variable="locator">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" locator="page">
+              <label variable="locator" form="short"/>
+            </if>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pageref-subsequent">
+    <label variable="locator" form="short" suffix=" "/>
+    <text variable="locator"/>
+  </macro>
+  <macro name="volref">
+    <text variable="volume"/>
+    <text variable="issue" prefix="(" suffix=")"/>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage post post-weblog report article-newspaper" match="any">
+        <choose>
+          <if variable="URL" match="any">
+            <group delimiter=" ">
+              <group delimiter=": ">
+                <text term="available at"/>
+                <text variable="URL" prefix=" " suffix=", "/>
+              </group>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="accessed"/>
+                <date variable="accessed">
+                  <date-part name="month" form="numeric" suffix="/"/>
+                  <date-part name="day" suffix="/"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator ibid" match="any">
+          <group delimiter=", ">
+            <text term="ibid" form="short" text-case="capitalize-first" font-style="italic"/>
+            <text macro="pageref"/>
+          </group>
+        </if>
+        <else-if match="any" position="subsequent">
+          <group delimiter=", ">
+            <text macro="author-short"/>
+            <text macro="title-short"/>
+            <text macro="pageref-subsequent"/>
+          </group>
+        </else-if>
+        <else>
+          <text macro="author"/>
+          <choose>
+            <if type="report thesis" match="any">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text variable="genre"/>
+                <text variable="publisher"/>
+                <text variable="number" prefix=" "/>
+                <text variable="collection-title"/>
+                <text macro="date"/>
+                <text macro="pageref"/>
+                <text macro="access"/>
+              </group>
+            </if>
+            <else-if type="bill book graphic legal_case motion_picture song" match="any">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="editor-translator"/>
+                <text macro="container"/>
+                <text macro="volumes"/>
+                <text macro="collection"/>
+                <text macro="volref"/>
+                <text macro="publisher"/>
+                <text macro="date"/>
+                <text macro="pageref"/>
+              </group>
+            </else-if>
+            <else-if type="chapter paper-conference" match="any">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="container-editor"/>
+                <text macro="container"/>
+                <text macro="volref"/>
+                <text macro="volumes"/>
+                <text macro="collection"/>
+                <text macro="publisher"/>
+                <text macro="date"/>
+                <text macro="pageno"/>
+                <text macro="pageref"/>
+              </group>
+            </else-if>
+            <else>
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="publisher"/>
+                <text macro="container"/>
+                <text macro="collection"/>
+                <text macro="volref"/>
+                <text macro="date"/>
+                <text macro="volumes"/>
+                <text macro="pageno"/>
+                <text macro="pageref"/>
+                <text macro="access"/>
+              </group>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+</style>

--- a/buildres/csl/csl-styles/revue-archeologique.csl
+++ b/buildres/csl/csl-styles/revue-archeologique.csl
@@ -213,7 +213,7 @@
             <else-if type="entry-dictionary entry-encyclopedia" match="any">
               <group delimiter=", ">
                 <text macro="title" quotes="true"/>
-                <text variable="title" form="short" font-style="italic"/>
+                <text variable="container-title" form="short" font-style="italic"/>
                 <group delimiter="&#160;">
                   <label variable="volume" form="short"/>
                   <text variable="volume"/>

--- a/buildres/csl/csl-styles/taylor-and-francis-council-of-science-editors-author-date.csl
+++ b/buildres/csl/csl-styles/taylor-and-francis-council-of-science-editors-author-date.csl
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Council of Science Editors style for T&amp;F journals as per guidelines (version 2.0, 18 Jan 2018).</summary>
-    <updated>2019-10-30T11:30:54+00:00</updated>
+    <updated>2021-04-09T11:30:54+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -37,7 +37,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=", " initialize-with="." and="symbol"/>
+      <name form="short" delimiter=", " initialize-with="." and="text"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/buildres/csl/csl-styles/triangle.csl
+++ b/buildres/csl/csl-styles/triangle.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" default-locale="fr-FR">
   <info>
     <title>Triangle (Français)</title>
     <id>http://www.zotero.org/styles/triangle</id>
@@ -20,7 +20,7 @@
     <category field="social_science"/>
     <summary>Derived from Style EHESS-histoire, available at http://www.boiteaoutils.info/2011/06/styles-francais-de-citation-sous-zotero.html
 		First version online in november 2012. Changes made to cover more documents types and to lighten URLS display. Should preferably be used ticking the quoting option (preferences/citer/styles): include URLs addresses in references.</summary>
-    <updated>2016-07-19T04:10:55+00:00</updated>
+    <updated>2021-04-07T01:50:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -239,6 +239,17 @@
           </group>
         </group>
       </if>
+      <else-if type="chapter" match="any">
+        <group delimiter=", " font-style="normal">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <group delimiter=" " font-style="normal">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
       <else-if type="entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=" " font-style="normal">
           <date variable="issued">
@@ -251,7 +262,7 @@
           </group>
         </group>
       </else-if>
-      <else-if type="article-journal chapter article-newspaper article-magazine" match="any">
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
         <group delimiter=" " font-style="normal">
           <label variable="page" form="short"/>
           <text variable="page"/>

--- a/buildres/csl/csl-styles/university-of-tasmania-simplified-author-date.csl
+++ b/buildres/csl/csl-styles/university-of-tasmania-simplified-author-date.csl
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB">
+  <info>
+    <title>University of Tasmania - Simplified Author-date</title>
+    <id>http://www.zotero.org/styles/university-of-tasmania-simplified-author-date</id>
+    <link href="http://www.zotero.org/styles/university-of-tasmania-simplified-author-date" rel="self"/>
+    <link href="https://utas.libguides.com/referencing/simplified_authordate" rel="documentation"/>
+    <author>
+      <name>Zephyr Apsara Ganesh</name>
+      <email>zaganesh@utas.edu.au</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <updated>2021-03-29T11:30:00+11:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="long" name-as-sort-order="all" sort-separator=" " initialize-with="" and="symbol"/>
+      <substitute>
+        <choose>
+          <if type="bill legal_case legislation" match="any">
+            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" form="numeric-leading-zeros" suffix=" "/>
+          <date-part name="month" form="short" strip-periods="true" suffix=" "/>
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title" text-case="title"/>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" prefix=", " suffix=" "/>
+        <names variable="editor translator" delimiter=", " suffix=", ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+        </names>
+        <group delimiter=", ">
+          <text variable="container-title" text-case="title"/>
+          <text variable="collection-title" text-case="title"/>
+        </group>
+      </if>
+      <else-if type="bill graphic legal_case legislation motion_picture song" match="any">
+        <group prefix=", " delimiter=", ">
+          <text variable="container-title"/>
+          <text variable="collection-title"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="edition">
+          <number variable="edition" form="ordinal"/>
+        </if>
+        <else>
+          <text variable="edition" suffix="."/>
+        </else>
+      </choose>
+      <text value="edn"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="container-title" font-style="italic"/>
+          </group>
+          <group>
+            <text variable="volume" prefix="vol."/>
+          </group>
+          <text variable="page" prefix="no."/>
+        </group>
+      </if>
+      <else-if type="bill report book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <group delimiter=", " prefix=", ">
+          <text macro="publisher" suffix="."/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="publisher"/>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <text variable="number" prefix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" cite-group-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="3" et-al-use-first="1" hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout>
+      <group>
+        <text macro="author-short"/>
+        <text macro="issued" prefix=", "/>
+        <group prefix=", ">
+          <choose>
+            <if type="chapter article-journal" match="any">
+              <text macro="title" prefix=" '" suffix="'"/>
+              <text macro="edition" prefix=", "/>
+              <text macro="container"/>
+            </if>
+            <else>
+              <text macro="title" font-style="italic"/>
+            </else>
+          </choose>
+          <text macro="locators"/>
+        </group>
+      </group>
+      <choose>
+        <if type="article article-magazine article-newspaper article-journal bill book broadcast chapter dataset entry entry-dictionary entry-encyclopedia figure graphic interview legislation legal_case manuscript map motion_picture musical_score pamphlet paper-conference patent post post-weblog personal_communication review review-book song speech thesis treaty" match="none">
+          <text variable="title-short" prefix=", "/>
+          <text macro="access" prefix=", "/>
+        </if>
+        <else>
+          <text macro="access" prefix=", "/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -720,7 +720,7 @@ public class JabRefFrame extends BorderPane {
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, Globals.getClipboardManager(), prefs.getPreviewPreferences())),
-                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR))),
+                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR,prefs))),
 
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, this, stateManager)),
 

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -15,7 +15,6 @@ import javafx.scene.input.ClipboardContent;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.actions.SimpleCommand;
@@ -28,6 +27,7 @@ import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.OS;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,20 +47,26 @@ public class ExportToClipboardAction extends SimpleCommand {
     private final ClipBoardManager clipBoardManager;
     private final TaskExecutor taskExecutor;
 
-    public ExportToClipboardAction(JabRefFrame frame, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor) {
+    private final PreferencesService preferences;
+
+
+    public ExportToClipboardAction(JabRefFrame frame, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor, PreferencesService prefs) {
         this.frame = frame;
         this.dialogService = dialogService;
         this.exporterFactory = exporterFactory;
         this.clipBoardManager = clipBoardManager;
         this.taskExecutor = taskExecutor;
+        this.preferences = prefs;
     }
 
-    public ExportToClipboardAction(LibraryTab panel, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor) {
+    public ExportToClipboardAction(LibraryTab panel, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor, PreferencesService prefs) {
         this.panel = panel;
         this.dialogService = dialogService;
         this.exporterFactory = exporterFactory;
         this.clipBoardManager = clipBoardManager;
         this.taskExecutor = taskExecutor;
+        this.preferences = prefs;
+
     }
 
     @Override
@@ -81,7 +87,7 @@ public class ExportToClipboardAction extends SimpleCommand {
 
         // Find default choice, if any
         Exporter defaultChoice = exporters.stream()
-                                          .filter(exporter -> exporter.getName().equals(Globals.prefs.getImportExportPreferences().getLastExportExtension()))
+                                          .filter(exporter -> exporter.getName().equals(preferences.getImportExportPreferences().getLastExportExtension()))
                                           .findAny()
                                           .orElse(null);
 
@@ -102,12 +108,12 @@ public class ExportToClipboardAction extends SimpleCommand {
         // Set the global variable for this database's file directory before exporting,
         // so formatters can resolve linked files correctly.
         // (This is an ugly hack!)
-        Globals.prefs.fileDirForDatabase = panel.getBibDatabaseContext()
-                                                .getFileDirectories(Globals.prefs.getFilePreferences());
+        preferences.storeFileDirforDatabase(panel.getBibDatabaseContext()
+                                                .getFileDirectories(preferences.getFilePreferences()));
 
         // Add chosen export type to last used preference, to become default
-        Globals.prefs.storeImportExportPreferences(
-                Globals.prefs.getImportExportPreferences().withLastExportExtension(exporter.getName()));
+        preferences.storeImportExportPreferences(
+               preferences.getImportExportPreferences().withLastExportExtension(exporter.getName()));
 
         Path tmp = null;
         try {
@@ -122,7 +128,7 @@ public class ExportToClipboardAction extends SimpleCommand {
                     panel.getBibDatabaseContext()
                          .getMetaData()
                          .getEncoding()
-                         .orElse(Globals.prefs.getDefaultEncoding()),
+                         .orElse(preferences.getDefaultEncoding()),
                     entries);
             // Read the file and put the contents on the clipboard:
 
@@ -159,7 +165,7 @@ public class ExportToClipboardAction extends SimpleCommand {
         try (BufferedReader reader = Files.newBufferedReader(tmp, panel.getBibDatabaseContext()
                                                                        .getMetaData()
                                                                        .getEncoding()
-                                                                       .orElse(Globals.prefs.getDefaultEncoding()))) {
+                                                                       .orElse(preferences.getDefaultEncoding()))) {
             return reader.lines().collect(Collectors.joining(OS.NEWLINE));
         }
     }

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -111,7 +111,7 @@ public class RightClickMenu {
             copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, previewPreferences)));
         }
 
-        copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.EXPORT_TO_CLIPBOARD, new ExportToClipboardAction(libraryTab, dialogService, Globals.exportFactory, clipBoardManager, Globals.TASK_EXECUTOR)));
+        copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.EXPORT_TO_CLIPBOARD, new ExportToClipboardAction(libraryTab, dialogService, Globals.exportFactory, clipBoardManager, Globals.TASK_EXECUTOR, preferencesService)));
         return copySpecialMenu;
     }
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1049,10 +1049,17 @@ public class JabRefPreferences implements PreferencesService {
         }
     }
 
-    private FileLinkPreferences getFileLinkPreferences() {
+    @Override
+    public FileLinkPreferences getFileLinkPreferences() {
         return new FileLinkPreferences(
                 get(MAIN_FILE_DIRECTORY), // REALLY HERE?
                 fileDirForDatabase);
+    }
+
+
+    @Override
+    public void storeFileDirforDatabase(List<Path> dirs) {
+        this.fileDirForDatabase = dirs;
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -34,6 +34,7 @@ import org.jabref.logic.journals.JournalAbbreviationPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.layout.format.FileLinkPreferences;
 import org.jabref.logic.layout.format.NameFormatterPreferences;
 import org.jabref.logic.net.ProxyPreferences;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
@@ -278,6 +279,10 @@ public interface PreferencesService {
 
     void storeShouldAutosave(boolean shouldAutosave);
 
+    FileLinkPreferences getFileLinkPreferences();
+
+    void storeFileDirforDatabase(List<Path> dirs);
+
     //*************************************************************************************************************
     // Import/Export preferences
     //*************************************************************************************************************
@@ -377,4 +382,6 @@ public interface PreferencesService {
     ProtectedTermsPreferences getProtectedTermsPreferences();
 
     void storeProtectedTermsPreferences(ProtectedTermsPreferences preferences);
+
+
 }

--- a/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
@@ -1,0 +1,168 @@
+package org.jabref.gui.edit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.JabRefDialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.StandardActions;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.PreferencesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CopyMoreActionTest {
+
+    private CopyMoreAction copyMoreAction;
+    private DialogService dialogService = spy(DialogService.class);
+    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private PreferencesService preferencesService = mock(PreferencesService.class);
+    private StateManager stateManager = mock(StateManager.class);
+    private BibEntry entry;
+    private List<String> titles = new ArrayList<String>();
+    private List<String> keys = new ArrayList<String>();
+
+    @BeforeEach
+    public void setUp() {
+        String title = "A tale from the trenches";
+        entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
+                .withField(StandardField.TITLE, title)
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1145/3377811.3380330")
+                .withField(StandardField.SUBTITLE, "cognitive biases and software development")
+                .withCitationKey("abc");
+        titles.add(title);
+        keys.add("abc");
+    }
+
+    @Test
+    public void testExecuteOnFail() {
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.empty());
+        when(stateManager.getSelectedEntries()).thenReturn(FXCollections.emptyObservableList());
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(0)).notify(any(String.class));
+    }
+
+    @Test
+    public void testExecuteCopyTitleWithNoTitle() {
+        BibEntry entryWithNoTitle = (BibEntry) entry.clone();
+        entryWithNoTitle.clearField(StandardField.TITLE);
+        ObservableList<BibEntry> entriesWithNoTitles = FXCollections.observableArrayList(entryWithNoTitle);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithNoTitles));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoTitles);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(1)).notify(Localization.lang("None of the selected entries have titles."));
+    }
+
+    @Test
+    public void testExecuteCopyTitleOnPartialSuccess() {
+        BibEntry entryWithNoTitle = (BibEntry) entry.clone();
+        entryWithNoTitle.clearField(StandardField.TITLE);
+        ObservableList<BibEntry> mixedEntries = FXCollections.observableArrayList(entryWithNoTitle, entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(mixedEntries));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedTitles = String.join("\n", titles);
+        verify(clipBoardManager, times(1)).setContent(copiedTitles);
+        verify(dialogService, times(1)).notify(Localization.lang("Warning: %0 out of %1 entries have undefined title.",
+                Integer.toString(mixedEntries.size() - titles.size()), Integer.toString(mixedEntries.size())));
+    }
+
+    @Test
+    public void testExecuteCopyTitleOnSuccess() {
+        ObservableList<BibEntry> entriesWithTitles = FXCollections.observableArrayList(entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithTitles));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithTitles);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedTitles = String.join("\n", titles);
+        verify(clipBoardManager, times(1)).setContent(copiedTitles);
+        verify(dialogService, times(1)).notify(Localization.lang("Copied '%0' to clipboard.",
+                JabRefDialogService.shortenDialogMessage(copiedTitles)));
+    }
+
+    @Test
+    public void testExecuteCopyKeyWithNoKey() {
+        BibEntry entryWithNoKey = (BibEntry) entry.clone();
+        entryWithNoKey.clearCiteKey();
+        ObservableList<BibEntry> entriesWithNoKeys = FXCollections.observableArrayList(entryWithNoKey);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithNoKeys));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoKeys);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(1)).notify(Localization.lang("None of the selected entries have citation keys."));
+    }
+
+    @Test
+    public void testExecuteCopyKeyOnPartialSuccess() {
+        BibEntry entryWithNoKey = (BibEntry) entry.clone();
+        entryWithNoKey.clearCiteKey();
+        ObservableList<BibEntry> mixedEntries = FXCollections.observableArrayList(entryWithNoKey, entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(mixedEntries));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedKeys = String.join("\n", keys);
+        verify(clipBoardManager, times(1)).setContent(copiedKeys);
+        verify(dialogService, times(1)).notify(Localization.lang("Warning: %0 out of %1 entries have undefined citation key.",
+                Integer.toString(mixedEntries.size() - titles.size()), Integer.toString(mixedEntries.size())));
+    }
+
+    @Test
+    public void testExecuteCopyKeyOnSuccess() {
+        ObservableList<BibEntry> entriesWithKeys = FXCollections.observableArrayList(entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithKeys));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithKeys);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedKeys = String.join("\n", keys);
+        verify(clipBoardManager, times(1)).setContent(copiedKeys);
+        verify(dialogService, times(1)).notify(Localization.lang("Copied '%0' to clipboard.",
+                JabRefDialogService.shortenDialogMessage(copiedKeys)));
+    }
+}

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -1,0 +1,113 @@
+package org.jabref.gui.exporter;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.Globals;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.LibraryTab;
+import org.jabref.gui.util.CurrentThreadTaskExecutor;
+import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.exporter.Exporter;
+import org.jabref.logic.exporter.ExporterFactory;
+import org.jabref.logic.exporter.SavePreferences;
+import org.jabref.logic.exporter.TemplateExporter;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.metadata.MetaData;
+import org.jabref.preferences.JabRefPreferences;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExportToClipboardActionTest {
+
+    private ExportToClipboardAction exportToClipboardAction;
+    private LibraryTab libraryTab = mock(LibraryTab.class);
+    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private DialogService dialogService = spy(DialogService.class);
+    private ExporterFactory exporterFactory;
+    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private TaskExecutor taskExecutor;
+    private List<BibEntry> selectedEntries;
+    private BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+
+    @BeforeEach
+    public void setUp() {
+//        if (Globals.prefs == null) {
+//            Globals.prefs = JabRefPreferences.getInstance();
+//        }
+        taskExecutor = new CurrentThreadTaskExecutor();
+
+        List<TemplateExporter> customFormats = new ArrayList<>();
+        LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        SavePreferences savePreferences = mock(SavePreferences.class);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
+        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor);
+
+        BibEntry entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
+                .withField(StandardField.TITLE, "A tale from the trenches")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1145/3377811.3380330")
+                .withField(StandardField.SUBTITLE, "cognitive biases and software development");
+
+        selectedEntries = new ArrayList<>();
+        selectedEntries.add(entry);
+    }
+
+    @Test
+    public void testExecuteIfNoSelectedEntries() {
+        when(libraryTab.getSelectedEntries()).thenReturn(Collections.EMPTY_LIST);
+
+        exportToClipboardAction.execute();
+        verify(dialogService, times(1)).notify(Localization.lang("This operation requires one or more entries to be selected."));
+    }
+
+    @Test
+    public void testExecuteOnSuccess() {
+        Exporter selectedExporter = new Exporter("html", "HTML", StandardFileType.HTML) {
+            @Override
+            public void export(BibDatabaseContext databaseContext, Path file, Charset encoding, List<BibEntry> entries) throws Exception {
+            }
+        };
+
+        when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
+        when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
+        when(databaseContext.getFileDirectories(Globals.prefs.getFilePreferences())).thenReturn(new ArrayList<Path>(Arrays.asList(Path.of("path"))));
+        when(databaseContext.getMetaData()).thenReturn(new MetaData());
+        when(dialogService.showChoiceDialogAndWait(
+                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
+                eq(Localization.lang("Export")), any(Exporter.class), anyCollection())).thenReturn(Optional.of(selectedExporter));
+
+        exportToClipboardAction.execute();
+        verify(dialogService, times(1)).showChoiceDialogAndWait(
+               eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
+                eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
+        verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
+    }
+}

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
@@ -28,15 +27,15 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.MetaData;
-import org.jabref.preferences.JabRefPreferences;
+import org.jabref.preferences.ImportExportPreferences;
+import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -46,20 +45,20 @@ import static org.mockito.Mockito.when;
 public class ExportToClipboardActionTest {
 
     private ExportToClipboardAction exportToClipboardAction;
-    private LibraryTab libraryTab = mock(LibraryTab.class);
-    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
-    private DialogService dialogService = spy(DialogService.class);
+    private final LibraryTab libraryTab = mock(LibraryTab.class);
+    private final JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private final DialogService dialogService = spy(DialogService.class);
     private ExporterFactory exporterFactory;
-    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private final ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
     private TaskExecutor taskExecutor;
     private List<BibEntry> selectedEntries;
-    private BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private final PreferencesService preferences = mock(PreferencesService.class, Answers.RETURNS_MOCKS);
+    private final ImportExportPreferences importExportPrefs = mock(ImportExportPreferences.class);
 
     @BeforeEach
     public void setUp() {
-//        if (Globals.prefs == null) {
-//            Globals.prefs = JabRefPreferences.getInstance();
-//        }
+
         taskExecutor = new CurrentThreadTaskExecutor();
 
         List<TemplateExporter> customFormats = new ArrayList<>();
@@ -67,7 +66,7 @@ public class ExportToClipboardActionTest {
         SavePreferences savePreferences = mock(SavePreferences.class);
         XmpPreferences xmpPreferences = mock(XmpPreferences.class);
         exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
-        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor);
+        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor, preferences);
 
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
@@ -90,15 +89,17 @@ public class ExportToClipboardActionTest {
 
     @Test
     public void testExecuteOnSuccess() {
+
         Exporter selectedExporter = new Exporter("html", "HTML", StandardFileType.HTML) {
             @Override
             public void export(BibDatabaseContext databaseContext, Path file, Charset encoding, List<BibEntry> entries) throws Exception {
             }
         };
 
+        when(importExportPrefs.getLastExportExtension()).thenReturn("html");
         when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
         when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
-        when(databaseContext.getFileDirectories(Globals.prefs.getFilePreferences())).thenReturn(new ArrayList<Path>(Arrays.asList(Path.of("path"))));
+        when(databaseContext.getFileDirectories(preferences.getFilePreferences())).thenReturn(new ArrayList<>(Arrays.asList(Path.of("path"))));
         when(databaseContext.getMetaData()).thenReturn(new MetaData());
         when(dialogService.showChoiceDialogAndWait(
                 eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
@@ -109,5 +110,6 @@ public class ExportToClipboardActionTest {
                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
                 eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
         verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
-    }
+
+        }
 }

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.exporter;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import org.jabref.preferences.PreferencesService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,12 +55,11 @@ public class ExportToClipboardActionTest {
     private TaskExecutor taskExecutor;
     private List<BibEntry> selectedEntries;
     private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
-    private final PreferencesService preferences = mock(PreferencesService.class, Answers.RETURNS_MOCKS);
+    private final PreferencesService preferences = spy(PreferencesService.class);
     private final ImportExportPreferences importExportPrefs = mock(ImportExportPreferences.class);
 
     @BeforeEach
     public void setUp() {
-
         taskExecutor = new CurrentThreadTaskExecutor();
 
         List<TemplateExporter> customFormats = new ArrayList<>();
@@ -96,7 +97,9 @@ public class ExportToClipboardActionTest {
             }
         };
 
-        when(importExportPrefs.getLastExportExtension()).thenReturn("html");
+        when(importExportPrefs.getLastExportExtension()).thenReturn("HTML");
+        when(preferences.getImportExportPreferences()).thenReturn(importExportPrefs);
+        when(preferences.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
         when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
         when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
         when(databaseContext.getFileDirectories(preferences.getFilePreferences())).thenReturn(new ArrayList<>(Arrays.asList(Path.of("path"))));
@@ -110,6 +113,5 @@ public class ExportToClipboardActionTest {
                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
                 eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
         verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
-
         }
 }

--- a/src/test/java/org/jabref/gui/importer/NewEntryActionTest.java
+++ b/src/test/java/org/jabref/gui/importer/NewEntryActionTest.java
@@ -1,0 +1,58 @@
+package org.jabref.gui.importer;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.EntryTypeView;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.LibraryTab;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.util.OptionalObjectProperty;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.PreferencesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NewEntryActionTest {
+
+    private NewEntryAction newEntryAction;
+    private LibraryTab libraryTab = mock(LibraryTab.class);
+    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private DialogService dialogService = spy(DialogService.class);
+    private PreferencesService preferencesService = mock(PreferencesService.class);
+    private StateManager stateManager = mock(StateManager.class);
+
+    @BeforeEach
+    public void setUp() {
+        when(jabRefFrame.getCurrentLibraryTab()).thenReturn(libraryTab);
+        when(stateManager.activeDatabaseProperty()).thenReturn(OptionalObjectProperty.empty());
+        newEntryAction = new NewEntryAction(jabRefFrame, dialogService, preferencesService, stateManager);
+    }
+
+    @Test
+    public void testExecuteIfNoBasePanel() {
+        when(jabRefFrame.getBasePanelCount()).thenReturn(0);
+
+        newEntryAction.execute();
+        verify(libraryTab, times(0)).insertEntry(any(BibEntry.class));
+        verify(dialogService, times(0)).showCustomDialogAndWait(any(EntryTypeView.class));
+    }
+
+    @Test
+    public void testExecuteOnSuccessWithFixedType() {
+        EntryType type = StandardEntryType.Article;
+        newEntryAction = new NewEntryAction(jabRefFrame, type, dialogService, preferencesService, stateManager);
+        when(jabRefFrame.getBasePanelCount()).thenReturn(1);
+
+        newEntryAction.execute();
+        verify(libraryTab, times(1)).insertEntry(new BibEntry(type));
+    }
+}


### PR DESCRIPTION
This pull request contributes to issue #6207, to add more unit tests to the gui package, specifically using test doubles.

Tests added:

NewEntryActionTest
CopyMoreActionTest
ExportToClipboardActionTest

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
