### PR TITLE
Refactor NoBibTexFieldCheckerTest to increase mutation coverage

### DIFF
--- a/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -10,7 +10,6 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -2,12 +2,17 @@ package org.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,86 +20,44 @@ class NoBibTexFieldCheckerTest {
 
     private final NoBibtexFieldChecker checker = new NoBibtexFieldChecker();
 
-    @Test
-    void abstractIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.ABSTRACT, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
+    private static Stream<Arguments> nonBiblatexOnlyFields() {
+        return Stream.of(
+                // arbitrary field
+                Arguments.of(new UnknownField("fieldNameNotDefinedInThebiblatexManual"), Collections.emptyList()),
+
+                // these fields are displayed by JabRef as default
+                Arguments.of(StandardField.ABSTRACT, Collections.emptyList()),
+                Arguments.of(StandardField.COMMENT, Collections.emptyList()),
+                Arguments.of(StandardField.DOI, Collections.emptyList()),
+                Arguments.of(StandardField.URL, Collections.emptyList()),
+
+                // these fields are not recognized as biblatex only fields
+                Arguments.of(StandardField.ADDRESS, Collections.emptyList()),
+                Arguments.of(StandardField.INSTITUTION, Collections.emptyList()),
+                Arguments.of(StandardField.JOURNAL, Collections.emptyList()),
+                Arguments.of(StandardField.KEYWORDS, Collections.emptyList()),
+                Arguments.of(StandardField.REVIEW, Collections.emptyList())
+        );
     }
 
-    @Test
-    void addressIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.ADDRESS, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
+    @ParameterizedTest()
+    @MethodSource("nonBiblatexOnlyFields")
+    void nonBiblatexOnlyField(Field field, List<IntegrityMessage> expectedResult) {
+        BibEntry entry = new BibEntry().withField(field, "test");
+        assertEquals(expectedResult, checker.check(entry));
     }
 
-    @Test
-    void afterwordIsRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AFTERWORD, "test");
-        IntegrityMessage message = new IntegrityMessage("biblatex field only", entry, StandardField.AFTERWORD);
+    @ParameterizedTest(name = "field={0}")
+    @CsvSource({
+            "AFTERWORD",
+            "JOURNALTITLE",
+            "LOCATION"
+    })
+    void biblatexOnlyField(StandardField field) {
+        BibEntry entry = new BibEntry().withField(field, "test");
+        IntegrityMessage message = new IntegrityMessage("biblatex field only", entry, field);
         List<IntegrityMessage> messages = checker.check(entry);
         assertEquals(Collections.singletonList(message), messages);
     }
 
-    @Test
-    void arbitraryNonBiblatexFieldIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(new UnknownField("fieldNameNotDefinedInThebiblatexManual"), "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
-
-    @Test
-    void commentIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.COMMENT, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
-
-    @Test
-    void instituationIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.INSTITUTION, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
-
-    @Test
-    void journalIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.JOURNAL, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
-
-    @Test
-    void journaltitleIsRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.JOURNALTITLE, "test");
-        IntegrityMessage message = new IntegrityMessage("biblatex field only", entry, StandardField.JOURNALTITLE);
-        List<IntegrityMessage> messages = checker.check(entry);
-        assertEquals(Collections.singletonList(message), messages);
-    }
-
-    @Test
-    void keywordsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.KEYWORDS, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
-
-    @Test
-    void locationIsRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.LOCATION, "test");
-        IntegrityMessage message = new IntegrityMessage("biblatex field only", entry, StandardField.LOCATION);
-        List<IntegrityMessage> messages = checker.check(entry);
-        assertEquals(Collections.singletonList(message), messages);
-    }
-
-    @Test
-    void reviewIsNotRecognizedAsBiblatexOnlyField() {
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.REVIEW, "test");
-        assertEquals(Collections.emptyList(), checker.check(entry));
-    }
 }

--- a/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -20,31 +20,29 @@ class NoBibTexFieldCheckerTest {
 
     private final NoBibtexFieldChecker checker = new NoBibtexFieldChecker();
 
-    private static Stream<Arguments> nonBiblatexOnlyFields() {
+    private static Stream<Field> nonBiblatexOnlyFields() {
         return Stream.of(
                 // arbitrary field
-                Arguments.of(new UnknownField("fieldNameNotDefinedInThebiblatexManual"), Collections.emptyList()),
-
-                // these fields are displayed by JabRef as default
-                Arguments.of(StandardField.ABSTRACT, Collections.emptyList()),
-                Arguments.of(StandardField.COMMENT, Collections.emptyList()),
-                Arguments.of(StandardField.DOI, Collections.emptyList()),
-                Arguments.of(StandardField.URL, Collections.emptyList()),
+                new UnknownField("fieldNameNotDefinedInThebiblatexManual"),
+                StandardField.ABSTRACT,
+                StandardField.COMMENT,
+                StandardField.DOI,
+                StandardField.URL,
 
                 // these fields are not recognized as biblatex only fields
-                Arguments.of(StandardField.ADDRESS, Collections.emptyList()),
-                Arguments.of(StandardField.INSTITUTION, Collections.emptyList()),
-                Arguments.of(StandardField.JOURNAL, Collections.emptyList()),
-                Arguments.of(StandardField.KEYWORDS, Collections.emptyList()),
-                Arguments.of(StandardField.REVIEW, Collections.emptyList())
+                StandardField.ADDRESS,
+                StandardField.INSTITUTION,
+                StandardField.JOURNAL,
+                StandardField.KEYWORDS,
+                StandardField.REVIEW
         );
     }
 
     @ParameterizedTest()
     @MethodSource("nonBiblatexOnlyFields")
-    void nonBiblatexOnlyField(Field field, List<IntegrityMessage> expectedResult) {
+    void nonBiblatexOnlyField(Field field) {
         BibEntry entry = new BibEntry().withField(field, "test");
-        assertEquals(expectedResult, checker.check(entry));
+        assertEquals(Collections.emptyList(), checker.check(entry));
     }
 
     @ParameterizedTest(name = "field={0}")


### PR DESCRIPTION
This pull request contributes to issue #6207, which is to add more unit tests or improve existing ones. I used Pitest to compute the mutation coverage and found that some conditions were not covered in the unit test and some conditions tested were redundant because they would not be reached.  Following are the changes:

1. Switched to using parametrized test
2. Covers missing conditions: StandardField.DOI, StandardField.URL
3. Redundant conditions (still remains in source code and tests): StandardField.ABSTRACT, StandardField.COMMENT (they are not included in the fields of neither BibtexEntryTypeDefinitions.ALL nor BiblatexEntryTypeDefinitions.ALL)

Before:
![image](https://user-images.githubusercontent.com/3387698/116923603-205c8a80-ac57-11eb-964b-2ee0e829f41f.png)


![image](https://user-images.githubusercontent.com/3387698/116923712-3ec28600-ac57-11eb-8447-986d04b9a179.png)

After:
![image](https://user-images.githubusercontent.com/3387698/116924716-8a296400-ac58-11eb-9b02-5d8e32b198cb.png)


![image](https://user-images.githubusercontent.com/3387698/116924826-a927f600-ac58-11eb-9f30-e3131147712c.png)


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
