### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -6,6 +6,9 @@ on:
     - cron: '1 2 1,15 * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Refresh Citation Style Language Files

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
     # Allow to run manually
 
+permissions:
+  contents: read
+
 jobs:
   publish:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Refresh Journal List Files
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -31,6 +31,9 @@ concurrency:
   group: fetcher-tests-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   fetchertests:
     name: Fetcher tests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
