### PR TITLE
Fix AuthorListParser#parse for two authors with comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where opening the changelog from withing JabRef led to a 404 error [#8563](https://github.com/JabRef/jabref/issues/8563)
 - We fixed an issue where not all found unlinked local files were imported correctly due to some race condition. [#8444](https://github.com/JabRef/jabref/issues/8444)
 - We fixed an issue where Merge entries dialog exceeds screen boundaries.
+- We fixe dan issue where the ISBN fetcher should have returned two authors, but returned only one.
 - We fixed an issue where the app lags when selecting an entry after a fresh start. [#8446](https://github.com/JabRef/jabref/issues/8446)
 - We fixed an issue where no citationkey was generated on import, pasting a doi or an entry on the main table [8406](https://github.com/JabRef/jabref/issues/8406), [koppor#553](https://github.com/koppor/jabref/issues/553)
 - We fixed an issue where accent search does not perform consistently. [#6815](https://github.com/JabRef/jabref/issues/6815)

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -1,7 +1,12 @@
 package org.jabref.logic.formatter.bibtexfields;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -134,10 +139,19 @@ public class NormalizeNamesFormatterTest {
         assertEquals("Mair, Jr, Daniel and Brühl, Sr, Daniel", formatter.format("Mair, Jr, Daniel, Brühl, Sr, Daniel"));
     }
 
-    @Test
-    public void testCommaSeperatedNames() {
-        assertEquals("Bosoi, Cristina and Oliveira, Mariana and Sanchez, Rafael Ochoa and Tremblay, Mélanie and TenHave, Gabrie and Deutz, Nicoolas and Rose, Christopher F. and Bemeur, Chantal",
-                formatter.format("Cristina Bosoi, Mariana Oliveira, Rafael Ochoa Sanchez, Mélanie Tremblay, Gabrie TenHave, Nicoolas Deutz, Christopher F. Rose, Chantal Bemeur"));
+    public static Stream<Arguments> testCommaSeperatedNames() {
+        return Stream.of(
+                Arguments.of("Bosoi, Cristina and Oliveira, Mariana and Sanchez, Rafael Ochoa and Tremblay, Mélanie and TenHave, Gabrie and Deutz, Nicoolas and Rose, Christopher F. and Bemeur, Chantal",
+                        "Cristina Bosoi, Mariana Oliveira, Rafael Ochoa Sanchez, Mélanie Tremblay, Gabrie TenHave, Nicoolas Deutz, Christopher F. Rose, Chantal Bemeur"),
+                Arguments.of("Habermann, Hans-Joachim  and Leymann, Frank",
+                        "Hans-Joachim Habermann, Frank Leymann")
+        );
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    public void testCommaSeperatedNames(String expected, String source) {
+        assertEquals(expected, formatter.format(source));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AuthorListParserTest {
 
-    private static Stream<Arguments> data() {
+    private static Stream<Arguments> parseCorrectlySingleAuthors() {
         return Stream.of(
                 Arguments.of("王, 军", new Author("军", "军.", null, "王", null)),
                 Arguments.of("Doe, John", new Author("John", "J.", null, "Doe", null)),
@@ -30,16 +30,44 @@ class AuthorListParserTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
-    void parseCorrectly(String authorsString, Author authorsParsed) {
+    @MethodSource
+    void parseCorrectlySingleAuthors(String authorsString, Author authorsParsed) {
         AuthorListParser parser = new AuthorListParser();
         Assertions.assertEquals(AuthorList.of(authorsParsed), parser.parse(authorsString));
     }
 
+    private static Stream<Arguments> parseCorrectlyMultipleAuthors() {
+        return Stream.of(
+                Arguments.of("First Habermann, Frank Leymann",
+                        AuthorList.of(
+                                new Author("First", "F.", null, "Habermann", null),
+                                new Author("Frank", "F.", null, "Leymann", null)
+                        )),
+                Arguments.of("Hans-Joachim Habermann, Frank Leymann",
+                        AuthorList.of(
+                                new Author("Hans-Joachim", "H.-J.", null, "Habermann", null),
+                                new Author("Frank", "F.", null, "Leymann", null)
+                        )),
+                // Example from code comment
+                Arguments.of("Ali Babar, M., Dingsøyr, T., Lago, P., van der Vliet, H.",
+                        AuthorList.of(
+                                new Author("M.", "M.", null, "Ali Babar", null),
+                                new Author("T.", "T.", null, "Dingsøyr", null),
+                                new Author("P.", "P.", null, "Lago", null),
+                                new Author("H.", "H.", "van der", "Vliet", null)
+                        )));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseCorrectlyMultipleAuthors(String authorsString, AuthorList authorsParsed) {
+        AuthorListParser parser = new AuthorListParser();
+        Assertions.assertEquals(authorsParsed, parser.parse(authorsString));
+    }
+
     @Test
     public void parseAuthorWithFirstNameAbbreviationContainingUmlaut() {
-        assertEquals(AuthorList.of(
-                new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
+        assertEquals(AuthorList.of(new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
                 new AuthorListParser().parse("{\\OE}rjan Umlauts"));
     }
 }


### PR DESCRIPTION
While reading https://github.com/JabRef/jabref/issues/8652, I found that ebook.de returns an "OKish" BibTeX:

https://www.ebook.de/de/tools/isbn2bibtex?isbn=9783110702125

```bibtex
@book{9783110702125,
  Author = {Hans-Joachim Habermann, Frank Leymann},
  Title = {Repository},
  Publisher = {Gruyter, Walter de GmbH},
  Year = {2020},
  Date = {2020-10-12},
  PageTotal = {294 Seiten},
  EAN = {9783110702125},
  URL = {https://www.ebook.de/de/product/41373251/hans_joachim_habermann_frank_leymann_repository.html}
}
```

We convert that to "good" BibTeX by using https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/logic/importer/AuthorListParser.java. This code, however, did not work in the special case of two authors. I added a new heuristics for that case and added more test cases for that.

In the concrete case, `{Hans-Joachim Habermann, Frank Leymann}` needs to be converted to `{Habermann, Hans-Joachim AND Leymann, Frank}`

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
