### PR TITLE
Fix 6966 multiple file open

### DIFF
--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -31,6 +31,7 @@ public enum StandardActions implements Action {
     DELETE_ENTRY(Localization.lang("Delete Entry"), IconTheme.JabRefIcons.DELETE_ENTRY, KeyBinding.DELETE_ENTRY),
     SEND_AS_EMAIL(Localization.lang("Send as email"), IconTheme.JabRefIcons.EMAIL),
     OPEN_EXTERNAL_FILE(Localization.lang("Open file"), IconTheme.JabRefIcons.FILE, KeyBinding.OPEN_FILE),
+    OPEN_MULTIPLE_EXTERNAL_FILE(Localization.lang("Open multiple files"), IconTheme.JabRefIcons.FILE, KeyBinding.OPEN_FILE),
     OPEN_URL(Localization.lang("Open URL or DOI"), IconTheme.JabRefIcons.WWW, KeyBinding.OPEN_URL_OR_DOI),
     SEARCH_SHORTSCIENCE(Localization.lang("Search ShortScience")),
     MERGE_WITH_FETCHED_ENTRY(Localization.lang("Get bibliographic data from %0", "DOI/ISBN/...")),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -31,7 +31,7 @@ public enum StandardActions implements Action {
     DELETE_ENTRY(Localization.lang("Delete Entry"), IconTheme.JabRefIcons.DELETE_ENTRY, KeyBinding.DELETE_ENTRY),
     SEND_AS_EMAIL(Localization.lang("Send as email"), IconTheme.JabRefIcons.EMAIL),
     OPEN_EXTERNAL_FILE(Localization.lang("Open file"), IconTheme.JabRefIcons.FILE, KeyBinding.OPEN_FILE),
-    OPEN_MULTIPLE_EXTERNAL_FILE(Localization.lang("Open multiple files"), IconTheme.JabRefIcons.FILE, KeyBinding.OPEN_FILE),
+    OPEN_MULTIPLE_EXTERNAL_FILE(Localization.lang("Open multiple files"), IconTheme.JabRefIcons.FILE),
     OPEN_URL(Localization.lang("Open URL or DOI"), IconTheme.JabRefIcons.WWW, KeyBinding.OPEN_URL_OR_DOI),
     SEARCH_SHORTSCIENCE(Localization.lang("Search ShortScience")),
     MERGE_WITH_FETCHED_ENTRY(Localization.lang("Get bibliographic data from %0", "DOI/ISBN/...")),

--- a/src/main/java/org/jabref/gui/maintable/OpenMultipleExternalFilesAction.java
+++ b/src/main/java/org/jabref/gui/maintable/OpenMultipleExternalFilesAction.java
@@ -37,7 +37,9 @@ public class OpenMultipleExternalFilesAction extends SimpleCommand {
         {
             final List<BibEntry> selectedEntries = stateManager.getSelectedEntries();
 
-            if (selectedEntries.size() != maxNumberOfFiles) {
+            if (selectedEntries.stream()
+                    .mapToInt(entry -> entry.getFiles().size())
+                    .sum() > maxNumberOfFiles) {
                 dialogService.notify(Localization.lang("This operation cannot exceed the max number of files to be opened at the same time, max is " + maxNumberOfFiles));
                 return;
             }

--- a/src/main/java/org/jabref/gui/maintable/OpenMultipleExternalFilesAction.java
+++ b/src/main/java/org/jabref/gui/maintable/OpenMultipleExternalFilesAction.java
@@ -1,0 +1,61 @@
+package org.jabref.gui.maintable;
+
+import java.util.List;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.Globals;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.ActionHelper;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.gui.fieldeditors.LinkedFileViewModel;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.preferences.PreferencesService;
+
+public class OpenMultipleExternalFilesAction extends SimpleCommand {
+
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private final PreferencesService preferencesService;
+
+    private final int maxNumberOfFiles = 20;
+
+    public OpenMultipleExternalFilesAction(DialogService dialogService, StateManager stateManager, PreferencesService preferencesService) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.preferencesService = preferencesService;
+
+        this.executable.bind(ActionHelper.isFilePresentForSelectedEntry(stateManager, preferencesService));
+    }
+
+    @Override
+    public void execute()
+    {
+        stateManager.getActiveDatabase().ifPresent(databaseContext ->
+        {
+            final List<BibEntry> selectedEntries = stateManager.getSelectedEntries();
+
+            if (selectedEntries.size() != maxNumberOfFiles) {
+                dialogService.notify(Localization.lang("This operation cannot exceed the max number of files to be opened at the same time, max is " + maxNumberOfFiles));
+                return;
+            }
+
+            for (BibEntry selectedEntry : selectedEntries) {
+                for (LinkedFile file : selectedEntry.getFiles()) {
+                    LinkedFileViewModel linkedFileViewModel = new LinkedFileViewModel(
+                            file,
+                            selectedEntry,
+                            databaseContext,
+                            Globals.TASK_EXECUTOR,
+                            dialogService,
+                            preferencesService.getXmpPreferences(),
+                            preferencesService.getFilePreferences(),
+                            ExternalFileTypes.getInstance());
+                    linkedFileViewModel.open();
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -69,6 +69,7 @@ public class RightClickMenu {
 
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_FOLDER, new OpenFolderAction(dialogService, stateManager, preferencesService)));
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_EXTERNAL_FILE, new OpenExternalFileAction(dialogService, stateManager, preferencesService)));
+        contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_MULTIPLE_EXTERNAL_FILE, new OpenMultipleExternalFilesAction(dialogService, stateManager, preferencesService)));
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.OPEN_URL, new OpenUrlAction(dialogService, stateManager, preferencesService)));
         contextMenu.getItems().add(factory.createMenuItem(StandardActions.SEARCH_SHORTSCIENCE, new SearchShortScienceAction(dialogService, stateManager)));
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

Created a simple command for opening multiple files when one or multiple entries are selected, and added it to the right menu. One single entry can have multiple files and this command (OpenMultipleExternalFilesAction) iterates not only over the selected entries, but also the files of each entry, and opens them all.
A security check was added so that the maximum number of files that can be open are 20.
The following images illustrate the solution 


https://github.com/CES21-Group-G/resources/blob/master/fix02/fix02-03.png
https://github.com/CES21-Group-G/resources/blob/master/fix02/fix02-04.png
