### PR TITLE
Fix for entering a backslash in the custom entry preview dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the RFC fetcher is not compatible with the draft [7305](https://github.com/JabRef/jabref/issues/7305)
 - We fixed an issue where duplicate files (both file names and contents are the same) is downloaded and add to linked files [#6197](https://github.com/JabRef/jabref/issues/6197)
 - We fixed an issue where changing the appearance of the preview tab did not trigger a restart warning. [#5464](https://github.com/JabRef/jabref/issues/5464)
+- We fixed an issue where editing "Custom preview style" triggers exception. [#7526](https://github.com/JabRef/jabref/issues/7526)
 - We fixed an issue where a title with multiple applied formattings in EndNote was not imported correctly [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)
 - We fixed an issue where a `report` in EndNote was imported as `article` [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)
 - We fixed an issue where the field `publisher` in EndNote was not imported in JabRef [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -188,7 +188,7 @@ public class LayoutHelper {
         }
     }
 
-    private void parse() throws IOException, StringIndexOutOfBoundsException {
+    private void parse() throws IOException {
         skipWhitespace();
 
         int c;
@@ -254,11 +254,15 @@ public class LayoutHelper {
 
                 if (name.isEmpty()) {
                     StringBuilder lastFive = new StringBuilder(10);
-                    for (StringInt entry : parsedEntries.subList(Math.max(0, parsedEntries.size() - 6),
-                            parsedEntries.size() - 1)) {
-                        lastFive.append(entry.s);
+                    if (parsedEntries.isEmpty()) {
+                        lastFive.append("unknown");
+                    } else {
+                        for (StringInt entry : parsedEntries.subList(Math.max(0, parsedEntries.size() - 6),
+                                parsedEntries.size() - 1)) {
+                            lastFive.append(entry.s);
+                        }
                     }
-                    throw new StringIndexOutOfBoundsException(
+                    throw new IOException(
                             "Backslash parsing error near \'" + lastFive.toString().replace("\n", " ") + '\'');
                 }
 

--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -1,0 +1,39 @@
+package org.jabref.logic.layout;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class LayoutHelperTest {
+
+    @Test
+    public void backslashDoesNotTriggerException() {
+        StringReader stringReader = new StringReader("\\");
+        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        assertThrows(IOException.class, () -> layoutHelper.getLayoutFromText());
+    }
+
+    @Test
+    public void unbalancedBeginEndIsParsed() throws Exception {
+        StringReader stringReader = new StringReader("\\begin{doi}, DOI: \\doi");
+        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        Layout layout = layoutHelper.getLayoutFromText();
+        assertNotNull(layout);
+    }
+
+    @Test
+    public void minimalExampleWithDoiGetsParsed() throws Exception {
+        StringReader stringReader = new StringReader("\\begin{doi}, DOI: \\doi\\end{doi}");
+        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        Layout layout = layoutHelper.getLayoutFromText();
+        assertNotNull(layout);
+    }
+}

--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -5,7 +5,8 @@ import java.io.StringReader;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 class LayoutHelperTest {

--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.layout;
 import java.io.IOException;
 import java.io.StringReader;
 
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
This fixes #7526 (besides https://github.com/JabRef/jabref/issues/7526#issuecomment-818895244). When entering a backslash, JabRef does not throw an exception any more.

I thought long about using Optionals for a good code quality (see https://github.com/JabRef/jabref/pull/7539/files#r611956179). After discussing with @calixtus, I think, this is still an exertional case and should be treated as such. I changed the implementation to return the declared exception only and added tests.

The exception is already properly handled in at `org.jabref.logic.layout.TextBasedPreviewLayout#setText`, thus I did not need to touch that code.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
