### PR TITLE
Fix possible NPE in exporter with empty charset

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,7 +47,7 @@ public class TemplateExporter extends Exporter {
     private final String directory;
     private final LayoutFormatterPreferences layoutPreferences;
     private final SavePreferences savePreferences;
-    private Charset encoding; // If this value is set, it will be used to override the default encoding for the getCurrentBasePanel.
+    private Charset encodingOverwritten; // If this value is set, it will be used to override the default encoding for the getCurrentBasePanel.
     private boolean customExport;
     private BlankLineBehaviour blankLineBehaviour;
 
@@ -145,7 +146,7 @@ public class TemplateExporter extends Exporter {
      * @param encoding The name of the encoding to use.
      */
     public TemplateExporter withEncoding(Charset encoding) {
-        this.encoding = encoding;
+        this.encodingOverwritten = encoding;
         return this;
     }
 
@@ -195,11 +196,20 @@ public class TemplateExporter extends Exporter {
                        final Charset encoding, List<BibEntry> entries) throws Exception {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
+
+
+        Charset encodingToUse = StandardCharsets.UTF_8;
+        if (encoding != null) {
+            encodingToUse = encoding;
+        } else if (this.encodingOverwritten != null) {
+            encodingToUse = this.encodingOverwritten;
+        }
+
         if (entries.isEmpty()) { // Do not export if no entries to export -- avoids exports with only template text
             return;
         }
 
-        try (AtomicFileWriter ps = new AtomicFileWriter(file, encoding)) {
+        try (AtomicFileWriter ps = new AtomicFileWriter(file, encodingToUse)) {
             Layout beginLayout = null;
 
             // Check if this export filter has bundled name formatters:
@@ -218,7 +228,7 @@ public class TemplateExporter extends Exporter {
             }
             // Write the header
             if (beginLayout != null) {
-                ps.write(beginLayout.doLayout(databaseContext, encoding));
+                ps.write(beginLayout.doLayout(databaseContext, encodingToUse));
                 missingFormatters.addAll(beginLayout.getMissingFormatters());
             }
 
@@ -300,7 +310,7 @@ public class TemplateExporter extends Exporter {
 
             // Write footer
             if (endLayout != null) {
-                ps.write(endLayout.doLayout(databaseContext, this.encoding));
+                ps.write(endLayout.doLayout(databaseContext, encodingToUse));
                 missingFormatters.addAll(endLayout.getMissingFormatters());
             }
 

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -197,7 +197,6 @@ public class TemplateExporter extends Exporter {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
 
-
         Charset encodingToUse = StandardCharsets.UTF_8;
         if (encoding != null) {
             encodingToUse = encoding;

--- a/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
@@ -115,7 +115,6 @@ public class YamlExporterTest {
             .withField(StandardField.URL, "http://example.com")
             .withField(StandardField.DATE, "2020-10-14");
 
-
         Path file = tempFile.resolve("RandomFileName");
         Files.createFile(file);
         yamlExporter.export(databaseContext, file, StandardCharsets.UTF_8, Collections.singletonList(entry));
@@ -144,7 +143,6 @@ public class YamlExporterTest {
             .withField(StandardField.URL, "http://example.com")
             .withField(StandardField.DATE, "2020-10-14");
 
-
         Path file = tempFile.resolve("RandomFileName");
         Files.createFile(file);
         yamlExporter.export(databaseContext, file, null, Collections.singletonList(entry));
@@ -172,7 +170,6 @@ public class YamlExporterTest {
             .withField(StandardField.TITLE, "細雪")
             .withField(StandardField.URL, "http://example.com")
             .withField(StandardField.DATE, "2020-10-14");
-
 
         Path file = tempFile.resolve("RandomFileName");
         Files.createFile(file);

--- a/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
@@ -105,4 +105,92 @@ public class YamlExporterTest {
 
         assertEquals(expected, Files.readAllLines(file));
     }
+
+    @Test
+    void passesModifiedCharset(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("test")
+            .withField(StandardField.AUTHOR, "谷崎 潤一郎")
+            .withField(StandardField.TITLE, "細雪")
+            .withField(StandardField.URL, "http://example.com")
+            .withField(StandardField.DATE, "2020-10-14");
+
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        yamlExporter.export(databaseContext, file, StandardCharsets.UTF_8, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "---",
+                "references:",
+                "- id: test",
+                "  type: article",
+                "  author:",
+                "  - literal: \"谷崎 潤一郎\"",
+                "  title: \"細雪\"",
+                "  issued: 2020-10-14",
+                "  url: http://example.com",
+                "---");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    void passesModifiedCharsetNull(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("test")
+            .withField(StandardField.AUTHOR, "谷崎 潤一郎")
+            .withField(StandardField.TITLE, "細雪")
+            .withField(StandardField.URL, "http://example.com")
+            .withField(StandardField.DATE, "2020-10-14");
+
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        yamlExporter.export(databaseContext, file, null, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "---",
+                "references:",
+                "- id: test",
+                "  type: article",
+                "  author:",
+                "  - literal: \"谷崎 潤一郎\"",
+                "  title: \"細雪\"",
+                "  issued: 2020-10-14",
+                "  url: http://example.com",
+                "---");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    void passesModifiedCharsetASCII(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("test")
+            .withField(StandardField.AUTHOR, "谷崎 潤一郎")
+            .withField(StandardField.TITLE, "細雪")
+            .withField(StandardField.URL, "http://example.com")
+            .withField(StandardField.DATE, "2020-10-14");
+
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        yamlExporter.export(databaseContext, file, StandardCharsets.US_ASCII, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "---",
+                "references:",
+                "- id: test",
+                "  type: article",
+                "  author:",
+                "  - literal: \"?? ???\"",
+                "  title: \"??\"",
+                "  issued: 2020-10-14",
+                "  url: http://example.com",
+                "---");
+
+        assertEquals(expected, Files.readAllLines(file));
+
+    }
 }


### PR DESCRIPTION
And fix issue where calling with Encoding would have no effect if the database was not UTF-8.

I stumbled upon while checking the [forum post](https://discourse.jabref.org/t/utf-8-encoding-in-rdf-file/2892/)

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
