### PR TITLE
Refactored UnicodeToLatexFormatterTest 

### DIFF
--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -22,16 +22,16 @@ class UnicodeToLatexFormatterTest {
         return Stream.of(
                 Arguments.of("", ""), // empty string input
                 Arguments.of("abc", "abc"), // non unicode input
-                Arguments.of("\u00E5\u00E4\u00F6", "{{\\aa}}{\\\"{a}}{\\\"{o}}"), // multiple unicodes input
-                Arguments.of("\u0081", ""), // high code point unicode, boundary case: cp = 129
-                Arguments.of("\u0080", ""), // high code point unicode, boundary case: cp = 128 < 129
-                Arguments.of(new UnicodeToLatexFormatter().getExampleInput(), "M{\\\"{o}}nch")
+                Arguments.of("{{\\aa}}{\\\"{a}}{\\\"{o}}", "\u00E5\u00E4\u00F6"), // multiple unicodes input
+                Arguments.of("", "\u0081"), // high code point unicode, boundary case: cp = 129
+                Arguments.of("", "\u0080"), // high code point unicode, boundary case: cp = 128 < 129
+                Arguments.of("M{\\\"{o}}nch", new UnicodeToLatexFormatter().getExampleInput())
         );
     }
 
     @ParameterizedTest()
     @MethodSource("testCases")
-    void testFormat(String input, String expectedResult){
+    void testFormat(String expectedResult, String input){
         assertEquals(expectedResult, formatter.format(input));
     }
 

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -1,7 +1,11 @@
 package org.jabref.logic.formatter.bibtexfields;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,23 +18,21 @@ class UnicodeToLatexFormatterTest {
         formatter = new UnicodeToLatexFormatter();
     }
 
-    @Test
-    void formatWithoutUnicodeCharactersReturnsSameString() {
-        assertEquals("abc", formatter.format("abc"));
+    private static Stream<Arguments> testCases() {
+        return Stream.of(
+                Arguments.of("", ""), // empty string input
+                Arguments.of("abc", "abc"), // non unicode input
+                Arguments.of("\u00E5\u00E4\u00F6", "{{\\aa}}{\\\"{a}}{\\\"{o}}"), // multiple unicodes input
+                Arguments.of("\u0081", ""), // high code point unicode, boundary case: cp = 129
+                Arguments.of("\u0080", ""), // high code point unicode, boundary case: cp = 128 < 129
+                Arguments.of(new UnicodeToLatexFormatter().getExampleInput(), "M{\\\"{o}}nch")
+        );
     }
 
-    @Test
-    void formatMultipleUnicodeCharacters() {
-        assertEquals("{{\\aa}}{\\\"{a}}{\\\"{o}}", formatter.format("\u00E5\u00E4\u00F6"));
+    @ParameterizedTest()
+    @MethodSource("testCases")
+    void testFormat(String input, String expectedResult){
+        assertEquals(expectedResult, formatter.format(input));
     }
 
-    @Test
-    void formatHighCodepointUnicodeCharacter() {
-        assertEquals("$\\epsilon$", formatter.format("\uD835\uDF16"));
-    }
-
-    @Test
-    void formatExample() {
-        assertEquals("M{\\\"{o}}nch", formatter.format(formatter.getExampleInput()));
-    }
 }


### PR DESCRIPTION
This pull request contributes to issue #6207, which is to add more unit tests or improve existing ones. I used Pitest to compute the line and mutation coverage. The empty string input was missing in the test, as well as the boundary case test for high code point unicode inputs. 

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
