### PR TITLE
sort standard fields by alphabetical order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,6 +476,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an option in preferences to allow for integers in field "edition" when running database in bibtex mode. [#4680](https://github.com/JabRef/jabref/issues/4680)
 - We added the ability to use negation in export filter layouts. [#5138](https://github.com/JabRef/jabref/pull/5138)
 - Focus on Name Area instead of 'OK' button whenever user presses 'Add subgroup'. [#6307](https://github.com/JabRef/jabref/issues/6307)
+- We sorted the standard fields by alphabetical order. [#7710](https://github.com/JabRef/jabref/issues/7710)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -1,13 +1,6 @@
 package org.jabref.model.entry.field;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -99,12 +92,13 @@ public class FieldFactory {
      */
     public static Set<Field> getCommonFields() {
         EnumSet<StandardField> allFields = EnumSet.allOf(StandardField.class);
+        List<StandardField> sortedAllFields = allFields.stream().sorted(Comparator.comparing(StandardField::getName)).collect(Collectors.toList());
 
         LinkedHashSet<Field> publicAndInternalFields = new LinkedHashSet<>(allFields.size() + 3);
         publicAndInternalFields.add(InternalField.INTERNAL_ALL_FIELD);
         publicAndInternalFields.add(InternalField.INTERNAL_ALL_TEXT_FIELDS_FIELD);
         publicAndInternalFields.add(InternalField.KEY_FIELD);
-        publicAndInternalFields.addAll(allFields);
+        publicAndInternalFields.addAll(sortedAllFields);
 
         return publicAndInternalFields;
     }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
I change the FieldFactory and sort the `sllFields` by its name. Do I need to add a separator as advised in the issue? I am not sure about it.
#7710

![test-for-jabref](https://user-images.githubusercontent.com/54058357/117481982-528f2480-af96-11eb-9d90-88b1bc2a15eb.png)


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
