### PR TITLE
Remove explicit XMP import for PDFs

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -91,33 +91,19 @@ public class ImportHandler {
 
                     try {
                         if (FileUtil.isPDFFile(file)) {
+                            var pdfImporterResult = contentImporter.importPDFContent(file);
+                            List<BibEntry> pdfEntriesInFile = pdfImporterResult.getDatabase().getEntries();
 
-                            var xmpParserResult = contentImporter.importXMPContent(file);
-                            List<BibEntry> xmpEntriesInFile = xmpParserResult.getDatabase().getEntries();
-
-                            if (xmpParserResult.hasWarnings()) {
-                                addResultToList(file, false, Localization.lang("Error reading XMP content: %0", xmpParserResult.getErrorMessage()));
+                            if (pdfImporterResult.hasWarnings()) {
+                                addResultToList(file, false, Localization.lang("Error reading PDF content: %0", pdfImporterResult.getErrorMessage()));
                             }
 
-                            // First try xmp import, if empty try pdf import, otherwise create empty entry
-                            if (!xmpEntriesInFile.isEmpty()) {
-                                entriesToAdd = xmpEntriesInFile;
-                                addResultToList(file, true, Localization.lang("Importing using XMP data..."));
+                            if (!pdfEntriesInFile.isEmpty()) {
+                                entriesToAdd = pdfEntriesInFile;
+                                addResultToList(file, true, Localization.lang("Importing using extracted PDF data"));
                             } else {
-                                var pdfImporterResult = contentImporter.importPDFContent(file);
-                                List<BibEntry> pdfEntriesInFile = pdfImporterResult.getDatabase().getEntries();
-
-                                if (pdfImporterResult.hasWarnings()) {
-                                    addResultToList(file, false, Localization.lang("Error reading PDF content: %0", pdfImporterResult.getErrorMessage()));
-                                }
-
-                                if (!pdfEntriesInFile.isEmpty()) {
-                                    entriesToAdd = pdfEntriesInFile;
-                                    addResultToList(file, true, Localization.lang("Importing using extracted PDF data"));
-                                } else {
-                                    entriesToAdd = Collections.singletonList(createEmptyEntryWithLink(file));
-                                    addResultToList(file, false, Localization.lang("No metadata found. Creating empty entry with file link"));
-                                }
+                                entriesToAdd = Collections.singletonList(createEmptyEntryWithLink(file));
+                                addResultToList(file, false, Localization.lang("No metadata found. Creating empty entry with file link"));
                             }
                         } else if (FileUtil.isBibFile(file)) {
                             var bibtexParserResult = contentImporter.importFromBibFile(file, fileUpdateMonitor);

--- a/src/main/java/org/jabref/logic/externalfiles/ExternalFilesContentImporter.java
+++ b/src/main/java/org/jabref/logic/externalfiles/ExternalFilesContentImporter.java
@@ -8,7 +8,6 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.OpenDatabase;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.fileformat.PdfMergeMetadataImporter;
-import org.jabref.logic.importer.fileformat.PdfXmpImporter;
 import org.jabref.logic.importer.importsettings.ImportSettingsPreferences;
 import org.jabref.model.util.FileUpdateMonitor;
 
@@ -28,10 +27,6 @@ public class ExternalFilesContentImporter {
         } catch (IOException e) {
            return ParserResult.fromError(e);
         }
-    }
-
-    public ParserResult importXMPContent(Path file) {
-        return new PdfXmpImporter(importFormatPreferences.getXmpPreferences()).importDatabase(file, StandardCharsets.UTF_8);
     }
 
     public ParserResult importFromBibFile(Path bibFile, FileUpdateMonitor fileUpdateMonitor) throws IOException {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2288,9 +2288,7 @@ Error\ importing.\ See\ the\ error\ log\ for\ details.=Error importing. See the 
 
 Error\ from\ import\:\ %0=Error from import\: %0
 Error\ reading\ PDF\ content\:\ %0=Error reading PDF content\: %0
-Error\ reading\ XMP\ content\:\ %0=Error reading XMP content\: %0
 Importing\ bib\ entry=Importing bib entry
-Importing\ using\ XMP\ data...=Importing using XMP data...
 Importing\ using\ extracted\ PDF\ data=Importing using extracted PDF data
 No\ BibTeX\ data\ found.\ Creating\ empty\ entry\ with\ file\ link=No BibTeX data found. Creating empty entry with file link
 No\ metadata\ found.\ Creating\ empty\ entry\ with\ file\ link=No metadata found. Creating empty entry with file link


### PR DESCRIPTION
Since XMP is imported by the MergeMetadataImporter anyways, there is no need to do it explicitly. This also respects the same prioritization that is used when importing PDFs.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.
