### PR TITLE
Support two argument form of \abx@aux@cite macro in DefaultAuxParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where "Copy DOI url" in the right-click menu of the Entry List would just copy the DOI and not the DOI url. [#8389](https://github.com/JabRef/jabref/issues/8389)
 - We fixed an issue where opening the console from the drop-down menu would cause an exception. [#8466](https://github.com/JabRef/jabref/issues/8466)
 - We fixed an issue where pasting a URL was replacing + signs by spaces making the URL unreachable. [#8448](https://github.com/JabRef/jabref/issues/8448)
+- We fixed an issue where creating subsidiary files from aux files created with some versions of biblatex would produce incorrect results. [#8513](https://github.com/JabRef/jabref/issues/8513)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/auxparser/DefaultAuxParser.java
+++ b/src/main/java/org/jabref/logic/auxparser/DefaultAuxParser.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultAuxParser implements AuxParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAuxParser.class);
 
-    private static final Pattern CITE_PATTERN = Pattern.compile("\\\\(citation|abx@aux@cite)\\{(.+)\\}");
+    private static final Pattern CITE_PATTERN = Pattern.compile("\\\\(citation|abx@aux@cite)(\\{\\d+\\})?\\{(?<citationkey>.+)\\}");
     private static final Pattern INPUT_PATTERN = Pattern.compile("\\\\@input\\{(.+)\\}");
 
     private final BibDatabase masterDatabase;
@@ -108,7 +108,7 @@ public class DefaultAuxParser implements AuxParser {
         Matcher citeMatch = CITE_PATTERN.matcher(line);
 
         while (citeMatch.find()) {
-            String keyString = citeMatch.group(2);
+            String keyString = citeMatch.group("citationkey");
             String[] keys = keyString.split(",");
 
             for (String key : keys) {

--- a/src/test/java/org/jabref/logic/auxparser/AuxParserTest.java
+++ b/src/test/java/org/jabref/logic/auxparser/AuxParserTest.java
@@ -65,6 +65,33 @@ class AuxParserTest {
     }
 
     @Test
+    void testTwoArgMacro() throws URISyntaxException, IOException {
+        // Result should be identical to that of testNormal
+
+        InputStream originalStream = AuxParserTest.class.getResourceAsStream("origin.bib");
+        Path auxFile = Path.of(AuxParserTest.class.getResource("papertwoargmacro.aux").toURI());
+        try (InputStreamReader originalReader = new InputStreamReader(originalStream, StandardCharsets.UTF_8)) {
+            ParserResult result = new BibtexParser(importFormatPreferences, new DummyFileUpdateMonitor()).parse(originalReader);
+
+            AuxParser auxParser = new DefaultAuxParser(result.getDatabase());
+            AuxParserResult auxResult = auxParser.parse(auxFile);
+
+            assertTrue(auxResult.getGeneratedBibDatabase().hasEntries());
+            assertEquals(0, auxResult.getUnresolvedKeysCount());
+            BibDatabase newDB = auxResult.getGeneratedBibDatabase();
+            List<BibEntry> newEntries = newDB.getEntries();
+            assertEquals(2, newEntries.size());
+            assertTrue(newEntries.get(0).hasChanged());
+            assertTrue(newEntries.get(1).hasChanged());
+            assertEquals(2, auxResult.getResolvedKeysCount());
+            assertEquals(2, auxResult.getFoundKeysInAux());
+            assertEquals(auxResult.getFoundKeysInAux() + auxResult.getCrossRefEntriesCount(),
+                    auxResult.getResolvedKeysCount() + auxResult.getUnresolvedKeysCount());
+            assertEquals(0, auxResult.getCrossRefEntriesCount());
+        }
+    }
+
+    @Test
     void testNotAllFound() throws URISyntaxException, IOException {
         InputStream originalStream = AuxParserTest.class.getResourceAsStream("origin.bib");
         Path auxFile = Path.of(AuxParserTest.class.getResource("badpaper.aux").toURI());

--- a/src/test/resources/org/jabref/logic/auxparser/papertwoargmacro.aux
+++ b/src/test/resources/org/jabref/logic/auxparser/papertwoargmacro.aux
@@ -1,0 +1,8 @@
+\relax
+\abx@aux@cite{0}{Darwin1888}
+\abx@aux@cite{0}{Einstein1920}
+\bibstyle{plain}
+\bibdata{origin}
+\bibcite{Darwin1888}{1}
+\bibcite{Einstein1920}{2}
+\@writefile{toc}{\contentsline {section}{\numberline {1}}{1}}


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #8513. I changed the regex as outlined in my [comment](https://github.com/JabRef/jabref/issues/8513#issuecomment-1060743243) on the issue, with the exception that I decided to go with a named group for the citation key rather than just incrementing the index.

I also added a test case for the `DefaultAuxParser` that ought to behave the exact same way that the normal case should, despite encountering the two argument variant of the cite macro.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
