### PR TITLE
Write temporary file on bib import in jabrefhost.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Changed
 
+- The JabRefHost on Windows now writes a temporary file and calls `-importToOpen` instead of passing the bibtex via `-importBibtex`. [#7374](https://github.com/JabRef/jabref/issues/7374), [JabRef Browser Ext #274](https://github.com/JabRef/JabRef-Browser-Extension/issues/274)
+
 ### Fixed
 
 - We fixed an issue when checking for a new version when JabRef is used behind a corporate proxy. [#7884](https://github.com/JabRef/jabref/issues/7884)

--- a/buildres/windows/JabRefHost.ps1
+++ b/buildres/windows/JabRefHost.ps1
@@ -38,7 +38,12 @@ try {
     #$wshell.Popup($message.Text,0,"JabRef", 0x0 + 0x30)
 
     $messageText = $message.Text.replace("`n"," ").replace("`r"," ")
-    $output = & $jabRefExe -importBibtex "$messageText" *>&1
+    $tempfile = New-TemporaryFile
+    # WriteAllLines should write the file as UTF-8 without BOM
+    # unlike Out-File which writes UTF-16 with BOM in ps5.1
+    [IO.File]::WriteAllLines($tempfile, $messageText)
+    $output = & $jabRefExe -importToOpen $tempfile *>&1
+    Remove-Item $tempfile
     #$output = "$messageText"
     #$wshell = New-Object -ComObject Wscript.Shell
     #$wshell.Popup($output,0,"JabRef", 0x0 + 0x30)


### PR DESCRIPTION
This resolves an issue where the encoding somehow got lost when using
the Jabref Browser extension. It will now write a temporary file
with UTF-8 encoding rather than passing the bibtex on the commandline.

See https://github.com/JabRef/JabRef-Browser-Extension/issues/274

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [] Tests created for changes (if applicable)
- [] Manually tested changed features in running JabRef (always required)
- [] Screenshots added in PR description (for UI changes)
- [] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
