### PR TITLE
Removed references to apache commons logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -649,7 +649,6 @@ jlink {
         provides 'org.mariadb.jdbc.credential.CredentialPlugin' with 'org.mariadb.jdbc.credential.aws.AwsIamCredentialPlugin',
                 'org.mariadb.jdbc.credential.env.EnvCredentialPlugin',
                 'org.mariadb.jdbc.credential.system.PropertiesCredentialPlugin'
-        provides 'org.apache.commons.logging.LogFactory' with 'org.apache.logging.log4j.jcl.LogFactoryImpl'
         provides 'org.slf4j.spi.SLF4JServiceProvider' with 'org.apache.logging.slf4j.SLF4JServiceProvider'
         provides 'org.apache.logging.log4j.spi.Provider' with 'org.apache.logging.log4j.core.impl.Log4jProvider'
         provides 'java.security.Provider' with 'org.bouncycastle.jce.provider.BouncyCastleProvider',

--- a/docs/getting-into-the-code/code-howtos.md
+++ b/docs/getting-into-the-code/code-howtos.md
@@ -124,7 +124,7 @@ JabRef uses the logging facade [SLF4j](https://www.slf4j.org/). All log messages
 * Obtaining a logger for a class:
 
   ```java
-  private static final Log LOGGER = LogFactory.getLog(<ClassName>.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(<ClassName>.class);
   ```
 
 * If the logging event is caused by an exception, please add the exception to the log message as:

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
@@ -8,15 +8,11 @@ import java.util.regex.Pattern;
 import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 /**
  * Cleanup URL link
  */
 public class CleanupUrlFormatter extends Formatter {
 
-    private static final Log LOGGER = LogFactory.getLog(CleanupUrlFormatter.class);
     // This regexp find "url=" or "to=" parameter in full link and get text after them
     private static final Pattern PATTERN_URL = Pattern.compile("(?:url|to)=([^&]*)");
 


### PR DESCRIPTION
code-howtos and build.gradle still referenced apache commons, but slf4j
should be used instead.
CleanupUrlFormatter was the only class still using it, but never
actually used the logger, so it was removed.

- [] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [] Screenshots added in PR description (for UI changes)
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
