### PR TITLE
Fix default directory of the "LaTeX Citations" tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,12 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The metadata-to-pdf actions now also embeds the bibfile to the PDF. [#8037](https://github.com/JabRef/jabref/pull/8037)
 - The snap was updated to use the core20 base and to use lzo compression for better startup performance [#8109](https://github.com/JabRef/jabref/pull/8109)
 - We improved the Drag and Drop behavior in the "Customize Entry Types" Dialog [#6338](https://github.com/JabRef/jabref/issues/6338)
-- When determing the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
+- When determining the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
 
 ### Fixed
 
-- We fixed an issue where an exception ocurred when a linked online file was edited in the entry editor [#8008](https://github.com/JabRef/jabref/issues/8008)
+- We fixed an issue where an exception occurred when a linked online file was edited in the entry editor [#8008](https://github.com/JabRef/jabref/issues/8008)
 - We fixed an issue when checking for a new version when JabRef is used behind a corporate proxy. [#7884](https://github.com/JabRef/jabref/issues/7884)
 - We fixed some icons that were drawn in the wrong color when JabRef used a custom theme. [#7853](https://github.com/JabRef/jabref/issues/7853)
 - We fixed an issue where the `Aux file` on `Edit group` doesn't support relative sub-directories path to import. [#7719](https://github.com/JabRef/jabref/issues/7719).
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where typing an invalid UNC path into the "Main file directory" text field caused an error. [#8107](https://github.com/JabRef/jabref/issues/8107)
 - We fixed an issue where "Open Folder" didn't select the file on macOS in Finder [#8130](https://github.com/JabRef/jabref/issues/8130)
 - We fixed an issue where importing PDFs resulted in an uncaught exception [#8143](https://github.com/JabRef/jabref/issues/8143)
+- The default directory of the "LaTeX Citations" tab is now the directory of the currently opened database (and not the directory chosen at the last open file dialog or the last database save) [koppor#538](https://github.com/koppor/jabref/issues/538)  
 - We fixed an issue where right-clicking on a tab and selecting close will close the focused tab even if it is not the tab we right-clicked [#8193](https://github.com/JabRef/jabref/pull/8193)
 
 ### Removed

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -27,6 +27,7 @@ import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.texparser.DefaultLatexParser;
+import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.texparser.Citation;
@@ -65,8 +66,8 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
         this.preferencesService = preferencesService;
         this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;
-        this.directory = new SimpleObjectProperty<>(databaseContext.getMetaData().getLatexFileDirectory(preferencesService.getUser())
-                                                                   .orElseGet(preferencesService::getWorkingDir));
+        this.directory = new SimpleObjectProperty(databaseContext.getMetaData().getLatexFileDirectory(preferencesService.getUser())
+                                                                          .orElse(FileUtil.getInitialDirectory(databaseContext, preferencesService)));
         this.citationList = FXCollections.observableArrayList();
         this.status = new SimpleObjectProperty<>(Status.IN_PROGRESS);
         this.searchError = new SimpleStringProperty("");
@@ -126,8 +127,9 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
     }
 
     private Collection<Citation> searchAndParse(String citeKey) throws IOException {
+        // we need to check whether the user meanwhile set the LaTeX file directory or the database changed locations
         Path newDirectory = databaseContext.getMetaData().getLatexFileDirectory(preferencesService.getUser())
-                                           .orElseGet(preferencesService::getWorkingDir);
+                                           .orElse(FileUtil.getInitialDirectory(databaseContext, preferencesService));
 
         if (latexParserResult == null || !newDirectory.equals(directory.get())) {
             directory.set(newDirectory);

--- a/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -435,7 +435,9 @@ public class GroupDialogViewModel {
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                 .addExtensionFilter(StandardFileType.AUX)
                 .withDefaultExtension(StandardFileType.AUX)
-                .withInitialDirectory(preferencesService.getWorkingDir()).build();
+                .withInitialDirectory(currentDatabase.getMetaData()
+                                                     .getLatexFileDirectory(preferencesService.getUser())
+                                                     .orElse(FileUtil.getInitialDirectory(currentDatabase, preferencesService))).build();
         dialogService.showFileOpenDialog(fileDialogConfiguration)
                      .ifPresent(file -> texGroupFilePathProperty.setValue(
                              FileUtil.relativize(file.toAbsolutePath(), getFileDirectoriesAsPaths()).toString()

--- a/src/main/java/org/jabref/gui/texparser/ParseLatexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseLatexDialogViewModel.java
@@ -30,6 +30,7 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.texparser.DefaultLatexParser;
 import org.jabref.logic.texparser.TexBibEntriesResolver;
+import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
@@ -58,8 +59,10 @@ public class ParseLatexDialogViewModel extends AbstractViewModel {
     private final BooleanProperty searchInProgress;
     private final BooleanProperty successfulSearch;
 
-    public ParseLatexDialogViewModel(BibDatabaseContext databaseContext, DialogService dialogService,
-                                     TaskExecutor taskExecutor, PreferencesService preferencesService,
+    public ParseLatexDialogViewModel(BibDatabaseContext databaseContext,
+                                     DialogService dialogService,
+                                     TaskExecutor taskExecutor,
+                                     PreferencesService preferencesService,
                                      FileUpdateMonitor fileMonitor) {
         this.databaseContext = databaseContext;
         this.dialogService = dialogService;
@@ -67,7 +70,7 @@ public class ParseLatexDialogViewModel extends AbstractViewModel {
         this.preferencesService = preferencesService;
         this.fileMonitor = fileMonitor;
         this.latexFileDirectory = new SimpleStringProperty(databaseContext.getMetaData().getLatexFileDirectory(preferencesService.getUser())
-                                                                          .orElseGet(preferencesService::getWorkingDir)
+                                                                          .orElse(FileUtil.getInitialDirectory(databaseContext, preferencesService))
                                                                           .toAbsolutePath().toString());
         this.root = new SimpleObjectProperty<>();
         this.checkedFileList = FXCollections.observableArrayList();

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -135,7 +135,7 @@ public class GroupsParser {
                 return newGroup;
             } catch (IOException ex) {
                 // Problem accessing file -> create without file monitoring
-                LOGGER.warn("Could not access file " + path + ". The group " + name + " will not reflect changes to the aux file.", ex);
+                LOGGER.warn("Could not access file {}. The group {} will not reflect changes to the aux file.", path, name, ex);
 
                 TexGroup newGroup = TexGroup.createWithoutFileMonitoring(name, context, path, new DefaultAuxParser(new BibDatabase()), fileMonitor, metaData);
                 addGroupDetails(tok, newGroup);

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -24,8 +24,10 @@ import java.util.stream.Stream;
 
 import org.jabref.logic.citationkeypattern.BracketedPattern;
 import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.OptionalUtil;
+import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -373,5 +375,12 @@ public class FileUtil {
      */
     public static boolean isPDFFile(Path file) {
         return getFileExtension(file).filter(type -> "pdf".equals(type)).isPresent();
+    }
+
+    /**
+     * @return Path of current panel database directory or the standard working directory in case the datbase was not saved yet
+     */
+    public static Path getInitialDirectory(BibDatabaseContext databaseContext, PreferencesService preferencesService) {
+        return databaseContext.getDatabasePath().map(Path::getParent).orElse(preferencesService.getWorkingDir());
     }
 }

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -296,8 +296,15 @@ public interface PreferencesService {
 
     void clearEditedFiles();
 
+    /**
+     * Gets the directory for file browsing dialogs. This ensures that each browse dialog starts in the last visited
+     * browse directory.
+     */
     Path getWorkingDir();
 
+    /**
+     * Stores the directory for file browsing dialogs
+     */
     void setWorkingDirectory(Path dir);
 
     //*************************************************************************************************************


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/538

The directory of the currently opened database is now used as default directory for the LaTeX Ciations Tab

## Before

![grafik](https://user-images.githubusercontent.com/1366654/140190644-4c6e7ffb-efe1-4239-b71b-6132ebedb9ef.png)

![grafik](https://user-images.githubusercontent.com/1366654/140190652-2865b2f2-9c6e-42fd-ae52-c4510f8c7b98.png)

## After

![grafik](https://user-images.githubusercontent.com/1366654/140196131-4fd9a3e5-f147-4aff-be30-127e36b8d2c2.png)

![grafik](https://user-images.githubusercontent.com/1366654/140196151-2e1137ba-0dd2-44a1-aebe-d7362162dcc8.png)

---

I did not dare to touch the logic of saving the "LatexFileDirectories". IMHO, they should be relative to the `.bib` file. This will be a longer discussion for a follow-up PR.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
