### PR TITLE
Add corporate proxy workaround for Version.getAllAvailableVersions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where a title with multiple applied formattings in EndNote was not imported correctly [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)
 - We fixed an issue where a `report` in EndNote was imported as `article` [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)
 - We fixed an issue where the field `publisher` in EndNote was not imported in JabRef [forum#2734](https://discourse.jabref.org/t/importing-endnote-label-field-to-jabref-from-xml-file/2734)
+- We fixed an issue when checking for a new version when JabRef is used behind a corporate proxy. [#7884](https://github.com/JabRef/jabref/issues/7884)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jabref.logic.net.URLDownload;
+
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 import org.slf4j.Logger;
@@ -94,6 +96,7 @@ public class Version {
      * Grabs all the available releases from the GitHub repository
      */
     public static List<Version> getAllAvailableVersions() throws IOException {
+        URLDownload.bypassSSLVerification();
         HttpURLConnection connection = (HttpURLConnection) new URL(JABREF_GITHUB_RELEASES).openConnection();
         connection.setRequestProperty("Accept-Charset", "UTF-8");
         try (BufferedReader rd = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -97,9 +97,8 @@ public class Version {
         HttpURLConnection connection = (HttpURLConnection) new URL(JABREF_GITHUB_RELEASES).openConnection();
         connection.setRequestProperty("Accept-Charset", "UTF-8");
         try (BufferedReader rd = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
-
-            List<Version> versions = new ArrayList<>();
             JSONArray objects = new JSONArray(rd.readLine());
+            List<Version> versions = new ArrayList<>(objects.length());
             for (int i = 0; i < objects.length(); i++) {
                 JSONObject jsonObject = objects.getJSONObject(i);
                 Version version = Version.parse(jsonObject.getString("tag_name").replaceFirst("v", ""));

--- a/src/test/java/org/jabref/logic/util/VersionTest.java
+++ b/src/test/java/org/jabref/logic/util/VersionTest.java
@@ -1,13 +1,18 @@
 package org.jabref.logic.util;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import org.jabref.support.DisabledOnCIServer;
+import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VersionTest {
@@ -293,5 +298,12 @@ public class VersionTest {
     public void ciSuffixShouldBeRemovedIfDateIsPresent() {
         Version v50ci = Version.parse("5.0-ci.1--2020-03-06--289142f");
         assertEquals("5.0--2020-03-06--289142f", v50ci.getFullVersion());
+    }
+
+    @Test
+    @FetcherTest
+    @DisabledOnCIServer("GitHub puts a low rate limit on unauthenticated calls")
+    public void getAllAvailableVersionsReturnsSomething() throws Exception {
+        assertNotEquals(Collections.emptyList(), Version.getAllAvailableVersions());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/7884 by adding a workaround.

Added test won't work on the CI, because of GitHub's rate limit.

```
java.io.IOException: Server returned HTTP response code: 403 for URL: https://api.github.com/repos/JabRef/JabRef/releases

	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1932)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1528)
	at java.base/sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:224)
	at org.jabref.logic.util.Version.getAllAvailableVersions(Version.java:99)
	at org.jabref.logic.util.VersionTest.getAllAvailableVersionsReturnsSomething(VersionTest.java:303)
```

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [] Tests created for changes (if applicable)
- [] Manually tested changed features in running JabRef (always required)
- [] Screenshots added in PR description (for UI changes)
- [] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
