### PR TITLE
Fix merge entries dialog exceeding screen size

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
@@ -31,6 +31,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
+import javafx.stage.Screen;
 
 import org.jabref.gui.Globals;
 import org.jabref.gui.icon.IconTheme.JabRefIcons;
@@ -142,7 +143,8 @@ public class MergeEntries extends BorderPane {
      * Main function for building the merge entry JPanel
      */
     private void initialize() {
-        setPrefWidth(800);
+        this.setPrefHeight(Screen.getPrimary().getBounds().getHeight() * 0.75);
+        this.setPrefWidth(Screen.getPrimary().getBounds().getWidth() * 0.75);
 
         setupFields();
 


### PR DESCRIPTION
## Screenshots
### Before
<img height="400px" src="https://user-images.githubusercontent.com/21198231/159604302-c2e5b795-4cbc-4d8f-b141-aedafcf95463.png"></img>

### After
<img height="400px" src="https://user-images.githubusercontent.com/21198231/159604447-e77d17e0-4c8d-4632-8dea-ac3699afd460.png"></img>

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
