### PR TITLE
Clicking a DOI link in the preview pane no longer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The default directory of the "LaTeX Citations" tab is now the directory of the currently opened database (and not the directory chosen at the last open file dialog or the last database save) [koppor#538](https://github.com/koppor/jabref/issues/538)
 - We fixed an issue where right-clicking on a tab and selecting close will close the focused tab even if it is not the tab we right-clicked [#8193](https://github.com/JabRef/jabref/pull/8193)
 - We fixed an issue where selecting a citation style in the preferences would sometimes produce an exception [#7860](https://github.com/JabRef/jabref/issues/7860)
-- We fixed an issue where an exception would occur when clicking on a DOI link in the preview pane [#7706](https://github.com/JabRef/jabref/issues/7706) 
+- We fixed an issue where an exception would occur when clicking on a DOI link in the preview pane [#7706](https://github.com/JabRef/jabref/issues/7706)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The default directory of the "LaTeX Citations" tab is now the directory of the currently opened database (and not the directory chosen at the last open file dialog or the last database save) [koppor#538](https://github.com/koppor/jabref/issues/538)
 - We fixed an issue where right-clicking on a tab and selecting close will close the focused tab even if it is not the tab we right-clicked [#8193](https://github.com/JabRef/jabref/pull/8193)
 - We fixed an issue where selecting a citation style in the preferences would sometimes produce an exception [#7860](https://github.com/JabRef/jabref/issues/7860)
+- We fixed an issue where an exception would occur when clicking on a DOI link in the preview pane [#7706](https://github.com/JabRef/jabref/issues/7706) 
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -1,5 +1,9 @@
 package org.jabref.gui.preview;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -30,6 +34,10 @@ import org.jabref.model.entry.BibEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.EventTarget;
+import org.w3c.dom.html.HTMLAnchorElement;
 
 /**
  * Displays an BibEntry using the given layout format.
@@ -137,6 +145,27 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
                 registered = true;
             }
             highlightSearchPattern();
+
+            // https://stackoverflow.com/questions/15555510/javafx-stop-opening-url-in-webview-open-in-browser-instead
+            NodeList anchorList = previewView.getEngine().getDocument().getElementsByTagName("a");
+            for (int i = 0; i < anchorList.getLength(); i++) {
+                Node node = anchorList.item(i);
+                EventTarget eventTarget = (EventTarget) node;
+                eventTarget.addEventListener("click", evt -> {
+                    EventTarget target = evt.getCurrentTarget();
+                    HTMLAnchorElement anchorElement = (HTMLAnchorElement) target;
+                    String href = anchorElement.getHref();
+                    try {
+                        java.awt.Desktop.getDesktop().browse(new URL(href).toURI());
+                    } catch (MalformedURLException | URISyntaxException exception) {
+                        exception.printStackTrace();
+                    } catch (IOException exception) {
+                        exception.printStackTrace();
+                    }
+
+                    evt.preventDefault();
+                }, false);
+            }
         });
     }
 

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -1,9 +1,5 @@
 package org.jabref.gui.preview;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -37,7 +33,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.events.EventTarget;
-import org.w3c.dom.html.HTMLAnchorElement;
 
 /**
  * Displays an BibEntry using the given layout format.
@@ -152,17 +147,6 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
                 Node node = anchorList.item(i);
                 EventTarget eventTarget = (EventTarget) node;
                 eventTarget.addEventListener("click", evt -> {
-                    EventTarget target = evt.getCurrentTarget();
-                    HTMLAnchorElement anchorElement = (HTMLAnchorElement) target;
-                    String href = anchorElement.getHref();
-                    try {
-                        java.awt.Desktop.getDesktop().browse(new URL(href).toURI());
-                    } catch (MalformedURLException | URISyntaxException exception) {
-                        exception.printStackTrace();
-                    } catch (IOException exception) {
-                        exception.printStackTrace();
-                    }
-
                     evt.preventDefault();
                 }, false);
             }

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -157,9 +157,9 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
                     try {
                         JabRefDesktop.openBrowser(href);
                     } catch (MalformedURLException exception) {
-                        exception.printStackTrace();
+                        LOGGER.error("Invalid URL", exception);
                     } catch (IOException exception) {
-                        exception.printStackTrace();
+                        LOGGER.error("Invalid URL Input", exception);
                     }
                     evt.preventDefault();
                 }, false);

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.preview;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -17,6 +19,7 @@ import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.gui.util.Theme;
@@ -33,6 +36,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.events.EventTarget;
+import org.w3c.dom.html.HTMLAnchorElement;
 
 /**
  * Displays an BibEntry using the given layout format.
@@ -147,6 +151,16 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
                 Node node = anchorList.item(i);
                 EventTarget eventTarget = (EventTarget) node;
                 eventTarget.addEventListener("click", evt -> {
+                    EventTarget target = evt.getCurrentTarget();
+                    HTMLAnchorElement anchorElement = (HTMLAnchorElement) target;
+                    String href = anchorElement.getHref();
+                    try {
+                        JabRefDesktop.openBrowser(href);
+                    } catch (MalformedURLException exception) {
+                        exception.printStackTrace();
+                    } catch (IOException exception) {
+                        exception.printStackTrace();
+                    }
                     evt.preventDefault();
                 }, false);
             }


### PR DESCRIPTION

Fixes #7706 
DOI links in the preview pane no longer open in the WebView and no longer cause uncaught exceptions as a consequence. Unfortunately wasn't able to find a clean solution to opening a browser window on all OS's without using java.awt



<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
