### PR TITLE
Stop fulltext-indexing on cancel

### DIFF
--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -39,7 +39,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
             isRunning = true;
         }
         updateProgress();
-        while (!taskQueue.isEmpty()) {
+        while (!taskQueue.isEmpty() && !isCanceled()) {
             taskQueue.poll().run();
             numOfIndexedFiles++;
             updateProgress();


### PR DESCRIPTION
When the user closes JabRef while indexing, a Dialog is shown asking whether to cancel the indexing. If the cancel is approved by the user, the indexing continued anyways. This is fixed with this PR.

Fixes koppor/jabref#516

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
