### PR TITLE
Don't register any database changes to the indexer while dropping a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception would occur when clicking on a DOI link in the preview pane [#7706](https://github.com/JabRef/jabref/issues/7706)
 - We fixed an issue where XMP and embedded BibTeX export would not work [#8278](https://github.com/JabRef/jabref/issues/8278)
 - We fixed an issue where the XMP and embedded BibTeX import of a file containing multiple schemas failed [#8278](https://github.com/JabRef/jabref/issues/8278)
+- We fixed an issue where pdf-paths and the pdf-indexer could get out of sync [#8182](https://github.com/JabRef/jabref/issues/8182)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -16,6 +16,7 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
@@ -33,11 +34,12 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
                                DialogService dialogService,
                                PreferencesService preferences,
                                StateManager stateManager,
+                               IndexingTaskManager indexingTaskManager,
                                BibEntryTypesManager entryTypesManager,
                                ExternalFileTypes externalFileTypes,
                                TaskExecutor taskExecutor,
                                JournalAbbreviationRepository journalAbbreviationRepository) {
-        super(false, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
+        super(false, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository, indexingTaskManager);
         this.entryTypesManager = entryTypesManager;
 
         setText(Localization.lang("Deprecated fields"));

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -143,11 +143,11 @@ public class EntryEditor extends BorderPane {
                 switch (event.getTransferMode()) {
                     case COPY -> {
                         LOGGER.debug("Mode COPY");
-                        fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
+                        fileLinker.copyFilesToFileDirAndAddToEntry(entry, files, libraryTab.getIndexingTaskManager());
                     }
                     case MOVE -> {
                         LOGGER.debug("Mode MOVE");
-                        fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
+                        fileLinker.moveFilesToFileDirAndAddToEntry(entry, files, libraryTab.getIndexingTaskManager());
                     }
                     case LINK -> {
                         LOGGER.debug("Mode LINK");
@@ -233,22 +233,22 @@ public class EntryEditor extends BorderPane {
 
     private List<EntryEditorTab> createTabs() {
         // Preview tab
-        entryEditorTabs.add(new PreviewTab(databaseContext, dialogService, preferencesService, stateManager, ExternalFileTypes.getInstance()));
+        entryEditorTabs.add(new PreviewTab(databaseContext, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), ExternalFileTypes.getInstance()));
 
         // Required fields
-        entryEditorTabs.add(new RequiredFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+        entryEditorTabs.add(new RequiredFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
 
         // Optional fields
-        entryEditorTabs.add(new OptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
-        entryEditorTabs.add(new OptionalFields2Tab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
-        entryEditorTabs.add(new DeprecatedFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+        entryEditorTabs.add(new OptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+        entryEditorTabs.add(new OptionalFields2Tab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+        entryEditorTabs.add(new DeprecatedFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
 
         // Other fields
-        entryEditorTabs.add(new OtherFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+        entryEditorTabs.add(new OtherFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
 
         // General fields from preferences
         for (Map.Entry<String, Set<Field>> tab : entryEditorPreferences.getEntryEditorTabList().entrySet()) {
-            entryEditorTabs.add(new UserDefinedFieldsTab(tab.getKey(), tab.getValue(), databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
+            entryEditorTabs.add(new UserDefinedFieldsTab(tab.getKey(), tab.getValue(), databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, libraryTab.getIndexingTaskManager(), Globals.entryTypesManager, ExternalFileTypes.getInstance(), Globals.TASK_EXECUTOR, Globals.journalAbbreviationRepository));
         }
 
         // Special tabs

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -33,6 +33,7 @@ import org.jabref.gui.fieldeditors.FieldNameLabel;
 import org.jabref.gui.preview.PreviewPanel;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
@@ -52,6 +53,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
     private final TaskExecutor taskExecutor;
     private final JournalAbbreviationRepository journalAbbreviationRepository;
     private final StateManager stateManager;
+    private final IndexingTaskManager indexingTaskManager;
     private PreviewPanel previewPanel;
     private final UndoManager undoManager;
     private Collection<Field> fields = new ArrayList<>();
@@ -66,7 +68,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
                            StateManager stateManager,
                            ExternalFileTypes externalFileTypes,
                            TaskExecutor taskExecutor,
-                           JournalAbbreviationRepository journalAbbreviationRepository) {
+                           JournalAbbreviationRepository journalAbbreviationRepository, IndexingTaskManager indexingTaskManager) {
         this.isCompressed = compressed;
         this.databaseContext = Objects.requireNonNull(databaseContext);
         this.suggestionProviders = Objects.requireNonNull(suggestionProviders);
@@ -77,6 +79,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         this.taskExecutor = Objects.requireNonNull(taskExecutor);
         this.journalAbbreviationRepository = Objects.requireNonNull(journalAbbreviationRepository);
         this.stateManager = stateManager;
+        this.indexingTaskManager = indexingTaskManager;
     }
 
     private static void addColumn(GridPane gridPane, int columnIndex, List<Label> nodes) {
@@ -230,7 +233,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
 
             SplitPane container = new SplitPane(scrollPane);
             if (!preferences.getPreviewPreferences().showPreviewAsExtraTab()) {
-                previewPanel = new PreviewPanel(databaseContext, dialogService, externalFileTypes, preferences.getKeyBindingRepository(), preferences, stateManager);
+                previewPanel = new PreviewPanel(databaseContext, dialogService, externalFileTypes, preferences.getKeyBindingRepository(), preferences, stateManager, indexingTaskManager);
                 container.getItems().add(previewPanel);
             }
 

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -9,6 +9,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
@@ -20,6 +21,7 @@ public class OptionalFields2Tab extends OptionalFieldsTabBase {
                               DialogService dialogService,
                               PreferencesService preferences,
                               StateManager stateManager,
+                              IndexingTaskManager indexingTaskManager,
                               BibEntryTypesManager entryTypesManager,
                               ExternalFileTypes externalFileTypes,
                               TaskExecutor taskExecutor,
@@ -33,6 +35,7 @@ public class OptionalFields2Tab extends OptionalFieldsTabBase {
                 dialogService,
                 preferences,
                 stateManager,
+                indexingTaskManager,
                 entryTypesManager,
                 externalFileTypes,
                 taskExecutor,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -9,6 +9,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.preferences.PreferencesService;
@@ -20,6 +21,7 @@ public class OptionalFieldsTab extends OptionalFieldsTabBase {
                              DialogService dialogService,
                              PreferencesService preferences,
                              StateManager stateManager,
+                             IndexingTaskManager indexingTaskManager,
                              BibEntryTypesManager entryTypesManager,
                              ExternalFileTypes externalFileTypes,
                              TaskExecutor taskExecutor,
@@ -33,6 +35,7 @@ public class OptionalFieldsTab extends OptionalFieldsTabBase {
                 dialogService,
                 preferences,
                 stateManager,
+                indexingTaskManager,
                 entryTypesManager,
                 externalFileTypes,
                 taskExecutor,

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTabBase.java
@@ -16,6 +16,7 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
@@ -35,11 +36,12 @@ public class OptionalFieldsTabBase extends FieldsEditorTab {
                                  DialogService dialogService,
                                  PreferencesService preferences,
                                  StateManager stateManager,
+                                 IndexingTaskManager indexingTaskManager,
                                  BibEntryTypesManager entryTypesManager,
                                  ExternalFileTypes externalFileTypes,
                                  TaskExecutor taskExecutor,
                                  JournalAbbreviationRepository journalAbbreviationRepository) {
-        super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
+        super(true, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository, indexingTaskManager);
         this.entryTypesManager = entryTypesManager;
         this.isPrimaryOptionalFields = isPrimaryOptionalFields;
         setText(title);

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -19,6 +19,7 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
@@ -39,6 +40,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
                           DialogService dialogService,
                           PreferencesService preferences,
                           StateManager stateManager,
+                          IndexingTaskManager indexingTaskManager,
                           BibEntryTypesManager entryTypesManager,
                           ExternalFileTypes externalFileTypes,
                           TaskExecutor taskExecutor,
@@ -52,7 +54,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
                 stateManager,
                 externalFileTypes,
                 taskExecutor,
-                journalAbbreviationRepository);
+                journalAbbreviationRepository, indexingTaskManager);
 
         this.entryTypesManager = entryTypesManager;
         this.customTabFieldNames = preferences.getAllDefaultTabFieldNames();

--- a/src/main/java/org/jabref/gui/entryeditor/PreviewTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/PreviewTab.java
@@ -6,6 +6,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preview.PreviewPanel;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.PreferencesService;
@@ -15,6 +16,7 @@ public class PreviewTab extends EntryEditorTab {
     private final BibDatabaseContext databaseContext;
     private final PreferencesService preferences;
     private final StateManager stateManager;
+    private final IndexingTaskManager indexingTaskManager;
     private final ExternalFileTypes externalFileTypes;
     private PreviewPanel previewPanel;
 
@@ -22,11 +24,12 @@ public class PreviewTab extends EntryEditorTab {
                       DialogService dialogService,
                       PreferencesService preferences,
                       StateManager stateManager,
-                      ExternalFileTypes externalFileTypes) {
+                      IndexingTaskManager indexingTaskManager, ExternalFileTypes externalFileTypes) {
         this.databaseContext = databaseContext;
         this.dialogService = dialogService;
         this.preferences = preferences;
         this.stateManager = stateManager;
+        this.indexingTaskManager = indexingTaskManager;
         this.externalFileTypes = externalFileTypes;
 
         setGraphic(IconTheme.JabRefIcons.TOGGLE_ENTRY_PREVIEW.getGraphicNode());
@@ -55,7 +58,7 @@ public class PreviewTab extends EntryEditorTab {
     @Override
     protected void bindToEntry(BibEntry entry) {
         if (previewPanel == null) {
-            previewPanel = new PreviewPanel(databaseContext, dialogService, externalFileTypes, preferences.getKeyBindingRepository(), preferences, stateManager);
+            previewPanel = new PreviewPanel(databaseContext, dialogService, externalFileTypes, preferences.getKeyBindingRepository(), preferences, stateManager, indexingTaskManager);
             setContent(previewPanel);
         }
 

--- a/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
@@ -16,6 +16,7 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
@@ -35,12 +36,13 @@ public class RequiredFieldsTab extends FieldsEditorTab {
                              DialogService dialogService,
                              PreferencesService preferences,
                              StateManager stateManager,
+                             IndexingTaskManager indexingTaskManager,
                              BibEntryTypesManager entryTypesManager,
                              ExternalFileTypes externalFileTypes,
                              TaskExecutor taskExecutor,
                              JournalAbbreviationRepository journalAbbreviationRepository) {
         super(false, databaseContext, suggestionProviders, undoManager, dialogService,
-                preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
+                preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository, indexingTaskManager);
         this.entryTypesManager = entryTypesManager;
 
         setText(Localization.lang("Required fields"));

--- a/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -12,6 +12,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
@@ -29,11 +30,12 @@ public class UserDefinedFieldsTab extends FieldsEditorTab {
                                 DialogService dialogService,
                                 PreferencesService preferences,
                                 StateManager stateManager,
+                                IndexingTaskManager indexingTaskManager,
                                 BibEntryTypesManager entryTypesManager,
                                 ExternalFileTypes externalFileTypes,
                                 TaskExecutor taskExecutor,
                                 JournalAbbreviationRepository journalAbbreviationRepository) {
-        super(false, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository);
+        super(false, databaseContext, suggestionProviders, undoManager, dialogService, preferences, stateManager, externalFileTypes, taskExecutor, journalAbbreviationRepository, indexingTaskManager);
 
         this.fields = new LinkedHashSet<>(fields);
 

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -390,16 +390,20 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                             }
                             case MOVE -> {
                                 LOGGER.debug("Mode MOVE"); // alt on win
-                                libraryTab.getIndexingTaskManager().setBlockingNewTasks(true);
-                                importHandler.getLinker().moveFilesToFileDirAndAddToEntry(entry, files);
-                                libraryTab.getIndexingTaskManager().setBlockingNewTasks(false);
+                                try (AutoCloseable blocker = libraryTab.getIndexingTaskManager().blockNewTasks()) {
+                                    importHandler.getLinker().moveFilesToFileDirAndAddToEntry(entry, files);
+                                } catch (Exception e) {
+                                    LOGGER.error("Could not block IndexingTaskManager", e);
+                                }
                                 libraryTab.getIndexingTaskManager().addToIndex(PdfIndexer.of(database, filePreferences), entry, database);
                             }
                             case COPY -> {
                                 LOGGER.debug("Mode Copy"); // ctrl on win
-                                libraryTab.getIndexingTaskManager().setBlockingNewTasks(true);
-                                importHandler.getLinker().copyFilesToFileDirAndAddToEntry(entry, files);
-                                libraryTab.getIndexingTaskManager().setBlockingNewTasks(false);
+                                try (AutoCloseable blocker = libraryTab.getIndexingTaskManager().blockNewTasks()) {
+                                    importHandler.getLinker().copyFilesToFileDirAndAddToEntry(entry, files);
+                                } catch (Exception e) {
+                                    LOGGER.error("Could not block IndexingTaskManager", e);
+                                }
                                 libraryTab.getIndexingTaskManager().addToIndex(PdfIndexer.of(database, filePreferences), entry, database);
                             }
                         }

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -24,6 +24,7 @@ import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -43,6 +44,7 @@ public class PreviewPanel extends VBox {
     private final PreferencesService preferences;
     private final DialogService dialogService;
     private final StateManager stateManager;
+    private final IndexingTaskManager indexingTaskManager;
     private BibEntry entry;
 
     public PreviewPanel(BibDatabaseContext database,
@@ -50,11 +52,12 @@ public class PreviewPanel extends VBox {
                         ExternalFileTypes externalFileTypes,
                         KeyBindingRepository keyBindingRepository,
                         PreferencesService preferences,
-                        StateManager stateManager) {
+                        StateManager stateManager, IndexingTaskManager indexingTaskManager) {
         this.keyBindingRepository = keyBindingRepository;
         this.dialogService = dialogService;
         this.stateManager = stateManager;
         this.preferences = preferences;
+        this.indexingTaskManager = indexingTaskManager;
         fileLinker = new ExternalFilesEntryLinker(externalFileTypes, preferences.getFilePreferences(), database);
 
         PreviewPreferences previewPreferences = preferences.getPreviewPreferences();
@@ -87,7 +90,7 @@ public class PreviewPanel extends VBox {
 
                 if (event.getTransferMode() == TransferMode.MOVE) {
                     LOGGER.debug("Mode MOVE"); // shift on win or no modifier
-                    fileLinker.moveFilesToFileDirAndAddToEntry(entry, files);
+                    fileLinker.moveFilesToFileDirAndAddToEntry(entry, files, indexingTaskManager);
                 }
                 if (event.getTransferMode() == TransferMode.LINK) {
                     LOGGER.debug("Node LINK"); // alt on win
@@ -95,7 +98,7 @@ public class PreviewPanel extends VBox {
                 }
                 if (event.getTransferMode() == TransferMode.COPY) {
                     LOGGER.debug("Mode Copy"); // ctrl on win, no modifier on Xubuntu
-                    fileLinker.copyFilesToFileDirAndAddToEntry(entry, files);
+                    fileLinker.copyFilesToFileDirAndAddToEntry(entry, files, indexingTaskManager);
                 }
                 success = true;
             }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -23,6 +23,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
 
     private final Object lock = new Object();
     private boolean isRunning = false;
+    private boolean isBlockingNewTasks = false;
 
     public IndexingTaskManager(TaskExecutor taskExecutor) {
         this.taskExecutor = taskExecutor;
@@ -58,14 +59,22 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
     }
 
     private void enqueueTask(Runnable indexingTask) {
-        taskQueue.add(indexingTask);
-        // What if already running?
-        synchronized (lock) {
-            if (!isRunning) {
-                isRunning = true;
-                this.executeWith(taskExecutor);
-                showToUser(false);
+        if (!isBlockingNewTasks) {
+            taskQueue.add(indexingTask);
+            // What if already running?
+            synchronized (lock) {
+                if (!isRunning) {
+                    isRunning = true;
+                    this.executeWith(taskExecutor);
+                    showToUser(false);
+                }
             }
+        }
+    }
+
+    public void setBlockingNewTasks(boolean blockingNewTasks) {
+        synchronized (lock) {
+            isBlockingNewTasks = blockingNewTasks;
         }
     }
 

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -72,10 +72,15 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         }
     }
 
-    public void setBlockingNewTasks(boolean blockingNewTasks) {
+    public AutoCloseable blockNewTasks() {
         synchronized (lock) {
-            isBlockingNewTasks = blockingNewTasks;
+            isBlockingNewTasks = true;
         }
+        return () -> {
+            synchronized (lock) {
+                isBlockingNewTasks = false;
+            }
+        };
     }
 
     public void createIndex(PdfIndexer indexer) {


### PR DESCRIPTION
There was a problem that involved the Indexer and Drag&Drop operations while having auto-file-move/rename enabled.

When dropping a File onto an entry, JabRef links that file to the entry and moves and renames the files according to the set preferences. It was possible for this to happen while the PDFIndexer was running. This could lead to:
- The pdf indexer not finding the file because it was invoked before the path changed
- The move/rename operation to fail because the indexer blocked the PDF

This was solved by not allowing for any files to be added to the indexer during drag&drop operations.

Fixes #8182.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
