### PR TITLE
Fix "Library has changed externally" with CRLF markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We Included all standard fields with citation key when exporting to Old OpenOffice/LibreOffice Calc Format [#8176](https://github.com/JabRef/jabref/pull/8176)
 - We present options to manually enter an article or return to the New Entry menu when the fetcher DOI fails to find an entry for an ID [#7870](https://github.com/JabRef/jabref/issues/7870)
 - We trim white space and non-ASCII characters from DOI [#8127](https://github.com/JabRef/jabref/issues/8127)
+- The duplicate checker now inspects other fields in case no difference in the required and optional fields are found.
 
 ### Fixed
 
@@ -57,6 +58,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where typing an invalid UNC path into the "Main file directory" text field caused an error. [#8107](https://github.com/JabRef/jabref/issues/8107)
 - We fixed an issue where "Open Folder" didn't select the file on macOS in Finder [#8130](https://github.com/JabRef/jabref/issues/8130)
 - We fixed an issue where importing PDFs resulted in an uncaught exception [#8143](https://github.com/JabRef/jabref/issues/8143)
+- We fixed "The library has been modified by another program" showing up when line breaks change [#4877](https://github.com/JabRef/jabref/issues/4877)
 - The default directory of the "LaTeX Citations" tab is now the directory of the currently opened database (and not the directory chosen at the last open file dialog or the last database save) [koppor#538](https://github.com/koppor/jabref/issues/538)
 - We fixed an issue where right-clicking on a tab and selecting close will close the focused tab even if it is not the tab we right-clicked [#8193](https://github.com/JabRef/jabref/pull/8193)
 - We fixed an issue where selecting a citation style in the preferences would sometimes produce an exception [#7860](https://github.com/JabRef/jabref/issues/7860)

--- a/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
@@ -24,6 +24,13 @@ public class EntryComparator implements Comparator<BibEntry> {
     private final boolean binary;
     private final Comparator<BibEntry> next;
 
+    /**
+     *
+     * @param binary true: the presence of fields is checked; false: the content of the fields is compared
+     * @param descending true: if the most different entry should get the highest score
+     * @param field the field to sort on
+     * @param next the next comparator to use (if the current comparator results in equality)
+     */
     public EntryComparator(boolean binary, boolean descending, Field field, Comparator<BibEntry> next) {
         this.binary = binary;
         this.sortField = field;
@@ -42,7 +49,7 @@ public class EntryComparator implements Comparator<BibEntry> {
     public int compare(BibEntry e1, BibEntry e2) {
         // default equals
         // TODO: with the new default equals this does not only return 0 for identical objects,
-        // but for all objects that have the same id and same fields
+        //       but for all objects that have the same id and same fields
         if (Objects.equals(e1, e2)) {
             return 0;
         }
@@ -103,21 +110,21 @@ public class EntryComparator implements Comparator<BibEntry> {
         int result;
 
         if ((f1 instanceof Integer) && (f2 instanceof Integer)) {
-            result = -((Integer) f1).compareTo((Integer) f2);
+            result = ((Integer) f1).compareTo((Integer) f2);
         } else if (f2 instanceof Integer) {
             Integer f1AsInteger = Integer.valueOf(f1.toString());
-            result = -f1AsInteger.compareTo((Integer) f2);
+            result = f1AsInteger.compareTo((Integer) f2);
         } else if (f1 instanceof Integer) {
             Integer f2AsInteger = Integer.valueOf(f2.toString());
-            result = -((Integer) f1).compareTo(f2AsInteger);
+            result = ((Integer) f1).compareTo(f2AsInteger);
         } else {
             String ours = ((String) f1).toLowerCase(Locale.ROOT);
             String theirs = ((String) f2).toLowerCase(Locale.ROOT);
             int comp = ours.compareTo(theirs);
-            result = -comp;
+            result = comp;
         }
         if (result != 0) {
-            return descending ? result : -result; // Primary sort.
+            return descending ? -result : result; // Primary sort.
         }
         if (next == null) {
             return idCompare(e1, e2); // If still equal, we use the unique IDs.

--- a/src/main/java/org/jabref/logic/importer/Importer.java
+++ b/src/main/java/org/jabref/logic/importer/Importer.java
@@ -1,14 +1,15 @@
 package org.jabref.logic.importer;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
 import org.jabref.logic.util.FileType;
@@ -123,7 +124,7 @@ public abstract class Importer implements Comparable<Importer> {
 
     public static BufferedReader getReader(Path filePath, Charset encoding)
             throws IOException {
-        InputStream stream = new FileInputStream(filePath.toFile());
+        InputStream stream = Files.newInputStream(filePath, StandardOpenOption.READ);
         return new BufferedReader(new InputStreamReader(stream, encoding));
     }
 

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -397,7 +397,7 @@ public class BibEntry implements Cloneable {
     }
 
     /**
-     * Returns an set containing the names of all fields that are set for this particular entry.
+     * Returns a set containing the names of all fields that are set for this particular entry.
      *
      * @return a set of existing field names
      */

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -394,6 +394,7 @@ public class StringUtil {
 
     /**
      * Replaces all platform-dependent line breaks by OS.NEWLINE line breaks.
+     * AKA normalize newlines
      * <p>
      * We do NOT use UNIX line breaks as the user explicitly configures its linebreaks and this method is used in bibtex field writing
      *

--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
@@ -50,6 +50,45 @@ class BibDatabaseDiffTest {
     }
 
     @Test
+    void compareOfTwoEntriesWithSameContentAndLfEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
+
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
+
+        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+
+        assertEquals(Collections.emptyList(), diff.getEntryDifferences());
+    }
+
+    @Test
+    void compareOfTwoEntriesWithSameContentAndCrLfEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
+
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
+
+        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+
+        assertEquals(Collections.emptyList(), diff.getEntryDifferences());
+    }
+
+    @Test
+    void compareOfTwoEntriesWithSameContentAndMixedLineEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
+
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
+
+        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+
+        assertEquals(Collections.emptyList(), diff.getEntryDifferences());
+    }
+
+    @Test
     void compareOfTwoDifferentEntriesWithDifferentDataReportsDifferences() throws Exception {
         BibEntry entryOne = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
         BibEntry entryTwo = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "another test");

--- a/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
@@ -99,6 +99,33 @@ class EntryComparatorTest {
         assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
         assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }
+
+    @Test
+    void compareWithCrLfFields() {
+        BibEntry e1 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        BibEntry e2 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        assertEquals(0, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
+    }
+
+    @Test
+    void compareWithLfFields() {
+        BibEntry e1 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibEntry e2 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        assertEquals(0, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
+    }
+
+    @Test
+    void compareWithMixedLineEndings() {
+        BibEntry e1 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibEntry e2 = new BibEntry()
+                .withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
+    }
 }
 
 

--- a/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
+++ b/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
@@ -306,4 +306,27 @@ public class DuplicateCheckTest {
 
         assertFalse(duplicateChecker.isDuplicate(editionOne, editionTwo, BibDatabaseMode.BIBTEX));
     }
+
+    @Test
+    void compareOfTwoEntriesWithSameContentAndLfEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    void compareOfTwoEntriesWithSameContentAndCrLfEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    void compareOfTwoEntriesWithSameContentAndMixedLineEndingsReportsNoDifferences() throws Exception {
+        BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
+        BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
+        assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
+    }
+
+
 }

--- a/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
+++ b/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
@@ -327,6 +327,4 @@ public class DuplicateCheckTest {
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
         assertTrue(duplicateChecker.isDuplicate(entryOne, entryTwo, BibDatabaseMode.BIBTEX));
     }
-
-
 }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/4877

When a user had `CRLF` configured as line ending and stored a multiline field (such as comment), JabRef always complained with "the library has been modified externally". See https://github.com/JabRef/jabref/issues/4877#issuecomment-967715080 for an MWE.

This PR fixes it and also refines the duplicate checker itself.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
