### PR TITLE
Fight EOL issues by pinning LF for *.java, *.fxml, and *.properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{fxml,java,properties,sh}]
+end_of_line = lf
+
 [*.md]
 trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,10 @@ gradlew text eol=lf
 # windows line endings at windows files
 *.bat text eol=crlf
 
-# ensure that line endings of *.java, and *.properties are normalized
-*.java text
-*.properties text
+# ensure that line endings of *.fxml, *.java, and *.properties are normalized
+*.fxml text eol=lf
+*.java text eol=lf
+*.properties text eol=lf
 
 # .bib files have to be written using OS specific line endings to enable our tests working
 *.bib text !eol


### PR DESCRIPTION
With IntelliJ 2022, I have issues with CRLF (IntelliJ) and LF (git config) line endings. With this PR, I kind of follow the recommendation from https://stackoverflow.com/a/42135910/873282 to have all source code files having the same line endings.


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
