### PR TITLE
Fix re-enabling "Jump to entry" for "linked" tokens in Field editors

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -1,7 +1,5 @@
 package org.jabref.gui.fieldeditors;
 
-import java.util.stream.Collectors;
-
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Parent;
@@ -42,7 +40,7 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
                 .withText(ParsedEntryLink::getKey);
         chipView.getAutoCompletePopup().setSuggestionsCellFactory(autoCompletionItemFactory);
         chipView.getAutoCompletePopup().setCellLimit(5);
-        chipView.getSuggestions().addAll(suggestionProvider.getPossibleSuggestions().stream().map(ParsedEntryLink::new).collect(Collectors.toList()));
+        chipView.getSuggestions().addAll(suggestionProvider.getPossibleSuggestions().stream().map(ParsedEntryLink::new).toList());
 
         chipView.setChipFactory((view, item) -> {
             JFXChip<ParsedEntryLink> chip = new JFXDefaultChip<>(view, item);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -5,11 +5,13 @@ import java.util.stream.Collectors;
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
 import javafx.scene.Parent;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.integrity.FieldCheckers;
+import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.ParsedEntryLink;
@@ -34,6 +36,7 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
                   .root(this)
                   .load();
 
+        chipView.setTooltip(new Tooltip(Localization.lang("Jump to entry")));
         chipView.setConverter(viewModel.getStringConverter());
         var autoCompletionItemFactory = new ViewModelListCellFactory<ParsedEntryLink>()
                 .withText(ParsedEntryLink::getKey);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
@@ -5,6 +5,7 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 import javafx.util.StringConverter;
 
+import org.jabref.gui.JabRefGUI;
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.gui.util.BindingsHelper;
 import org.jabref.logic.integrity.FieldCheckers;
@@ -53,13 +54,12 @@ public class LinkedEntriesEditorViewModel extends AbstractEditorViewModel {
     }
 
     public void jumpToEntry(ParsedEntryLink parsedEntryLink) {
-        // TODO: Implement jump to entry
-        // TODO: Add toolitp for tag: Localization.lang("Jump to entry")
-        // This feature was removed while converting the linked entries editor to JavaFX
-        // Right now there is no nice way to re-implement it as we have no good interface to control the focus of the main table
-        // (except directly using the JabRefFrame class as below)
-        // parsedEntryLink.getLinkedEntry().ifPresent(
-        //        e -> frame.getCurrentBasePanel().highlightEntry(e)
-        // );
+        var linkedEntry = parsedEntryLink.getLinkedEntry();
+        if (linkedEntry.isPresent()) {
+            var currentLibraryTab = JabRefGUI.getMainFrame().getCurrentLibraryTab();
+            if (databaseContext.equals(currentLibraryTab.getBibDatabaseContext())) {
+                currentLibraryTab.clearAndSelect(linkedEntry.get());
+            }
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
@@ -40,10 +40,7 @@ public class LinkedEntriesEditorViewModel extends AbstractEditorViewModel {
 
             @Override
             public String toString(ParsedEntryLink linkedEntry) {
-                if (linkedEntry == null) {
-                    return "";
-                }
-                return linkedEntry.getKey();
+                return linkedEntry == null ? "" : linkedEntry.getKey();
             }
 
             @Override


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #5484 by enabling "Jump to entry" for,

* `CROSSREF`
* `XREF`
* `ENTRYSET`
* `IDS`
* `RELATED`
* `XDATA`

in the Entry Editor.

I have only verified it for `CROSSREF` since I don't know how the others are supposed to work. But, since this is re-enabling a feature disabled in #2840 I expect that it is how things used to be.

@tobiasdiez there is a risk this is doing almost exactly what you didn't want in #2840 (directly use the `JabRefFrame` class).

---

Todo:

- [ ] Update `CHANGELOG.md`
- [ ] Add test cases
- [ ] See if addressing https://github.com/JabRef/jabref/issues/5284 is within the scope of this issue or re-open it again (i.e., is the wrong "chip"/"tag" factory being used)

---

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
