### PR TITLE
Fulltext Index: Only index local pdf files

### DIFF
--- a/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import javafx.collections.ObservableList;
 
 import org.jabref.gui.LibraryTab;
-import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
@@ -11,6 +11,8 @@ import java.util.concurrent.TimeUnit;
 import javafx.collections.ObservableList;
 
 import org.jabref.gui.LibraryTab;
+import org.jabref.logic.util.FileType;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -188,6 +190,9 @@ public class PdfIndexer {
      * @param linkedFile the file to write to the index
      */
     private void writeToIndex(BibEntry entry, LinkedFile linkedFile) {
+        if (linkedFile.isOnlineLink() || !StandardFileType.PDF.getName().equals(linkedFile.getFileType())) {
+            return;
+        }
         Optional<Path> resolvedPath = linkedFile.findIn(databaseContext, filePreferences);
         if (resolvedPath.isEmpty()) {
             LOGGER.warn("Could not find {}", linkedFile.getLink());

--- a/src/test/java/org/jabref/logic/pdf/search/indexing/PdfIndexerTest.java
+++ b/src/test/java/org/jabref/logic/pdf/search/indexing/PdfIndexerTest.java
@@ -61,6 +61,38 @@ public class PdfIndexerTest {
     }
 
     @Test
+    public void dontIndexNonPdf() throws IOException {
+        // given
+        BibEntry entry = new BibEntry(StandardEntryType.PhdThesis);
+        entry.setFiles(Collections.singletonList(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.AUX.getName())));
+        database.insertEntry(entry);
+
+        // when
+        indexer.createIndex(database, context);
+
+        // then
+        try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
+            assertEquals(0, reader.numDocs());
+        }
+    }
+
+    @Test
+    public void dontIndexOnlineLinks() throws IOException {
+        // given
+        BibEntry entry = new BibEntry(StandardEntryType.PhdThesis);
+        entry.setFiles(Collections.singletonList(new LinkedFile("Example Thesis", "https://raw.githubusercontent.com/JabRef/jabref/main/src/test/resources/pdfs/thesis-example.pdf", StandardFileType.PDF.getName())));
+        database.insertEntry(entry);
+
+        // when
+        indexer.createIndex(database, context);
+
+        // then
+        try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
+            assertEquals(0, reader.numDocs());
+        }
+    }
+
+    @Test
     public void exampleThesisIndexWithKey() throws IOException {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis);


### PR DESCRIPTION
Filter for locally-stored PDF files when adding to the fulltext search index.

First attempt at fixing #7942.
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
