### PR TITLE
Fix fetchers Title and Inspire

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/TitleFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/TitleFetcher.java
@@ -10,6 +10,7 @@ import org.jabref.logic.importer.WebFetchers;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
+import org.jabref.model.strings.StringUtil;
 
 public class TitleFetcher implements IdBasedFetcher {
 
@@ -31,15 +32,19 @@ public class TitleFetcher implements IdBasedFetcher {
 
     @Override
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
+        if (StringUtil.isBlank(identifier)) {
+            return Optional.empty();
+        }
+
         BibEntry entry = new BibEntry();
         entry.setField(StandardField.TITLE, identifier);
+
         Optional<DOI> doi = WebFetchers.getIdFetcherForIdentifier(DOI.class).findIdentifier(entry);
-        if (!doi.isPresent()) {
+        if (doi.isEmpty()) {
             return Optional.empty();
         }
 
         DoiFetcher doiFetcher = new DoiFetcher(this.preferences);
-
         return doiFetcher.performSearchById(doi.get().getDOI());
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
@@ -33,15 +33,15 @@ class INSPIREFetcherTest {
     @Test
     void searchByQueryFindsEntry() throws Exception {
         BibEntry master = new BibEntry(StandardEntryType.MastersThesis)
-                .withCitationKey("Diez:2014ppa")
+                .withCitationKey("Diez:2013fdp")
                 .withField(StandardField.AUTHOR, "Diez, Tobias")
-                .withField(StandardField.TITLE, "Slice theorem for Fr\\'echet group actions and covariant symplectic field theory")
+                .withField(StandardField.TITLE, "Slice theorem for Fréchet group actions and covariant symplectic field theory")
                 .withField(StandardField.SCHOOL, "Leipzig U.")
                 .withField(StandardField.YEAR, "2013")
                 .withField(StandardField.EPRINT, "1405.2249")
                 .withField(StandardField.ARCHIVEPREFIX, "arXiv")
                 .withField(StandardField.PRIMARYCLASS, "math-ph");
-        List<BibEntry> fetchedEntries = fetcher.performSearch("Fr\\´echet group actions field");
+        List<BibEntry> fetchedEntries = fetcher.performSearch("Fréchet group actions field");
         assertEquals(Collections.singletonList(master), fetchedEntries);
     }
 


### PR DESCRIPTION
Fixed fetcher tests:
1. Inspire (Seems to return UTF-8 now: `Fréchet` instead of `Fr\\'echet`)

2. Title (Strange: crossref seems to return a list of some random bibentries when called with an empty search string)



- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
