### PR TITLE
Prevent group expansion arrow from activating group when expanding or collapsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - Writing BibTeX data into a PDF (XMP) does not write the `file` field.
 - Writing BibTeX data into a PDF (XMP) considers the configured keyword separator (and does not use "," as default any more)
 - The Medline/Pubmed search now also supports the [default fields and operators for searching](https://docs.jabref.org/collect/import-using-online-bibliographic-database#search-syntax). [forum#3554](https://discourse.jabref.org/t/native-pubmed-search/3354)
-- We improved group expansion arrow that prevent it from activating group when expanding or collapsing. [#7982](https://github.com/JabRef/jabref/issues/7982)
+- We improved group expansion arrow that prevent it from activating group when expanding or collapsing. [#7982](https://github.com/JabRef/jabref/issues/7982), [#3176](https://github.com/JabRef/jabref/issues/3176)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - Writing BibTeX data into a PDF (XMP) does not write the `file` field.
 - Writing BibTeX data into a PDF (XMP) considers the configured keyword separator (and does not use "," as default any more)
 - The Medline/Pubmed search now also supports the [default fields and operators for searching](https://docs.jabref.org/collect/import-using-online-bibliographic-database#search-syntax). [forum#3554](https://discourse.jabref.org/t/native-pubmed-search/3354)
+- We improved group expansion arrow that prevent it from activating group when expanding or collapsing. [#7982](https://github.com/JabRef/jabref/issues/7982)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -260,7 +260,11 @@ public class GroupTreeView extends BorderPane {
                             .map(this::createContextMenuForGroup)
                             .orElse((ContextMenu) null));
             row.addEventFilter(MouseEvent.MOUSE_PRESSED, event -> {
-                if (event.getButton() == MouseButton.SECONDARY || event.getTarget() instanceof StackPane) {
+                if (event.getTarget() instanceof StackPane) {
+                    if (((StackPane) event.getTarget()).getStyleClass().toString().equals("arrow") || ((StackPane) event.getTarget()).getStyleClass().toString().equals("tree-disclosure-node")) {
+                        event.consume();
+                    }
+                } else if (event.getButton() == MouseButton.SECONDARY) {
                     // Prevent right-click to select group
                     event.consume();
                 }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -269,8 +269,8 @@ public class GroupTreeView extends BorderPane {
                 if (event.getButton() == MouseButton.SECONDARY) {
                     // Prevent right-click to select group
                     event.consume();
-                } else if (event.getTarget() instanceof StackPane) {
-                    if (((StackPane) event.getTarget()).getStyleClass().toString().equals("arrow") || ((StackPane) event.getTarget()).getStyleClass().toString().equals("tree-disclosure-node")) {
+                } else if (event.getTarget() instanceof StackPane pane) {
+                    if (pane.getStyleClass().toString().equals("arrow") || pane.getStyleClass().toString().equals("tree-disclosure-node")) {
                         event.consume();
                     }
                 }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -266,13 +266,13 @@ public class GroupTreeView extends BorderPane {
                             .map(this::createContextMenuForGroup)
                             .orElse((ContextMenu) null));
             row.addEventFilter(MouseEvent.MOUSE_PRESSED, event -> {
-                if (event.getTarget() instanceof StackPane) {
+                if (event.getButton() == MouseButton.SECONDARY) {
+                    // Prevent right-click to select group
+                    event.consume();
+                } else if (event.getTarget() instanceof StackPane) {
                     if (((StackPane) event.getTarget()).getStyleClass().toString().equals("arrow") || ((StackPane) event.getTarget()).getStyleClass().toString().equals("tree-disclosure-node")) {
                         event.consume();
                     }
-                } else if (event.getButton() == MouseButton.SECONDARY) {
-                    // Prevent right-click to select group
-                    event.consume();
                 }
             });
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -260,7 +260,7 @@ public class GroupTreeView extends BorderPane {
                             .map(this::createContextMenuForGroup)
                             .orElse((ContextMenu) null));
             row.addEventFilter(MouseEvent.MOUSE_PRESSED, event -> {
-                if (event.getButton() == MouseButton.SECONDARY) {
+                if (event.getButton() == MouseButton.SECONDARY || event.getTarget() instanceof StackPane) {
                     // Prevent right-click to select group
                     event.consume();
                 }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -270,7 +270,7 @@ public class GroupTreeView extends BorderPane {
                     // Prevent right-click to select group
                     event.consume();
                 } else if (event.getTarget() instanceof StackPane pane) {
-                    if (pane.getStyleClass().toString().equals("arrow") || pane.getStyleClass().toString().equals("tree-disclosure-node")) {
+                    if (pane.getStyleClass().contains("arrow") || pane.getStyleClass().contains("tree-disclosure-node")) {
                         event.consume();
                     }
                 }


### PR DESCRIPTION
## Previous discussion for group activation when expanding or collapsing group #7982 
> When I want to assign an entry to a subgroup, I have to first expand the parent group and then drag-and-drop my entry in the appropriate subgroup. The problem is that when I expand the group, by clicking on the arrow on the right, the group gets activated (the entry table only shows the group entries) and, therefore, I have to go back to "All entries" and locate my entry again. The parent group gets activated when collapsing it as well.

## Proposal solution: Prevent group activation/select when user clicks on group expanding or collapsing arrow
Fixes: #7982 
Fixes #3176 
```
if (event.getButton() == MouseButton.SECONDARY || event.getTarget() instanceof StackPane) {
          // Prevent right-click to select group
          event.consume();
}
```

https://user-images.githubusercontent.com/49628911/167790196-3190698a-dafb-4752-9807-6b790f0f9277.mp4

## Further discussion
It might not be a good idea to only check eventTarget that returns StackPane class, as the group expand arrow is the only column that is using the StackPane class at current JabRef version. Any feedbacks are much appreciated!

## PR Checklist:
<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
