### PR TITLE
Do not resize main table columns in search dialog window

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -104,7 +104,8 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         externalFileTypes,
                         libraryTab.getUndoManager(),
                         dialogService,
-                        stateManager).createColumns());
+                        stateManager,
+                        true).createColumns());
 
         new ViewModelTableRowFactory<BibEntryTableViewModel>()
                 .withOnMouseClickedEvent((entry, event) -> {

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -59,13 +59,16 @@ public class MainTableColumnFactory {
     private final UndoManager undoManager;
     private final DialogService dialogService;
     private final StateManager stateManager;
+    private final boolean withListener;
 
     public MainTableColumnFactory(BibDatabaseContext database,
                                   PreferencesService preferencesService,
                                   ExternalFileTypes externalFileTypes,
                                   UndoManager undoManager,
                                   DialogService dialogService,
-                                  StateManager stateManager) {
+                                  StateManager stateManager,
+                                  boolean withListener) {
+
         this.database = Objects.requireNonNull(database);
         this.preferencesService = Objects.requireNonNull(preferencesService);
         this.columnPreferences = preferencesService.getColumnPreferences();
@@ -74,6 +77,7 @@ public class MainTableColumnFactory {
         this.cellFactory = new CellFactory(externalFileTypes, preferencesService, undoManager);
         this.undoManager = undoManager;
         this.stateManager = stateManager;
+        this.withListener = withListener;
     }
 
     public List<TableColumn<BibEntryTableViewModel, ?>> createColumns() {
@@ -132,7 +136,7 @@ public class MainTableColumnFactory {
      * Creates a column with a continous number
      */
     private TableColumn<BibEntryTableViewModel, String> createIndexColumn(MainTableColumnModel columnModel) {
-        TableColumn<BibEntryTableViewModel, String> column = new MainTableColumn<>(columnModel);
+        TableColumn<BibEntryTableViewModel, String> column = new MainTableColumn<>(columnModel, withListener);
         Node header = new Text("#");
         header.getStyleClass().add("mainTable-header");
         Tooltip.install(header, new Tooltip(MainTableColumnModel.Type.INDEX.getDisplayName()));
@@ -151,7 +155,7 @@ public class MainTableColumnFactory {
      * Creates a column for group color bars.
      */
     private TableColumn<BibEntryTableViewModel, ?> createGroupColumn(MainTableColumnModel columnModel) {
-        TableColumn<BibEntryTableViewModel, List<AbstractGroup>> column = new MainTableColumn<>(columnModel);
+        TableColumn<BibEntryTableViewModel, List<AbstractGroup>> column = new MainTableColumn<>(columnModel, withListener);
         Node headerGraphic = IconTheme.JabRefIcons.DEFAULT_GROUP_ICON.getGraphicNode();
         Tooltip.install(headerGraphic, new Tooltip(Localization.lang("Group color")));
         column.setGraphic(headerGraphic);
@@ -204,21 +208,21 @@ public class MainTableColumnFactory {
      * Creates a text column to display any standard field.
      */
     private TableColumn<BibEntryTableViewModel, ?> createFieldColumn(MainTableColumnModel columnModel) {
-        return new FieldColumn(columnModel);
+        return new FieldColumn(columnModel, withListener);
     }
 
     /**
      * Creates a clickable icons column for DOIs, URLs, URIs and EPrints.
      */
     private TableColumn<BibEntryTableViewModel, Map<Field, String>> createIdentifierColumn(MainTableColumnModel columnModel) {
-        return new LinkedIdentifierColumn(columnModel, cellFactory, database, dialogService, preferencesService, stateManager);
+        return new LinkedIdentifierColumn(columnModel, cellFactory, database, dialogService, preferencesService, stateManager, withListener);
     }
 
     /**
      * Creates a column that displays a {@link SpecialField}
      */
     private TableColumn<BibEntryTableViewModel, Optional<SpecialFieldValueViewModel>> createSpecialFieldColumn(MainTableColumnModel columnModel) {
-        return new SpecialFieldColumn(columnModel, preferencesService, undoManager);
+        return new SpecialFieldColumn(columnModel, preferencesService, undoManager, withListener);
     }
 
     /**
@@ -230,7 +234,8 @@ public class MainTableColumnFactory {
                 database,
                 externalFileTypes,
                 dialogService,
-                preferencesService);
+                preferencesService,
+                withListener);
     }
 
     /**
@@ -242,6 +247,7 @@ public class MainTableColumnFactory {
                 externalFileTypes,
                 dialogService,
                 preferencesService,
-                columnModel.getQualifier());
+                columnModel.getQualifier(),
+                withListener);
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/columns/FieldColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FieldColumn.java
@@ -20,8 +20,8 @@ public class FieldColumn extends MainTableColumn<String> {
 
     private final OrFields fields;
 
-    public FieldColumn(MainTableColumnModel model) {
-        super(model);
+    public FieldColumn(MainTableColumnModel model, boolean withListener) {
+        super(model, withListener);
         this.fields = FieldFactory.parseOrFields(model.getQualifier());
 
         setText(getDisplayName());
@@ -35,7 +35,7 @@ public class FieldColumn extends MainTableColumn<String> {
             // comparator can't parse more than one value
             Field field = Iterables.getOnlyElement(fields);
 
-            if (field instanceof UnknownField || field.isNumeric()) {
+            if ((field instanceof UnknownField) || field.isNumeric()) {
                 this.setComparator(new NumericFieldComparator());
             }
         }

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -39,13 +39,15 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
 
     /**
      * Creates a joined column for all the linked files.
+     *
      */
     public FileColumn(MainTableColumnModel model,
                       BibDatabaseContext database,
                       ExternalFileTypes externalFileTypes,
                       DialogService dialogService,
-                      PreferencesService preferencesService) {
-        super(model);
+                      PreferencesService preferencesService,
+                      boolean withListener) {
+        super(model, withListener);
         this.externalFileTypes = Objects.requireNonNull(externalFileTypes);
         this.database = Objects.requireNonNull(database);
         this.dialogService = dialogService;
@@ -84,8 +86,9 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
                       ExternalFileTypes externalFileTypes,
                       DialogService dialogService,
                       PreferencesService preferencesService,
-                      String fileType) {
-        super(model);
+                      String fileType,
+                      boolean withListener) {
+        super(model, withListener);
         this.externalFileTypes = Objects.requireNonNull(externalFileTypes);
         this.database = Objects.requireNonNull(database);
         this.dialogService = dialogService;

--- a/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
@@ -42,8 +42,9 @@ public class LinkedIdentifierColumn extends MainTableColumn<Map<Field, String>> 
                                   BibDatabaseContext database,
                                   DialogService dialogService,
                                   PreferencesService preferences,
-                                  StateManager stateManager) {
-        super(model);
+                                  StateManager stateManager,
+                                  boolean withListener) {
+        super(model, withListener);
         this.database = database;
         this.cellFactory = cellFactory;
         this.dialogService = dialogService;

--- a/src/main/java/org/jabref/gui/maintable/columns/MainTableColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/MainTableColumn.java
@@ -9,22 +9,29 @@ import org.jabref.gui.util.BindingsHelper;
 
 public class MainTableColumn<T> extends TableColumn<BibEntryTableViewModel, T> {
 
-    private MainTableColumnModel model;
+    private final MainTableColumnModel model;
 
-    public MainTableColumn(MainTableColumnModel model) {
+    /**
+     *
+     * @param model The MainTableColumn model
+     * @param withListener boolean, true to indicate that listeners to columns are added for sort type and width
+     */
+    public MainTableColumn(MainTableColumnModel model, boolean withListener) {
         this.model = model;
 
-        BindingsHelper.bindBidirectional(
-                this.widthProperty(),
-                model.widthProperty(),
-                value -> this.setPrefWidth(model.widthProperty().getValue()),
-                value -> model.widthProperty().setValue(this.getWidth()));
+        if (withListener) {
+            BindingsHelper.bindBidirectional(
+                    this.widthProperty(),
+                    model.widthProperty(),
+                    value -> this.setPrefWidth(model.widthProperty().getValue()),
+                    value -> model.widthProperty().setValue(this.getWidth()));
 
-        BindingsHelper.bindBidirectional(
-                this.sortTypeProperty(),
-                (ObservableValue<SortType>) model.sortTypeProperty(),
-                value -> this.setSortType(model.sortTypeProperty().getValue()),
-                value -> model.sortTypeProperty().setValue(this.getSortType()));
+            BindingsHelper.bindBidirectional(
+                    this.sortTypeProperty(),
+                    (ObservableValue<SortType>) model.sortTypeProperty(),
+                    value -> this.setSortType(model.sortTypeProperty().getValue()),
+                    value -> model.sortTypeProperty().setValue(this.getSortType()));
+        }
     }
 
     public MainTableColumnModel getModel() {

--- a/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
@@ -38,8 +38,8 @@ public class SpecialFieldColumn extends MainTableColumn<Optional<SpecialFieldVal
     private final PreferencesService preferencesService;
     private final UndoManager undoManager;
 
-    public SpecialFieldColumn(MainTableColumnModel model, PreferencesService preferencesService, UndoManager undoManager) {
-        super(model);
+    public SpecialFieldColumn(MainTableColumnModel model, PreferencesService preferencesService, UndoManager undoManager, boolean withListener) {
+        super(model, withListener);
         this.preferencesService = preferencesService;
         this.undoManager = undoManager;
 

--- a/src/main/java/org/jabref/gui/search/SearchResultsTable.java
+++ b/src/main/java/org/jabref/gui/search/SearchResultsTable.java
@@ -11,9 +11,6 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.maintable.BibEntryTableViewModel;
 import org.jabref.gui.maintable.MainTable;
 import org.jabref.gui.maintable.MainTableColumnFactory;
-import org.jabref.gui.maintable.MainTablePreferences;
-import org.jabref.gui.maintable.SmartConstrainedResizePolicy;
-import org.jabref.gui.maintable.columns.MainTableColumn;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.preferences.PreferencesService;
 
@@ -28,27 +25,14 @@ public class SearchResultsTable extends TableView<BibEntryTableViewModel> {
                               ExternalFileTypes externalFileTypes) {
         super();
 
-        MainTablePreferences mainTablePreferences = preferencesService.getMainTablePreferences();
-
         this.getColumns().addAll(new MainTableColumnFactory(
                 database,
                 preferencesService,
                 externalFileTypes,
                 undoManager,
                 dialogService,
-                stateManager).createColumns());
-
-        this.getSortOrder().clear();
-        mainTablePreferences.getColumnPreferences().getColumnSortOrder().forEach(columnModel ->
-                this.getColumns().stream()
-                    .map(column -> (MainTableColumn<?>) column)
-                    .filter(column -> column.getModel().equals(columnModel))
-                    .findFirst()
-                    .ifPresent(column -> this.getSortOrder().add(column)));
-
-        if (mainTablePreferences.getResizeColumnsToFit()) {
-            this.setColumnResizePolicy(new SmartConstrainedResizePolicy());
-        }
+                stateManager,
+                false).createColumns());
 
         this.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         this.setItems(model.getEntriesFilteredAndSorted());


### PR DESCRIPTION
Fixes part of #8054 

Add flag if listeners should be used.

The only drawback is that it's impossible to store the dialog colunn size.
Edit// I thought about a possible way but this is currently not really possible without duplicating all the code 

<img width="1403" alt="Bildschirmfoto 2021-10-09 um 18 45 00" src="https://user-images.githubusercontent.com/320228/136667234-db206e1f-bebb-4ed7-bc98-ac3470680b86.png">
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~~
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
