### PR TITLE
Fix exception when searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,7 +524,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the "Search for unlinked local files" would throw an exception when parsing the content of a PDF-file with missing "series" information [#5128](https://github.com/JabRef/jabref/issues/5128)
 - We fixed an issue where the XMP Importer would incorrectly return an empty default entry when importing pdfs [#6577](https://github.com/JabRef/jabref/issues/6577)
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
-- We fixed an issue where has exception when importing library [#7343](https://github.com/JabRef/jabref/issues/7343)
+- We fixed an issue when importing resulted in an exception [#7343](https://github.com/JabRef/jabref/issues/7343)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -524,6 +524,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the "Search for unlinked local files" would throw an exception when parsing the content of a PDF-file with missing "series" information [#5128](https://github.com/JabRef/jabref/issues/5128)
 - We fixed an issue where the XMP Importer would incorrectly return an empty default entry when importing pdfs [#6577](https://github.com/JabRef/jabref/issues/6577)
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
+- We fixed an issue where has exception when importing library [#7343](https://github.com/JabRef/jabref/issues/7343)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/ImportCleanup.java
+++ b/src/main/java/org/jabref/logic/importer/ImportCleanup.java
@@ -33,6 +33,6 @@ public class ImportCleanup {
      * Performs a format conversion of the given entry collection into the targeted format.
      */
     public void doPostCleanup(Collection<BibEntry> entries) {
-        entries.parallelStream().forEach(entry -> doPostCleanup(entry));
+        entries.forEach(this::doPostCleanup);
     }
 }

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
-import javafx.application.Platform;
 import javafx.beans.Observable;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -561,9 +560,7 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         invalidateFieldCache(field);
-        Platform.runLater(() -> {
-            fields.put(field, value.intern());
-        });
+        fields.put(field, value.intern());
 
         FieldChange change = new FieldChange(this, field, oldValue, value);
         if (isNewField) {
@@ -609,9 +606,7 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         invalidateFieldCache(field);
-        Platform.runLater(() -> {
-            fields.remove(field);
-        });
+        fields.remove(field);
 
         FieldChange change = new FieldChange(this, field, oldValue.get(), null);
         eventBus.post(new FieldAddedOrRemovedEvent(change, eventSource));

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -14,12 +14,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
+import javafx.application.Platform;
 import javafx.beans.Observable;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
-import javafx.application.Platform;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.bibtex.FileFieldWriter;

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -19,6 +19,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableMap;
+import javafx.application.Platform;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.bibtex.FileFieldWriter;
@@ -560,7 +561,9 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         invalidateFieldCache(field);
-        fields.put(field, value.intern());
+        Platform.runLater(() -> {
+            fields.put(field, value.intern());
+        });
 
         FieldChange change = new FieldChange(this, field, oldValue, value);
         if (isNewField) {
@@ -606,7 +609,9 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         invalidateFieldCache(field);
-        fields.remove(field);
+        Platform.runLater(() -> {
+            fields.remove(field);
+        });
 
         FieldChange change = new FieldChange(this, field, oldValue.get(), null);
         eventBus.post(new FieldAddedOrRemovedEvent(change, eventSource));


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
We fix the issue that uncaught exception when searching in dark mode. In fact, we found that this issue is not a dark mode issue and this is a threading issue. So we use Platform.runLater() to ensure that there will be no conflicts when adding key-value pairs to the map.
fixes [#7343](https://github.com/JabRef/jabref/issues/7343)
<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.