### PR TITLE
Unittest: assure preamble parses with arbitrary brackets

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -858,6 +858,15 @@ class BibtexParserTest {
     }
 
     @Test
+    void parseRecognizesPreambleWithArbitraryBracketPairAndSpace() throws IOException {
+        ParserResult result = parser
+                .parse(new StringReader("@preamble{some (  {text    )}) and \\latex}"));
+        //                                                               |> the rest got cut-off
+
+        assertEquals(Optional.of("some ( {text )}"), result.getDatabase().getPreamble());
+    }
+
+    @Test
     void parseRecognizesString() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@string{bourdieu = {Bourdieu, Pierre}}"));


### PR DESCRIPTION
The preamble part of the bibtext parser (logic/importer/fileformat/BibtextParser) has a `parseBracketedText` method that accepts any pairing of curly bracket and round bracket, for example
```
@preamble{ some (  { text ) } )
```
is acceptable.

I'm writing a new test case for that to indicate that this 'feature' is tested so that developers should know this is a feature not a bug.

I assume that this is designed as is, so that it won't break on opening current acceptable bibtex files. But if this is indeed a bug, please let me know so that I can get a PR for this.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
