### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: JabRef
 patreon: # Patreon user account
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
Add GitHub sponsorship? Have I missed any discussion on this topic or [is this not correct?](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository#:~:text=github%3A%20USERNAME%20or%20github%3A%20%5BUSERNAME%2C%20USERNAME%2C%20USERNAME%2C%20USERNAME%5D) since we now have a [GitHub organization sponsorship page](https://github.com/sponsors/JabRef).

If GitHub still [covers transaction fees](https://github.blog/2020-05-12-github-sponsors-is-out-of-beta-for-sponsored-organizations/#:~:text=And%20since%20GitHub%20covers%20payment,goes%20to%20the%20sponsored%20project.) it seems like a very good option.