### PR TITLE
Fix icon color in dark mode 

### DIFF
--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -60,7 +60,7 @@
 
     -jr-icon-background: transparent;
     -jr-icon-background-active: #0001;
-    -jr-icon-background-armed: #0002;
+    -jr-icon-background-armed: #0002
 
     /* Colors for messages and errors */
     -jr-info: -jr-light-green;
@@ -269,7 +269,7 @@
     -fx-bounds-type: logical_vertical_center;
 
     /* The base color of icons should always be the same as the text. */
-    -fx-fill: -fx-text-base-color;
+    -fx-fill: derive(-fx-color, -5%);
 }
 
 .tooltip {

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -60,7 +60,7 @@
 
     -jr-icon-background: transparent;
     -jr-icon-background-active: #0001;
-    -jr-icon-background-armed: #0002
+    -jr-icon-background-armed: #0002;
 
     /* Colors for messages and errors */
     -jr-info: -jr-light-green;
@@ -269,7 +269,7 @@
     -fx-bounds-type: logical_vertical_center;
 
     /* The base color of icons should always be the same as the text. */
-    -fx-fill: derive(-fx-color, -5%);
+    -fx-fill: -fx-text-base-color;
 }
 
 .tooltip {

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -117,3 +117,7 @@
     -fx-fill: derive(-jr-search-text, 80%);
     -fx-text-fill: derive(-jr-search-text, 80%);
 }
+.button {
+    -fx-background-color: #6b727a;
+    -fx-border-color: transparent;
+}


### PR DESCRIPTION
Solution to, fixes #7853
After checking [dark.css](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/gui/Dark.css) and [base.css](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/gui/Base.css), and tempting change color of the icons, but find out the color of icons can not be changed, because the icon imported from Package org.kordamp.ikonli.mamaterialdesign is colored and can not be changed. So rather than import another set of icons, I prefer adjusting icon-background-color in dark mode. Then you can find the icon button easily. The effect is shown in the [figure.](https://img-blog.csdnimg.cn/20210718163715348.png)

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.

