### PR TITLE
Log message after checking if the optional contains a value

### DIFF
--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -39,7 +39,7 @@ public class BibDatabaseContext {
     /**
      * The path where this database was last saved to.
      */
-    private Optional<Path> path;
+    private Path path;
 
     private DatabaseSynchronizer dbmsSynchronizer;
     private CoarseChangeFilter dbmsListener;
@@ -57,7 +57,6 @@ public class BibDatabaseContext {
         this.database = Objects.requireNonNull(database);
         this.metaData = Objects.requireNonNull(metaData);
         this.location = DatabaseLocation.LOCAL;
-        this.path = Optional.empty();
     }
 
     public BibDatabaseContext(BibDatabase database, MetaData metaData, Path path) {
@@ -67,7 +66,7 @@ public class BibDatabaseContext {
     public BibDatabaseContext(BibDatabase database, MetaData metaData, Path path, DatabaseLocation location) {
         this(database, metaData);
         Objects.requireNonNull(location);
-        this.path = Optional.ofNullable(path);
+        this.path = path;
 
         if (location == DatabaseLocation.LOCAL) {
             convertToLocalDatabase();
@@ -83,7 +82,7 @@ public class BibDatabaseContext {
     }
 
     public void setDatabasePath(Path file) {
-        this.path = Optional.ofNullable(file);
+        this.path = file;
     }
 
     /**
@@ -92,11 +91,11 @@ public class BibDatabaseContext {
      * @return Optional of the relevant Path, or Optional.empty() if none is defined.
      */
     public Optional<Path> getDatabasePath() {
-        return path;
+        return Optional.ofNullable(path);
     }
 
     public void clearDatabasePath() {
-        this.path = Optional.empty();
+        this.path = null;
     }
 
     public BibDatabase getDatabase() {
@@ -220,10 +219,12 @@ public class BibDatabaseContext {
 
     public Path getFulltextIndexPath() {
         Path appData = getFulltextIndexBasePath();
-        LOGGER.info("Index path for {} is {}", getDatabasePath().get(), appData.toString());
+
         if (getDatabasePath().isPresent()) {
+            LOGGER.info("Index path for {} is {}", getDatabasePath().get(), appData.toString());
             return appData.resolve(String.valueOf(this.getDatabasePath().get().hashCode()));
         }
+
         return appData.resolve("unsaved");
     }
 

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -12,7 +12,6 @@ import org.jabref.preferences.FilePreferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,8 +33,7 @@ class BibDatabaseContextTest {
     void getFileDirectoriesWithEmptyDbParent() {
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(Path.of("biblio.bib"));
-        assertEquals(Collections.singletonList(currentWorkingDir),
-                database.getFileDirectories(fileDirPrefs));
+        assertEquals(Collections.singletonList(currentWorkingDir), database.getFileDirectories(fileDirPrefs));
     }
 
     @Test
@@ -44,8 +42,7 @@ class BibDatabaseContextTest {
 
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
-        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())),
-                database.getFileDirectories(fileDirPrefs));
+        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())), database.getFileDirectories(fileDirPrefs));
     }
 
     @Test
@@ -54,8 +51,7 @@ class BibDatabaseContextTest {
 
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
-        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())),
-                database.getFileDirectories(fileDirPrefs));
+        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())), database.getFileDirectories(fileDirPrefs));
     }
 
     @Test
@@ -64,8 +60,7 @@ class BibDatabaseContextTest {
 
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
-        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())),
-                database.getFileDirectories(fileDirPrefs));
+        assertEquals(Collections.singletonList(currentWorkingDir.resolve(file.getParent())), database.getFileDirectories(fileDirPrefs));
     }
 
     @Test
@@ -75,8 +70,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
         database.getMetaData().setDefaultFileDirectory("../Literature");
-        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()),
-                Path.of("/absolute/Literature").toAbsolutePath()),
+        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()), Path.of("/absolute/Literature").toAbsolutePath()),
                 database.getFileDirectories(fileDirPrefs));
     }
 
@@ -87,8 +81,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
         database.getMetaData().setDefaultFileDirectory("Literature");
-        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()),
-                Path.of("/absolute/subdir/Literature").toAbsolutePath()),
+        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()), Path.of("/absolute/subdir/Literature").toAbsolutePath()),
                 database.getFileDirectories(fileDirPrefs));
     }
 
@@ -138,8 +131,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
         bibDatabaseContext.setDatabasePath(existingPath);
 
-        Path expectedPath =
-                BibDatabaseContext.getFulltextIndexBasePath().resolve(String.valueOf(existingPath.hashCode()));
+        Path expectedPath = BibDatabaseContext.getFulltextIndexBasePath().resolve(existingPath.hashCode() + "");
         Path actualPath = bibDatabaseContext.getFulltextIndexPath();
 
         assertEquals(expectedPath, actualPath);

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -12,6 +12,7 @@ import org.jabref.preferences.FilePreferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -74,7 +75,8 @@ class BibDatabaseContextTest {
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
         database.getMetaData().setDefaultFileDirectory("../Literature");
-        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()), Path.of("/absolute/Literature").toAbsolutePath()),
+        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()),
+                Path.of("/absolute/Literature").toAbsolutePath()),
                 database.getFileDirectories(fileDirPrefs));
     }
 
@@ -85,7 +87,8 @@ class BibDatabaseContextTest {
         BibDatabaseContext database = new BibDatabaseContext();
         database.setDatabasePath(file);
         database.getMetaData().setDefaultFileDirectory("Literature");
-        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()), Path.of("/absolute/subdir/Literature").toAbsolutePath()),
+        assertEquals(Arrays.asList(currentWorkingDir.resolve(file.getParent()),
+                Path.of("/absolute/subdir/Literature").toAbsolutePath()),
                 database.getFileDirectories(fileDirPrefs));
     }
 
@@ -115,5 +118,30 @@ class BibDatabaseContextTest {
 
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(db);
         assertEquals(BibDatabaseMode.BIBLATEX, bibDatabaseContext.getMode());
+    }
+
+    @Test
+    void testGetFullTextIndexPathWhenPathIsNull() {
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
+        bibDatabaseContext.setDatabasePath(null);
+
+        Path expectedPath = BibDatabaseContext.getFulltextIndexBasePath().resolve("unsaved");
+        Path actualPath = bibDatabaseContext.getFulltextIndexPath();
+
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    void testGetFullTextIndexPathWhenPathIsNotNull() {
+        Path existingPath = Path.of("some_path.bib");
+
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
+        bibDatabaseContext.setDatabasePath(existingPath);
+
+        Path expectedPath =
+                BibDatabaseContext.getFulltextIndexBasePath().resolve(String.valueOf(existingPath.hashCode()));
+        Path actualPath = bibDatabaseContext.getFulltextIndexPath();
+
+        assertEquals(expectedPath, actualPath);
     }
 }


### PR DESCRIPTION
Fixes #7933 

Hello folks! I discovered this project yesterday and I downloaded the repo and started to play around with UI when I found this unexpected behavior when trying to create a new library. After checking the stack trace, I found a log statement that tries to get a value from an `Optional` before checking if it is present. So, I change the position of the statement. Additionally, I refactored the path attribute, unwrapping it from the `Optional`. Ideally, the `Optional` should only be used as return type of methods, as advocated by [Brain Goetz](https://stackoverflow.com/questions/26327957/should-java-8-getters-return-optional-type/26328555#26328555) (Java Language Architect at Oracle).
<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.