### PR TITLE
Fight EOL issues by pinning LF for *.java and *.properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{fxml,java,properties,sh}]
+end_of_line = lf
+
 [*.md]
 trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,10 @@ gradlew text eol=lf
 # windows line endings at windows files
 *.bat text eol=crlf
 
-# ensure that line endings of *.java, and *.properties are normalized
-*.java text
-*.properties text
+# ensure that line endings of *.fxml, *.java, and *.properties are normalized
+*.fxml text eol=lf
+*.java text eol=lf
+*.properties text eol=lf
 
 # .bib files have to be written using OS specific line endings to enable our tests working
 *.bib text !eol


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
