### PR TITLE
Implemented a select all button for the library import function (issue #7786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a feature that allows the user to choose whether to trust the target site when unable to find a valid certification path from the file download site. [#7616](https://github.com/JabRef/jabref/issues/7616)
 - We added a feature that allows the user to open all linked files of multiple selected entries by "Open file" option. [#6966](https://github.com/JabRef/jabref/issues/6966)
 - We added a keybinding preset for new entries. [#7705](https://github.com/JabRef/jabref/issues/7705)
+- We added a select all button for the library import function. [#7786](https://github.com/JabRef/jabref/issues/7786)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -19,6 +19,7 @@
             <CheckListView fx:id="entriesListView" VBox.vgrow="ALWAYS"/>
             <HBox spacing="4">
                 <Button onAction="#selectAllNewEntries" styleClass="text-button" text="%Select all new entries"/>
+                <Button onAction="#selectAllEntries" styleClass="text-button" text="%Select all entries"/>
                 <Button onAction="#unselectAll" styleClass="text-button" text="%Unselect all"/>
                 <HBox HBox.hgrow="ALWAYS"/>
                 <GridPane hgap="4.0" vgap="4.0">

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -202,8 +202,6 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
 
     public void selectAllEntries() {
         unselectAll();
-        for (BibEntry entry : entriesListView.getItems()) {
-            entriesListView.getCheckModel().check(entry);
-        }
+        entriesListView.getCheckModel().checkAll();
     }
 }

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -199,4 +199,11 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
             }
         }
     }
+
+    public void selectAllEntries() {
+        unselectAll();
+        for (BibEntry entry : entriesListView.getItems()) {
+            entriesListView.getCheckModel().check(entry);
+        }
+    }
 }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1869,6 +1869,7 @@ Cancel\ import=Cancel import
 Continue\ with\ import=Continue with import
 Import\ canceled=Import canceled
 Select\ all\ new\ entries=Select all new entries
+Select\ all\ entries=Select all entries
 Total\ items\ found\:=Total items found:
 Selected\ items\:=Selected items:
 Download\ linked\ online\ files=Download linked online files


### PR DESCRIPTION
Fixes #7768

![SelectAllScreenshot](https://user-images.githubusercontent.com/55059816/121120358-3d462980-c7d2-11eb-9120-eebf3d5125c8.png)

We implemented a select all button for the library import function that fixes issue #7786. 
Added a new function selectAllEntires() to ImportEntriesDialog and a button to ImportEntriesDialog.fxml.
New localization String "Select all entries" also added to JabRef_en.properties.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [X] Screenshots added in PR description (for UI changes)
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
