### PR TITLE
Fix arXiv fetcher tests

### DIFF
--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -654,7 +654,6 @@ public class StringUtil {
      * Return string enclosed in HTML bold tags  if not null, otherwise return alternative text in HTML bold tags
      */
     public static String boldHTML(String input, String alternative) {
-
         if (input == null) {
             return "<b>" + alternative + "</b>";
         }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -131,7 +131,7 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
         entry.setField(StandardField.AUTHOR, "Zhang, Ruohan and Guo");
 
-        assertEquals(Optional.of(new URL("https://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -99,7 +99,7 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     void findFullTextByTitleWithCurlyBracket() throws IOException {
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
 
-        assertEquals(Optional.of(new URL("https://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2010.15942v2")), fetcher.findFullText(entry));
     }
 
     @Test


### PR DESCRIPTION
arXiv does not use `https`, but `http`. Fixed in the test.

I also added some code comments to the fetcher

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
