### PR TITLE
Fix plural s in library properties tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where clicking on headings in the entry preview could lead to an exception. [#8292](https://github.com/JabRef/jabref/issues/8292)
 - We fixed an issue where IntegrityCheck used the system's character encoding instead of the one set by the library or in preferences [#8022](https://github.com/JabRef/jabref/issues/8022)
 - We fixed an issue about empty metadata in library properties when called from the right click menu. [#8358](https://github.com/JabRef/jabref/issues/8358)
+- We fixed a typo in the library properties tab: "String constants". There, one can configure [BibTeX string constants](https://docs.jabref.org/advanced/strings).
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
@@ -44,7 +44,7 @@ public class ConstantsPropertiesView extends AbstractPropertiesTabView<Constants
 
     @Override
     public String getTabName() {
-        return Localization.lang("Strings constants");
+        return Localization.lang("String constants");
     }
 
     public void initialize() {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -821,7 +821,6 @@ Special\ name\ formatters=Special name formatters
 Statically\ group\ entries\ by\ manual\ assignment=Statically group entries by manual assignment
 
 Status=Status
-Strings\ constants=Strings constants
 
 Sublibrary\ from\ AUX\ to\ BibTeX=Sublibrary from AUX to BibTeX
 


### PR DESCRIPTION
Before:

![grafik](https://user-images.githubusercontent.com/1366654/148677019-ab7d8636-e1a9-4704-9582-fa02f58e573a.png)

After:

![grafik](https://user-images.githubusercontent.com/1366654/148676964-8cb95475-10f6-4d1e-be67-1e659c2102af.png)


- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
