### PR TITLE
Fix ScienceDirect fetcher

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -46,13 +46,14 @@ public class ScienceDirect implements FulltextFetcher {
             return Optional.empty();
         }
 
-        String sciLink = getUrlByDoi(doi.get().getDOI());
-        if (sciLink.isEmpty()) {
+        String urlFromDoi = getUrlByDoi(doi.get().getDOI());
+        if (urlFromDoi.isEmpty()) {
             return Optional.empty();
         }
+        URL url = new URL(urlFromDoi);
 
         // scrape the web page not as mobile client!
-        Document html = Jsoup.connect(sciLink)
+        Document html = Jsoup.connect(urlFromDoi)
                              .userAgent(URLDownload.USER_AGENT)
                              .referrer("https://www.jabref.org")
                              .ignoreHttpErrors(true).get();
@@ -67,9 +68,8 @@ public class ScienceDirect implements FulltextFetcher {
         // We now have the ScienceDirect page with the article - and the link to the PDF
         // Example page: https://www.sciencedirect.com/science/article/pii/S1674775515001079
 
-        URL scienceDirectUrl = new URL(sciLink);
-        String protocol = scienceDirectUrl.getProtocol();
-        String authority = scienceDirectUrl.getAuthority();
+        String protocol = url.getProtocol();
+        String authority = url.getAuthority();
 
         Optional<JSONObject> pdfDownloadOptional = html
                 .getElementsByAttributeValue("type", "application/json")

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -29,7 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * FulltextFetcher implementation that attempts to find a PDF URL at <a href="https://www.sciencedirect.com/">ScienceDirect</a>. See <a href="https://dev.elsevier.com/">https://dev.elsevier.com/</a>
+ * FulltextFetcher implementation that attempts to find a PDF URL at <a href="https://www.sciencedirect.com/">ScienceDirect</a>.
+ * See <a href="https://dev.elsevier.com/">https://dev.elsevier.com/</a>.
  */
 public class ScienceDirect implements FulltextFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScienceDirect.class);
@@ -135,7 +136,9 @@ public class ScienceDirect implements FulltextFetcher {
                                                          .asJson();
 
             JSONObject json = jsonResponse.getBody().getObject();
-            JSONArray links = json.getJSONObject("full-text-retrieval-response").getJSONObject("coredata").getJSONArray("link");
+            JSONArray links = json.getJSONObject("full-text-retrieval-response")
+                                  .getJSONObject("coredata")
+                                  .getJSONArray("link");
 
             for (int i = 0; i < links.length(); i++) {
                 JSONObject link = links.getJSONObject(i);

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -2,11 +2,9 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.importer.FulltextFetcher;

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -55,7 +55,8 @@ public class ScienceDirect implements FulltextFetcher {
         Document html = Jsoup.connect(urlFromDoi)
                              .userAgent(URLDownload.USER_AGENT)
                              .referrer("https://www.google.com")
-                             .ignoreHttpErrors(true).get();
+                             .ignoreHttpErrors(true)
+                             .get();
 
         // Retrieve PDF link from meta data (most recent)
         Elements metaLinks = html.getElementsByAttributeValue("name", "citation_pdf_url");
@@ -83,7 +84,7 @@ public class ScienceDirect implements FulltextFetcher {
                 .findAny();
 
         if (pdfDownloadOptional.isEmpty()) {
-            LOGGER.debug("No pdfDownload key found in JSON information");
+            LOGGER.debug("No 'pdfDownload' key found in JSON information");
             return Optional.empty();
         }
 
@@ -106,7 +107,7 @@ public class ScienceDirect implements FulltextFetcher {
                     urlMetadata.getString("pdfExtension"),
                     queryParameters);
         } else {
-            LOGGER.debug("No suitable meta data information in JSON information");
+            LOGGER.debug("No suitable data in JSON information");
             return Optional.empty();
         }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
@@ -28,7 +28,7 @@ class ScienceDirectTest {
 
     @Test
     @DisabledOnCIServer("CI server is blocked")
-    void findByDOIOldPage() throws IOException {
+    void findByDoiOldPage() throws IOException {
         entry.setField(StandardField.DOI, "10.1016/j.jrmge.2015.08.004");
 
         assertEquals(
@@ -39,7 +39,7 @@ class ScienceDirectTest {
 
     @Test
     @DisabledOnCIServer("CI server is blocked")
-    void findByDOINewPage() throws IOException {
+    void findByDoiNewPage() throws IOException {
         entry.setField(StandardField.DOI, "10.1016/j.aasri.2014.09.002");
 
         assertEquals(
@@ -62,7 +62,7 @@ class ScienceDirectTest {
 
     @Test
     @DisabledOnCIServer("CI server is blocked")
-    void notFoundByDOI() throws IOException {
+    void notFoundByDoi() throws IOException {
         entry.setField(StandardField.DOI, "10.1016/j.aasri.2014.0559.002");
 
         assertEquals(Optional.empty(), finder.findFullText(entry));


### PR DESCRIPTION
For the test PDF, the json structure does not contain the full text any more. One has to use other meta data. This PR does that

Excerpt of new meta data:

```json
    "pdfDownload": {
      "linkType": "DOWNLOAD",
      "isPdfFullText": false,
      "urlMetadata": {
        "queryParams": {
          "md5": "2b19b19a387cffbae237ca6a987279df",
          "pid": "1-s2.0-S1674775515001079-main.pdf"
        },
        "pii": "S1674775515001079",
        "pdfExtension": "/pdfft",
        "path": "science/article/pii"
      }
    },
```


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
