### PR TITLE
Fix IEEE test

### DIFF
--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -86,6 +86,7 @@ public class URLDownload {
     public URLDownload(URL source) {
         this.source = source;
         this.addHeader("User-Agent", URLDownload.USER_AGENT);
+        bypassSSLVerification();
     }
 
     /**
@@ -200,7 +201,7 @@ public class URLDownload {
         Unirest.config().setDefaultHeader("User-Agent", "Mozilla/5.0 (Windows; U; WindowsNT 5.1; en-US; rv1.8.1.6) Gecko/20070725 Firefox/2.0.0.6");
 
         int statusCode = Unirest.head(source.toString()).asString().getStatus();
-        return statusCode >= 200 && statusCode < 300;
+        return (statusCode >= 200) && (statusCode < 300);
     }
 
     public boolean isMimeType(String type) {

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -70,7 +70,7 @@ class CompositeIdFetcherTest {
                                 .withField(StandardField.PUBLISHER, "Addison Wesley")
                                 .withField(StandardField.YEAR, "2018")
                                 .withField(StandardField.AUTHOR, "Bloch, Joshua")
-                                .withField(StandardField.DATE, "2018-01-01")
+                                .withField(StandardField.DATE, "2018-01-31")
                                 .withField(new UnknownField("ean"), "9780134685991")
                                 .withField(StandardField.ISBN, "0134685997")
                                 .withField(StandardField.URL, "https://www.ebook.de/de/product/28983211/joshua_bloch_effective_java.html")
@@ -86,7 +86,7 @@ class CompositeIdFetcherTest {
                                 .withField(StandardField.AUTHOR, "Barry Burd")
                                 .withField(StandardField.MONTH, "jul")
                                 .withField(StandardField.DOI, "10.1002/9781118257517")
-                                .withCitationKey("2011"),
+                                .withCitationKey("Burd_2011"),
                         "10.1002/9781118257517"
                 )
         );


### PR DESCRIPTION
Bypass SSL Verification in URLDownload
It was only set when JabRef was started normally

Fixes #8305 

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
