### PR TITLE
Reordered Pdf-Importer priorities

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -45,10 +45,10 @@ public class PdfMergeMetadataImporter extends Importer {
     public PdfMergeMetadataImporter(ImportFormatPreferences importFormatPreferences) {
         this.importFormatPreferences = importFormatPreferences;
         this.metadataImporters = List.of(
-                new PdfGrobidImporter(GrobidCitationFetcher.GROBID_URL, importFormatPreferences),
-                new PdfEmbeddedBibFileImporter(importFormatPreferences),
-                new PdfXmpImporter(importFormatPreferences.getXmpPreferences()),
                 new PdfVerbatimBibTextImporter(importFormatPreferences),
+                new PdfEmbeddedBibFileImporter(importFormatPreferences),
+                new PdfGrobidImporter(GrobidCitationFetcher.GROBID_URL, importFormatPreferences),
+                new PdfXmpImporter(importFormatPreferences.getXmpPreferences()),
                 new PdfContentImporter(importFormatPreferences)
         );
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
@@ -59,12 +59,11 @@ class PdfMergeMetadataImporterTest {
 
         // From DOI (contained in embedded bib file)
         BibEntry expected = new BibEntry(StandardEntryType.Book);
-        expected.setCitationKey("Burd_2011");
-        expected.setField(StandardField.AUTHOR, "Barry Burd");
-        expected.setField(StandardField.TITLE, "Java{\\textregistered} For Dummies{\\textregistered}");
-        expected.setField(StandardField.PUBLISHER, "Wiley Publishing, Inc.");
-        expected.setField(StandardField.YEAR, "2011");
-        expected.setField(StandardField.AUTHOR, "Barry Burd");
+        expected.setCitationKey("9780134685991");
+        expected.setField(StandardField.AUTHOR, "Bloch, Joshua");
+        expected.setField(StandardField.TITLE, "Effective Java");
+        expected.setField(StandardField.PUBLISHER, "Addison Wesley");
+        expected.setField(StandardField.YEAR, "2018");
         expected.setField(StandardField.MONTH, "jul");
         expected.setField(StandardField.DOI, "10.1002/9781118257517");
 


### PR DESCRIPTION
Changed the list, that implies priority, of PdfImporters in the PdfMergeMetadataImporter.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes https://github.com/koppor/jabref/issues/169

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
