### PR TITLE
fixes CSL and entry table renders $ only, when it is backslashed. E.g. \$ #8650

### DIFF
--- a/src/main/java/org/jabref/logic/layout/LaTex2UnicodePreviewLayout.java
+++ b/src/main/java/org/jabref/logic/layout/LaTex2UnicodePreviewLayout.java
@@ -1,0 +1,69 @@
+package org.jabref.logic.layout.format;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.Layout;
+import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.layout.LayoutHelper;
+import org.jabref.logic.layout.TextBasedPreviewLayout;
+import org.jabref.logic.preview.PreviewLayout;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+/**
+ * Implements the preview based JabRef's <a href="https://docs.jabref.org/import-export/export/customexports">Custom export fitlters</a>.
+ */
+public class LaTex2UnicodePreviewLayout extends TextBasedPreviewLayout implements PreviewLayout {
+    public static final String NAME = "Unicode";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LaTex2UnicodePreviewLayout.class);
+    private Layout layout;
+    private String text;
+    private LayoutFormatterPreferences layoutFormatterPreferences;
+
+    public LaTex2UnicodePreviewLayout(String text, LayoutFormatterPreferences layoutFormatterPreferences) {
+        super(text, layoutFormatterPreferences);
+    }
+
+    public LaTex2UnicodePreviewLayout(Layout layout) {
+        super(layout);
+    }
+
+    public void setText(String text) {
+        this.text = text;
+        StringReader sr = new StringReader(text.replace("__NEWLINE__", "\n"));
+        try {
+            layout = new LayoutHelper(sr, layoutFormatterPreferences).getLayoutFromText();
+        } catch (IOException e) {
+            LOGGER.error("Could not generate layout", e);
+        }
+    }
+
+    @Override
+    public String generatePreview(BibEntry entry, BibDatabaseContext databaseContext) {
+        if (layout != null) {
+            LatexToUnicodeFormatter latexToUnicodeFormatter=new LatexToUnicodeFormatter();
+            return latexToUnicodeFormatter.format(layout.doLayout(entry, databaseContext.getDatabase()));
+        } else {
+            return "";
+        }
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Localization.lang("Unicode");
+    }
+}


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
--> 
I write a class called "LaTex2UnicodePreviewLayout". And this class uses a LatexToUnicodeFormatter to convert the text into the Unicode format. And finally, the text after converting will display in the preview.  However, this class also needs to be called by the UI interface in the program. You can call this class in later modifications for usage purposes. I will continue to improve it next. 
Link: (https://github.com/JabRef/jabref/issues/8650)


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
