### PR TITLE
Update Gradle Wrapper from 7.0 to 7.0.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=eb8b89184261025b0430f5b2233701ff1377f96da1ef5e278af6ae8bac5cc305
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionSha256Sum=0e46229820205440b48a5501122002842b82886e76af35f0f3a069243dca4b3c
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 7.0 to 7.0.2.

Read the release notes: https://docs.gradle.org/7.0.2/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `7.0.2`
- Distribution (-bin) zip checksum: `0e46229820205440b48a5501122002842b82886e76af35f0f3a069243dca4b3c`
- Wrapper JAR Checksum: `e996d452d2645e70c01c11143ca2d3742734a28da2bf61f25c82bdc288c9e637`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>