### PR TITLE
Add initial custom constructor to VMException with statusCode

### DIFF
--- a/src/main/java/org/jabref/logic/bst/VMException.java
+++ b/src/main/java/org/jabref/logic/bst/VMException.java
@@ -1,8 +1,16 @@
 package org.jabref.logic.bst;
 
 public class VMException extends RuntimeException {
-
+    private String statusCode;
     public VMException(String string) {
         super(string);
+    }
+    public VMException(String message, String statusCode){
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public String getStatusCode(){
+        return this.statusCode;
     }
 }

--- a/src/test/java/org/jabref/logic/bst/VMExceptionTest.java
+++ b/src/test/java/org/jabref/logic/bst/VMExceptionTest.java
@@ -1,0 +1,25 @@
+package org.jabref.logic.bst;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VMExceptionTest {
+
+    @Test
+    void ShouldGetSameErrorMessage() {
+        VMException error = new VMException("Something Went Wrong");
+        assertEquals("Something Went Wrong", error.getMessage());
+    }
+
+    @Test
+    void shouldAssertEqualsMessageUsingNewConstructor() {
+        VMException error = new VMException("Something Went Wrong", "JAB-768");
+        assertEquals("Something Went Wrong", error.getMessage());
+    }
+
+    @Test
+    void shouldAssertEqualsInternalCodeUsingNewConstructor() {
+        VMException error = new VMException("Something Went Wrong", "JAB-768");
+        assertEquals("JAB-768", error.getStatusCode());
+    }
+}


### PR DESCRIPTION
## Description
 
The purpose of this PR is to start an error mapping on project, I started with the initial implementation of VMException with statusCode, accompanied by some tests (I used TDD). issue : #8633 

## Tasks

- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)

## Screenshots 

![Screenshot from 2022-04-15 09-34-52](https://user-images.githubusercontent.com/62192072/163572865-fa249c94-aca9-490a-ae66-8718ec3b6151.png)

![Screenshot from 2022-04-15 09-31-57](https://user-images.githubusercontent.com/62192072/163572982-ef49af88-7b4b-414f-b93e-da563da6712b.png)

![Screenshot from 2022-04-15 09-33-49](https://user-images.githubusercontent.com/62192072/163572994-e3a117c1-d874-4026-a6f7-ac0d3bff17c2.png)

