### PR TITLE
Add initial telemetry development documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,6 +15,7 @@
   * [Custom SVG icons](advanced-reading/custom-svg-icons.md)
   * [Recommendations for UI design](advanced-reading/ui-recommendations.md)
   * [Remote Storage](advanced-reading/remote-storage.md)
+  * [Telemetry](advanced-reading/telemetry.md)
   * [Working on fetchers](advanced-reading/fetchers.md)
 * [JabRef and Software Engineering Training](teaching.md)
 * [Readings on Coding](readings-on-coding/README.md)

--- a/docs/advanced-reading/telemetry.md
+++ b/docs/advanced-reading/telemetry.md
@@ -1,0 +1,11 @@
+# Telemetry
+
+JabRef aims for improving user experience. For that, it employs telemetry and, for instance, checks for used features.
+
+The pull requests introducing the first version was <https://github.com/JabRef/jabref/pull/2283>.
+Self-hosted alternative [Matomo Java Tracker](https://github.com/matomo-org/matomo-java-tracker) where neglected, because the JabRef team currently does not have the resources to maintain a server.
+
+## Implementation hints
+
+The ApplicationInsights library that we use supports a special way to submit additional details: <https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#properties>.
+Especially, one has to send `source` as property.


### PR DESCRIPTION
We have discussions on telemetry these days. I would like to collect the thoughts and result of discussions.

This PR adds the hint of https://github.com/JabRef/jabref/pull/5150#discussion_r307860859.

Initial telemetry PR was https://github.com/JabRef/jabref/pull/2283

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
