### PR TITLE
Fix for issue 7633: Unable to download arXiv pdfs if Title contains curly brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
+- we fixed an issue where download article title with curly braces fail to download arXiv links (pdf files).  [#7633](https://github.com/JabRef/jabref/issues/7633)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
-- We fixed an issue where the article title with curly braces fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
+- We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
-- we fixed an issue where download article title with curly braces fail to download arXiv links (pdf files).  [#7633](https://github.com/JabRef/jabref/issues/7633)
+- We fixed an issue where the article title with curly braces fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -136,7 +136,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
             query = "doi:" + doi.get();
         } else {
             Optional<String> authorQuery = entry.getField(StandardField.AUTHOR).map(author -> "au:" + author);
-            Optional<String> titleQuery = entry.getField(StandardField.TITLE).map(title -> "ti:" + StringUtil.ignoreCurlyBraces(title));
+            Optional<String> titleQuery = entry.getField(StandardField.TITLE).map(title -> "ti:" + StringUtil.ignoreCurlyBracket(title));
             query = OptionalUtil.toList(authorQuery, titleQuery).stream().collect(Collectors.joining("+AND+"));
         }
 
@@ -146,7 +146,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
             // Check if entry is a match
             StringSimilarity match = new StringSimilarity();
             String arxivTitle = arxivEntry.get().title.orElse("");
-            String entryTitle = StringUtil.ignoreCurlyBraces(entry.getField(StandardField.TITLE).orElse(""));
+            String entryTitle = StringUtil.ignoreCurlyBracket(entry.getField(StandardField.TITLE).orElse(""));
 
             if (match.isSimilar(arxivTitle, entryTitle)) {
                 return OptionalUtil.toList(arxivEntry);

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -136,7 +136,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
             query = "doi:" + doi.get();
         } else {
             Optional<String> authorQuery = entry.getField(StandardField.AUTHOR).map(author -> "au:" + author);
-            Optional<String> titleQuery = entry.getField(StandardField.TITLE).map(title -> "ti:" + title);
+            Optional<String> titleQuery = entry.getField(StandardField.TITLE).map(title -> "ti:" + StringUtil.ignoreCurlyBraces(title));
             query = OptionalUtil.toList(authorQuery, titleQuery).stream().collect(Collectors.joining("+AND+"));
         }
 
@@ -146,7 +146,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
             // Check if entry is a match
             StringSimilarity match = new StringSimilarity();
             String arxivTitle = arxivEntry.get().title.orElse("");
-            String entryTitle = entry.getField(StandardField.TITLE).orElse("");
+            String entryTitle = StringUtil.ignoreCurlyBraces(entry.getField(StandardField.TITLE).orElse(""));
 
             if (match.isSimilar(arxivTitle, entryTitle)) {
                 return OptionalUtil.toList(arxivEntry);

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -737,6 +737,6 @@ public class StringUtil {
     }
 
     public static String ignoreCurlyBracket(String title){
-        return isNotBlank(title) ? title.replace("{","").replace("}","") : title;
+        return isNotBlank(title) ? title.replace("{", "").replace("}", "") : title;
     }
 }

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -735,4 +735,8 @@ public class StringUtil {
     public static String substringBetween(String str, String open, String close) {
         return StringUtils.substringBetween(str, open, close);
     }
+
+    public static String ignoreCurlyBraces(String title){
+        return isNotBlank(title) ? title.replace("{","").replace("}","") : title;
+    }
 }

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -736,7 +736,7 @@ public class StringUtil {
         return StringUtils.substringBetween(str, open, close);
     }
 
-    public static String ignoreCurlyBraces(String title){
+    public static String ignoreCurlyBracket(String title){
         return isNotBlank(title) ? title.replace("{","").replace("}","") : title;
     }
 }

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -736,7 +736,7 @@ public class StringUtil {
         return StringUtils.substringBetween(str, open, close);
     }
 
-    public static String ignoreCurlyBracket(String title){
+    public static String ignoreCurlyBracket(String title) {
         return isNotBlank(title) ? title.replace("{", "").replace("}", "") : title;
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -96,9 +96,24 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     }
 
     @Test
+    void findFullTextByTitleWithCurlyBrace() throws IOException {
+        entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
+
+        assertEquals(Optional.of(new URL("https://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
+    }
+
+    @Test
     void findFullTextByTitleAndPartOfAuthor() throws IOException {
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
         entry.setField(StandardField.AUTHOR, "Weeks and Lucks");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
+    }
+
+    @Test
+    void findFullTextByTitleWithCurlyBraceAndPartOfAuthor() throws IOException {
+        entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
+        entry.setField(StandardField.AUTHOR, "Zhang, Ruohan and Guo");
 
         assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -96,7 +96,7 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     }
 
     @Test
-    void findFullTextByTitleWithCurlyBrace() throws IOException {
+    void findFullTextByTitleWithCurlyBracket() throws IOException {
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
 
         assertEquals(Optional.of(new URL("https://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
@@ -111,7 +111,7 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     }
 
     @Test
-    void findFullTextByTitleWithCurlyBraceAndPartOfAuthor() throws IOException {
+    void findFullTextByTitleWithCurlyBracketAndPartOfAuthor() throws IOException {
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
         entry.setField(StandardField.AUTHOR, "Zhang, Ruohan and Guo");
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -115,7 +115,7 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
         entry.setField(StandardField.AUTHOR, "Zhang, Ruohan and Guo");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(new URL("https://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
     }
 
     @Test


### PR DESCRIPTION
Fix [#7633](https://github.com/JabRef/jabref/issues/7633)
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

## Reproduce the issue:

1 Open library, select the .bib file as below

```
@Article{zhang_machine_2021v2,
  author  = {Zhang, Ruohan and Guo, Sihang and Liu, Bo and Zhu, Yifeng and Hayhoe, Mary and Ballard, Dana and Stone, Peter},
  journal = {arXiv:2010.15942v2 [cs]},
  title   = {Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}},
  year    = {2021},
  month   = feb,
  url     = {http://arxiv.org/abs/2010.15942v2},
}
```

2 Double click the entry and then click the **Get fulltext** on the right of **general | file **, it will give a message of "No full text document found"

3 And if we erase the curly brackets in the title, with other keep the same, it will download the pdf file successfully , the new title is given below

```
Machine versus Human Attention in Deep Reinforcement Learning Tasks
```


After reading the source code, I thought that it is the case that doi is not present and we need to use the author and title to query the url of the pdf file.  However, the title with curly brackets may fail to search a arXiv entry, or the search is success but the title fails to match the  arXiv title.


## Process to fix the issue:

1 The arXiv-related work is in the **ArXiv.java** 

2 Then I found the url of pdf  is defined in the function **findFullText**, and it further invoke function **searchForEntries**

3 I defined a method called **ignoreCurlyBracket** in **StringUtil.java** to erase the curly brackets in the title if the title is not blank. 

4 In the function **searchForEntries**, I invoke **ignoreCurlyBracket** to fix the title before it serve as a parameter to search arXiv entry and before the comparison with arXiv title.

## Screenshots of  the result:

### Before

![image-20210419154425138](https://user-images.githubusercontent.com/73102892/115348021-af43be80-a1e4-11eb-9989-d3e2fe1635d1.png)


### After

Download successfully

![image-20210419205905217](https://user-images.githubusercontent.com/73102892/115348190-e4501100-a1e4-11eb-8285-19b6cdc19b82.png)

![image-20210419210151694](https://user-images.githubusercontent.com/73102892/115348221-f0d46980-a1e4-11eb-8721-d02246ea0463.png)



