### PR TITLE
Test UI popup window with TestFX (ReplaceStringView.java)

### DIFF
--- a/src/test/java/org/jabref/gui/edit/ReplaceStringViewTest.java
+++ b/src/test/java/org/jabref/gui/edit/ReplaceStringViewTest.java
@@ -1,0 +1,81 @@
+package org.jabref.gui.edit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.scene.control.*;
+import javafx.stage.Stage;
+
+import org.jabref.gui.LibraryTab;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import org.testfx.framework.junit5.ApplicationTest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ReplaceStringViewTest extends ApplicationTest {
+
+    private ReplaceStringView replaceStringView;
+    private LibraryTab libraryTab = mock(LibraryTab.class);
+    private BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
+    private DialogPane dialogPane;
+    private BibEntry entry;
+
+    @Override
+    public void start (Stage stage) throws Exception {
+        // Globals.prefs = JabRefPreferences.getInstance();
+        // Globals.startBackgroundTasks();
+
+        entry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Souti Chattopadhyay and Nicholas Nelson and Audrey Au and Natalia Morales and Christopher Sanchez and Rahul Pandita and Anita Sarma")
+                .withField(StandardField.TITLE, "A tale from the trenches")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.DOI, "10.1145/3377811.3380330")
+                .withField(StandardField.SUBTITLE, "cognitive biases and software development")
+                .withCitationKey("abc");
+        List<BibEntry> entries = new ArrayList<>();
+        entries.add(entry);
+
+        when(libraryTab.getSelectedEntries()).thenReturn(entries);
+        when(libraryTab.getDatabase()).thenReturn(new BibDatabase(entries));
+        replaceStringView = new ReplaceStringView(libraryTab);
+        dialogPane = replaceStringView.getDialogPane();
+        stage.setScene(dialogPane.getScene());
+        stage.show();
+    }
+
+    @Test
+    public void testReplace() throws Exception {
+
+        // verify that the Year field text is of the initial value (2020)
+        assertEquals(Optional.of("2020"), entry.getField(StandardField.YEAR));
+
+        // enter find field
+        clickOn("#findField");
+        write("2020");
+
+        // enter replace field
+        clickOn("#replaceField");
+        write("2021");
+
+        // click on "Replace" button
+        for (ButtonType buttonType : dialogPane.getButtonTypes()) {
+            if (buttonType.getText().equals("Replace")) {
+                Button replaceButton = (Button) dialogPane.lookupButton(buttonType);
+                clickOn(replaceButton);
+            }
+        }
+
+        // verify that the Year field text has been replaced by new value (2021)
+        assertEquals(Optional.of("2021"), entry.getField(StandardField.YEAR));
+    }
+}


### PR DESCRIPTION
This pull requests relates to #6089, which is testing the UI using TestFX as suggested by @koppor. It also contributes to #6207 for adding more tests to the project. Test added:

ReplaceStringViewTest.java

This test uses TestFX to mock the ReplaceStringView and its fxml, brings up the dialogPane and executes a series of actions using FxRobot on the UI to verify the replace string action. However, it requires the Globals.prefs and Globals.fileUpdateMonitor variables to not be null, which implies a refactoring on the BaseDialog.java class and all its dependencies. Right now I initialized the Globals.prefs in the test to prove the concept that TestFX works.

Video of the test:
https://drive.google.com/file/d/1YTdLYF1SKNyjSvR9GRcz4Lv4S_yYzXcO/view?usp=sharing

Screenshot of the test:
![image](https://user-images.githubusercontent.com/3387698/115355542-0f256f80-a1bb-11eb-9391-6b2138e4c6ab.png)


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
