### PR TITLE
Fix PdfMergeMetaImporterTest on Windows

### DIFF
--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -27,6 +27,7 @@ import org.jabref.preferences.FilePreferences;
 public class LinkedFile implements Serializable {
 
     private static final LinkedFile NULL_OBJECT = new LinkedFile("", Path.of(""), "");
+
     // We have to mark these properties as transient because they can't be serialized directly
     private transient StringProperty description = new SimpleStringProperty();
     private transient StringProperty link = new SimpleStringProperty();

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
@@ -9,6 +9,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -83,7 +84,7 @@ class PdfMergeMetadataImporterTest {
         expected.setField(StandardField.VOLUME, "1");
 
         // From merge
-        expected.setField(StandardField.FILE, ":" + file.toAbsolutePath().toString() + ":" + StandardFileType.PDF.getName());
+        expected.setFiles(List.of(new LinkedFile("", file.toAbsolutePath(), StandardFileType.PDF.getName())));
 
         assertEquals(Collections.singletonList(expected), result);
     }


### PR DESCRIPTION
On Windows, the filename was not correctly written in the expected case. I fixed it by using the "standard" procedure to get file links

Now, it works "on my machine".

The CI (on another branch at https://github.com/JabRef/jabref/runs/3513022608?check_suite_focus=true) output following. Here, the `month` field was not included. Could not reproduce. Here for historical reasons (maybe I need to reference it)

```
org.jabref.logic.importer.fileformat.PdfMergeMetadataImporterTest

  Test importWorksAsExpected() FAILED (17.9s)

  org.opentest4j.AssertionFailedError: expected: <[
```

```bibtex
@book{9780134685991,
    author = {Bloch, Joshua},
    comment = {From embedded bib},
    date = {2018-01-01},
    doi = {10.1002/9781118257517},
    ean = {9780134685991},
    file = {:/home/runner/work/jabref/jabref/build/resources/test/org/jabref/logic/importer/fileformat/mixedMetadata.pdf:PDF},
    isbn = {0134685997},
    journal = {Some Journal},
    month = {jul},
    publisher = {Addison Wesley},
    title = {Effective Java},
    url = {https://www.ebook.de/de/product/28983211/joshua_bloch_effective_java.html},
    volume = {1},
    year = {2018},
    _jabref_shared = {sharedId: -1, version: 1}
  }
```

```
]> but was: <[
```

```bibtex
@book{9780134685991,
    author = {Bloch, Joshua},
    comment = {From embedded bib},
    date = {2018-01-01},
    doi = {10.1002/9781118257517},
    ean = {9780134685991},
    file = {:/home/runner/work/jabref/jabref/build/resources/test/org/jabref/logic/importer/fileformat/mixedMetadata.pdf:PDF},
    isbn = {0134685997},
    journal = {Some Journal},
    publisher = {Addison Wesley},
    title = {Effective Java},
    url = {https://www.ebook.de/de/product/28983211/joshua_bloch_effective_java.html},
    volume = {1},
    year = {2018},
    _jabref_shared = {sharedId: -1, version: 1}
  }
```

```
]>
```

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
