### PR TITLE
Changed encoding used by IntegrityCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Fixed
 
 - We fixed an issue where clicking on headings in the entry preview could lead to an exception [#8292](https://github.com/JabRef/jabref/issues/8292)
+- We fixed an issue where IntegrityCheck used the system's character encoding instead of the one set by the library or in preferences [#8022](https://github.com/JabRef/jabref/issues/8022) 
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
+++ b/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
@@ -40,8 +40,7 @@ public class IntegrityCheckAction extends SimpleCommand {
     public void execute() {
         BibDatabaseContext database = stateManager.getActiveDatabase().orElseThrow(() -> new NullPointerException("Database null"));
         IntegrityCheck check = new IntegrityCheck(database,
-                Globals.prefs.getFilePreferences(),
-                Globals.prefs.getCitationKeyPatternPreferences(),
+                Globals.prefs,
                 Globals.journalAbbreviationRepository,
                 Globals.prefs.getEntryEditorPreferences().shouldAllowIntegerEditionBibtex());
 

--- a/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
+++ b/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
@@ -40,7 +40,9 @@ public class IntegrityCheckAction extends SimpleCommand {
     public void execute() {
         BibDatabaseContext database = stateManager.getActiveDatabase().orElseThrow(() -> new NullPointerException("Database null"));
         IntegrityCheck check = new IntegrityCheck(database,
-                Globals.prefs,
+                Globals.prefs.getFilePreferences(),
+                Globals.prefs.getCitationKeyPatternPreferences(),
+                Globals.prefs.getGeneralPreferences().getDefaultEncoding(),
                 Globals.journalAbbreviationRepository,
                 Globals.prefs.getEntryEditorPreferences().shouldAllowIntegerEditionBibtex());
 

--- a/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.integrity;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +11,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.preferences.FilePreferences;
+import org.jabref.preferences.PreferencesService;
 
 public class IntegrityCheck {
 
@@ -18,11 +20,14 @@ public class IntegrityCheck {
     private final List<EntryChecker> entryCheckers;
 
     public IntegrityCheck(BibDatabaseContext bibDatabaseContext,
-                          FilePreferences filePreferences,
-                          CitationKeyPatternPreferences citationKeyPatternPreferences,
+                          PreferencesService preferencesService,
                           JournalAbbreviationRepository journalAbbreviationRepository,
                           boolean allowIntegerEdition) {
         this.bibDatabaseContext = bibDatabaseContext;
+
+        Charset defaultEncoding = preferencesService.getGeneralPreferences().getDefaultEncoding();
+        FilePreferences filePreferences = preferencesService.getFilePreferences();
+        CitationKeyPatternPreferences citationKeyPatternPreferences = preferencesService.getCitationKeyPatternPreferences();
 
         fieldCheckers = new FieldCheckers(bibDatabaseContext,
                 filePreferences,
@@ -41,8 +46,8 @@ public class IntegrityCheck {
         if (bibDatabaseContext.isBiblatexMode()) {
             entryCheckers.addAll(List.of(
                     new JournalInAbbreviationListChecker(StandardField.JOURNALTITLE, journalAbbreviationRepository),
-                    new UTF8Checker())
-            );
+                    new UTF8Checker(bibDatabaseContext.getMetaData().getEncoding().orElse(defaultEncoding))
+            ));
         } else {
             entryCheckers.addAll(List.of(
                     new JournalInAbbreviationListChecker(StandardField.JOURNAL, journalAbbreviationRepository),

--- a/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
@@ -11,7 +11,6 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.preferences.FilePreferences;
-import org.jabref.preferences.PreferencesService;
 
 public class IntegrityCheck {
 
@@ -20,14 +19,12 @@ public class IntegrityCheck {
     private final List<EntryChecker> entryCheckers;
 
     public IntegrityCheck(BibDatabaseContext bibDatabaseContext,
-                          PreferencesService preferencesService,
+                          FilePreferences filePreferences,
+                          CitationKeyPatternPreferences citationKeyPatternPreferences,
+                          Charset defaultEncoding,
                           JournalAbbreviationRepository journalAbbreviationRepository,
                           boolean allowIntegerEdition) {
         this.bibDatabaseContext = bibDatabaseContext;
-
-        Charset defaultEncoding = preferencesService.getGeneralPreferences().getDefaultEncoding();
-        FilePreferences filePreferences = preferencesService.getFilePreferences();
-        CitationKeyPatternPreferences citationKeyPatternPreferences = preferencesService.getCitationKeyPatternPreferences();
 
         fieldCheckers = new FieldCheckers(bibDatabaseContext,
                 filePreferences,

--- a/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
+++ b/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
@@ -16,12 +16,22 @@ import org.jabref.model.entry.field.Field;
 public class UTF8Checker implements EntryChecker {
     private final Charset charset;
 
+    /**
+     * Creates a UTF8Checker that,
+     * <ol>
+     * <li>decode a String into a bytes array</li>
+     * <li>attempts to decode the bytes array to a character array using the UTF-8 Charset</li>
+     * <ol/>
+     *
+     * @param charset the charset used to decode BibEntry fields
+     */
     public UTF8Checker(Charset charset) {
         this.charset = charset;
     }
 
     /**
      * Detect any non UTF-8 encoded field
+     *
      * @param entry the BibEntry of BibLatex.
      * @return return the warning of UTF-8 check for BibLatex.
      */

--- a/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
+++ b/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
@@ -14,6 +14,11 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 
 public class UTF8Checker implements EntryChecker {
+    private final Charset charset;
+
+    public UTF8Checker(Charset charset) {
+        this.charset = charset;
+    }
 
     /**
      * Detect any non UTF-8 encoded field
@@ -23,7 +28,6 @@ public class UTF8Checker implements EntryChecker {
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
         List<IntegrityMessage> results = new ArrayList<>();
-        Charset charset = Charset.forName(System.getProperty("file.encoding"));
         for (Map.Entry<Field, String> field : entry.getFieldMap().entrySet()) {
             boolean utfOnly = UTF8EncodingChecker(field.getValue().getBytes(charset));
             if (!utfOnly) {

--- a/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
+++ b/src/main/java/org/jabref/logic/integrity/UTF8Checker.java
@@ -21,7 +21,7 @@ public class UTF8Checker implements EntryChecker {
      * <ol>
      * <li>decode a String into a bytes array</li>
      * <li>attempts to decode the bytes array to a character array using the UTF-8 Charset</li>
-     * <ol/>
+     * </ol>
      *
      * @param charset the charset used to decode BibEntry fields
      */

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -26,15 +26,11 @@ import org.jabref.model.entry.types.IEEETranEntryType;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.preferences.FilePreferences;
-import org.jabref.preferences.GeneralPreferences;
-import org.jabref.preferences.PreferencesService;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,24 +45,6 @@ import static org.mockito.Mockito.when;
  * this test has to go to a test belonging to the respective checker. See PersonNamesCheckerTest for an example test.
  */
 class IntegrityCheckTest {
-    private PreferencesService preferenceService;
-
-    @BeforeEach
-    void setUp() {
-        preferenceService = mock(PreferencesService.class);
-
-        GeneralPreferences generalPreferences = mock(GeneralPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(generalPreferences.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
-
-        when(preferenceService.getGeneralPreferences()).thenReturn(generalPreferences);
-
-        FilePreferences filePreferencesMock = mock(FilePreferences.class);
-        when(filePreferencesMock.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
-
-        when(preferenceService.getFilePreferences()).thenReturn(filePreferencesMock);
-
-        when(preferenceService.getCitationKeyPatternPreferences()).thenReturn(createCitationKeyPatternPreferences());
-    }
 
     @Test
     void bibTexAcceptsStandardEntryType() {
@@ -160,7 +138,9 @@ class IntegrityCheckTest {
         BibDatabaseContext context = new BibDatabaseContext(bibDatabase);
 
         new IntegrityCheck(context,
-                preferenceService,
+                mock(FilePreferences.class),
+                createCitationKeyPatternPreferences(),
+                StandardCharsets.UTF_8,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false)
                 .check();
 
@@ -192,15 +172,21 @@ class IntegrityCheckTest {
 
     private void assertWrong(BibDatabaseContext context) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                preferenceService,
+                mock(FilePreferences.class),
+                createCitationKeyPatternPreferences(),
+                StandardCharsets.UTF_8,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false)
                 .check();
         assertNotEquals(Collections.emptyList(), messages);
     }
 
     private void assertCorrect(BibDatabaseContext context) {
+        FilePreferences filePreferencesMock = mock(FilePreferences.class);
+        when(filePreferencesMock.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                preferenceService,
+                filePreferencesMock,
+                createCitationKeyPatternPreferences(),
+                StandardCharsets.UTF_8,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false
         ).check();
         assertEquals(Collections.emptyList(), messages);

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.integrity;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -25,11 +26,15 @@ import org.jabref.model.entry.types.IEEETranEntryType;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.preferences.FilePreferences;
+import org.jabref.preferences.GeneralPreferences;
+import org.jabref.preferences.PreferencesService;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,6 +49,24 @@ import static org.mockito.Mockito.when;
  * this test has to go to a test belonging to the respective checker. See PersonNamesCheckerTest for an example test.
  */
 class IntegrityCheckTest {
+    private PreferencesService preferenceService;
+
+    @BeforeEach
+    void setUp() {
+        preferenceService = mock(PreferencesService.class);
+
+        GeneralPreferences generalPreferences = mock(GeneralPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(generalPreferences.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
+
+        when(preferenceService.getGeneralPreferences()).thenReturn(generalPreferences);
+
+        FilePreferences filePreferencesMock = mock(FilePreferences.class);
+        when(filePreferencesMock.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
+
+        when(preferenceService.getFilePreferences()).thenReturn(filePreferencesMock);
+
+        when(preferenceService.getCitationKeyPatternPreferences()).thenReturn(createCitationKeyPatternPreferences());
+    }
 
     @Test
     void bibTexAcceptsStandardEntryType() {
@@ -137,8 +160,7 @@ class IntegrityCheckTest {
         BibDatabaseContext context = new BibDatabaseContext(bibDatabase);
 
         new IntegrityCheck(context,
-                mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
+                preferenceService,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false)
                 .check();
 
@@ -170,30 +192,17 @@ class IntegrityCheckTest {
 
     private void assertWrong(BibDatabaseContext context) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
+                preferenceService,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false)
                 .check();
         assertNotEquals(Collections.emptyList(), messages);
     }
 
     private void assertCorrect(BibDatabaseContext context) {
-        FilePreferences filePreferencesMock = mock(FilePreferences.class);
-        when(filePreferencesMock.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                filePreferencesMock,
-                createCitationKeyPatternPreferences(),
+                preferenceService,
                 JournalAbbreviationLoader.loadBuiltInRepository(), false
         ).check();
-        assertEquals(Collections.emptyList(), messages);
-    }
-
-    private void assertCorrect(BibDatabaseContext context, boolean allowIntegerEdition) {
-        List<IntegrityMessage> messages = new IntegrityCheck(context,
-                mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
-                JournalAbbreviationLoader.loadBuiltInRepository(),
-                allowIntegerEdition).check();
         assertEquals(Collections.emptyList(), messages);
     }
 

--- a/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.integrity;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +32,7 @@ public class UTF8CheckerTest {
 
     /**
      * fieldDoesNotAcceptUmlauts to check UTF8Checker's result set
-     * when the entry is encoded in Non-Utf-8 charset and the System
+     * when the entry is encoded in Non-Utf-8 charset and the Library
      * environment is Non UTF-8.
      * Finally we need to reset the environment charset.
      * @throws UnsupportedEncodingException initial a String in charset GBK
@@ -39,13 +40,10 @@ public class UTF8CheckerTest {
      */
     @Test
     void fieldDoesNotAcceptUmlauts() throws UnsupportedEncodingException {
-        String defaultCharset = System.getProperty("file.encoding");
-        System.getProperties().put("file.encoding", "GBK");
-        UTF8Checker checker = new UTF8Checker(StandardCharsets.UTF_8);
+        UTF8Checker checker = new UTF8Checker(Charset.forName("GBK"));
         String NonUTF8 = new String("你好，这条语句使用GBK字符集".getBytes(), "GBK");
         entry.setField(StandardField.MONTH, NonUTF8);
         assertEquals(List.of(new IntegrityMessage("Non-UTF-8 encoded field found", entry, StandardField.MONTH)), checker.check(entry));
-        System.getProperties().put("file.encoding", defaultCharset);
     }
 
     /**

--- a/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
@@ -24,7 +24,7 @@ public class UTF8CheckerTest {
      */
     @Test
     void fieldAcceptsUTF8() {
-        UTF8Checker checker = new UTF8Checker();
+        UTF8Checker checker = new UTF8Checker(StandardCharsets.UTF_8);
         entry.setField(StandardField.TITLE, "Only ascii characters!'@12");
         assertEquals(Collections.emptyList(), checker.check(entry));
     }
@@ -41,7 +41,7 @@ public class UTF8CheckerTest {
     void fieldDoesNotAcceptUmlauts() throws UnsupportedEncodingException {
         String defaultCharset = System.getProperty("file.encoding");
         System.getProperties().put("file.encoding", "GBK");
-        UTF8Checker checker = new UTF8Checker();
+        UTF8Checker checker = new UTF8Checker(StandardCharsets.UTF_8);
         String NonUTF8 = new String("你好，这条语句使用GBK字符集".getBytes(), "GBK");
         entry.setField(StandardField.MONTH, NonUTF8);
         assertEquals(List.of(new IntegrityMessage("Non-UTF-8 encoded field found", entry, StandardField.MONTH)), checker.check(entry));


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #8022.

Previous method used `System.getProperty("file.encoding")` to get the current character encoding).
Changed to use,

1. `bibDatabaseContext.getMetaData().getEncoding()`
2. `preferencesService.getGeneralPreferences().getDefaultEncoding()`

**Todo**:

1. ~I don't think it can distinguish GBK from UTF-8~

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] ~Tests created for changes (if applicable)~
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

Refs issue https://github.com/JabRef/jabref/issues/5850 and PR https://github.com/JabRef/jabref/pull/7639
