### PR TITLE
Only show exit warning if running tasks will not be recovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We introduced a preference to disable fulltext indexing [#8468](https://github.com/JabRef/jabref/issues/8468)
 - When exporting entries, the encoding is always UTF-8
 - When embedding BibTeX data into a PDF, the encoding is always UTF-8
+- We now only show a warning when exiting for tasks that will not be recovered automatically upon relaunch of JabRef. [#8468](https://github.com/JabRef/jabref/issues/8468)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -323,7 +323,7 @@ public class JabRefDialogService implements DialogService {
         alert.initOwner(mainWindow);
         themeManager.installCss(alert.getDialogPane().getScene());
 
-        stateManager.getAnyTaskRunning().addListener((observable, oldValue, newValue) -> {
+        stateManager.getAnyTasksThatWillNotBeRecoveredRunning().addListener((observable, oldValue, newValue) -> {
             if (!newValue) {
                 alert.setResult(ButtonType.YES);
                 alert.close();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -384,7 +384,7 @@ public class JabRefFrame extends BorderPane {
         It is important to wait for unfinished background tasks before checking if a save-operation is needed, because
         the background tasks may make changes themselves that need saving.
          */
-        if (stateManager.getAnyTaskRunning().getValue()) {
+        if (stateManager.getAnyTasksThatWillNotBeRecoveredRunning().getValue()) {
             Optional<ButtonType> shouldClose = dialogService.showBackgroundProgressDialogAndWait(
                     Localization.lang("Please wait..."),
                     Localization.lang("Waiting for background tasks to finish. Quit anyway?"),

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -16,8 +16,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.concurrent.Task;
 import javafx.scene.Node;
+import javafx.util.Pair;
 
 import org.jabref.gui.sidepane.SidePaneType;
+import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.CustomLocalDragboard;
 import org.jabref.gui.util.DialogWindowState;
 import org.jabref.gui.util.OptionalObjectProperty;
@@ -53,9 +55,10 @@ public class StateManager {
     private final OptionalObjectProperty<SearchQuery> activeSearchQuery = OptionalObjectProperty.empty();
     private final ObservableMap<BibDatabaseContext, IntegerProperty> searchResultMap = FXCollections.observableHashMap();
     private final OptionalObjectProperty<Node> focusOwner = OptionalObjectProperty.empty();
-    private final ObservableList<Task<?>> backgroundTasks = FXCollections.observableArrayList(task -> new Observable[] {task.progressProperty(), task.runningProperty()});
-    private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.anyMatch(Task::isRunning));
-    private final EasyBinding<Double> tasksProgress = EasyBind.reduce(backgroundTasks, tasks -> tasks.filter(Task::isRunning).mapToDouble(Task::getProgress).average().orElse(1));
+    private final ObservableList<Pair<BackgroundTask, Task<?>>> backgroundTasks = FXCollections.observableArrayList(task -> new Observable[] {task.getValue().progressProperty(), task.getValue().runningProperty()});
+    private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.map(Pair::getValue).anyMatch(Task::isRunning));
+    private final EasyBinding<Boolean> anyTasksThatWillNotBeRecoveredRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.anyMatch(task -> !task.getKey().willBeRecoveredAutomatically() && task.getValue().isRunning()));
+    private final EasyBinding<Double> tasksProgress = EasyBind.reduce(backgroundTasks, tasks -> tasks.map(Pair::getValue).filter(Task::isRunning).mapToDouble(Task::getProgress).average().orElse(1));
     private final ObservableMap<String, DialogWindowState> dialogWindowStates = FXCollections.observableHashMap();
     private final ObservableList<SidePaneType> visibleSidePanes = FXCollections.observableArrayList();
 
@@ -143,15 +146,19 @@ public class StateManager {
     }
 
     public ObservableList<Task<?>> getBackgroundTasks() {
-        return backgroundTasks;
+        return EasyBind.map(backgroundTasks, Pair::getValue);
     }
 
-    public void addBackgroundTask(Task<?> backgroundTask) {
-        this.backgroundTasks.add(0, backgroundTask);
+    public void addBackgroundTask(BackgroundTask backgroundTask, Task<?> task) {
+        this.backgroundTasks.add(0, new Pair<>(backgroundTask, task));
     }
 
     public EasyBinding<Boolean> getAnyTaskRunning() {
         return anyTaskRunning;
+    }
+
+    public EasyBinding<Boolean> getAnyTasksThatWillNotBeRecoveredRunning() {
+        return anyTasksThatWillNotBeRecoveredRunning;
     }
 
     public EasyBinding<Double> getTasksProgress() {

--- a/src/main/java/org/jabref/gui/util/BackgroundTask.java
+++ b/src/main/java/org/jabref/gui/util/BackgroundTask.java
@@ -47,6 +47,7 @@ public abstract class BackgroundTask<V> {
     private final StringProperty title = new SimpleStringProperty(this.getClass().getSimpleName());
     private final DoubleProperty workDonePercentage = new SimpleDoubleProperty(0);
     private final BooleanProperty showToUser = new SimpleBooleanProperty(false);
+    private final BooleanProperty willBeRecoveredAutomatically = new SimpleBooleanProperty(false);
 
     public BackgroundTask() {
         workDonePercentage.bind(EasyBind.map(progress, BackgroundTask.BackgroundProgress::getWorkDonePercentage));
@@ -128,6 +129,14 @@ public abstract class BackgroundTask<V> {
 
     public void showToUser(boolean show) {
         showToUser.set(show);
+    }
+
+    public boolean willBeRecoveredAutomatically() {
+        return willBeRecoveredAutomatically.get();
+    }
+
+    public void willBeRecoveredAutomatically(boolean willBeRecoveredAutomatically) {
+        this.willBeRecoveredAutomatically.set(willBeRecoveredAutomatically);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
@@ -106,7 +106,7 @@ public class DefaultTaskExecutor implements TaskExecutor {
     public <V> Future<V> execute(BackgroundTask<V> task) {
         Task<V> javafxTask = getJavaFXTask(task);
         if (task.showToUser()) {
-            stateManager.addBackgroundTask(javafxTask);
+            stateManager.addBackgroundTask(task, javafxTask);
         }
         return execute(javafxTask);
     }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -28,6 +28,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
     public IndexingTaskManager(TaskExecutor taskExecutor) {
         this.taskExecutor = taskExecutor;
         showToUser(true);
+        willBeRecoveredAutomatically(true);
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             this.updateProgress(1, 1);
             this.titleProperty().set(Localization.lang("Indexing pdf files"));


### PR DESCRIPTION
BackgroundTasks have a new flag that indicates whether JabRef will automatically resume/recover this task when relaunched. Such tasks should not interrupt a user shut-down.
I.e. indexing tasks, that will be continued when launching JabRef again.

Fixes #8468

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
