### PR TITLE
Fix some typos

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -79,7 +79,7 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         ControlHelper.setAction(generateButton, this.getDialogPane(), event -> viewModel.runFetcherWorker());
 
         setResultConverter(button -> {
-            // The buttonType will always be cancel, even if we pressed one of the entry type buttons
+            // The buttonType will always be "cancel", even if we pressed one of the entry type buttons
             return type;
         });
 

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -113,16 +113,14 @@ public class EntryTypeViewModel {
 
         @Override
         protected Optional<BibEntry> call() throws InterruptedException, FetcherException {
-            Optional<BibEntry> bibEntry = Optional.empty();
-
             searchingProperty().setValue(true);
             storeSelectedFetcher();
             fetcher = selectedItemProperty().getValue();
             searchID = idText.getValue();
-            if (!searchID.isEmpty()) {
-                bibEntry = fetcher.performSearchById(searchID);
+            if (searchID.isEmpty()) {
+                return Optional.empty();
             }
-            return bibEntry;
+            return fetcher.performSearchById(searchID);
         }
     }
 

--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -66,7 +66,6 @@ public class JabRefGUI {
     }
 
     private void openWindow(Stage mainStage) {
-
         LOGGER.debug("Initializing frame");
         mainFrame.init();
 

--- a/src/main/java/org/jabref/gui/JabRefMain.java
+++ b/src/main/java/org/jabref/gui/JabRefMain.java
@@ -139,8 +139,8 @@ public class JabRefMain extends Application {
         // Initialize protected terms loader
         Globals.protectedTermsLoader = new ProtectedTermsLoader(preferences.getProtectedTermsPreferences());
 
-        // Override used newline character with the one stored in the preferences
-        // The preferences return the system newline character sequence as default
+        // Override used newline character with the one stored in the preferences.
+        // The preferences return the system newline character sequence as default.
         OS.NEWLINE = preferences.getNewLineSeparator().toString();
     }
 


### PR DESCRIPTION
While coding, I saw that IntelliJ marks some code comments as typos. This PR fixes that.

Additionally, one small code change to keep the variable declaration close to the usage.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
