### PR TITLE
Add check for empty lines at beginning / end of block

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -21,6 +21,18 @@
     <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile"/>
 
+    <!-- Prevent empty start and end of blocks - source: comments to https://stackoverflow.com/a/48027770/873282 -->
+    <module name="RegexpMultiline">
+        <property name="message" value="Blank line at start of block should be removed" />
+        <property name="format" value="(\(.*\)|else)\s*\{\s*[\r]?\n\s*[\r]?\n" />
+        <property name="fileExtensions" value="groovy,java" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="message" value="Blank line at end of block should be removed" />
+        <property name="format" value="[\r]?\n\s*[\r]?\n\s*\}" />
+        <property name="fileExtensions" value="groovy,java" />
+    </module>
+
     <!-- Checks for size violations: https://checkstyle.sourceforge.io/config_sizes.html -->
 
     <!-- LineLength not in place as PreviewerViewer and RelatedArticlesTab have line length with more than 500 charachters -->

--- a/config/checkstyle/checkstyle_reviewdog.xml
+++ b/config/checkstyle/checkstyle_reviewdog.xml
@@ -21,6 +21,18 @@
     <module name="FileTabCharacter"/>
     <module name="NewlineAtEndOfFile"/>
 
+    <!-- Prevent empty start and end of blocks - source: comments to https://stackoverflow.com/a/48027770/873282 -->
+    <module name="RegexpMultiline">
+        <property name="message" value="Blank line at start of block should be removed" />
+        <property name="format" value="(\(.*\)|else)\s*\{\s*[\r]?\n\s*[\r]?\n" />
+        <property name="fileExtensions" value="groovy,java" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="message" value="Blank line at end of block should be removed" />
+        <property name="format" value="[\r]?\n\s*[\r]?\n\s*\}" />
+        <property name="fileExtensions" value="groovy,java" />
+    </module>
+
     <!-- Checks for size violations: https://checkstyle.sourceforge.io/config_sizes.html -->
 
     <!-- LineLength not in place as PreviewerViewer and RelatedArticlesTab have line length with more than 500 charachters -->

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -178,7 +178,6 @@ public class ArgumentProcessor {
     }
 
     private List<ParserResult> processArguments() {
-
         if (!cli.isBlank() && cli.isDebugLogging()) {
             System.err.println("use java property -Dtinylog.level=debug");
         }
@@ -301,7 +300,6 @@ public class ArgumentProcessor {
 
         writeMetadatatoPdfByCitekey(databaseContext, dataBase, citeKeys, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
         writeMetadatatoPdfByFileNames(databaseContext, dataBase, pdfs, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
-
     }
 
     private void writeMetadatatoPDFsOfEntry(BibDatabaseContext databaseContext, String citeKey, BibEntry entry, FilePreferences filePreferences, XmpPdfExporter xmpPdfExporter, EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter, boolean writeXMP, boolean embeddBibfile) {

--- a/src/main/java/org/jabref/cli/CrossrefFetcherEvaluator.java
+++ b/src/main/java/org/jabref/cli/CrossrefFetcherEvaluator.java
@@ -50,7 +50,6 @@ public class CrossrefFetcherEvaluator {
 
             for (BibEntry entry : entries) {
                 executorService.execute(new Runnable() {
-
                     @Override
                     public void run() {
                         Optional<DOI> origDOI = entry.getField(StandardField.DOI).flatMap(DOI::parse);

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -99,7 +99,6 @@ public class JabRefDialogService implements DialogService {
         // Create a new dialog pane that has a checkbox instead of the hide/show details button
         // Use the supplied callback for the action of the checkbox
         alert.setDialogPane(new DialogPane() {
-
             @Override
             protected Node createDetailsButton() {
                 CheckBox optOut = new CheckBox();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -300,7 +300,6 @@ public class JabRefFrame extends BorderPane {
     private void initShowTrackingNotification() {
         if (prefs.getTelemetryPreferences().shouldAskToCollectTelemetry()) {
             JabRefExecutorService.INSTANCE.submit(new TimerTask() {
-
                 @Override
                 public void run() {
                     DefaultTaskExecutor.runInJavaFXThread(JabRefFrame.this::showTrackingNotification);
@@ -445,7 +444,6 @@ public class JabRefFrame extends BorderPane {
 
         // We need to wait with setting the divider since it gets reset a few times during the initial set-up
         mainStage.showingProperty().addListener(new InvalidationListener() {
-
             @Override
             public void invalidated(Observable observable) {
                 if (mainStage.isShowing()) {

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -317,7 +317,6 @@ public class LibraryTab extends Tab {
             // Unique path fragment
             Optional<String> uniquePathPart = FileUtil.getUniquePathFragment(collectAllDatabasePaths(), databasePath);
             uniquePathPart.ifPresent(part -> tabTitle.append(" \u2013 ").append(part));
-
         } else {
             if (databaseLocation == DatabaseLocation.LOCAL) {
                 tabTitle.append(Localization.lang("untitled"));
@@ -611,7 +610,6 @@ public class LibraryTab extends Tab {
      * Closes the entry editor if it is showing any of the given entries.
      */
     private void ensureNotShowingBottomPanel(List<BibEntry> entriesToCheck) {
-
         // This method is not able to close the bottom pane currently
 
         if ((mode == BasePanelMode.SHOWING_EDITOR) && (entriesToCheck.contains(entryEditor.getEntry()))) {

--- a/src/main/java/org/jabref/gui/actions/ActionHelper.java
+++ b/src/main/java/org/jabref/gui/actions/ActionHelper.java
@@ -57,7 +57,6 @@ public class ActionHelper {
     }
 
     public static BooleanExpression isFilePresentForSelectedEntry(StateManager stateManager, PreferencesService preferencesService) {
-
         ObservableList<BibEntry> selectedEntries = stateManager.getSelectedEntries();
         Binding<Boolean> fileIsPresent = EasyBind.valueAt(selectedEntries, 0).map(entry -> {
             List<LinkedFile> files = entry.getFiles();
@@ -75,7 +74,6 @@ public class ActionHelper {
             } else {
                 return false;
             }
-
         }).orElse(false);
 
         return BooleanExpression.booleanExpression(fileIsPresent);

--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
@@ -39,7 +39,6 @@ public class PersonNameStringConverter extends StringConverter<Author> {
 
     @Override
     public String toString(Author author) {
-
         if (autoCompLF) {
             switch (autoCompleteFirstNameMode) {
                 case ONLY_ABBREVIATED:

--- a/src/main/java/org/jabref/gui/citationkeypattern/GenerateCitationKeyAction.java
+++ b/src/main/java/org/jabref/gui/citationkeypattern/GenerateCitationKeyAction.java
@@ -96,7 +96,6 @@ public class GenerateCitationKeyAction extends SimpleCommand {
 
     private BackgroundTask generateKeysInBackground() {
         return new BackgroundTask<Void>() {
-
             private NamedCompound compound;
 
             @Override
@@ -141,7 +140,6 @@ public class GenerateCitationKeyAction extends SimpleCommand {
                 return super.onSuccess(onSuccess);
             }
         };
-
     }
 
     private String formatOutputMessage(String start, int count) {

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
@@ -63,9 +63,7 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
         String currentDate = currentTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss"));
 
         try (BufferedWriter bw = Files.newBufferedWriter(exportPath.resolve(LOGFILE_PREFIX + currentDate + LOGFILE_EXT), StandardCharsets.UTF_8)) {
-
             for (int i = 0; i < entries.size(); i++) {
-
                 if (isCancelled()) {
                     break;
                 }
@@ -73,7 +71,6 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
                 List<LinkedFile> files = entries.get(i).getFiles();
 
                 for (int j = 0; j < files.size(); j++) {
-
                     if (isCancelled()) {
                         break;
                     }
@@ -87,7 +84,6 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
                     newPath = OptionalUtil.combine(Optional.of(exportPath), fileToExport, resolvePathFilename);
 
                     if (newPath.isPresent()) {
-
                         Path newFile = newPath.get();
                         boolean success = FileUtil.copyFile(fileToExport.get(), newFile, false);
                         updateProgress(totalFilesCounter++, totalFilesCount);
@@ -105,7 +101,6 @@ public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
                             writeLogMessage(newFile, bw, localizedSucessMessage);
                             addResultToList(newFile, success, localizedSucessMessage);
                         } else {
-
                             updateMessage(localizedErrorMessage);
                             writeLogMessage(newFile, bw, localizedErrorMessage);
                             addResultToList(newFile, success, localizedErrorMessage);

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypeDialogViewModel.java
@@ -191,7 +191,6 @@ public class CustomEntryTypeDialogViewModel {
     }
 
     public void apply() {
-
         for (var typeWithField : entryTypesWithFields) {
             BibEntryType type = typeWithField.entryType().getValue();
             List<FieldViewModel> allFields = typeWithField.fields();

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomizeEntryTypeDialogView.java
@@ -109,7 +109,6 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
     }
 
     private void setupTable() {
-
         // Table View must be editable, otherwise the change of the Radiobuttons does not propagate the commit event
         fields.setEditable(true);
         entryTypColumn.setCellValueFactory(cellData -> new ReadOnlyStringWrapper(cellData.getValue().entryType().get().getType().getDisplayName()));
@@ -213,7 +212,6 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
     }
 
     private void handleOnDragDropped(TableRow<FieldViewModel> row, FieldViewModel originalItem, DragEvent event) {
-
         if (localDragboard.hasType(FieldViewModel.class)) {
             FieldViewModel field = localDragboard.getValue(FieldViewModel.class);
             fields.getItems().remove(field);
@@ -256,6 +254,5 @@ public class CustomizeEntryTypeDialogView extends BaseDialog<Void> {
             viewModel.addAllTypes();
             this.entryTypes.refresh();
         }
-
     }
 }

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeViewModel.java
@@ -60,5 +60,4 @@ public class EntryTypeViewModel {
     public String toString() {
         return "CustomEntryTypeViewModel [entryType=" + entryType + ", fields=" + fields + "]";
     }
-
 }

--- a/src/main/java/org/jabref/gui/edit/EditAction.java
+++ b/src/main/java/org/jabref/gui/edit/EditAction.java
@@ -57,7 +57,6 @@ public class EditAction extends SimpleCommand {
                     case DELETE_ENTRY -> textInput.deleteNextChar();
                     default -> throw new IllegalStateException("Only cut/copy/paste supported in TextInputControl but got " + action);
                 }
-
             } else if ((focusOwner instanceof CodeArea) || (focusOwner instanceof WebView)) {
                 return;
             } else {

--- a/src/main/java/org/jabref/gui/edit/ManageKeywordsViewModel.java
+++ b/src/main/java/org/jabref/gui/edit/ManageKeywordsViewModel.java
@@ -53,7 +53,6 @@ public class ManageKeywordsViewModel {
                 sortedKeywordsOfAllEntriesBeforeUpdateByUser.addAll(separatedKeywords);
             }
         } else if (type == ManageKeywordsDisplayType.CONTAINED_IN_ANY_ENTRY) {
-
             // all keywords from first entry have to be added
             BibEntry firstEntry = entries.get(0);
             KeywordList separatedKeywords = firstEntry.getKeywords(preferences.getKeywordDelimiter());

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -54,7 +54,6 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
         if (entryType.isPresent()) {
             return entryType.get().getDeprecatedFields();
-
         } else {
             // Entry type unknown -> treat all fields as required
             return Collections.emptySet();

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -335,5 +335,4 @@ public class SourceTab extends EntryEditorTab {
             }
         });
     }
-
 }

--- a/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -80,7 +80,6 @@ public class ErrorConsoleView extends BaseDialog<Void> {
 
     private Callback<ListView<LogEventViewModel>, ListCell<LogEventViewModel>> createCellFactory() {
         return cell -> new ListCell<>() {
-
             private HBox graphic;
             private Node icon;
             private VBox message;

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
@@ -62,7 +62,6 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
         // Check that there are no empty strings.
         if (layoutFile.get().isEmpty() || name.get().isEmpty() || extension.get().isEmpty()
                 || !layoutFile.get().endsWith(".layout")) {
-
             LOGGER.info("One of the fields is empty or invalid!");
             return null;
         }

--- a/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
@@ -89,7 +89,6 @@ public class WriteMetadataToPdfAction extends SimpleCommand {
         entries = stateManager.getSelectedEntries();
 
         if (entries.isEmpty()) {
-
             entries = database.getEntries();
 
             if (entries.isEmpty()) {

--- a/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/EditExternalFileTypeViewModel.java
@@ -61,7 +61,6 @@ public class EditExternalFileTypeViewModel {
     }
 
     public void storeSettings() {
-
         fileType.setName(nameProperty.getValue().trim());
         fileType.setMimeType(mimeTypeProperty.getValue().trim());
 

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypes.java
@@ -133,7 +133,6 @@ public class ExternalFileTypes {
      * @param types The new List of external file types. This is the complete list, not just new entries.
      */
     public void setExternalFileTypes(List<ExternalFileType> types) {
-
         // First find a list of the default types:
         List<ExternalFileType> defTypes = new ArrayList<>(getDefaultExternalFileTypes());
         // Make a list of types that are unchanged:

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
@@ -22,7 +22,6 @@ public class DateEditorViewModel extends AbstractEditorViewModel {
 
     public StringConverter<TemporalAccessor> getDateToStringConverter() {
         return new StringConverter<TemporalAccessor>() {
-
             @Override
             public String toString(TemporalAccessor date) {
                 if (date != null) {

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
@@ -50,7 +50,6 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
                 new Tooltip(Localization.lang("Look up %0", field.getDisplayName())));
 
         if (field.equals(StandardField.DOI)) {
-
             textArea.initContextMenu(EditorMenus.getDOIMenu(textArea));
         } else {
             textArea.initContextMenu(new DefaultMenu(textArea));

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
@@ -36,7 +36,6 @@ public class LinkedEntriesEditorViewModel extends AbstractEditorViewModel {
 
     public StringConverter<ParsedEntryLink> getStringConverter() {
         return new StringConverter<>() {
-
             @Override
             public String toString(ParsedEntryLink linkedEntry) {
                 if (linkedEntry == null) {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -126,20 +126,19 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         ObservableList<LinkedFileViewModel> items = listView.itemsProperty().get();
 
         if (dragboard.hasContent(DragAndDropDataFormats.LINKED_FILE)) {
-
             LinkedFile linkedFile = (LinkedFile) dragboard.getContent(DragAndDropDataFormats.LINKED_FILE);
-            LinkedFileViewModel transferedItem = null;
+            LinkedFileViewModel transferredItem = null;
             int draggedIdx = 0;
             for (int i = 0; i < items.size(); i++) {
                 if (items.get(i).getFile().equals(linkedFile)) {
                     draggedIdx = i;
-                    transferedItem = items.get(i);
+                    transferredItem = items.get(i);
                     break;
                 }
             }
             int thisIdx = items.indexOf(originalItem);
             items.set(draggedIdx, originalItem);
-            items.set(thisIdx, transferedItem);
+            items.set(thisIdx, transferredItem);
             success = true;
         }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/MapBasedEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/MapBasedEditorViewModel.java
@@ -29,7 +29,6 @@ public abstract class MapBasedEditorViewModel<T> extends OptionEditorViewModel<T
     @Override
     public StringConverter<T> getStringConverter() {
         return new StringConverter<T>() {
-
             @Override
             public String toString(T object) {
                 if (object == null) {

--- a/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -247,7 +247,6 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         popOver.setCornerRadius(0);
         popOver.setTitle("Icon picker");
         popOver.show(iconPickerButton);
-
     }
 
     public class IkonliCell extends GridCell<Ikon> {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -392,7 +392,6 @@ public class GroupTreeView extends BorderPane {
     }
 
     private ContextMenu createContextMenuForGroup(GroupNodeViewModel group) {
-
         ContextMenu menu = new ContextMenu();
         Menu removeGroup = new Menu(Localization.lang("Remove group"));
 

--- a/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
+++ b/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
@@ -75,5 +75,4 @@ public class InternalMaterialDesignIcon implements JabRefIcon {
     public Ikon getIkon() {
         return icons.get(0);
     }
-
 }

--- a/src/main/java/org/jabref/gui/icon/JabRefIconView.java
+++ b/src/main/java/org/jabref/gui/icon/JabRefIconView.java
@@ -29,7 +29,6 @@ public class JabRefIconView extends FontIcon {
     }
 
     public JabRefIconView(IconTheme.JabRefIcons icon) {
-
         super(icon.getIkon());
         Size size = new Size(1.0, SizeUnits.EM);
         this.glyph = new SimpleObjectProperty<>(icon);

--- a/src/main/java/org/jabref/gui/icon/JabRefIkonHandler.java
+++ b/src/main/java/org/jabref/gui/icon/JabRefIkonHandler.java
@@ -34,5 +34,4 @@ public class JabRefIkonHandler extends AbstractIkonHandler {
     public String getFontFamily() {
         return "JabRefMaterialDesign";
     }
-
 }

--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
@@ -75,7 +75,6 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
 
     private BackgroundTask<Optional<BibEntry>> searchAndImportEntryInBackground() {
         return new BackgroundTask<>() {
-
             @Override
             protected Optional<BibEntry> call() throws JabRefException {
                 if (isCanceled()) {
@@ -85,12 +84,10 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
                 updateMessage(Localization.lang("Searching..."));
                 try {
                     return new CompositeIdFetcher(preferencesService.getImportFormatPreferences()).performSearchById(identifier);
-
                 } catch (FetcherException fetcherException) {
                     throw new JabRefException("Fetcher error: %s".formatted(fetcherException.getMessage()));
                 }
             }
         };
     }
-
 }

--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdDialog.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdDialog.java
@@ -68,5 +68,4 @@ public class GenerateEntryFromIdDialog {
     public DialogPane getDialogPane() {
         return dialogPane;
     }
-
 }

--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -68,7 +68,6 @@ public class OpenDatabaseAction extends SimpleCommand {
         this.dialogService = dialogService;
         this.stateManager = stateManager;
         this.themeManager = themeManager;
-
     }
 
     /**

--- a/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
@@ -63,7 +63,6 @@ public class LookupIdentifierAction<T extends Identifier> extends SimpleCommand 
 
     public Action getAction() {
         return new Action() {
-
             @Override
             public Optional<JabRefIcon> getIcon() {
                 return Optional.empty();

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -61,7 +61,6 @@ public class AbbreviateAction extends SimpleCommand {
 
     @Override
     public void execute() {
-
         if (action == StandardActions.ABBREVIATE_DEFAULT
                 || action == StandardActions.ABBREVIATE_MEDLINE
                 || action == StandardActions.ABBREVIATE_SHORTEST_UNIQUE) {
@@ -72,7 +71,6 @@ public class AbbreviateAction extends SimpleCommand {
                                   .onSuccess(dialogService::notify)
                                   .executeWith(Globals.TASK_EXECUTOR));
         } else if (action == StandardActions.UNABBREVIATE) {
-
             dialogService.notify(Localization.lang("Unabbreviating..."));
             stateManager.getActiveDatabase().ifPresent(databaseContext ->
                     BackgroundTask.wrap(() -> unabbreviate(stateManager.getActiveDatabase().get(), stateManager.getSelectedEntries()))

--- a/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/LibraryPropertiesViewModel.java
@@ -15,7 +15,6 @@ public class LibraryPropertiesViewModel {
     private final ObservableList<PropertiesTab> propertiesTabs;
 
     public LibraryPropertiesViewModel(BibDatabaseContext databaseContext) {
-
         propertiesTabs = FXCollections.observableArrayList(
                 new GeneralPropertiesView(databaseContext),
                 new SavingPropertiesView(databaseContext),

--- a/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogView.java
+++ b/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogView.java
@@ -55,7 +55,6 @@ public class LinkedFileEditDialogView extends BaseDialog<LinkedFile> {
 
     @FXML
     private void initialize() {
-
         viewModel = new LinkedFilesEditDialogViewModel(linkedFile, stateManager.getActiveDatabase().get(), dialogService, preferences.getFilePreferences(), externalFileTypes);
         fileType.itemsProperty().bindBidirectional(viewModel.externalFileTypeProperty());
         description.textProperty().bindBidirectional(viewModel.descriptionProperty());

--- a/src/main/java/org/jabref/gui/linkedfile/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/linkedfile/LinkedFilesEditDialogViewModel.java
@@ -56,7 +56,6 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
 
     private void setExternalFileTypeByExtension(String link) {
         if (!link.isEmpty()) {
-
             // Check if this looks like a remote link:
             if (REMOTE_LINK_PATTERN.matcher(link).matches()) {
                 externalFileTypes.getExternalFileTypeByExt("html").ifPresent(selectedExternalFileType::setValue);

--- a/src/main/java/org/jabref/gui/logging/ApplicationInsightsLogEvent.java
+++ b/src/main/java/org/jabref/gui/logging/ApplicationInsightsLogEvent.java
@@ -65,7 +65,6 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
 
     @Override
     public Map<String, String> getCustomParameters() {
-
         Map<String, String> metaData = new HashMap<>();
 
         metaData.put("SourceType", "slf4j");
@@ -78,13 +77,11 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
             addLogEventProperty("Logger Message", getMessage(), metaData);
 
             for (StackTraceElement stackTraceElement : logEvent.getException().getStackTrace()) {
-
                 addLogEventProperty("ClassName", stackTraceElement.getClassName(), metaData);
                 addLogEventProperty("FileName", stackTraceElement.getFileName(), metaData);
                 addLogEventProperty("MethodName", stackTraceElement.getMethodName(), metaData);
                 addLogEventProperty("LineNumber", String.valueOf(stackTraceElement.getLineNumber()), metaData);
             }
-
         }
 
         for (Entry<String, String> entry : logEvent.getContext().entrySet()) {
@@ -102,7 +99,6 @@ public final class ApplicationInsightsLogEvent extends ApplicationInsightsEvent 
         org.tinylog.Level logEventLevel = logEvent.getLevel();
 
         switch (logEventLevel) {
-
             case ERROR:
                 return SeverityLevel.Error;
             case WARN:

--- a/src/main/java/org/jabref/gui/logging/ApplicationInsightsWriter.java
+++ b/src/main/java/org/jabref/gui/logging/ApplicationInsightsWriter.java
@@ -55,6 +55,5 @@ public class ApplicationInsightsWriter extends AbstractFormatPatternWriter {
 
     @Override
     public void close() throws Exception {
-
     }
 }

--- a/src/main/java/org/jabref/gui/logging/GuiWriter.java
+++ b/src/main/java/org/jabref/gui/logging/GuiWriter.java
@@ -39,5 +39,4 @@ public class GuiWriter extends AbstractFormatPatternWriter {
     @Override
     public void close() throws Exception {
     }
-
 }

--- a/src/main/java/org/jabref/gui/maintable/columns/LibraryColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/LibraryColumn.java
@@ -21,5 +21,4 @@ public class LibraryColumn extends MainTableColumn<String> {
     public LibraryColumn() {
         this(new MainTableColumnModel(Type.LIBRARY_NAME));
     }
-
 }

--- a/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
+++ b/src/main/java/org/jabref/gui/menus/ChangeEntryTypeMenu.java
@@ -32,7 +32,6 @@ import org.jabref.model.strings.StringUtil;
 public class ChangeEntryTypeMenu {
 
     public ChangeEntryTypeMenu() {
-
     }
 
     public static MenuItem createMenuItem(EntryType type, List<BibEntry> entries, UndoManager undoManager) {

--- a/src/main/java/org/jabref/gui/openoffice/AdvancedCiteDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/AdvancedCiteDialogView.java
@@ -20,7 +20,6 @@ public class AdvancedCiteDialogView extends BaseDialog<AdvancedCiteDialogViewMod
     private AdvancedCiteDialogViewModel viewModel;
 
     public AdvancedCiteDialogView() {
-
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);

--- a/src/main/java/org/jabref/gui/openoffice/Bootstrap.java
+++ b/src/main/java/org/jabref/gui/openoffice/Bootstrap.java
@@ -334,9 +334,7 @@ public class Bootstrap {
     }
 
     private static void pipe(final InputStream in, final PrintStream out, final String prefix) {
-
         new Thread("Pipe: " + prefix) {
-
             @Override
             public void run() {
                 try {

--- a/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
+++ b/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
@@ -36,7 +36,6 @@ public class DetectOpenOfficeInstallation {
     }
 
     public Optional<Path> selectInstallationPath() {
-
         final NativeDesktop nativeDesktop = JabRefDesktop.getNativeDesktop();
 
         dialogService.showInformationDialogAndWait(Localization.lang("Could not find OpenOffice/LibreOffice installation"),

--- a/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/ManageCitationsDialogView.java
@@ -54,7 +54,6 @@ public class ManageCitationsDialogView extends BaseDialog<Void> {
 
     @FXML
     private void initialize() {
-
         viewModel = new ManageCitationsDialogViewModel(ooBase, dialogService);
 
         citation.setCellValueFactory(cellData -> cellData.getValue().citationProperty());
@@ -73,7 +72,6 @@ public class ManageCitationsDialogView extends BaseDialog<Void> {
     }
 
     private Node getText(String citationContext) {
-
         String inBetween = StringUtil.substringBetween(citationContext, HTML_BOLD_START_TAG, HTML_BOLD_END_TAG);
         String start = citationContext.substring(0, citationContext.indexOf(HTML_BOLD_START_TAG));
         String end = citationContext.substring(citationContext.lastIndexOf(HTML_BOLD_END_TAG) + HTML_BOLD_END_TAG.length());

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -180,7 +180,6 @@ class OOBibBase {
      * Get the cursor positioned by the user for inserting text.
      */
     OOResult<XTextCursor, OOError> getUserCursorForTextInsertion(XTextDocument doc, String errorTitle) {
-
         // Get the cursor positioned by the user.
         XTextCursor cursor = UnoCursor.getViewCursor(doc).orElse(null);
 
@@ -265,7 +264,6 @@ class OOBibBase {
      * ******************************************************/
 
     private static OOVoidResult<OOError> checkIfOpenOfficeIsRecordingChanges(XTextDocument doc) {
-
         String errorTitle = Localization.lang("Recording and/or Recorded changes");
         try {
             boolean recordingChanges = UnoRedlines.getRecordChanges(doc);
@@ -393,7 +391,6 @@ class OOBibBase {
     }
 
     public OOVoidResult<OOError> checkStylesExistInTheDocument(OOBibStyle style, XTextDocument doc) {
-
         String pathToStyleFile = style.getPath();
 
         List<OOVoidResult<OOError>> results = new ArrayList<>();
@@ -430,7 +427,6 @@ class OOBibBase {
      *
      * ******************************************************/
     public Optional<List<CitationEntry>> guiActionGetCitationEntries() {
-
         final Optional<List<CitationEntry>> FAIL = Optional.empty();
         final String errorTitle = Localization.lang("Problem collecting citations");
 
@@ -481,7 +477,6 @@ class OOBibBase {
      * </ul>
      */
     public void guiActionApplyCitationEntries(List<CitationEntry> citationEntries) {
-
         final String errorTitle = Localization.lang("Problem modifying citation");
 
         OOResult<XTextDocument, OOError> odoc = getXTextDocument();
@@ -617,7 +612,6 @@ class OOBibBase {
      * GUI action "Merge citations"
      */
     public void guiActionMergeCitationGroups(List<BibDatabase> databases, OOBibStyle style) {
-
         final String errorTitle = Localization.lang("Problem combining cite markers");
 
         OOResult<XTextDocument, OOError> odoc = getXTextDocument();
@@ -672,7 +666,6 @@ class OOBibBase {
      * Do the opposite of MergeCitationGroups. Combined markers are split, with a space inserted between.
      */
     public void guiActionSeparateCitations(List<BibDatabase> databases, OOBibStyle style) {
-
         final String errorTitle = Localization.lang("Problem during separating cite markers");
 
         OOResult<XTextDocument, OOError> odoc = getXTextDocument();
@@ -729,7 +722,6 @@ class OOBibBase {
      * @param returnPartialResult If there are some unresolved keys, shall we return an otherwise nonempty result, or Optional.empty()?
      */
     public Optional<BibDatabase> exportCitedHelper(List<BibDatabase> databases, boolean returnPartialResult) {
-
         final Optional<BibDatabase> FAIL = Optional.empty();
         final String errorTitle = Localization.lang("Unable to generate new library");
 
@@ -798,7 +790,6 @@ class OOBibBase {
      * @param style     Style.
      */
     public void guiActionUpdateDocument(List<BibDatabase> databases, OOBibStyle style) {
-
         final String errorTitle = Localization.lang("Unable to synchronize bibliography");
 
         try {

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -168,7 +168,6 @@ public class OpenOfficePanel {
     }
 
     private void initPanel() {
-
         connect.setOnAction(e -> connectAutomatically());
         manualConnect.setOnAction(e -> connectManually());
 
@@ -285,9 +284,7 @@ public class OpenOfficePanel {
         if (officeInstallation.isExecutablePathDefined()) {
             connect();
         } else {
-
             Task<List<Path>> taskConnectIfInstalled = new Task<>() {
-
                 @Override
                 protected List<Path> call() {
                     return OpenOfficeFileSearch.detectInstallations();
@@ -319,7 +316,6 @@ public class OpenOfficePanel {
         DetectOpenOfficeInstallation officeInstallation = new DetectOpenOfficeInstallation(preferencesService, dialogService);
 
         if (selectedPath.isPresent()) {
-
             BackgroundTask.wrap(() -> officeInstallation.setOpenOfficePreferences(selectedPath.get()))
                           .withInitialMessage("Searching for executable")
                           .onFailure(dialogService::showErrorDialogAndWait).onSuccess(value -> {
@@ -365,7 +361,6 @@ public class OpenOfficePanel {
         openOfficePreferences = preferencesService.getOpenOfficePreferences();
 
         Task<OOBibBase> connectTask = new Task<>() {
-
             @Override
             protected OOBibBase call() throws Exception {
                 updateProgress(ProgressBar.INDETERMINATE_PROGRESS, ProgressBar.INDETERMINATE_PROGRESS);
@@ -465,7 +460,6 @@ public class OpenOfficePanel {
 
             Optional<AdvancedCiteDialogViewModel> citeDialogViewModel = dialogService.showCustomDialogAndWait(new AdvancedCiteDialogView());
             if (citeDialogViewModel.isPresent()) {
-
                 AdvancedCiteDialogViewModel model = citeDialogViewModel.get();
                 if (!model.pageInfoProperty().getValue().isEmpty()) {
                     pageInfo = model.pageInfoProperty().getValue();
@@ -548,7 +542,6 @@ public class OpenOfficePanel {
     }
 
     private ContextMenu createSettingsPopup() {
-
         ContextMenu contextMenu = new ContextMenu();
 
         CheckMenuItem autoSync = new CheckMenuItem(Localization.lang("Automatically sync bibliography when inserting citations"));

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogView.java
@@ -55,7 +55,6 @@ public class StyleSelectDialogView extends BaseDialog<OOBibStyle> {
     private PreviewViewer previewBook;
 
     public StyleSelectDialogView(StyleLoader loader) {
-
         this.loader = loader;
 
         ViewLoader.view(this)

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -85,7 +85,6 @@ public class StyleSelectDialogViewModel {
     }
 
     public void deleteStyle() {
-
         OOBibStyle style = selectedItem.getValue().getStyle();
         if (loader.removeStyle(style)) {
             styles.remove(selectedItem.get());

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -79,7 +79,6 @@ class PreferencesSearchHandler {
             if (builder instanceof Parent) {
                 Parent parentBuilder = (Parent) builder;
                 scanLabeledControls(parentBuilder, prefsTabLabelMap, preferencesTab);
-
             }
         }
         return prefsTabLabelMap;
@@ -92,10 +91,8 @@ class PreferencesSearchHandler {
     private static void scanLabeledControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
         for (Node child : parent.getChildrenUnmodifiable()) {
             if (!(child instanceof Labeled)) {
-
                 scanLabeledControls((Parent) child, prefsTabLabelMap, preferencesTab);
             } else {
-
                 Labeled labeled = (Labeled) child;
                 if (!labeled.getText().isEmpty()) {
                     prefsTabLabelMap.put(preferencesTab, labeled);

--- a/src/main/java/org/jabref/gui/preferences/nameformatter/NameFormatterTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/nameformatter/NameFormatterTabViewModel.java
@@ -58,7 +58,6 @@ public class NameFormatterTabViewModel implements PreferenceTabViewModel {
     public void addFormatter() {
         if (!StringUtil.isNullOrEmpty(addFormatterNameProperty.getValue()) &&
                 !StringUtil.isNullOrEmpty(addFormatterStringProperty.getValue())) {
-
             formatterListProperty.add(new NameFormatterItemModel(
                     addFormatterNameProperty.getValue(), addFormatterStringProperty.getValue()));
 

--- a/src/main/java/org/jabref/gui/preferences/network/NetworkTab.java
+++ b/src/main/java/org/jabref/gui/preferences/network/NetworkTab.java
@@ -137,7 +137,6 @@ public class NetworkTab extends AbstractPreferenceTabView<NetworkTabViewModel> i
                 .withTooltip(name -> Localization.lang("Remove formatter '%0'", name))
                 .withOnMouseClickedEvent(thumbprint -> evt -> viewModel.customCertificateListProperty().removeIf(cert -> cert.getThumbprint().equals(thumbprint)))
                 .install(actionsColumn);
-
     }
 
     private String formatDate(LocalDate localDate) {

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -293,7 +293,6 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
      * @return highlighted span for codeArea
      */
     public StyleSpans<Collection<String>> computeHighlighting(String text) {
-
         final Pattern XML_TAG = Pattern.compile("(?<ELEMENT>(</?\\h*)(\\w+)([^<>]*)(\\h*/?>))"
                 + "|(?<COMMENT><!--[^<>]+-->)");
         final Pattern ATTRIBUTES = Pattern.compile("(\\w+\\h*)(=)(\\h*\"[^\"]+\")");
@@ -310,7 +309,6 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         int lastKeywordEnd = 0;
         StyleSpansBuilder<Collection<String>> spansBuilder = new StyleSpansBuilder<>();
         while (matcher.find()) {
-
             spansBuilder.add(Collections.emptyList(), matcher.start() - lastKeywordEnd);
             if (matcher.group("COMMENT") != null) {
                 spansBuilder.add(Collections.singleton("comment"), matcher.end() - matcher.start());
@@ -322,7 +320,6 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
                     spansBuilder.add(Collections.singleton("anytag"), matcher.end(GROUP_ELEMENT_NAME) - matcher.end(GROUP_OPEN_BRACKET));
 
                     if (!attributesText.isEmpty()) {
-
                         lastKeywordEnd = 0;
 
                         Matcher attributesMatcher = ATTRIBUTES.matcher(attributesText);

--- a/src/main/java/org/jabref/gui/preferences/protectedterms/ProtectedTermsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/protectedterms/ProtectedTermsTabViewModel.java
@@ -112,7 +112,6 @@ public class ProtectedTermsTabViewModel implements PreferenceTabViewModel {
                 Localization.lang("Are you sure you want to remove the protected terms file?"),
                 Localization.lang("Remove protected terms file"),
                 Localization.lang("Cancel"))) {
-
             itemModel.enabledProperty().setValue(false);
             if (!termsFilesProperty.remove(itemModel)) {
                 LOGGER.info("Problem removing protected terms file");

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -268,7 +268,6 @@ public class GlobalSearchBar extends HBox {
     }
 
     public void performSearch() {
-
         LOGGER.debug("Flags: {}", searchPreferences.getSearchFlags());
         LOGGER.debug("Run search " + searchField.getText());
 

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
@@ -135,7 +135,6 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
 
     private boolean openSharedDatabase(DBMSConnectionProperties connectionProperties) {
         if (isSharedDatabaseAlreadyPresent(connectionProperties)) {
-
             dialogService.showWarningDialogAndWait(Localization.lang("Shared database connection"),
                     Localization.lang("You are already connected to a database using entered connection details."));
             return true;
@@ -145,7 +144,6 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
             Path localFilePath = Path.of(folder.getValue());
 
             if (Files.exists(localFilePath) && !Files.isDirectory(localFilePath)) {
-
                 boolean overwriteFilePressed = dialogService.showConfirmationDialogAndWait(Localization.lang("Existing file"),
                         Localization.lang("'%0' exists. Overwrite file?", localFilePath.getFileName().toString()),
                         Localization.lang("Overwrite file"),
@@ -173,7 +171,6 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
 
             return true;
         } catch (SQLException | InvalidDBMSConnectionPropertiesException exception) {
-
             frame.getDialogService().showErrorDialogAndWait(Localization.lang("Connection error"), exception);
         } catch (DatabaseNotSupportedException exception) {
             ButtonType openHelp = new ButtonType("Open Help", ButtonData.OTHER);

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
@@ -48,7 +48,6 @@ public class SharedDatabaseUIManager {
 
     @Subscribe
     public void listen(ConnectionLostEvent connectionLostEvent) {
-
         ButtonType reconnect = new ButtonType(Localization.lang("Reconnect"), ButtonData.YES);
         ButtonType workOffline = new ButtonType(Localization.lang("Work offline"), ButtonData.NO);
         ButtonType closeLibrary = new ButtonType(Localization.lang("Close library"), ButtonData.CANCEL_CLOSE);
@@ -76,7 +75,6 @@ public class SharedDatabaseUIManager {
 
     @Subscribe
     public void listen(UpdateRefusedEvent updateRefusedEvent) {
-
         jabRefFrame.getDialogService().notify(Localization.lang("Update refused."));
 
         BibEntry localBibEntry = updateRefusedEvent.getLocalBibEntry();
@@ -121,7 +119,6 @@ public class SharedDatabaseUIManager {
         libraryTab.getUndoManager().addEdit(new UndoableRemoveEntries(libraryTab.getDatabase(), event.getBibEntries()));
 
         if (Objects.nonNull(entryEditor) && (event.getBibEntries().contains(entryEditor.getEntry()))) {
-
             dialogService.showInformationDialogAndWait(Localization.lang("Shared entry is no longer present"),
                     Localization.lang("The entry you currently work on has been deleted on the shared side.")
                             + "\n"

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
@@ -62,7 +62,6 @@ public class SidePaneViewModel extends AbstractViewModel {
     }
 
     protected SidePaneComponent getSidePaneComponent(SidePaneType pane) {
-
         SidePaneComponent sidePaneComponent = sidePaneComponentLookup.get(pane);
         if (sidePaneComponent == null) {
             sidePaneComponent = switch (pane) {

--- a/src/main/java/org/jabref/gui/util/BindingsHelper.java
+++ b/src/main/java/org/jabref/gui/util/BindingsHelper.java
@@ -43,7 +43,6 @@ public class BindingsHelper {
 
     public static <T, U> ObservableList<U> map(ObservableValue<T> source, Function<T, List<U>> mapper) {
         PreboundBinding<List<U>> binding = new PreboundBinding<>(source) {
-
             @Override
             protected List<U> computeValue() {
                 return mapper.apply(source.getValue());
@@ -134,7 +133,6 @@ public class BindingsHelper {
 
     public static <T> ObservableValue<T> constantOf(T value) {
         return new ObjectBinding<>() {
-
             @Override
             protected T computeValue() {
                 return value;
@@ -144,7 +142,6 @@ public class BindingsHelper {
 
     public static ObservableValue<Boolean> constantOf(boolean value) {
         return new BooleanBinding() {
-
             @Override
             protected boolean computeValue() {
                 return value;
@@ -154,7 +151,6 @@ public class BindingsHelper {
 
     public static ObservableValue<? extends String> emptyString() {
         return new StringBinding() {
-
             @Override
             protected String computeValue() {
                 return "";

--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -113,6 +113,5 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
         } catch (IOException e) {
             LOGGER.error("error closing watcher", e);
         }
-
     }
 }

--- a/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
@@ -142,7 +142,6 @@ public class DefaultTaskExecutor implements TaskExecutor {
 
     private <V> Task<V> getJavaFXTask(BackgroundTask<V> task) {
         Task<V> javaTask = new Task<V>() {
-
             {
                 this.updateMessage(task.messageProperty().get());
                 this.updateTitle(task.titleProperty().get());

--- a/src/main/java/org/jabref/gui/util/DirectoryDialogConfiguration.java
+++ b/src/main/java/org/jabref/gui/util/DirectoryDialogConfiguration.java
@@ -25,17 +25,17 @@ public class DirectoryDialogConfiguration {
         }
 
         public Builder withInitialDirectory(Path directory) {
-
             directory = directory.toAbsolutePath();
+
             // Dir must be a folder, not a file
             if (!Files.isDirectory(directory)) {
                 directory = directory.getParent();
             }
+
             // The lines above work also if the dir does not exist at all!
-            // NULL is accepted by the filechooser as no inital path
+            // NULL is accepted by the filechooser as no initial path
 
             if (!Files.exists(directory)) {
-
                 directory = null;
             }
             initialDirectory = directory;

--- a/src/main/java/org/jabref/gui/util/FileNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/util/FileNodeViewModel.java
@@ -50,7 +50,6 @@ public class FileNodeViewModel {
      * Return a string of a FileTime in a yyyy-MM-dd HH:mm format.
      */
     public static String formatDateTime(FileTime fileTime) {
-
         LocalDateTime localDateTime = fileTime
                 .toInstant()
                 .atZone(ZoneId.systemDefault())

--- a/src/main/java/org/jabref/gui/util/ValueTableCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ValueTableCellFactory.java
@@ -92,7 +92,6 @@ public class ValueTableCellFactory<S, T> implements Callback<TableColumn<S, T>, 
     @Override
     public TableCell<S, T> call(TableColumn<S, T> param) {
         return new TableCell<>() {
-
             @Override
             protected void updateItem(T item, boolean empty) {
                 super.updateItem(item, empty);

--- a/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
@@ -151,9 +151,7 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
 
     @Override
     public ListCell<T> call(ListView<T> param) {
-
         return new ListCell<>() {
-
             final List<Subscription> subscriptions = new ArrayList<>();
 
             @Override

--- a/src/main/java/org/jabref/gui/util/ViewModelTextFieldTableCellVisualizationFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTextFieldTableCellVisualizationFactory.java
@@ -39,7 +39,6 @@ public class ViewModelTextFieldTableCellVisualizationFactory<S, T> implements Ca
     @Override
     public TextFieldTableCell<S, T> call(TableColumn<S, T> param) {
         return new TextFieldTableCell<>(stringConverter) {
-
             final List<Subscription> subscriptions = new ArrayList<>();
 
             @Override

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeTableCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeTableCellFactory.java
@@ -51,9 +51,7 @@ public class ViewModelTreeTableCellFactory<S> implements Callback<TreeTableColum
 
     @Override
     public TreeTableCell<S, S> call(TreeTableColumn<S, S> param) {
-
         return new TreeTableCell<S, S>() {
-
             @Override
             protected void updateItem(S viewModel, boolean empty) {
                 super.updateItem(viewModel, empty);

--- a/src/main/java/org/jabref/logic/bibtex/comparator/BibtexStringComparator.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/BibtexStringComparator.java
@@ -20,7 +20,6 @@ public class BibtexStringComparator implements Comparator<BibtexString> {
 
     @Override
     public int compare(BibtexString s1, BibtexString s2) {
-
         int res;
 
         // First check their names:
@@ -36,7 +35,6 @@ public class BibtexStringComparator implements Comparator<BibtexString> {
         // Then, if we are supposed to, see if the ordering needs
         // to be changed because of one string referring to the other.x
         if (considerRefs) {
-
             // First order them:
             BibtexString pre;
             BibtexString post;

--- a/src/main/java/org/jabref/logic/bst/BibtexNameFormatter.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexNameFormatter.java
@@ -52,7 +52,6 @@ public class BibtexNameFormatter {
      * @param warn collects the warnings, may-be-null
      */
     public static String formatName(Author author, String format, Warn warn) {
-
         StringBuilder sb = new StringBuilder();
 
         char[] c = format.toCharArray();
@@ -156,7 +155,6 @@ public class BibtexNameFormatter {
                 int groupStart = sb.length();
 
                 for (int j = 0; j < d.length; j++) {
-
                     if (Character.isLetter(d[j]) && (bLevel == 1)) {
                         groupStart = sb.length();
                         if (!abbreviateThatIsSingleLetter) {
@@ -240,14 +238,8 @@ public class BibtexNameFormatter {
 
     /**
      * Including the matching brace.
-     *
-     * @param interTokenSb
-     * @param c
-     * @param pos
-     * @return
      */
     public static int consumeToMatchingBrace(StringBuilder interTokenSb, char[] c, int pos) {
-
         int braceLevel = 0;
 
         for (int i = pos; i < c.length; i++) {
@@ -267,9 +259,6 @@ public class BibtexNameFormatter {
 
     /**
      * Takes care of special characters too
-     *
-     * @param s
-     * @return
      */
     public static String getFirstCharOfString(String s) {
         char[] c = s.toCharArray();

--- a/src/main/java/org/jabref/logic/bst/BibtexPurify.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexPurify.java
@@ -21,7 +21,6 @@ public class BibtexPurify {
      * @return
      */
     public static String purify(String toPurify, Warn warn) {
-
         StringBuilder sb = new StringBuilder();
 
         char[] cs = toPurify.toCharArray();

--- a/src/main/java/org/jabref/logic/bst/BibtexWidth.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexWidth.java
@@ -159,7 +159,6 @@ public class BibtexWidth {
     }
 
     public static int getCharWidth(char c) {
-
         if ((c >= 0) && (c < 128)) {
             return BibtexWidth.widths[c];
         } else {
@@ -168,7 +167,6 @@ public class BibtexWidth {
     }
 
     public static int width(String toMeasure) {
-
         /*
          * From Bibtex: We use the natural width for all but special characters,
          * and we complain if the string isn't brace-balanced.

--- a/src/main/java/org/jabref/logic/bst/VM.java
+++ b/src/main/java/org/jabref/logic/bst/VM.java
@@ -594,7 +594,6 @@ public class VM implements Warn {
          * messages issued.
          */
         buildInFunctions.put("warning$", new BstFunction() {
-
             int warning = 1;
 
             @Override
@@ -804,7 +803,6 @@ public class VM implements Warn {
     }
 
     private boolean assign(BstEntry context, Object o1, Object o2) {
-
         if (!(o1 instanceof Identifier) || !((o2 instanceof String) || (o2 instanceof Integer))) {
             throw new VMException("Invalid parameters");
         }
@@ -812,7 +810,6 @@ public class VM implements Warn {
         String name = ((Identifier) o1).getName();
 
         if (o2 instanceof String) {
-
             if ((context != null) && context.localStrings.containsKey(name)) {
                 context.localStrings.put(name, (String) o2);
                 return true;
@@ -1037,7 +1034,6 @@ public class VM implements Warn {
     }
 
     private void reverse(Tree child) {
-
         BstFunction f = functions.get(child.getChild(0).getText());
 
         ListIterator<BstEntry> i = entries.listIterator(entries.size());
@@ -1088,9 +1084,7 @@ public class VM implements Warn {
 
         @Override
         public void execute(BstEntry context) {
-
             for (int i = 0; i < localTree.getChildCount(); i++) {
-
                 Tree c = localTree.getChild(i);
                 try {
 
@@ -1130,9 +1124,7 @@ public class VM implements Warn {
     }
 
     private void execute(String name, BstEntry context) {
-
         if (context != null) {
-
             if (context.fields.containsKey(name)) {
                 stack.push(context.fields.get(name));
                 return;

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -99,7 +99,6 @@ public class CSLAdapter {
          * Converts the {@link BibEntry} into {@link CSLItemData}.
          */
         private static CSLItemData bibEntryToCSLItemData(BibEntry bibEntry, BibDatabaseContext bibDatabaseContext, BibEntryTypesManager entryTypesManager) {
-
             String citeKey = bibEntry.getCitationKey().orElse("");
             BibTeXEntry bibTeXEntry = new BibTeXEntry(new Key(bibEntry.getType().getName()), new Key(citeKey));
 
@@ -120,7 +119,6 @@ public class CSLAdapter {
                                 value = bibEntry.getMonth().map(Month::getShortName).orElse(value);
                             }
                             bibTeXEntry.addField(new Key(key.getName()), new DigitStringValue(value));
-
                         });
             }
             return BIBTEX_CONVERTER.toItemData(bibTeXEntry);

--- a/src/main/java/org/jabref/logic/cleanup/Cleanups.java
+++ b/src/main/java/org/jabref/logic/cleanup/Cleanups.java
@@ -56,7 +56,6 @@ public class Cleanups {
     }
 
     public static List<FieldFormatterCleanup> parse(String formatterString) {
-
         if ((formatterString == null) || formatterString.isEmpty()) {
             // no save actions defined in the meta data
             return new ArrayList<>();
@@ -109,7 +108,6 @@ public class Cleanups {
     }
 
     public static FieldFormatterCleanups parse(List<String> formatterMetaList) {
-
         if ((formatterMetaList != null) && (formatterMetaList.size() >= 2)) {
             boolean enablementStatus = FieldFormatterCleanups.ENABLED.equals(formatterMetaList.get(0));
             String formatterString = formatterMetaList.get(1);

--- a/src/main/java/org/jabref/logic/cleanup/DoiCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/DoiCleanup.java
@@ -25,7 +25,6 @@ public class DoiCleanup implements CleanupJob {
 
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
-
         List<FieldChange> changes = new ArrayList<>();
 
         // First check if the Doi Field is empty

--- a/src/main/java/org/jabref/logic/cleanup/EprintCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/EprintCleanup.java
@@ -18,7 +18,6 @@ public class EprintCleanup implements CleanupJob {
 
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
-
         List<FieldChange> changes = new ArrayList<>();
 
         for (Field field : Arrays.asList(StandardField.URL, StandardField.JOURNAL, StandardField.JOURNALTITLE, StandardField.NOTE)) {

--- a/src/main/java/org/jabref/logic/cleanup/MoveFieldCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/MoveFieldCleanup.java
@@ -23,7 +23,6 @@ public class MoveFieldCleanup implements CleanupJob {
 
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
-
         Optional<FieldChange> setFieldChange = entry.getField(sourceField).flatMap(
                 value -> entry.setField(targetField, value));
         Optional<FieldChange> clearFieldChange = entry.clearField(sourceField);

--- a/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
@@ -129,7 +129,6 @@ public class EmbeddedBibFilePdfExporter extends Exporter {
             }
             document.save(newFile.toFile());
             FileUtil.copyFile(newFile, path, true);
-
         }
         Files.delete(newFile);
     }

--- a/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
@@ -100,7 +100,6 @@ public class GroupSerializer {
      * @return a representation of the tree based at this node as a list of strings
      */
     public List<String> serializeTree(GroupTreeNode node) {
-
         List<String> representation = new ArrayList<>();
 
         // Append current node

--- a/src/main/java/org/jabref/logic/exporter/OpenDocumentSpreadsheetCreator.java
+++ b/src/main/java/org/jabref/logic/exporter/OpenDocumentSpreadsheetCreator.java
@@ -49,7 +49,6 @@ public class OpenDocumentSpreadsheetCreator extends Exporter {
     private static void storeOpenDocumentSpreadsheetFile(Path file, InputStream source) throws IOException {
 
         try (ZipOutputStream out = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(file)))) {
-
             // addResourceFile("mimetype", "/resource/ods/mimetype", out);
             ZipEntry ze = new ZipEntry("mimetype");
             String mime = "application/vnd.oasis.opendocument.spreadsheet";
@@ -112,7 +111,6 @@ public class OpenDocumentSpreadsheetCreator extends Exporter {
         OpenDocumentRepresentation od = new OpenDocumentRepresentation(database, entries);
 
         try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
-
             DOMSource source = new DOMSource(od.getDOMrepresentation());
             StreamResult result = new StreamResult(ps);
             Transformer trans = TransformerFactory.newInstance().newTransformer();

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -41,7 +41,6 @@ public class HtmlToLatexFormatter extends Formatter implements LayoutFormatter {
         // Note that (at least) the IEEE Xplore fetcher must be fixed as it relies on the current way to
         // remove tags for its image alt-tag to equation converter
         for (int i = 0; i < result.length(); i++) {
-
             int c = result.charAt(i);
 
             if (c == '<') {

--- a/src/main/java/org/jabref/logic/importer/Importer.java
+++ b/src/main/java/org/jabref/logic/importer/Importer.java
@@ -133,7 +133,6 @@ public abstract class Importer implements Comparable<Importer> {
             if (matches[0] != null) {
                 return Charset.forName(matches[0].getName());
             }
-
         } catch (IOException e) {
             LOGGER.error("Could not determine charset. Using default one.", e);
         }
@@ -165,7 +164,6 @@ public abstract class Importer implements Comparable<Importer> {
         }
 
         return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
-
     }
 
     public static BufferedReader getReader(InputStream stream) throws IOException {

--- a/src/main/java/org/jabref/logic/importer/PagedSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/PagedSearchBasedFetcher.java
@@ -55,5 +55,4 @@ public interface PagedSearchBasedFetcher extends SearchBasedFetcher {
     default List<BibEntry> performSearch(QueryNode luceneQuery) throws FetcherException {
         return new ArrayList<>(performSearchPaged(luceneQuery, 0).getContent());
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ACMPortalFetcher.java
@@ -62,5 +62,4 @@ public class ACMPortalFetcher implements SearchBasedParserFetcher {
     public Parser getParser() {
         return new ACMPortalParser();
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ApsFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ApsFetcher.java
@@ -41,7 +41,6 @@ public class ApsFetcher implements FulltextFetcher {
         Optional<String> id = getId(doi.get().getDOI());
 
         if (id.isPresent()) {
-
             String pdfRequestUrl = PDF_URL + id.get();
             int code = Unirest.head(pdfRequestUrl).asJson().getStatus();
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -309,5 +309,4 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, PagedSearch
         urlDownload.addHeader("Authorization", "Bearer " + API_KEY);
         return urlDownload;
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -136,7 +136,6 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher {
         // Try URL first -- will primarily work for entries from the old IEEE search
         Optional<String> urlString = entry.getField(StandardField.URL);
         if (urlString.isPresent()) {
-
             Matcher documentUrlMatcher = DOCUMENT_PATTERN.matcher(urlString.get());
             if (documentUrlMatcher.find()) {
                 String docId = documentUrlMatcher.group(1);

--- a/src/main/java/org/jabref/logic/importer/fetcher/transformers/ArXivQueryTransformer.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/transformers/ArXivQueryTransformer.java
@@ -47,5 +47,4 @@ public class ArXivQueryTransformer extends YearRangeByFilteringQueryTransformer 
     protected Optional<String> handleUnFieldedTerm(String term) {
         return Optional.of(createKeyValuePair("all", term));
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/transformers/SpringerQueryTransformer.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/transformers/SpringerQueryTransformer.java
@@ -35,7 +35,6 @@ public class SpringerQueryTransformer extends AbstractQueryTransformer {
     @Override
     protected String handleJournal(String journalTitle) {
         return createKeyValuePair("journal", journalTitle);
-
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/ACMPortalParser.java
@@ -227,5 +227,4 @@ public class ACMPortalParser implements Parser {
 
         return bibEntry;
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -302,7 +302,6 @@ public class BibtexParser implements Parser {
 
         String comment = buffer.toString().replaceAll("[\\x0d\\x0a]", "");
         if (comment.substring(0, Math.min(comment.length(), MetaData.META_FLAG.length())).equals(MetaData.META_FLAG)) {
-
             if (comment.startsWith(MetaData.META_FLAG)) {
                 String rest = comment.substring(MetaData.META_FLAG.length());
 
@@ -410,7 +409,6 @@ public class BibtexParser implements Parser {
      * @return a String without eof characters
      */
     private String purgeEOFCharacters(String input) {
-
         StringBuilder remainingText = new StringBuilder();
         for (Character character : input.toCharArray()) {
             if (!(isEOFCharacter(character))) {
@@ -726,7 +724,6 @@ public class BibtexParser implements Parser {
                     // Begin of entryfieldname (e.g. author) -> push back:
                     unread(currentChar);
                     if ((currentChar == ' ') || (currentChar == '\n')) {
-
                         /*
                          * found whitespaces, entryfieldname completed -> key in
                          * keybuffer, skip whitespaces
@@ -816,7 +813,6 @@ public class BibtexParser implements Parser {
                     || (character == ':') || ("#{}~,=\uFFFD".indexOf(character) == -1))) {
                 token.append((char) character);
             } else {
-
                 if (Character.isWhitespace((char) character)) {
                     // We have encountered white space instead of the comma at
                     // the end of
@@ -847,7 +843,6 @@ public class BibtexParser implements Parser {
         int brackets = 0;
 
         while (!((isClosingBracketNext()) && (brackets == 0))) {
-
             int character = read();
             if (isEOFCharacter(character)) {
                 throw new IOException("Error in line " + line + ": EOF in mid-string");

--- a/src/main/java/org/jabref/logic/importer/fileformat/CffImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CffImporter.java
@@ -75,7 +75,6 @@ public class CffImporter extends Importer {
         private void setValues(String key, String value) {
             values.put(key, value);
         }
-
     }
 
     private static class CffIdentifier {

--- a/src/main/java/org/jabref/logic/importer/fileformat/CopacImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CopacImporter.java
@@ -76,7 +76,6 @@ public class CopacImporter extends Importer {
         String str;
 
         while ((str = reader.readLine()) != null) {
-
             if (str.length() < 4) {
                 continue;
             }
@@ -86,8 +85,7 @@ public class CopacImporter extends Importer {
             if ("    ".equals(code)) {
                 sb.append(' ').append(str.trim());
             } else {
-
-                // begining of a new item
+                // beginning of a new item
                 if ("TI- ".equals(str.substring(0, 4))) {
                     if (sb.length() > 0) {
                         entries.add(sb.toString());
@@ -105,7 +103,6 @@ public class CopacImporter extends Importer {
         List<BibEntry> results = new LinkedList<>();
 
         for (String entry : entries) {
-
             // Copac does not contain enough information on the type of the
             // document. A book is assumed.
             BibEntry b = new BibEntry(StandardEntryType.Book);

--- a/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
@@ -57,7 +57,6 @@ public class CustomImporter extends Importer {
 
     @Override
     public boolean equals(Object other) {
-
         if (this == other) {
             return true;
         }

--- a/src/main/java/org/jabref/logic/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/EndnoteImporter.java
@@ -111,7 +111,6 @@ public class EndnoteImporter extends Importer {
             boolean isEditedBook = false;
             String[] fields = entry.trim().substring(1).split("\n%");
             for (String field : fields) {
-
                 if (field.length() < 3) {
                     continue;
                 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
@@ -305,7 +305,6 @@ public class EndnoteXmlImporter extends Importer implements Parser {
     private List<String> getKeywords(Record record) {
         Keywords keywords = record.getKeywords();
         if (keywords != null) {
-
             return keywords.getKeyword()
                            .stream()
                            .map(keyword -> keyword.getStyle())

--- a/src/main/java/org/jabref/logic/importer/fileformat/IsiImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/IsiImporter.java
@@ -74,7 +74,6 @@ public class IsiImporter extends Importer {
         String str;
         int i = 0;
         while (((str = reader.readLine()) != null) && (i < 50)) {
-
             /*
              * The following line gives false positives for RIS files, so it
              * should not be uncommented. The hypen is a characteristic of the
@@ -92,17 +91,14 @@ public class IsiImporter extends Importer {
     }
 
     public static void processSubSup(Map<Field, String> map) {
-
         Field[] subsup = {StandardField.TITLE, StandardField.ABSTRACT, StandardField.REVIEW, new UnknownField("notes")};
 
         for (Field aSubsup : subsup) {
             if (map.containsKey(aSubsup)) {
-
                 Matcher m = IsiImporter.SUB_SUP_PATTERN.matcher(map.get(aSubsup));
                 StringBuilder sb = new StringBuilder();
 
                 while (m.find()) {
-
                     String group2 = m.group(2);
                     group2 = group2.replaceAll("\\$", "\\\\\\\\\\\\\\$"); // Escaping
                     // insanity!
@@ -123,13 +119,10 @@ public class IsiImporter extends Importer {
     }
 
     private static void processCapitalization(Map<Field, String> map) {
-
         Field[] subsup = {StandardField.TITLE, StandardField.JOURNAL, StandardField.PUBLISHER};
 
         for (Field aSubsup : subsup) {
-
             if (map.containsKey(aSubsup)) {
-
                 String s = map.get(aSubsup);
                 if (s.toUpperCase(Locale.ROOT).equals(s)) {
                     s = new TitleCaseFormatter().format(s);
@@ -364,7 +357,6 @@ public class IsiImporter extends Importer {
      * Fixed bug from: http://sourceforge.net/tracker/index.php?func=detail&aid=1542552&group_id=92314&atid=600306
      */
     public static String isiAuthorConvert(String author) {
-
         String[] s = author.split(",");
         if (s.length != 2) {
             return author;
@@ -380,7 +372,6 @@ public class IsiImporter extends Importer {
         String[] firstParts = first.split("\\s+");
 
         for (int i = 0; i < firstParts.length; i++) {
-
             first = firstParts[i];
 
             // Do we have only uppercase chars?
@@ -404,7 +395,6 @@ public class IsiImporter extends Importer {
     }
 
     private static String[] isiAuthorsConvert(String[] authors) {
-
         String[] result = new String[authors.length];
         for (int i = 0; i < result.length; i++) {
             result[i] = IsiImporter.isiAuthorConvert(authors[i]);

--- a/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -129,7 +129,6 @@ public class MedlineImporter extends Importer implements Parser {
         String str;
         int i = 0;
         while (((str = reader.readLine()) != null) && (i < 50)) {
-
             if (str.toLowerCase(ENGLISH).contains("<pubmedarticle>")
                     || str.toLowerCase(ENGLISH).contains("<pubmedbookarticle>")) {
                 return true;

--- a/src/main/java/org/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -80,7 +80,6 @@ public class MedlinePlainImporter extends Importer {
                                         .split("\\n\\n");
 
         for (String entry1 : entries) {
-
             if (entry1.trim().isEmpty() || !entry1.contains("-")) {
                 continue;
             }
@@ -94,7 +93,6 @@ public class MedlinePlainImporter extends Importer {
             String[] lines = entry1.split("\n");
 
             for (int j = 0; j < lines.length; j++) {
-
                 StringBuilder current = new StringBuilder(lines[j]);
                 boolean done = false;
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
@@ -148,7 +148,6 @@ public class ModsImporter extends Importer implements Parser {
         List<String> notes = new ArrayList<>();
 
         for (Object groupElement : modsGroup) {
-
             // Get the element. Only one of the elements should be not an empty optional.
             Optional<AbstractDefinition> abstractDefinition = getElement(groupElement, AbstractDefinition.class);
             Optional<GenreDefinition> genreDefinition = getElement(groupElement, GenreDefinition.class);
@@ -195,7 +194,6 @@ public class ModsImporter extends Importer implements Parser {
             identifierDefinition.ifPresent(identifier -> parseIdentifier(fields, identifier, entry));
 
             titleInfoDefinition.ifPresent(titleInfo -> parseTitle(fields, titleInfo.getTitleOrSubTitleOrPartNumber()));
-
         }
 
         // The element subject can appear more than one time, that's why the keywords has to be put out of the for loop
@@ -203,7 +201,6 @@ public class ModsImporter extends Importer implements Parser {
         // same goes for authors and notes
         putIfListIsNotEmpty(fields, authors, StandardField.AUTHOR, " and ");
         putIfListIsNotEmpty(fields, notes, StandardField.NOTE, ", ");
-
     }
 
     private void parseTitle(Map<Field, String> fields, List<Object> titleOrSubTitleOrPartNumber) {
@@ -394,7 +391,6 @@ public class ModsImporter extends Importer implements Parser {
     private void putDate(Map<Field, String> fields, String elementName, DateDefinition date) {
         if (date.getValue() != null) {
             switch (elementName) {
-
                 case "dateIssued":
                     // The first 4 digits of dateIssued should be the year
                     fields.put(StandardField.YEAR, date.getValue().replaceAll("[^0-9]*", "").replaceAll("\\(\\d?\\d?\\d?\\d?.*\\)", "\1"));

--- a/src/main/java/org/jabref/logic/importer/fileformat/MsBibImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MsBibImporter.java
@@ -43,7 +43,6 @@ public class MsBibImporter extends Importer {
         try {
             DocumentBuilder dbuild = makeSafeDocBuilderFactory(DocumentBuilderFactory.newInstance()).newDocumentBuilder();
             dbuild.setErrorHandler(new ErrorHandler() {
-
                 @Override
                 public void warning(SAXParseException exception) throws SAXException {
                     // ignore warnings

--- a/src/main/java/org/jabref/logic/importer/fileformat/OvidImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/OvidImporter.java
@@ -67,11 +67,9 @@ public class OvidImporter extends Importer {
         String str;
         int i = 0;
         while (((str = reader.readLine()) != null) && (i < MAX_ITEMS)) {
-
             if (OvidImporter.OVID_PATTERN.matcher(str).find()) {
                 return true;
             }
-
             i++;
         }
         return false;
@@ -111,7 +109,6 @@ public class OvidImporter extends Importer {
                     content = content.substring(0, content.length() - 1);
                 }
                 if (isAuthor) {
-
                     h.put(StandardField.AUTHOR, content);
                 } else if (fieldName.startsWith("Title")) {
                     content = content.replaceAll("\\[.+\\]", "").trim();
@@ -135,7 +132,6 @@ public class OvidImporter extends Importer {
                         h.put(StandardField.PAGES, matcher.group(3));
                         h.put(StandardField.YEAR, matcher.group(4));
                     } else if ((matcher = OvidImporter.OVID_SOURCE_PATTERN_2.matcher(content)).find()) {
-
                         h.put(StandardField.JOURNAL, matcher.group(1));
                         h.put(StandardField.VOLUME, matcher.group(2));
                         h.put(StandardField.ISSUE, matcher.group(3));

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -216,7 +216,6 @@ public class PdfContentImporter extends Importer {
 
     // make this method package visible so we can test it
     Optional<BibEntry> getEntryFromPDFContent(String firstpageContents, String lineSeparator) {
-
         // idea: split[] contains the different lines
         // blocks are separated by empty lines
         // treat each block
@@ -605,5 +604,4 @@ public class PdfContentImporter extends Importer {
     public String getDescription() {
         return "PdfContentImporter parses data of the first page of the PDF and creates a BibTeX entry. Currently, Springer and IEEE formats are supported.";
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporter.java
@@ -163,5 +163,4 @@ public class PdfEmbeddedBibFileImporter extends Importer {
     public String getDescription() {
         return "PdfEmbeddedBibFileImporter imports an embedded Bib-File from the PDF.";
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporter.java
@@ -98,5 +98,4 @@ public class PdfVerbatimBibTextImporter extends Importer {
     public String getDescription() {
         return "PdfVerbatimBibTextImporter imports a verbatim BibTeX entry from the first page of the PDF.";
     }
-
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -250,7 +250,6 @@ public class RepecNepImporter extends Importer {
         List<String> authors = new ArrayList<>();
         StringBuilder institutions = new StringBuilder();
         while ((this.lastLine != null) && !"".equals(this.lastLine) && !startsWithKeyword(RepecNepImporter.RECOGNIZED_FIELDS)) {
-
             // read single author
             String author;
             StringBuilder institution = new StringBuilder();
@@ -323,7 +322,6 @@ public class RepecNepImporter extends Importer {
 
         // read other fields
         while ((this.lastLine != null) && !isStartOfWorkingPaper() && (startsWithKeyword(RepecNepImporter.RECOGNIZED_FIELDS) || "".equals(this.lastLine))) {
-
             // if multiple lines for a field are allowed and field consists of multiple lines, join them
             String keyword = "".equals(this.lastLine) ? "" : this.lastLine.substring(0, this.lastLine.indexOf(':')).trim();
             // skip keyword
@@ -379,7 +377,6 @@ public class RepecNepImporter extends Importer {
         try {
             readLine(reader); // skip header and editor information
             while (this.lastLine != null) {
-
                 if (this.lastLine.startsWith("-----------------------------")) {
                     this.inOverviewSection = this.preLine.startsWith("In this issue we have");
                 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RisImporter.java
@@ -68,7 +68,6 @@ public class RisImporter extends Importer {
         List<String> dateTags = Arrays.asList("Y1", "PY", "DA", "Y2");
 
         for (String entry1 : entries) {
-
             String dateTag = "";
             String dateValue = "";
             int datePriority = dateTags.size();
@@ -205,7 +204,6 @@ public class RisImporter extends Importer {
                     } else if ("UR".equals(tag) || "L2".equals(tag) || "LK".equals(tag)) {
                         fields.put(StandardField.URL, value);
                     } else if (((tagPriority = dateTags.indexOf(tag)) != -1) && (value.length() >= 4)) {
-
                         if (tagPriority < datePriority) {
                             String year = value.substring(0, 4);
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/SilverPlatterImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/SilverPlatterImporter.java
@@ -50,7 +50,6 @@ public class SilverPlatterImporter extends Importer {
         // accepting the Inspec format. Then we look for the title entry.
         String str;
         while ((str = reader.readLine()) != null) {
-
             if (START_PATTERN.matcher(str).find()) {
                 return false; // This is an Inspec file, so return false.
             }

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -304,7 +304,6 @@ class LayoutEntry {
                         }
                     }
                 } else {
-
                     // if previous was skipped --> remove leading line
                     // breaks
                     if (previousSkipped) {
@@ -528,14 +527,12 @@ class LayoutEntry {
     }
 
     public static List<List<String>> parseMethodsCalls(String calls) {
-
         List<List<String>> result = new ArrayList<>();
 
         char[] c = calls.toCharArray();
 
         int i = 0;
         while (i < c.length) {
-
             int start = i;
             if (Character.isJavaIdentifierStart(c[i])) {
                 i++;
@@ -543,7 +540,6 @@ class LayoutEntry {
                     i++;
                 }
                 if ((i < c.length) && (c[i] == '(')) {
-
                     String method = calls.substring(start, i);
 
                     // Skip the brace

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -175,14 +175,12 @@ public class LayoutHelper {
                 }
 
                 if (start) {
-
                     // changed section begin - arudert
                     // keep the backslash so we know wether this is a fieldname or an ordinary parameter
                     // if (c != '\\') {
                     buffer.append((char) c);
                     // }
                     // changed section end - arudert
-
                 }
             }
         }

--- a/src/main/java/org/jabref/logic/layout/ParamLayoutFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/ParamLayoutFormatter.java
@@ -16,5 +16,4 @@ public interface ParamLayoutFormatter extends LayoutFormatter {
      * @param arg A String argument.
      */
     void setArgument(String arg);
-
 }

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacer.java
@@ -9,7 +9,6 @@ public class AuthorAndsCommaReplacer implements LayoutFormatter {
 
     @Override
     public String format(String fieldText) {
-
         String[] authors = fieldText.split(" and ");
         String s;
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
@@ -13,7 +13,6 @@ public class AuthorAndsReplacer implements LayoutFormatter {
      */
     @Override
     public String format(String fieldText) {
-
         if (fieldText == null) {
             return null;
         }

--- a/src/main/java/org/jabref/logic/layout/format/CreateDocBook5Authors.java
+++ b/src/main/java/org/jabref/logic/layout/format/CreateDocBook5Authors.java
@@ -11,7 +11,6 @@ public class CreateDocBook5Authors implements LayoutFormatter {
 
     @Override
     public String format(String fieldText) {
-
         StringBuilder sb = new StringBuilder(100);
         AuthorList al = AuthorList.parse(fieldText);
 

--- a/src/main/java/org/jabref/logic/layout/format/HTMLParagraphs.java
+++ b/src/main/java/org/jabref/logic/layout/format/HTMLParagraphs.java
@@ -15,7 +15,6 @@ public class HTMLParagraphs implements LayoutFormatter {
 
     @Override
     public String format(String fieldText) {
-
         if (fieldText == null) {
             return fieldText;
         }

--- a/src/main/java/org/jabref/logic/layout/format/NameFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/NameFormatter.java
@@ -79,7 +79,6 @@ public class NameFormatter implements LayoutFormatter {
     private String parameter = NameFormatter.DEFAULT_FORMAT;
 
     private static String format(String toFormat, AuthorList al, String[] formats) {
-
         StringBuilder sb = new StringBuilder();
 
         int n = al.getNumberOfAuthors();

--- a/src/main/java/org/jabref/logic/layout/format/RTFChars.java
+++ b/src/main/java/org/jabref/logic/layout/format/RTFChars.java
@@ -36,7 +36,6 @@ public class RTFChars implements LayoutFormatter {
         boolean escaped = false;
         boolean incommand = false;
         for (int i = 0; i < field.length(); i++) {
-
             char c = field.charAt(i);
 
             if (escaped && (c == '\\')) {

--- a/src/main/java/org/jabref/logic/layout/format/WrapFileLinks.java
+++ b/src/main/java/org/jabref/logic/layout/format/WrapFileLinks.java
@@ -172,7 +172,6 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
 
     @Override
     public String format(String field) {
-
         if (field == null) {
             return "";
         }
@@ -185,7 +184,6 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
         for (LinkedFile flEntry : fileList) {
             // Use this entry if we don't discriminate on types, or if the type fits:
             if ((fileType == null) || flEntry.getFileType().equalsIgnoreCase(fileType)) {
-
                 for (FormatEntry entry : format) {
                     switch (entry.getType()) {
                         case STRING:

--- a/src/main/java/org/jabref/logic/layout/format/XMLChars.java
+++ b/src/main/java/org/jabref/logic/layout/format/XMLChars.java
@@ -25,7 +25,6 @@ public class XMLChars implements LayoutFormatter {
 
     @Override
     public String format(String fieldText) {
-
         if (fieldText == null) {
             return fieldText;
         }
@@ -53,7 +52,6 @@ public class XMLChars implements LayoutFormatter {
     }
 
     private String restFormat(String toFormat) {
-
         String fieldText = toFormat.replace("}", "").replace("{", "");
 
         // now some copy-paste problems most often occuring in abstracts when

--- a/src/main/java/org/jabref/logic/msbib/MSBibEntry.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibEntry.java
@@ -323,7 +323,6 @@ class MSBibEntry {
             corporate.setTextContent(person.getFirstLast());
             authorTop.appendChild(corporate);
         } else {
-
             Element nameList = document.createElementNS(MSBibDatabase.NAMESPACE, MSBibDatabase.PREFIX + "NameList");
             for (MsBibAuthor name : authorsLst) {
                 Element person = document.createElementNS(MSBibDatabase.NAMESPACE, MSBibDatabase.PREFIX + "Person");

--- a/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
+++ b/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
@@ -31,7 +31,6 @@ public class MsBibAuthor {
     }
 
     public String getFirstName() {
-
         if (!"".equals(firstName)) {
             return firstName;
         }

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -106,7 +106,6 @@ public class URLDownload {
 
         // Create a trust manager that does not validate certificate chains
         TrustManager[] trustAllCerts = {new X509TrustManager() {
-
             @Override
             public void checkClientTrusted(X509Certificate[] chain, String authType) {
             }
@@ -326,7 +325,6 @@ public class URLDownload {
     private void copy(InputStream in, Writer out, Charset encoding) throws IOException {
         Reader r = new InputStreamReader(in, encoding);
         try (BufferedReader read = new BufferedReader(r)) {
-
             String line;
             while ((line = read.readLine()) != null) {
                 out.write(line);

--- a/src/main/java/org/jabref/logic/net/ssl/SSLPreferences.java
+++ b/src/main/java/org/jabref/logic/net/ssl/SSLPreferences.java
@@ -17,5 +17,4 @@ public class SSLPreferences {
     public String getTruststorePath() {
         return truststorePath.getValue();
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
+++ b/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
@@ -42,7 +42,6 @@ public class OpenOfficeFileSearch {
     }
 
     private static List<Path> findOpenOfficeDirectories(List<Path> programDirectories) {
-
         BiPredicate<Path, BasicFileAttributes> filePredicate = (path, attr) ->
                 attr.isDirectory() && (path.toString().toLowerCase(Locale.ROOT).contains("openoffice")
                         || path.toString().toLowerCase(Locale.ROOT).contains("libreoffice"));

--- a/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
@@ -57,7 +57,6 @@ public class EditMerge {
             List<JoinableGroupData> joinableGroups = EditMerge.scan(doc, frontend);
 
             for (JoinableGroupData joinableGroupData : joinableGroups) {
-
                 List<CitationGroup> groups = joinableGroupData.group;
 
                 List<Citation> newCitations = (groups.stream()
@@ -154,7 +153,6 @@ public class EditMerge {
      * @return false if cannot add, true if can.  If returned true, then state.cursorBetween and state.currentGroupCursor are expanded to end at the start of currentRange.
      */
     private static boolean checkAddToGroup(ScanState state, CitationGroup group, XTextRange currentRange) {
-
         if (state.currentGroup.isEmpty()) {
             return false;
         }
@@ -170,7 +168,6 @@ public class EditMerge {
         }
 
         if (state.prev != null) {
-
             // Even if we combine AUTHORYEAR_INTEXT citations, we would not mix them with AUTHORYEAR_PAR
             if (group.citationType != state.prev.citationType) {
                 return false;
@@ -301,7 +298,6 @@ public class EditMerge {
         ScanState state = new ScanState();
 
         for (CitationGroup group : groups) {
-
             XTextRange currentRange = (frontend.getMarkRange(doc, group)
                                                .orElseThrow(IllegalStateException::new));
 

--- a/src/main/java/org/jabref/logic/openoffice/action/EditSeparate.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditSeparate.java
@@ -55,7 +55,6 @@ public class EditSeparate {
             UnoScreenRefresh.lockControllers(doc);
 
             for (CitationGroup group : groups) {
-
                 XTextRange range1 = (frontend
                         .getMarkRange(doc, group)
                         .orElseThrow(IllegalStateException::new));

--- a/src/main/java/org/jabref/logic/openoffice/backend/Codec52.java
+++ b/src/main/java/org/jabref/logic/openoffice/backend/Codec52.java
@@ -105,7 +105,6 @@ class Codec52 {
      * @return Optional.empty() on failure.
      */
     public static Optional<ParsedMarkName> parseMarkName(String refMarkName) {
-
         Matcher citeMatcher = CITE_PATTERN.matcher(refMarkName);
         if (!citeMatcher.find()) {
             return Optional.empty();

--- a/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -137,7 +137,6 @@ public class OOFrontend {
         // build final list
         List<RangeSortEntry<CitationGroup>> result = new ArrayList<>();
         for (List<RangeSortEntry<CitationGroup>> partition : partitions.getPartitions()) {
-
             int indexInPartition = 0;
             for (RangeSortEntry<CitationGroup> sortable : partition) {
                 sortable.setIndexInPosition(indexInPartition++);
@@ -327,7 +326,6 @@ public class OOFrontend {
     }
 
     public List<RangeForOverlapCheck<CitationGroupId>> viewCursorRanges(XTextDocument doc) {
-
         List<RangeForOverlapCheck<CitationGroupId>> result = new ArrayList<>();
 
         Optional<XTextRange> range = UnoCursor.getViewCursor(doc).map(e -> e);
@@ -348,7 +346,6 @@ public class OOFrontend {
      */
     public List<RangeForOverlapCheck<CitationGroupId>>
     footnoteMarkRanges(XTextDocument doc, List<RangeForOverlapCheck<CitationGroupId>> citationRanges) {
-
         // We partition by XText and use a single range from
         // each partition to get at the corresponding footnotemark range.
 
@@ -381,7 +378,6 @@ public class OOFrontend {
     }
 
     static String rangeOverlapsToMessage(List<RangeOverlap<RangeForOverlapCheck<CitationGroupId>>> overlaps) {
-
         if (overlaps.isEmpty()) {
             return "(*no overlaps*)";
         }

--- a/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
@@ -46,7 +46,6 @@ public class UpdateCitationMarkers {
         CitationGroups citationGroups = frontend.citationGroups;
 
         for (CitationGroup group : citationGroups.getCitationGroupsUnordered()) {
-
             boolean withText = (group.citationType != CitationType.INVISIBLE_CIT);
             Optional<OOText> marker = group.getCitationMarker();
 
@@ -57,11 +56,8 @@ public class UpdateCitationMarkers {
             }
 
             if (withText && marker.isPresent()) {
-
                 XTextCursor cursor = frontend.getFillCursorForCitationGroup(doc, group);
-
                 fillCitationMarkInCursor(doc, cursor, marker.get(), withText, style);
-
                 frontend.cleanFillCursorForCitationGroup(doc, group);
             }
         }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
@@ -376,7 +376,6 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private void handleStructureLine(String line) {
         int index = line.indexOf('=');
         if ((index > 0) && (index < (line.length() - 1))) {
-
             try {
                 final String typeName = line.substring(0, index);
                 final String formatString = line.substring(index + 1);
@@ -923,5 +922,4 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
                 ? OOFormat.paragraph(title)
                 : OOFormat.paragraph(title, parStyle));
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -156,7 +156,6 @@ class OOBibStyleGetCitationMarker {
         }
 
         if (nAuthors >= 2) {
-
             if (emitAllAuthors) {
                 // Emit last names, except for the last author
                 int j = 1;
@@ -174,7 +173,6 @@ class OOBibStyleGetCitationMarker {
                 stringBuilder.append(andString);
                 String name = getAuthorLastName(authorList, nAuthors - 1);
                 stringBuilder.append(markupAuthorName(style, name));
-
             } else {
                 // Emit last names up to nAuthorsToEmit.
                 //
@@ -293,7 +291,6 @@ class OOBibStyleGetCitationMarker {
     }
 
     private static AuthorList getAuthorList(OOBibStyle style, CitationLookupResult db) {
-
         // The bibtex fields providing author names, e.g. "author" or
         // "editor".
         OrFields authorFieldNames = style.getAuthorFieldNames();
@@ -315,7 +312,6 @@ class OOBibStyleGetCitationMarker {
      * If entry is unresolved, return 0.
      */
     private static int calculateNAuthorsToEmit(OOBibStyle style, CitationMarkerEntry entry) {
-
         if (entry.getLookupResult().isEmpty()) {
             // unresolved
             return 0;
@@ -453,7 +449,6 @@ class OOBibStyleGetCitationMarker {
                     stringBuilder.append(pageInfoPart);
                 }
             } else {
-
                 CitationLookupResult db = entry.getLookupResult().get();
 
                 int maxAuthors = (purpose == AuthorYearMarkerPurpose.NORMALIZED

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetNumCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetNumCitationMarker.java
@@ -112,7 +112,6 @@ class OOBibStyleGetNumCitationMarker {
         }
 
         if (blockSize >= 2) {
-
             /*
              * Check assumptions
              */
@@ -147,7 +146,6 @@ class OOBibStyleGetNumCitationMarker {
                 stringBuilder.append(style.getGroupedNumbersSeparator());
                 stringBuilder.append(last);
             } else {
-
                 // Emit: first, first+1,..., last
                 for (int j = 0; j < blockSize; j++) {
                     if (j > 0) {
@@ -217,7 +215,6 @@ class OOBibStyleGetNumCitationMarker {
         List<CitationMarkerNumericEntry> nextBlock = new ArrayList<>();
 
         for (int i = 0; i < nCitations; i++) {
-
             final CitationMarkerNumericEntry current = sorted.get(i);
             if (current.getNumber().isPresent() && current.getNumber().get() < 0) {
                 throw new IllegalArgumentException("getNumCitationMarker2: found negative number");
@@ -254,7 +251,6 @@ class OOBibStyleGetNumCitationMarker {
                 currentBlock = nextBlock;
                 nextBlock = new ArrayList<>();
             }
-
         }
 
         if (!nextBlock.isEmpty()) {
@@ -273,5 +269,4 @@ class OOBibStyleGetNumCitationMarker {
         stringBuilder.append(bracketAfter);
         return OOText.fromString(stringBuilder.toString());
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOFormatBibliography.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOFormatBibliography.java
@@ -155,7 +155,6 @@ public class OOFormatBibliography {
      *   - We do not control the text shown, that is provided by OpenOffice.
      */
     private static OOText formatCitedOnPages(CitationGroups citationGroups, CitedKey citedKey) {
-
         if (!citationGroups.citationGroupsProvideReferenceMarkNameForLinking()) {
             return OOText.fromString("");
         }
@@ -196,5 +195,4 @@ public class OOFormatBibliography {
         stringBuilder.append(suffix);
         return OOText.fromString(stringBuilder.toString());
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOProcess.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOProcess.java
@@ -54,7 +54,6 @@ public class OOProcess {
      *  according to style.
      */
     public static void produceCitationMarkers(CitationGroups citationGroups, List<BibDatabase> databases, OOBibStyle style) {
-
         if (!citationGroups.hasGlobalOrder()) {
             throw new IllegalStateException("produceCitationMarkers: globalOrder is misssing in citationGroups");
         }
@@ -71,5 +70,4 @@ public class OOProcess {
             OOProcessAuthorYearMarkers.produceCitationMarkers(citationGroups, style);
         }
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOProcessAuthorYearMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOProcessAuthorYearMarkers.java
@@ -28,7 +28,6 @@ class OOProcessAuthorYearMarkers {
      *  Fills {@code sortedCitedKeys//normCitMarker}
      */
     private static void createNormalizedCitationMarkers(CitedKeys sortedCitedKeys, OOBibStyle style) {
-
         for (CitedKey ck : sortedCitedKeys.values()) {
             ck.setNormalizedCitationMarker(Optional.of(style.getNormalizedCitationMarker(ck)));
         }
@@ -50,7 +49,6 @@ class OOProcessAuthorYearMarkers {
      *  Depends on: style, citations and their order.
      */
     private static void createUniqueLetters(CitedKeys sortedCitedKeys, CitationGroups citationGroups) {
-
         // The entries in the clashingKeys lists preserve
         // firstAppearance order from sortedCitedKeys.values().
         //
@@ -130,7 +128,6 @@ class OOProcessAuthorYearMarkers {
      * @param style              Bibliography style.
      */
     static void produceCitationMarkers(CitationGroups citationGroups, OOBibStyle style) {
-
         assert !style.isCitationKeyCiteMarkers();
         assert !style.isNumberEntries();
         // Citations in (Au1, Au2 2000) form
@@ -145,7 +142,6 @@ class OOProcessAuthorYearMarkers {
         setIsFirstAppearanceOfSourceInCitations(citationGroups);
 
         for (CitationGroup group : citationGroups.getCitationGroupsInGlobalOrder()) {
-
             final boolean inParenthesis = (group.citationType == CitationType.AUTHORYEAR_PAR);
             final NonUniqueCitationMarker strictlyUnique = NonUniqueCitationMarker.THROWS;
 
@@ -157,5 +153,4 @@ class OOProcessAuthorYearMarkers {
             group.setCitationMarker(Optional.of(citMarker));
         }
     }
-
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOProcessCitationKeyMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOProcessCitationKeyMarkers.java
@@ -18,7 +18,6 @@ class OOProcessCitationKeyMarkers {
      *  markers are the citation keys themselves, separated by commas.
      */
     static void produceCitationMarkers(CitationGroups citationGroups, OOBibStyle style) {
-
         assert style.isCitationKeyCiteMarkers();
 
         citationGroups.createPlainBibliographySortedByComparator(OOProcess.AUTHOR_YEAR_TITLE_COMPARATOR);

--- a/src/main/java/org/jabref/logic/openoffice/style/OOProcessNumericMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOProcessNumericMarkers.java
@@ -27,7 +27,6 @@ class OOProcessNumericMarkers {
      *
      */
     static void produceCitationMarkers(CitationGroups citationGroups, OOBibStyle style) {
-
         assert style.isNumberEntries();
 
         if (style.isSortByPosition()) {
@@ -42,5 +41,4 @@ class OOProcessNumericMarkers {
             group.setCitationMarker(Optional.of(citMarker));
         }
     }
-
 }

--- a/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
+++ b/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
@@ -29,7 +29,6 @@ public class FileAnnotationCache {
      * hitting the bug https://github.com/AdamBien/afterburner.fx/issues/71 .
      */
     public FileAnnotationCache() {
-
     }
 
     public FileAnnotationCache(BibDatabaseContext context, FilePreferences filePreferences) {

--- a/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
+++ b/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
@@ -36,7 +36,6 @@ public class PdfAnnotationImporter implements AnnotationImporter {
      */
     @Override
     public List<FileAnnotation> importAnnotations(final Path path) {
-
         if (!validatePath(path)) {
             // Path could not be validated, return default result
             return Collections.emptyList();

--- a/src/main/java/org/jabref/logic/pdf/search/retrieval/PdfSearcher.java
+++ b/src/main/java/org/jabref/logic/pdf/search/retrieval/PdfSearcher.java
@@ -37,7 +37,6 @@ public final class PdfSearcher {
     private PdfSearcher(Directory indexDirectory) {
         this.indexDirectory = indexDirectory;
         Codec.forName("Lucene91");
-
     }
 
     public static PdfSearcher of(BibDatabaseContext databaseContext) throws IOException {
@@ -75,7 +74,6 @@ public final class PdfSearcher {
                 resultDocs.add(new SearchResult(searcher, query, scoreDoc));
             }
             return new PdfSearchResults(resultDocs);
-
         } catch (ParseException e) {
             LOGGER.warn("Could not parse query: '{}'!\n{}", searchString, e.getMessage());
             return new PdfSearchResults();

--- a/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
@@ -199,7 +199,6 @@ public abstract class DBMSProcessor {
      * @return <code>true</code> if existent, else <code>false</code>
      */
     private List<BibEntry> getNotYetExistingEntries(List<BibEntry> bibEntries) {
-
         List<Integer> remoteIds = new ArrayList<>();
         List<Integer> localIds = bibEntries.stream()
                                            .map(BibEntry::getSharedBibEntryData)
@@ -305,7 +304,6 @@ public abstract class DBMSProcessor {
             // update only if local version is higher or the entries are equal
             if ((localBibEntry.getSharedBibEntryData().getVersion() >= sharedBibEntry.getSharedBibEntryData()
                                                                                      .getVersion()) || localBibEntry.equals(sharedBibEntry)) {
-
                 insertOrUpdateFields(localBibEntry);
 
                 // updating entry type

--- a/src/main/java/org/jabref/logic/shared/OracleProcessor.java
+++ b/src/main/java/org/jabref/logic/shared/OracleProcessor.java
@@ -72,7 +72,6 @@ public class OracleProcessor extends DBMSProcessor {
 
     @Override
     public void startNotificationListener(DBMSSynchronizer dbmsSynchronizer) {
-
         this.listener = new OracleNotificationListener(dbmsSynchronizer);
 
         try {

--- a/src/main/java/org/jabref/logic/util/CoarseChangeFilter.java
+++ b/src/main/java/org/jabref/logic/util/CoarseChangeFilter.java
@@ -34,7 +34,6 @@ public class CoarseChangeFilter {
 
     @Subscribe
     public synchronized void listen(BibDatabaseContextChangedEvent event) {
-
         if (event instanceof FieldChangedEvent) {
             // Only relay event if the field changes are more than one character or a new field is edited
             FieldChangedEvent fieldChange = (FieldChangedEvent) event;

--- a/src/main/java/org/jabref/logic/util/TestEntry.java
+++ b/src/main/java/org/jabref/logic/util/TestEntry.java
@@ -12,7 +12,6 @@ public class TestEntry {
     }
 
     public static BibEntry getTestEntry() {
-
         BibEntry entry = new BibEntry(StandardEntryType.Article);
         entry.setCitationKey("Smith2016");
         entry.setField(StandardField.AUTHOR, "Smith, Bill and Jones, Bob and Williams, Jeff");

--- a/src/main/java/org/jabref/logic/util/UpdateField.java
+++ b/src/main/java/org/jabref/logic/util/UpdateField.java
@@ -99,7 +99,6 @@ public class UpdateField {
     }
 
     private static void setAutomaticFields(BibEntry entry, boolean setOwner, String owner, boolean setTimeStamp, String timeStamp) {
-
         // Set owner field if this option is enabled:
         if (setOwner) {
             // Set owner field to default value

--- a/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
+++ b/src/main/java/org/jabref/logic/util/io/FileNameUniqueness.java
@@ -22,7 +22,6 @@ public class FileNameUniqueness {
      * @return a file name such that it does not match any existing files in targetDirectory
      */
     public static String getNonOverWritingFileName(Path targetDirectory, String fileName) {
-
         Optional<String> extensionOptional = FileUtil.getFileExtension(fileName);
 
         // the suffix include the '.' , if extension is present Eg: ".pdf"

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -108,7 +108,6 @@ public class FileUtil {
     }
 
     public static Optional<String> getUniquePathFragment(List<String> paths, Path databasePath) {
-
         String fileName = databasePath.getFileName().toString();
 
         List<String> uniquePathParts = uniquePathSubstrings(paths);

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -762,7 +762,6 @@ public class HTMLUnicodeConversionMaps {
             {"119978", "Oscr", "$\\mathcal{O}$"}, // script capital O -- possibly use \mathscr
             {"119984", "Uscr", "$\\mathcal{U}$"}, // script capital U -- possibly use \mathscr
             {"120598", "", "$\\epsilon$"}, // mathematical italic epsilon U+1D716 -- requires amsmath
-
     };
 
     // List of combining accents

--- a/src/main/java/org/jabref/logic/xmp/DocumentInformationExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DocumentInformationExtractor.java
@@ -85,7 +85,6 @@ public class DocumentInformationExtractor {
      * @return The bibtex entry found in the document information.
      */
     public Optional<BibEntry> extractBibtexEntry() {
-
         bibEntry.setType(BibEntry.DEFAULT_TYPE);
 
         this.extractAuthor();

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -79,7 +79,6 @@ public class DublinCoreExtractor {
     private void extractDate() {
         List<String> dates = dcSchema.getUnqualifiedSequenceValueList("date");
         if ((dates != null) && !dates.isEmpty()) {
-
             String date = dates.get(0).trim();
             Date.parse(date)
                     .ifPresent(dateValue -> {

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
@@ -78,7 +78,6 @@ public class XmpUtilReader {
             if (!xmpMetaList.isEmpty()) {
                 // Only support Dublin Core since JabRef 4.2
                 for (XMPMetadata xmpMeta : xmpMetaList) {
-
                     DublinCoreSchema dcSchema = DublinCoreSchemaCustom.copyDublinCoreSchema(xmpMeta.getDublinCoreSchema());
                     if (dcSchema != null) {
                         DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, new BibEntry());

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -136,7 +136,6 @@ public class PreferencesMigrations {
      * exist
      */
     private static void upgradeSortOrder(JabRefPreferences prefs) {
-
         if (prefs.get(JabRefPreferences.EXPORT_IN_SPECIFIED_ORDER, null) == null) {
             if (prefs.getBoolean("exportInStandardOrder", false)) {
                 prefs.putBoolean(JabRefPreferences.EXPORT_IN_SPECIFIED_ORDER, true);
@@ -163,7 +162,6 @@ public class PreferencesMigrations {
      * Migrate all customized entry types from versions <=3.7
      */
     private static void upgradeStoredBibEntryTypes(JabRefPreferences prefs, Preferences mainPrefsNode) {
-
         try {
             if (mainPrefsNode.nodeExists(JabRefPreferences.CUSTOMIZED_BIBTEX_TYPES) ||
                     mainPrefsNode.nodeExists(JabRefPreferences.CUSTOMIZED_BIBLATEX_TYPES)) {
@@ -181,7 +179,6 @@ public class PreferencesMigrations {
      * Migrate LabelPattern configuration from versions <=3.5 to new CitationKeyPatterns
      */
     private static void upgradeLabelPatternToCitationKeyPattern(JabRefPreferences prefs) {
-
         try {
             Preferences mainPrefsNode = Preferences.userRoot().node("/org/jabref");
 
@@ -242,11 +239,9 @@ public class PreferencesMigrations {
     }
 
     static void upgradeImportFileAndDirePatterns(JabRefPreferences prefs, Preferences mainPrefsNode) {
-
         // Migrate Import patterns
         // Check for prefs node for Version <= 4.0
         if (mainPrefsNode.get(JabRefPreferences.IMPORT_FILENAMEPATTERN, null) != null) {
-
             String[] oldStylePatterns = new String[]{
                     "\\bibtexkey",
                     "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}"};

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -437,7 +437,6 @@ public class BibDatabase {
      * given BibtexEntries is modified.
      */
     public BibEntry resolveForStrings(BibEntry entry, boolean inPlace) {
-
         BibEntry resultingEntry;
         if (inPlace) {
             resultingEntry = entry;
@@ -504,7 +503,6 @@ public class BibDatabase {
             int piv = 0;
             int next;
             while ((next = res.indexOf(FieldWriter.BIBTEX_STRING_START_END_SYMBOL, piv)) >= 0) {
-
                 // We found the next string ref. Append the text
                 // up to it.
                 if (next > 0) {
@@ -646,5 +644,4 @@ public class BibDatabase {
     public String getNewLineSeparator() {
         return newLineSeparator;
     }
-
 }

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -1007,5 +1007,4 @@ public class BibEntry implements Cloneable {
         }
         entry.setFiles(linkedFiles);
     }
-
 }

--- a/src/main/java/org/jabref/model/entry/BibEntryType.java
+++ b/src/main/java/org/jabref/model/entry/BibEntryType.java
@@ -124,7 +124,6 @@ public class BibEntryType implements Comparable<BibEntryType> {
         return type.equals(that.type) &&
                Objects.equals(requiredFields, that.requiredFields) &&
                Objects.equals(fields, that.fields);
-
     }
 
     @Override

--- a/src/main/java/org/jabref/model/entry/Date.java
+++ b/src/main/java/org/jabref/model/entry/Date.java
@@ -96,7 +96,6 @@ public class Date {
             } catch (DateTimeParseException ignored) {
                 return Optional.empty();
             }
-
         }
 
         try {

--- a/src/main/java/org/jabref/model/entry/types/EntryTypeFactory.java
+++ b/src/main/java/org/jabref/model/entry/types/EntryTypeFactory.java
@@ -47,7 +47,6 @@ public class EntryTypeFactory {
     }
 
     public static EntryType parse(String typeName) {
-
         List<EntryType> types = new ArrayList<>(Arrays.<EntryType>asList(StandardEntryType.values()));
         types.addAll(Arrays.<EntryType>asList(IEEETranEntryType.values()));
         types.addAll(Arrays.<EntryType>asList(SystematicLiteratureReviewStudyEntryType.values()));

--- a/src/main/java/org/jabref/model/groups/RegexKeywordGroup.java
+++ b/src/main/java/org/jabref/model/groups/RegexKeywordGroup.java
@@ -20,14 +20,12 @@ public class RegexKeywordGroup extends KeywordGroup {
     }
 
     private static Pattern compilePattern(String searchExpression, boolean caseSensitive) {
-
         return caseSensitive ? Pattern.compile("\\b" + searchExpression + "\\b") : Pattern.compile(
                 "\\b" + searchExpression + "\\b", Pattern.CASE_INSENSITIVE);
     }
 
     @Override
     public boolean contains(BibEntry entry) {
-
         Optional<String> content = entry.getField(searchField);
         return content.map(value -> pattern.matcher(value).find()).orElse(false);
     }

--- a/src/main/java/org/jabref/model/metadata/SaveOrderConfig.java
+++ b/src/main/java/org/jabref/model/metadata/SaveOrderConfig.java
@@ -167,7 +167,6 @@ public class SaveOrderConfig {
         }
 
         public SortCriterion() {
-
         }
 
         @Override

--- a/src/main/java/org/jabref/model/openoffice/ootext/OOText.java
+++ b/src/main/java/org/jabref/model/openoffice/ootext/OOText.java
@@ -43,7 +43,6 @@ public class OOText {
 
     @Override
     public boolean equals(Object object) {
-
         if (object == this) {
             return true;
         }

--- a/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
+++ b/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
@@ -151,7 +151,6 @@ public class OOTextIntoOO {
         int piv = 0;
         Matcher tagMatcher = HTML_TAG.matcher(lText);
         while (tagMatcher.find()) {
-
             String currentSubstring = lText.substring(piv, tagMatcher.start());
             if (!currentSubstring.isEmpty()) {
                 cursor.setString(currentSubstring);
@@ -318,7 +317,6 @@ public class OOTextIntoOO {
      * In particular, when filling the bibliography title and body.
      */
     public static void removeDirectFormatting(XTextCursor cursor) {
-
         XMultiPropertyStates mpss = UnoCast.cast(XMultiPropertyStates.class, cursor).get();
 
         XPropertySet propertySet = UnoCast.cast(XPropertySet.class, cursor).get();
@@ -443,7 +441,6 @@ public class OOTextIntoOO {
         final Stack<ArrayList<Optional<Object>>> layers;
 
         MyPropertyStack(XTextCursor cursor) {
-
             XPropertySet propertySet = UnoCast.cast(XPropertySet.class, cursor).get();
             XPropertySetInfo propertySetInfo = propertySet.getPropertySetInfo();
 

--- a/src/main/java/org/jabref/model/openoffice/rangesort/FunctionalTextViewCursor.java
+++ b/src/main/java/org/jabref/model/openoffice/rangesort/FunctionalTextViewCursor.java
@@ -69,7 +69,6 @@ public class FunctionalTextViewCursor {
      * instance.restore() after finished using the cursor.
      */
     public static OOResult<FunctionalTextViewCursor, String> get(XTextDocument doc) {
-
         Objects.requireNonNull(doc);
 
         XTextRange initialPosition = null;

--- a/src/main/java/org/jabref/model/openoffice/rangesort/RangeSortVisual.java
+++ b/src/main/java/org/jabref/model/openoffice/rangesort/RangeSortVisual.java
@@ -95,7 +95,6 @@ public class RangeSortVisual {
     }
 
     private static <T> int compareTopToBottomLeftToRight(ComparableMark<T> a, ComparableMark<T> b) {
-
         if (a.position.Y != b.position.Y) {
             return a.position.Y - b.position.Y;
         }

--- a/src/main/java/org/jabref/model/openoffice/style/CitationGroup.java
+++ b/src/main/java/org/jabref/model/openoffice/style/CitationGroup.java
@@ -82,7 +82,6 @@ public class CitationGroup {
      * Sort citations for presentation within a CitationGroup.
      */
     void imposeLocalOrder(Comparator<BibEntry> entryComparator) {
-
         // For JabRef52 the single pageInfo is always in the last-in-localorder citation.
         // We adjust here accordingly by taking it out and adding it back after sorting.
         final int last = this.numberOfCitations() - 1;

--- a/src/main/java/org/jabref/model/openoffice/style/CitationGroups.java
+++ b/src/main/java/org/jabref/model/openoffice/style/CitationGroups.java
@@ -42,7 +42,6 @@ public class CitationGroups {
      * Constructor
      */
     public CitationGroups(Map<CitationGroupId, CitationGroup> citationGroups) {
-
         this.citationGroupsUnordered = citationGroups;
 
         this.globalOrder = Optional.empty();
@@ -200,7 +199,6 @@ public class CitationGroups {
      * @return Citation keys where lookupCitations() failed.
      */
     public List<String> getUnresolvedKeys() {
-
         CitedKeys bib = getBibliography().orElse(getCitedKeysUnordered());
 
         List<String> unresolvedKeys = new ArrayList<>();

--- a/src/main/java/org/jabref/model/openoffice/style/CitedKey.java
+++ b/src/main/java/org/jabref/model/openoffice/style/CitedKey.java
@@ -27,7 +27,6 @@ public class CitedKey implements
     private Optional<OOText> normCitMarker;  // For AuthorYear citation styles.
 
     CitedKey(String citationKey, CitationPath path, Citation citation) {
-
         this.citationKey = citationKey;
         this.where = new ArrayList<>(); // remember order
         this.where.add(path);

--- a/src/main/java/org/jabref/model/openoffice/style/CitedKeys.java
+++ b/src/main/java/org/jabref/model/openoffice/style/CitedKeys.java
@@ -80,5 +80,4 @@ public class CitedKeys {
             ck.distributeUniqueLetter(citationGroups);
         }
     }
-
 }

--- a/src/main/java/org/jabref/model/openoffice/style/PageInfo.java
+++ b/src/main/java/org/jabref/model/openoffice/style/PageInfo.java
@@ -30,7 +30,6 @@ public class PageInfo {
      * Optional.empty comes before non-empty.
      */
     public static int comparePageInfo(Optional<OOText> a, Optional<OOText> b) {
-
         Optional<OOText> aa = PageInfo.normalizePageInfo(a);
         Optional<OOText> bb = PageInfo.normalizePageInfo(b);
         if (aa.isEmpty() && bb.isEmpty()) {

--- a/src/main/java/org/jabref/model/openoffice/uno/UnoTextDocument.java
+++ b/src/main/java/org/jabref/model/openoffice/uno/UnoTextDocument.java
@@ -24,7 +24,6 @@ public class UnoTextDocument {
      * @return True if we cannot reach the current document.
      */
     public static boolean isDocumentConnectionMissing(XTextDocument doc) {
-
         boolean missing = doc == null;
 
         // Attempt to check document is really available
@@ -55,7 +54,6 @@ public class UnoTextDocument {
      * @return The title or Optional.empty()
      */
     public static Optional<String> getFrameTitle(XTextDocument doc) {
-
         Optional<XFrame> frame = getCurrentController(doc).map(XController::getFrame);
         if (frame.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/org/jabref/model/push/PushToApplicationConstants.java
+++ b/src/main/java/org/jabref/model/push/PushToApplicationConstants.java
@@ -11,5 +11,4 @@ public class PushToApplicationConstants {
 
     private PushToApplicationConstants() {
     }
-
 }

--- a/src/main/java/org/jabref/model/search/rules/ContainsBasedSearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/ContainsBasedSearchRule.java
@@ -56,5 +56,4 @@ public class ContainsBasedSearchRule extends FullTextSearchRule {
 
         return getFulltextResults(query, bibEntry).numSearchResults() > 0; // Didn't match all words.
     }
-
 }

--- a/src/main/java/org/jabref/model/search/rules/RegexBasedSearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/RegexBasedSearchRule.java
@@ -59,5 +59,4 @@ public class RegexBasedSearchRule extends FullTextSearchRule {
         }
         return getFulltextResults(query, bibEntry).numSearchResults() > 0;
     }
-
 }

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -198,7 +198,6 @@ public class StringUtil {
         // remove all whitespace at the end of the string, this especially includes \r created when the field content has \r\n as line separator
         addWrappedLine(result, CharMatcher.whitespace().trimTrailingFrom(lines[0]), wrapAmount, newline);
         for (int i = 1; i < lines.length; i++) {
-
             if (lines[i].trim().isEmpty()) {
                 result.append(newline);
                 result.append('\t');
@@ -311,7 +310,6 @@ public class StringUtil {
      * @return The resulting string after wrapping capitals.
      */
     public static String putBracesAroundCapitals(String s) {
-
         boolean inString = false;
         boolean isBracing = false;
         boolean escaped = false;
@@ -331,14 +329,12 @@ public class StringUtil {
             // See if we should start bracing:
             if ((inBrace == 0) && !isBracing && !inString && Character.isLetter((char) c)
                     && Character.isUpperCase((char) c)) {
-
                 buf.append('{');
                 isBracing = true;
             }
 
             // See if we should close a brace set:
             if (isBracing && !(Character.isLetter((char) c) && Character.isUpperCase((char) c))) {
-
                 buf.append('}');
                 isBracing = false;
             }
@@ -705,7 +701,6 @@ public class StringUtil {
         } else {
             return toCapitalize.toUpperCase(Locale.ROOT);
         }
-
     }
 
     /**

--- a/src/main/java/org/jabref/model/study/StudyQuery.java
+++ b/src/main/java/org/jabref/model/study/StudyQuery.java
@@ -11,7 +11,6 @@ public class StudyQuery {
      * Used for Jackson deserialization
      */
     public StudyQuery() {
-
     }
 
     public String getQuery() {

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -285,5 +285,4 @@ public interface PreferencesService {
     MrDlibPreferences getMrDlibPreferences();
 
     ProtectedTermsPreferences getProtectedTermsPreferences();
-
 }

--- a/src/test/java/org/jabref/architecture/TestArchitectureTests.java
+++ b/src/test/java/org/jabref/architecture/TestArchitectureTests.java
@@ -30,7 +30,6 @@ public class TestArchitectureTests {
     private final List<String> exceptions;
 
     public TestArchitectureTests() {
-
         // Add exceptions for the architectural test here
         // Note that bending the architectural constraints should not be done inconsiderately
         exceptions = new ArrayList<>();

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -337,5 +337,4 @@ class LinkedFileViewModelTest {
         // Assert fail if no PDF type was found
         fail();
     }
-
 }

--- a/src/test/java/org/jabref/gui/util/OpenConsoleActionTest.java
+++ b/src/test/java/org/jabref/gui/util/OpenConsoleActionTest.java
@@ -52,5 +52,4 @@ public class OpenConsoleActionTest {
         verify(stateManager, times(1)).getActiveDatabase();
         verify(current, times(1)).getDatabasePath();
     }
-
 }

--- a/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
+++ b/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
@@ -72,5 +72,4 @@ public class NumericFieldComparatorTest {
     void compareNumericSignalAfterNumber() {
         assertEquals(-2, comparator.compare("5- ", "7+ "));
     }
-
 }

--- a/src/test/java/org/jabref/logic/auxparser/DefaultAuxParserTest.java
+++ b/src/test/java/org/jabref/logic/auxparser/DefaultAuxParserTest.java
@@ -4,5 +4,4 @@ package org.jabref.logic.auxparser;
  * Please see {@link AuxParserTest} for the test cases
  */
 class DefaultAuxParserTest {
-
 }

--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
@@ -104,7 +104,6 @@ class BibDatabaseDiffTest {
         assertNull(diff.getEntryDifferences().get(0).getNewEntry(), "newEntry is not null");
         assertEquals(entryTwo, diff.getEntryDifferences().get(1).getNewEntry(), "there is another value as newEntry");
         assertNull(diff.getEntryDifferences().get(1).getOriginalEntry(), "originalEntry is not null");
-
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/bibtex/comparator/GroupDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/GroupDiffTest.java
@@ -61,5 +61,4 @@ public class GroupDiffTest {
         assertEquals(expectedGroupDiff.get().getNewGroupRoot(), groupDiff.get().getNewGroupRoot());
         assertEquals(expectedGroupDiff.get().getOriginalGroupRoot(), groupDiff.get().getOriginalGroupRoot());
     }
-
 }

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
@@ -22,7 +22,6 @@ class CitationStyleTest {
 
     @Test
     void testDefaultCitation() {
-
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
         context.setMode(BibDatabaseMode.BIBLATEX);
         String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), CitationStyle.getDefault().getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());

--- a/src/test/java/org/jabref/logic/cleanup/ConvertToBiblatexCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/ConvertToBiblatexCleanupTest.java
@@ -97,5 +97,4 @@ public class ConvertToBiblatexCleanupTest {
         assertEquals(Optional.empty(), entry.getField(StandardField.JOURNAL));
         assertEquals(Optional.of("Best of JabRef"), entry.getField(StandardField.JOURNALTITLE));
     }
-
 }

--- a/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/DoiCleanupTest.java
@@ -63,5 +63,4 @@ public class DoiCleanupTest {
                         .withField(unknownField, "https://doi.org/10.1145/2594455"))
         );
     }
-
 }

--- a/src/test/java/org/jabref/logic/cleanup/TimeStampToCreationDateTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/TimeStampToCreationDateTest.java
@@ -176,5 +176,4 @@ class TimeStampToCreationDateTest {
         migrator.cleanup(input);
         assertEquals(expected, input);
     }
-
 }

--- a/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
@@ -74,5 +74,4 @@ public class DocbookExporterTest {
         assertEquals(20, lines.size());
         assertEquals("   <citetitle pubwork=\"article\">Insect neuropeptide bursicon homodimers induce innate immune and stress genes during molting by activating the NF&#45;&#954;B transcription factor Relish.</citetitle>", lines.get(9));
     }
-
 }

--- a/src/test/java/org/jabref/logic/exporter/FieldFormatterCleanupsTest.java
+++ b/src/test/java/org/jabref/logic/exporter/FieldFormatterCleanupsTest.java
@@ -42,7 +42,6 @@ public class FieldFormatterCleanupsTest {
 
     @Test
     public void checkSimpleUseCase() {
-
         FieldFormatterCleanups actions = new FieldFormatterCleanups(true, Cleanups.parse("title[identity]"));
 
         FieldFormatterCleanup identityInTitle = new FieldFormatterCleanup(StandardField.TITLE, new IdentityFormatter());
@@ -66,7 +65,6 @@ public class FieldFormatterCleanupsTest {
 
     @Test
     public void checkLowerCaseSaveAction() {
-
         FieldFormatterCleanups actions = new FieldFormatterCleanups(true, Cleanups.parse("title[lower_case]"));
 
         FieldFormatterCleanup lowerCaseTitle = new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter());
@@ -92,7 +90,6 @@ public class FieldFormatterCleanupsTest {
 
     @Test
     public void checkThreeSaveActionsForOneField() {
-
         FieldFormatterCleanups actions = new FieldFormatterCleanups(true, Cleanups.parse("title[lower_case,identity,normalize_date]"));
 
         FieldFormatterCleanup lowerCaseTitle = new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter());
@@ -107,7 +104,6 @@ public class FieldFormatterCleanupsTest {
 
     @Test
     public void checkMultipleSaveActions() {
-
         FieldFormatterCleanups actions = new FieldFormatterCleanups(true, Cleanups.parse("pages[normalize_page_numbers]title[lower_case]"));
         List<FieldFormatterCleanup> formatterCleanups = actions.getConfiguredActions();
 
@@ -123,7 +119,6 @@ public class FieldFormatterCleanupsTest {
 
     @Test
     public void checkMultipleSaveActionsWithMultipleFormatters() {
-
         FieldFormatterCleanups actions = new FieldFormatterCleanups(true,
                 Cleanups.parse("pages[normalize_page_numbers,normalize_date]title[lower_case]"));
         List<FieldFormatterCleanup> formatterCleanups = actions.getConfiguredActions();

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -33,5 +33,4 @@ class UnicodeToLatexFormatterTest {
     void testFormat(String expectedResult, String input) {
         assertEquals(expectedResult, formatter.format(input));
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/ImportDataTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImportDataTest.java
@@ -22,7 +22,6 @@ public class ImportDataTest {
      */
     @Test
     void testTestingEnvironment() {
-
         assertTrue(Files.exists(ImportDataTest.EXISTING_FOLDER), "EXISTING_FOLDER does not exist");
         assertTrue(Files.isDirectory(ImportDataTest.EXISTING_FOLDER), "EXISTING_FOLDER is not a directory");
 

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -43,7 +43,6 @@ class WebFetchersTest {
         Set<IdBasedFetcher> idFetchers = WebFetchers.getIdBasedFetchers(importFormatPreferences);
 
         try (ScanResult scanResult = classGraph.scan()) {
-
             ClassInfoList controlClasses = scanResult.getClassesImplementing(IdBasedFetcher.class.getCanonicalName());
             Set<Class<?>> expected = new HashSet<>(controlClasses.loadClasses());
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ACMPortalFetcherTest.java
@@ -33,7 +33,6 @@ class ACMPortalFetcherTest {
 
     @Test
     void searchByQueryFindsEntry() throws Exception {
-
         BibEntry searchEntry = new BibEntry(StandardEntryType.Conference)
                         .withField(StandardField.AUTHOR, "Tobias Olsson and Morgan Ericsson and Anna Wingkvist")
                         .withField(StandardField.YEAR, "2017")
@@ -74,5 +73,4 @@ class ACMPortalFetcherTest {
         ACMPortalParser expected = new ACMPortalParser();
         assertEquals(expected.getClass(), fetcher.getParser().getClass());
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -272,7 +272,6 @@ class ArXivTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherT
     @Test
     @Override
     public void supportsYearRangeSearch() throws Exception {
-
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -111,5 +111,4 @@ class CompositeIdFetcherTest {
     void performSearchByIdReturnsCorrectEntryForIdentifier(String name, BibEntry bibEntry, String identifier) throws FetcherException {
         assertEquals(Optional.of(bibEntry), compositeIdFetcher.performSearchById(identifier));
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
@@ -82,7 +82,6 @@ public class DoiFetcherTest {
         bibEntryStenzel2020.setField(StandardField.PUBLISHER, "American Physical Society ({APS})");
         bibEntryStenzel2020.setField(StandardField.PAGES, "023315");
         bibEntryStenzel2020.setField(StandardField.NUMBER, "2");
-
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcherTest.java
@@ -86,5 +86,4 @@ public class IsbnViaEbookDeFetcherTest extends AbstractIsbnFetcherTest {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("3728128155");
         assertEquals(Optional.empty(), fetchedEntry);
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaOttoBibFetcherTest.java
@@ -77,12 +77,10 @@ public class IsbnViaOttoBibFetcherTest extends AbstractIsbnFetcherTest {
      * Checks whether the given ISBN is <emph>NOT</emph> available at any ISBN fetcher
      */
     @Test
-    public void testIsbnNeitherAvaiableOnEbookDeNorOrViaChimbori() throws Exception {
+    public void testIsbnNeitherAvailableOnEbookDeNorOrViaChimbori() throws Exception {
         // In this test, the ISBN needs to be a valid (syntax+checksum) ISBN number
         // However, the ISBN number must not be assigned to a real book
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("978-8-8264-2303-6");
         assertEquals(Optional.empty(), fetchedEntry);
-
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
@@ -93,18 +93,15 @@ public class JstorFetcherTest implements SearchBasedFetcherCapabilityTest {
     @Disabled("jstor does not support search only based on year")
     @Override
     public void supportsYearRangeSearch() throws Exception {
-
     }
 
     @Disabled("jstor does not provide articles with journals")
     @Override
     public void supportsJournalSearch() throws Exception {
-
     }
 
     @Disabled("jstor does not support search only based on year")
     @Override
     public void supportsYearSearch() throws Exception {
-
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedraTest.java
@@ -88,5 +88,4 @@ public class MedraTest {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById(identifier);
         assertEquals(expected, fetchedEntry);
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/ArXivQueryTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/ArXivQueryTransformerTest.java
@@ -44,5 +44,4 @@ class ArXivQueryTransformerTest extends YearRangeByFilteringQueryTransformerTest
         assertEquals(2018, transformer.getStartYear());
         assertEquals(2018, transformer.getEndYear());
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/CollectionOfComputerScienceBibliographiesQueryTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/CollectionOfComputerScienceBibliographiesQueryTransformerTest.java
@@ -49,5 +49,4 @@ class CollectionOfComputerScienceBibliographiesQueryTransformerTest extends Infi
         Optional<String> query = getTransformer().transformLuceneQuery(luceneQuery);
         assertEquals(Optional.of("year:2018 OR year:2019 OR year:2020 OR year:2021"), query);
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/ScholarQueryTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/ScholarQueryTransformerTest.java
@@ -26,5 +26,4 @@ class ScholarQueryTransformerTest extends YearAndYearRangeByFilteringQueryTransf
     public String getTitlePrefix() {
         return "allintitle:";
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/YearRangeByFilteringQueryTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/YearRangeByFilteringQueryTransformerTest.java
@@ -27,5 +27,4 @@ public abstract class YearRangeByFilteringQueryTransformerTest<T extends YearRan
         assertEquals(2018, transformer.getStartYear());
         assertEquals(2021, transformer.getEndYear());
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
@@ -58,7 +58,6 @@ public class BibtexImporterTest {
         assertEquals(4, bibEntries.size());
 
         for (BibEntry entry : bibEntries) {
-
             if (entry.getCitationKey().get().equals("aksin")) {
                 assertEquals(
                         Optional.of(

--- a/src/test/java/org/jabref/logic/importer/fileformat/CffImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/CffImporterTest.java
@@ -85,7 +85,6 @@ public class CffImporterTest {
         BibEntry expected = getPopulatedEntry();
 
         assertEquals(entry, expected);
-
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -62,7 +62,6 @@ class PdfContentImporterTest {
 
     @Test
     void testParsingEditorWithoutPagesorSeriesInformation() {
-
         BibEntry entry = new BibEntry(StandardEntryType.InProceedings);
         entry.setField(StandardField.AUTHOR, "Anke Lüdeling and Merja Kytö (Eds.)");
         entry.setField(StandardField.EDITOR, "Anke Lüdeling and Merja Kytö");
@@ -107,6 +106,5 @@ class PdfContentImporterTest {
                                    + "Master of Research (MRes) thesis, University of Kent,.";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
-
     }
 }

--- a/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
@@ -89,5 +89,4 @@ public class GrobidServiceTest {
         assertEquals(Optional.of("Paper Title"), be0.getField(StandardField.TITLE));
         assertEquals(Optional.of("2014-10-05"), be0.getField(StandardField.DATE));
     }
-
 }

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -139,6 +139,5 @@ class GroupsParserTest {
         SearchGroup expected = new SearchGroup("Data", GroupHierarchyType.INCLUDING, "project=data|number|quant*", EnumSet.of(SearchRules.SearchFlags.REGULAR_EXPRESSION));
         AbstractGroup parsed = GroupsParser.fromString("SearchGroup:Data;2;project=data|number|quant*;0;1;1;;;;;", ',', fileMonitor, metaData);
         assertEquals(expected, parsed);
-
     }
 }

--- a/src/test/java/org/jabref/logic/importer/util/JsonReaderTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/JsonReaderTest.java
@@ -46,5 +46,4 @@ class JsonReaderTest {
         JSONObject result = JsonReader.toJsonObject(new ByteArrayInputStream(input.getBytes()));
         assertEquals(input, result.toString());
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/ASCIICharacterCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/ASCIICharacterCheckerTest.java
@@ -49,5 +49,4 @@ public class ASCIICharacterCheckerTest {
         entry.setField(StandardField.TITLE, field);
         assertEquals(List.of(new IntegrityMessage("Non-ASCII encoded character found", entry, StandardField.TITLE)), checker.check(entry));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/AbbreviationCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/AbbreviationCheckerTest.java
@@ -44,5 +44,4 @@ class AbbreviationCheckerTest {
     void checkValueDoesNotComplainAboutJournalNameThatHasΝοInput() {
         assertEquals(Optional.empty(), checker.checkValue(""));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/BooktitleCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/BooktitleCheckerTest.java
@@ -25,5 +25,4 @@ public class BooktitleCheckerTest {
     void booktitleIsBlank() {
         assertEquals(Optional.empty(), checker.checkValue(" "));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/HowPublishedCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/HowPublishedCheckerTest.java
@@ -55,5 +55,4 @@ public class HowPublishedCheckerTest {
     void bibLaTexAcceptsStringWithLowercaseFirstLetter() {
         assertEquals(Optional.empty(), checkerBiblatex.checkValue("lorem ipsum"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/ISSNCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/ISSNCheckerTest.java
@@ -55,5 +55,4 @@ public class ISSNCheckerTest {
                 Arguments.of("0020~72109")
         );
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/NoteCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/NoteCheckerTest.java
@@ -24,7 +24,6 @@ public class NoteCheckerTest {
         checker = new NoteChecker(database);
         databaseBiblatex.setMode(BibDatabaseMode.BIBLATEX);
         checkerBiblatex = new NoteChecker(databaseBiblatex);
-
     }
 
     @Test
@@ -56,5 +55,4 @@ public class NoteCheckerTest {
     void bibLaTexAcceptsFirstLowercaseLetter() {
         assertEquals(Optional.empty(), checkerBiblatex.checkValue("lorem ipsum"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/PagesCheckerBibLatexTest.java
+++ b/src/test/java/org/jabref/logic/integrity/PagesCheckerBibLatexTest.java
@@ -111,5 +111,4 @@ class PagesCheckerBibLatexTest {
     void bibLaTexAcceptsMorePageNumbersWithRangeOfNumbers() {
         assertEquals(Optional.empty(), checker.checkValue("7+,41--43,73"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/PagesCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/PagesCheckerTest.java
@@ -61,5 +61,4 @@ public class PagesCheckerTest {
     void bibTexAcceptsMorePageNumbersWithRangeOfNumbers() {
         assertEquals(Optional.empty(), checker.checkValue("7+,41--43,73"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/PersonNamesCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/PersonNamesCheckerTest.java
@@ -93,5 +93,4 @@ public class PersonNamesCheckerTest {
                                       ", and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and ,",
                          "and Kurt Cobain and A. Einstein", "Donald E. Knuth and Kurt Cobain and");
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/TitleCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/TitleCheckerTest.java
@@ -220,5 +220,4 @@ public class TitleCheckerTest {
     void bibLaTexAcceptsCapitalLetterNotOnlyAfterSpecialCharacter() {
         assertEquals(Optional.empty(), checkerBiblatex.checkValue("This!is!!A!TitlE??"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/TypeCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/TypeCheckerTest.java
@@ -29,5 +29,4 @@ public class TypeCheckerTest {
         entry.setField(StandardField.PAGES, "11--15");
         assertEquals(List.of(new IntegrityMessage("wrong entry type as proceedings has page numbers", entry, StandardField.PAGES)), checker.check(entry));
     }
-
 }

--- a/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/UTF8CheckerTest.java
@@ -57,7 +57,6 @@ public class UTF8CheckerTest {
     void NonUTF8EncodingCheckerTest() throws UnsupportedEncodingException {
         String NonUTF8 = new String("你好，这条语句使用GBK字符集".getBytes(), "GBK");
             assertFalse(UTF8Checker.UTF8EncodingChecker(NonUTF8.getBytes("GBK")));
-
     }
 
     /**

--- a/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -182,7 +182,6 @@ public class LocalizationParser {
 
         // Record which keys are requested; we pretend that we have all keys
         ResourceBundle registerUsageResourceBundle = new ResourceBundle() {
-
             @Override
             protected Object handleGetObject(String key) {
                 result.add(key);

--- a/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -69,7 +69,6 @@ public class LayoutEntryTest {
 
     @Test
     public void testParseMethodCalls() {
-
         assertEquals(1, LayoutEntry.parseMethodsCalls("bla").size());
         assertEquals("bla", (LayoutEntry.parseMethodsCalls("bla").get(0)).get(0));
 

--- a/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -127,7 +127,6 @@ class LayoutTest {
                 "\\begin{editor&&!author}\\format[HTMLChars]{\\editor} (eds.)\\end{editor&&!author}", entry);
 
         assertEquals("Author", layoutText);
-
     }
 
     /**

--- a/src/test/java/org/jabref/logic/layout/format/AuthorAbbreviatorTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorAbbreviatorTest.java
@@ -13,7 +13,6 @@ public class AuthorAbbreviatorTest {
 
     @Test
     public void testFormat() {
-
         LayoutFormatter a = new AuthorLastFirstAbbreviator();
         LayoutFormatter b = new AuthorAbbreviator();
 

--- a/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
@@ -13,7 +13,6 @@ public class AuthorAndsCommaReplacerTest {
      */
     @Test
     public void testFormat() {
-
         LayoutFormatter a = new AuthorAndsCommaReplacer();
 
         // Empty case

--- a/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
@@ -13,7 +13,6 @@ public class AuthorLastFirstCommasTest {
      */
     @Test
     public void testFormat() {
-
         LayoutFormatter a = new AuthorLastFirstCommas();
 
         // Empty case

--- a/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
@@ -18,7 +18,6 @@ public class HTMLCharsTest {
 
     @Test
     public void testBasicFormat() {
-
         assertEquals("", layout.format(""));
 
         assertEquals("hallo", layout.format("hallo"));

--- a/src/test/java/org/jabref/logic/layout/format/LastPageTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LastPageTest.java
@@ -29,6 +29,5 @@ public class LastPageTest {
                 Arguments.of("350", "345--350"),
                 Arguments.of("", "--")
         );
-
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/NameFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/NameFormatterTest.java
@@ -8,7 +8,6 @@ public class NameFormatterTest {
 
     @Test
     public void testFormatStringStringBibtexEntry() {
-
         NameFormatter l = new NameFormatter();
 
         assertEquals("Doe", l.format("Joe Doe", "1@*@{ll}"));
@@ -32,7 +31,6 @@ public class NameFormatterTest {
 
     @Test
     public void testFormat() {
-
         NameFormatter a = new NameFormatter();
 
         // Empty case

--- a/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -130,7 +130,6 @@ class RTFCharsTest {
         assertEquals("\\u182P", formatter.format("{\\P}")); // ¶
         assertEquals("\\u169?", formatter.format("{\\copyright}")); // ©
         assertEquals("\\u163?", formatter.format("{\\pounds}")); // £
-
     }
 
     @ParameterizedTest(name = "specialChar={0}, formattedStr={1}")

--- a/src/test/java/org/jabref/logic/msbib/MsBibAuthorTest.java
+++ b/src/test/java/org/jabref/logic/msbib/MsBibAuthorTest.java
@@ -24,7 +24,6 @@ public class MsBibAuthorTest {
 
     @Test
     public void testGetNoMiddleName() {
-
         Author author = new Author("Gustav", null, null, "Bach", null);
         MsBibAuthor msBibAuthor = new MsBibAuthor(author);
         assertEquals(null, msBibAuthor.getMiddleName());
@@ -32,7 +31,6 @@ public class MsBibAuthorTest {
 
     @Test
     public void testGetNoFirstName() {
-
         Author author = new Author(null, null, null, "Bach", null);
         MsBibAuthor msBibAuthor = new MsBibAuthor(author);
         assertEquals(null, msBibAuthor.getMiddleName());

--- a/src/test/java/org/jabref/logic/net/URLUtilTest.java
+++ b/src/test/java/org/jabref/logic/net/URLUtilTest.java
@@ -73,5 +73,4 @@ class URLUtilTest {
         assertFalse(URLUtil.isURL("www.google.com"));
         assertFalse(URLUtil.isURL("google.com"));
     }
-
 }

--- a/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
+++ b/src/test/java/org/jabref/logic/protectedterms/ProtectedTermsLoaderTest.java
@@ -105,7 +105,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testNewListsAreIncluded() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(),
                         Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
@@ -114,7 +113,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testNewListsAreEnabled() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(),
                         Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
@@ -125,7 +123,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testInitalizedAllInternalDisabled() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -136,7 +133,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testUnknownExternalFileWillNotLoad() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(ProtectedTermsLoader.getInternalLists(),
                         Collections.singletonList("someUnlikelyNameThatNeverWillExist"), Collections.emptyList(),
@@ -146,7 +142,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testAllDisabledNoWords() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -155,7 +150,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testDoNotLoadTheSameInternalListTwice() {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(ProtectedTermsLoader.getInternalLists(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -164,7 +158,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testAddNewTermListAddsList(@TempDir Path tempDir) {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -174,7 +167,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testAddNewTermListNewListInList(@TempDir Path tempDir) {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -185,7 +177,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testRemoveTermList(@TempDir Path tempDir) {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -195,7 +186,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testRemoveTermListReduceTheCount(@TempDir Path tempDir) {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));
@@ -207,7 +197,6 @@ class ProtectedTermsLoaderTest {
 
     @Test
     void testAddNewTermListSetsCorrectDescription(@TempDir Path tempDir) {
-
         ProtectedTermsLoader localLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(Collections.emptyList(), Collections.emptyList(),
                         ProtectedTermsLoader.getInternalLists(), Collections.emptyList()));

--- a/src/test/java/org/jabref/logic/shared/SynchronizationTestSimulator.java
+++ b/src/test/java/org/jabref/logic/shared/SynchronizationTestSimulator.java
@@ -164,5 +164,4 @@ public class SynchronizationTestSimulator {
         // In this case an BibEntry merge dialog pops up.
         assertNotNull(eventListenerB.getUpdateRefusedEvent());
     }
-
 }

--- a/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileNameUniquenessTest.java
@@ -101,5 +101,4 @@ public class FileNameUniquenessTest {
         String fileName2 = FileNameUniqueness.eraseDuplicateMarks(fileName1);
         assertEquals("abc def", fileName2);
     }
-
 }

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
@@ -45,7 +45,6 @@ class XmpUtilReaderTest {
         when(xmpPreferences.getKeywordSeparator()).thenReturn(',');
 
         testImporter = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor());
-
     }
 
     /**

--- a/src/test/java/org/jabref/migrations/PreferencesMigrationsTest.java
+++ b/src/test/java/org/jabref/migrations/PreferencesMigrationsTest.java
@@ -45,7 +45,6 @@ class PreferencesMigrationsTest {
 
     @Test
     void testOldStyleBibtexkeyPattern1() {
-
         when(prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(oldStylePatterns[1]);
         when(mainPrefsNode.get(JabRefPreferences.IMPORT_FILENAMEPATTERN, null)).thenReturn(oldStylePatterns[1]);
         when(prefs.hasKey(JabRefPreferences.IMPORT_FILENAMEPATTERN)).thenReturn(true);

--- a/src/test/java/org/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListTest.java
@@ -117,7 +117,6 @@ public class AuthorListTest {
 
     @Test
     public void testFixAuthorFirstNameFirstCommas() {
-
         // No Commas
         assertEquals("", AuthorList.fixAuthorFirstNameFirstCommas("", true, false));
         assertEquals("", AuthorList.fixAuthorFirstNameFirstCommas("", false, false));
@@ -137,7 +136,7 @@ public class AuthorListTest {
         assertEquals("J. Smith and P. Black Brown", AuthorList.fixAuthorFirstNameFirstCommas(
                 "John Smith and Black Brown, Peter", true, false));
 
-        // Method description is different than code -> additional comma
+        // Method description is different from code -> additional comma
         // there
         assertEquals("John von Neumann, John Smith and Peter Black Brown", AuthorList
                 .fixAuthorFirstNameFirstCommas(
@@ -560,7 +559,6 @@ public class AuthorListTest {
 
     @Test
     public void testFixAuthorLastNameFirst() {
-
         // Test helper method
 
         assertEquals("Smith, John", AuthorList.fixAuthorLastNameFirst("John Smith"));
@@ -615,7 +613,6 @@ public class AuthorListTest {
 
     @Test
     public void testFixAuthorLastNameOnlyCommas() {
-
         // No comma before and
         assertEquals("", AuthorList.fixAuthorLastNameOnlyCommas("", false));
         assertEquals("Smith", AuthorList.fixAuthorLastNameOnlyCommas("John Smith", false));
@@ -703,7 +700,6 @@ public class AuthorListTest {
 
     @Test
     public void testSize() {
-
         assertEquals(0, AuthorListTest.size(""));
         assertEquals(1, AuthorListTest.size("Bar"));
         assertEquals(1, AuthorListTest.size("Foo Bar"));
@@ -737,7 +733,6 @@ public class AuthorListTest {
 
     @Test
     public void testGetAuthor() {
-
         Author author = AuthorList.parse("John Smith and von Neumann, Jr, John").getAuthor(0);
         assertEquals(Optional.of("John"), author.getFirst());
         assertEquals(Optional.of("J."), author.getFirstAbbr());
@@ -824,7 +819,6 @@ public class AuthorListTest {
 
     @Test
     public void testGetAuthorsLastOnly() {
-
         // No comma before and
         assertEquals("", AuthorList.parse("").getAsLastNames(false));
         assertEquals("Smith", AuthorList.parse("John Smith").getAsLastNames(false));
@@ -925,7 +919,6 @@ public class AuthorListTest {
 
     @Test
     public void testGetAuthorsFirstFirst() {
-
         AuthorList al;
 
         al = AuthorList.parse("");

--- a/src/test/java/org/jabref/model/entry/AuthorTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorTest.java
@@ -75,5 +75,4 @@ class AuthorTest {
     void addDotIfAbbreviationIfStartsWithNumber(String input) {
         assertEquals(input, Author.addDotIfAbbreviation(input));
     }
-
 }

--- a/src/test/java/org/jabref/model/entry/BibEntryTypesManagerTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTypesManagerTest.java
@@ -162,7 +162,6 @@ class BibEntryTypesManagerTest {
     @ParameterizedTest
     @MethodSource("mode")
     void testsModifyingArticle(BibDatabaseMode mode) {
-
         overwrittenStandardType = new BibEntryType(
                                                    StandardEntryType.Article,
                                                    List.of(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT),
@@ -178,7 +177,6 @@ class BibEntryTypesManagerTest {
     @ParameterizedTest
     @MethodSource("mode")
     void testsModifyingArticleWithParsing(BibDatabaseMode mode) {
-
         overwrittenStandardType = new BibEntryType(
                                                    StandardEntryType.Article,
                                                    List.of(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT),
@@ -197,7 +195,6 @@ class BibEntryTypesManagerTest {
     @ParameterizedTest
     @MethodSource("mode")
     void testsModifyingArticleWithParsingKeepsListOrder(BibDatabaseMode mode) {
-
         overwrittenStandardType = new BibEntryType(
                                                    StandardEntryType.Article,
                                                    List.of(new BibField(StandardField.TITLE, FieldPriority.IMPORTANT),

--- a/src/test/java/org/jabref/model/entry/DateTest.java
+++ b/src/test/java/org/jabref/model/entry/DateTest.java
@@ -55,7 +55,6 @@ class DateTest {
     @MethodSource("provideInvalidCornerCaseArguments")
     public void nonExistentDates(String invalidDate, String errorMessage) {
         assertEquals(Optional.empty(), Date.parse(invalidDate), errorMessage);
-
     }
 
     private static Stream<Arguments> provideInvalidCornerCaseArguments() {

--- a/src/test/java/org/jabref/model/entry/IdGeneratorTest.java
+++ b/src/test/java/org/jabref/model/entry/IdGeneratorTest.java
@@ -10,7 +10,6 @@ public class IdGeneratorTest {
 
     @Test
     public void testCreateNeutralId() {
-
         HashSet<String> set = new HashSet<>();
         for (int i = 0; i < 10000; i++) {
             String string = IdGenerator.next();

--- a/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
@@ -170,5 +170,4 @@ class ArXivIdentifierTest {
         Optional<ArXivIdentifier> parsed = ArXivIdentifier.parse("0706.0001v1");
         assertEquals(Optional.of(new URI("https://arxiv.org/abs/0706.0001v1")), parsed.get().getExternalURI());
     }
-
 }

--- a/src/test/java/org/jabref/model/entry/identifier/IacrEprintTest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/IacrEprintTest.java
@@ -56,5 +56,4 @@ public class IacrEprintTest {
     public void constructValidIacrEprintUrl() {
         assertEquals("https://ia.cr/2019/001", new IacrEprint("2019/001").getAsciiUrl());
     }
-
 }

--- a/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
+++ b/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
@@ -39,5 +39,4 @@ class AutomaticKeywordGroupTest {
 
         return expectedKeywordsSubgroup;
     }
-
 }

--- a/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -109,7 +109,6 @@ class StringUtilTest {
 
     @Test
     void testShaveString() {
-
         assertEquals("", StringUtil.shaveString(null));
         assertEquals("", StringUtil.shaveString(""));
         assertEquals("aaa", StringUtil.shaveString("   aaa\t\t\n\r"));


### PR DESCRIPTION
We often have the issue that contributors have an empty line at the beginning of a block (`{`) or before at the end of a block (`}`). This PR adds a check for it and fixes these issues in the code base.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
