### PR TITLE
Fix#7195 partly Opacity of disabled icon-buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
+- We fixed an issue with opacity of disabled icon-buttons [#7195](https://github.com/JabRef/jabref/issues/7195)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -376,6 +376,10 @@
     -fx-fill: white;
 }
 
+.icon-button:disabled {
+    -fx-opacity: 0.4;
+}
+
 .toggle-button:selected {
     -fx-background-color: -jr-icon-background-active;
     -fx-text-fill: -jr-selected;


### PR DESCRIPTION
Fixes #7195 
Opacity of disabled icon-buttons

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Add the disabled icon style in `Base.css`

- No tabs opened:
![i1](https://user-images.githubusercontent.com/48386227/115385506-cc8b8380-a20a-11eb-9cd6-bb2b9adbf331.png)

- Open a tab and do not select any entry:
![i2](https://user-images.githubusercontent.com/48386227/115385596-e3ca7100-a20a-11eb-9e88-391a824a0e80.png)

- Select an entry in the opened tab:
![i3](https://user-images.githubusercontent.com/48386227/115385630-edec6f80-a20a-11eb-95b5-a15a8deeddd6.png)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
