### PR TITLE
snap: Use lzo compression & switch to core20 base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the export order in the preferences from `File` to `Import and Export`. [#7935](https://github.com/JabRef/jabref/pull/7935)
 - We reworked the export order in the preferences and the save order in the library preferences. You can now set more than three sort criteria in your library preferences. [#7935](https://github.com/JabRef/jabref/pull/7935)
 - The metadata-to-pdf actions now also embeds the bibfile to the PDF. [#8037](https://github.com/JabRef/jabref/pull/8037)
+- The snap was updated to use the core20 base and to use lzo compression for better startup performance [#8109](https://github.com/JabRef/jabref/pull/8109)
 
 ### Fixed
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,8 @@ description: |
   `snap connect jabref:removable-media`
 grade: stable
 confinement: strict
-base: core18
+base: core20
+compression: lzo
 architectures:
   - build-on: amd64
 
@@ -44,10 +45,10 @@ layout:
 apps:
   jabref:
     command: bin/JabRef
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
   browser-proxy:
     command: lib/jabrefHost.py
-    extensions: [gnome-3-34]
+    extensions: [gnome-3-38]
 
 environment:
   _JAVA_OPTIONS: "-Duser.home=$SNAP_USER_DATA"


### PR DESCRIPTION
LZO compression speeds up cold starts tremendously while
increasing the download size a moderate amount.

Also switch to core20 and its more recent gnome extension.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
