### PR TITLE
Fix Toggle of special fields does not work for sorted entries #7016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
+- We fixed an issue with toggle of special fields does not work for sorted entries [#7016](https://github.com/JabRef/jabref/issues/7016)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
 - We fixed an issue with toggle of special fields does not work for sorted entries [#7016](https://github.com/JabRef/jabref/issues/7016)
+- We fixed an issue with opacity of disabled icon-buttons [#7195](https://github.com/JabRef/jabref/issues/7195)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -376,6 +376,10 @@
     -fx-fill: white;
 }
 
+.icon-button:disabled {
+    -fx-opacity: 0.4;
+}
+
 .toggle-button:selected {
     -fx-background-color: -jr-icon-background-active;
     -fx-text-fill: -jr-selected;

--- a/src/main/java/org/jabref/gui/specialfields/SpecialFieldAction.java
+++ b/src/main/java/org/jabref/gui/specialfields/SpecialFieldAction.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.specialfields;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -69,7 +70,8 @@ public class SpecialFieldAction extends SimpleCommand {
                 return;
             }
             NamedCompound ce = new NamedCompound(undoText);
-            for (BibEntry bibEntry : bes) {
+            List<BibEntry> besCopy = new ArrayList<>(bes);
+            for (BibEntry bibEntry : besCopy) {
                 // if (value==null) and then call nullField has been omitted as updatefield also handles value==null
                 Optional<FieldChange> change = UpdateField.updateField(bibEntry, specialField, value, nullFieldIfValueIsTheSame);
 


### PR DESCRIPTION
Fixes #7016 
Make a copy of selected entries and change field in the copy so that the sort strategy will not influence the result.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
The original version used for-each on the selected entry list but ConcurrentModificationException happened. Then I tried to replace it with normal for loop but the toggle problem still exist, though the exception did not occur any more. By checking the list in each loop I found that the order of the items in this list was changed during the for loop. Not exactly knowing how the sorting strategy is performed, I make a copy of the list and do field change on the copied list. Finally the toggle action performs correctly.

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
