### PR TITLE
Fix SSLHandshake Exception by using bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added two new fields to track the creation and most recent modification date and time for each entry. [koppor#130](https://github.com/koppor/jabref/issues/130)
 - We added a feature that allows the user to copy highlighted text in the preview window. [#6962](https://github.com/JabRef/jabref/issues/6962)
 - We added a feature that allows you to create new BibEntry via paste arxivId [#2292](https://github.com/JabRef/jabref/issues/2292)
+- We added a feature that allows the user to choose whether to trust the target site when unable to find a valid certification path from the file download site. [#7616](https://github.com/JabRef/jabref/issues/7616)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -481,8 +481,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     URLDownload.bypassSSLVerification();
                     return true;
                 } else {
-                    dialogService.showInformationDialogAndWait(Localization.lang("Download file"),
-                            Localization.lang("Operation canceled."));
+                    dialogService.notify(Localization.lang("Download operation canceled."));
                 }
             }
             return false;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 import javax.xml.transform.TransformerException;
 
 import javafx.beans.Observable;
@@ -425,6 +428,10 @@ public class LinkedFileViewModel extends AbstractViewModel {
             }
 
             URLDownload urlDownload = new URLDownload(linkedFile.getLink());
+            if (!checkSSLHandshake(urlDownload)) {
+                return;
+            }
+
             BackgroundTask<Path> downloadTask = prepareDownloadTask(targetDirectory.get(), urlDownload);
             downloadTask.onSuccess(destination -> {
                 LinkedFile newLinkedFile = LinkedFilesEditorViewModel.fromFile(destination, databaseContext.getFileDirectories(filePreferences), externalFileTypes);
@@ -463,7 +470,29 @@ public class LinkedFileViewModel extends AbstractViewModel {
         }
     }
 
+    public boolean checkSSLHandshake(URLDownload urlDownload) {
+        try {
+            urlDownload.canBeReached();
+        } catch (kong.unirest.UnirestException ex) {
+            if (ex.getCause() instanceof javax.net.ssl.SSLHandshakeException) {
+                if (dialogService.showConfirmationDialogAndWait(Localization.lang("Download file"),
+                        Localization.lang("Unable to find valid certification path to requested target(%0), download anyway?",
+                                urlDownload.getSource().toString()))) {
+                    URLDownload.bypassSSLVerification();
+                    return true;
+                } else {
+                    dialogService.showInformationDialogAndWait(Localization.lang("Download file"),
+                            Localization.lang("Operation canceled."));
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
     public BackgroundTask<Path> prepareDownloadTask(Path targetDirectory, URLDownload urlDownload) {
+        SSLSocketFactory defaultSSLSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
+        HostnameVerifier defaultHostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier();
         BackgroundTask<Path> downloadTask = BackgroundTask
                 .wrap(() -> {
                     Optional<ExternalFileType> suggestedType = inferFileType(urlDownload);
@@ -476,6 +505,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     return targetDirectory.resolve(fulltextDir).resolve(suggestedName);
                 })
                 .then(destination -> new FileDownloadTask(urlDownload.getSource(), destination))
+                .onFinished(() -> URLDownload.setSSLVerification(defaultSSLSocketFactory, defaultHostnameVerifier))
                 .onFailure(exception -> dialogService.showErrorDialogAndWait("Download failed", exception));
         return downloadTask;
     }

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -36,9 +36,9 @@ import java.util.Map.Entry;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import javax.net.ssl.SSLSocketFactory;
 
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.util.FileHelper;
@@ -138,7 +138,7 @@ public class URLDownload {
      * @param sf trust manager
      * @param v host verifier
      */
-    public static void setSSLVerification(SSLSocketFactory sf, HostnameVerifier v){
+    public static void setSSLVerification(SSLSocketFactory sf, HostnameVerifier v) {
         try {
             HttpsURLConnection.setDefaultSSLSocketFactory(sf);
             HttpsURLConnection.setDefaultHostnameVerifier(v);

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -38,6 +38,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLSocketFactory;
 
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.util.FileHelper;
@@ -129,6 +130,20 @@ public class URLDownload {
             HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
         } catch (Exception e) {
             LOGGER.error("A problem occurred when bypassing SSL verification", e);
+        }
+    }
+
+    /**
+     *
+     * @param sf trust manager
+     * @param v host verifier
+     */
+    public static void setSSLVerification(SSLSocketFactory sf, HostnameVerifier v){
+        try {
+            HttpsURLConnection.setDefaultSSLSocketFactory(sf);
+            HttpsURLConnection.setDefaultHostnameVerifier(v);
+        } catch (Exception e) {
+            LOGGER.error("A problem occurred when reset SSL verification", e);
         }
     }
 

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -138,7 +138,7 @@ public class URLDownload {
      * @param sf trust manager
      * @param v host verifier
      */
-    public static void setSSLVerification(SSLSocketFactory sf, HostnameVerifier v) {
+    public static void setSSLVerification(SSLSocketFactory socketFactory, HostnameVerifier verifier) {
         try {
             HttpsURLConnection.setDefaultSSLSocketFactory(sf);
             HttpsURLConnection.setDefaultHostnameVerifier(v);

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -135,13 +135,13 @@ public class URLDownload {
 
     /**
      *
-     * @param sf trust manager
-     * @param v host verifier
+     * @param socketFactory trust manager
+     * @param verifier host verifier
      */
     public static void setSSLVerification(SSLSocketFactory socketFactory, HostnameVerifier verifier) {
         try {
-            HttpsURLConnection.setDefaultSSLSocketFactory(sf);
-            HttpsURLConnection.setDefaultHostnameVerifier(v);
+            HttpsURLConnection.setDefaultSSLSocketFactory(socketFactory);
+            HttpsURLConnection.setDefaultHostnameVerifier(verifier);
         } catch (Exception e) {
             LOGGER.error("A problem occurred when reset SSL verification", e);
         }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2292,3 +2292,5 @@ Import\ settings=Import settings
 Custom\ DOI\ URI=Custom DOI URI
 Customization=Customization
 Use\ custom\ DOI\ base\ URI\ for\ article\ access=Use custom DOI base URI for article access
+
+Unable\ to\ find\ valid\ certification\ path\ to\ requested\ target(%0),\ download\ anyway?=Unable to find valid certification path to requested target(%0), download anyway?

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2294,3 +2294,4 @@ Customization=Customization
 Use\ custom\ DOI\ base\ URI\ for\ article\ access=Use custom DOI base URI for article access
 
 Unable\ to\ find\ valid\ certification\ path\ to\ requested\ target(%0),\ download\ anyway?=Unable to find valid certification path to requested target(%0), download anyway?
+Download\ operation\ canceled.=Download operation canceled.


### PR DESCRIPTION
Fixes #7616 

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.


File download path: https://www.serbski-institut.de/os/dnlarchiv/Kleine_Reihe_27_web.2217.pdf

<br>

A valid authentication path cannot be found from the site where the downloaded file is located, prompting the user with the option of whether to continue the download.
![warning](https://user-images.githubusercontent.com/47767371/115521609-e4700f80-a2bd-11eb-81e1-847244f177a6.png)

<br>

The user chooses to cancel the download.
![canceled_tip](https://user-images.githubusercontent.com/47767371/115521968-416bc580-a2be-11eb-98ba-f2669356065e.png)

<br>

The user chooses to download anyway.
![download](https://user-images.githubusercontent.com/47767371/115522090-652f0b80-a2be-11eb-9dc0-49157e482c6d.png)

