### PR TITLE
Observable Preferences K (Integration of wild preferences)

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -364,7 +364,6 @@ public class JabRefFrame extends BorderPane {
             }
         }
 
-        fileHistory.storeHistory();
         prefs.flush();
     }
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -350,7 +350,7 @@ public class JabRefFrame extends BorderPane {
      * set to true
      */
     private void tearDownJabRef(List<String> filenames) {
-        if (prefs.getGuiPreferences().shouldOpenLastEdited()) {
+        if (prefs.getImportExportPreferences().shouldOpenLastEdited()) {
             // Here we store the names of all current files. If there is no current file, we remove any
             // previously stored filename.
             if (filenames.isEmpty()) {
@@ -1113,10 +1113,10 @@ public class JabRefFrame extends BorderPane {
     }
 
     private boolean readyForAutosave(BibDatabaseContext context) {
-        return ((context.getLocation() == DatabaseLocation.SHARED) ||
-                ((context.getLocation() == DatabaseLocation.LOCAL) && prefs.shouldAutosave()))
-                &&
-                context.getDatabasePath().isPresent();
+        return ((context.getLocation() == DatabaseLocation.SHARED)
+                || ((context.getLocation() == DatabaseLocation.LOCAL)
+                && prefs.getImportExportPreferences().shouldAutoSave()))
+                && context.getDatabasePath().isPresent();
     }
 
     /**

--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -128,7 +128,7 @@ public class JabRefGUI {
 
     private void openDatabases() {
         // If the option is enabled, open the last edited libraries, if any.
-        if (!isBlank && preferencesService.getGuiPreferences().shouldOpenLastEdited()) {
+        if (!isBlank && preferencesService.getImportExportPreferences().shouldOpenLastEdited()) {
             openLastEditedDatabases();
         }
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -261,10 +261,10 @@ public class LibraryTab extends Tab {
     }
 
     private boolean isDatabaseReadyForAutoSave(BibDatabaseContext context) {
-        return ((context.getLocation() == DatabaseLocation.SHARED) ||
-                ((context.getLocation() == DatabaseLocation.LOCAL) && preferencesService.shouldAutosave()))
-                &&
-                context.getDatabasePath().isPresent();
+        return ((context.getLocation() == DatabaseLocation.SHARED)
+                || ((context.getLocation() == DatabaseLocation.LOCAL)
+                && preferencesService.getImportExportPreferences().shouldAutoSave()))
+                && context.getDatabasePath().isPresent();
     }
 
     /**
@@ -275,7 +275,7 @@ public class LibraryTab extends Tab {
      * Example: *jabref-authors.bib – testbib
      */
     public void updateTabTitle(boolean isChanged) {
-        boolean isAutosaveEnabled = preferencesService.shouldAutosave();
+        boolean isAutosaveEnabled = preferencesService.getImportExportPreferences().shouldAutoSave();
 
         DatabaseLocation databaseLocation = bibDatabaseContext.getLocation();
         Optional<Path> file = bibDatabaseContext.getDatabasePath();

--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -283,11 +283,10 @@ public class SaveDatabaseAction {
     }
 
     private boolean readyForAutosave(BibDatabaseContext context) {
-        return ((context.getLocation() == DatabaseLocation.SHARED) ||
-                ((context.getLocation() == DatabaseLocation.LOCAL)
-                        && preferences.shouldAutosave()))
-                &&
-                context.getDatabasePath().isPresent();
+        return ((context.getLocation() == DatabaseLocation.SHARED)
+                || ((context.getLocation() == DatabaseLocation.LOCAL)
+                && preferences.getImportExportPreferences().shouldAutoSave()))
+                && context.getDatabasePath().isPresent();
     }
 
     private boolean readyForBackup(BibDatabaseContext context) {

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -112,7 +112,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean shouldDownloadFiles) {
         // Check if we are supposed to warn about duplicates.
         // If so, then see if there are duplicates, and warn if yes.
-        if (preferences.shouldWarnAboutDuplicatesForImport()) {
+        if (preferences.getImportExportPreferences().shouldWarnAboutDuplicatesOnImport()) {
             BackgroundTask.wrap(() -> entriesToImport.stream()
                                                      .anyMatch(this::hasDuplicate)).onSuccess(duplicateFound -> {
                 if (duplicateFound) {
@@ -121,7 +121,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                             Localization.lang("Continue with import"),
                             Localization.lang("Cancel import"),
                             Localization.lang("Do not ask again"),
-                            optOut -> preferences.setShouldWarnAboutDuplicatesForImport(!optOut));
+                            optOut -> preferences.getImportExportPreferences().setWarnAboutDuplicatesOnImport(!optOut));
 
                     if (!continueImport) {
                         dialogService.notify(Localization.lang("Import canceled"));

--- a/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/menus/FileHistoryMenu.java
@@ -26,7 +26,7 @@ public class FileHistoryMenu extends Menu {
         this.preferences = preferences;
         this.dialogService = dialogService;
         this.openDatabaseAction = openDatabaseAction;
-        history = preferences.getFileHistory();
+        history = preferences.getGuiPreferences().getFileHistory();
         if (history.isEmpty()) {
             setDisable(true);
         } else {
@@ -80,10 +80,6 @@ public class FileHistoryMenu extends Menu {
         item.setMnemonicParsing(false);
         item.setOnAction(event -> openFile(file));
         getItems().add(item);
-    }
-
-    public void storeHistory() {
-        preferences.storeFileHistory(history);
     }
 
     public void openFile(Path file) {

--- a/src/main/java/org/jabref/gui/mergeentries/DiffHighlightingEllipsingTextFlow.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffHighlightingEllipsingTextFlow.java
@@ -21,15 +21,15 @@ public class DiffHighlightingEllipsingTextFlow extends TextFlow {
     private final static String DEFAULT_ELLIPSIS_STRING = "...";
     private StringProperty ellipsisString;
 
-    private ObservableList<Node> allChildren = FXCollections.observableArrayList();
-    private ChangeListener sizeChangeListener = (observableValue, number, t1) -> adjustText();
-    private ListChangeListener<Node> listChangeListener = this::adjustChildren;
+    private final ObservableList<Node> allChildren = FXCollections.observableArrayList();
+    private final ChangeListener<Number> sizeChangeListener = (observableValue, number, t1) -> adjustText();
+    private final ListChangeListener<Node> listChangeListener = this::adjustChildren;
 
     private final String fullText;
     private final EasyObservableValue<String> comparisonString;
-    private final ObjectProperty<MergeEntries.DiffMode> diffMode;
+    private final ObjectProperty<DiffMode> diffMode;
 
-    public DiffHighlightingEllipsingTextFlow(String fullText, EasyObservableValue<String> comparisonString, ObjectProperty<MergeEntries.DiffMode> diffMode) {
+    public DiffHighlightingEllipsingTextFlow(String fullText, EasyObservableValue<String> comparisonString, ObjectProperty<DiffMode> diffMode) {
         this.fullText = fullText;
         allChildren.addListener(listChangeListener);
         widthProperty().addListener(sizeChangeListener);

--- a/src/main/java/org/jabref/gui/mergeentries/DiffMode.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffMode.java
@@ -1,0 +1,30 @@
+package org.jabref.gui.mergeentries;
+
+import org.jabref.logic.l10n.Localization;
+
+public enum DiffMode {
+
+    PLAIN(Localization.lang("None")),
+    WORD(Localization.lang("Word by word")),
+    CHARACTER(Localization.lang("Character by character")),
+    WORD_SYMMETRIC(Localization.lang("Symmetric word by word")),
+    CHARACTER_SYMMETRIC(Localization.lang("Symmetric character by character"));
+
+    private final String text;
+
+    DiffMode(String text) {
+        this.text = text;
+    }
+
+    public static DiffMode parse(String name) {
+        try {
+            return DiffMode.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return WORD; // default
+        }
+    }
+
+    public String getDisplayText() {
+        return text;
+    }
+}

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
@@ -129,20 +129,13 @@ public class MergeEntries extends BorderPane {
     }
 
     private static String getDisplayText(DiffMode mode) {
-        switch (mode) {
-            case PLAIN:
-                return Localization.lang("Plain text");
-            case WORD:
-                return Localization.lang("Show diff") + " - " + Localization.lang("word");
-            case CHARACTER:
-                return Localization.lang("Show diff") + " - " + Localization.lang("character");
-            case WORD_SYMMETRIC:
-                return Localization.lang("Show symmetric diff") + " - " + Localization.lang("word");
-            case CHARACTER_SYMMETRIC:
-                return Localization.lang("Show symmetric diff") + " - " + Localization.lang("character");
-            default:
-                throw new UnsupportedOperationException("Not implemented: " + mode);
-        }
+        return switch (mode) {
+            case PLAIN -> Localization.lang("Plain text");
+            case WORD -> Localization.lang("Show diff") + " - " + Localization.lang("word");
+            case CHARACTER -> Localization.lang("Show diff") + " - " + Localization.lang("character");
+            case WORD_SYMMETRIC -> Localization.lang("Show symmetric diff") + " - " + Localization.lang("word");
+            case CHARACTER_SYMMETRIC -> Localization.lang("Show symmetric diff") + " - " + Localization.lang("character");
+        };
     }
 
     /**
@@ -223,7 +216,7 @@ public class MergeEntries extends BorderPane {
                 if (leftString.isPresent()) {
                     leftRadioButtons.add(list.get(LEFT_RADIOBUTTON_INDEX));
                     list.get(LEFT_RADIOBUTTON_INDEX).setSelected(true);
-                    if (!rightString.isPresent()) {
+                    if (rightString.isEmpty()) {
                         list.get(RIGHT_RADIOBUTTON_INDEX).setDisable(true);
                     } else if (this.defaultRadioButtonSelectionMode == DefaultRadioButtonSelectionMode.RIGHT) {
                         list.get(RIGHT_RADIOBUTTON_INDEX).setSelected(true);
@@ -308,13 +301,11 @@ public class MergeEntries extends BorderPane {
         new ViewModelListCellFactory<DiffMode>()
                 .withText(MergeEntries::getDisplayText)
                 .install(diffMode);
-        DiffMode diffModePref = Globals.prefs.getMergeDiffMode()
-                                             .flatMap(DiffMode::parse)
-                                             .orElse(DiffMode.WORD);
+        DiffMode diffModePref = Globals.prefs.getGuiPreferences().getMergeDiffMode();
         diffMode.setValue(diffModePref);
         EasyBind.subscribe(this.diffMode.valueProperty(), mode -> {
             updateFieldValues(differentFields);
-            Globals.prefs.storeMergeDiffMode(mode.name());
+            Globals.prefs.getGuiPreferences().setMergeDiffMode(mode);
         });
 
         HBox heading = new HBox(10);
@@ -421,33 +412,6 @@ public class MergeEntries extends BorderPane {
     public void setRightHeaderText(String rightHeaderText) {
         columnHeadings.set(5, rightHeaderText);
         initialize();
-    }
-
-    public enum DiffMode {
-
-        PLAIN(Localization.lang("None")),
-        WORD(Localization.lang("Word by word")),
-        CHARACTER(Localization.lang("Character by character")),
-        WORD_SYMMETRIC(Localization.lang("Symmetric word by word")),
-        CHARACTER_SYMMETRIC(Localization.lang("Symmetric character by character"));
-
-        private final String text;
-
-        DiffMode(String text) {
-            this.text = text;
-        }
-
-        public static Optional<DiffMode> parse(String name) {
-            try {
-                return Optional.of(DiffMode.valueOf(name));
-            } catch (IllegalArgumentException e) {
-                return Optional.empty();
-            }
-        }
-
-        public String getDisplayText() {
-            return text;
-        }
     }
 
     public enum DefaultRadioButtonSelectionMode {

--- a/src/main/java/org/jabref/gui/preferences/file/FileTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTab.fxml
@@ -8,7 +8,6 @@
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.file.FileTab">
@@ -43,4 +42,5 @@
     </HBox>
 
     <CheckBox fx:id="alwaysReformatBib" text="%Always reformat BIB file on save and export"/>
+    <CheckBox fx:id="warnAboutDuplicatesOnImport" text="%Warn about duplicates on import"/>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/file/FileTab.java
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTab.java
@@ -25,6 +25,7 @@ public class FileTab extends AbstractPreferenceTabView<FileTabViewModel> impleme
     @FXML private RadioButton resolveStrings;
     @FXML private TextField resolveStringsForFields;
     @FXML private CheckBox alwaysReformatBib;
+    @FXML private CheckBox warnAboutDuplicatesOnImport;
 
     @FXML private CheckBox autosaveLocalLibraries;
     @FXML private Button autosaveLocalLibrariesHelp;
@@ -47,6 +48,7 @@ public class FileTab extends AbstractPreferenceTabView<FileTabViewModel> impleme
         resolveStringsForFields.disableProperty().bind(doNotResolveStrings.selectedProperty());
 
         alwaysReformatBib.selectedProperty().bindBidirectional(viewModel.alwaysReformatBibProperty());
+        warnAboutDuplicatesOnImport.selectedProperty().bindBidirectional(viewModel.warnAboutDuplicatesOnImportProperty());
         autosaveLocalLibraries.selectedProperty().bindBidirectional(viewModel.autosaveLocalLibrariesProperty());
 
         ActionFactory actionFactory = new ActionFactory(Globals.getKeyPrefs());

--- a/src/main/java/org/jabref/gui/preferences/file/FileTab.java
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTab.java
@@ -36,7 +36,8 @@ public class FileTab extends AbstractPreferenceTabView<FileTabViewModel> impleme
     }
 
     public void initialize() {
-        this.viewModel = new FileTabViewModel(preferencesService);
+        this.viewModel = new FileTabViewModel(preferencesService.getImportExportPreferences());
+
         openLastStartup.selectedProperty().bindBidirectional(viewModel.openLastStartupProperty());
         noWrapFiles.textProperty().bindBidirectional(viewModel.noWrapFilesProperty());
         resolveStringsBibTex.selectedProperty().bindBidirectional(viewModel.resolveStringsBibTexProperty());

--- a/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
@@ -16,6 +16,7 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty resolveStringsProperty = new SimpleBooleanProperty();
     private final StringProperty resolveStringsForFieldsProperty = new SimpleStringProperty("");
     private final BooleanProperty alwaysReformatBibProperty = new SimpleBooleanProperty();
+    private final BooleanProperty warnAboutDuplicatesOnImportProperty = new SimpleBooleanProperty();
     private final BooleanProperty autosaveLocalLibraries = new SimpleBooleanProperty();
 
     private final ImportExportPreferences importExportPreferences;
@@ -33,6 +34,7 @@ public class FileTabViewModel implements PreferenceTabViewModel {
         resolveStringsProperty.setValue(importExportPreferences.resolveStrings());
         resolveStringsForFieldsProperty.setValue(importExportPreferences.getResolvableFields());
         alwaysReformatBibProperty.setValue(importExportPreferences.shouldAlwaysReformatOnSave());
+        warnAboutDuplicatesOnImportProperty.setValue(importExportPreferences.shouldWarnAboutDuplicatesOnImport());
         autosaveLocalLibraries.setValue(importExportPreferences.shouldAutoSave());
     }
 
@@ -43,6 +45,7 @@ public class FileTabViewModel implements PreferenceTabViewModel {
         importExportPreferences.setNonWrappableFields(noWrapFilesProperty.getValue().trim());
         importExportPreferences.setResolvableFields(resolveStringsForFieldsProperty.getValue().trim());
         importExportPreferences.setAlwaysReformatOnSave(alwaysReformatBibProperty.getValue());
+        importExportPreferences.setWarnAboutDuplicatesOnImport(warnAboutDuplicatesOnImportProperty.getValue());
         importExportPreferences.setAutoSave(autosaveLocalLibraries.getValue());
     }
 
@@ -73,6 +76,8 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     public BooleanProperty alwaysReformatBibProperty() {
         return alwaysReformatBibProperty;
     }
+
+    public BooleanProperty warnAboutDuplicatesOnImportProperty() { return warnAboutDuplicatesOnImportProperty; }
 
     // Autosave
     public BooleanProperty autosaveLocalLibrariesProperty() {

--- a/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
@@ -7,7 +7,6 @@ import javafx.beans.property.StringProperty;
 
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.preferences.ImportExportPreferences;
-import org.jabref.preferences.PreferencesService;
 
 public class FileTabViewModel implements PreferenceTabViewModel {
 
@@ -19,39 +18,32 @@ public class FileTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty alwaysReformatBibProperty = new SimpleBooleanProperty();
     private final BooleanProperty autosaveLocalLibraries = new SimpleBooleanProperty();
 
-    private final PreferencesService preferences;
     private final ImportExportPreferences importExportPreferences;
 
-    FileTabViewModel(PreferencesService preferences) {
-        this.preferences = preferences;
-        this.importExportPreferences = preferences.getImportExportPreferences();
+    FileTabViewModel(ImportExportPreferences importExportPreferences) {
+        this.importExportPreferences = importExportPreferences;
     }
 
     @Override
     public void setValues() {
-        openLastStartupProperty.setValue(preferences.shouldOpenLastFilesOnStartup());
-
+        openLastStartupProperty.setValue(importExportPreferences.shouldOpenLastEdited());
         noWrapFilesProperty.setValue(importExportPreferences.getNonWrappableFields());
         resolveStringsAllProperty.setValue(importExportPreferences.shouldResolveStringsForAllStrings()); // Flipped around
         resolveStringsBibTexProperty.setValue(importExportPreferences.shouldResolveStringsForStandardBibtexFields());
         resolveStringsExceptProperty.setValue(importExportPreferences.getNonResolvableFields());
-
         alwaysReformatBibProperty.setValue(importExportPreferences.shouldAlwaysReformatOnSave());
-
-        autosaveLocalLibraries.setValue(preferences.shouldAutosave());
+        autosaveLocalLibraries.setValue(importExportPreferences.shouldAutoSave());
     }
 
     @Override
     public void storeSettings() {
-        preferences.storeOpenLastFilesOnStartup(openLastStartupProperty.getValue());
-
+        importExportPreferences.setOpenLastEdited(openLastStartupProperty.getValue());
         importExportPreferences.setNonWrappableFields(noWrapFilesProperty.getValue().trim());
         importExportPreferences.setResolveStringsForStandardBibtexFields(resolveStringsBibTexProperty.getValue());
         importExportPreferences.setResolveStringsForAllStrings(resolveStringsAllProperty.getValue());
         importExportPreferences.setNonResolvableFields(resolveStringsExceptProperty.getValue().trim());
         importExportPreferences.setAlwaysReformatOnSave(alwaysReformatBibProperty.getValue());
-
-        preferences.storeShouldAutosave(autosaveLocalLibraries.getValue());
+        importExportPreferences.setAutoSave(autosaveLocalLibraries.getValue());
     }
 
     // General

--- a/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/file/FileTabViewModel.java
@@ -77,7 +77,9 @@ public class FileTabViewModel implements PreferenceTabViewModel {
         return alwaysReformatBibProperty;
     }
 
-    public BooleanProperty warnAboutDuplicatesOnImportProperty() { return warnAboutDuplicatesOnImportProperty; }
+    public BooleanProperty warnAboutDuplicatesOnImportProperty() {
+        return warnAboutDuplicatesOnImportProperty;
+    }
 
     // Autosave
     public BooleanProperty autosaveLocalLibrariesProperty() {

--- a/src/main/java/org/jabref/logic/util/io/FileHistory.java
+++ b/src/main/java/org/jabref/logic/util/io/FileHistory.java
@@ -1,19 +1,20 @@
 package org.jabref.logic.util.io;
 
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 public class FileHistory {
 
     private static final int HISTORY_SIZE = 8;
 
-    private final LinkedList<Path> history;
+    private final ObservableList<Path> history;
 
     public FileHistory(List<Path> files) {
-        history = new LinkedList<>(Objects.requireNonNull(files));
+        history = FXCollections.observableList(Objects.requireNonNull(files));
     }
 
     public int size() {
@@ -29,9 +30,9 @@ public class FileHistory {
      */
     public void newFile(Path file) {
         removeItem(file);
-        history.addFirst(file);
+        history.add(0, file);
         while (size() > HISTORY_SIZE) {
-            history.removeLast();
+            history.remove(HISTORY_SIZE);
         }
     }
 
@@ -43,7 +44,7 @@ public class FileHistory {
         history.remove(file);
     }
 
-    public List<Path> getHistory() {
-        return Collections.unmodifiableList(history);
+    public ObservableList<Path> getHistory() {
+        return FXCollections.unmodifiableObservableList(history);
     }
 }

--- a/src/main/java/org/jabref/logic/util/io/FileHistory.java
+++ b/src/main/java/org/jabref/logic/util/io/FileHistory.java
@@ -45,6 +45,6 @@ public class FileHistory {
     }
 
     public ObservableList<Path> getHistory() {
-        return FXCollections.unmodifiableObservableList(history);
+        return history;
     }
 }

--- a/src/main/java/org/jabref/preferences/GuiPreferences.java
+++ b/src/main/java/org/jabref/preferences/GuiPreferences.java
@@ -20,7 +20,6 @@ public class GuiPreferences {
 
     private final BooleanProperty windowMaximised;
 
-    private final BooleanProperty shouldOpenLastEdited;
     private final ObservableList<String> lastFilesOpened;
     private final ObjectProperty<Path> lastFocusedFile;
     private final DoubleProperty sidePaneWidth;
@@ -30,15 +29,14 @@ public class GuiPreferences {
                           double sizeX,
                           double sizeY,
                           boolean windowMaximised,
-                          boolean shouldOpenLastEdited,
                           List<String> lastFilesOpened,
-                          Path lastFocusedFile, double sidePaneWidth) {
+                          Path lastFocusedFile,
+                          double sidePaneWidth) {
         this.positionX = new SimpleDoubleProperty(positionX);
         this.positionY = new SimpleDoubleProperty(positionY);
         this.sizeX = new SimpleDoubleProperty(sizeX);
         this.sizeY = new SimpleDoubleProperty(sizeY);
         this.windowMaximised = new SimpleBooleanProperty(windowMaximised);
-        this.shouldOpenLastEdited = new SimpleBooleanProperty(shouldOpenLastEdited);
         this.lastFilesOpened = FXCollections.observableArrayList(lastFilesOpened);
         this.lastFocusedFile = new SimpleObjectProperty<>(lastFocusedFile);
         this.sidePaneWidth = new SimpleDoubleProperty(sidePaneWidth);
@@ -102,18 +100,6 @@ public class GuiPreferences {
 
     public void setWindowMaximised(boolean windowMaximised) {
         this.windowMaximised.set(windowMaximised);
-    }
-
-    public boolean shouldOpenLastEdited() {
-        return shouldOpenLastEdited.get();
-    }
-
-    public BooleanProperty openLastEditedProperty() {
-        return shouldOpenLastEdited;
-    }
-
-    public void setOpenLastEdited(boolean shouldOpenLastEdited) {
-        this.shouldOpenLastEdited.set(shouldOpenLastEdited);
     }
 
     public ObservableList<String> getLastFilesOpened() {

--- a/src/main/java/org/jabref/preferences/GuiPreferences.java
+++ b/src/main/java/org/jabref/preferences/GuiPreferences.java
@@ -14,6 +14,7 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import org.jabref.gui.mergeentries.DiffMode;
 import org.jabref.logic.util.io.FileHistory;
 
 public class GuiPreferences {
@@ -30,6 +31,8 @@ public class GuiPreferences {
 
     private final StringProperty lastSelectedIdBasedFetcher;
 
+    private final ObjectProperty<DiffMode> mergeDiffMode;
+
     private final DoubleProperty sidePaneWidth;
 
     public GuiPreferences(double positionX,
@@ -41,6 +44,7 @@ public class GuiPreferences {
                           Path lastFocusedFile,
                           FileHistory fileHistory,
                           String lastSelectedIdBasedFetcher,
+                          DiffMode mergeDiffMode,
                           double sidePaneWidth) {
         this.positionX = new SimpleDoubleProperty(positionX);
         this.positionY = new SimpleDoubleProperty(positionY);
@@ -50,6 +54,7 @@ public class GuiPreferences {
         this.lastFilesOpened = FXCollections.observableArrayList(lastFilesOpened);
         this.lastFocusedFile = new SimpleObjectProperty<>(lastFocusedFile);
         this.lastSelectedIdBasedFetcher = new SimpleStringProperty(lastSelectedIdBasedFetcher);
+        this.mergeDiffMode = new SimpleObjectProperty<>(mergeDiffMode);
         this.sidePaneWidth = new SimpleDoubleProperty(sidePaneWidth);
         this.fileHistory = fileHistory;
     }
@@ -134,18 +139,6 @@ public class GuiPreferences {
         this.lastFocusedFile.set(lastFocusedFile);
     }
 
-    public double getSidePaneWidth() {
-        return sidePaneWidth.get();
-    }
-
-    public DoubleProperty sidePaneWidthProperty() {
-        return sidePaneWidth;
-    }
-
-    public void setSidePaneWidth(double sidePaneWidth) {
-        this.sidePaneWidth.set(sidePaneWidth);
-    }
-
     public FileHistory getFileHistory() {
         return fileHistory;
     }
@@ -160,5 +153,29 @@ public class GuiPreferences {
 
     public void setLastSelectedIdBasedFetcher(String lastSelectedIdBasedFetcher) {
         this.lastSelectedIdBasedFetcher.set(lastSelectedIdBasedFetcher);
+    }
+
+    public DiffMode getMergeDiffMode() {
+        return mergeDiffMode.get();
+    }
+
+    public ObjectProperty<DiffMode> mergeDiffModeProperty() {
+        return mergeDiffMode;
+    }
+
+    public void setMergeDiffMode(DiffMode mergeDiffMode) {
+        this.mergeDiffMode.set(mergeDiffMode);
+    }
+
+    public double getSidePaneWidth() {
+        return sidePaneWidth.get();
+    }
+
+    public DoubleProperty sidePaneWidthProperty() {
+        return sidePaneWidth;
+    }
+
+    public void setSidePaneWidth(double sidePaneWidth) {
+        this.sidePaneWidth.set(sidePaneWidth);
     }
 }

--- a/src/main/java/org/jabref/preferences/GuiPreferences.java
+++ b/src/main/java/org/jabref/preferences/GuiPreferences.java
@@ -12,6 +12,8 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import org.jabref.logic.util.io.FileHistory;
+
 public class GuiPreferences {
     private final DoubleProperty positionX;
     private final DoubleProperty positionY;
@@ -22,6 +24,8 @@ public class GuiPreferences {
 
     private final ObservableList<String> lastFilesOpened;
     private final ObjectProperty<Path> lastFocusedFile;
+    private final FileHistory fileHistory;
+
     private final DoubleProperty sidePaneWidth;
 
     public GuiPreferences(double positionX,
@@ -31,6 +35,7 @@ public class GuiPreferences {
                           boolean windowMaximised,
                           List<String> lastFilesOpened,
                           Path lastFocusedFile,
+                          FileHistory fileHistory,
                           double sidePaneWidth) {
         this.positionX = new SimpleDoubleProperty(positionX);
         this.positionY = new SimpleDoubleProperty(positionY);
@@ -40,6 +45,7 @@ public class GuiPreferences {
         this.lastFilesOpened = FXCollections.observableArrayList(lastFilesOpened);
         this.lastFocusedFile = new SimpleObjectProperty<>(lastFocusedFile);
         this.sidePaneWidth = new SimpleDoubleProperty(sidePaneWidth);
+        this.fileHistory = fileHistory;
     }
 
     public double getPositionX() {
@@ -132,5 +138,9 @@ public class GuiPreferences {
 
     public void setSidePaneWidth(double sidePaneWidth) {
         this.sidePaneWidth.set(sidePaneWidth);
+    }
+
+    public FileHistory getFileHistory() {
+        return fileHistory;
     }
 }

--- a/src/main/java/org/jabref/preferences/GuiPreferences.java
+++ b/src/main/java/org/jabref/preferences/GuiPreferences.java
@@ -9,6 +9,8 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -26,6 +28,8 @@ public class GuiPreferences {
     private final ObjectProperty<Path> lastFocusedFile;
     private final FileHistory fileHistory;
 
+    private final StringProperty lastSelectedIdBasedFetcher;
+
     private final DoubleProperty sidePaneWidth;
 
     public GuiPreferences(double positionX,
@@ -36,6 +40,7 @@ public class GuiPreferences {
                           List<String> lastFilesOpened,
                           Path lastFocusedFile,
                           FileHistory fileHistory,
+                          String lastSelectedIdBasedFetcher,
                           double sidePaneWidth) {
         this.positionX = new SimpleDoubleProperty(positionX);
         this.positionY = new SimpleDoubleProperty(positionY);
@@ -44,6 +49,7 @@ public class GuiPreferences {
         this.windowMaximised = new SimpleBooleanProperty(windowMaximised);
         this.lastFilesOpened = FXCollections.observableArrayList(lastFilesOpened);
         this.lastFocusedFile = new SimpleObjectProperty<>(lastFocusedFile);
+        this.lastSelectedIdBasedFetcher = new SimpleStringProperty(lastSelectedIdBasedFetcher);
         this.sidePaneWidth = new SimpleDoubleProperty(sidePaneWidth);
         this.fileHistory = fileHistory;
     }
@@ -142,5 +148,17 @@ public class GuiPreferences {
 
     public FileHistory getFileHistory() {
         return fileHistory;
+    }
+
+    public String getLastSelectedIdBasedFetcher() {
+        return lastSelectedIdBasedFetcher.get();
+    }
+
+    public StringProperty lastSelectedIdBasedFetcherProperty() {
+        return lastSelectedIdBasedFetcher;
+    }
+
+    public void setLastSelectedIdBasedFetcher(String lastSelectedIdBasedFetcher) {
+        this.lastSelectedIdBasedFetcher.set(lastSelectedIdBasedFetcher);
     }
 }

--- a/src/main/java/org/jabref/preferences/ImportExportPreferences.java
+++ b/src/main/java/org/jabref/preferences/ImportExportPreferences.java
@@ -19,6 +19,7 @@ public class ImportExportPreferences {
     private final StringProperty lastExportExtension;
     private final ObjectProperty<Path> exportWorkingDirectory;
     private final BooleanProperty autoSave;
+    private final BooleanProperty warnAboutDuplicatesOnImport;
 
     public ImportExportPreferences(boolean shouldOpenLastEdited,
                                    String nonWrappableFields,
@@ -28,7 +29,8 @@ public class ImportExportPreferences {
                                    Path importWorkingDirectory,
                                    String lastExportExtension,
                                    Path exportWorkingDirectory,
-                                   boolean autoSave) {
+                                   boolean autoSave,
+                                   boolean warnAboutDuplicatesOnImport) {
         this.shouldOpenLastEdited = new SimpleBooleanProperty(shouldOpenLastEdited);
         this.nonWrappableFields = new SimpleStringProperty(nonWrappableFields);
         this.resolveStrings = new SimpleBooleanProperty(resolveStrings);
@@ -38,6 +40,7 @@ public class ImportExportPreferences {
         this.lastExportExtension = new SimpleStringProperty(lastExportExtension);
         this.exportWorkingDirectory = new SimpleObjectProperty<>(exportWorkingDirectory);
         this.autoSave = new SimpleBooleanProperty(autoSave);
+        this.warnAboutDuplicatesOnImport = new SimpleBooleanProperty(warnAboutDuplicatesOnImport);
     }
 
     public boolean shouldOpenLastEdited() {
@@ -146,5 +149,17 @@ public class ImportExportPreferences {
 
     public void setAutoSave(boolean shouldAutoSave) {
         this.autoSave.set(shouldAutoSave);
+    }
+
+    public boolean shouldWarnAboutDuplicatesOnImport() {
+        return warnAboutDuplicatesOnImport.get();
+    }
+
+    public BooleanProperty warnAboutDuplicatesOnImportProperty() {
+        return warnAboutDuplicatesOnImport;
+    }
+
+    public void setWarnAboutDuplicatesOnImport(boolean warnAboutDuplicatesOnImport) {
+        this.warnAboutDuplicatesOnImport.set(warnAboutDuplicatesOnImport);
     }
 }

--- a/src/main/java/org/jabref/preferences/ImportExportPreferences.java
+++ b/src/main/java/org/jabref/preferences/ImportExportPreferences.java
@@ -10,6 +10,7 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
 public class ImportExportPreferences {
+    private final BooleanProperty shouldOpenLastEdited;
     private final StringProperty nonWrappableFields;
     private final BooleanProperty resolveStringsForStandardBibtexFields;
     private final BooleanProperty resolveStringsForAllStrings;
@@ -18,15 +19,19 @@ public class ImportExportPreferences {
     private final ObjectProperty<Path> importWorkingDirectory;
     private final StringProperty lastExportExtension;
     private final ObjectProperty<Path> exportWorkingDirectory;
+    private final BooleanProperty autoSave;
 
-    public ImportExportPreferences(String nonWrappableFields,
+    public ImportExportPreferences(boolean shouldOpenLastEdited,
+                                   String nonWrappableFields,
                                    boolean resolveStringsForStandardBibtexFields,
                                    boolean resolveStringsForAllStrings,
                                    String nonResolvableFields,
                                    boolean alwaysReformatOnSave,
                                    Path importWorkingDirectory,
                                    String lastExportExtension,
-                                   Path exportWorkingDirectory) {
+                                   Path exportWorkingDirectory,
+                                   boolean autoSave) {
+        this.shouldOpenLastEdited = new SimpleBooleanProperty(shouldOpenLastEdited);
         this.nonWrappableFields = new SimpleStringProperty(nonWrappableFields);
         this.resolveStringsForStandardBibtexFields = new SimpleBooleanProperty(resolveStringsForStandardBibtexFields);
         this.resolveStringsForAllStrings = new SimpleBooleanProperty(resolveStringsForAllStrings);
@@ -35,7 +40,21 @@ public class ImportExportPreferences {
         this.importWorkingDirectory = new SimpleObjectProperty<>(importWorkingDirectory);
         this.lastExportExtension = new SimpleStringProperty(lastExportExtension);
         this.exportWorkingDirectory = new SimpleObjectProperty<>(exportWorkingDirectory);
+        this.autoSave = new SimpleBooleanProperty(autoSave);
     }
+
+    public boolean shouldOpenLastEdited() {
+        return shouldOpenLastEdited.get();
+    }
+
+    public BooleanProperty openLastEditedProperty() {
+        return shouldOpenLastEdited;
+    }
+
+    public void setOpenLastEdited(boolean shouldOpenLastEdited) {
+        this.shouldOpenLastEdited.set(shouldOpenLastEdited);
+    }
+
 
     public String getNonWrappableFields() {
         return nonWrappableFields.get();
@@ -131,5 +150,17 @@ public class ImportExportPreferences {
 
     public void setExportWorkingDirectory(Path exportWorkingDirectory) {
         this.exportWorkingDirectory.set(exportWorkingDirectory);
+    }
+
+    public boolean shouldAutoSave() {
+        return autoSave.get();
+    }
+
+    public BooleanProperty autoSaveProperty() {
+        return autoSave;
+    }
+
+    public void setAutoSave(boolean shouldAutoSave) {
+        this.autoSave.set(shouldAutoSave);
     }
 }

--- a/src/main/java/org/jabref/preferences/ImportExportPreferences.java
+++ b/src/main/java/org/jabref/preferences/ImportExportPreferences.java
@@ -55,7 +55,6 @@ public class ImportExportPreferences {
         this.shouldOpenLastEdited.set(shouldOpenLastEdited);
     }
 
-
     public String getNonWrappableFields() {
         return nonWrappableFields.get();
     }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2545,6 +2545,7 @@ public class JabRefPreferences implements PreferencesService {
                 getStringList(LAST_EDITED),
                 Path.of(get(LAST_FOCUSED)),
                 getFileHistory(),
+                get(ID_ENTRY_GENERATOR),
                 getDouble(SIDE_PANE_WIDTH));
 
         EasyBind.listen(guiPreferences.positionXProperty(), (obs, oldValue, newValue) -> putDouble(POS_X, newValue.doubleValue()));
@@ -2562,6 +2563,7 @@ public class JabRefPreferences implements PreferencesService {
             }
         });
         guiPreferences.getFileHistory().getHistory().addListener((InvalidationListener) change -> storeFileHistory(guiPreferences.getFileHistory()));
+        EasyBind.listen(guiPreferences.lastSelectedIdBasedFetcherProperty(), (obs, oldValue, newValue) -> put(ID_ENTRY_GENERATOR, newValue));
         EasyBind.listen(guiPreferences.sidePaneWidthProperty(), (obs, oldValue, newValue) -> putDouble(SIDE_PANE_WIDTH, newValue.doubleValue()));
 
         return guiPreferences;
@@ -2772,16 +2774,6 @@ public class JabRefPreferences implements PreferencesService {
         EasyBind.listen(mrDlibPreferences.sendTimezoneProperty(), (obs, oldValue, newValue) -> putBoolean(SEND_TIMEZONE_DATA, newValue));
 
         return mrDlibPreferences;
-    }
-
-    @Override
-    public String getIdBasedFetcherForEntryGenerator() {
-        return get(ID_ENTRY_GENERATOR);
-    }
-
-    @Override
-    public void storeIdBasedFetcherForEntryGenerator(String fetcherName) {
-        put(ID_ENTRY_GENERATOR, fetcherName);
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2178,22 +2178,6 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     @Override
-    public FileHistory getFileHistory() {
-        return new FileHistory(getStringList(RECENT_DATABASES).stream().map(Path::of).collect(Collectors.toList()));
-    }
-
-    @Override
-    public void storeFileHistory(FileHistory history) {
-        if (!history.isEmpty()) {
-            putStringList(RECENT_DATABASES, history.getHistory()
-                                                   .stream()
-                                                   .map(Path::toAbsolutePath)
-                                                   .map(Path::toString)
-                                                   .collect(Collectors.toList()));
-        }
-    }
-
-    @Override
     public FilePreferences getFilePreferences() {
         if (Objects.nonNull(filePreferences)) {
             return filePreferences;
@@ -2562,6 +2546,7 @@ public class JabRefPreferences implements PreferencesService {
                 getBoolean(WINDOW_MAXIMISED),
                 getStringList(LAST_EDITED),
                 Path.of(get(LAST_FOCUSED)),
+                getFileHistory(),
                 getDouble(SIDE_PANE_WIDTH));
 
         EasyBind.listen(guiPreferences.positionXProperty(), (obs, oldValue, newValue) -> putDouble(POS_X, newValue.doubleValue()));
@@ -2578,9 +2563,26 @@ public class JabRefPreferences implements PreferencesService {
                 remove(LAST_EDITED);
             }
         });
+        guiPreferences.getFileHistory().getHistory().addListener((InvalidationListener) change -> storeFileHistory(guiPreferences.getFileHistory()));
         EasyBind.listen(guiPreferences.sidePaneWidthProperty(), (obs, oldValue, newValue) -> putDouble(SIDE_PANE_WIDTH, newValue.doubleValue()));
 
         return guiPreferences;
+    }
+
+    private FileHistory getFileHistory() {
+        return new FileHistory(getStringList(RECENT_DATABASES).stream()
+                                                              .map(Path::of)
+                                                              .collect(Collectors.toList()));
+    }
+
+    private void storeFileHistory(FileHistory history) {
+        if (!history.isEmpty()) {
+            putStringList(RECENT_DATABASES, history.getHistory()
+                                                   .stream()
+                                                   .map(Path::toAbsolutePath)
+                                                   .map(Path::toString)
+                                                   .collect(Collectors.toList()));
+        }
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -52,7 +52,7 @@ import org.jabref.gui.maintable.MainTableNameFormatPreferences;
 import org.jabref.gui.maintable.MainTableNameFormatPreferences.AbbreviationStyle;
 import org.jabref.gui.maintable.MainTableNameFormatPreferences.DisplayStyle;
 import org.jabref.gui.maintable.MainTablePreferences;
-import org.jabref.gui.mergeentries.MergeEntries;
+import org.jabref.gui.mergeentries.DiffMode;
 import org.jabref.gui.search.SearchDisplayMode;
 import org.jabref.gui.sidepane.SidePaneType;
 import org.jabref.gui.specialfields.SpecialFieldsPreferences;
@@ -572,7 +572,7 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(LAST_FOCUSED, "");
         defaults.put(DEFAULT_SHOW_SOURCE, Boolean.FALSE);
 
-        defaults.put(MERGE_ENTRIES_DIFF_MODE, MergeEntries.DiffMode.WORD.name());
+        defaults.put(MERGE_ENTRIES_DIFF_MODE, DiffMode.WORD.name());
 
         defaults.put(SHOW_RECOMMENDATIONS, Boolean.TRUE);
         defaults.put(ACCEPT_RECOMMENDATIONS, Boolean.FALSE);
@@ -2546,6 +2546,7 @@ public class JabRefPreferences implements PreferencesService {
                 Path.of(get(LAST_FOCUSED)),
                 getFileHistory(),
                 get(ID_ENTRY_GENERATOR),
+                DiffMode.parse(get(MERGE_ENTRIES_DIFF_MODE)),
                 getDouble(SIDE_PANE_WIDTH));
 
         EasyBind.listen(guiPreferences.positionXProperty(), (obs, oldValue, newValue) -> putDouble(POS_X, newValue.doubleValue()));
@@ -2564,6 +2565,7 @@ public class JabRefPreferences implements PreferencesService {
         });
         guiPreferences.getFileHistory().getHistory().addListener((InvalidationListener) change -> storeFileHistory(guiPreferences.getFileHistory()));
         EasyBind.listen(guiPreferences.lastSelectedIdBasedFetcherProperty(), (obs, oldValue, newValue) -> put(ID_ENTRY_GENERATOR, newValue));
+        EasyBind.listen(guiPreferences.mergeDiffModeProperty(), (obs, oldValue, newValue) -> put(MERGE_ENTRIES_DIFF_MODE, newValue.name()));
         EasyBind.listen(guiPreferences.sidePaneWidthProperty(), (obs, oldValue, newValue) -> putDouble(SIDE_PANE_WIDTH, newValue.doubleValue()));
 
         return guiPreferences;
@@ -2744,16 +2746,6 @@ public class JabRefPreferences implements PreferencesService {
     @Override
     public void storeExternalFileTypes(String externalFileTypes) {
         put(EXTERNAL_FILE_TYPES, externalFileTypes);
-    }
-
-    @Override
-    public Optional<String> getMergeDiffMode() {
-        return getAsOptional(MERGE_ENTRIES_DIFF_MODE);
-    }
-
-    @Override
-    public void storeMergeDiffMode(String diffMode) {
-        put(MERGE_ENTRIES_DIFF_MODE, diffMode);
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2164,16 +2164,6 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     @Override
-    public boolean shouldOpenLastFilesOnStartup() {
-        return getBoolean(OPEN_LAST_EDITED);
-    }
-
-    @Override
-    public void storeOpenLastFilesOnStartup(boolean openLastFilesOnStartup) {
-        putBoolean(OPEN_LAST_EDITED, openLastFilesOnStartup);
-    }
-
-    @Override
     public FieldContentFormatterPreferences getFieldContentParserPreferences() {
         return new FieldContentFormatterPreferences(
                 getStringList(NON_WRAPPABLE_FIELDS).stream().map(FieldFactory::parseField).collect(Collectors.toList()));
@@ -2272,16 +2262,6 @@ public class JabRefPreferences implements PreferencesService {
         return autoLinkPreferences;
     }
 
-    @Override
-    public boolean shouldAutosave() {
-        return getBoolean(LOCAL_AUTO_SAVE);
-    }
-
-    @Override
-    public void storeShouldAutosave(boolean shouldAutosave) {
-        putBoolean(LOCAL_AUTO_SAVE, shouldAutosave);
-    }
-
     //*************************************************************************************************************
     // Import/Export preferences
     //*************************************************************************************************************
@@ -2293,6 +2273,7 @@ public class JabRefPreferences implements PreferencesService {
         }
 
         importExportPreferences = new ImportExportPreferences(
+                getBoolean(OPEN_LAST_EDITED),
                 get(NON_WRAPPABLE_FIELDS),
                 !getBoolean(RESOLVE_STRINGS_ALL_FIELDS),
                 getBoolean(RESOLVE_STRINGS_ALL_FIELDS),
@@ -2300,8 +2281,10 @@ public class JabRefPreferences implements PreferencesService {
                 getBoolean(REFORMAT_FILE_ON_SAVE_AND_EXPORT),
                 Path.of(get(IMPORT_WORKING_DIRECTORY)),
                 get(LAST_USED_EXPORT),
-                Path.of(get(EXPORT_WORKING_DIRECTORY)));
+                Path.of(get(EXPORT_WORKING_DIRECTORY)),
+                getBoolean(LOCAL_AUTO_SAVE));
 
+        EasyBind.listen(importExportPreferences.openLastEditedProperty(), (obs, oldValue, newValue) -> putBoolean(OPEN_LAST_EDITED, newValue));
         EasyBind.listen(importExportPreferences.nonWrappableFieldsProperty(), (obs, oldValue, newValue) -> put(NON_WRAPPABLE_FIELDS, newValue));
         EasyBind.listen(importExportPreferences.resolveStringsForStandardBibtexFieldsProperty(), (obs, oldValue, newValue) -> putBoolean(RESOLVE_STRINGS_ALL_FIELDS, newValue));
         EasyBind.listen(importExportPreferences.resolveStringsForAllStringsProperty(), (obs, oldValue, newValue) -> putBoolean(RESOLVE_STRINGS_ALL_FIELDS, newValue));
@@ -2310,6 +2293,7 @@ public class JabRefPreferences implements PreferencesService {
         EasyBind.listen(importExportPreferences.importWorkingDirectoryProperty(), (obs, oldValue, newValue) -> put(IMPORT_WORKING_DIRECTORY, newValue.toString()));
         EasyBind.listen(importExportPreferences.lastExportExtensionProperty(), (obs, oldValue, newValue) -> put(LAST_USED_EXPORT, newValue));
         EasyBind.listen(importExportPreferences.exportWorkingDirectoryProperty(), (obs, oldValue, newValue) -> put(EXPORT_WORKING_DIRECTORY, newValue.toString()));
+        EasyBind.listen(importExportPreferences.autoSaveProperty(), (obs, oldValue, newValue) -> putBoolean(LOCAL_AUTO_SAVE, newValue));
 
         return importExportPreferences;
     }
@@ -2576,7 +2560,6 @@ public class JabRefPreferences implements PreferencesService {
                 getDouble(SIZE_X),
                 getDouble(SIZE_Y),
                 getBoolean(WINDOW_MAXIMISED),
-                getBoolean(OPEN_LAST_EDITED),
                 getStringList(LAST_EDITED),
                 Path.of(get(LAST_FOCUSED)),
                 getDouble(SIDE_PANE_WIDTH));
@@ -2586,7 +2569,6 @@ public class JabRefPreferences implements PreferencesService {
         EasyBind.listen(guiPreferences.sizeXProperty(), (obs, oldValue, newValue) -> putDouble(SIZE_X, newValue.doubleValue()));
         EasyBind.listen(guiPreferences.sizeYProperty(), (obs, oldValue, newValue) -> putDouble(SIZE_Y, newValue.doubleValue()));
         EasyBind.listen(guiPreferences.windowMaximisedProperty(), (obs, oldValue, newValue) -> putBoolean(WINDOW_MAXIMISED, newValue));
-        EasyBind.listen(guiPreferences.openLastEditedProperty(), (obs, oldValue, newValue) -> putBoolean(OPEN_LAST_EDITED, newValue));
         guiPreferences.getLastFilesOpened().addListener((InvalidationListener) change ->
                 putStringList(LAST_EDITED, guiPreferences.getLastFilesOpened()));
         EasyBind.listen(guiPreferences.lastFocusedFileProperty(), (obs, oldValue, newValue) -> {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1180,16 +1180,6 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     @Override
-    public boolean shouldWarnAboutDuplicatesForImport() {
-        return getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION);
-    }
-
-    @Override
-    public void setShouldWarnAboutDuplicatesForImport(boolean value) {
-        putBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION, value);
-    }
-
-    @Override
     @Deprecated
     public String getDefaultsDefaultCitationKeyPattern() {
         return (String) defaults.get(DEFAULT_CITATION_KEY_PATTERN);
@@ -2265,7 +2255,8 @@ public class JabRefPreferences implements PreferencesService {
                 Path.of(get(IMPORT_WORKING_DIRECTORY)),
                 get(LAST_USED_EXPORT),
                 Path.of(get(EXPORT_WORKING_DIRECTORY)),
-                getBoolean(LOCAL_AUTO_SAVE));
+                getBoolean(LOCAL_AUTO_SAVE),
+                getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION));
 
         EasyBind.listen(importExportPreferences.openLastEditedProperty(), (obs, oldValue, newValue) -> putBoolean(OPEN_LAST_EDITED, newValue));
         EasyBind.listen(importExportPreferences.nonWrappableFieldsProperty(), (obs, oldValue, newValue) -> put(NON_WRAPPABLE_FIELDS, newValue));
@@ -2276,6 +2267,7 @@ public class JabRefPreferences implements PreferencesService {
         EasyBind.listen(importExportPreferences.lastExportExtensionProperty(), (obs, oldValue, newValue) -> put(LAST_USED_EXPORT, newValue));
         EasyBind.listen(importExportPreferences.exportWorkingDirectoryProperty(), (obs, oldValue, newValue) -> put(EXPORT_WORKING_DIRECTORY, newValue.toString()));
         EasyBind.listen(importExportPreferences.autoSaveProperty(), (obs, oldValue, newValue) -> putBoolean(LOCAL_AUTO_SAVE, newValue));
+        EasyBind.listen(importExportPreferences.warnAboutDuplicatesOnImportProperty(), (obs, oldValue, newValue) -> putBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION, newValue));
 
         return importExportPreferences;
     }

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -41,7 +41,6 @@ import org.jabref.logic.preferences.TimestampPreferences;
 import org.jabref.logic.protectedterms.ProtectedTermsPreferences;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.util.io.AutoLinkPreferences;
-import org.jabref.logic.util.io.FileHistory;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntryType;
@@ -64,10 +63,6 @@ public interface PreferencesService {
     FilePreferences getFilePreferences();
 
     FieldWriterPreferences getFieldWriterPreferences();
-
-    FileHistory getFileHistory();
-
-    void storeFileHistory(FileHistory history);
 
     FieldContentFormatterPreferences getFieldContentParserPreferences();
 

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -90,10 +90,6 @@ public interface PreferencesService {
 
     void storeExportSaveOrder(SaveOrderConfig config);
 
-    boolean shouldWarnAboutDuplicatesForImport();
-
-    void setShouldWarnAboutDuplicatesForImport(boolean value);
-
     void clear() throws BackingStoreException;
 
     void deleteKey(String key) throws IllegalArgumentException;

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -289,10 +289,6 @@ public interface PreferencesService {
 
     MrDlibPreferences getMrDlibPreferences();
 
-    String getIdBasedFetcherForEntryGenerator();
-
-    void storeIdBasedFetcherForEntryGenerator(String fetcherName);
-
     ProtectedTermsPreferences getProtectedTermsPreferences();
 
 }

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -224,15 +224,7 @@ public interface PreferencesService {
     // File preferences
     //*************************************************************************************************************
 
-    boolean shouldOpenLastFilesOnStartup();
-
-    void storeOpenLastFilesOnStartup(boolean openLastFilesOnStartup);
-
     AutoLinkPreferences getAutoLinkPreferences();
-
-    boolean shouldAutosave();
-
-    void storeShouldAutosave(boolean shouldAutosave);
 
     FileLinkPreferences getFileLinkPreferences();
 

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -283,10 +283,6 @@ public interface PreferencesService {
 
     void storeExternalFileTypes(String externalFileTypes);
 
-    Optional<String> getMergeDiffMode();
-
-    void storeMergeDiffMode(String diffMode);
-
     MrDlibPreferences getMrDlibPreferences();
 
     ProtectedTermsPreferences getProtectedTermsPreferences();

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2316,6 +2316,7 @@ Error\ connecting\ to\ Writer\ document=Error connecting to Writer document
 You\ need\ to\ open\ Writer\ with\ a\ document\ before\ connecting=You need to open Writer with a document before connecting
 
 Generate\ a\ new\ key\ for\ imported\ entries\ (overwriting\ their\ default)=Generate a new key for imported entries (overwriting their default)
+Warn\ about\ duplicates\ on\ import=Warn about duplicates on import
 Import\ and\ Export=Import and Export
 Custom\ DOI\ URI=Custom DOI URI
 Use\ custom\ DOI\ base\ URI\ for\ article\ access=Use custom DOI base URI for article access


### PR DESCRIPTION
Follow up to #8370 

- Integrated some loose preferences:
   - openLastEdited
   - autoSave
   - FileHistory ~(still a bug)~
   - mergeDiffMode
   - lastSelectedIdBasedFetcher
   - warnAboutDuplicatesForImport
- Extracted DiffMode to a separate class

.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
