### PR TITLE
MS Office XML: Export month name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the linking of the `python3` interpreter via the shebang to dynamically use the systems default Python. Related to [JabRef-Browser-Extension #177](https://github.com/JabRef/JabRef-Browser-Extension/issues/177)
 - Automatically found pdf files now have the linking button to the far left and uses a link icon with a plus instead of a briefcase. The file name also has lowered opacity(70%) until added. [#3607](https://github.com/JabRef/jabref/issues/3607)
 - We simplified the select entry type form by splitting it into two parts ("Recommended" and "Others") based on internal usage data. [#6730](https://github.com/JabRef/jabref/issues/6730)
-- - The export to MS Office XML now uses the month name for the field `Month` instead of the two digit number [forum#2685](https://discourse.jabref.org/t/export-month-as-text-not-number/2685)
+- The export to MS Office XML now uses the month name for the field `Month` instead of the two digit number [forum#2685](https://discourse.jabref.org/t/export-month-as-text-not-number/2685)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the linking of the `python3` interpreter via the shebang to dynamically use the systems default Python. Related to [JabRef-Browser-Extension #177](https://github.com/JabRef/JabRef-Browser-Extension/issues/177)
 - Automatically found pdf files now have the linking button to the far left and uses a link icon with a plus instead of a briefcase. The file name also has lowered opacity(70%) until added. [#3607](https://github.com/JabRef/jabref/issues/3607)
 - We simplified the select entry type form by splitting it into two parts ("Recommended" and "Others") based on internal usage data. [#6730](https://github.com/JabRef/jabref/issues/6730)
+- - The export to MS Office XML now uses the month name for the field `Month` instead of the two digit number [forum#2685](https://discourse.jabref.org/t/export-month-as-text-not-number/2685)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -63,7 +63,7 @@ public class MSBibConverter {
         }
 
         result.day = entry.getFieldOrAliasLatexFree(StandardField.DAY).orElse(null);
-        result.month = entry.getMonth().map(Month::getFullName).map(Object::toString).orElse(null);
+        result.month = entry.getMonth().map(Month::getFullName).orElse(null);
 
         if (!entry.getLatexFreeField(StandardField.YEAR).isPresent()) {
             result.year = entry.getFieldOrAliasLatexFree(StandardField.YEAR).orElse(null);

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -63,7 +63,7 @@ public class MSBibConverter {
         }
 
         result.day = entry.getFieldOrAliasLatexFree(StandardField.DAY).orElse(null);
-        result.month = entry.getMonth().map(Month::getNumber).map(Object::toString).orElse(null);
+        result.month = entry.getMonth().map(Month::getFullName).map(Object::toString).orElse(null);
 
         if (!entry.getLatexFreeField(StandardField.YEAR).isPresent()) {
             result.year = entry.getFieldOrAliasLatexFree(StandardField.YEAR).orElse(null);

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDay.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDay.xml
@@ -16,7 +16,7 @@
             </b:Author>
         </b:Author>
         <b:Year>2002</b:Year>
-        <b:Month>7</b:Month>
+        <b:Month>July</b:Month>
         <b:Day>3</b:Day>
         <b:ThesisType>Tech. rep.</b:ThesisType>
     </b:Source>

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDayBiblatex.bib
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDayBiblatex.bib
@@ -1,0 +1,8 @@
+% Encoding: UTF-8
+
+@TechReport{,
+  author    = {Sam and jason},
+  date      = {2002-07-03},
+}
+
+@Comment{jabref-meta: databaseType:biblatex;}

--- a/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDayBiblatex.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MsBibExportFormatTestDayBiblatex.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
+    <b:Source>
+        <b:BIBTEX_Entry>techreport</b:BIBTEX_Entry>
+        <b:SourceType>Report</b:SourceType>
+        <b:Author>
+            <b:Author>
+                <b:NameList>
+                    <b:Person>
+                        <b:Last>Sam</b:Last>
+                    </b:Person>
+                    <b:Person>
+                        <b:Last>jason</b:Last>
+                    </b:Person>
+                </b:NameList>
+            </b:Author>
+        </b:Author>
+        <b:Year>2002</b:Year>
+        <b:Month>July</b:Month>
+        <b:Day>3</b:Day>
+        <b:ThesisType>Tech. rep.</b:ThesisType>
+    </b:Source>
+</b:Sources>


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/export-month-as-text-not-number/2685

The month field is also the full name in the example listed here https://docs.microsoft.com/de-de/dotnet/api/documentformat.openxml.bibliography.month?view=openxml-2.8.1

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
