### PR TITLE
Make key for ScienceDirect configurable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,8 @@ processResources {
                 "azureInstrumentationKey": System.getenv('AzureInstrumentationKey') ? System.getenv('AzureInstrumentationKey') : '',
                 "springerNatureAPIKey": System.getenv('SpringerNatureAPIKey') ? System.getenv('SpringerNatureAPIKey') : '',
                 "astrophysicsDataSystemAPIKey": System.getenv('AstrophysicsDataSystemAPIKey') ? System.getenv('AstrophysicsDataSystemAPIKey') : '',
-                "ieeeAPIKey": System.getenv('IEEEAPIKey') ? System.getenv('IEEEAPIKey') : ''
+                "ieeeAPIKey": System.getenv('IEEEAPIKey') ? System.getenv('IEEEAPIKey') : '',
+                "scienceDirectApiKey": System.getenv('SCIENCEDIRECTAPIKEY') ? System.getenv('SCIENCEDIRECTAPIKEY') : ''
         )
         filteringCharset = 'UTF-8'
     }

--- a/docs/advanced-reading/fetchers.md
+++ b/docs/advanced-reading/fetchers.md
@@ -7,6 +7,7 @@ Fetchers are the implementation of the [search using online services](https://do
 | [IEEEXplore](https://docs.jabref.org/collect/import-using-online-bibliographic-database/ieeexplore) | [IEEE Xplore API portal](https://developer.ieee.org/) | `IEEEAPIKey` | 200 calls/day |
 | [MathSciNet](http://www.ams.org/mathscinet) | \(none\) | \(none\) | Depending on the current network |
 | [SAO/NASA Astrophysics Data System](https://docs.jabref.org/collect/import-using-online-bibliographic-database/ads) | [ADS UI](https://ui.adsabs.harvard.edu/user/settings/token) | `AstrophysicsDataSystemAPIKey` | 5000 calls/day |
+| [ScienceDirect](https://www.sciencedirect.com/) | | `ScienceDirectApiKey` | |
 | [Springer Nature](https://docs.jabref.org/collect/import-using-online-bibliographic-database/springer) | [Springer Nature API Portal](https://dev.springernature.com/) | `SpringerNatureAPIKey` | 5000 calls/day |
 | [Zentralblatt Math](https://www.zbmath.org/) | \(none\) | \(none\) | Depending on the current network |
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.jabref.logic.importer.FulltextFetcher;
 import org.jabref.logic.net.URLDownload;
+import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
@@ -31,7 +32,7 @@ public class ScienceDirect implements FulltextFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScienceDirect.class);
 
     private static final String API_URL = "http://api.elsevier.com/content/article/doi/";
-    private static final String API_KEY = "fb82f2e692b3c72dafe5f4f1fa0ac00b";
+    private static final String API_KEY = new BuildInfo().scienceDirectApiKey;
 
     @Override
     public Optional<URL> findFullText(BibEntry entry) throws IOException {

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -26,6 +26,7 @@ public final class BuildInfo {
     public final String springerNatureAPIKey;
     public final String astrophysicsDataSystemAPIKey;
     public final String ieeeAPIKey;
+    public final String scienceDirectApiKey;
     public final String minRequiredJavaVersion;
     public final boolean allowJava9;
 
@@ -53,6 +54,7 @@ public final class BuildInfo {
         springerNatureAPIKey = BuildInfo.getValue(properties, "springerNatureAPIKey", "118d90a519d0fc2a01ee9715400054d4");
         astrophysicsDataSystemAPIKey = BuildInfo.getValue(properties, "astrophysicsDataSystemAPIKey", "tAhPRKADc6cC26mZUnAoBt3MAjCvKbuCZsB4lI3c");
         ieeeAPIKey = BuildInfo.getValue(properties, "ieeeAPIKey", "5jv3wyt4tt2bwcwv7jjk7pc3");
+        scienceDirectApiKey = BuildInfo.getValue(properties, "scienceDirectApiKey", "fb82f2e692b3c72dafe5f4f1fa0ac00b");
         minRequiredJavaVersion = properties.getProperty("minRequiredJavaVersion", "1.8");
         allowJava9 = "true".equals(properties.getProperty("allowJava9", "true"));
     }


### PR DESCRIPTION
This PR aligns the key handling code of ScienceDirect to the one of other fetchers.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
