### PR TITLE
Fix for unlinked file importer that did not import all importable files (#8444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue when reading non-UTF-8 encoded. When no encoding header is present, the encoding is now detected from the file content (and the preference option is disregarded) [#8417](https://github.com/JabRef/jabref/issues/8417)
 - We fixed an issue where pasting a URL was replacing + signs by spaces making the URL unreachable. [#8448](https://github.com/JabRef/jabref/issues/8448)
 - We fixed an issue where creating subsidiary files from aux files created with some versions of biblatex would produce incorrect results. [#8513](https://github.com/JabRef/jabref/issues/8513)
+- We fixed an issue where not all found unlinked local files were imported correctly due to some race condition. [#8444](https://github.com/JabRef/jabref/issues/8444)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -68,18 +68,17 @@ public class ImportHandler {
         return linker;
     }
 
-    public BackgroundTask<List<ImportFilesResultItemViewModel>> importFilesInBackground(List<Path> files) {
+    public BackgroundTask<List<ImportFilesResultItemViewModel>> importFilesInBackground(final List<Path> files) {
         return new BackgroundTask<>() {
             private int counter;
-            private List<BibEntry> entriesToAdd;
             private final List<ImportFilesResultItemViewModel> results = new ArrayList<>();
 
             @Override
             protected List<ImportFilesResultItemViewModel> call() {
                 counter = 1;
                 CompoundEdit ce = new CompoundEdit();
-                for (Path file: files) {
-                    entriesToAdd = Collections.emptyList();
+                for (final Path file : files) {
+                    final List<BibEntry> entriesToAdd = new ArrayList<>();
 
                     if (isCanceled()) {
                         break;
@@ -87,7 +86,7 @@ public class ImportHandler {
 
                     DefaultTaskExecutor.runInJavaFXThread(() -> {
                         updateMessage(Localization.lang("Processing file %0", file.getFileName()));
-                        updateProgress(counter, files.size() - 1);
+                        updateProgress(counter, files.size() - 1d);
                     });
 
                     try {
@@ -100,10 +99,10 @@ public class ImportHandler {
                             }
 
                             if (!pdfEntriesInFile.isEmpty()) {
-                                entriesToAdd = pdfEntriesInFile;
+                                entriesToAdd.addAll(pdfEntriesInFile);
                                 addResultToList(file, true, Localization.lang("Importing using extracted PDF data"));
                             } else {
-                                entriesToAdd = Collections.singletonList(createEmptyEntryWithLink(file));
+                                entriesToAdd.add(createEmptyEntryWithLink(file));
                                 addResultToList(file, false, Localization.lang("No metadata found. Creating empty entry with file link"));
                             }
                         } else if (FileUtil.isBibFile(file)) {
@@ -112,10 +111,10 @@ public class ImportHandler {
                                 addResultToList(file, false, bibtexParserResult.getErrorMessage());
                             }
 
-                            entriesToAdd = bibtexParserResult.getDatabaseContext().getEntries();
+                            entriesToAdd.addAll(bibtexParserResult.getDatabaseContext().getEntries());
                             addResultToList(file, false, Localization.lang("Importing bib entry"));
                         } else {
-                            entriesToAdd = Collections.singletonList(createEmptyEntryWithLink(file));
+                            entriesToAdd.add(createEmptyEntryWithLink(file));
                             addResultToList(file, false, Localization.lang("No BibTeX data found. Creating empty entry with file link"));
                         }
                     } catch (IOException ex) {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #8444 

Not all unlinked local files that are found in a directory were imported correctly due to some race condition. 

The import takes place in a UI background thread and the passed closure referenced a list of entries to add. This list was an instance field of another class and not final. In some cases this list was changed/reassigned before the UI thread ran the closure and accessed the list. Therefor some entries were missing after the import.

Manually tested with 256 files.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
