### PR TITLE
Fixes Jabref#7660 Unable to download some arXiv links if the "eprint" field is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with very large page numbers [#7590](https://github.com/JabRef/jabref/issues/7590)
 - We fixed an issue where journal abbreviations in UTF-8 were not recognized [#5850](https://github.com/JabRef/jabref/issues/5850)
 - We fixed an issue where the article title with curly brackets fails to download the arXiv link (pdf file). [#7633](https://github.com/JabRef/jabref/issues/7633)
+- We fixed an issue where the article title with colon fails to download the arXiv link (pdf file). [#7660](https://github.com/JabRef/issues/7660)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -16,6 +16,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.jabref.logic.cleanup.CleanupJob;
+import org.jabref.logic.cleanup.EprintCleanup;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.FulltextFetcher;
@@ -116,6 +118,9 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
     }
 
     private List<ArXivEntry> searchForEntries(BibEntry entry) throws FetcherException {
+        entry = (BibEntry) entry.clone();
+        CleanupJob cleanupJob = new EprintCleanup();
+        cleanupJob.cleanup(entry);
         // 1. Eprint
         Optional<String> identifier = entry.getField(StandardField.EPRINT);
         if (StringUtil.isNotBlank(identifier)) {

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -103,6 +103,22 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     }
 
     @Test
+    void findFullTextByTitleWithColonAndJournalWithoutEprint() throws IOException {
+        entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
+        entry.setField(StandardField.JOURNAL, "arXiv:2002.10248v4 [cs]");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+    }
+
+    @Test
+    void findFullTextByTitleWithColonAndUrlWithoutEprint() throws IOException {
+        entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
+        entry.setField(StandardField.URL, "http://arxiv.org/abs/2002.10248v4");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+    }
+
+    @Test
     void findFullTextByTitleAndPartOfAuthor() throws IOException {
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
         entry.setField(StandardField.AUTHOR, "Weeks and Lucks");


### PR DESCRIPTION
Fixes #7660
## Brief summary
1. Run EprintCleanup on a copy of the entry the ArXiv fetcher is fetching before getting arXiv id from the eprint field;
2. Add two test method. One finds full text with title containing colon and journal, while another finds full text with title containing colon and url.

## Problem
When finding full text, this BibTeX reference works:
```
@Article{booth_bayes-trex_2020,
  author        = {Serena Booth and Yilun Zhou and Ankit Shah and Julie Shah},
  journal       = {arXiv:2002.10248v4 [cs]},
  title         = {Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example},
  year          = {2020},
  month         = dec,
  archiveprefix = {arXiv},
  eprint        = {2002.10248},
  url           = {http://arxiv.org/abs/2002.10248v4},
}
```
![#7660-0](https://user-images.githubusercontent.com/48386227/115873907-13c97c80-a476-11eb-821f-24598bd1a8a9.png)

But when `eprint` field is missing, no full text will be found:
```
@Article{booth_bayes-trex_2020,
  author        = {Serena Booth and Yilun Zhou and Ankit Shah and Julie Shah},
  journal       = {arXiv:2002.10248v4 [cs]},
  title         = {Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example},
  year          = {2020},
  month         = dec,
  archiveprefix = {arXiv},
  url           = {http://arxiv.org/abs/2002.10248v4},
}
```
![#7660-1](https://user-images.githubusercontent.com/48386227/115873922-188e3080-a476-11eb-80e7-222c58ee4e09.png)

## Solution
Since the title contains colon and arXiv uses colon to represent key and value, the title may be recognized mistakenly. So use other fields to get the eprint field to avoid this problem. Thanks to the advice from @tobiasdiez .

## Screenshots
After fix:
![#7660-2](https://user-images.githubusercontent.com/48386227/115873880-0f04c880-a476-11eb-9291-82e011f87ab3.png)


- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
