### PR TITLE
fetch by DOI or ISBN in web search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where journal abbreviations in UTF-8 were not recognized [#5850](https://github.com/JabRef/jabref/issues/5850)
 - We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
 - We fixed an issue where the article title with colon fails to download the arXiv link (pdf file). [#7660](https://github.com/JabRef/issues/7660)
+- We fixed an issue when throw an exception if you put ISBN or DOI in web search [#7575](https://github.com/JabRef/jabref/issues/7575)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
+- We fixed an issue with opacity of disabled icon-buttons [#7195](https://github.com/JabRef/jabref/issues/7195)
 - We fixed an issue where journal abbreviations in UTF-8 were not recognized [#5850](https://github.com/JabRef/jabref/issues/5850)
 - We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening BibTex file (doubleclick) from Folder with spaces not working. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue with saving large `.bib` files [#7265](https://github.com/JabRef/jabref/issues/7265)
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
+- We fixed an issue where journal abbreviations in UTF-8 were not recognized [#5850](https://github.com/JabRef/jabref/issues/5850)
 - We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -540,6 +540,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the "Search for unlinked local files" would throw an exception when parsing the content of a PDF-file with missing "series" information [#5128](https://github.com/JabRef/jabref/issues/5128)
 - We fixed an issue where the XMP Importer would incorrectly return an empty default entry when importing pdfs [#6577](https://github.com/JabRef/jabref/issues/6577)
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
+- We fixed an issue when importing resulted in an exception [#7343](https://github.com/JabRef/jabref/issues/7343)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with opacity of disabled icon-buttons [#7195](https://github.com/JabRef/jabref/issues/7195)
 - We fixed an issue where journal abbreviations in UTF-8 were not recognized [#5850](https://github.com/JabRef/jabref/issues/5850)
 - We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
+- We fixed an issue where the article title with colon fails to download the arXiv link (pdf file). [#7660](https://github.com/JabRef/issues/7660)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -376,6 +376,10 @@
     -fx-fill: white;
 }
 
+.icon-button:disabled {
+    -fx-opacity: 0.4;
+}
+
 .toggle-button:selected {
     -fx-background-color: -jr-icon-background-active;
     -fx-text-fill: -jr-selected;

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -130,7 +130,7 @@ public class WebSearchPaneViewModel {
 
             return new ParserResult(activeFetcher.performSearch(getQuery().trim()));
         }).withInitialMessage(Localization.lang("Processing %0", getQuery().trim()));
-        
+
         task.onFailure(dialogService::showErrorDialogAndWait);
 
         ImportEntriesDialog dialog = new ImportEntriesDialog(stateManager.getActiveDatabase().get(), task);

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -112,6 +112,7 @@ public class WebSearchPaneViewModel {
                         return new ParserResult(Collections.singletonList(bibEntry.get()));
                     }
                 } catch (FetcherException ignore) {
+                    // Ignored, because it can be something else
                 }
             }
 
@@ -123,6 +124,7 @@ public class WebSearchPaneViewModel {
                         return new ParserResult(Collections.singletonList(bibEntry.get()));
                     }
                 } catch (FetcherException ignore) {
+                    // Ignored, because it can be something els
                 }
             }
 

--- a/src/main/java/org/jabref/logic/importer/ImportCleanup.java
+++ b/src/main/java/org/jabref/logic/importer/ImportCleanup.java
@@ -33,6 +33,6 @@ public class ImportCleanup {
      * Performs a format conversion of the given entry collection into the targeted format.
      */
     public void doPostCleanup(Collection<BibEntry> entries) {
-        entries.parallelStream().forEach(entry -> doPostCleanup(entry));
+        entries.forEach(this::doPostCleanup);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -16,6 +16,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jabref.logic.cleanup.CleanupJob;
+import org.jabref.logic.cleanup.EprintCleanup;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.FulltextFetcher;
@@ -116,6 +118,9 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
     }
 
     private List<ArXivEntry> searchForEntries(BibEntry entry) throws FetcherException {
+        entry = (BibEntry) entry.clone();
+        CleanupJob cleanupJob = new EprintCleanup();
+        cleanupJob.cleanup(entry);
         // 1. Eprint
         Optional<String> identifier = entry.getField(StandardField.EPRINT);
         if (StringUtil.isNotBlank(identifier)) {

--- a/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
@@ -38,9 +38,11 @@ public class IntegrityCheck {
                 new CitationKeyDeviationChecker(bibDatabaseContext, citationKeyPatternPreferences),
                 new CitationKeyDuplicationChecker(bibDatabaseContext.getDatabase())
         ));
-
         if (bibDatabaseContext.isBiblatexMode()) {
-            entryCheckers.add(new JournalInAbbreviationListChecker(StandardField.JOURNALTITLE, journalAbbreviationRepository));
+            entryCheckers.addAll(List.of(
+                    new JournalInAbbreviationListChecker(StandardField.JOURNALTITLE, journalAbbreviationRepository),
+                    new UTF8Checker())
+            );
         } else {
             entryCheckers.addAll(List.of(
                     new JournalInAbbreviationListChecker(StandardField.JOURNAL, journalAbbreviationRepository),
@@ -59,7 +61,6 @@ public class IntegrityCheck {
         for (BibEntry entry : database.getEntries()) {
             result.addAll(checkEntry(entry));
         }
-
         result.addAll(checkDatabase(database));
 
         return result;

--- a/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
+++ b/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
@@ -1,0 +1,53 @@
+package org.jabref.logic.integrity;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+
+public class UTF8Checker implements EntryChecker {
+
+    /**
+     * Detect any non UTF-8 encoded field
+     * @param entry the BibEntry of BibLatex.
+     * @return return the warning of UTF-8 check for BibLatex.
+     */
+    @Override
+    public List<IntegrityMessage> check(BibEntry entry) {
+        List<IntegrityMessage> results = new ArrayList<>();
+        Charset charset = Charset.forName(System.getProperty("file.encoding"));
+        for (Map.Entry<Field, String> field : entry.getFieldMap().entrySet()) {
+            boolean utfOnly = UTF8EncodingChecker(field.getValue().getBytes(charset));
+            if (!utfOnly) {
+                results.add(new IntegrityMessage(Localization.lang("Non-UTF-8 encoded field found"), entry,
+                        field.getKey()));
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Check whether a byte array is encoded in UTF-8 charset
+     *
+     * Use java api decoder and try&catch block to check the charset.
+     * @param data the byte array used to check the encoding charset
+     * @return true if is encoded in UTF-8 & false is not encoded in UTF-8
+     */
+    public static boolean UTF8EncodingChecker(byte[] data) {
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        try {
+            decoder.decode(ByteBuffer.wrap(data));
+        } catch (CharacterCodingException ex) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1629,6 +1629,7 @@ Style\ file=Style file
 Open\ OpenOffice/LibreOffice\ connection=Open OpenOffice/LibreOffice connection
 You\ must\ enter\ at\ least\ one\ field\ name=You must enter at least one field name
 Non-ASCII\ encoded\ character\ found=Non-ASCII encoded character found
+Non-UTF-8\ encoded\ field\ found=Non-UTF-8 encoded field found
 Toggle\ web\ search\ interface=Toggle web search interface
 
 Migration\ help\ information=Migration help information

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -103,6 +103,22 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     }
 
     @Test
+    void findFullTextByTitleWithColonAndJournalWithoutEprint() throws IOException {
+        entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
+        entry.setField(StandardField.JOURNAL, "arXiv:2002.10248v4 [cs]");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+    }
+
+    @Test
+    void findFullTextByTitleWithColonAndUrlWithoutEprint() throws IOException {
+        entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
+        entry.setField(StandardField.URL, "http://arxiv.org/abs/2002.10248v4");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+    }
+
+    @Test
     void findFullTextByTitleAndPartOfAuthor() throws IOException {
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
         entry.setField(StandardField.AUTHOR, "Weeks and Lucks");

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -87,9 +87,9 @@ class IntegrityCheckTest {
 
     private static Stream<String> provideIncorrectFormat() {
         return Stream.of("   Knuth, Donald E. ",
-                         "Knuth, Donald E. and Kurt Cobain and A. Einstein",
-                         ", and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and ,",
-                         "and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and");
+                "Knuth, Donald E. and Kurt Cobain and A. Einstein",
+                ", and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and ,",
+                "and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and");
     }
 
     @Test
@@ -190,10 +190,10 @@ class IntegrityCheckTest {
 
     private void assertCorrect(BibDatabaseContext context, boolean allowIntegerEdition) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                                                             mock(FilePreferences.class),
-                                                             createCitationKeyPatternPreferences(),
-                                                             JournalAbbreviationLoader.loadBuiltInRepository(),
-                                                             allowIntegerEdition).check();
+                mock(FilePreferences.class),
+                createCitationKeyPatternPreferences(),
+                JournalAbbreviationLoader.loadBuiltInRepository(),
+                allowIntegerEdition).check();
         assertEquals(Collections.emptyList(), messages);
     }
 

--- a/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
@@ -1,0 +1,74 @@
+package org.jabref.logic.integrity;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UTF8CheckerTest {
+
+    private final BibEntry entry = new BibEntry();
+
+    /**
+     * fieldAcceptsUTF8 to check UTF8Checker's result set
+     * when the entry is encoded in UTF-8 (should be empty)
+     */
+    @Test
+    void fieldAcceptsUTF8() {
+        UTF8Checker checker = new UTF8Checker();
+        entry.setField(StandardField.TITLE, "Only ascii characters!'@12");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    /**
+     * fieldDoesNotAcceptUmlauts to check UTF8Checker's result set
+     * when the entry is encoded in Non-Utf-8 charset and the System
+     * environment is Non UTF-8.
+     * Finally we need to reset the environment charset.
+     * @throws UnsupportedEncodingException initial a String in charset GBK
+     * Demo: new String(StringDemo.getBytes(), "GBK");
+     */
+    @Test
+    void fieldDoesNotAcceptUmlauts() throws UnsupportedEncodingException {
+        String defaultCharset = System.getProperty("file.encoding");
+        System.getProperties().put("file.encoding", "GBK");
+        UTF8Checker checker = new UTF8Checker();
+        String NonUTF8 = new String("你好，这条语句使用GBK字符集".getBytes(), "GBK");
+        entry.setField(StandardField.MONTH, NonUTF8);
+        assertEquals(List.of(new IntegrityMessage("Non-UTF-8 encoded field found", entry, StandardField.MONTH)), checker.check(entry));
+        System.getProperties().put("file.encoding", defaultCharset);
+    }
+
+    /**
+     * To check the UTF8Checker.UTF8EncodingChecker
+     * in NonUTF8 char array (should return false)
+     *
+     * @throws UnsupportedEncodingException initial a String in charset GBK
+     * Demo: new String(StringDemo.getBytes(), "GBK");
+     */
+    @Test
+    void NonUTF8EncodingCheckerTest() throws UnsupportedEncodingException {
+        String NonUTF8 = new String("你好，这条语句使用GBK字符集".getBytes(), "GBK");
+            assertFalse(UTF8Checker.UTF8EncodingChecker(NonUTF8.getBytes("GBK")));
+
+    }
+
+    /**
+     * To check the UTF8Checker.UTF8EncodingChecker
+     * in UTF-8 char array (should return true)
+     */
+    @Test
+    void UTF8EncodingCheckerTest() {
+        String UTF8Demo = new String("你好，这条语句使用GBK字符集".getBytes(), StandardCharsets.UTF_8);
+            assertTrue(UTF8Checker.UTF8EncodingChecker(UTF8Demo.getBytes(StandardCharsets.UTF_8)));
+    }
+}


### PR DESCRIPTION
Fixes #7575 
We won't throw an exception if the user put into web search an ISBN or DOI, instead we will try to fetch it 


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
