### PR TITLE
Add `unprotect_terms` to the list of modifiers for bracketed patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - We added the option to copy the DOI of an entry directly from the context menu copy submenu. [#7826](https://github.com/JabRef/jabref/issues/7826)
 - We added a fulltext search feature. [#2838](https://github.com/JabRef/jabref/pull/2838)
+- We added unprotect_terms to the list of bracketed pattern modifiers [#7826](https://github.com/JabRef/jabref/pull/7960)
 
 ### Changed
 

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -29,6 +29,7 @@ import org.jabref.logic.formatter.casechanger.CapitalizeFormatter;
 import org.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import org.jabref.logic.formatter.casechanger.SentenceCaseFormatter;
 import org.jabref.logic.formatter.casechanger.TitleCaseFormatter;
+import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.logic.formatter.casechanger.UpperCaseFormatter;
 import org.jabref.logic.formatter.minifier.MinifyNameListFormatter;
 import org.jabref.logic.formatter.minifier.TruncateFormatter;
@@ -74,7 +75,8 @@ public class Formatters {
                 new UnitsToLatexFormatter(),
                 new EscapeUnderscoresFormatter(),
                 new EscapeAmpersandsFormatter(),
-                new ShortenDOIFormatter()
+                new ShortenDOIFormatter(),
+                new UnprotectTermsFormatter()
         );
     }
 

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -386,6 +386,13 @@ class BracketedPatternTest {
                 BracketedPattern.expandBrackets("[author] have published [title] in [journal].", ',', entry, database));
     }
 
+    @Test
+    void expandBracketsWithoutProtectiveBracesUsingUnprotectTermsModifier() {
+        BibEntry bibEntry = new BibEntry()
+                .withField(StandardField.JOURNAL, "{ACS} Medicinal Chemistry Letters");
+        assertEquals("ACS Medicinal Chemistry Letters", BracketedPattern.expandBrackets("[JOURNAL:unprotect_terms]", null, bibEntry, null));
+    }
+
     @ParameterizedTest
     @MethodSource("provideArgumentsForFallback")
     void expandBracketsWithFallback(String expandResult, String pattern) {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

The bracketed patterns for renaming files don't translate fields to Unicode, so if there are protected terms (`{In} {CDMA}`) the brackets will be translated to underscore, (`_In_ _CDMA_`) which cannot be removed by the regex modifier (which respects protected terms).

This PR adds the already existing `UnprotectTermsFormatter` to the list of available modifiers, which can be used through the key `unprotect_terms`.

The motivation for adding it is https://discourse.jabref.org/t/filename-format-pattern-novice-user/2872 .

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
