### PR TITLE
Rename occurrences of OS X to macOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,7 +27,7 @@ body:
       options:
         - Windows
         - GNU / Linux
-        - mac OS
+        - macOS
         - Other (please describe below)
     validations:
       required: true
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Details on version and operating system
       description: OS Version, distribution, desktop environment, older JabRef version etc.
-      placeholder: Ubuntu 21.04 with Plasma 5.22 / Windows 10 21H1 / Mac OS 10.14
+      placeholder: Ubuntu 21.04 with Plasma 5.22 / Windows 10 21H1 / macOS 10.14
     validations:
       required: false
 

--- a/buildres/mac/README.md
+++ b/buildres/mac/README.md
@@ -3,7 +3,7 @@
 ## Modifying DMG Setup scpt
 
 Rename `JabRef-dmg-setup.scpt script` to  `JabRef-dmg-setup.applescript`.
-Only modify the `JabRef-dmg-setup.applescript` in the OS X Script Editor. Afterwards copy over the file and rename it to `JabRef-dmg-setup.scpt`.
+Only modify the `JabRef-dmg-setup.applescript` in the macOS Script Editor. Afterwards copy over the file and rename it to `JabRef-dmg-setup.scpt`.
 Normally the `scpt` file is a binary compiled variant and the `.applescript` the uncompiled format but jpackage expects the sctp in uncompiled format
 
 ## Generate iconsets

--- a/config/README.md
+++ b/config/README.md
@@ -3,7 +3,7 @@
 IntelliJ IDEA comes with a powerful code formatter that helps you to keep the formatting consistent with the style JabRef uses.
 Style-checks are done for each pull request and installing this code style configuration helps you to ensure that this test passes. To install it, you need to do the following steps:
 
-1. Go to *Preferences* or press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd> (<kbd>Cmd</kbd> + <kbd>,</kbd> on Mac OS X)
+1. Go to *Preferences* or press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>S</kbd> (<kbd>Cmd</kbd> + <kbd>,</kbd> on macOS)
 2. Go to "Editor > Code Style"
 3. Click the gear (right of "Scheme: ...")
 4. Click "Import Scheme >"

--- a/docs/advanced-reading/jpackage.md
+++ b/docs/advanced-reading/jpackage.md
@@ -1,6 +1,6 @@
 # Creating a binary and debug it
 
-JabRef uses [jpackage](https://docs.oracle.com/en/java/javase/14/jpackage/) to build binary application bundles and installers for Windows, Linux, and Mac OS X. For Gradle, we use the [Badass JLink Plugin](https://badass-jlink-plugin.beryx.org/releases/latest/).
+JabRef uses [jpackage](https://docs.oracle.com/en/java/javase/14/jpackage/) to build binary application bundles and installers for Windows, Linux, and macOS. For Gradle, we use the [Badass JLink Plugin](https://badass-jlink-plugin.beryx.org/releases/latest/).
 
 ## Build Windows binaries locally
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -289,7 +289,7 @@ public class JabRefPreferences implements PreferencesService {
 
     /**
      * The OpenOffice/LibreOffice connection preferences are:
-     * OO_PATH main directory for OO/LO installation, used to detect location on Win/OS X when using manual connect
+     * OO_PATH main directory for OO/LO installation, used to detect location on Win/macOS when using manual connect
      * OO_EXECUTABLE_PATH path to soffice-file
      * OO_JARS_PATH directory that contains juh.jar, jurt.jar, ridl.jar, unoil.jar
      * OO_SYNC_WHEN_CITING true if the reference list is updated when adding a new citation

--- a/src/main/resources/resource/layout/endnote/Readme.txt
+++ b/src/main/resources/resource/layout/endnote/Readme.txt
@@ -14,7 +14,7 @@ The EndNote Export Filter for JabRef (when combined with the "EndNote Import fro
 Installation:
 *********************************************************************************
 EndNote Import from JabRef.eni
-This file must be placed in your EndNote Filters directory. On a Mac OS X system, the default directory is /Applications/EndNote 7/Filters. On a Windows XP system, the default directory is C:\Program Files\EndNote\Filters. The default EndNote Import filter will be able to import the files from JabRef, but supports fewer fields. You should then open up the Filter Manager (Edit->Import Filters->Open Filter Manager) and add it to your Favorites.
+This file must be placed in your EndNote Filters directory. On a macOS system, the default directory is /Applications/EndNote 7/Filters. On a Windows XP system, the default directory is C:\Program Files\EndNote\Filters. The default EndNote Import filter will be able to import the files from JabRef, but supports fewer fields. You should then open up the Filter Manager (Edit->Import Filters->Open Filter Manager) and add it to your Favorites.
 
 EndNote Preferences
 The filter provided will only work if certain fields are added to EndNote's default Reference Types. Open up Preferences and click on Reference Types, then Modify Reference Types. The following table lists the field names that must be added to certain reference types for EndNote to support these fields. For example, the Publisher field for Journal Article is blank by default; Type in Publisher in this field. 
@@ -40,7 +40,7 @@ EndNote.tab:
 This is the tab-delimited spreadsheet containing a list of all the Refer codes, how they map to the Generic EndNote fields, and how the JabRef fields for the default BibTeX types are mapped to the Generic EndNote fields.
 
 BibTeX Export to JabRef, BibTeX Export to JabRef*
-These file are optional for if you wish to re-export these entries to JabRef. They must be placed in your EndNote Styles directory. On a Mac OS X system, the default directory is /Applications/EndNote 7/Styles. On a Windows XP system, the default directory is C:\Program Files\EndNote\Styles. You may then want to open up the Filter Manager (Edit->Output Styles->Open Style Manager) and add it to your Favorites.
+These file are optional for if you wish to re-export these entries to JabRef. They must be placed in your EndNote Styles directory. On a macOS system, the default directory is /Applications/EndNote 7/Styles. On a Windows XP system, the default directory is C:\Program Files\EndNote\Styles. You may then want to open up the Filter Manager (Edit->Output Styles->Open Style Manager) and add it to your Favorites.
 
 *********************************************************************************
 Usage


### PR DESCRIPTION
The name of this operating system is `macOS` since 2016, so I though it would be a good idea to name it consistently. 