### PR TITLE
Fix entry editor column visibility

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -126,6 +126,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
             addColumn(gridPane, 1, editors.values().stream().map(FieldEditorFX::getNode).limit(rows));
             addColumn(gridPane, 4, editors.values().stream().map(FieldEditorFX::getNode).skip(rows));
 
+            columnExpand.setPercentWidth(40);
             gridPane.getColumnConstraints().addAll(columnDoNotContract, columnExpand, new ColumnConstraints(10),
                     columnDoNotContract, columnExpand);
 

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -8,6 +8,7 @@ import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
@@ -24,7 +25,7 @@ public class OptionalFields2Tab extends OptionalFieldsTabBase {
                               TaskExecutor taskExecutor,
                               JournalAbbreviationRepository journalAbbreviationRepository) {
         super(
-                "Optional fields 2",
+                Localization.lang("Optional fields 2"),
                 false,
                 databaseContext,
                 suggestionProviders,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -1,32 +1,18 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
-import javax.swing.undo.UndoManager;
-
-import javafx.scene.control.Tooltip;
-
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
-import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.Field;
 import org.jabref.preferences.PreferencesService;
 
-public class OptionalFields2Tab extends FieldsEditorTab {
+import javax.swing.undo.UndoManager;
 
-    private final BibEntryTypesManager entryTypesManager;
-
+public class OptionalFields2Tab extends OptionalFieldsTabBase {
     public OptionalFields2Tab(BibDatabaseContext databaseContext,
                               SuggestionProviders suggestionProviders,
                               UndoManager undoManager,
@@ -37,22 +23,19 @@ public class OptionalFields2Tab extends FieldsEditorTab {
                               ExternalFileTypes externalFileTypes,
                               TaskExecutor taskExecutor,
                               JournalAbbreviationRepository journalAbbreviationRepository) {
-        super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
-        this.entryTypesManager = entryTypesManager;
-
-        setText(Localization.lang("Optional fields 2"));
-        setTooltip(new Tooltip(Localization.lang("Show optional fields")));
-        setGraphic(IconTheme.JabRefIcons.OPTIONAL.getGraphicNode());
-    }
-
-    @Override
-    protected Set<Field> determineFieldsToShow(BibEntry entry) {
-        Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
-        if (entryType.isPresent()) {
-            return entryType.get().getSecondaryOptionalNotDeprecatedFields();
-        } else {
-            // Entry type unknown -> treat all fields as required
-            return Collections.emptySet();
-        }
+        super(
+                "Optional fields 2",
+                false,
+                databaseContext,
+                suggestionProviders,
+                undoManager,
+                dialogService,
+                preferences,
+                stateManager,
+                entryTypesManager,
+                externalFileTypes,
+                taskExecutor,
+                journalAbbreviationRepository
+        );
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.entryeditor;
 
+import javax.swing.undo.UndoManager;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProviders;
@@ -9,8 +11,6 @@ import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
-
-import javax.swing.undo.UndoManager;
 
 public class OptionalFields2Tab extends OptionalFieldsTabBase {
     public OptionalFields2Tab(BibDatabaseContext databaseContext,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.entryeditor;
 
+import javax.swing.undo.UndoManager;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProviders;
@@ -9,8 +11,6 @@ import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
-
-import javax.swing.undo.UndoManager;
 
 public class OptionalFieldsTab extends OptionalFieldsTabBase {
     public OptionalFieldsTab(BibDatabaseContext databaseContext,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -8,6 +8,7 @@ import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
@@ -24,7 +25,7 @@ public class OptionalFieldsTab extends OptionalFieldsTabBase {
                              TaskExecutor taskExecutor,
                              JournalAbbreviationRepository journalAbbreviationRepository) {
         super(
-                "Optional fields",
+                Localization.lang("Optional fields"),
                 true,
                 databaseContext,
                 suggestionProviders,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -1,31 +1,18 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-
-import javax.swing.undo.UndoManager;
-
-import javafx.scene.control.Tooltip;
-
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
-import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.Field;
 import org.jabref.preferences.PreferencesService;
 
-public class OptionalFieldsTab extends FieldsEditorTab {
-    private final BibEntryTypesManager entryTypesManager;
+import javax.swing.undo.UndoManager;
 
+public class OptionalFieldsTab extends OptionalFieldsTabBase {
     public OptionalFieldsTab(BibDatabaseContext databaseContext,
                              SuggestionProviders suggestionProviders,
                              UndoManager undoManager,
@@ -36,22 +23,19 @@ public class OptionalFieldsTab extends FieldsEditorTab {
                              ExternalFileTypes externalFileTypes,
                              TaskExecutor taskExecutor,
                              JournalAbbreviationRepository journalAbbreviationRepository) {
-        super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
-        this.entryTypesManager = entryTypesManager;
-
-        setText(Localization.lang("Optional fields"));
-        setTooltip(new Tooltip(Localization.lang("Show optional fields")));
-        setGraphic(IconTheme.JabRefIcons.OPTIONAL.getGraphicNode());
-    }
-
-    @Override
-    protected Set<Field> determineFieldsToShow(BibEntry entry) {
-        Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
-        if (entryType.isPresent()) {
-            return entryType.get().getPrimaryOptionalFields();
-        } else {
-            // Entry type unknown -> treat all fields as required
-            return Collections.emptySet();
-        }
+        super(
+                "Optional fields",
+                true,
+                databaseContext,
+                suggestionProviders,
+                undoManager,
+                dialogService,
+                preferences,
+                stateManager,
+                entryTypesManager,
+                externalFileTypes,
+                taskExecutor,
+                journalAbbreviationRepository
+        );
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
@@ -42,7 +42,7 @@ public class OptionalFieldsTabBase extends FieldsEditorTab {
         super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
         this.entryTypesManager = entryTypesManager;
         this.isPrimaryOptionalFields = isPrimaryOptionalFields;
-        setText(Localization.lang(title));
+        setText(title);
         setTooltip(new Tooltip(Localization.lang("Show optional fields")));
         setGraphic(IconTheme.JabRefIcons.OPTIONAL.getGraphicNode());
     }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
@@ -1,0 +1,62 @@
+package org.jabref.gui.entryeditor;
+
+import javafx.scene.control.Tooltip;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.autocompleter.SuggestionProviders;
+import org.jabref.gui.externalfiletype.ExternalFileTypes;
+import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryType;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.Field;
+import org.jabref.preferences.PreferencesService;
+
+import javax.swing.undo.UndoManager;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class OptionalFieldsTabBase extends FieldsEditorTab {
+    private final BibEntryTypesManager entryTypesManager;
+    private final boolean isPrimaryOptionalFields;
+
+    public OptionalFieldsTabBase(String title,
+                                 boolean isPrimaryOptionalFields,
+                                 BibDatabaseContext databaseContext,
+                                 SuggestionProviders suggestionProviders,
+                                 UndoManager undoManager,
+                                 DialogService dialogService,
+                                 PreferencesService preferences,
+                                 StateManager stateManager,
+                                 BibEntryTypesManager entryTypesManager,
+                                 ExternalFileTypes externalFileTypes,
+                                 TaskExecutor taskExecutor,
+                                 JournalAbbreviationRepository journalAbbreviationRepository) {
+        super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
+        this.entryTypesManager = entryTypesManager;
+        this.isPrimaryOptionalFields = isPrimaryOptionalFields;
+        setText(Localization.lang(title));
+        setTooltip(new Tooltip(Localization.lang("Show optional fields")));
+        setGraphic(IconTheme.JabRefIcons.OPTIONAL.getGraphicNode());
+    }
+
+    @Override
+    protected Set<Field> determineFieldsToShow(BibEntry entry) {
+        Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
+        if (entryType.isPresent()) {
+            if (isPrimaryOptionalFields) {
+                return entryType.get().getPrimaryOptionalFields();
+            } else {
+                return entryType.get().getSecondaryOptionalNotDeprecatedFields();
+            }
+        } else {
+            // Entry type unknown -> treat all fields as required
+            return Collections.emptySet();
+        }
+    }
+}

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
@@ -1,6 +1,13 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.swing.undo.UndoManager;
+
 import javafx.scene.control.Tooltip;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProviders;
@@ -15,11 +22,6 @@ import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.Field;
 import org.jabref.preferences.PreferencesService;
-
-import javax.swing.undo.UndoManager;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 
 public class OptionalFieldsTabBase extends FieldsEditorTab {
     private final BibEntryTypesManager entryTypesManager;


### PR DESCRIPTION
Fixes #7986 

Description:
This PR is to fix the entry editor -> Optional Fields tab first column fields invisibility issue when the width is too small. 

Solution:
As "Optional Fields tab" is a compressed double columns layout, I'd like to make two columns grow/shrink equally. As such, the first column won't be invisible anymore while the second column is shown.

![image](https://user-images.githubusercontent.com/3086064/141249324-bb67912e-9315-4340-9af6-fc2f5ff378ae.png)
