### PR TITLE
Fixes RFC fetcher test case

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/RfcFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/RfcFetcherTest.java
@@ -66,7 +66,7 @@ public class RfcFetcherTest {
         bibDraftEntry.setField(StandardField.URL, "https://datatracker.ietf.org/doc/html/draft-fielding-http-spec-01");
         bibDraftEntry.setField(StandardField.YEAR, "1994");
         bibDraftEntry.setField(StandardField.ABSTRACT, "The Hypertext Transfer Protocol (HTTP) is an application-level protocol with the lightness and speed necessary for distributed, collaborative, hypermedia information systems. It is a generic, stateless, object-oriented protocol which can be used for many tasks, such as name servers and distributed object management systems, through extension of its request methods (commands). A feature of HTTP is the typing and negotiation of data representation, allowing systems to be built independently of the data being transferred. HTTP has been in use by the World-Wide Web global information initiative since 1990. This specification reflects preferred usage of the protocol referred to as 'HTTP/1.0', and is compatible with the most commonly used HTTP server and client programs implemented prior to November 1994.");
-        bibDraftEntry.setCommentsBeforeEntry("%% You should probably cite draft-ietf-http-v10-spec instead of this I-D.");
+        bibDraftEntry.setCommentsBeforeEntry("%% You should probably cite draft-ietf-http-v10-spec instead of this I-D.\n");
 
         assertEquals(Optional.of(bibDraftEntry), fetcher.performSearchById("draft-fielding-http-spec"));
     }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/8263

The underlying discussion is whether the Java-programmer facing interface should be strict or relaxed.

@calixtus and me currently think that the newline character has to be provided.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
