### PR TITLE
Fix grobid test

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/GrobidService.java
+++ b/src/main/java/org/jabref/logic/importer/util/GrobidService.java
@@ -54,7 +54,7 @@ public class GrobidService {
      * Calls the Grobid server for converting the citation into a BibEntry
      *
      * @return A BibEntry for the String
-     * @throws IOException if an I/O excecption during the call ocurred or no BibTeX entry could be determiend
+     * @throws IOException if an I/O exception during the call occurred or no BibTeX entry could be determined
      */
     public Optional<BibEntry> processCitation(String rawCitation, ImportFormatPreferences importFormatPreferences, ConsolidateCitations consolidateCitations) throws IOException, ParseException {
         Connection.Response response = Jsoup.connect(importerPreferences.getGrobidURL() + "/api/processCitation")

--- a/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
@@ -75,7 +75,7 @@ public class GrobidServiceTest {
 
     @Test
     public void failsWhenGrobidDisabled() {
-        ImporterPreferences importSettingsWithGrobidDisabled = new ImporterPreferences(false, true, false, "http://grobid.jabref.org:8070");
+        ImporterPreferences importSettingsWithGrobidDisabled = new ImporterPreferences(false, false, false, "http://grobid.jabref.org:8070");
         assertThrows(UnsupportedOperationException.class, () -> new GrobidService(importSettingsWithGrobidDisabled));
     }
 


### PR DESCRIPTION
There was a `true`/`false` mixup at the `ImporterPreferences`. This PR fixes it.

It also fixes some typos.

I know that we discussed the usage of [EnumSet](https://docs.oracle.com/javase/7/docs/api/java/util/EnumSet.html)s to avoid Booleans. Too much effort for me to implement it here 😇 

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
