### PR TITLE
Fix l10n and fix some missing type args

### DIFF
--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -19,7 +19,7 @@ public class JabRefCLI {
     private static final int WIDTH = 100; // Number of characters per line
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefCLI.class);
     private final CommandLine cl;
-    private List<String> leftOver;
+    private final List<String> leftOver;
 
     public JabRefCLI(String[] args) throws ParseException {
         Options options = getOptions();
@@ -271,7 +271,7 @@ public class JabRefCLI {
         options.addOption(Option
                 .builder()
                 .longOpt("embeddBibfileInPdf")
-                .desc(String.format("%s: '%s'", Localization.lang("Embedd BibTeXEntry in PDF."), "-w pathToMyOwnPaper.pdf"))
+                .desc(String.format("%s: '%s'", Localization.lang("Embed BibTeXEntry in PDF."), "-w pathToMyOwnPaper.pdf"))
                 .hasArg()
                 .argName("CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all")
                 .build());

--- a/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
@@ -69,11 +69,11 @@ public class EmbeddedBibFilePdfExporter extends Exporter {
         try (PDDocument document = PDDocument.load(file.toFile())) {
             PDDocumentNameDictionary nameDictionary = document.getDocumentCatalog().getNames();
             PDEmbeddedFilesNameTreeNode efTree;
-            Map names;
+            Map<String, PDComplexFileSpecification> names;
 
             if (nameDictionary == null) {
                 efTree = new PDEmbeddedFilesNameTreeNode();
-                names = new HashMap();
+                names = new HashMap<>();
                 nameDictionary = new PDDocumentNameDictionary(document.getDocumentCatalog());
                 nameDictionary.setEmbeddedFiles(efTree);
                 document.getDocumentCatalog().setNames(nameDictionary);

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -904,7 +904,7 @@ Writing\ metadata\ for\ selected\ entries...=Writing metadata for selected entri
 Writing\ metadata...=Writing metadata...
 
 Write\ XMP=Write XMP
-Embedd\ BibTeXEntry\ in\ PDF.=Embedd BibTeXEntry in PDF.
+Embed\ BibTeXEntry\ in\ PDF.=Embed BibTeXEntry in PDF.
 Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Write BibTeXEntry as XMP metadata to PDF.
 Write\ BibTeXEntry\ metadata\ to\ PDF.=Write BibTeXEntry metadata to PDF.
 Write\ metadata\ to\ PDF\ files=Write metadata to PDF files

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -29,6 +29,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.preferences.FilePreferences;
 import org.jabref.preferences.PreferencesService;
+import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -219,6 +220,7 @@ class LinkedFileViewModelTest {
         new CurrentThreadTaskExecutor().execute(task);
     }
 
+    @FetcherTest
     @Test
     void downloadHtmlWhenLinkedFilePointsToHtml() throws MalformedURLException {
         // the link mentioned in issue #7452


### PR DESCRIPTION
Spotted by @hakova  on Crowdin

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
