### PR TITLE
Don't throw exception when validating invalid paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where it was impossible to add or modify groups. [#7912](https://github.com/JabRef/jabref/pull/793://github.com/JabRef/jabref/pull/7921)
 - We fixed an issue where exported entries from a Citavi bib containing URLs could not be imported [#7892](https://github.com/JabRef/jabref/issues/7882)
 - We fixed an issue where the icons in the search bar had the same color, toggled as well as untoggled. [#8014](https://github.com/JabRef/jabref/pull/8014)
+- We fixed an issue where typing an invalid UNC path into the "Main file directory" text field caused an error. [#8107](https://github.com/JabRef/jabref/issues/8107) 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where it was impossible to add or modify groups. [#7912](https://github.com/JabRef/jabref/pull/793://github.com/JabRef/jabref/pull/7921)
 - We fixed an issue where exported entries from a Citavi bib containing URLs could not be imported [#7892](https://github.com/JabRef/jabref/issues/7882)
 - We fixed an issue where the icons in the search bar had the same color, toggled as well as untoggled. [#8014](https://github.com/JabRef/jabref/pull/8014)
-- We fixed an issue where typing an invalid UNC path into the "Main file directory" text field caused an error. [#8107](https://github.com/JabRef/jabref/issues/8107) 
+- We fixed an issue where typing an invalid UNC path into the "Main file directory" text field caused an error. [#8107](https://github.com/JabRef/jabref/issues/8107)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -59,8 +59,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
                     try {
                         Path path = Path.of(mainFileDirectoryProperty.getValue());
                         return (Files.exists(path) && Files.isDirectory(path));
-                    }
-                    catch(InvalidPathException ex) {
+                    } catch (InvalidPathException ex) {
                         return false;
                     }
                 },

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.preferences.linkedfiles;
 
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
 import javafx.beans.property.BooleanProperty;
@@ -55,8 +56,13 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         mainFileDirValidator = new FunctionBasedValidator<>(
                 mainFileDirectoryProperty,
                 input -> {
-                    Path path = Path.of(mainFileDirectoryProperty.getValue());
-                    return (Files.exists(path) && Files.isDirectory(path));
+                    try {
+                        Path path = Path.of(mainFileDirectoryProperty.getValue());
+                        return (Files.exists(path) && Files.isDirectory(path));
+                    }
+                    catch(InvalidPathException ex) {
+                        return false;
+                    }
                 },
                 ValidationMessage.error(String.format("%s > %s > %s %n %n %s",
                         Localization.lang("File"),


### PR DESCRIPTION
Fixes #8107

While usually I don't advocate silently catching exceptions, in this case I think it's the right thing to do as we just want a true / false value as to whether the path is valid or not. If we catch an `InvalidPathException` then we *always* know that the path is invalid - so this fixes the attached issue with UNC paths, as well as any other theoretical invalid path that might throw this exception.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
