### PR TITLE
Switch to GitHub's concurrency feature

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -7,6 +7,7 @@ on:
   schedule:
     # Run on the first of each month at 9:00 AM (See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)
     - cron: "0 9 1 * *"
+  workflow_dispatch:
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,6 +26,10 @@ env:
   GRADLE_OPTS: -Xmx4g -Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false
   JAVA_OPTS: -Xmx4g
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:
@@ -45,10 +49,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Create installer and portable version for ${{ matrix.displayName }}
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -6,6 +6,7 @@ on:
       - gource
   schedule:
     - cron:  '15 3 1 1,4,7,10 *'
+  workflow_dispatch:
 
 jobs:
   action:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -9,6 +9,10 @@ on:
    # run on each day
   - cron: "33 4 * * *"
 
+concurrency:
+  group: snap-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -27,6 +27,10 @@ env:
   AstrophysicsDataSystemAPIKey: ${{ secrets.AstrophysicsDataSystemAPIKey_FOR_TESTS }}
   IEEEAPIKey: ${{ secrets.IEEEAPIKey_FOR_TESTS }}
 
+concurrency:
+  group: fetcher-tests-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   fetchertests:
     name: Fetcher tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,11 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
+      - main-release
   pull_request:
     # always run on pull requests
+  workflow_dispatch:
 
 env:
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}
@@ -14,15 +16,15 @@ env:
   GRADLE_OPTS: -Xmx4g
   JAVA_OPTS: -Xmx4g
 
+concurrency:
+  group: tests-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   checkstyle:
     name: Checkstyle
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout source
         uses: actions/checkout@v2
       - name: Set up JDK


### PR DESCRIPTION
Switch from <https://github.com/styfle/cancel-workflow-action> to GitHub's internal concurrency feature.

See https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
