### PR TITLE
fixed issue #7606 Searching for bibliographies and importing them triggers uncaught java.lang.IndexOutOfBoundsException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where searching for bibliographies and importing them triggers uncaught java.lang.IndexOutOfBoundsException [#7606](https://github.com/JabRef/jabref/issues/7606)
 - We fixed an issue where the table column sort order was not properly stored and resulted in unsorted eports [#7524](https://github.com/JabRef/jabref/issues/7524)
 - We fixed an issue where the value of the field `school` or `institution` would be printed twice in the HTML Export [forum#2634](https://discourse.jabref.org/t/problem-with-exporting-techreport-phdthesis-mastersthesis-to-html/2634)
 - We fixed an issue preventing to connect to a shared database. [#7570](https://github.com/JabRef/jabref/pull/7570)

--- a/src/main/java/org/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Windows.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 
+
 public class Windows implements NativeDesktop {
     private static final String DEFAULT_EXECUTABLE_EXTENSION = ".exe";
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -264,6 +264,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
         List<BibEntry> searchResult = searchForEntries(transformedQuery, pageNumber).stream()
                                                                                     .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.getKeywordSeparator()))
                                                                                     .collect(Collectors.toList());
+        CompositeSearchBasedFetcher.PerformSucceed();
         return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
     }
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -271,6 +271,7 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
         CompositeSearchBasedFetcher.PerformSucceed();
         return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
     }
+    //when perform pages set onPerformSearch to true
 
     private List<BibEntry> filterYears(List<BibEntry> searchResult, ArXivQueryTransformer transformer) {
         return searchResult.stream()

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -254,6 +254,10 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
     /**
      * Constructs a complex query string using the field prefixes specified at https://arxiv.org/help/api/user-manual
      *
+     * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
+     *
+     * Set the onPerformSucceed to true after performedPage
+     *
      * @param luceneQuery the root node of the lucene query
      * @return A list of entries matching the complex query
      */

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXiv.java
@@ -268,10 +268,10 @@ public class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedF
         List<BibEntry> searchResult = searchForEntries(transformedQuery, pageNumber).stream()
                                                                                     .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.getKeywordSeparator()))
                                                                                     .collect(Collectors.toList());
-        CompositeSearchBasedFetcher.PerformSucceed();
+        CompositeSearchBasedFetcher.performSucceed();
         return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
     }
-    //when perform pages set onPerformSearch to true
+    // when perform pages set onPerformSearch to true
 
     private List<BibEntry> filterYears(List<BibEntry> searchResult, ArXivQueryTransformer transformer) {
         return searchResult.stream()

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -17,7 +17,6 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
     public static volatile Boolean onPerformSucceed = false;
 
@@ -42,10 +41,11 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
      * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
      * Set onPerformSucceed to true at performSearchPaged method in ArXiv
      */
-    public static void PerformSucceed(){
+    public static void performSucceed() {
         onPerformSucceed = true;
     }
     // keep a status of perform search to make sure the execute order
+
     @Override
     public String getName() {
         return "SearchAll";
@@ -72,7 +72,7 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
         return fetchers.stream()
                        .flatMap(searchBasedFetcher -> {
                            try {
-                               onPerformSucceed  = false;
+                               onPerformSucceed = false;
                                return searchBasedFetcher.performSearch(luceneQuery).stream();
                            } catch (FetcherException e) {
                                LOGGER.warn(String.format("%s API request failed", searchBasedFetcher.getName()), e);
@@ -80,7 +80,7 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
                            }
                        })
                        .limit(maximumNumberOfReturnedResults)
-                       .map(x->{
+                       .map(x-> {
                            while (!onPerformSucceed) {
                                Thread.onSpinWait();
                            }
@@ -89,4 +89,4 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
                        .collect(Collectors.toList());
     }
 }
-//clear only after the perform search
+// clear only after the perform search

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -38,7 +38,11 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
         this.maximumNumberOfReturnedResults = maximumNumberOfReturnedResults;
     }
 
-
+    /**
+     * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
+     *
+     * Set onPerformSucceed to true at performSearchPaged method in ArXiv
+     */
     public static void PerformSucceed(){
         onPerformSucceed = true;
     }
@@ -53,6 +57,15 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
         return Optional.empty();
     }
 
+    /**
+     * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
+     *
+     * @param luceneQuery the root node of the lucene query
+     *
+     * @return return the fetchers stream
+     *
+     * @throws FetcherException when API request failed at searchBasedFetcher.getName()
+     */
     @Override
     public List<BibEntry> performSearch(QueryNode luceneQuery) throws FetcherException {
         ImportCleanup cleanup = new ImportCleanup(BibDatabaseMode.BIBTEX);

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -45,7 +45,7 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
     public static void PerformSucceed(){
         onPerformSucceed = true;
     }
-
+    // keep a status of perform search to make sure the execute order
     @Override
     public String getName() {
         return "SearchAll";
@@ -89,3 +89,4 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
                        .collect(Collectors.toList());
     }
 }
+//clear only after the perform search

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -40,7 +40,6 @@ public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
     /**
      * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
-     *
      * Set onPerformSucceed to true at performSearchPaged method in ArXiv
      */
     public static void PerformSucceed(){

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
@@ -40,9 +40,12 @@ public class CompositeSearchBasedFetcherTest {
                 () -> new CompositeSearchBasedFetcher(null, 0));
     }
 
+    /***
+     * CS304 Issue Link: https://github.com/JabRef/jabref/issues/7606
+     */
     @Test
     public void setPerformSucceed() {
-        CompositeSearchBasedFetcher.PerformSucceed();
+        CompositeSearchBasedFetcher.performSucceed();
         Assertions.assertEquals(true, CompositeSearchBasedFetcher.onPerformSucceed);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
@@ -41,6 +41,12 @@ public class CompositeSearchBasedFetcherTest {
     }
 
     @Test
+    public void setPerformSucceed() {
+        CompositeSearchBasedFetcher.PerformSucceed();
+        Assertions.assertEquals(true, CompositeSearchBasedFetcher.onPerformSucceed);
+    }
+
+    @Test
     public void performSearchWithoutFetchers() throws Exception {
         Set<SearchBasedFetcher> empty = new HashSet<>();
         CompositeSearchBasedFetcher fetcher = new CompositeSearchBasedFetcher(empty, Integer.MAX_VALUE);


### PR DESCRIPTION
Fixes #7606 

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at 

### Bug:
The parallelStream cause performSearch excute in a background thread and **the Cleanup operation excute before the performSearch** so it may cause an _java.lang.IndexOutOfBoundsException_. 

### The way to fix:
Use **stream to instead of parallelStream** and use a **spinlock** to prevent the Cleanup excute before the performSearch operation .
(In fact, I think use stream to instead of parallelStream can solve this problem and I test many times manually there are no bug in #7606 after this way. But I'm not sure whether this can solve the problem , could you offer me some suggestions !)
