### PR TITLE
Allowing changing entry types of multiple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where right clicking multiple entries and pressing "Change entry type" would only change one entry. [#8654](https://github.com/JabRef/jabref/issues/8654)
 - We fixed an issue where it was no longer possible to add or delete multiple files in the `file` field in the entry editor [#8659](https://github.com/JabRef/jabref/issues/8659)
 - We fixed an issue where the author's lastname was not used for the citation key generation if it started with a lowercase letter [#8601](https://github.com/JabRef/jabref/issues/8601)
 - We fixed an issue where custom "Protected terms" files were missing after a restart of JabRef [#8608](https://github.com/JabRef/jabref/issues/8608)

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -2,6 +2,7 @@ package org.jabref.gui.entryeditor;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -360,7 +361,7 @@ public class EntryEditor extends BorderPane {
         typeLabel.setText(typedEntry.getTypeForDisplay());
 
         // Add type change menu
-        ContextMenu typeMenu = new ChangeEntryTypeMenu().getChangeEntryTypePopupMenu(entry, databaseContext, undoManager);
+        ContextMenu typeMenu = new ChangeEntryTypeMenu().getChangeEntryTypePopupMenu(Collections.singletonList(entry), databaseContext, undoManager);
         typeLabel.setOnMouseClicked(event -> typeMenu.show(typeLabel, Side.RIGHT, 0, 0));
         typeChangeButton.setOnMouseClicked(event -> typeMenu.show(typeChangeButton, Side.RIGHT, 0, 0));
 

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -76,7 +76,7 @@ public class RightClickMenu {
 
                 new SeparatorMenuItem(),
 
-                new ChangeEntryTypeMenu().getChangeEntryTypeMenu(entry.getEntry(), libraryTab.getBibDatabaseContext(), libraryTab.getUndoManager()),
+                new ChangeEntryTypeMenu().getChangeEntryTypeMenu(libraryTab.getSelectedEntries(), libraryTab.getBibDatabaseContext(), libraryTab.getUndoManager()),
                 factory.createMenuItem(StandardActions.MERGE_WITH_FETCHED_ENTRY, new MergeWithFetchedEntryAction(libraryTab, dialogService, stateManager))
         );
 

--- a/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
+++ b/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
@@ -35,12 +35,12 @@ public class ChangeEntryTypeMenu {
 
     }
 
-    public static MenuItem createMenuItem(EntryType type, BibEntry entry, UndoManager undoManager) {
+    public static MenuItem createMenuItem(EntryType type, List<BibEntry> entries, UndoManager undoManager) {
         CustomMenuItem menuItem = new CustomMenuItem(new Label(type.getDisplayName()));
         menuItem.setOnAction(event -> {
             NamedCompound compound = new NamedCompound(Localization.lang("Change entry type"));
-            entry.setType(type)
-                 .ifPresent(change -> compound.addEdit(new UndoableChangeType(change)));
+            entries.forEach(e -> e.setType(type)
+                 .ifPresent(change -> compound.addEdit(new UndoableChangeType(change))));
             undoManager.addEdit(compound);
         });
         String description = EntryTypeView.getDescription(type);
@@ -51,55 +51,55 @@ public class ChangeEntryTypeMenu {
         return menuItem;
     }
 
-    public ContextMenu getChangeEntryTypePopupMenu(BibEntry entry, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
+    public ContextMenu getChangeEntryTypePopupMenu(List<BibEntry> entries, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
         ContextMenu menu = new ContextMenu();
-        populateComplete(menu.getItems(), entry, bibDatabaseContext, undoManager);
+        populateComplete(menu.getItems(), entries, bibDatabaseContext, undoManager);
         return menu;
     }
 
-    public Menu getChangeEntryTypeMenu(BibEntry entry, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
+    public Menu getChangeEntryTypeMenu(List<BibEntry> entries, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
         Menu menu = new Menu();
         menu.setText(Localization.lang("Change entry type"));
-        populateComplete(menu.getItems(), entry, bibDatabaseContext, undoManager);
+        populateComplete(menu.getItems(), entries, bibDatabaseContext, undoManager);
         return menu;
     }
 
-    private void populateComplete(ObservableList<MenuItem> items, BibEntry entry, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
+    private void populateComplete(ObservableList<MenuItem> items, List<BibEntry> entries, BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager) {
         if (bibDatabaseContext.isBiblatexMode()) {
             // Default BibLaTeX
-            populate(items, Globals.entryTypesManager.getAllTypes(BibDatabaseMode.BIBLATEX), entry, undoManager);
+            populate(items, Globals.entryTypesManager.getAllTypes(BibDatabaseMode.BIBLATEX), entries, undoManager);
 
             // Custom types
-            populateSubMenu(items, Localization.lang("Custom"), Globals.entryTypesManager.getAllCustomTypes(BibDatabaseMode.BIBLATEX), entry, undoManager);
+            populateSubMenu(items, Localization.lang("Custom"), Globals.entryTypesManager.getAllCustomTypes(BibDatabaseMode.BIBLATEX), entries, undoManager);
         } else {
             // Default BibTeX
-            populateSubMenu(items, BibDatabaseMode.BIBTEX.getFormattedName(), BibtexEntryTypeDefinitions.ALL, entry, undoManager);
+            populateSubMenu(items, BibDatabaseMode.BIBTEX.getFormattedName(), BibtexEntryTypeDefinitions.ALL, entries, undoManager);
             items.remove(0); // Remove separator
 
             // IEEETran
-            populateSubMenu(items, "IEEETran", IEEETranEntryTypeDefinitions.ALL, entry, undoManager);
+            populateSubMenu(items, "IEEETran", IEEETranEntryTypeDefinitions.ALL, entries, undoManager);
 
             // Custom types
-            populateSubMenu(items, Localization.lang("Custom"), Globals.entryTypesManager.getAllCustomTypes(BibDatabaseMode.BIBTEX), entry, undoManager);
+            populateSubMenu(items, Localization.lang("Custom"), Globals.entryTypesManager.getAllCustomTypes(BibDatabaseMode.BIBTEX), entries, undoManager);
         }
     }
 
-    private void populateSubMenu(ObservableList<MenuItem> items, String text, List<BibEntryType> entryTypes, BibEntry entry, CountingUndoManager undoManager) {
+    private void populateSubMenu(ObservableList<MenuItem> items, String text, List<BibEntryType> entryTypes, List<BibEntry> entries, CountingUndoManager undoManager) {
         if (!entryTypes.isEmpty()) {
             items.add(new SeparatorMenuItem());
             Menu custom = new Menu(text);
-            populate(custom, entryTypes, entry, undoManager);
+            populate(custom, entryTypes, entries, undoManager);
             items.add(custom);
         }
     }
 
-    private void populate(ObservableList<MenuItem> items, Collection<BibEntryType> types, BibEntry entry, UndoManager undoManager) {
+    private void populate(ObservableList<MenuItem> items, Collection<BibEntryType> types, List<BibEntry> entries, UndoManager undoManager) {
         for (BibEntryType type : types) {
-            items.add(createMenuItem(type.getType(), entry, undoManager));
+            items.add(createMenuItem(type.getType(), entries, undoManager));
         }
     }
 
-    private void populate(Menu menu, Collection<BibEntryType> types, BibEntry entry, UndoManager undoManager) {
-        populate(menu.getItems(), types, entry, undoManager);
+    private void populate(Menu menu, Collection<BibEntryType> types, List<BibEntry> entries, UndoManager undoManager) {
+        populate(menu.getItems(), types, entries, undoManager);
     }
 }


### PR DESCRIPTION
Fixes #8654
This allows for the right click option "Change entry type" to change the entry types of multiple entries at once.
Trying to change the entry type by first double clicking on the entry still behaves normally.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
