### PR TITLE
Use new "cache" property of setup-java

### DIFF
--- a/.github/workflows/check-outdated-dependencies.yml
+++ b/.github/workflows/check-outdated-dependencies.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Look for outdated dependencies
         run: ./gradlew -q checkOutdatedDependencies
       - name: Report issues

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -64,15 +64,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - name: Restore gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7x-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7x-
+          cache: 'gradle'
       - name: Setup OSX key chain on OSX
         if: matrix.os == 'macos-latest'
         uses: apple-actions/import-codesign-certs@v1

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -20,11 +20,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - uses: actions/cache@v1
-        name: Restore gradle wrapper
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          cache: 'gradle'
       - name: Update journal lists
         run: |
           set +o pipefail

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -38,15 +38,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - uses: actions/cache@v2
-        name: Restore gradle cache
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Run fetcher tests
         run: ./gradlew fetcherTest
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,15 +28,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - name: Restore gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7-
+          cache: 'gradle'
       - name: Run check style reporter
         uses: nikitasavinov/checkstyle-action@master
         with:
@@ -60,15 +52,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - uses: actions/cache@v2
-        name: Restore gradle cache
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7-
+          cache: 'gradle'
       - name: Run tests
         run: xvfb-run --auto-servernum ./gradlew check -x checkstyleJmh -x checkstyleMain -x checkstyleTest
         env:
@@ -100,15 +84,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - name: Restore gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7-
+          cache: 'gradle'
       - name: Run tests on PostgreSQL
         run: ./gradlew databaseTest --rerun-tasks
         env:
@@ -142,15 +118,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - uses: actions/cache@v2
-        name: Restore gradle cache
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7-
+          cache: 'gradle'
       - name: Run GUI tests
         run: xvfb-run --auto-servernum ./gradlew guiTest
         env:
@@ -188,15 +156,7 @@ jobs:
         with:
           java-version: 16
           distribution: 'adopt'
-      - name: Restore gradle cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle7-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle7-
+          cache: 'gradle'
       - name: Update test coverage metrics
         if: ${{ steps.checksecrets.outputs.secretspresent }}
         run: xvfb-run --auto-servernum ./gradlew jacocoTestReport && bash <(curl -s https://codecov.io/bash);


### PR DESCRIPTION
Since 5 days, `setup-java` supports caching by itself. See https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/ for details.

I think, GitHub knows better than us how to correctly cache. Thus, I removed custom calls to the cache action and used the new cache property.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
