### PR TITLE
Abbreviation toggle within the JournalEditorViewModel now ignores curly braces (issue #7773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We reintroduced missing default keybindings for new entries. [#7346](https://github.com/JabRef/jabref/issues/7346) [#7439](https://github.com/JabRef/jabref/issues/7439)
 - Lists of available fields are now sorted alphabetically. [#7716](https://github.com/JabRef/jabref/issues/7716)
 - We moved the select/collapse buttons in the unlinked files dialog into a context menu. [#7383](https://github.com/JabRef/jabref/issues/7383)
-- We changed the abbreviation toggle within the JournalEditorViewModel.java to ignore curly braces when matching. [#7773](https://github.com/JabRef/jabref/issues/7773)
+- We fixed an issue where journal abbreviations containing curly braces were not recognized  [#7773](https://github.com/JabRef/jabref/issues/7773)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We reintroduced missing default keybindings for new entries. [#7346](https://github.com/JabRef/jabref/issues/7346) [#7439](https://github.com/JabRef/jabref/issues/7439)
 - Lists of available fields are now sorted alphabetically. [#7716](https://github.com/JabRef/jabref/issues/7716)
 - We moved the select/collapse buttons in the unlinked files dialog into a context menu. [#7383](https://github.com/JabRef/jabref/issues/7383)
+- We changed the abbreviation toggle within the JournalEditorViewModel.java to ignore curly braces when matching. [#7773](https://github.com/JabRef/jabref/issues/7773)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
@@ -22,8 +22,11 @@ public class JournalEditorViewModel extends AbstractEditorViewModel {
             return;
         }
 
-        if (journalAbbreviationRepository.isKnownName(text.get())) {
-            Optional<String> nextAbbreviation = journalAbbreviationRepository.getNextAbbreviation(text.get());
+        // Ignore brackets when matching abbreviations.
+        final String name = text.get().replaceAll("[{}]", "");
+
+        if (journalAbbreviationRepository.isKnownName(name)) {
+            Optional<String> nextAbbreviation = journalAbbreviationRepository.getNextAbbreviation(name);
 
             if (nextAbbreviation.isPresent()) {
                 text.set(nextAbbreviation.get());

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
@@ -23,7 +23,7 @@ public class JournalEditorViewModel extends AbstractEditorViewModel {
         }
 
         // Ignore brackets when matching abbreviations.
-        final String name = text.get().replaceAll("[{}]", "");
+        final String name = StringUtil.ignoreCurlyBracket(text.get());
 
         if (journalAbbreviationRepository.isKnownName(name)) {
             Optional<String> nextAbbreviation = journalAbbreviationRepository.getNextAbbreviation(name);


### PR DESCRIPTION
We changed the abbreviation toggle (shown in the entry editor for the journal field) in JournalEditorViewModel to ignore curly braces when matching. 
The field text is stripped of any left or right curly braces before it is passed to isKnownName() and getNextAbbreviation().
Fixes  #7773.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
