### PR TITLE
Fix notifications that overlap task bar

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -339,6 +339,7 @@ public class JabRefDialogService implements DialogService {
             .text(message)
             .position(Pos.BOTTOM_CENTER)
             .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
+            .threshold(5, Notifications.create().title("Collapsed Notification").text(message))
             .hideCloseButton()
             .show();
         });

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -340,7 +340,7 @@ public class JabRefDialogService implements DialogService {
             .position(Pos.BOTTOM_CENTER)
             .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
             .owner(mainWindow)
-            .threshold(5, Notifications.create().title(Localization.lang("Collapsed Notification")).text(message))
+            .threshold(5, Notifications.create().title(Localization.lang("Collapsed Notification")).text(Localization.lang("See event log for further messages.")))
             .hideCloseButton()
             .show();
         });

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -63,7 +63,6 @@ import org.slf4j.LoggerFactory;
  * advised to rather create a new sub class of {@link FXDialog}.
  */
 public class JabRefDialogService implements DialogService {
-
     // Snackbar dialog maximum size
     public static final int DIALOG_SIZE_LIMIT = 300;
 
@@ -98,7 +97,6 @@ public class JabRefDialogService implements DialogService {
         // Create a new dialog pane that has a checkbox instead of the hide/show details button
         // Use the supplied callback for the action of the checkbox
         alert.setDialogPane(new DialogPane() {
-
             @Override
             protected Node createDetailsButton() {
                 CheckBox optOut = new CheckBox();
@@ -344,8 +342,9 @@ public class JabRefDialogService implements DialogService {
                          .owner(mainWindow)
                          .threshold(5,
                                  Notifications.create()
-                                              .title("Last notification")
-                                              .text( "(" + Localization.lang("Check the event log to see all notifications") + ")"
+                                              .title(Localization.lang("Last notification"))
+                                              .text(
+                                                    "(" + Localization.lang("Check the event log to see all notifications") + ")"
                                                      + "\n\n" + message))
                          .hideCloseButton()
                          .show();

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -339,6 +339,7 @@ public class JabRefDialogService implements DialogService {
             .text(message)
             .position(Pos.BOTTOM_CENTER)
             .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
+            .owner(JabRefGUI.getMainFrame().getScene().getWindow())
             .threshold(5, Notifications.create().title("Collapsed Notification").text(message))
             .hideCloseButton()
             .show();

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -336,13 +336,19 @@ public class JabRefDialogService implements DialogService {
 
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             Notifications.create()
-            .text(message)
-            .position(Pos.BOTTOM_CENTER)
-            .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
-            .owner(mainWindow)
-            .threshold(5, Notifications.create().title(Localization.lang("Collapsed Notification")).text(Localization.lang("See event log for further messages.")))
-            .hideCloseButton()
-            .show();
+                         .text(message)
+                         .position(Pos.BOTTOM_CENTER)
+                         .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
+                         .owner(mainWindow)
+                         .threshold(5,
+                                 Notifications.create()
+                                              .title("Last notification")
+                                              .text(
+                                                      message + "\n\n" +
+                                                              "(" + Localization.lang("See event log for all messages") + ")"
+                                              ))
+                         .hideCloseButton()
+                         .show();
         });
     }
 

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
  * advised to rather create a new sub class of {@link FXDialog}.
  */
 public class JabRefDialogService implements DialogService {
+
     // Snackbar dialog maximum size
     public static final int DIALOG_SIZE_LIMIT = 300;
 
@@ -97,6 +98,7 @@ public class JabRefDialogService implements DialogService {
         // Create a new dialog pane that has a checkbox instead of the hide/show details button
         // Use the supplied callback for the action of the checkbox
         alert.setDialogPane(new DialogPane() {
+
             @Override
             protected Node createDetailsButton() {
                 CheckBox optOut = new CheckBox();
@@ -343,10 +345,8 @@ public class JabRefDialogService implements DialogService {
                          .threshold(5,
                                  Notifications.create()
                                               .title("Last notification")
-                                              .text(
-                                                      message + "\n\n" +
-                                                              "(" + Localization.lang("See event log for all messages") + ")"
-                                              ))
+                                              .text( "(" + Localization.lang("Check the event log to see all notifications") + ")"
+                                                     + "\n\n" + message))
                          .hideCloseButton()
                          .show();
         });

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -339,8 +339,8 @@ public class JabRefDialogService implements DialogService {
             .text(message)
             .position(Pos.BOTTOM_CENTER)
             .hideAfter(TOAST_MESSAGE_DISPLAY_TIME)
-            .owner(JabRefGUI.getMainFrame().getScene().getWindow())
-            .threshold(5, Notifications.create().title("Collapsed Notification").text(message))
+            .owner(mainWindow)
+            .threshold(5, Notifications.create().title(Localization.lang("Collapsed Notification")).text(message))
             .hideCloseButton()
             .show();
         });

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1669,7 +1669,7 @@ Your\ issue\ was\ reported\ in\ your\ browser.=Your issue was reported in your b
 The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=The log and exception information was copied to your clipboard.
 Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Please paste this information (with Ctrl+V) in the issue description.
 Last\ notification=Last notification
-See\ event\ log\ for\ all\ messages=See event log for all messages
+Check\ the\ event\ log\ to\ see\ all\ notifications=Check the event log to see all notifications
 
 Host=Host
 Port=Port

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2485,3 +2485,6 @@ Success\!\ Finished\ writing\ metadata.=Success! Finished writing metadata.
 
 Custom\ API\ key=Custom API key
 Check\ %0\ API\ Key\ Setting=Check %0 API Key Setting
+
+Collapsed\ Notification=Collapsed Notification
+See\ event\ log\ for\ further\ messages.=See event log for further messages.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1668,6 +1668,8 @@ Issue\ report\ successful=Issue report successful
 Your\ issue\ was\ reported\ in\ your\ browser.=Your issue was reported in your browser.
 The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=The log and exception information was copied to your clipboard.
 Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Please paste this information (with Ctrl+V) in the issue description.
+Last\ notification=Last notification
+See\ event\ log\ for\ all\ messages=See event log for all messages
 
 Host=Host
 Port=Port
@@ -2485,6 +2487,3 @@ Success\!\ Finished\ writing\ metadata.=Success! Finished writing metadata.
 
 Custom\ API\ key=Custom API key
 Check\ %0\ API\ Key\ Setting=Check %0 API Key Setting
-
-Collapsed\ Notification=Collapsed Notification
-See\ event\ log\ for\ further\ messages.=See event log for further messages.


### PR DESCRIPTION
## Previous discussion for notification system that overlaps task bar: #8769 
> The new notification system works fine, but I am having the issue that the notifications overlap the task bar on Windows.

## Proposal solution: Set owner of notification to Jabref window instead of whole screen
Fixes: #8769 
```
.owner(JabRefGUI.getMainFrame().getScene().getWindow())
```
![1 1](https://user-images.githubusercontent.com/49628911/167630428-f8172793-d082-45f9-afce-81996f35d591.png)

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

## PR Checklist:

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
