### PR TITLE
Switch from src-gen to src/main/generated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,7 @@ modularity.disableEffectiveArgumentsAdjustment()
 sourceSets {
     main {
         java {
-            // src-gen reasoning: https://stackoverflow.com/a/64612308/873282
-            srcDirs = ["src/main/java", "src-gen/main/java"]
+            srcDirs = ["src/main/java", "src/main/generated"]
         }
         resources {
             srcDirs = ["src/main/java", "src/main/resources"]
@@ -270,7 +269,6 @@ task checkOutdatedDependencies(dependsOn: dependencyUpdates) {
 
 clean {
     delete "src/main/generated"
-    delete "src-gen"
 }
 
 processResources {
@@ -319,8 +317,8 @@ tasks.register("generateBstGrammarSource", JavaExec) {
     description = 'Generates BstLexer.java and BstParser.java from the Bst.g grammar file using antlr3.'
 
     inputs.dir('src/main/antlr3/org/jabref/bst/')
-    outputs.dir("src-gen/main/java/org/jabref/logic/bst/")
-    args = ["-o", "src-gen/main/java/org/jabref/logic/bst/" , "$projectDir/src/main/antlr3/org/jabref/bst/Bst.g" ]
+    outputs.dir("src/main/generated/org/jabref/logic/bst/")
+    args = ["-o", "src/main/generated/org/jabref/logic/bst/" , "$projectDir/src/main/antlr3/org/jabref/bst/Bst.g" ]
 }
 
 tasks.register("generateSearchGrammarSource", JavaExec) {
@@ -330,8 +328,8 @@ tasks.register("generateSearchGrammarSource", JavaExec) {
     description = "Generates java files for Search.g antlr4."
 
     inputs.dir("src/main/antlr4/org/jabref/search/")
-    outputs.dir("src-gen/main/java/org/jabref/search/")
-    args  = ["-o","src-gen/main/java/org/jabref/search" , "-visitor", "-no-listener", "-package", "org.jabref.search", "$projectDir/src/main/antlr4/org/jabref/search/Search.g4"]
+    outputs.dir("src/main/generated/org/jabref/search/")
+    args  = ["-o","src/main/generated/org/jabref/search" , "-visitor", "-no-listener", "-package", "org.jabref.search", "$projectDir/src/main/antlr4/org/jabref/search/Search.g4"]
 }
 
 task generateMedlineSource(type: XjcTask) {
@@ -339,7 +337,7 @@ task generateMedlineSource(type: XjcTask) {
     description = "Generates java files for the medline importer."
 
     schemaFile = "src/main/resources/xjc/medline/medline.xsd"
-    outputDirectory = "src-gen/main/java"
+    outputDirectory = "src/main/generated"
     javaPackage = "org.jabref.logic.importer.fileformat.medline"
 }
 
@@ -348,7 +346,7 @@ task generateBibtexmlSource(type: XjcTask) {
     description = "Generates java files for the bibtexml importer."
 
     schemaFile = "src/main/resources/xjc/bibtexml/bibtexml.xsd"
-    outputDirectory = "src-gen/main/java/"
+    outputDirectory = "src/main/generated/"
     javaPackage = "org.jabref.logic.importer.fileformat.bibtexml"
 }
 
@@ -357,7 +355,7 @@ task generateEndnoteSource(type: XjcTask) {
     description = "Generates java files for the endnote importer."
 
     schemaFile = "src/main/resources/xjc/endnote/endnote.xsd"
-    outputDirectory = "src-gen/main/java/"
+    outputDirectory = "src/main/generated/"
     javaPackage = "org.jabref.logic.importer.fileformat.endnote"
 }
 
@@ -367,7 +365,7 @@ task generateModsSource(type: XjcTask) {
 
     schemaFile = "src/main/resources/xjc/mods/mods-3-7.xsd"
     bindingFile = "src/main/resources/xjc/mods/mods-binding.xjb"
-    outputDirectory = "src-gen/main/java"
+    outputDirectory = "src/main/generated"
     javaPackage = "org.jabref.logic.importer.fileformat.mods"
     arguments = '-npa'
 }
@@ -391,7 +389,7 @@ compileJava {
     options.compilerArgs << "-Xlint:none"
     dependsOn "generateSource"
 
-    options.annotationProcessorGeneratedSourcesDirectory = file("src-gen/main/java")
+    options.annotationProcessorGeneratedSourcesDirectory = file("src/main/generated")
 
     moduleOptions {
         // TODO: Remove access to internal api

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
@@ -153,18 +153,7 @@ To use IntelliJ IDEA's internal build system when you build JabRef through **Bui
 
   ![Ignore the Gradle project &quot;buildSrc&quot;](../.gitbook/assets/intellij-gradle-config-ignore-buildSrc%20%282%29%20%282%29%20%282%29%20%283%29%20%283%29%20%286%29%20%284%29.png)
 
-* Add `src-gen` as root:
-  1. Right click on the project "jabref".
-  2. Select "Open Module Settings"
-  3. Expand "JabRef"
-  4. Select "main"
-  5. Select tab "Sources"
-  6. Click "+ Add Content Root"
-  7. Select the `src-gen` directory
-  8. Click "OK". When expanding "main", "java" should have been selected as source
-  9. Click "OK" to save the changes
-* In case the above step does not work, run with gradle, import gradle project again, and try again.
-* Delete `org.jabref.gui.logging.plugins.Log4jPlugins` \(location: `src-gen/main/java/org/jabref/gui/logging/plugins/Log4jPlugins.java`\). Otherwise, you will see following error:
+* Delete `org.jabref.gui.logging.plugins.Log4jPlugins` \(location: `src/main/generated/org/jabref/gui/logging/plugins/Log4jPlugins.java`\). Otherwise, you will see following error:
 
   ```text
   Error:java: Unable to create Plugin Service Class org.jabref.gui.logging.plugins.Log4jPlugins


### PR DESCRIPTION
IntelliJ proposes `src/generated` as generated sources dir:

![generated-intellij](https://user-images.githubusercontent.com/1366654/131529681-01531f89-40e4-4f9a-b45c-a187a07d0db8.png)

Filed to https://youtrack.jetbrains.com/issue/IDEA-255367#focus=Comments-27-5158152.0-0

Current issue: IntelliJ editor does not show any error, but IntelliJ compiler shows error:

![grafik](https://user-images.githubusercontent.com/1366654/131531844-e10a8e31-70ef-414a-9206-076c5aea7b53.png)

