### PR TITLE
fix backslash parsing error in preview layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the RFC fetcher is not compatible with the draft [7305](https://github.com/JabRef/jabref/issues/7305)
 - We fixed an issue where duplicate files (both file names and contents are the same) is downloaded and add to linked files [#6197](https://github.com/JabRef/jabref/issues/6197)
 - We fixed an issue where changing the appearance of the preview tab did not trigger a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
+- We fixed an issue where typing a backslash in the customized preview style editor displayed a backslash parsing error to the user. [#7526](https://github.com/JabRef/jabref/issues/7526)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -236,7 +236,7 @@ public class LayoutHelper {
         }
     }
 
-    private void parseField() throws IOException {
+    private void parseField() throws IOException, StringIndexOutOfBoundsException {
         int c;
         StringBuilder buffer = null;
         String name;

--- a/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
@@ -37,6 +37,8 @@ public class TextBasedPreviewLayout implements PreviewLayout {
         StringReader sr = new StringReader(text.replace("__NEWLINE__", "\n"));
         try {
             layout = new LayoutHelper(sr, layoutFormatterPreferences).getLayoutFromText();
+        } catch (StringIndexOutOfBoundsException e) {
+            LOGGER.error("Could not generate layout", e);
         } catch (IOException e) {
             LOGGER.error("Could not generate layout", e);
         }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #7526, catches the StringIndexOutOfBoundsException in TextBasedPreviewLayout.java in order to prevent a backslash parsing error being displayed to the user. When calling .getLayoutFromText() on line 39 of TextBasedPreviewLayout.java, the StringIndexOutOfBoundsException is only thrown on line 261 of LayoutHelper.java (specifically for the backslash parsing error), meaning catching it on line 40 of TextBasedPreviewLayout.java should not adversely affect any other parts of the code.   

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
