### PR TITLE
Fixed the issue where import hangs for ris files with "ER - " failed #7737

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where import hangs for ris files with "ER - " failed [#7737](https://github.com/JabRef/jabref/issues/7737)
 - We fixed an issue where getting bibliograhpic data from DOI or another identifer did not respect the library mode (BibTeX/biblatex)[#1018](https://github.com/JabRef/jabref/issues/6267)
 - We fixed an issue where importing entries would not respect the library mode (BibTeX/biblatex)[#1018](https://github.com/JabRef/jabref/issues/1018)
 - We fixed an issue where an exception occured when importing entries from a web search [#7606](https://github.com/JabRef/jabref/issues/7606)

--- a/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
@@ -62,7 +62,7 @@ public class RisImporter extends Importer {
         String linesAsString = reader.lines().reduce((line, nextline) -> line + "\n" + nextline).orElse("");
 
         String[] entries = linesAsString.replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
-                                        .split("ER  -.*\\n");
+                                        .split("ER  -.*(\\n)*");
 
         // stores all the date tags from highest to lowest priority
         List<String> dateTags = Arrays.asList("Y1", "PY", "DA", "Y2");

--- a/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
@@ -32,6 +32,11 @@ public class RisImporter extends Importer {
 
     private static final Pattern RECOGNIZED_FORMAT_PATTERN = Pattern.compile("TY  - .*");
     private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy");
+    /**
+     * CS304 issue link :https://github.com/JabRef/jabref/issues/7737
+     * use for check the result of split
+     */
+    private static String[] entries;
 
     @Override
     public String getName() {
@@ -54,6 +59,13 @@ public class RisImporter extends Importer {
         return reader.lines().anyMatch(line -> RECOGNIZED_FORMAT_PATTERN.matcher(line).find());
     }
 
+    /**
+     * use for check the result of split
+     */
+    public String[] getEntries() {
+        return entries;
+    }
+
     @Override
     public ParserResult importDatabase(BufferedReader reader) throws IOException {
         List<BibEntry> bibitems = new ArrayList<>();
@@ -61,7 +73,8 @@ public class RisImporter extends Importer {
         // use optional here, so that no exception will be thrown if the file is empty
         String linesAsString = reader.lines().reduce((line, nextline) -> line + "\n" + nextline).orElse("");
 
-        String[] entries = linesAsString.replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
+        // use split(ER  -.*(\\n)*) to instead of split(ER  -.\\n) to solve the problem of hangs of ris file import
+        entries = linesAsString.replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
                                         .split("ER  -.*(\\n)*");
 
         // stores all the date tags from highest to lowest priority

--- a/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
@@ -32,10 +32,6 @@ public class RisImporter extends Importer {
 
     private static final Pattern RECOGNIZED_FORMAT_PATTERN = Pattern.compile("TY  - .*");
     private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy");
-    /**
-     * CS304 issue link :https://github.com/JabRef/jabref/issues/7737
-     * use for check the result of split
-     */
     private static String[] entries;
 
     @Override
@@ -59,9 +55,6 @@ public class RisImporter extends Importer {
         return reader.lines().anyMatch(line -> RECOGNIZED_FORMAT_PATTERN.matcher(line).find());
     }
 
-    /**
-     * use for check the result of split
-     */
     public String[] getEntries() {
         return entries;
     }
@@ -73,7 +66,6 @@ public class RisImporter extends Importer {
         // use optional here, so that no exception will be thrown if the file is empty
         String linesAsString = reader.lines().reduce((line, nextline) -> line + "\n" + nextline).orElse("");
 
-        // use split(ER  -.*(\\n)*) to instead of split(ER  -.\\n) to solve the problem of hangs of ris file import
         entries = linesAsString.replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
                                         .split("ER  -.*(\\n)*");
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -47,4 +47,18 @@ public class RISImporterTest {
         Path file = Path.of(RISImporterTest.class.getResource("RisImporterCorrupted.ris").toURI());
         assertFalse(importer.isRecognizedFormat(file, StandardCharsets.UTF_8));
     }
+
+    /**
+     * CS304 (manually written) issue link: https://github.com/JabRef/jabref/issues/7737
+     * Test if split the lines remove "ER  -" correctly
+     */
+    @Test
+    public void testIfSplitCorrect(){
+        String[] entries = importer.gerEntries;
+        for (String entry : entries) {
+            assertFalse(entry.equals("ER  - "));
+        }
+    }
+
+
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -48,10 +48,6 @@ public class RISImporterTest {
         assertFalse(importer.isRecognizedFormat(file, StandardCharsets.UTF_8));
     }
 
-    /**
-     * CS304 (manually written) issue link: https://github.com/JabRef/jabref/issues/7737
-     * Test if split the lines remove "ER  -" correctly
-     */
     @Test
     public void testIfSplitCorrect(){
         String[] entries = importer.gerEntries;


### PR DESCRIPTION
fixed the issue where import hangs for ris files with "ER - " failed [#7737](https://github.com/JabRef/jabref/issues/7737)

fixes #7737 

The test file in issue[#7737](https://github.com/JabRef/jabref/issues/7737) like error1.ris and error2.ris have a same problem that the last line "ER  - " with no line break(/n) , so it isn't eliminate by split("ER  -.\\n") , use split("ER  -.\*(\\n)*") can solve this problem 

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

