### PR TITLE
Don't write enclosing braces to PDF metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added two new web and fulltext fetchers: SemanticScholar and ResearchGate.
 - We added notifications on success and failure when writing metadata to a PDF-file [#8276](https://github.com/JabRef/jabref/issues/8276)
 - We added a cleanup action that escapes `$` (by adding a backslash in front) [#8673](https://github.com/JabRef/jabref/issues/8673)
+- We added a checkbox that prevent enclosing braces from being written to metadata [#8452](https://github.com/JabRef/jabref/issues/8452)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
@@ -194,7 +194,7 @@ public class WriteMetadataToPdfAction extends SimpleCommand {
     synchronized private void writeMetadataToFile(Path file, BibEntry entry, BibDatabaseContext databaseContext, BibDatabase database) throws Exception {
         XmpUtilWriter.writeXmp(file, entry, database, xmpPreferences);
 
-        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), entryTypesManager, fieldWriterPreferences);
+        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), entryTypesManager, fieldWriterPreferences, xmpPreferences);
         embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, file);
     }
 

--- a/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTab.fxml
@@ -10,11 +10,13 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
+<?import javafx.scene.canvas.Canvas?>
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.xmp.XmpPrivacyTab">
     <Label styleClass="titleHeader" text="%XMP export privacy settings"/>
     <CheckBox fx:id="enableXmpFilter" text="%Do not write the following fields to XMP Metadata"/>
+    <CheckBox fx:id="enableEnclosingBracketsFilter" text="%Do not write enclosing brackets to XMP Metadata"/>
     <HBox alignment="BOTTOM_LEFT" spacing="4.0">
         <VBox spacing="4.0">
             <TableView fx:id="filterList" prefHeight="300.0" prefWidth="200.0">

--- a/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTab.java
+++ b/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTab.java
@@ -26,6 +26,7 @@ import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class XmpPrivacyTab extends AbstractPreferenceTabView<XmpPrivacyTabViewModel> implements PreferencesTab {
 
+    @FXML public CheckBox enableEnclosingBracketsFilter;
     @FXML private CheckBox enableXmpFilter;
     @FXML private TableView<Field> filterList;
     @FXML private TableColumn<Field, Field> fieldColumn;
@@ -50,6 +51,8 @@ public class XmpPrivacyTab extends AbstractPreferenceTabView<XmpPrivacyTabViewMo
         this.viewModel = new XmpPrivacyTabViewModel(dialogService, preferencesService.getXmpPreferences());
 
         enableXmpFilter.selectedProperty().bindBidirectional(viewModel.xmpFilterEnabledProperty());
+        enableEnclosingBracketsFilter.selectedProperty().bindBidirectional(viewModel.enclosingBracketsFilterEnabledProperty());
+
         filterList.disableProperty().bind(viewModel.xmpFilterEnabledProperty().not());
         addFieldName.disableProperty().bind(viewModel.xmpFilterEnabledProperty().not());
         addField.disableProperty().bind(viewModel.xmpFilterEnabledProperty().not());

--- a/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTabViewModel.java
@@ -25,6 +25,7 @@ import de.saxsys.mvvmfx.utils.validation.Validator;
 public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty xmpFilterEnabledProperty = new SimpleBooleanProperty();
+    private final BooleanProperty enclosingBracketsFilterEnabledProperty = new SimpleBooleanProperty();
     private final ListProperty<Field> xmpFilterListProperty = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ListProperty<Field> availableFieldsProperty = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<Field> addFieldProperty = new SimpleObjectProperty<>();
@@ -50,6 +51,7 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
     @Override
     public void setValues() {
         xmpFilterEnabledProperty.setValue(xmpPreferences.shouldUseXmpPrivacyFilter());
+        enclosingBracketsFilterEnabledProperty.setValue(xmpPreferences.shouldEnableEnclosingBracketsFilter());
 
         xmpFilterListProperty.clear();
         xmpFilterListProperty.addAll(xmpPreferences.getXmpPrivacyFilter());
@@ -61,6 +63,7 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public void storeSettings() {
+        xmpPreferences.setEnableEnclosingBracketsFilter(enclosingBracketsFilterEnabledProperty.getValue());
         xmpPreferences.setUseXmpPrivacyFilter(xmpFilterEnabledProperty.getValue());
         xmpPreferences.getXmpPrivacyFilter().clear();
         xmpPreferences.getXmpPrivacyFilter().addAll(xmpFilterListProperty.getValue());
@@ -98,6 +101,9 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty xmpFilterEnabledProperty() {
         return xmpFilterEnabledProperty;
+    }
+    public BooleanProperty enclosingBracketsFilterEnabledProperty() {
+        return enclosingBracketsFilterEnabledProperty;
     }
 
     public ListProperty<Field> filterListProperty() {

--- a/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporter.java
@@ -19,6 +19,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.OS;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.util.io.FileUtil;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.logic.xmp.XmpUtilWriter;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -42,12 +43,21 @@ public class EmbeddedBibFilePdfExporter extends Exporter {
     private final BibDatabaseMode bibDatabaseMode;
     private final BibEntryTypesManager bibEntryTypesManager;
     private final FieldWriterPreferences fieldWriterPreferences;
+    private final XmpPreferences xmpPreferences;
 
     public EmbeddedBibFilePdfExporter(BibDatabaseMode bibDatabaseMode, BibEntryTypesManager bibEntryTypesManager, FieldWriterPreferences fieldWriterPreferences) {
         super("bib", "Embedded BibTeX", StandardFileType.PDF);
         this.bibDatabaseMode = bibDatabaseMode;
         this.bibEntryTypesManager = bibEntryTypesManager;
         this.fieldWriterPreferences = fieldWriterPreferences;
+        this.xmpPreferences = null;
+    }
+    public EmbeddedBibFilePdfExporter(BibDatabaseMode bibDatabaseMode, BibEntryTypesManager bibEntryTypesManager, FieldWriterPreferences fieldWriterPreferences, XmpPreferences xmpPreferences) {
+        super("bib", "Embedded BibTeX", StandardFileType.PDF);
+        this.bibDatabaseMode = bibDatabaseMode;
+        this.bibEntryTypesManager = bibEntryTypesManager;
+        this.fieldWriterPreferences = fieldWriterPreferences;
+        this.xmpPreferences = xmpPreferences;
     }
 
     /**
@@ -136,7 +146,7 @@ public class EmbeddedBibFilePdfExporter extends Exporter {
     private String getBibString(List<BibEntry> entries) throws IOException {
         StringWriter stringWriter = new StringWriter();
         BibWriter bibWriter = new BibWriter(stringWriter, OS.NEWLINE);
-        FieldWriter fieldWriter = FieldWriter.buildIgnoreHashes(fieldWriterPreferences);
+        FieldWriter fieldWriter = FieldWriter.buildIgnoreHashes(fieldWriterPreferences, xmpPreferences);
         BibEntryWriter bibEntryWriter = new BibEntryWriter(fieldWriter, bibEntryTypesManager);
         for (BibEntry entry : entries) {
             bibEntryWriter.write(entry, bibWriter, bibDatabaseMode);

--- a/src/main/java/org/jabref/logic/xmp/XmpPreferences.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpPreferences.java
@@ -13,25 +13,38 @@ import org.jabref.model.entry.field.Field;
 public class XmpPreferences {
 
     private final BooleanProperty useXmpPrivacyFilter;
+    private final BooleanProperty enableEnclosingBracketsFilter;
+
     private final ObservableSet<Field> xmpPrivacyFilter;
     private final ObjectProperty<Character> keywordSeparator;
 
-    public XmpPreferences(boolean useXmpPrivacyFilter, Set<Field> xmpPrivacyFilter, ObjectProperty<Character> keywordSeparator) {
+    public XmpPreferences(boolean useXmpPrivacyFilter, Set<Field> xmpPrivacyFilter, ObjectProperty<Character> keywordSeparator, boolean enableEnclosingBracketsFilter) {
         this.useXmpPrivacyFilter = new SimpleBooleanProperty(useXmpPrivacyFilter);
         this.xmpPrivacyFilter = FXCollections.observableSet(xmpPrivacyFilter);
+        this.enableEnclosingBracketsFilter = new SimpleBooleanProperty(enableEnclosingBracketsFilter);
         this.keywordSeparator = keywordSeparator;
     }
 
     public boolean shouldUseXmpPrivacyFilter() {
         return useXmpPrivacyFilter.getValue();
     }
+    public boolean shouldEnableEnclosingBracketsFilter(){
+        return enableEnclosingBracketsFilter.getValue();
+    }
+
 
     public BooleanProperty useXmpPrivacyFilterProperty() {
         return useXmpPrivacyFilter;
     }
+    public BooleanProperty enableEnclosingBracketsFilterProperty() {
+        return enableEnclosingBracketsFilter;
+    }
 
     public void setUseXmpPrivacyFilter(boolean useXmpPrivacyFilter) {
         this.useXmpPrivacyFilter.set(useXmpPrivacyFilter);
+    }
+    public void setEnableEnclosingBracketsFilter(boolean enableEnclosingBracketsFilter) {
+        this.enableEnclosingBracketsFilter.set(enableEnclosingBracketsFilter);
     }
 
     public ObservableSet<Field> getXmpPrivacyFilter() {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -184,6 +184,7 @@ public class JabRefPreferences implements PreferencesService {
     public static final String SIDE_PANE_COMPONENT_NAMES = "sidePaneComponentNames";
     public static final String XMP_PRIVACY_FILTERS = "xmpPrivacyFilters";
     public static final String USE_XMP_PRIVACY_FILTER = "useXmpPrivacyFilter";
+    public static final String ENABLE_ENCLOSING_BRACKETS_FILTER = "enableEnclosingBracketsFilter";
     public static final String DEFAULT_SHOW_SOURCE = "defaultShowSource";
     // Window sizes
     public static final String SIZE_Y = "mainWindowSizeY";
@@ -572,6 +573,7 @@ public class JabRefPreferences implements PreferencesService {
 
         defaults.put(XMP_PRIVACY_FILTERS, "pdf;timestamp;keywords;owner;note;review");
         defaults.put(USE_XMP_PRIVACY_FILTER, Boolean.FALSE);
+        defaults.put(ENABLE_ENCLOSING_BRACKETS_FILTER, Boolean.FALSE);
         defaults.put(WORKING_DIRECTORY, USER_HOME);
         defaults.put(EXPORT_WORKING_DIRECTORY, USER_HOME);
         // Remembers working directory of last import
@@ -2667,8 +2669,12 @@ public class JabRefPreferences implements PreferencesService {
         xmpPreferences = new XmpPreferences(
                 getBoolean(USE_XMP_PRIVACY_FILTER),
                 getStringList(XMP_PRIVACY_FILTERS).stream().map(FieldFactory::parseField).collect(Collectors.toSet()),
-                getInternalPreferences().keywordSeparatorProperty());
+                getInternalPreferences().keywordSeparatorProperty(),
+                getBoolean(ENABLE_ENCLOSING_BRACKETS_FILTER));
 
+
+        EasyBind.listen(xmpPreferences.enableEnclosingBracketsFilterProperty(),
+                (obs, oldValue, newValue) -> putBoolean(ENABLE_ENCLOSING_BRACKETS_FILTER, newValue));
         EasyBind.listen(xmpPreferences.useXmpPrivacyFilterProperty(),
                 (obs, oldValue, newValue) -> putBoolean(USE_XMP_PRIVACY_FILTER, newValue));
         xmpPreferences.getXmpPrivacyFilter().addListener((SetChangeListener<Field>) c ->

--- a/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
@@ -98,7 +98,7 @@ class XmpPdfExporterTest {
      */
     @BeforeEach
     void setUp() throws IOException {
-        xmpPreferences = new XmpPreferences(false, Collections.emptySet(), new SimpleObjectProperty<>(','));
+        xmpPreferences = new XmpPreferences(false, Collections.emptySet(), new SimpleObjectProperty<>(','), false);
 
         encoding = Charset.defaultCharset();
 

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -120,38 +120,20 @@ class XmpUtilWriterTest {
      * Test for writing a PDF file with a single DublinCore metadata entry.
      */
     @Test
-    void testWriteXmp(@TempDir Path tempDir) throws Exception {
-        BibDatabaseMode bibDatabaseMode = BibDatabaseMode.BIBTEX;
-        BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
-        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
-        BibDatabaseContext databaseContext = new BibDatabaseContext();
-        BibDatabase database = databaseContext.getDatabase();
+    void testWriteXmp(@TempDir Path tempDir) throws IOException, TransformerException {
+        Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
 
-        FilePreferences filePreferences = mock(FilePreferences.class);
-        when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
-        when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
-
-//        Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
-        Path pdfFile = tempDir.resolve("existing.pdf").toAbsolutePath();
         // read a bib entry from the tests before
         BibEntry entry = vapnik2000;
-        LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
-        entry.setFiles(Arrays.asList(linkedFile));
-        database.insertEntry(entry);
+        entry.setCitationKey("WriteXMPTest");
+        entry.setId("ID4711");
 
         // write the changed bib entry to the PDF
         XmpUtilWriter.writeXmp(pdfFile.toAbsolutePath().toString(), entry, null, xmpPreferences);
 
-        // export
-        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(bibDatabaseMode, bibEntryTypesManager, fieldWriterPreferences, xmpPreferences);
-        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, pdfFile);
-
         // read entry again
         List<BibEntry> entriesWritten = XmpUtilReader.readXmp(pdfFile.toAbsolutePath().toString(), xmpPreferences);
         BibEntry entryWritten = entriesWritten.get(0);
-
-        System.out.println(entryWritten);
-
         entryWritten.clearField(StandardField.FILE);
 
         // compare the two entries

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -1,25 +1,45 @@
 package org.jabref.logic.xmp;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.transform.TransformerException;
 
+import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
+import org.jabref.logic.bibtex.FieldWriterPreferences;
+import org.jabref.logic.exporter.EmbeddedBibFilePdfExporter;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.Date;
+import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.Month;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.FilePreferences;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
+import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
+import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.jabref.logic.exporter.EmbeddedBibFilePdfExporter.EMBEDDED_FILE_NAME;
 import static org.jabref.logic.xmp.DublinCoreExtractor.DC_COVERAGE;
 import static org.jabref.logic.xmp.DublinCoreExtractor.DC_RIGHTS;
 import static org.jabref.logic.xmp.DublinCoreExtractor.DC_SOURCE;
@@ -89,6 +109,7 @@ class XmpUtilWriterTest {
         xmpPreferences = mock(XmpPreferences.class);
         // The code assumes privacy filters to be off
         when(xmpPreferences.shouldUseXmpPrivacyFilter()).thenReturn(false);
+        when(xmpPreferences.shouldEnableEnclosingBracketsFilter()).thenReturn(false);
 
         when(xmpPreferences.getKeywordSeparator()).thenReturn(',');
 
@@ -99,20 +120,38 @@ class XmpUtilWriterTest {
      * Test for writing a PDF file with a single DublinCore metadata entry.
      */
     @Test
-    void testWriteXmp(@TempDir Path tempDir) throws IOException, TransformerException {
-        Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
+    void testWriteXmp(@TempDir Path tempDir) throws Exception {
+        BibDatabaseMode bibDatabaseMode = BibDatabaseMode.BIBTEX;
+        BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
+        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+        BibDatabase database = databaseContext.getDatabase();
 
+        FilePreferences filePreferences = mock(FilePreferences.class);
+        when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
+        when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
+
+//        Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
+        Path pdfFile = tempDir.resolve("existing.pdf").toAbsolutePath();
         // read a bib entry from the tests before
         BibEntry entry = vapnik2000;
-        entry.setCitationKey("WriteXMPTest");
-        entry.setId("ID4711");
+        LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
+        entry.setFiles(Arrays.asList(linkedFile));
+        database.insertEntry(entry);
 
         // write the changed bib entry to the PDF
         XmpUtilWriter.writeXmp(pdfFile.toAbsolutePath().toString(), entry, null, xmpPreferences);
 
+        // export
+        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(bibDatabaseMode, bibEntryTypesManager, fieldWriterPreferences, xmpPreferences);
+        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, pdfFile);
+
         // read entry again
         List<BibEntry> entriesWritten = XmpUtilReader.readXmp(pdfFile.toAbsolutePath().toString(), xmpPreferences);
         BibEntry entryWritten = entriesWritten.get(0);
+
+        System.out.println(entryWritten);
+
         entryWritten.clearField(StandardField.FILE);
 
         // compare the two entries
@@ -134,6 +173,136 @@ class XmpUtilWriterTest {
         assertEquals(3, entryList.size());
     }
 
+    /**
+     * Test for writing XMP metadata to PDF file and export without enclosing braces.
+     */
+    @Test
+    void testWriteAndExportXmpWithoutEnclosingBraces(@TempDir Path tempDir) throws Exception {
+        // turn filter on
+        when(xmpPreferences.shouldEnableEnclosingBracketsFilter()).thenReturn(true);
+        // some initialization
+        BibDatabaseMode bibDatabaseMode = BibDatabaseMode.BIBTEX;
+        BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
+        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+        BibDatabase database = databaseContext.getDatabase();
+
+        FilePreferences filePreferences = mock(FilePreferences.class);
+        when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
+        when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
+
+        Path pdfFile = tempDir.resolve("existing.pdf").toAbsolutePath();
+        // read a bib entry from the tests before
+        BibEntry entry = vapnik2000;
+        // link file to entry
+        LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
+        entry.setFiles(Arrays.asList(linkedFile));
+        // insert entry to database
+        database.insertEntry(entry);
+
+        String expectBibTeX = "@Book{vapnik2000,\n" +
+                "  author    = Vladimir N. Vapnik,\n" +
+                "  publisher = Springer Science + Business Media,\n" +
+                "  title     = The Nature of Statistical Learning Theory,\n" +
+                "  year      = 2000,\n" +
+                "  month     = may,\n" +
+                "  coverage  = coverageField,\n" +
+                "  doi       = 10.1007/978-1-4757-3264-1,\n" +
+                "  language  = English, Japanese,\n" +
+                "  owner     = Ich,\n" +
+                "  rights    = Right To X,\n" +
+                "  source    = JabRef,\n" +
+                "}";
+
+        // write the bib entry to the PDF and export
+        XmpUtilWriter.writeXmp(pdfFile.toAbsolutePath().toString(), entry, null, xmpPreferences);
+        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(bibDatabaseMode, bibEntryTypesManager, fieldWriterPreferences, xmpPreferences);
+        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, pdfFile);
+
+        // extract bibTeX embedded in PDF
+        String bibTeX = extractBibTeX(pdfFile);
+
+        // remove FILE for now due to different separator
+        // not sure why
+        bibTeX = bibTeX.replaceAll("(?m)^  file.*(?:\\r?\\n)?", "").strip().replaceAll("\\r\\n?", "\n");
+
+        assertEquals(expectBibTeX, bibTeX);
+    }
+
+    /**
+     * Test for writing XMP metadata to PDF file and export with enclosing braces.
+     */
+    @Test
+    void testWriteAndExportXmpWithEnclosingBraces(@TempDir Path tempDir) throws Exception {
+        // turn filter on
+        when(xmpPreferences.shouldEnableEnclosingBracketsFilter()).thenReturn(false);
+        // some initialization
+        BibDatabaseMode bibDatabaseMode = BibDatabaseMode.BIBTEX;
+        BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
+        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+        BibDatabase database = databaseContext.getDatabase();
+
+        FilePreferences filePreferences = mock(FilePreferences.class);
+        when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
+        when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
+
+        Path pdfFile = tempDir.resolve("existing.pdf").toAbsolutePath();
+        // read a bib entry from the tests before
+        BibEntry entry = vapnik2000;
+        // link file to entry
+        LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
+        entry.setFiles(Arrays.asList(linkedFile));
+        // insert entry to database
+        database.insertEntry(entry);
+
+        String expectBibTeX = "@Book{vapnik2000,\n" +
+                "  author    = {Vladimir N. Vapnik},\n" +
+                "  publisher = {Springer Science + Business Media},\n" +
+                "  title     = {The Nature of Statistical Learning Theory},\n" +
+                "  year      = {2000},\n" +
+                "  month     = may,\n" +
+                "  coverage  = {coverageField},\n" +
+                "  doi       = {10.1007/978-1-4757-3264-1},\n" +
+                "  language  = {English, Japanese},\n" +
+                "  owner     = {Ich},\n" +
+                "  rights    = {Right To X},\n" +
+                "  source    = {JabRef},\n" +
+                "}";
+
+        // write the bib entry to the PDF and export
+        XmpUtilWriter.writeXmp(pdfFile.toAbsolutePath().toString(), entry, null, xmpPreferences);
+        EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(bibDatabaseMode, bibEntryTypesManager, fieldWriterPreferences, xmpPreferences);
+        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, pdfFile);
+
+        // extract bibTeX embedded in PDF
+        String bibTeX = extractBibTeX(pdfFile);
+
+        // remove FILE for now due to different separator
+        // not sure why
+        bibTeX = bibTeX.replaceAll("(?m)^  file.*(?:\\r?\\n)?", "").strip().replaceAll("\\r\\n?", "\n");
+
+        assertEquals(expectBibTeX, bibTeX);
+    }
+
+    /**
+     * Extract BibTeX that is embedded in the PDF file during export.
+     */
+    private String extractBibTeX(Path path) throws IOException {
+        PDDocument document = Loader.loadPDF(path.toFile());
+        PDDocumentCatalog documentCatalog = document.getDocumentCatalog();
+        PDDocumentNameDictionary nameDictionary = documentCatalog.getNames();
+        PDEmbeddedFilesNameTreeNode efTree = nameDictionary.getEmbeddedFiles();
+        Map<String, PDComplexFileSpecification> names = efTree.getNames();
+        PDComplexFileSpecification fileSpecification = names.get(EMBEDDED_FILE_NAME);
+        PDEmbeddedFile embeddedFile = fileSpecification.getEmbeddedFile();
+        InputStream inputStream = embeddedFile.createInputStream();
+
+        String bibTeX = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+
+        return bibTeX;
+    }
+
     private Path createDefaultFile(String fileName, Path tempDir) throws IOException {
         // create a default PDF
         Path pdfFile = tempDir.resolve(fileName);
@@ -144,5 +313,17 @@ class XmpUtilWriterTest {
         }
 
         return pdfFile;
+    }
+
+    private static LinkedFile createDefaultLinkedFile(String fileName, Path tempDir) throws IOException {
+        Path pdfFile = tempDir.resolve(fileName);
+        try (PDDocument pdf = new PDDocument()) {
+            pdf.addPage(new PDPage());
+            pdf.save(pdfFile.toAbsolutePath().toString());
+        }
+
+        LinkedFile linkedFile = new LinkedFile("A linked pdf", pdfFile, "PDF");
+
+        return linkedFile;
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #8452

UI changes:
- Checkbox to prevent writing enclosing braces to metadata:

  ![image](https://user-images.githubusercontent.com/70904744/165000297-df01c618-07d4-4bb0-ac9d-bd3963074592.png)

Testing:
- Two JUnit tests in which enclosing braces are written and not written to the the metadata respectively.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
