### PR TITLE
Fix for issue 8396: filter out the empty field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Fixed
 
 - We fixed an issue where the notification bar message, icon and actions appeared to be invisible. [#8761](https://github.com/JabRef/jabref/issues/8761)
+- We fixed an issue where deprecated fields tab is shown when the fields don't contain any values. [#8396](https://github.com/JabRef/jabref/issues/8396)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -54,14 +54,7 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
     protected Set<Field> determineFieldsToShow(BibEntry entry) {
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
         if (entryType.isPresent()) {
-            Set<Field> validDeprecatedFields = new HashSet<>();
-            for (Field field : entryType.get().getDeprecatedFields()) {
-                Optional<String> fieldValue = entry.getField(field);
-                if (fieldValue.isPresent()) {
-                    validDeprecatedFields.add(field);
-                }
-            }
-            return validDeprecatedFields;
+        return entryType.get().getDeprecatedFields().stream().filter(field->! entry.getField(field).isEmpty()).collect(Collectors.toSet());
         } else {
             // Entry type unknown -> treat all fields as required
             return Collections.emptySet();

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,7 +54,14 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
     protected Set<Field> determineFieldsToShow(BibEntry entry) {
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
         if (entryType.isPresent()) {
-            return entryType.get().getDeprecatedFields();
+            Set<Field> validDeprecatedFields = new HashSet<>();
+            for (Field field : entryType.get().getDeprecatedFields()) {
+                Optional<String> fieldValue = entry.getField(field);
+                if (fieldValue.isPresent()) {
+                    validDeprecatedFields.add(field);
+                }
+            }
+            return validDeprecatedFields;
         } else {
             // Entry type unknown -> treat all fields as required
             return Collections.emptySet();

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -54,7 +54,7 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
     protected Set<Field> determineFieldsToShow(BibEntry entry) {
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), databaseContext.getMode());
         if (entryType.isPresent()) {
-        return entryType.get().getDeprecatedFields().stream().filter(field->! entry.getField(field).isEmpty()).collect(Collectors.toSet());
+            return entryType.get().getDeprecatedFields().stream().filter(field -> !entry.getField(field).isEmpty()).collect(Collectors.toSet());
         } else {
             // Entry type unknown -> treat all fields as required
             return Collections.emptySet();

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -1,9 +1,9 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
 


### PR DESCRIPTION
<!-- 

Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
# Fixes #8396
>  Only show deprecated fields tab if they contain values

### Descripion
Fixes #8396 by filtering out the empty deprecated fields.
The issue was caused because it always returns a valid deprecated field set but didn't check whether is empty or not.

### JabRef version
5.4 (latest release)

### Operating system
Mac OS

### Details on version and operating system
Monterey 12.2.1

Before
![Screen Shot 2022-05-10 at 1 38 47 PM](https://user-images.githubusercontent.com/33810960/167718473-cd70ddbb-45d8-45fa-9600-b4a3b60b3d42.png)
After
![Screen Shot 2022-05-10 at 1 37 31 PM](https://user-images.githubusercontent.com/33810960/167718518-e7c87112-24a7-49dc-b23f-ab7c6055aae2.png)


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->
### PR Checklist

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
