### PR TITLE
Present options to create an article for manual entry or return to the new entry dialog box when failed to find DOI ID ... #7870

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the Drag and Drop behavior in the "Customize Entry Types" Dialog [#6338](https://github.com/JabRef/jabref/issues/6338)
 - When determing the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
-- We present options to return to the 'Select entry type' menu or create an article for manual entry when the fetcher DOI failed to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
+- We present options to manually enter an article or return to the New Entry menu when the fetcher DOI fails to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
+
 ### Fixed
 
 - We fixed an issue where an exception ocurred when a linked online file was edited in the entry editor [#8008](https://github.com/JabRef/jabref/issues/8008)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the Drag and Drop behavior in the "Customize Entry Types" Dialog [#6338](https://github.com/JabRef/jabref/issues/6338)
 - When determing the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
-
+- We present options to return to the 'Select entry type' menu or create an article for manual entry when the fetcher DOI failed to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
 ### Fixed
 
 - We fixed an issue where an exception ocurred when a linked online file was edited in the entry editor [#8008](https://github.com/JabRef/jabref/issues/8008)

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -182,9 +182,12 @@ public class EntryTypeViewModel {
             } else if (result.isEmpty()) {
                 String fetcher = selectedItemProperty().getValue().getName();
                 String searchId = idText.getValue();
+                // When DOI ID is not found, allow the user to either return to the dialog or
+                // add entry manually
                 boolean addEntryFlag = dialogService.showConfirmationDialogAndWait("DOI not found",
                         Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId),
-                        "Add entry manually", "Return to dialog");
+                        Localization.lang("Add entry manually"),
+                        Localization.lang("Return to dialog"));
                 if (addEntryFlag) {
                     new NewEntryAction(libraryTab.frame(), StandardEntryType.Article, dialogService, preferencesService, stateManager).execute();
                     searchSuccesfulProperty.set(true);

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -184,7 +184,7 @@ public class EntryTypeViewModel {
                 String searchId = idText.getValue();
                 // When DOI ID is not found, allow the user to either return to the dialog or
                 // add entry manually
-                boolean addEntryFlag = dialogService.showConfirmationDialogAndWait("DOI not found",
+                boolean addEntryFlag = dialogService.showConfirmationDialogAndWait(Localization.lang("DOI not found"),
                         Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId),
                         Localization.lang("Add entry manually"),
                         Localization.lang("Return to dialog"));

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -25,8 +25,8 @@ import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.strings.StringUtil;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.strings.StringUtil;
 import org.jabref.preferences.PreferencesService;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -15,6 +15,7 @@ import javafx.concurrent.Task;
 import javafx.concurrent.Worker;
 
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
+import org.jabref.gui.importer.NewEntryAction;
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.database.DuplicateCheck;
 import org.jabref.logic.importer.FetcherException;
@@ -25,6 +26,7 @@ import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.strings.StringUtil;
+import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.preferences.PreferencesService;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
@@ -180,7 +182,13 @@ public class EntryTypeViewModel {
             } else if (result.isEmpty()) {
                 String fetcher = selectedItemProperty().getValue().getName();
                 String searchId = idText.getValue();
-                dialogService.showErrorDialogAndWait(Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId));
+                boolean addEntryFlag = dialogService.showConfirmationDialogAndWait("DOI not found",
+                        Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher, searchId),
+                        "Add entry manually", "Return to dialog");
+                if (addEntryFlag) {
+                    new NewEntryAction(libraryTab.frame(), StandardEntryType.Article, dialogService, preferencesService, stateManager).execute();
+                    searchSuccesfulProperty.set(true);
+                }
             }
             fetcherWorker = new FetcherWorker();
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -919,7 +919,7 @@ public class JabRefFrame extends BorderPane {
         newEntryFromIdButton.setFocusTraversable(false);
         newEntryFromIdButton.disableProperty().bind(ActionHelper.needsDatabase(stateManager).not());
         newEntryFromIdButton.setOnMouseClicked(event -> {
-            GenerateEntryFromIdDialog entryFromId = new GenerateEntryFromIdDialog(getCurrentLibraryTab(), dialogService, prefs, taskExecutor);
+            GenerateEntryFromIdDialog entryFromId = new GenerateEntryFromIdDialog(getCurrentLibraryTab(), dialogService, prefs, taskExecutor, stateManager);
 
             if (entryFromIdPopOver == null) {
                 entryFromIdPopOver = new PopOver(entryFromId.getDialogPane());

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -372,6 +372,10 @@ public class LibraryTab extends Tab {
         return frame;
     }
 
+    public StateManager stateManager() {
+        return stateManager;
+    }
+
     /**
      * Removes the selected entries from the database
      *

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -372,10 +372,6 @@ public class LibraryTab extends Tab {
         return frame;
     }
 
-    public StateManager stateManager() {
-        return stateManager;
-    }
-
     /**
      * Removes the selected entries from the database
      *

--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
@@ -31,14 +31,14 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
     private final PopOver entryFromIdPopOver;
     private final StateManager stateManager;
 
-    public GenerateEntryFromIdAction(LibraryTab libraryTab, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor, PopOver entryFromIdPopOver, String identifier) {
+    public GenerateEntryFromIdAction(LibraryTab libraryTab, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor, PopOver entryFromIdPopOver, String identifier, StateManager stateManager) {
         this.libraryTab = libraryTab;
         this.dialogService = dialogService;
         this.preferencesService = preferencesService;
         this.identifier = identifier;
         this.taskExecutor = taskExecutor;
         this.entryFromIdPopOver = entryFromIdPopOver;
-        this.stateManager = new StateManager();
+        this.stateManager = stateManager;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.LibraryTab;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
@@ -28,6 +29,7 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
     private final String identifier;
     private final TaskExecutor taskExecutor;
     private final PopOver entryFromIdPopOver;
+    private final StateManager stateManager;
 
     public GenerateEntryFromIdAction(LibraryTab libraryTab, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor, PopOver entryFromIdPopOver, String identifier) {
         this.libraryTab = libraryTab;
@@ -36,6 +38,7 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
         this.identifier = identifier;
         this.taskExecutor = taskExecutor;
         this.entryFromIdPopOver = entryFromIdPopOver;
+        this.stateManager = new StateManager();
     }
 
     @Override
@@ -52,7 +55,7 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
             if (addEntryFlag) {
                 // add entry manually
                 new NewEntryAction(libraryTab.frame(), StandardEntryType.Article, dialogService,
-                                    preferencesService, libraryTab.stateManager()).execute();
+                                    preferencesService, stateManager).execute();
             }
         });
         backgroundTask.onSuccess((bibEntry) -> bibEntry.ifPresentOrElse((entry) -> {

--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdDialog.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdDialog.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TextField;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
@@ -25,16 +26,17 @@ public class GenerateEntryFromIdDialog {
     private final DialogService dialogService;
     private final LibraryTab libraryTab;
     private final TaskExecutor taskExecutor;
+    private final StateManager stateManager;
 
     private PopOver entryFromIdPopOver;
 
-    public GenerateEntryFromIdDialog(LibraryTab libraryTab, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor) {
+    public GenerateEntryFromIdDialog(LibraryTab libraryTab, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor, StateManager stateManager) {
         ViewLoader.view(this).load();
         this.preferencesService = preferencesService;
         this.dialogService = dialogService;
         this.libraryTab = libraryTab;
         this.taskExecutor = taskExecutor;
-
+        this.stateManager = stateManager;
         this.generateButton.setGraphic(IconTheme.JabRefIcons.IMPORT.getGraphicNode());
         this.generateButton.setDefaultButton(true);
     }
@@ -53,7 +55,8 @@ public class GenerateEntryFromIdDialog {
                 preferencesService,
                 taskExecutor,
                 entryFromIdPopOver,
-                idTextField.getText()
+                idTextField.getText(),
+                stateManager
         );
         generateEntryFromIdAction.execute();
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -44,6 +44,8 @@ The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=The path need not be o
 
 Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Add a regular expression for the key pattern.
 
+Add\ entry\ manually=Add entry manually
+
 Add\ selected\ entries\ to\ this\ group=Add selected entries to this group
 
 Add\ subgroup=Add subgroup
@@ -206,6 +208,7 @@ cut\ entries=cut entries
 
 cut\ entry\ %0=cut entry %0
 
+DOI\ not\ found=DOI not found
 
 Library\ encoding=Library encoding
 
@@ -322,6 +325,8 @@ External\ changes=External changes
 External\ file\ links=External file links
 
 External\ programs=External programs
+
+Failed\ to\ import\ by\ ID=Failed to import by ID
 
 Field=Field
 
@@ -723,6 +728,8 @@ resolved=resolved
 Restart=Restart
 
 Restart\ required=Restart required
+
+Return\ to\ dialog=Return to dialog
 
 Review=Review
 Review\ changes=Review changes


### PR DESCRIPTION
Fixes stuck-in-library issue when the fetcher DOI failed to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870). User can now choose to add entry manually instead of returning to the new entry dialog box

![image](https://user-images.githubusercontent.com/16965203/139607113-c9aa666b-de86-4848-b57a-780311d8be11.png)

![image](https://user-images.githubusercontent.com/16965203/139607137-8a085fc6-10af-4a4f-837b-0a1d22d49ff1.png)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
