### PR TITLE
remove the Accelerator for the context menus

### DIFF
--- a/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
+++ b/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
@@ -54,6 +54,7 @@ public class ChangeEntryTypeMenu {
     public ContextMenu getChangeEntryTypePopupMenu(BibEntry entry, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
         ContextMenu menu = new ContextMenu();
         populateComplete(menu.getItems(), entry, bibDatabaseContext, undoManager);
+        menu.deleteAccelerateor();
         return menu;
     }
 


### PR DESCRIPTION
<!-- 
One problem seems to be that the accelerator of the ContextMenu MenuItem overlaps with that of the main menu.
Possible solutions:
Context-sensitive filters in the menuItem event handler. If fired from the accelerator of the ContextMenu menu item, this event is ignored.Or we can remove the context menu accelerator.
Link issues that are fixed, e.g. "Fixes #7392".
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [] Tests created for changes (if applicable)
- [] Manually tested changed features in running JabRef (always required)
- [] Screenshots added in PR description (for UI changes)
- [] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
