### PR TITLE
Fix lucence segment error by checking for existing index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where the fulltext search on an empty library with no documents would lead to an exception [koppor#522](https://github.com/koppor/jabref/issues/522)
 - We fixed an issue where clicking on "Accept changes" in the merge dialog would lead to an exception [forum#2418](https://discourse.jabref.org/t/the-library-has-been-modified-by-another-program/2418/8)
 - We fixed an issue where clicking on headings in the entry preview could lead to an exception. [#8292](https://github.com/JabRef/jabref/issues/8292)
 - We fixed an issue where IntegrityCheck used the system's character encoding instead of the one set by the library or in preferences [#8022](https://github.com/JabRef/jabref/issues/8022)

--- a/src/main/java/org/jabref/logic/pdf/search/retrieval/PdfSearcher.java
+++ b/src/main/java/org/jabref/logic/pdf/search/retrieval/PdfSearcher.java
@@ -65,7 +65,6 @@ public final class PdfSearcher {
         }
 
         try (IndexReader reader = DirectoryReader.open(indexDirectory)) {
-
             IndexSearcher searcher = new IndexSearcher(reader);
             Query query = new MultiFieldQueryParser(PDF_FIELDS, new EnglishStemAnalyzer()).parse(searchString);
             TopDocs results = searcher.search(query, maxHits);
@@ -73,9 +72,8 @@ public final class PdfSearcher {
                 resultDocs.add(new SearchResult(searcher, query, scoreDoc));
             }
             return new PdfSearchResults(resultDocs);
-
         } catch (ParseException e) {
-            LOGGER.warn("Could not parse query: '" + searchString + "'! \n" + e.getMessage());
+            LOGGER.warn("Could not parse query: '{}'!\n{}", searchString, e.getMessage());
             return new PdfSearchResults();
         }
     }


### PR DESCRIPTION
fix some potential resource leaks

Fixes https://github.com/koppor/jabref/issues/522

I also tested the jpackage binaries

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
