### PR TITLE
Creating units tests for BibStringDiff Equals

### DIFF
--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibStringDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibStringDiffTest.java
@@ -31,4 +31,41 @@ public class BibStringDiffTest {
         List<BibStringDiff> result = BibStringDiff.compare(originalDataBase, newDataBase);
         assertEquals(List.of(diff), result);
     }
+
+    @Test
+    void compareWithNullObject() {
+
+        assertEquals(this.diff.equals(null), false);
+    }
+
+    @Test
+    void compareWithDifferentClass() {
+        assertEquals(this.diff.equals(this.newDataBase), false);
+    }
+
+    @Test
+    void compareWithDifferentNewString() {
+        final BibStringDiff other = new BibStringDiff(new BibtexString("name2", "content2"), new BibtexString("name1", "content1"));
+
+        assertEquals(this.diff.equals(other), false);
+    }
+
+    @Test
+    void compareWithDifferentOriginalString() {
+        final BibStringDiff other = new BibStringDiff(new BibtexString("name1", "content1"), new BibtexString("name2", "content3"));
+
+        assertEquals(this.diff.equals(other), false);
+    }
+
+    @Test
+    void compareWithSameObject() {
+        assertEquals(this.diff.equals(this.diff), true);
+    }
+
+    @Test
+    void compareWithEqualObject() {
+        final BibStringDiff other = new BibStringDiff(new BibtexString("name2", "content2"), new BibtexString("name2", "content3"));
+
+        assertEquals(this.diff.equals(other), true);
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Adding units test to Equals method of BibStringDiff

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
