### PR TITLE
Disable telemetry client due to incompatibilites with jakarta

### DIFF
--- a/src/main/java/org/jabref/gui/Globals.java
+++ b/src/main/java/org/jabref/gui/Globals.java
@@ -1,6 +1,5 @@
 package org.jabref.gui;
 
-import java.awt.GraphicsEnvironment;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -115,10 +114,10 @@ public class Globals {
     public static void startBackgroundTasks() {
         Globals.fileUpdateMonitor = new DefaultFileUpdateMonitor();
         JabRefExecutorService.INSTANCE.executeInterruptableTask(Globals.fileUpdateMonitor, "FileUpdateMonitor");
-
-        if (Globals.prefs.getTelemetryPreferences().shouldCollectTelemetry() && !GraphicsEnvironment.isHeadless()) {
+        // TODO Currently deactivated due to incompatibilities in XML
+      /*  if (Globals.prefs.getTelemetryPreferences().shouldCollectTelemetry() && !GraphicsEnvironment.isHeadless()) {
             startTelemetryClient();
-        }
+        } */
     }
 
     private static void stopTelemetryClient() {


### PR DESCRIPTION
Quick fix fixes #8525 

Tobi will hate me, but we really need to either get rid of it completely or move to version 3.x which comes as an agent.
2.6.x is not working with jpms.
I had to disable it due to  #8525  which fails due to Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
