### PR TITLE
Add "Do not ask again" for empty entry confirmation

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTab.fxml
@@ -33,6 +33,7 @@
     <CheckBox fx:id="inspectionWarningDuplicate"
               text="%Warn about unresolved duplicates when closing inspection window"/>
     <CheckBox fx:id="confirmDelete" text="%Show confirmation dialog when deleting entries"/>
+    <CheckBox fx:id="confirmDeleteEmptyEntries" text="%Show confirmation dialog when deleting empty entries"/>
     <CheckBox fx:id="memoryStickMode"
               text="%Load and Save preferences from/to jabref.xml on start-up (memory stick mode)"/>
     <CheckBox fx:id="collectTelemetry" text="%Collect and share telemetry data to help improve JabRef"/>

--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
@@ -29,6 +29,7 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     @FXML private ComboBox<BibDatabaseMode> biblatexMode;
     @FXML private CheckBox inspectionWarningDuplicate;
     @FXML private CheckBox confirmDelete;
+    @FXML private CheckBox confirmDeleteEmptyEntries;
     @FXML private CheckBox memoryStickMode;
     @FXML private CheckBox collectTelemetry;
     @FXML private CheckBox showAdvancedHints;
@@ -67,6 +68,7 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
 
         inspectionWarningDuplicate.selectedProperty().bindBidirectional(viewModel.inspectionWarningDuplicateProperty());
         confirmDelete.selectedProperty().bindBidirectional(viewModel.confirmDeleteProperty());
+        confirmDeleteEmptyEntries.selectedProperty().bindBidirectional(viewModel.confirmDeleteEmptyEntriesProperty());
         memoryStickMode.selectedProperty().bindBidirectional(viewModel.memoryStickModeProperty());
         collectTelemetry.selectedProperty().bindBidirectional(viewModel.collectTelemetryProperty());
         showAdvancedHints.selectedProperty().bindBidirectional(viewModel.showAdvancedHintsProperty());

--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -38,6 +38,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty inspectionWarningDuplicateProperty = new SimpleBooleanProperty();
     private final BooleanProperty confirmDeleteProperty = new SimpleBooleanProperty();
+    private final BooleanProperty confirmDeleteEmptyEntriesProperty = new SimpleBooleanProperty();
     private final BooleanProperty memoryStickModeProperty = new SimpleBooleanProperty();
     private final BooleanProperty collectTelemetryProperty = new SimpleBooleanProperty();
     private final BooleanProperty showAdvancedHintsProperty = new SimpleBooleanProperty();
@@ -77,6 +78,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
         inspectionWarningDuplicateProperty.setValue(generalPreferences.warnAboutDuplicatesInInspection());
         confirmDeleteProperty.setValue(generalPreferences.shouldConfirmDelete());
+        confirmDeleteEmptyEntriesProperty.setValue(generalPreferences.shouldConfirmDeleteEmptyEntries());
         memoryStickModeProperty.setValue(generalPreferences.isMemoryStickMode());
         collectTelemetryProperty.setValue(telemetryPreferences.shouldCollectTelemetry());
         showAdvancedHintsProperty.setValue(generalPreferences.shouldShowAdvancedHints());
@@ -106,6 +108,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
         generalPreferences.setDefaultBibDatabaseMode(selectedBiblatexModeProperty.getValue());
         generalPreferences.setWarnAboutDuplicatesInInspection(inspectionWarningDuplicateProperty.getValue());
         generalPreferences.setConfirmDelete(confirmDeleteProperty.getValue());
+        generalPreferences.setConfirmDeleteEmptyEntries(confirmDeleteEmptyEntriesProperty.getValue());
         generalPreferences.setMemoryStickMode(memoryStickModeProperty.getValue());
         generalPreferences.setShowAdvancedHints(showAdvancedHintsProperty.getValue());
 
@@ -156,6 +159,10 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty confirmDeleteProperty() {
         return this.confirmDeleteProperty;
+    }
+
+    public BooleanProperty confirmDeleteEmptyEntriesProperty() {
+        return this.confirmDeleteEmptyEntriesProperty;
     }
 
     public BooleanProperty memoryStickModeProperty() {

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -41,7 +41,7 @@ import org.jabref.gui.util.BindingsHelper;
 public class TemporalAccessorPicker extends DatePicker {
     private final ObjectProperty<TemporalAccessor> temporalAccessorValue = new SimpleObjectProperty<>(null);
 
-    private final DateTimeFormatter defaultFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private final DateTimeFormatter defaultFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss[xxx][xx][X]");
     private final ObjectProperty<StringConverter<TemporalAccessor>> converter = new SimpleObjectProperty<>(null);
 
     public TemporalAccessorPicker() {
@@ -139,6 +139,7 @@ public class TemporalAccessorPicker extends DatePicker {
 
             TemporalAccessor dateTime = getStringConverter().fromString(value);
             temporalAccessorValue.set(dateTime);
+            System.out.print(temporalAccessorValue);
             return getLocalDate(dateTime);
         }
     }

--- a/src/main/java/org/jabref/preferences/GeneralPreferences.java
+++ b/src/main/java/org/jabref/preferences/GeneralPreferences.java
@@ -11,6 +11,8 @@ public class GeneralPreferences {
     private final ObjectProperty<BibDatabaseMode> defaultBibDatabaseMode;
     private final BooleanProperty warnAboutDuplicatesInInspection;
     private final BooleanProperty confirmDelete;
+    private final BooleanProperty confirmDeleteEmptyEntries;
+    private final BooleanProperty deleteEmptyEntries;
 
     private final BooleanProperty memoryStickMode;
     private final BooleanProperty showAdvancedHints;
@@ -18,12 +20,15 @@ public class GeneralPreferences {
     public GeneralPreferences(BibDatabaseMode defaultBibDatabaseMode,
                               boolean warnAboutDuplicatesInInspection,
                               boolean confirmDelete,
+                              boolean confirmDeleteEmptyEntries,
+                              boolean deleteEmptyEntries,
                               boolean memoryStickMode,
                               boolean showAdvancedHints) {
         this.defaultBibDatabaseMode = new SimpleObjectProperty<>(defaultBibDatabaseMode);
         this.warnAboutDuplicatesInInspection = new SimpleBooleanProperty(warnAboutDuplicatesInInspection);
         this.confirmDelete = new SimpleBooleanProperty(confirmDelete);
-
+        this.confirmDeleteEmptyEntries = new SimpleBooleanProperty(confirmDeleteEmptyEntries);
+        this.deleteEmptyEntries = new SimpleBooleanProperty(deleteEmptyEntries);
         this.memoryStickMode = new SimpleBooleanProperty(memoryStickMode);
         this.showAdvancedHints = new SimpleBooleanProperty(showAdvancedHints);
     }
@@ -62,6 +67,30 @@ public class GeneralPreferences {
 
     public void setConfirmDelete(boolean confirmDelete) {
         this.confirmDelete.set(confirmDelete);
+    }
+
+    public boolean shouldConfirmDeleteEmptyEntries() {
+        return confirmDeleteEmptyEntries.get();
+    }
+
+    public BooleanProperty confirmDeleteEmptyEntriesProperty() {
+        return confirmDeleteEmptyEntries;
+    }
+
+    public void setConfirmDeleteEmptyEntries(boolean confirmDeleteEmptyEntries) {
+        this.confirmDeleteEmptyEntries.set(confirmDeleteEmptyEntries);
+    }
+
+    public boolean shouldDeleteEmptyEntries() {
+        return deleteEmptyEntries.get();
+    }
+
+    public BooleanProperty deleteEmptyEntriesProperty() {
+        return deleteEmptyEntries;
+    }
+
+    public void setDeleteEmptyEntries(boolean deleteEmptyEntries) {
+        this.deleteEmptyEntries.set(deleteEmptyEntries);
     }
 
     public boolean isMemoryStickMode() {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -263,6 +263,8 @@ public class JabRefPreferences implements PreferencesService {
     public static final String DEFAULT_CITATION_KEY_PATTERN = "defaultBibtexKeyPattern";
     public static final String UNWANTED_CITATION_KEY_CHARACTERS = "defaultUnwantedBibtexKeyCharacters";
     public static final String CONFIRM_DELETE = "confirmDelete";
+    public static final String CONFIRM_DELETE_EMPTY_ENTRIES = "confirmDeleteEmptyEntries";
+    public static final String DELETE_EMPTY_ENTRIES = "deleteEmptyEntries";
     public static final String WARN_BEFORE_OVERWRITING_KEY = "warnBeforeOverwritingKey";
     public static final String AVOID_OVERWRITING_KEY = "avoidOverwritingKey";
     public static final String AUTOLINK_EXACT_KEY_ONLY = "autolinkExactKeyOnly";
@@ -638,6 +640,8 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(AVOID_OVERWRITING_KEY, Boolean.FALSE);
         defaults.put(WARN_BEFORE_OVERWRITING_KEY, Boolean.TRUE);
         defaults.put(CONFIRM_DELETE, Boolean.TRUE);
+        defaults.put(CONFIRM_DELETE_EMPTY_ENTRIES, Boolean.TRUE);
+        defaults.put(DELETE_EMPTY_ENTRIES, Boolean.FALSE);
         defaults.put(DEFAULT_CITATION_KEY_PATTERN, "[auth][year]");
         defaults.put(UNWANTED_CITATION_KEY_CHARACTERS, "-`ʹ:!;?^+");
         defaults.put(RESOLVE_STRINGS_FOR_FIELDS, "author;booktitle;editor;editora;editorb;editorc;institution;issuetitle;journal;journalsubtitle;journaltitle;mainsubtitle;month;publisher;shortauthor;shorteditor;subtitle;titleaddon");
@@ -1311,12 +1315,16 @@ public class JabRefPreferences implements PreferencesService {
                 getBoolean(BIBLATEX_DEFAULT_MODE) ? BibDatabaseMode.BIBLATEX : BibDatabaseMode.BIBTEX,
                 getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION),
                 getBoolean(CONFIRM_DELETE),
+                getBoolean(CONFIRM_DELETE_EMPTY_ENTRIES),
+                getBoolean(DELETE_EMPTY_ENTRIES),
                 getBoolean(MEMORY_STICK_MODE),
                 getBoolean(SHOW_ADVANCED_HINTS));
 
         EasyBind.listen(generalPreferences.defaultBibDatabaseModeProperty(), (obs, oldValue, newValue) -> putBoolean(BIBLATEX_DEFAULT_MODE, (newValue == BibDatabaseMode.BIBLATEX)));
         EasyBind.listen(generalPreferences.isWarnAboutDuplicatesInInspectionProperty(), (obs, oldValue, newValue) -> putBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION, newValue));
         EasyBind.listen(generalPreferences.confirmDeleteProperty(), (obs, oldValue, newValue) -> putBoolean(CONFIRM_DELETE, newValue));
+        EasyBind.listen(generalPreferences.confirmDeleteEmptyEntriesProperty(), (obs, oldValue, newValue) -> putBoolean(CONFIRM_DELETE_EMPTY_ENTRIES, newValue));
+        EasyBind.listen(generalPreferences.deleteEmptyEntriesProperty(), (obs, oldValue, newValue) -> putBoolean(DELETE_EMPTY_ENTRIES, newValue));
         EasyBind.listen(generalPreferences.memoryStickModeProperty(), (obs, oldValue, newValue) -> putBoolean(MEMORY_STICK_MODE, newValue));
         EasyBind.listen(generalPreferences.showAdvancedHintsProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_ADVANCED_HINTS, newValue));
 

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -659,6 +659,8 @@ Show\ BibTeX\ source\ by\ default=Vis BibTeX-kode som standard
 
 Show\ confirmation\ dialog\ when\ deleting\ entries=Vis dialog for at bekræfte sletning af poster
 
+Show\ confirmation\ dialog\ when\ deleting\ empty\ entries=Vis dialog
+
 Show\ last\ names\ only=Vis kun efternavn
 
 Show\ names\ unchanged=Vis navn uændret


### PR DESCRIPTION
## Previous discussion about add "Do not ask again" for empty entry confirmation in JabRef #8296
> add checkbox for do not ask for this kind of issue again for empty entry confirmations

## Proposed solution:
* Add a checkbox for `Do not ask again` in dialog box when user closes a tab or quit.
* After the `Do not ask again` checkbox is ticked and:
  * user clicks on "Delete" button, all empty entries will be deleted in future without showing confirmation dialog
  * user clicks on "Cancel" button, all empty entries will retain in future without showing confirmation dialog
* User able to turn on confirmation dialog by ticking `Show confirmation dialog when deleting empty entries` (Options -> Preferences -> General)

![1 1](https://user-images.githubusercontent.com/49628911/167339516-5fab748e-2bd0-4a2b-a68d-06057878c9c4.png)
![1 2](https://user-images.githubusercontent.com/49628911/167340402-3bde988e-d67e-4734-bf8f-3b4992ed219d.png)



<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->
## PR Checklist:
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
