### PR TITLE
Right clicking a group and choosing "remove selected entries from this group" leads to error when {}Bibtex source is selected #8012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the app lags when selecting an entry after a fresh start. [#8446](https://github.com/JabRef/jabref/issues/8446)
 - We fixed an issue where no citationkey was generated on import, pasting a doi or an entry on the main table [8406](https://github.com/JabRef/jabref/issues/8406), [koppor#553](https://github.com/koppor/jabref/issues/553)
 - We fixed an issue where accent search does not perform consistently. [#6815](https://github.com/JabRef/jabref/issues/6815)
+- We fixed an issue where right clicking a group and choosing "remove selected entries from this group" leads to error when {}Bibtex source is selected [#8012](https://github.com/JabRef/jabref/issues/8012)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -235,6 +235,9 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
+//        if (entry.isRemoved()){
+//            return;
+//        }
         if ((previousEntry != null) && (codeArea != null)) {
             storeSource(previousEntry, codeArea.textProperty().getValue());
         }
@@ -248,6 +251,9 @@ public class SourceTab extends EntryEditorTab {
 
     private void storeSource(BibEntry outOfFocusEntry, String text) {
         if ((outOfFocusEntry == null) || text.isEmpty()) {
+            return;
+        }
+        if(outOfFocusEntry.isRemoved()){
             return;
         }
 
@@ -304,7 +310,6 @@ public class SourceTab extends EntryEditorTab {
                 if (!Objects.equals(oldValue, newValue)) {
                     // Test if the field is legally set.
                     new FieldWriter(fieldWriterPreferences).write(fieldName, newValue);
-
                     compound.addEdit(new UndoableFieldChange(outOfFocusEntry, fieldName, oldValue, newValue));
                     outOfFocusEntry.setField(fieldName, newValue);
                 }
@@ -335,4 +340,5 @@ public class SourceTab extends EntryEditorTab {
             }
         });
     }
+
 }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -235,9 +235,7 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-//        if (entry.isRemoved()){
-//            return;
-//        }
+
         if ((previousEntry != null) && (codeArea != null)) {
             storeSource(previousEntry, codeArea.textProperty().getValue());
         }

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -98,6 +98,16 @@ public class BibEntry implements Cloneable {
      */
     private boolean changed;
 
+    public boolean isRemoved() {
+        return removed;
+    }
+
+    public void setRemoved(boolean removed) {
+        this.removed = removed;
+    }
+
+    private boolean removed;
+
     /**
      * Constructs a new BibEntry. The internal ID is set to IdGenerator.next()
      */
@@ -542,6 +552,7 @@ public class BibEntry implements Cloneable {
      * @param eventSource Source the event is sent from
      */
     public Optional<FieldChange> setField(Field field, String value, EntriesEventSource eventSource) {
+
         Objects.requireNonNull(field, "field name must not be null");
         Objects.requireNonNull(value, "field value must not be null");
 
@@ -1007,4 +1018,5 @@ public class BibEntry implements Cloneable {
         }
         entry.setFiles(linkedFiles);
     }
+
 }

--- a/src/main/java/org/jabref/model/groups/GroupTreeNode.java
+++ b/src/main/java/org/jabref/model/groups/GroupTreeNode.java
@@ -300,6 +300,9 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
      */
     public List<FieldChange> removeEntriesFromGroup(List<BibEntry> entries) {
         if (getGroup() instanceof GroupEntryChanger) {
+            for (BibEntry entry:entries){
+                entry.setRemoved(true);
+            }
             return ((GroupEntryChanger) getGroup()).remove(entries);
         } else {
             return Collections.emptyList();


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

https://user-images.githubusercontent.com/65015480/164723025-e9c43bd0-7928-4761-a4a2-36ca1daa53bd.mp4

#8012 