### PR TITLE
Add unit test for serializeAll() to BibEntryWriterTest.java

### DIFF
--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -5,7 +5,10 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParserResult;
@@ -623,5 +626,69 @@ class BibEntryWriterTest {
         // @formatter:on
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void testSerializeAll() throws IOException {
+        BibEntry entry1 = new BibEntry(StandardEntryType.Article);
+        // required fields
+        entry1.setField(StandardField.AUTHOR, "Journal Author");
+        entry1.setField(StandardField.JOURNALTITLE, "Journal of Words");
+        entry1.setField(StandardField.TITLE, "Entry Title");
+        entry1.setField(StandardField.DATE, "2020-11-16");
+
+        // optional fields
+        entry1.setField(StandardField.NUMBER, "1");
+        entry1.setField(StandardField.NOTE, "some note");
+        // unknown fields
+        entry1.setField(StandardField.YEAR, "2019");
+        entry1.setField(StandardField.CHAPTER, "chapter");
+
+        BibEntry entry2 = new BibEntry(StandardEntryType.Book);
+        // required fields
+        entry2.setField(StandardField.AUTHOR, "John Book");
+        entry2.setField(StandardField.BOOKTITLE, "The Big Book of Books");
+        entry2.setField(StandardField.TITLE, "Entry Title");
+        entry2.setField(StandardField.DATE, "2017-12-20");
+
+        // optional fields
+        entry2.setField(StandardField.NUMBER, "1");
+        entry2.setField(StandardField.NOTE, "some note");
+        // unknown fields
+        entry2.setField(StandardField.YEAR, "2020");
+        entry2.setField(StandardField.CHAPTER, "chapter");
+
+        String output = writer.serializeAll(List.of(entry1, entry2), BibDatabaseMode.BIBLATEX);
+
+
+        // @formatter:off
+        String expected1 = OS.NEWLINE + "@Article{," + OS.NEWLINE +
+                "  author       = {Journal Author}," + OS.NEWLINE +
+                "  date         = {2020-11-16}," + OS.NEWLINE +
+                "  journaltitle = {Journal of Words}," + OS.NEWLINE +
+                "  title        = {Entry Title}," + OS.NEWLINE +
+                "  note         = {some note}," + OS.NEWLINE +
+                "  number       = {1}," + OS.NEWLINE +
+                "  chapter      = {chapter}," + OS.NEWLINE +
+                "  year         = {2019}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
+        // @formatter:on
+
+        // @formatter:off
+        String expected2 = OS.NEWLINE + "@Book{," + OS.NEWLINE +
+                "  author    = {John Book}," + OS.NEWLINE +
+                "  date      = {2017-12-20}," + OS.NEWLINE +
+                "  title     = {Entry Title}," + OS.NEWLINE +
+                "  chapter   = {chapter}," + OS.NEWLINE +
+                "  note      = {some note}," + OS.NEWLINE +
+                "  number    = {1}," + OS.NEWLINE +
+                "  booktitle = {The Big Book of Books}," + OS.NEWLINE +
+                "  year      = {2020}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
+        // @formatter:on
+
+
+        assertEquals(expected1 + expected2, output);
+
     }
 }

--- a/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -5,10 +5,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParserResult;
@@ -660,7 +658,6 @@ class BibEntryWriterTest {
 
         String output = writer.serializeAll(List.of(entry1, entry2), BibDatabaseMode.BIBLATEX);
 
-
         // @formatter:off
         String expected1 = OS.NEWLINE + "@Article{," + OS.NEWLINE +
                 "  author       = {Journal Author}," + OS.NEWLINE +
@@ -686,7 +683,6 @@ class BibEntryWriterTest {
                 "  year      = {2020}," + OS.NEWLINE +
                 "}" + OS.NEWLINE;
         // @formatter:on
-
 
         assertEquals(expected1 + expected2, output);
 


### PR DESCRIPTION
Add unit test to BibEntryWriterTest.java in order to cover previously uncovered method serializeAll().

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
