### PR TITLE
Fix search: NOT binds more than AND

### DIFF
--- a/src/main/antlr4/org/jabref/search/Search.g4
+++ b/src/main/antlr4/org/jabref/search/Search.g4
@@ -37,7 +37,7 @@ expression:
     LPAREN expression RPAREN                         #parenExpression  // example: (author=miller)
     | NOT expression                                 #unaryExpression  // example: not author = miller
     | left=expression operator=AND right=expression  #binaryExpression // example: author = miller and title = test
-    | left=expression operator=OR right=expression   #binaryExpression // example: author = miller and title = test
+    | left=expression operator=OR right=expression   #binaryExpression // example: author = miller or title = test
     | comparison                                     #atomExpression
     ;
 

--- a/src/main/antlr4/org/jabref/search/Search.g4
+++ b/src/main/antlr4/org/jabref/search/Search.g4
@@ -34,10 +34,11 @@ start:
 // labels are used to refer to parts of the rules in the generated code later on
 // label=actualThingy
 expression:
-    LPAREN expression RPAREN                                  #parenExpression  // example: (author=miller)
-    | left=expression operator=(AND | OR) right=expression    #binaryExpression // example: author = miller and title = test
-    | NOT expression                                          #unaryExpression  // example: not author = miller
-    | comparison                                              #atomExpression
+    LPAREN expression RPAREN                         #parenExpression  // example: (author=miller)
+    | NOT expression                                 #unaryExpression  // example: not author = miller
+    | left=expression operator=AND right=expression  #binaryExpression // example: author = miller and title = test
+    | left=expression operator=OR right=expression   #binaryExpression // example: author = miller and title = test
+    | comparison                                     #atomExpression
     ;
 
 comparison:

--- a/src/test/java/org/jabref/model/groups/SearchGroupTest.java
+++ b/src/test/java/org/jabref/model/groups/SearchGroupTest.java
@@ -3,6 +3,7 @@ package org.jabref.model.groups;
 import java.util.EnumSet;
 
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.search.rules.SearchRules;
 
 import org.junit.jupiter.api.Test;
@@ -28,5 +29,25 @@ public class SearchGroupTest {
         entry.addKeyword("review", ',');
 
         assertFalse(group.contains(entry));
+    }
+
+    @Test
+    public void notQueryWorksWithLeftPartOfQuery() {
+        SearchGroup groupToBeClassified = new SearchGroup("to-be-classified", GroupHierarchyType.INDEPENDENT, "NOT(groups=alpha) AND NOT(groups=beta)", EnumSet.noneOf(SearchRules.SearchFlags.class));
+
+        BibEntry alphaEntry = new BibEntry()
+                .withCitationKey("alpha")
+                .withField(StandardField.GROUPS, "alpha");
+        assertFalse(groupToBeClassified.contains(alphaEntry));
+    }
+
+    @Test
+    public void notQueryWorksWithLRightPartOfQuery() {
+        SearchGroup groupToBeClassified = new SearchGroup("to-be-classified", GroupHierarchyType.INDEPENDENT, "NOT(groups=alpha) AND NOT(groups=beta)", EnumSet.noneOf(SearchRules.SearchFlags.class));
+
+        BibEntry betaEntry = new BibEntry()
+                .withCitationKey("beta")
+                .withField(StandardField.GROUPS, "beta");
+        assertFalse(groupToBeClassified.contains(betaEntry));
     }
 }


### PR DESCRIPTION
I had issues with a search like `NOT(groups=alpha) AND NOT(groups=beta)`. It did not work, in case `beta` was the hit group. Therefore, I created https://github.com/JabRef/jabref/pull/8206.

After thinking more, the solution was that the search grammar was wrong: NOT was too low in the ordering (hint via https://stackoverflow.com/a/30987142/873282).

This PR fixes NOT and AND to be defined as in Boolean algebra. Before, NOT bound wrong and AND and OR were treated equally.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
