### PR TITLE
Create .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,15 @@
+version = 1
+
+[[analyzers]]
+name = "java"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "15"
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"


### PR DESCRIPTION
The #hacktoberfest initiative recommends using https://deepsource.io to analyze code issues ([Details](https://deepsource.io/blog/hacktoberfest-21/)). As part of our [Teaching initiative](https://devdocs.jabref.org/teaching), I would like to offer the comparability of multiple code issue finders. Thus, I would like to enable deepsource.io.

Currently, not a single Java project is listed at deepsource: https://deepsource.io/discover/java

![grafik](https://user-images.githubusercontent.com/1366654/137618760-e2ed60cd-e50a-42e0-95bf-7b3071e4fbbb.png)

Just enabling deepsource.io doesn't help as they automatically analyze the ruby files from our CSL styles and some bash scripts. 

![grafik](https://user-images.githubusercontent.com/1366654/137618871-6e86678d-9926-4311-aab5-970b3da51d62.png)

With the configuration proposed at this PR, only the languages used in our project: Java and Python (for helper scripts) are enabled.

Current impression: deepsource found issues only in our test files. Maybe I should configure it to check our "live" code only?

JabRef maintainers can IMHO join by following https://deepsource.io/gh/JabRef/jabref/.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
