### PR TITLE
Added DoiDuplicationCheckerTest to increase coverage

### DIFF
--- a/src/test/java/org/jabref/logic/integrity/DoiDuplicationCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/DoiDuplicationCheckerTest.java
@@ -1,0 +1,66 @@
+package org.jabref.logic.integrity;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DoiDuplicationCheckerTest {
+
+    private final DoiDuplicationChecker checker = new DoiDuplicationChecker();
+    private BibEntry entry1;
+    private BibEntry entry2;
+    private BibEntry entry3;
+    private BibEntry entry4;
+    private BibEntry entry5;
+
+    @BeforeEach
+    void setUp() {
+        // entry1 and entry2 have duplicate DOI
+        entry1 = new BibEntry().withField(StandardField.DOI, "10.1023/A:1022883727209");
+        entry2 = new BibEntry().withField(StandardField.DOI, "10.1023/A:1022883727209");
+
+        // entry3 and entry4 have duplicate DOI
+        entry3 = new BibEntry().withField(StandardField.DOI, "10.1177/1461444811422887");
+        entry4 = new BibEntry().withField(StandardField.DOI, "10.1177/1461444811422887");
+
+        // entry5 has a different DOI than the above
+        entry5 = new BibEntry().withField(StandardField.DOI, "10.1145/2568225.2568315");
+
+    }
+
+    @Test
+    public void testOnePairDuplicateDOI() {
+        List<BibEntry> entries = List.of(entry1, entry2, entry5);
+        BibDatabase database = new BibDatabase(entries);
+        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry1, StandardField.DOI),
+        new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry2, StandardField.DOI));
+        assertEquals(results, checker.check(database));
+    }
+
+    @Test
+    public void testMultiPairsDuplicateDOI() {
+        List<BibEntry> entries = List.of(entry1, entry2, entry3, entry4, entry5);
+        BibDatabase database = new BibDatabase(entries);
+        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry1, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry2, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry3, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry4, StandardField.DOI));
+        assertEquals(results, checker.check(database));
+    }
+
+    @Test
+    public void testNoDuplicateDOI() {
+        List<BibEntry> entries = List.of(entry1, entry3, entry5);
+        BibDatabase database = new BibDatabase(entries);
+        assertEquals(Collections.emptyList(), checker.check(database));
+    }
+}

--- a/src/test/java/org/jabref/logic/integrity/DoiDuplicationCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/DoiDuplicationCheckerTest.java
@@ -8,7 +8,6 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,50 +15,38 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class DoiDuplicationCheckerTest {
 
     private final DoiDuplicationChecker checker = new DoiDuplicationChecker();
-    private BibEntry entry1;
-    private BibEntry entry2;
-    private BibEntry entry3;
-    private BibEntry entry4;
-    private BibEntry entry5;
-
-    @BeforeEach
-    void setUp() {
-        // entry1 and entry2 have duplicate DOI
-        entry1 = new BibEntry().withField(StandardField.DOI, "10.1023/A:1022883727209");
-        entry2 = new BibEntry().withField(StandardField.DOI, "10.1023/A:1022883727209");
-
-        // entry3 and entry4 have duplicate DOI
-        entry3 = new BibEntry().withField(StandardField.DOI, "10.1177/1461444811422887");
-        entry4 = new BibEntry().withField(StandardField.DOI, "10.1177/1461444811422887");
-
-        // entry5 has a different DOI than the above
-        entry5 = new BibEntry().withField(StandardField.DOI, "10.1145/2568225.2568315");
-
-    }
+    private String doiA = "10.1023/A:1022883727209";
+    private String doiB = "10.1177/1461444811422887";
+    private String doiC = "10.1145/2568225.2568315";
+    private BibEntry doiA_entry1 = new BibEntry().withField(StandardField.DOI, doiA);
+    private BibEntry doiA_entry2 = new BibEntry().withField(StandardField.DOI, doiA);
+    private BibEntry doiB_entry1 = new BibEntry().withField(StandardField.DOI, doiB);
+    private BibEntry doiB_entry2 = new BibEntry().withField(StandardField.DOI, doiB);
+    private BibEntry doiC_entry1 = new BibEntry().withField(StandardField.DOI, doiC);
 
     @Test
     public void testOnePairDuplicateDOI() {
-        List<BibEntry> entries = List.of(entry1, entry2, entry5);
+        List<BibEntry> entries = List.of(doiA_entry1, doiA_entry2, doiC_entry1);
         BibDatabase database = new BibDatabase(entries);
-        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry1, StandardField.DOI),
-        new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry2, StandardField.DOI));
+        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiA_entry1, StandardField.DOI),
+        new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiA_entry2, StandardField.DOI));
         assertEquals(results, checker.check(database));
     }
 
     @Test
     public void testMultiPairsDuplicateDOI() {
-        List<BibEntry> entries = List.of(entry1, entry2, entry3, entry4, entry5);
+        List<BibEntry> entries = List.of(doiA_entry1, doiA_entry2, doiB_entry1, doiB_entry2, doiC_entry1);
         BibDatabase database = new BibDatabase(entries);
-        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry1, StandardField.DOI),
-                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry2, StandardField.DOI),
-                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry3, StandardField.DOI),
-                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), entry4, StandardField.DOI));
+        List<IntegrityMessage> results = List.of(new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiA_entry1, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiA_entry2, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiB_entry1, StandardField.DOI),
+                new IntegrityMessage(Localization.lang("Same DOI used in multiple entries"), doiB_entry2, StandardField.DOI));
         assertEquals(results, checker.check(database));
     }
 
     @Test
     public void testNoDuplicateDOI() {
-        List<BibEntry> entries = List.of(entry1, entry3, entry5);
+        List<BibEntry> entries = List.of(doiA_entry1, doiB_entry1, doiC_entry1);
         BibDatabase database = new BibDatabase(entries);
         assertEquals(Collections.emptyList(), checker.check(database));
     }


### PR DESCRIPTION
This pull request contributes to issue #6207, which is to add more unit tests or improve existing ones. I used Pitest to compute the line and mutation coverage. Since DoiDuplicationChecker did not have its unit test (its method was being tested in other test classes), I added the test to increase both coverages. 

Before:                                                                            
![image](https://user-images.githubusercontent.com/3387698/116928883-f064b580-ac5d-11eb-9f8d-c7fa80a31c90.png)

After:
![image](https://user-images.githubusercontent.com/3387698/116928941-ffe3fe80-ac5d-11eb-819b-7663ad6043a1.png)


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
