### PR TITLE
Adding notifications when writing metadata to pdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a new section to network preferences to allow using custom SSL certificates. [#8126](https://github.com/JabRef/jabref/issues/8126)
 - We improved the version check to take also beta version into account and now redirect to the right changelog for the version.
 - We added two new web and fulltext fetchers: SemanticScholar and ResearchGate.
-- We added notifications when when writing metadata in a pdf [#8276](https://github.com/JabRef/jabref/issues/8276)
+- We added notifications on sucess and failure when writing metadata to a PDF-file [#8276](https://github.com/JabRef/jabref/issues/8276)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a new section to network preferences to allow using custom SSL certificates. [#8126](https://github.com/JabRef/jabref/issues/8126)
 - We improved the version check to take also beta version into account and now redirect to the right changelog for the version.
 - We added two new web and fulltext fetchers: SemanticScholar and ResearchGate.
+- We added notifications when when writing metadata in a pdf [#8276](https://github.com/JabRef/jabref/issues/8276)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -421,7 +421,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         BackgroundTask<Void> writeTask = BackgroundTask.wrap(() -> {
             Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
             if (file.isEmpty()) {
-                dialogService.notify(Localization.lang("File not found"));
+                dialogService.notify(Localization.lang("Failed to write metadata, file not found."));
             } else {
                 try {
                     XmpUtilWriter.writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
@@ -429,9 +429,10 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(preferences.getGeneralPreferences().getDefaultBibDatabaseMode(), Globals.entryTypesManager, preferences.getFieldWriterPreferences());
                     embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());
                     
-                    dialogService.notify(Localization.lang("Finished writing metadata!"));
+                    dialogService.notify(Localization.lang("Success! Finished writing metadata."));
                 } catch (IOException | TransformerException ex) {
-                    dialogService.notify(Localization.lang("Error while writing") + " '" + file.toString() + "': " + ex);
+                    dialogService.notify(Localization.lang("Error while writing metadata. See the error log for details."));
+                    LOGGER.error("Error while writing metadata in" + " '" + file.toString() + "'", ex);
                 }
             }
             return null;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -421,23 +421,22 @@ public class LinkedFileViewModel extends AbstractViewModel {
         BackgroundTask<Void> writeTask = BackgroundTask.wrap(() -> {
             Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
             if (file.isEmpty()) {
-                // TODO: Print error message
-                // Localization.lang("PDF does not exist");
+                dialogService.notify(Localization.lang("File not found"));
             } else {
                 try {
                     XmpUtilWriter.writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
 
                     EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(preferences.getGeneralPreferences().getDefaultBibDatabaseMode(), Globals.entryTypesManager, preferences.getFieldWriterPreferences());
                     embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());
+                    
+                    dialogService.notify(Localization.lang("Finished writing metadata!"));
                 } catch (IOException | TransformerException ex) {
-                    // TODO: Print error message
-                    // Localization.lang("Error while writing") + " '" + file.toString() + "': " + ex;
+                    dialogService.notify(Localization.lang("Error while writing") + " '" + file.toString() + "': " + ex);
                 }
             }
             return null;
         });
 
-        // TODO: Show progress
         taskExecutor.execute(writeTask);
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -421,18 +421,18 @@ public class LinkedFileViewModel extends AbstractViewModel {
         BackgroundTask<Void> writeTask = BackgroundTask.wrap(() -> {
             Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
             if (file.isEmpty()) {
-                dialogService.notify(Localization.lang("Failed to write metadata, file not found."));
+                dialogService.notify(Localization.lang("Failed to write metadata, file %1 not found.", file.map(Path::toString).orElse("")));
             } else {
                 try {
                     XmpUtilWriter.writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
 
                     EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(preferences.getGeneralPreferences().getDefaultBibDatabaseMode(), Globals.entryTypesManager, preferences.getFieldWriterPreferences());
                     embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());
-                    
+
                     dialogService.notify(Localization.lang("Success! Finished writing metadata."));
                 } catch (IOException | TransformerException ex) {
                     dialogService.notify(Localization.lang("Error while writing metadata. See the error log for details."));
-                    LOGGER.error("Error while writing metadata in" + " '" + file.toString() + "'", ex);
+                    LOGGER.error("Error while writing metadata to {}", file.map(Path::toString).orElse(""), ex);
                 }
             }
             return null;

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -638,8 +638,6 @@ Path\ to\ %0\ not\ defined=Path to %0 not defined
 
 Path\ to\ LyX\ pipe=Path to LyX pipe
 
-PDF\ does\ not\ exist=PDF does not exist
-
 File\ has\ no\ attached\ annotations=File has no attached annotations
 
 Please\ enter\ a\ name\ for\ the\ group.=Please enter a name for the group.
@@ -2474,3 +2472,7 @@ Duplicate\ Certificates=Duplicate Certificates
 You\ already\ added\ this\ certificate=You already added this certificate
 
 Error\ downloading=Error downloading
+
+Error\ while\ writing\ metadata.\ See\ the\ error\ log\ for\ details.=Error while writing metadata. See the error log for details.
+Failed\ to\ write\ metadata,\ file\ %1\ not\ found.=Failed to write metadata, file %1 not found.
+Success\!\ Finished\ writing\ metadata.=Success! Finished writing metadata.


### PR DESCRIPTION
Adding notifications when writing metadata to pdfs

Fixes #8276

Simple notifications added when clicking in this button specifically, as mentioned in issue #8276
![button](https://user-images.githubusercontent.com/78360676/161815355-ef8ac9a5-f0bd-4d83-91cb-f5f96dc4f83f.png)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

Screenshot with success:
![success](https://user-images.githubusercontent.com/78360676/162103234-36970c3a-f87f-4923-bb3b-3953f3708b2b.png)

Screenshot when writting in a deleted file:
![notfound](https://user-images.githubusercontent.com/78360676/162103253-16d41f33-cc5b-4fe2-a542-8f91edb10d04.png)

Screenshot when writting in a corrupted file:
![error](https://user-images.githubusercontent.com/78360676/162103266-2737c894-196b-46d5-b6fb-658dc0f0a32f.png)

Error log when writting in a corrupted file:
![log](https://user-images.githubusercontent.com/78360676/162103354-c94e60bd-f200-4b88-9902-00aeb3ddfbf8.png)
