### PR TITLE
Refs for issue 5464: Entry preview as tab: Full change only takes effect after restart of program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a bug where the selection of groups was lost after drag and drop. [#2868](https://github.com/JabRef/jabref/issues/2868)
 - We fixed an issue where the custom entry types didn't show the correct display name [#5651](https://github.com/JabRef/jabref/issues/5651)
 - We fixed an issue where full change only takes effect after restart of program of entry preview as tab by giving a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
+
 ### Removed
 
 - We removed some obsolete notifications. [#5555](https://github.com/JabRef/jabref/issues/5555)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the article title with colon fails to download the arXiv link (pdf file). [#7660](https://github.com/JabRef/issues/7660)
 - We fixed an issue where the keybinding for delete entry did not work on the main table [7580](https://github.com/JabRef/jabref/pull/7580)
 - We fixed an issue where the RFC fetcher is not compatible with the draft [7305](https://github.com/JabRef/jabref/issues/7305)
+- We fixed an issue where changing the appearance of the preview tab did not trigger a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
 
 ### Removed
 
@@ -408,7 +409,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a window which is on an external screen gets unreachable when external screen is removed. [#5037](https://github.com/JabRef/jabref/issues/5037)
 - We fixed a bug where the selection of groups was lost after drag and drop. [#2868](https://github.com/JabRef/jabref/issues/2868)
 - We fixed an issue where the custom entry types didn't show the correct display name [#5651](https://github.com/JabRef/jabref/issues/5651)
-- We fixed an issue where full change only takes effect after restart of program of entry preview as tab by giving a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,7 +408,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a window which is on an external screen gets unreachable when external screen is removed. [#5037](https://github.com/JabRef/jabref/issues/5037)
 - We fixed a bug where the selection of groups was lost after drag and drop. [#2868](https://github.com/JabRef/jabref/issues/2868)
 - We fixed an issue where the custom entry types didn't show the correct display name [#5651](https://github.com/JabRef/jabref/issues/5651)
-
+- We fixed an issue where full change only takes effect after restart of program of entry preview as tab by giving a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
 ### Removed
 
 - We removed some obsolete notifications. [#5555](https://github.com/JabRef/jabref/issues/5555)

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -194,7 +194,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     }
 
     /**
-     * Get warning info of change the settings of preview.
+     * Getter method for warning list.
      * @return list of string with warning information.
      */
     @Override
@@ -203,7 +203,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     }
 
     /**
-     * Store the changes in preview settings of preference.
+     * Store the changes of preference-preview settings.
      */
     @Override
     public void storeSettings() {
@@ -239,7 +239,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         for (LibraryTab libraryTab : JabRefGUI.getMainFrame().getLibraryTabs()) {
             // TODO: Find a better way to update preview
             libraryTab.closeBottomPane();
-//          basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
+            //  basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
         }
     }
 

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -239,7 +239,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         for (LibraryTab libraryTab : JabRefGUI.getMainFrame().getLibraryTabs()) {
             // TODO: Find a better way to update preview
             libraryTab.closeBottomPane();
-            //  basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
+            // basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
         }
     }
 

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -218,7 +218,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             previewStyle = previewPreferences.getTextBasedPreviewLayout();
         }
         if (showAsExtraTab.getValue() != initialPreviewPreferences.showPreviewAsExtraTab()) {
-            restartWarning.add(Localization.lang("Show preview as extra tab."));
+            restartWarning.add(Localization.lang("Show preview as a tab in entry editor."));
         }
 
         PreviewPreferences newPreviewPreferences = preferences.getPreviewPreferences()

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -83,6 +83,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
     private final CustomLocalDragboard localDragboard;
     private ListProperty<PreviewLayout> dragSourceList = null;
     private ObjectProperty<MultipleSelectionModel<PreviewLayout>> dragSourceSelectionModel = null;
+    private List<String> restartWarning = new ArrayList<>();
 
     public PreviewTabViewModel(DialogService dialogService, PreferencesService preferences, TaskExecutor taskExecutor, StateManager stateManager) {
         this.dialogService = dialogService;
@@ -192,6 +193,18 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         return layout;
     }
 
+    /**
+     * Get warning info of change the settings of preview.
+     * @return list of string with warning information.
+     */
+    @Override
+    public List<String> getRestartWarnings() {
+        return restartWarning;
+    }
+
+    /**
+     * Store the changes in preview settings of preference.
+     */
     @Override
     public void storeSettings() {
         PreviewPreferences previewPreferences = preferences.getPreviewPreferences();
@@ -203,6 +216,9 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         PreviewLayout previewStyle = findLayoutByName(TextBasedPreviewLayout.NAME);
         if (previewStyle == null) {
             previewStyle = previewPreferences.getTextBasedPreviewLayout();
+        }
+        if (showAsExtraTab.getValue() != initialPreviewPreferences.showPreviewAsExtraTab()) {
+            restartWarning.add(Localization.lang("Preview settings changed."));
         }
 
         PreviewPreferences newPreviewPreferences = preferences.getPreviewPreferences()
@@ -223,7 +239,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         for (LibraryTab libraryTab : JabRefGUI.getMainFrame().getLibraryTabs()) {
             // TODO: Find a better way to update preview
             libraryTab.closeBottomPane();
-            // basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
+//          basePanel.getPreviewPanel().updateLayout(preferences.getPreviewPreferences());
         }
     }
 

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -218,7 +218,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             previewStyle = previewPreferences.getTextBasedPreviewLayout();
         }
         if (showAsExtraTab.getValue() != initialPreviewPreferences.showPreviewAsExtraTab()) {
-            restartWarning.add(Localization.lang("Preview settings changed."));
+            restartWarning.add(Localization.lang("Show preview as extra tab."));
         }
 
         PreviewPreferences newPreviewPreferences = preferences.getPreviewPreferences()

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -218,7 +218,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             previewStyle = previewPreferences.getTextBasedPreviewLayout();
         }
         if (showAsExtraTab.getValue() != initialPreviewPreferences.showPreviewAsExtraTab()) {
-            restartWarning.add(Localization.lang("Show preview as a tab in entry editor."));
+            restartWarning.add(Localization.lang("Show preview as a tab in entry editor"));
         }
 
         PreviewPreferences newPreviewPreferences = preferences.getPreviewPreferences()

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1971,8 +1971,7 @@ Filter\ List=Filter List
 Open\ files...=Open files...
 
 Affected\ fields\:=Affected fields:
-Show\ preview\ as\ a\ tab\ in\ entry\ editor=Show preview as a tab in entry editor
-Preview\ settings\ changed.=Preview settings changed.
+Show\ preview\ as\ a\ tab\ in\ entry\ editor.=Show preview as a tab in entry editor.
 Font=Font
 Visual\ theme=Visual theme
 Light\ theme=Light theme

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1972,6 +1972,7 @@ Open\ files...=Open files...
 
 Affected\ fields\:=Affected fields:
 Show\ preview\ as\ a\ tab\ in\ entry\ editor=Show preview as a tab in entry editor
+Preview\ settings\ changed.=Preview settings changed.
 Font=Font
 Visual\ theme=Visual theme
 Light\ theme=Light theme

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1971,7 +1971,7 @@ Filter\ List=Filter List
 Open\ files...=Open files...
 
 Affected\ fields\:=Affected fields:
-Show\ preview\ as\ a\ tab\ in\ entry\ editor.=Show preview as a tab in entry editor.
+Show\ preview\ as\ a\ tab\ in\ entry\ editor=Show preview as a tab in entry editor
 Font=Font
 Visual\ theme=Visual theme
 Light\ theme=Light theme


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g., "Fixes #333".
If you fixed a copper issue, link it, e.g., "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue because GitHub does not support auto-linking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x].`
- Please don't remove any items; leave them unchecked if they are not applicable.
-->

Refs #5464 
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

### Reproduce this issue
1. Options -> Preference -> Entry Preview
2. Change the setting of `Show preview as a tab in the entry editor.`
3. Save
Then we can find that the preview still exists in Entry Editors:
![image](https://user-images.githubusercontent.com/71220965/117662356-0a5c4600-b1d2-11eb-9a30-445f95fd3f47.png)

### The way to enhancement:
When detects the change of preview settings, throw a warning:
![image](https://user-images.githubusercontent.com/71220965/117662573-47c0d380-b1d2-11eb-8e1b-5b64787a6fc5.png)

In code, I detect the change and add the warning. 
```
if (showAsExtraTab.getValue() != initialPreviewPreferences.showPreviewAsExtraTab()) {
            restartWarning.add(Localization.lang("Preview settings changed."));
        }
```