### PR TITLE
Made search button in Web search wider. Also skewed side panel titles to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Changed
 
+- We made the Search button in Web Search wider. We also skewed the left panel titles to the left [#8397](https://github.com/JabRef/jabref/issues/8397)
+
 ### Fixed
 
 - We fixed an issue where an exception could occur when saving the preferences [#7614](https://github.com/JabRef/jabref/issues/7614)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Changed
 
-- We made the Search button in Web Search wider. We also skewed the left panel titles to the left [#8397](https://github.com/JabRef/jabref/issues/8397)
+- We made the Search button in Web Search wider. We also skewed the panel titles to the left [#8397](https://github.com/JabRef/jabref/issues/8397)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
@@ -45,7 +45,7 @@ public class WebSearchPaneView extends VBox {
         fetchers.itemsProperty().bind(viewModel.fetchersProperty());
         fetchers.valueProperty().bindBidirectional(viewModel.selectedFetcherProperty());
         fetchers.setMaxWidth(Double.POSITIVE_INFINITY);
-//        setAlignment(Pos.BASELINE_RIGHT);
+
         // Create help button for currently selected fetcher
         StackPane helpButtonContainer = new StackPane();
         ActionFactory factory = new ActionFactory(preferences.getKeyBindingRepository());

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.importer.fetcher;
 
 import javafx.css.PseudoClass;
-import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
@@ -88,8 +87,7 @@ public class WebSearchPaneView extends VBox {
         Button search = new Button(Localization.lang("Search"));
         search.setDefaultButton(false);
         search.setOnAction(event -> viewModel.search());
-
-        setAlignment(Pos.CENTER);
+        search.setMaxWidth(Double.MAX_VALUE);
         getChildren().addAll(fetcherContainer, query, search);
     }
 }

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneView.java
@@ -45,7 +45,7 @@ public class WebSearchPaneView extends VBox {
         fetchers.itemsProperty().bind(viewModel.fetchersProperty());
         fetchers.valueProperty().bindBidirectional(viewModel.selectedFetcherProperty());
         fetchers.setMaxWidth(Double.POSITIVE_INFINITY);
-
+//        setAlignment(Pos.BASELINE_RIGHT);
         // Create help button for currently selected fetcher
         StackPane helpButtonContainer = new StackPane();
         ActionFactory factory = new ActionFactory(preferences.getKeyBindingRepository());

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneComponent.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneComponent.java
@@ -61,7 +61,7 @@ public class SidePaneComponent extends BorderPane {
         Label label = new Label(sidePaneType.getTitle());
 
         BorderPane headerView = new BorderPane();
-        headerView.setCenter(label);
+        headerView.setLeft(label);
         headerView.setRight(buttonContainer);
         headerView.getStyleClass().add("sidePaneComponentHeader");
 


### PR DESCRIPTION
Made search button in Web search wider. Also skewed side panel titles to the left
Before:
![image](https://user-images.githubusercontent.com/56233132/150847205-7732a696-dfc2-4f74-a777-2cabb1c4ec3c.png)
After:
![image](https://user-images.githubusercontent.com/56233132/150847415-eb39973e-843e-4f27-ba8a-5ea52351e1f9.png)

Fixes #8397 

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
