### PR TITLE
issue(8448): allow URL with + sign in entry tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception could occur when saving the preferences [#7614](https://github.com/JabRef/jabref/issues/7614)
 - We fixed an issue where "Copy DOI url" in the right-click menu of the Entry List would just copy the DOI and not the DOI url. [#8389](https://github.com/JabRef/jabref/issues/8389)
 - We fixed an issue where opening the console from the drop-down menu would cause an exception. [#8466](https://github.com/JabRef/jabref/issues/8466)
+- We fixed an issue where pasting a URL was replacing + signs by spaces making the URL unreachable. [#8448](https://github.com/JabRef/jabref/issues/8448)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
@@ -1,7 +1,9 @@
 package org.jabref.logic.formatter.bibtexfields;
 
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -9,7 +11,10 @@ import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 /**
- * Cleanup URL link
+ * Cleanup URL link.
+ * <p>
+ *     Expose string representations URL links clean up logic.
+ * </p>
  */
 public class CleanupUrlFormatter extends Formatter {
 
@@ -26,14 +31,30 @@ public class CleanupUrlFormatter extends Formatter {
         return "cleanup_url";
     }
 
+    /**
+     * Escape and decodes a String from the application/x-www-form-urlencoded MIME format.
+     * <p>
+     * Method will also try to find a URL placed after "url=" or "to=".
+     * <p>
+     * The conversion process is the same as executed by {@link URLDecoder} to try to
+     * take guarantees against code injections.
+     * <p>
+     * The plus sign is replaced by its correspondent code (%2b) to avoid the character
+     * to be replaced by a space during the decoding execution.
+     *
+     * @param url should not be null
+     * @return the decoded URL as a String representation
+     *
+     * @see URLDecoder#decode(String, Charset)
+     */
     @Override
-    public String format(String value) {
-        String decodedLink = value;
-        String toDecode = value;
-
-        Matcher matcher = PATTERN_URL.matcher(value);
+    public String format(String url) {
+        var toDecode = Objects
+                .requireNonNull(url, "Null url")
+                .replaceAll("\\+", "%2b");
+        Matcher matcher = PATTERN_URL.matcher(toDecode);
         if (matcher.find()) {
-            toDecode = matcher.group(1);
+            return URLDecoder.decode(matcher.group(1), StandardCharsets.UTF_8);
         }
         return URLDecoder.decode(toDecode, StandardCharsets.UTF_8);
     }
@@ -46,8 +67,9 @@ public class CleanupUrlFormatter extends Formatter {
     @Override
     public String getExampleInput() {
         return "https://www.google.de/url?sa=t&rct=j&q=&esrc=s&source=web&cd=11&cad=" +
-                "rja&uact=8&ved=0ahUKEwjg3ZrB_ZPXAhVGuhoKHYdOBOg4ChAWCCYwAA&url=" +
-                "http%3A%2F%2Fwww.focus.de%2Fgesundheit%2Fratgeber%2Fherz%2Ftest%2" +
-                "Flebenserwartung-werden-sie-100-jahre-alt_aid_363828.html" + "&usg=AOvVaw1G6m2jf-pTHYkXceii4hXU";
+               "rja&uact=8&ved=0ahUKEwjg3ZrB_ZPXAhVGuhoKHYdOBOg4ChAWCCYwAA&url=" +
+               "http%3A%2F%2Fwww.focus.de%2Fgesundheit%2Fratgeber%2Fherz%2Ftest%2" +
+               "Flebenserwartung-werden-sie-100-jahre-alt_aid_363828.html" +
+               "&usg=AOvVaw1G6m2jf-pTHYkXceii4hXU";
     }
 }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatterTest.java
@@ -51,4 +51,12 @@ class CleanupUrlFormatterTest {
                         "gesundheit/ratgeber/herz/test/lebenserwartung-werden-sie-100-jahre-alt_aid_363828.html",
                 formatter.format(formatter.getExampleInput()));
     }
+
+    @Test
+    void shouldNotReplacePlusOperatorAsASignInURL() {
+        assertEquals(
+                "https://www.chicago.gov/content/dam/city/depts/cdot/Red Light Cameras/2022/Sutton+Tilahun_Chicago-Camera-Ticket_Exec Summary-Final-Jan10.pdf",
+                formatter.format("https://www.chicago.gov/content/dam/city/depts/cdot/Red Light Cameras/2022/Sutton+Tilahun_Chicago-Camera-Ticket_Exec Summary-Final-Jan10.pdf")
+        );
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes  #8448 

* What: Allow the URL fields to accept URL containing + sign.
* Why: Some URLs are changed by JabRef when copy/paste from a navigation bar, making a bib pointing to an false URL.
* How: this is done by replacing all the + sign UTF-8 code by it's escape sequence code %2b. The code is placed in the `CleanupUrlFormatter` in the `org.jabref.logic.formatter.bibtexfields` package. A test with the given case is provided also.

**Note**: please let me know in the PR comments what type of comment you want in `CHANGELOG.md` and if you need a screenshot.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
