### PR TITLE
Added preset for new entry keybindings

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -21,6 +21,7 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.gui.preferences.keybindings.presets.BashKeyBindingPreset;
 import org.jabref.gui.preferences.keybindings.presets.KeyBindingPreset;
+import org.jabref.gui.preferences.keybindings.presets.NewEntryBindingPreset;
 import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.PreferencesService;
@@ -45,6 +46,7 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
         this.preferences = Objects.requireNonNull(preferences);
 
         keyBindingPresets.add(new BashKeyBindingPreset());
+        keyBindingPresets.add(new NewEntryBindingPreset());
     }
 
     /**

--- a/src/main/java/org/jabref/gui/preferences/keybindings/presets/NewEntryBindingPreset.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/presets/NewEntryBindingPreset.java
@@ -1,0 +1,39 @@
+package org.jabref.gui.preferences.keybindings.presets;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jabref.gui.keyboard.KeyBinding;
+
+public class NewEntryBindingPreset implements KeyBindingPreset {
+
+    private static final Map<KeyBinding, String> KEY_BINDINGS = new HashMap<>();
+
+    static {
+        // Clear conflicting default presets
+        KEY_BINDINGS.put(KeyBinding.PULL_CHANGES_FROM_SHARED_DATABASE, "");
+
+        // Add new entry presets
+        KEY_BINDINGS.put(KeyBinding.NEW_ARTICLE,"Ctrl+shift+A");
+        KEY_BINDINGS.put(KeyBinding.NEW_BOOK,"Ctrl+shift+B");
+        KEY_BINDINGS.put(KeyBinding.NEW_ENTRY,"Ctrl+N");
+        KEY_BINDINGS.put(KeyBinding.NEW_ENTRY_FROM_PLAIN_TEXT,"Ctrl+shift+N");
+        KEY_BINDINGS.put(KeyBinding.NEW_INBOOK,"Ctrl+shift+I");
+        KEY_BINDINGS.put(KeyBinding.NEW_INPROCEEDINGS,"Ctrl+shift+C");
+        KEY_BINDINGS.put(KeyBinding.NEW_MASTERSTHESIS,"Ctrl+shift+M");
+        KEY_BINDINGS.put(KeyBinding.NEW_PHDTHESIS,"Ctrl+shift+T");
+        KEY_BINDINGS.put(KeyBinding.NEW_PROCEEDINGS,"Ctrl+shift+P");
+        KEY_BINDINGS.put(KeyBinding.NEW_TECHREPORT,"Ctrl+shift+R");
+        KEY_BINDINGS.put(KeyBinding.NEW_UNPUBLISHED,"Ctrl+shift+U");
+    }
+
+    @Override
+    public String getName() {
+        return "New Entries";
+    }
+
+    @Override
+    public Map<KeyBinding, String> getKeyBindings() {
+        return KEY_BINDINGS;
+    }
+}


### PR DESCRIPTION
Added preset for new entry keybindings on public demand.

Fixes #7346
Fixes #7439

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
