### PR TITLE
Update RemoteSetupTest.java, adding eq() function from mockito

### DIFF
--- a/src/test/java/org/jabref/logic/remote/RemoteSetupTest.java
+++ b/src/test/java/org/jabref/logic/remote/RemoteSetupTest.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.eq;
 
 /**
  * Tests where the remote client and server setup is wrong.

--- a/src/test/java/org/jabref/logic/remote/RemoteSetupTest.java
+++ b/src/test/java/org/jabref/logic/remote/RemoteSetupTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
 
 /**
  * Tests where the remote client and server setup is wrong.
@@ -94,7 +95,7 @@ class RemoteSetupTest {
                 assertFalse(server.isOpen());
                 server.openAndStart(messageHandler, port, preferencesService);
                 assertFalse(server.isOpen());
-                verify(messageHandler, never()).handleCommandLineArguments(any(), preferencesService);
+                verify(messageHandler, never()).handleCommandLineArguments(any(), eq(preferencesService));
             }
         }
     }


### PR DESCRIPTION
Fixes #8558 

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
