### PR TITLE
Fix annotation + package of ACMPortalParserTest

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
@@ -1,4 +1,4 @@
-package org.jabref.logic.importer;
+package org.jabref.logic.importer.fileformat;
 
 import java.io.IOException;
 import java.net.CookieHandler;
@@ -9,11 +9,13 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.importer.fileformat.ACMPortalParser;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.testutils.category.FetcherTest;
 
 import com.microsoft.applicationinsights.core.dependencies.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@FetcherTest
 public class ACMPortalParserTest {
 
     ACMPortalParser parser;


### PR DESCRIPTION
`ACMPortalParserTest` was in the wrong package. Test connects to an external service, therefore annotated with FetcherTest

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
