### PR TITLE
Use regexp to remove non-ASCII characters from DOI and inform user when data for valid DOI does not exist #8127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - When determining the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
 - We present options to manually enter an article or return to the New Entry menu when the fetcher DOI fails to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
+- We trim non-ASCII, ASCII control and non-printable characters from DOI [#8127](https://github.com/JabRef/jabref/issues/8127)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - When determining the URL of an ArXiV eprint, the URL now points to the version [#8149](https://github.com/JabRef/jabref/pull/8149)
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
 - We present options to manually enter an article or return to the New Entry menu when the fetcher DOI fails to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
-- We trim non-ASCII, ASCII control and non-printable characters from DOI [#8127](https://github.com/JabRef/jabref/issues/8127)
+- We trim white space and non-ASCII characters from DOI [#8127](https://github.com/JabRef/jabref/issues/8127)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -61,8 +61,9 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
 
     @Override
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-
+        System.out.println("identifier: "+identifier);
         Optional<DOI> doi = DOI.parse(identifier);
+        System.out.println("after parsing: "+identifier);
 
         try {
             if (doi.isPresent()) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -61,9 +61,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
 
     @Override
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        System.out.println("identifier: "+identifier);
         Optional<DOI> doi = DOI.parse(identifier);
-        System.out.println("after parsing: "+identifier);
 
         try {
             if (doi.isPresent()) {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -92,9 +92,9 @@ public class DOI implements Identifier {
     // See https://www.baeldung.com/java-regex-s-splus for explanation of \\s+
     // See https://stackoverflow.com/questions/3203190/regex-any-ascii-character for the regexp that includes ASCII characters only
     // Another reference for regexp for ASCII characters: https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-    private static final String PARSE_DOI  = "[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
-                                           + "[^\\x00-\\x7F]" // strips off all non-ASCII characters
-                                           + "]";
+    private static final String PARSE_DOI = "[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
+                                          + "[^\\x00-\\x7F]" // strips off all non-ASCII characters
+                                          + "]";
 
     // DOI
     private final String doi;

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -113,7 +113,7 @@ public class DOI implements Identifier {
         trimmedDoi = trimmedDoi.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
         // removes non-printable characters from Unicode
         trimmedDoi = trimmedDoi.replaceAll("\\p{C}", "");
-        
+
         // HTTP URL decoding
         if (doi.matches(HTTP_EXP) || doi.matches(SHORT_DOI_HTTP_EXP)) {
             try {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -92,9 +92,9 @@ public class DOI implements Identifier {
     // See https://www.baeldung.com/java-regex-s-splus for explanation of \\s+
     // See https://stackoverflow.com/questions/3203190/regex-any-ascii-character for the regexp that includes ASCII characters only
     // Another reference for regexp for ASCII characters: https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-    private static final String PARSE_DOI ="[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
-                                          +"[^\\x00-\\x7F]" // strips off all non-ASCII characters
-                                          +"]";
+    private static final String PARSE_DOI  = "[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
+                                           + "[^\\x00-\\x7F]" // strips off all non-ASCII characters
+                                           + "]";
 
     // DOI
     private final String doi;
@@ -160,9 +160,7 @@ public class DOI implements Identifier {
     public static Optional<DOI> parse(String doi) {
         try {
             String cleanedDOI = doi;
-            System.out.println("doi: "+doi);
-            cleanedDOI = cleanedDOI.replaceAll(PARSE_DOI,"");
-            System.out.println("cleanedDOI: "+cleanedDOI);
+            cleanedDOI = cleanedDOI.replaceAll(PARSE_DOI, "");
 
             return Optional.of(new DOI(cleanedDOI));
         } catch (IllegalArgumentException | NullPointerException e) {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -88,6 +88,14 @@ public class DOI implements Identifier {
     private static final Pattern FIND_SHORT_DOI_SHORTCUT = Pattern.compile(IN_TEXT_SHORT_DOI_SHORTCUT, Pattern.CASE_INSENSITIVE); // eg doi.org/bfrhmx (no "10/")
     private static final Pattern EXACT_SHORT_DOI_PATT = Pattern.compile(SHORT_DOI_EXP_PREFIX + SHORT_DOI_EXP, Pattern.CASE_INSENSITIVE);
     private static final Pattern FIND_SHORT_DOI_PATT = Pattern.compile("(?:https?://[^\\s]+?)?" + FIND_SHORT_DOI_EXP, Pattern.CASE_INSENSITIVE);
+
+    // See https://www.baeldung.com/java-regex-s-splus for explanation of \\s+
+    // See https://stackoverflow.com/questions/3203190/regex-any-ascii-character for the regexp that includes ASCII characters only
+    // Another reference for regexp for ASCII characters: https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
+    private static final String PARSE_DOI ="[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
+                                          +"[^\\x00-\\x7F]" // strips off all non-ASCII characters
+                                          +"]";
+
     // DOI
     private final String doi;
     // Short DOI
@@ -151,15 +159,10 @@ public class DOI implements Identifier {
      */
     public static Optional<DOI> parse(String doi) {
         try {
-            String cleanedDOI = doi.trim();
-            cleanedDOI = cleanedDOI.replaceAll("\\s+",""); // remove white space
-            // https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-            String pattern = "["
-                            +"^\\x00-\\x7F" // strips off all non-ASCII characters
-                            +"\\p{Cntrl}&&[^\r\n\t]" // erases all the ASCII control characters
-                            +"\\p{C}" // removes non-printable characters from Unicode
-                            +"]";
-            cleanedDOI = cleanedDOI.replaceAll(pattern,"");
+            String cleanedDOI = doi;
+            System.out.println("doi: "+doi);
+            cleanedDOI = cleanedDOI.replaceAll(PARSE_DOI,"");
+            System.out.println("cleanedDOI: "+cleanedDOI);
 
             return Optional.of(new DOI(cleanedDOI));
         } catch (IllegalArgumentException | NullPointerException e) {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -106,14 +106,6 @@ public class DOI implements Identifier {
         // Remove whitespace
         String trimmedDoi = doi.trim();
 
-        // https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-        // strips off all non-ASCII characters
-        trimmedDoi = trimmedDoi.replaceAll("[^\\x00-\\x7F]", "");
-        // erases all the ASCII control characters
-        trimmedDoi = trimmedDoi.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
-        // removes non-printable characters from Unicode
-        trimmedDoi = trimmedDoi.replaceAll("\\p{C}", "");
-
         // HTTP URL decoding
         if (doi.matches(HTTP_EXP) || doi.matches(SHORT_DOI_HTTP_EXP)) {
             try {
@@ -161,6 +153,15 @@ public class DOI implements Identifier {
         try {
             String cleanedDOI = doi.trim();
             cleanedDOI = doi.replaceAll(" ", "");
+
+            // https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
+            // strips off all non-ASCII characters
+            cleanedDOI = cleanedDOI.replaceAll("[^\\x00-\\x7F]", "");
+            // erases all the ASCII control characters
+            cleanedDOI = cleanedDOI.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
+            // removes non-printable characters from Unicode
+            cleanedDOI = cleanedDOI.replaceAll("\\p{C}", "");
+
             return Optional.of(new DOI(cleanedDOI));
         } catch (IllegalArgumentException | NullPointerException e) {
             return Optional.empty();

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -152,15 +152,14 @@ public class DOI implements Identifier {
     public static Optional<DOI> parse(String doi) {
         try {
             String cleanedDOI = doi.trim();
-            cleanedDOI = doi.replaceAll(" ", "");
-
+            cleanedDOI = cleanedDOI.replaceAll("\\s+",""); // remove white space
             // https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-            // strips off all non-ASCII characters
-            cleanedDOI = cleanedDOI.replaceAll("[^\\x00-\\x7F]", "");
-            // erases all the ASCII control characters
-            cleanedDOI = cleanedDOI.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
-            // removes non-printable characters from Unicode
-            cleanedDOI = cleanedDOI.replaceAll("\\p{C}", "");
+            String pattern = "["
+                            +"^\\x00-\\x7F" // strips off all non-ASCII characters
+                            +"\\p{Cntrl}&&[^\r\n\t]" // erases all the ASCII control characters
+                            +"\\p{C}" // removes non-printable characters from Unicode
+                            +"]";
+            cleanedDOI = cleanedDOI.replaceAll(pattern,"");
 
             return Optional.of(new DOI(cleanedDOI));
         } catch (IllegalArgumentException | NullPointerException e) {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -92,9 +92,9 @@ public class DOI implements Identifier {
     // See https://www.baeldung.com/java-regex-s-splus for explanation of \\s+
     // See https://stackoverflow.com/questions/3203190/regex-any-ascii-character for the regexp that includes ASCII characters only
     // Another reference for regexp for ASCII characters: https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
-    private static final String PARSE_DOI = "[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
-                                          + "[^\\x00-\\x7F]" // strips off all non-ASCII characters
-                                          + "]";
+    private static final String CHARS_TO_REMOVE = "[\\s+" // remove white space characters, i.e, \t, \n, \x0B, \f, \r . + is a greedy quantifier
+                                                + "[^\\x00-\\x7F]" // strips off all non-ASCII characters
+                                                + "]";
 
     // DOI
     private final String doi;
@@ -160,7 +160,7 @@ public class DOI implements Identifier {
     public static Optional<DOI> parse(String doi) {
         try {
             String cleanedDOI = doi;
-            cleanedDOI = cleanedDOI.replaceAll(PARSE_DOI, "");
+            cleanedDOI = cleanedDOI.replaceAll(CHARS_TO_REMOVE, "");
 
             return Optional.of(new DOI(cleanedDOI));
         } catch (IllegalArgumentException | NullPointerException e) {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -106,6 +106,14 @@ public class DOI implements Identifier {
         // Remove whitespace
         String trimmedDoi = doi.trim();
 
+        // https://howtodoinjava.com/java/regex/java-clean-ascii-text-non-printable-chars/
+        // strips off all non-ASCII characters
+        trimmedDoi = trimmedDoi.replaceAll("[^\\x00-\\x7F]", "");
+        // erases all the ASCII control characters
+        trimmedDoi = trimmedDoi.replaceAll("[\\p{Cntrl}&&[^\r\n\t]]", "");
+        // removes non-printable characters from Unicode
+        trimmedDoi = trimmedDoi.replaceAll("\\p{C}", "");
+        
         // HTTP URL decoding
         if (doi.matches(HTTP_EXP) || doi.matches(SHORT_DOI_HTTP_EXP)) {
             try {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -555,6 +555,8 @@ No\ journal\ names\ could\ be\ abbreviated.=No journal names could be abbreviate
 
 No\ journal\ names\ could\ be\ unabbreviated.=No journal names could be unabbreviated.
 
+No\ DOI\ data\ exists=No DOI data exists
+
 not=not
 
 not\ found=not found

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -121,8 +121,8 @@ public class DOITest {
                 // parse DOI with non-ASCII characters and whitespace
                 Arguments.of("https://doi.org/10/gf4gqc", DOI.parse("�https : \n  ␛ / / doi.org / \t 10 / \r gf4gqc�␛").get().getURIAsASCIIString()),
                 Arguments.of("10/gf4gqc", DOI.parse("�https : \n  ␛ / / doi.org / \t 10 / \r gf4gqc�␛").get().getDOI()),
-                Arguments.of("10/gf4gqc", DOI.parse("10 / gf4gqc").get().getDOI()),
-                Arguments.of("10.3218/3846-0", DOI.parse("�10.3218\n/384␛6-0�").get().getDOI()),
+                Arguments.of("10/gf4gqc", DOI.parse(" 10 / gf4gqc ").get().getDOI()),
+                Arguments.of("10.3218/3846-0", DOI.parse(" �10.3218\n/384␛6-0�").get().getDOI()),
                 // parse already-cleaned DOI
                 Arguments.of("10.3218/3846-0", DOI.parse("10.3218/3846-0").get().getDOI()),
 

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -118,6 +118,13 @@ public class DOITest {
                 Arguments.of("https://doi.org/10.1109/VLHCC.2004.20", DOI.parse("https : / / doi.org / 10 .1109 /V LHCC.20 04.20").get().getURIAsASCIIString()),
                 // parse short DOI with whitespace
                 Arguments.of("https://doi.org/10/gf4gqc", DOI.parse("https : / / doi.org / 10 / gf4gqc").get().getURIAsASCIIString()),
+                // parse DOI with non-ASCII characters and whitespace
+                Arguments.of("https://doi.org/10/gf4gqc", DOI.parse("�https : \n  ␛ / / doi.org / \t 10 / \r gf4gqc�␛").get().getURIAsASCIIString()),
+                Arguments.of("10/gf4gqc", DOI.parse("�https : \n  ␛ / / doi.org / \t 10 / \r gf4gqc�␛").get().getDOI()),
+                Arguments.of("10/gf4gqc", DOI.parse("10 / gf4gqc").get().getDOI()),
+                Arguments.of("10.3218/3846-0", DOI.parse("�10.3218\n/384␛6-0�").get().getDOI()),
+                // parse already-cleaned DOI
+                Arguments.of("10.3218/3846-0", DOI.parse("10.3218/3846-0").get().getDOI()),
 
                 // correctlyEncodeDOIs
                 // See http://www.doi.org/doi_handbook/2_Numbering.html#2.5.2.4


### PR DESCRIPTION
Use single regexp to remove white-space and non-ASCII characters in DOI to fixes #8127. Further inform the user that "No DOI data exists" if DOI is valid and unable to find the article. Works for cases where DOI.findInText does not #8227. For example, the DOI "https : / / doi.org / 10 / gf4gqc" with the quote removed will result in an error not capture by Jabref itself. The reason is that the pattern used by DOI.findInText to extract DOI is not comprehensive. DOI.findInText is only tested in DOITest but not used elsewhere in the source code. However, DOI.parse is used in both DoiFetcher and CompositeIdFetcher, so it is probably better to improve DOI.parse.   

With DOI.findInText:
![image](https://user-images.githubusercontent.com/16965203/140884265-01115978-762f-4cb7-96fc-52bc9f520961.png)

With this PR:
![image](https://user-images.githubusercontent.com/16965203/140884572-e37d3993-f688-4e92-be2c-de552eea3fd5.png)

With this PR, user is informed that no data exists if the DOI is valid but no data is found online
![image](https://user-images.githubusercontent.com/16965203/141398507-97ef3562-42cd-4d06-8de3-cb974453c3c2.png)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
