### PR TITLE
Pin version of citeproc-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,9 +190,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
 
-    // SNAPSHOT is required because of plain-java support
-    // See https://github.com/michel-kraemer/citeproc-java/issues/92 for details
-    implementation 'de.undercouch:citeproc-java:3.0.0-SNAPSHOT'
+    implementation 'de.undercouch:citeproc-java:3.0.0-alpha.1'
 
     implementation group: 'jakarta.activation', name: 'jakarta.activation-api', version: '1.2.1'
     implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.2'


### PR DESCRIPTION
Use the latest release (to enable stable builds) of citeproc-java.

See https://github.com/michel-kraemer/citeproc-java/issues/92#issuecomment-798419164 for details.

- [] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [] Tests created for changes (if applicable)
- [] Manually tested changed features in running JabRef (always required)
- [] Screenshots added in PR description (for UI changes)
- [] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
