### PR TITLE
Update citeproc-java to 3.0.0-alpha.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
     annotationProcessor group: 'org.apache.logging.log4j', name: 'log4j-core', version: '3.0.0-SNAPSHOT'
 
-    implementation 'de.undercouch:citeproc-java:3.0.0-alpha.1'
+    implementation 'de.undercouch:citeproc-java:3.0.0-alpha.2'
 
     implementation group: 'jakarta.activation', name: 'jakarta.activation-api', version: '1.2.1'
     implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '2.3.2'

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -539,7 +539,7 @@ commons-codec:commons-codec:1.11
 commons-logging:commons-logging:1.2
 de.saxsys:mvvmfx-validation:1.9.0-SNAPSHOT
 de.saxsys:mvvmfx:1.8.0
-de.undercouch:citeproc-java:3.0.0-alpha.1
+de.undercouch:citeproc-java:3.0.0-alpha.2
 eu.lestard:doc-annotations:0.2
 info.debatty:java-string-similarity:2.0.0
 io.github.java-diff-utils:java-diff-utils:4.10

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -3,6 +3,7 @@ package org.jabref.logic.citationstyle;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
@@ -124,10 +125,10 @@ public class CSLAdapter {
         }
 
         @Override
-        public String[] getIds() {
+        public Collection<String> getIds() {
             return data.stream()
                        .map(entry -> entry.getCitationKey().orElse(""))
-                       .toArray(String[]::new);
+                       .toList();
         }
     }
 }


### PR DESCRIPTION
Upgrade citeproc-java from 3.0.0-alpha.1 to 3.0.0-alpha.2.

This fixes #7637 and provides further improvements.


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
