### PR TITLE
Add more unit tests to three gui classes 

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -720,7 +720,7 @@ public class JabRefFrame extends BorderPane {
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, Globals.getClipboardManager(), prefs.getPreviewPreferences())),
-                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR))),
+                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR,prefs))),
 
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, this, stateManager)),
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -720,7 +720,7 @@ public class JabRefFrame extends BorderPane {
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
                         factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, Globals.getClipboardManager(), prefs.getPreviewPreferences())),
-                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR,prefs))),
+                        factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(this, dialogService, Globals.exportFactory, Globals.getClipboardManager(), Globals.TASK_EXECUTOR, prefs))),
 
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, this, stateManager)),
 

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -15,7 +15,6 @@ import javafx.scene.input.ClipboardContent;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.actions.SimpleCommand;
@@ -28,6 +27,7 @@ import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.OS;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,20 +47,26 @@ public class ExportToClipboardAction extends SimpleCommand {
     private final ClipBoardManager clipBoardManager;
     private final TaskExecutor taskExecutor;
 
-    public ExportToClipboardAction(JabRefFrame frame, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor) {
+    private final PreferencesService preferences;
+
+
+    public ExportToClipboardAction(JabRefFrame frame, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor, PreferencesService prefs) {
         this.frame = frame;
         this.dialogService = dialogService;
         this.exporterFactory = exporterFactory;
         this.clipBoardManager = clipBoardManager;
         this.taskExecutor = taskExecutor;
+        this.preferences = prefs;
     }
 
-    public ExportToClipboardAction(LibraryTab panel, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor) {
+    public ExportToClipboardAction(LibraryTab panel, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor, PreferencesService prefs) {
         this.panel = panel;
         this.dialogService = dialogService;
         this.exporterFactory = exporterFactory;
         this.clipBoardManager = clipBoardManager;
         this.taskExecutor = taskExecutor;
+        this.preferences = prefs;
+
     }
 
     @Override
@@ -81,7 +87,7 @@ public class ExportToClipboardAction extends SimpleCommand {
 
         // Find default choice, if any
         Exporter defaultChoice = exporters.stream()
-                                          .filter(exporter -> exporter.getName().equals(Globals.prefs.getImportExportPreferences().getLastExportExtension()))
+                                          .filter(exporter -> exporter.getName().equals(preferences.getImportExportPreferences().getLastExportExtension()))
                                           .findAny()
                                           .orElse(null);
 
@@ -102,12 +108,12 @@ public class ExportToClipboardAction extends SimpleCommand {
         // Set the global variable for this database's file directory before exporting,
         // so formatters can resolve linked files correctly.
         // (This is an ugly hack!)
-        Globals.prefs.fileDirForDatabase = panel.getBibDatabaseContext()
-                                                .getFileDirectories(Globals.prefs.getFilePreferences());
+        preferences.storeFileDirforDatabase(panel.getBibDatabaseContext()
+                                                .getFileDirectories(preferences.getFilePreferences()));
 
         // Add chosen export type to last used preference, to become default
-        Globals.prefs.storeImportExportPreferences(
-                Globals.prefs.getImportExportPreferences().withLastExportExtension(exporter.getName()));
+        preferences.storeImportExportPreferences(
+               preferences.getImportExportPreferences().withLastExportExtension(exporter.getName()));
 
         Path tmp = null;
         try {
@@ -122,7 +128,7 @@ public class ExportToClipboardAction extends SimpleCommand {
                     panel.getBibDatabaseContext()
                          .getMetaData()
                          .getEncoding()
-                         .orElse(Globals.prefs.getDefaultEncoding()),
+                         .orElse(preferences.getDefaultEncoding()),
                     entries);
             // Read the file and put the contents on the clipboard:
 
@@ -159,7 +165,7 @@ public class ExportToClipboardAction extends SimpleCommand {
         try (BufferedReader reader = Files.newBufferedReader(tmp, panel.getBibDatabaseContext()
                                                                        .getMetaData()
                                                                        .getEncoding()
-                                                                       .orElse(Globals.prefs.getDefaultEncoding()))) {
+                                                                       .orElse(preferences.getDefaultEncoding()))) {
             return reader.lines().collect(Collectors.joining(OS.NEWLINE));
         }
     }

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -46,9 +46,7 @@ public class ExportToClipboardAction extends SimpleCommand {
     private final ExporterFactory exporterFactory;
     private final ClipBoardManager clipBoardManager;
     private final TaskExecutor taskExecutor;
-
     private final PreferencesService preferences;
-
 
     public ExportToClipboardAction(JabRefFrame frame, DialogService dialogService, ExporterFactory exporterFactory, ClipBoardManager clipBoardManager, TaskExecutor taskExecutor, PreferencesService prefs) {
         this.frame = frame;

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -111,7 +111,7 @@ public class RightClickMenu {
             copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, previewPreferences)));
         }
 
-        copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.EXPORT_TO_CLIPBOARD, new ExportToClipboardAction(libraryTab, dialogService, Globals.exportFactory, clipBoardManager, Globals.TASK_EXECUTOR)));
+        copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.EXPORT_TO_CLIPBOARD, new ExportToClipboardAction(libraryTab, dialogService, Globals.exportFactory, clipBoardManager, Globals.TASK_EXECUTOR, preferencesService)));
         return copySpecialMenu;
     }
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1056,7 +1056,6 @@ public class JabRefPreferences implements PreferencesService {
                 fileDirForDatabase);
     }
 
-
     @Override
     public void storeFileDirforDatabase(List<Path> dirs) {
         this.fileDirForDatabase = dirs;

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1049,10 +1049,17 @@ public class JabRefPreferences implements PreferencesService {
         }
     }
 
-    private FileLinkPreferences getFileLinkPreferences() {
+    @Override
+    public FileLinkPreferences getFileLinkPreferences() {
         return new FileLinkPreferences(
                 get(MAIN_FILE_DIRECTORY), // REALLY HERE?
                 fileDirForDatabase);
+    }
+
+
+    @Override
+    public void storeFileDirforDatabase(List<Path> dirs) {
+        this.fileDirForDatabase = dirs;
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -382,6 +382,4 @@ public interface PreferencesService {
     ProtectedTermsPreferences getProtectedTermsPreferences();
 
     void storeProtectedTermsPreferences(ProtectedTermsPreferences preferences);
-
-
 }

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -34,6 +34,7 @@ import org.jabref.logic.journals.JournalAbbreviationPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.layout.format.FileLinkPreferences;
 import org.jabref.logic.layout.format.NameFormatterPreferences;
 import org.jabref.logic.net.ProxyPreferences;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
@@ -278,6 +279,10 @@ public interface PreferencesService {
 
     void storeShouldAutosave(boolean shouldAutosave);
 
+    FileLinkPreferences getFileLinkPreferences();
+
+    void storeFileDirforDatabase(List<Path> dirs);
+
     //*************************************************************************************************************
     // Import/Export preferences
     //*************************************************************************************************************
@@ -377,4 +382,6 @@ public interface PreferencesService {
     ProtectedTermsPreferences getProtectedTermsPreferences();
 
     void storeProtectedTermsPreferences(ProtectedTermsPreferences preferences);
+
+
 }

--- a/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
@@ -1,0 +1,168 @@
+package org.jabref.gui.edit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.JabRefDialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.StandardActions;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.PreferencesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CopyMoreActionTest {
+
+    private CopyMoreAction copyMoreAction;
+    private DialogService dialogService = spy(DialogService.class);
+    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private PreferencesService preferencesService = mock(PreferencesService.class);
+    private StateManager stateManager = mock(StateManager.class);
+    private BibEntry entry;
+    private List<String> titles = new ArrayList<String>();
+    private List<String> keys = new ArrayList<String>();
+
+    @BeforeEach
+    public void setUp() {
+        String title = "A tale from the trenches";
+        entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
+                .withField(StandardField.TITLE, title)
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1145/3377811.3380330")
+                .withField(StandardField.SUBTITLE, "cognitive biases and software development")
+                .withCitationKey("abc");
+        titles.add(title);
+        keys.add("abc");
+    }
+
+    @Test
+    public void testExecuteOnFail() {
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.empty());
+        when(stateManager.getSelectedEntries()).thenReturn(FXCollections.emptyObservableList());
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(0)).notify(any(String.class));
+    }
+
+    @Test
+    public void testExecuteCopyTitleWithNoTitle() {
+        BibEntry entryWithNoTitle = (BibEntry) entry.clone();
+        entryWithNoTitle.clearField(StandardField.TITLE);
+        ObservableList<BibEntry> entriesWithNoTitles = FXCollections.observableArrayList(entryWithNoTitle);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithNoTitles));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoTitles);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(1)).notify(Localization.lang("None of the selected entries have titles."));
+    }
+
+    @Test
+    public void testExecuteCopyTitleOnPartialSuccess() {
+        BibEntry entryWithNoTitle = (BibEntry) entry.clone();
+        entryWithNoTitle.clearField(StandardField.TITLE);
+        ObservableList<BibEntry> mixedEntries = FXCollections.observableArrayList(entryWithNoTitle, entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(mixedEntries));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedTitles = String.join("\n", titles);
+        verify(clipBoardManager, times(1)).setContent(copiedTitles);
+        verify(dialogService, times(1)).notify(Localization.lang("Warning: %0 out of %1 entries have undefined title.",
+                Integer.toString(mixedEntries.size() - titles.size()), Integer.toString(mixedEntries.size())));
+    }
+
+    @Test
+    public void testExecuteCopyTitleOnSuccess() {
+        ObservableList<BibEntry> entriesWithTitles = FXCollections.observableArrayList(entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithTitles));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithTitles);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedTitles = String.join("\n", titles);
+        verify(clipBoardManager, times(1)).setContent(copiedTitles);
+        verify(dialogService, times(1)).notify(Localization.lang("Copied '%0' to clipboard.",
+                JabRefDialogService.shortenDialogMessage(copiedTitles)));
+    }
+
+    @Test
+    public void testExecuteCopyKeyWithNoKey() {
+        BibEntry entryWithNoKey = (BibEntry) entry.clone();
+        entryWithNoKey.clearCiteKey();
+        ObservableList<BibEntry> entriesWithNoKeys = FXCollections.observableArrayList(entryWithNoKey);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithNoKeys));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoKeys);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        verify(clipBoardManager, times(0)).setContent(any(String.class));
+        verify(dialogService, times(1)).notify(Localization.lang("None of the selected entries have citation keys."));
+    }
+
+    @Test
+    public void testExecuteCopyKeyOnPartialSuccess() {
+        BibEntry entryWithNoKey = (BibEntry) entry.clone();
+        entryWithNoKey.clearCiteKey();
+        ObservableList<BibEntry> mixedEntries = FXCollections.observableArrayList(entryWithNoKey, entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(mixedEntries));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedKeys = String.join("\n", keys);
+        verify(clipBoardManager, times(1)).setContent(copiedKeys);
+        verify(dialogService, times(1)).notify(Localization.lang("Warning: %0 out of %1 entries have undefined citation key.",
+                Integer.toString(mixedEntries.size() - titles.size()), Integer.toString(mixedEntries.size())));
+    }
+
+    @Test
+    public void testExecuteCopyKeyOnSuccess() {
+        ObservableList<BibEntry> entriesWithKeys = FXCollections.observableArrayList(entry);
+        BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(entriesWithKeys));
+
+        when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
+        when(stateManager.getSelectedEntries()).thenReturn(entriesWithKeys);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction.execute();
+
+        String copiedKeys = String.join("\n", keys);
+        verify(clipBoardManager, times(1)).setContent(copiedKeys);
+        verify(dialogService, times(1)).notify(Localization.lang("Copied '%0' to clipboard.",
+                JabRefDialogService.shortenDialogMessage(copiedKeys)));
+    }
+}

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -1,0 +1,113 @@
+package org.jabref.gui.exporter;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.Globals;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.LibraryTab;
+import org.jabref.gui.util.CurrentThreadTaskExecutor;
+import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.exporter.Exporter;
+import org.jabref.logic.exporter.ExporterFactory;
+import org.jabref.logic.exporter.SavePreferences;
+import org.jabref.logic.exporter.TemplateExporter;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.metadata.MetaData;
+import org.jabref.preferences.JabRefPreferences;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExportToClipboardActionTest {
+
+    private ExportToClipboardAction exportToClipboardAction;
+    private LibraryTab libraryTab = mock(LibraryTab.class);
+    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private DialogService dialogService = spy(DialogService.class);
+    private ExporterFactory exporterFactory;
+    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private TaskExecutor taskExecutor;
+    private List<BibEntry> selectedEntries;
+    private BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+
+    @BeforeEach
+    public void setUp() {
+//        if (Globals.prefs == null) {
+//            Globals.prefs = JabRefPreferences.getInstance();
+//        }
+        taskExecutor = new CurrentThreadTaskExecutor();
+
+        List<TemplateExporter> customFormats = new ArrayList<>();
+        LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        SavePreferences savePreferences = mock(SavePreferences.class);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
+        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor);
+
+        BibEntry entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
+                .withField(StandardField.TITLE, "A tale from the trenches")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1145/3377811.3380330")
+                .withField(StandardField.SUBTITLE, "cognitive biases and software development");
+
+        selectedEntries = new ArrayList<>();
+        selectedEntries.add(entry);
+    }
+
+    @Test
+    public void testExecuteIfNoSelectedEntries() {
+        when(libraryTab.getSelectedEntries()).thenReturn(Collections.EMPTY_LIST);
+
+        exportToClipboardAction.execute();
+        verify(dialogService, times(1)).notify(Localization.lang("This operation requires one or more entries to be selected."));
+    }
+
+    @Test
+    public void testExecuteOnSuccess() {
+        Exporter selectedExporter = new Exporter("html", "HTML", StandardFileType.HTML) {
+            @Override
+            public void export(BibDatabaseContext databaseContext, Path file, Charset encoding, List<BibEntry> entries) throws Exception {
+            }
+        };
+
+        when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
+        when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
+        when(databaseContext.getFileDirectories(Globals.prefs.getFilePreferences())).thenReturn(new ArrayList<Path>(Arrays.asList(Path.of("path"))));
+        when(databaseContext.getMetaData()).thenReturn(new MetaData());
+        when(dialogService.showChoiceDialogAndWait(
+                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
+                eq(Localization.lang("Export")), any(Exporter.class), anyCollection())).thenReturn(Optional.of(selectedExporter));
+
+        exportToClipboardAction.execute();
+        verify(dialogService, times(1)).showChoiceDialogAndWait(
+               eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
+                eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
+        verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
+    }
+}

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
@@ -28,15 +27,15 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.MetaData;
-import org.jabref.preferences.JabRefPreferences;
+import org.jabref.preferences.ImportExportPreferences;
+import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyCollection;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -46,20 +45,20 @@ import static org.mockito.Mockito.when;
 public class ExportToClipboardActionTest {
 
     private ExportToClipboardAction exportToClipboardAction;
-    private LibraryTab libraryTab = mock(LibraryTab.class);
-    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
-    private DialogService dialogService = spy(DialogService.class);
+    private final LibraryTab libraryTab = mock(LibraryTab.class);
+    private final JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private final DialogService dialogService = spy(DialogService.class);
     private ExporterFactory exporterFactory;
-    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private final ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
     private TaskExecutor taskExecutor;
     private List<BibEntry> selectedEntries;
-    private BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private final PreferencesService preferences = mock(PreferencesService.class, Answers.RETURNS_MOCKS);
+    private final ImportExportPreferences importExportPrefs = mock(ImportExportPreferences.class);
 
     @BeforeEach
     public void setUp() {
-//        if (Globals.prefs == null) {
-//            Globals.prefs = JabRefPreferences.getInstance();
-//        }
+
         taskExecutor = new CurrentThreadTaskExecutor();
 
         List<TemplateExporter> customFormats = new ArrayList<>();
@@ -67,7 +66,7 @@ public class ExportToClipboardActionTest {
         SavePreferences savePreferences = mock(SavePreferences.class);
         XmpPreferences xmpPreferences = mock(XmpPreferences.class);
         exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
-        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor);
+        exportToClipboardAction = new ExportToClipboardAction(libraryTab, dialogService, exporterFactory, clipBoardManager, taskExecutor, preferences);
 
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
@@ -90,15 +89,17 @@ public class ExportToClipboardActionTest {
 
     @Test
     public void testExecuteOnSuccess() {
+
         Exporter selectedExporter = new Exporter("html", "HTML", StandardFileType.HTML) {
             @Override
             public void export(BibDatabaseContext databaseContext, Path file, Charset encoding, List<BibEntry> entries) throws Exception {
             }
         };
 
+        when(importExportPrefs.getLastExportExtension()).thenReturn("html");
         when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
         when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
-        when(databaseContext.getFileDirectories(Globals.prefs.getFilePreferences())).thenReturn(new ArrayList<Path>(Arrays.asList(Path.of("path"))));
+        when(databaseContext.getFileDirectories(preferences.getFilePreferences())).thenReturn(new ArrayList<>(Arrays.asList(Path.of("path"))));
         when(databaseContext.getMetaData()).thenReturn(new MetaData());
         when(dialogService.showChoiceDialogAndWait(
                 eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
@@ -109,5 +110,6 @@ public class ExportToClipboardActionTest {
                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
                 eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
         verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
-    }
+
+        }
 }

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.exporter;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import org.jabref.preferences.PreferencesService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,12 +55,11 @@ public class ExportToClipboardActionTest {
     private TaskExecutor taskExecutor;
     private List<BibEntry> selectedEntries;
     private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
-    private final PreferencesService preferences = mock(PreferencesService.class, Answers.RETURNS_MOCKS);
+    private final PreferencesService preferences = spy(PreferencesService.class);
     private final ImportExportPreferences importExportPrefs = mock(ImportExportPreferences.class);
 
     @BeforeEach
     public void setUp() {
-
         taskExecutor = new CurrentThreadTaskExecutor();
 
         List<TemplateExporter> customFormats = new ArrayList<>();
@@ -96,7 +97,9 @@ public class ExportToClipboardActionTest {
             }
         };
 
-        when(importExportPrefs.getLastExportExtension()).thenReturn("html");
+        when(importExportPrefs.getLastExportExtension()).thenReturn("HTML");
+        when(preferences.getImportExportPreferences()).thenReturn(importExportPrefs);
+        when(preferences.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
         when(libraryTab.getSelectedEntries()).thenReturn(selectedEntries);
         when(libraryTab.getBibDatabaseContext()).thenReturn(databaseContext);
         when(databaseContext.getFileDirectories(preferences.getFilePreferences())).thenReturn(new ArrayList<>(Arrays.asList(Path.of("path"))));
@@ -110,6 +113,5 @@ public class ExportToClipboardActionTest {
                eq(Localization.lang("Export")), eq(Localization.lang("Select export format")),
                 eq(Localization.lang("Export")), any(Exporter.class), anyCollection());
         verify(dialogService, times(1)).notify(Localization.lang("Entries exported to clipboard") + ": " + selectedEntries.size());
-
         }
 }

--- a/src/test/java/org/jabref/gui/importer/NewEntryActionTest.java
+++ b/src/test/java/org/jabref/gui/importer/NewEntryActionTest.java
@@ -1,0 +1,58 @@
+package org.jabref.gui.importer;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.EntryTypeView;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.LibraryTab;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.util.OptionalObjectProperty;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.PreferencesService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NewEntryActionTest {
+
+    private NewEntryAction newEntryAction;
+    private LibraryTab libraryTab = mock(LibraryTab.class);
+    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private DialogService dialogService = spy(DialogService.class);
+    private PreferencesService preferencesService = mock(PreferencesService.class);
+    private StateManager stateManager = mock(StateManager.class);
+
+    @BeforeEach
+    public void setUp() {
+        when(jabRefFrame.getCurrentLibraryTab()).thenReturn(libraryTab);
+        when(stateManager.activeDatabaseProperty()).thenReturn(OptionalObjectProperty.empty());
+        newEntryAction = new NewEntryAction(jabRefFrame, dialogService, preferencesService, stateManager);
+    }
+
+    @Test
+    public void testExecuteIfNoBasePanel() {
+        when(jabRefFrame.getBasePanelCount()).thenReturn(0);
+
+        newEntryAction.execute();
+        verify(libraryTab, times(0)).insertEntry(any(BibEntry.class));
+        verify(dialogService, times(0)).showCustomDialogAndWait(any(EntryTypeView.class));
+    }
+
+    @Test
+    public void testExecuteOnSuccessWithFixedType() {
+        EntryType type = StandardEntryType.Article;
+        newEntryAction = new NewEntryAction(jabRefFrame, type, dialogService, preferencesService, stateManager);
+        when(jabRefFrame.getBasePanelCount()).thenReturn(1);
+
+        newEntryAction.execute();
+        verify(libraryTab, times(1)).insertEntry(new BibEntry(type));
+    }
+}


### PR DESCRIPTION
This pull request replaces #7635 (closed/not merged), and it contributes to issue #6207, which is to add more unit tests to the project,  in this case specifically in the gui package using test doubles.

Tests added:

NewEntryActionTest
CopyMoreActionTest
ExportToClipboardActionTest

In order to add the ExportToClipboardActionTest and to migrate to using PreferencesService, code refactoring has been done as suggested by @Siedlerchr. The purpose of the refactoring is to add PreferencesService as a parameter in the constructors of ExportToClipboardAction to replace the Globals variable. Refactored classes are as follows:

ExportToClipboardAction.java 
JabRefFrame.java 
RightClickMenu.java 
JabRefPreferences.java 
PreferencesService.java 

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
