### PR TITLE
cleanup temporary files, use prefix "jabref-"

### DIFF
--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -25,9 +25,12 @@ public class JournalAbbreviationLoader {
         JournalAbbreviationRepository repository;
         // Initialize with built-in list
         try {
-            Path tempJournalList = Files.createTempDirectory("journal").resolve("journalList.mv");
+            Path tempDir = Files.createTempDirectory("jabref-journal");
+            Path tempJournalList = tempDir.resolve("journalList.mv");
             Files.copy(JournalAbbreviationRepository.class.getResourceAsStream("/journals/journalList.mv"), tempJournalList);
             repository = new JournalAbbreviationRepository(tempJournalList);
+            tempDir.toFile().deleteOnExit();
+            tempJournalList.toFile().deleteOnExit();
         } catch (IOException e) {
             LOGGER.error("Error while copying journal list", e);
             return null;

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -305,11 +305,12 @@ public class URLDownload {
 
         // Take everything after the last '/' as name + extension
         String fileNameWithExtension = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
-        String fileName = FileUtil.getBaseName(fileNameWithExtension);
+        String fileName = "jabref-" + FileUtil.getBaseName(fileNameWithExtension);
         String extension = "." + FileHelper.getFileExtension(fileNameWithExtension).orElse("tmp");
 
         // Create temporary file and download to it
         Path file = Files.createTempFile(fileName, extension);
+        file.toFile().deleteOnExit();
         toFile(file);
 
         return file;


### PR DESCRIPTION


Problem

- The two changed locations create temporary files, but do not arrange to clean them up.
- The tests create sevaral copies of journalList.mv, tends to fill up /tmp 

Now:

- these files and directoriees are removed on normal exit
- they are prefixed with "jabref-" to
  -  (1) let the user know who to complain
          and which program should not run while removing 
  - (2) make it easier to remove them after abnormal exit

<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
      NA
- [ ] Tests created for changes (if applicable)
       NA
- [X ] Manually tested changed features in running JabRef (always required)
   -  also with gradlew test

- [ ] Screenshots added in PR description (for UI changes)
      NA
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
       NA