### PR TITLE
"% Encoding" is written again in the case of non-UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue about empty metadata in library properties when called from the right click menu. [#8358](https://github.com/JabRef/jabref/issues/8358)
 - We fixed an issue where someone could add a duplicate field in the customize entry type dialog. [#8194](https://github.com/JabRef/jabref/issues/8194)
 - We fixed a typo in the library properties tab: "String constants". There, one can configure [BibTeX string constants](https://docs.jabref.org/advanced/strings).
+- We fixed an issue when writing a non-UTF-8 encoded file: The header is written again. [#8417](https://github.com/JabRef/jabref/issues/8417)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
@@ -183,7 +183,8 @@ public abstract class BibDatabaseWriter {
 
         // Some file formats write something at the start of the file (like the encoding)
         if (savePreferences.getSaveType() != SavePreferences.DatabaseSaveType.PLAIN_BIBTEX) {
-            writeProlog(bibDatabaseContext, generalPreferences.getDefaultEncoding());
+            Charset charset = bibDatabaseContext.getMetaData().getEncoding().orElse(generalPreferences.getDefaultEncoding());
+            writeProlog(bibDatabaseContext, charset);
         }
 
         bibWriter.finishBlock();

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -104,12 +104,43 @@ public class BibtexDatabaseWriterTest {
     }
 
     @Test
-    void writeEncoding() throws Exception {
+    void writeEncodingUsAsciiWhenSetInPreferences() throws Exception {
         when(generalPreferences.getDefaultEncoding()).thenReturn(StandardCharsets.US_ASCII);
 
         databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
 
         assertEquals("% Encoding: US-ASCII" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void writeEncodingUsAsciiWhenSetInPreferencesAndHeader() throws Exception {
+        when(generalPreferences.getDefaultEncoding()).thenReturn(StandardCharsets.US_ASCII);
+        metaData.setEncoding(StandardCharsets.US_ASCII);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
+
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void writeEncodingWindows1252WhenSetInPreferences() throws Exception {
+        Charset charsetWindows1252 = Charset.forName("windows-1252");
+        when(generalPreferences.getDefaultEncoding()).thenReturn(charsetWindows1252);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
+
+        assertEquals("% Encoding: windows-1252" + OS.NEWLINE, stringWriter.toString());
+    }
+
+    @Test
+    void writeEncodingWindows1252WhenSetInPreferencesAndHeader() throws Exception {
+        Charset charsetWindows1252 = Charset.forName("windows-1252");
+        when(generalPreferences.getDefaultEncoding()).thenReturn(charsetWindows1252);
+        metaData.setEncoding(charsetWindows1252);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
+
+        assertEquals("% Encoding: windows-1252" + OS.NEWLINE, stringWriter.toString());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
@@ -2,16 +2,19 @@ package org.jabref.logic.importer.fileformat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
+import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -124,5 +127,24 @@ public class BibtexImporterTest {
         Path file = Path.of(BibtexImporterTest.class.getResource("AutosavedSharedDatabase.bib").toURI());
         String sharedDatabaseID = importer.importDatabase(file, StandardCharsets.UTF_8).getDatabase().getSharedDatabaseID().get();
         assertEquals("13ceoc8dm42f5g1iitao3dj2ap", sharedDatabaseID);
+    }
+
+    @Test
+    public void testParsingOfWindows1252EncodedFileReturnsCorrectHeader() throws Exception {
+        ParserResult parserResult = importer.importDatabase(
+                Path.of(BibtexImporterTest.class.getResource("encoding-windows-1252-with-header.bib").toURI()),
+                StandardCharsets.UTF_8);
+        assertEquals(Optional.of(Charset.forName("Windows-1252")), parserResult.getMetaData().getEncoding());
+    }
+
+    @Test
+    public void testParsingOfWindows1252EncodedFileReadsDegreeCharacterCorrectly() throws Exception {
+        ParserResult parserResult = importer.importDatabase(
+                Path.of(BibtexImporterTest.class.getResource("encoding-windows-1252-with-header.bib").toURI()),
+                StandardCharsets.UTF_8);
+        List<BibEntry> bibEntries = parserResult.getDatabase().getEntries();
+        assertEquals(
+                List.of(new BibEntry(StandardEntryType.Article).withField(StandardField.ABSTRACT, "25° C")),
+                bibEntries);
     }
 }

--- a/src/test/resources/org/jabref/logic/importer/fileformat/encoding-windows-1252-with-header.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/encoding-windows-1252-with-header.bib
@@ -1,0 +1,5 @@
+% Encoding: windows-1252
+
+@Article{,
+  abstract = {25° C},
+}


### PR DESCRIPTION
Fixes #8417

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
