### PR TITLE
Add lucence backwards codec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,7 @@ dependencies {
     implementation 'org.apache.lucene:lucene-queries:9.1.0'
     implementation 'org.apache.lucene:lucene-analysis-common:9.1.0'
     implementation 'org.apache.lucene:lucene-highlighter:9.1.0'
+    implementation 'org.apache.lucene:lucene-backward-codecs:9.1.0'
 
     implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.9.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -102,6 +102,8 @@ open module org.jabref {
     // fulltext search
     requires org.apache.lucene.core;
     uses org.apache.lucene.codecs.lucene91.Lucene91Codec;
+    requires org.apache.lucene.backward_codecs;
+    uses org.apache.lucene.backward_codecs.lucene87.Lucene87Codec;
 
     requires org.apache.lucene.queryparser;
     uses org.apache.lucene.queryparser.classic.MultiFieldQueryParser;


### PR DESCRIPTION
Somehow I got this error today that I am maybe missing some codecs

>java.lang.IllegalArgumentException: Could not load codec 'Lucene87'. Did you forget to add lucene-backward-codecs.jar?


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
