### PR TITLE
Fix for issue 8198 : Save sort order switching between "Keep original order" and "Use current table sort order" problem

### DIFF
--- a/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesDialogViewModel.java
@@ -168,7 +168,7 @@ public class LibraryPropertiesDialogViewModel {
         }
 
         SaveOrderConfig newSaveOrderConfig = new SaveOrderConfig(
-                SaveOrderConfig.OrderType.fromBooleans(saveInSpecifiedOrderProperty.getValue(), saveInOriginalProperty.getValue()),
+                SaveOrderConfig.OrderType.fromBooleans(saveInSpecifiedOrderProperty.getValue(), saveInTableOrderProperty.getValue()),
                 sortCriteriaProperty.stream().map(SortCriterionViewModel::getCriterion).toList());
 
         if (!newSaveOrderConfig.equals(initialSaveOrderConfig)) {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

Fix [#8198](https://github.com/JabRef/jabref/issues/8198)