### PR TITLE
Add Tests to DoiCleanup 

### DIFF
--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -50,4 +50,26 @@ public class DoiCleanupTest {
         assertEquals(expected, input);
     }
 
+    @Test
+    void cleanupDoiEntryDoiFieldsWithoutHttp() {
+
+        UnknownField unknownField = new UnknownField("ee");
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.DOI, "10.1145/2594455")
+                .withField(StandardField.NOTE, "This is a random note to this Doi")
+                .withField(unknownField, "This is a random ee field for this Doi");
+
+        BibEntry output = new BibEntry()
+                .withField(StandardField.DOI, "10.1145/2594455")
+                .withField(StandardField.NOTE, "This is a random note to this Doi")
+                .withField(unknownField, "This is a random ee field for this Doi");
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(output, input);
+    }
+
+
 }

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -83,5 +83,16 @@ public class DoiCleanupTest {
         assertEquals(expected, input);
     }
 
+    @Test
+    void cleanupDoiJustUrl() {
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.URL, "https://doi.org/10.1145/2594455");
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
 
 }

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -107,5 +107,19 @@ public class DoiCleanupTest {
         assertEquals(expected, input);
     }
 
+    @Test
+    void cleanupDoiJustEe() {
+
+        UnknownField unknownField = new UnknownField("ee");
+
+        BibEntry input = new BibEntry()
+                .withField(unknownField, "https://doi.org/10.1145/2594455");
+
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
 
 }

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -71,5 +71,17 @@ public class DoiCleanupTest {
         assertEquals(output, input);
     }
 
+    @Test
+    void cleanupDoiEntryDoiWithSpaces() {
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.DOI, "10.1145 / 2594455");
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
+
 
 }

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -1,0 +1,34 @@
+package org.jabref.logic.cleanup;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DoiCleanupTest {
+
+    private BibEntry expected;
+
+    @BeforeEach
+    public void setUp() {
+        expected = new BibEntry()
+                .withField(StandardField.DOI, "10.1145/2594455");
+    }
+
+    @Test
+    void cleanupDoiEntryJustDoi() {
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.DOI, "10.1145/2594455");
+
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
+
+}

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -3,6 +3,7 @@ package org.jabref.logic.cleanup;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
+import org.jabref.model.entry.field.UnknownField;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,24 @@ public class DoiCleanupTest {
 
         BibEntry input = new BibEntry()
                 .withField(StandardField.DOI, "10.1145/2594455");
+
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
+
+    @Test
+    void cleanupDoiEntryJustDoiAllEntries() {
+
+        UnknownField unknownField = new UnknownField("ee");
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.DOI, "10.1145/2594455")
+                .withField(StandardField.URL, "https://doi.org/10.1145/2594455")
+                .withField(StandardField.NOTE, "https://doi.org/10.1145/2594455")
+                .withField(unknownField, "https://doi.org/10.1145/2594455");
 
 
         DoiCleanup cleanup = new DoiCleanup();

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -95,4 +95,17 @@ public class DoiCleanupTest {
         assertEquals(expected, input);
     }
 
+    @Test
+    void cleanupDoiJustNote() {
+
+        BibEntry input = new BibEntry()
+                .withField(StandardField.NOTE, "https://doi.org/10.1145/2594455");
+
+        DoiCleanup cleanup = new DoiCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
+
+
 }


### PR DESCRIPTION
Adding unit tests to DoiCleanup class, to improve the coverage of the project.

I added 7 test to the file:
- cleanupDoientryJustdoi
- cleanupDoiEntryJustDoiAllEntries
- cleanupDoiEntryDoiFieldsWithoutHttp
- cleanupDoiEntryDoiWithSpaces
- cleanupDoiJustUrl
- cleanupDoiJustNote
- cleanupDoiJustEe

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
