### PR TITLE
Fixes the ISBN test

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcherTest.java
@@ -73,20 +73,15 @@ public class IsbnViaOttoBibFetcherTest extends AbstractIsbnFetcherTest {
         assertEquals(Optional.of(bibEntry), fetchedEntry);
     }
 
+    /**
+     * Checks whether the given ISBN is <emph>NOT</emph> available at any ISBN fetcher
+     */
     @Test
-    public void testISBNNotAvaiableOnEbookDeOrChimbori() throws Exception {
-        bibEntry = new BibEntry();
-        bibEntry.setType(StandardEntryType.Book);
-        bibEntry.setCitationKey("denis2012les");
-        bibEntry.setField(StandardField.TITLE, "Les mots du passé : roman");
-        bibEntry.setField(StandardField.PUBLISHER, "Éd. les Nouveaux auteurs");
-        bibEntry.setField(StandardField.ADDRESS, "Paris");
-        bibEntry.setField(StandardField.YEAR, "2012");
-        bibEntry.setField(StandardField.AUTHOR, "Denis, ");
-        bibEntry.setField(StandardField.ISBN, "9782819502746");
-
-        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("978-2-8195-02746");
-        assertEquals(Optional.of(bibEntry), fetchedEntry);
+    public void testIsbnNeitherAvaiableOnEbookDeNorOrViaChimbori() throws Exception {
+        // In this test, the ISBN needs to be a valid (syntax+checksum) ISBN number
+        // However, the ISBN number must not be assigned to a real book
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("978-8-8264-2303-6");
+        assertEquals(Optional.empty(), fetchedEntry);
 
     }
 


### PR DESCRIPTION
The ISBN fetcher has a test for ISBN returning **no** data. However, there came back results since two years. Now, there is no result any more.

I updated the test:

- Change name and JavaDoc to really indicate we do not want any results
- Changed the ISBN number to an artificially one to ensure no results are returned.

---

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
