### PR TITLE
Improve XMP handling - latex free field, remove file field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Changed
 
 - We improved the Latex2Unicode conversion [#8639](https://github.com/JabRef/jabref/pull/8639)
+- XMP writing does not write the `file` field.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We improved the Latex2Unicode conversion [#8639](https://github.com/JabRef/jabref/pull/8639)
 - Writing BibTeX data into a PDF (XMP) removes braces. [#8452](https://github.com/JabRef/jabref/issues/8452)
 - Writing BibTeX data into a PDF (XMP) does not write the `file` field.
+- Writing BibTeX data into a PDF (XMP) considers the configured keyboard separator (and does not use "," as default any more)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Changed
 
 - We improved the Latex2Unicode conversion [#8639](https://github.com/JabRef/jabref/pull/8639)
-- XMP writing does not write the `file` field.
+- Writing BibTeX data into a PDF (XMP) removes braces. [#8452](https://github.com/JabRef/jabref/issues/8452)
+- Writing BibTeX data into a PDF (XMP) does not write the `file` field.
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
@@ -192,7 +192,7 @@ public class WriteMetadataToPdfAction extends SimpleCommand {
      * This writes both XMP data and embeds a corresponding .bib file
      */
     synchronized private void writeMetadataToFile(Path file, BibEntry entry, BibDatabaseContext databaseContext, BibDatabase database) throws Exception {
-        XmpUtilWriter.writeXmp(file, entry, database, xmpPreferences);
+        new XmpUtilWriter().writeXmp(file, entry, database, xmpPreferences);
 
         EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), entryTypesManager, fieldWriterPreferences);
         embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, file);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -426,7 +426,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                 synchronized (linkedFile) {
                     try {
                         // Similar code can be found at {@link org.jabref.gui.exporter.WriteMetadataToPdfAction.writeMetadataToFile}
-                        new XmpUtilWriter().writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
+                        new XmpUtilWriter(preferences.getXmpPreferences()).writeXmp(file.get(), entry, databaseContext.getDatabase());
 
                         EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), Globals.entryTypesManager, preferences.getFieldWriterPreferences());
                         embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());
@@ -462,7 +462,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
             BackgroundTask<Path> downloadTask = prepareDownloadTask(targetDirectory.get(), urlDownload);
             downloadTask.onSuccess(destination -> {
-                boolean isDuplicate = false;
+                boolean isDuplicate;
                 try {
                     isDuplicate = FileNameUniqueness.isDuplicatedFile(targetDirectory.get(), destination.getFileName(), dialogService);
                 } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -426,7 +426,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                 synchronized (linkedFile) {
                     try {
                         // Similar code can be found at {@link org.jabref.gui.exporter.WriteMetadataToPdfAction.writeMetadataToFile}
-                        XmpUtilWriter.writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
+                        new XmpUtilWriter().writeXmp(file.get(), entry, databaseContext.getDatabase(), preferences.getXmpPreferences());
 
                         EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), Globals.entryTypesManager, preferences.getFieldWriterPreferences());
                         embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());

--- a/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
@@ -66,7 +66,7 @@ public class EntryComparator implements Comparator<BibEntry> {
             }
         }
 
-        // If the field is author or editor, we rearrange names so they are
+        // If the field is author or editor, we rearrange names to achieve that they are
         // sorted according to last name.
         if (sortField.getProperties().contains(FieldProperty.PERSON_NAMES)) {
             if (f1 != null) {

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -1,8 +1,6 @@
 package org.jabref.logic.exporter;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -57,7 +57,7 @@ public class XmpExporter extends Exporter {
                 if (file.getParent() == null) {
                     entryFile = Path.of(suffix);
                 } else {
-                    entryFile = Path.of(file.getParent().toString() + "/" + suffix);
+                    entryFile = Path.of(file.getParent() + "/" + suffix);
                 }
                 this.writeBibToXmp(entryFile, Collections.singletonList(entry));
             }
@@ -67,7 +67,7 @@ public class XmpExporter extends Exporter {
     }
 
     private void writeBibToXmp(Path file, List<BibEntry> entries) throws IOException {
-        String xmpContent = new XmpUtilWriter().generateXmpStringWithoutXmpDeclaration(entries, this.xmpPreferences);
+        String xmpContent = new XmpUtilWriter(this.xmpPreferences).generateXmpStringWithoutXmpDeclaration(entries);
         try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
             writer.write(xmpContent);
             writer.flush();

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -67,7 +67,7 @@ public class XmpExporter extends Exporter {
     }
 
     private void writeBibToXmp(Path file, List<BibEntry> entries) throws IOException {
-        String xmpContent = XmpUtilWriter.generateXmpStringWithoutXmpDeclaration(entries, this.xmpPreferences);
+        String xmpContent = new XmpUtilWriter().generateXmpStringWithoutXmpDeclaration(entries, this.xmpPreferences);
         try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
             writer.write(xmpContent);
             writer.flush();

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -68,9 +68,6 @@ public class XmpExporter extends Exporter {
 
     private void writeBibToXmp(Path file, List<BibEntry> entries) throws IOException {
         String xmpContent = new XmpUtilWriter(this.xmpPreferences).generateXmpStringWithoutXmpDeclaration(entries);
-        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
-            writer.write(xmpContent);
-            writer.flush();
-        }
+        Files.writeString(file, xmpContent);
     }
 }

--- a/src/main/java/org/jabref/logic/exporter/XmpPdfExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpPdfExporter.java
@@ -27,7 +27,7 @@ public class XmpPdfExporter extends Exporter {
         Objects.requireNonNull(entries);
 
         if (pdfFile.toString().endsWith(".pdf")) {
-            new XmpUtilWriter().writeXmp(pdfFile, entries, databaseContext.getDatabase(), xmpPreferences);
+            new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile, entries, databaseContext.getDatabase());
         }
     }
 }

--- a/src/main/java/org/jabref/logic/exporter/XmpPdfExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpPdfExporter.java
@@ -27,7 +27,7 @@ public class XmpPdfExporter extends Exporter {
         Objects.requireNonNull(entries);
 
         if (pdfFile.toString().endsWith(".pdf")) {
-            XmpUtilWriter.writeXmp(pdfFile, entries, databaseContext.getDatabase(), xmpPreferences);
+            new XmpUtilWriter().writeXmp(pdfFile, entries, databaseContext.getDatabase(), xmpPreferences);
         }
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -200,7 +200,7 @@ public class PdfContentImporter extends Importer {
     @Override
     public ParserResult importDatabase(Path filePath) {
         final ArrayList<BibEntry> result = new ArrayList<>(1);
-        try (PDDocument document = XmpUtilReader.loadWithAutomaticDecryption(filePath)) {
+        try (PDDocument document = new XmpUtilReader().loadWithAutomaticDecryption(filePath)) {
             String firstPageContents = getFirstPageContents(document);
             Optional<BibEntry> entry = getEntryFromPDFContent(firstPageContents, OS.NEWLINE);
             entry.ifPresent(result::add);

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporter.java
@@ -64,7 +64,7 @@ public class PdfEmbeddedBibFileImporter extends Importer {
 
     @Override
     public ParserResult importDatabase(Path filePath) {
-        try (PDDocument document = XmpUtilReader.loadWithAutomaticDecryption(filePath)) {
+        try (PDDocument document = new XmpUtilReader().loadWithAutomaticDecryption(filePath)) {
             return new ParserResult(getEmbeddedBibFileEntries(document));
         } catch (EncryptedPdfsNotSupportedException e) {
             return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."));

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporter.java
@@ -56,7 +56,7 @@ public class PdfVerbatimBibTextImporter extends Importer {
     @Override
     public ParserResult importDatabase(Path filePath) {
         List<BibEntry> result = new ArrayList<>(1);
-        try (PDDocument document = XmpUtilReader.loadWithAutomaticDecryption(filePath)) {
+        try (PDDocument document = new XmpUtilReader().loadWithAutomaticDecryption(filePath)) {
             String firstPageContents = getFirstPageContents(document);
             BibtexParser parser = new BibtexParser(importFormatPreferences, new DummyFileUpdateMonitor());
             result = parser.parseEntries(firstPageContents);

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfXmpImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfXmpImporter.java
@@ -54,7 +54,7 @@ public class PdfXmpImporter extends Importer {
     public ParserResult importDatabase(Path filePath) {
         Objects.requireNonNull(filePath);
         try {
-            return new ParserResult(XmpUtilReader.readXmp(filePath, xmpPreferences));
+            return new ParserResult(new XmpUtilReader().readXmp(filePath, xmpPreferences));
         } catch (IOException exception) {
             return ParserResult.fromError(exception);
         }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -421,14 +421,14 @@ public class DublinCoreExtractor {
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.shouldUseXmpPrivacyFilter();
 
+        dcSchema.setFormat("application/pdf");
+        fillType();
+
         Set<Field> fields = bibEntry.getFields();
         for (Field field : fields) {
             if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {
                 continue;
             }
-
-            dcSchema.setFormat("application/pdf");
-            fillType();
 
             String value = unprotectTermsFormatter.format(bibEntry.getField(field).get());
             if (field instanceof StandardField standardField) {

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -9,6 +9,7 @@ import java.util.function.Predicate;
 
 import org.jabref.logic.TypedBibEntry;
 import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
@@ -22,6 +23,7 @@ import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.EntryTypeFactory;
 import org.jabref.model.strings.StringUtil;
 
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.xmpbox.schema.DublinCoreSchema;
 import org.apache.xmpbox.type.BadFieldValueException;
 import org.slf4j.Logger;
@@ -415,6 +417,9 @@ public class DublinCoreExtractor {
      * Converts the content of the bibEntry to dublin core.
      * <p>
      * The opposite method is {@link DublinCoreExtractor#extractBibtexEntry()}.
+     * <p>
+     *     A similar method for writing the DocumentInformationItem (DII) is {@link XmpUtilWriter#writeDocumentInformation(PDDocument, BibEntry, BibDatabase, XmpPreferences)}
+     * </p>
      */
     public void fillDublinCoreSchema() {
         // Query privacy filter settings

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -1,9 +1,12 @@
 package org.jabref.logic.xmp;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -421,10 +424,8 @@ public class DublinCoreExtractor {
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.shouldUseXmpPrivacyFilter();
 
-        dcSchema.setFormat("application/pdf");
-        fillType();
-
-        Set<Field> fields = bibEntry.getFields();
+        SortedSet<Field> fields = new TreeSet<>(Comparator.comparing(field -> field.getName()));
+        fields.addAll(bibEntry.getFields());
         for (Field field : fields) {
             if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {
                 continue;
@@ -475,5 +476,8 @@ public class DublinCoreExtractor {
                 }
             }
         }
+
+        dcSchema.setFormat("application/pdf");
+        fillType();
     }
 }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -49,7 +49,6 @@ public class DublinCoreExtractor {
     public DublinCoreExtractor(DublinCoreSchema dcSchema, XmpPreferences xmpPreferences, BibEntry resolvedEntry) {
         this.dcSchema = dcSchema;
         this.xmpPreferences = xmpPreferences;
-
         this.bibEntry = resolvedEntry;
     }
 
@@ -447,8 +446,12 @@ public class DublinCoreExtractor {
                     case LANGUAGE:
                         this.fillLanguages(field.getValue());
                         break;
+                    case FILE:
+                        // we do not write the "file" field, because the file is the PDF itself
+                        break;
                     case DAY:
                     case MONTH:
+                        // we do not write day and month separately if dc:year can be used
                         if (hasStandardYearField) {
                             break;
                         }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -290,7 +290,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX-Fields used: editor, Field: 'dc:contributor'
+     * BibTeX: editor; DC: 'dc:contributor'
      *
      * @param authors
      */
@@ -302,7 +302,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX-Fields used: author, Field: 'dc:creator'
+     * BibTeX: author; DC: 'dc:creator'
      *
      * @param creators
      */
@@ -314,7 +314,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX-Fields used: year, month, Field: 'dc:date'
+     * BibTeX: year, month; DC: 'dc:date'
      */
     private void fillDate() {
         bibEntry.getFieldOrAlias(StandardField.DATE)
@@ -322,28 +322,28 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX-Fields used: abstract, Field: 'dc:description'
+     * BibTeX: abstract; DC: 'dc:description'
      */
     private void fillDescription(String description) {
         dcSchema.setDescription(description);
     }
 
     /**
-     * BibTeX-Fields used: doi, Field: 'dc:identifier'
+     * BibTeX:doi; DC: 'dc:identifier'
      */
     private void fillIdentifier(String identifier) {
         dcSchema.setIdentifier(identifier);
     }
 
     /**
-     * BibTeX-Fields used: publisher, Field: dc:publisher
+     * BibTeX: publisher, DC: dc:publisher
      */
     private void fillPublisher(String publisher) {
         dcSchema.addPublisher(publisher);
     }
 
     /**
-     * BibTeX-Fields used: keywords, Field: 'dc:subject'
+     * BibTeX: keywords; DC: 'dc:subject'
      */
     private void fillKeywords(String value) {
         String[] keywords = value.split(xmpPreferences.getKeywordSeparator().toString());
@@ -353,21 +353,21 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX-Fields used: title, Field: 'dc:title'
+     * BibTeX: title; DC: 'dc:title'
      */
     private void fillTitle(String title) {
         dcSchema.setTitle(title);
     }
 
     /**
-     * BibTeX : Coverage (Custom Field); DC Field : Coverage
+     * BibTeX: Coverage (Custom Field); DC Field : Coverage
      */
     private void fillCoverage(String coverage) {
         dcSchema.setCoverage(coverage);
     }
 
     /**
-     * BibTeX Field : language ; DC Field : dc:language
+     * BibTeX: language; DC: dc:language
      */
     private void fillLanguages(String languages) {
         Arrays.stream(languages.split(","))
@@ -375,14 +375,14 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTeX : Rights (Custom Field); DC Field : dc:rights
+     * BibTeX: Rights (Custom Field); DC: dc:rights
      */
     private void fillRights(String rights) {
         dcSchema.addRights(null, rights.split(",")[0]);
     }
 
     /**
-     * BibTeX : Source (Custom Field); DC Field : Source
+     * BibTeX: Source (Custom Field); DC: Source
      */
     private void fillSource(String source) {
         dcSchema.setSource(source);
@@ -402,7 +402,7 @@ public class DublinCoreExtractor {
      * Opposite method: {@link DublinCoreExtractor#extractType()}
      */
     private void fillType() {
-        // Bibtex-Fields used: entrytype, Field: 'dc:type'
+        // BibTeX: entry type; DC: 'dc:type'
         TypedBibEntry typedEntry = new TypedBibEntry(bibEntry, BibDatabaseMode.BIBTEX);
         String o = typedEntry.getTypeForDisplay();
         if (!o.isEmpty()) {

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -346,7 +346,7 @@ public class DublinCoreExtractor {
      * BibTeX-Fields used: keywords, Field: 'dc:subject'
      */
     private void fillKeywords(String value) {
-        String[] keywords = value.split(",");
+        String[] keywords = value.split(xmpPreferences.getKeywordSeparator().toString());
         for (String keyword : keywords) {
             dcSchema.addSubject(keyword.trim());
         }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -260,6 +260,7 @@ public class DublinCoreExtractor {
      * <p>
      * The opposite method is {@link DublinCoreExtractor#fillDublinCoreSchema()}
      * </p>
+     *
      * @return The bibEntry extracted from the document information.
      */
     public Optional<BibEntry> extractBibtexEntry() {
@@ -408,6 +409,7 @@ public class DublinCoreExtractor {
             dcSchema.addType(o);
         }
     }
+
     /**
      * Converts the content of the bibEntry to dublin core.
      * <p>

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -389,12 +389,13 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * All others (+ citation key) get packaged in the relation attribute
-     *
-     * @param field Key of the metadata attribute
-     * @param value Value of the metadata attribute
+     * All others (+ citation key) get packaged in the dc:relation attribute with <code>bibtex/</code> prefix in the content.
+     * The value of the given field is fetched from the class variable {@link DublinCoreExtractor#bibEntry}.
      */
-    private void fillCustomField(Field field, String value) {
+    private void fillCustomField(Field field) {
+        // We write the plain content of the field, because this is a custom DC field content with the semantics that
+        // BibTeX data is stored. Thus, we do not need to get rid of BibTeX, but can keep it.
+        String value = bibEntry.getField(field).get();
         dcSchema.addRelation("bibtex/" + field.getName() + '/' + value);
     }
 
@@ -469,7 +470,7 @@ public class DublinCoreExtractor {
                             break;
                         }
                     default:
-                        this.fillCustomField(field, value);
+                        this.fillCustomField(field);
                 }
             } else {
                 if (DC_COVERAGE.equals(field.getName())) {
@@ -479,7 +480,7 @@ public class DublinCoreExtractor {
                 } else if (DC_SOURCE.equals(field.getName())) {
                     this.fillSource(value);
                 } else {
-                    this.fillCustomField(field, value);
+                    this.fillCustomField(field);
                 }
             }
         }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -419,43 +419,46 @@ public class DublinCoreExtractor {
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.shouldUseXmpPrivacyFilter();
 
-        Set<Entry<Field, String>> fieldValues = new TreeSet<>(Comparator.comparing(fieldStringEntry -> fieldStringEntry.getKey().getName()));
-        fieldValues.addAll(bibEntry.getFieldMap().entrySet());
-        boolean hasStandardYearField = fieldValues.stream().anyMatch(field -> StandardField.YEAR.equals(field.getKey()));
-        for (Entry<Field, String> field : fieldValues) {
-            if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field.getKey())) {
+        Set<Field> fields = bibEntry.getFields();
+        boolean hasStandardYearField = bibEntry.hasField(StandardField.YEAR);
+        for (Field field : fields) {
+            if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {
                 continue;
             }
 
-            Field fieldEntry = field.getKey();
-            if (fieldEntry instanceof StandardField) {
-                switch ((StandardField) fieldEntry) {
+            dcSchema.setFormat("application/pdf");
+            fillType();
+
+            // String value = bibEntry.getLatexFreeField(field).get();
+            String value = bibEntry.getField(field).get();
+            if (field instanceof StandardField) {
+                switch ((StandardField) field) {
                     case EDITOR:
-                        this.fillContributor(field.getValue());
+                        this.fillContributor(value);
                         break;
                     case AUTHOR:
-                        this.fillCreator(field.getValue());
+                        this.fillCreator(value);
                         break;
                     case YEAR:
                         this.fillDate();
                         break;
                     case ABSTRACT:
-                        this.fillDescription(field.getValue());
+                        this.fillDescription(value);
                         break;
                     case DOI:
-                        this.fillIdentifier(field.getValue());
+                        this.fillIdentifier(value);
                         break;
                     case PUBLISHER:
-                        this.fillPublisher(field.getValue());
+                        this.fillPublisher(value);
                         break;
                     case KEYWORDS:
-                        this.fillKeywords(field.getValue());
+                        this.fillKeywords(value);
                         break;
                     case TITLE:
-                        this.fillTitle(field.getValue());
+                        this.fillTitle(value);
                         break;
                     case LANGUAGE:
-                        this.fillLanguages(field.getValue());
+                        this.fillLanguages(value);
                         break;
                     case FILE:
                         // we do not write the "file" field, because the file is the PDF itself
@@ -467,23 +470,19 @@ public class DublinCoreExtractor {
                             break;
                         }
                     default:
-                        this.fillCustomField(field.getKey(), field.getValue());
+                        this.fillCustomField(field, value);
                 }
             } else {
-                if (DC_COVERAGE.equals(fieldEntry.getName())) {
-                    this.fillCoverage(field.getValue());
-                } else if (DC_RIGHTS.equals(fieldEntry.getName())) {
-                    this.fillRights(field.getValue());
-                } else if (DC_SOURCE.equals(fieldEntry.getName())) {
-                    this.fillSource(field.getValue());
+                if (DC_COVERAGE.equals(field.getName())) {
+                    this.fillCoverage(value);
+                } else if (DC_RIGHTS.equals(field.getName())) {
+                    this.fillRights(value);
+                } else if (DC_SOURCE.equals(field.getName())) {
+                    this.fillSource(value);
                 } else {
-                    this.fillCustomField(field.getKey(), field.getValue());
+                    this.fillCustomField(field, value);
                 }
             }
         }
-
-        dcSchema.setFormat("application/pdf");
-
-        fillType();
     }
 }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -1,16 +1,14 @@
 package org.jabref.logic.xmp;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.jabref.logic.TypedBibEntry;
+import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
@@ -44,6 +42,8 @@ public class DublinCoreExtractor {
     private final XmpPreferences xmpPreferences;
 
     private final BibEntry bibEntry;
+
+    private UnprotectTermsFormatter unprotectTermsFormatter = new UnprotectTermsFormatter();
 
     /**
      * @param dcSchema      Metadata in DublinCore format.
@@ -429,8 +429,7 @@ public class DublinCoreExtractor {
             dcSchema.setFormat("application/pdf");
             fillType();
 
-            // String value = bibEntry.getLatexFreeField(field).get();
-            String value = bibEntry.getField(field).get();
+            String value = unprotectTermsFormatter.format(bibEntry.getField(field).get());
             if (field instanceof StandardField) {
                 switch ((StandardField) field) {
                     case EDITOR:

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -56,7 +56,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Editor in BibTex - Contributor in DublinCore
+     * Editor in BibTeX - Contributor in DublinCore
      */
     private void extractEditor() {
         List<String> contributors = dcSchema.getContributors();
@@ -66,7 +66,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Author in BibTex - Creator in DublinCore
+     * Author in BibTeX - Creator in DublinCore
      */
     private void extractAuthor() {
         List<String> creators = dcSchema.getCreators();
@@ -76,7 +76,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields : year, [month], [day] - 'dc:date' in DublinCore
+     * BibTeX-Fields : year, [month], [day] - 'dc:date' in DublinCore
      */
     private void extractDate() {
         List<String> dates = dcSchema.getUnqualifiedSequenceValueList("date");
@@ -92,7 +92,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Abstract in BibTex - Description in DublinCore
+     * Abstract in BibTeX - Description in DublinCore
      */
     private void extractAbstract() {
         String description = null;
@@ -107,7 +107,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * DOI in BibTex - Identifier in DublinCore
+     * DOI in BibTeX - Identifier in DublinCore
      */
     private void extractDOI() {
         String identifier = dcSchema.getIdentifier();
@@ -117,7 +117,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Publisher are equivalent in both formats (BibTex and DublinCore)
+     * Publisher are equivalent in both formats (BibTeX and DublinCore)
      */
     private void extractPublisher() {
         List<String> publishers = dcSchema.getPublishers();
@@ -130,7 +130,7 @@ public class DublinCoreExtractor {
      * This method sets all fields, which are custom in BibTeX and therefore supported by JabRef, but which are not
      * included in the DublinCore format.
      * <p>
-     * The relation attribute of DublinCore is abused to insert these custom fields.
+     * The relation attribute of DublinCore is abused to store these custom fields. The prefix <code>bibtex</code> is used.
      */
     private void extractBibTexFields() {
         Predicate<String> isBibTeXElement = s -> s.startsWith("bibtex/");
@@ -163,7 +163,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Rights are equivalent in both formats (BibTex and DublinCore)
+     * Rights are equivalent in both formats (BibTeX and DublinCore)
      */
     private void extractRights() {
         String rights = null;
@@ -178,7 +178,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Source is equivalent in both formats (BibTex and DublinCore)
+     * Source is equivalent in both formats (BibTeX and DublinCore)
      */
     private void extractSource() {
         String source = dcSchema.getSource();
@@ -188,7 +188,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Keywords in BibTex - Subjects in DublinCore
+     * Keywords in BibTeX - Subjects in DublinCore
      */
     private void extractSubject() {
         List<String> subjects = dcSchema.getSubjects();
@@ -198,7 +198,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Title is equivalent in both formats (BibTex and DublinCore)
+     * Title is equivalent in both formats (BibTeX and DublinCore)
      */
     private void extractTitle() {
         String title = null;
@@ -227,7 +227,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * No Equivalent in BibTex. Will create an Unknown "Coverage" Field
+     * No Equivalent in BibTeX. Will create an Unknown "Coverage" Field
      */
     private void extractCoverage() {
         String coverage = dcSchema.getCoverage();
@@ -290,7 +290,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields used: editor, Field: 'dc:contributor'
+     * BibTeX-Fields used: editor, Field: 'dc:contributor'
      *
      * @param authors
      */
@@ -302,7 +302,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields used: author, Field: 'dc:creator'
+     * BibTeX-Fields used: author, Field: 'dc:creator'
      *
      * @param creators
      */
@@ -314,7 +314,7 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields used: year, month, Field: 'dc:date'
+     * BibTeX-Fields used: year, month, Field: 'dc:date'
      */
     private void fillDate() {
         bibEntry.getFieldOrAlias(StandardField.DATE)
@@ -322,28 +322,28 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields used: abstract, Field: 'dc:description'
+     * BibTeX-Fields used: abstract, Field: 'dc:description'
      */
     private void fillDescription(String description) {
         dcSchema.setDescription(description);
     }
 
     /**
-     * Bibtex-Fields used: doi, Field: 'dc:identifier'
+     * BibTeX-Fields used: doi, Field: 'dc:identifier'
      */
     private void fillIdentifier(String identifier) {
         dcSchema.setIdentifier(identifier);
     }
 
     /**
-     * Bibtex-Fields used: publisher, Field: dc:publisher
+     * BibTeX-Fields used: publisher, Field: dc:publisher
      */
     private void fillPublisher(String publisher) {
         dcSchema.addPublisher(publisher);
     }
 
     /**
-     * Bibtex-Fields used: keywords, Field: 'dc:subject'
+     * BibTeX-Fields used: keywords, Field: 'dc:subject'
      */
     private void fillKeywords(String value) {
         String[] keywords = value.split(",");
@@ -353,21 +353,21 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * Bibtex-Fields used: title, Field: 'dc:title'
+     * BibTeX-Fields used: title, Field: 'dc:title'
      */
     private void fillTitle(String title) {
         dcSchema.setTitle(title);
     }
 
     /**
-     * BibTex : Coverage (Custom Field); DC Field : Coverage
+     * BibTeX : Coverage (Custom Field); DC Field : Coverage
      */
     private void fillCoverage(String coverage) {
         dcSchema.setCoverage(coverage);
     }
 
     /**
-     * BibTex Field : language ; DC Field : dc:language
+     * BibTeX Field : language ; DC Field : dc:language
      */
     private void fillLanguages(String languages) {
         Arrays.stream(languages.split(","))
@@ -375,14 +375,14 @@ public class DublinCoreExtractor {
     }
 
     /**
-     * BibTex : Rights (Custom Field); DC Field : dc:rights
+     * BibTeX : Rights (Custom Field); DC Field : dc:rights
      */
     private void fillRights(String rights) {
         dcSchema.addRights(null, rights.split(",")[0]);
     }
 
     /**
-     * BibTex : Source (Custom Field); DC Field : Source
+     * BibTeX : Source (Custom Field); DC Field : Source
      */
     private void fillSource(String source) {
         dcSchema.setSource(source);

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Consumer;

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
@@ -72,9 +72,7 @@ public class XmpUtilReader {
                     if (dcSchema != null) {
                         DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, new BibEntry());
                         Optional<BibEntry> entry = dcExtractor.extractBibtexEntry();
-                        if (entry.isPresent()) {
-                            result.add(entry.get());
-                        }
+                        entry.ifPresent(result::add);
                     }
                 }
             }
@@ -146,7 +144,6 @@ public class XmpUtilReader {
     public PDDocument loadWithAutomaticDecryption(Path path) throws IOException {
         // try to load the document
         // also uses an empty string as default password
-        PDDocument doc = Loader.loadPDF(path.toFile());
-        return doc;
+        return Loader.loadPDF(path.toFile());
     }
 }

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
@@ -29,7 +29,7 @@ public class XmpUtilReader {
     private static final String START_TAG = "<rdf:Description";
     private static final String END_TAG = "</rdf:Description>";
 
-    private XmpUtilReader() {
+    public XmpUtilReader() {
         // See: https://pdfbox.apache.org/2.0/getting-started.html
         System.setProperty("sun.java2d.cmm", "sun.java2d.cmm.kcms.KcmsServiceProvider"); // To get higher rendering speed on java 8 oder 9 for images
     }
@@ -40,20 +40,10 @@ public class XmpUtilReader {
      * @param path The path to read the XMPMetadata from.
      * @return The XMPMetadata object found in the file
      */
-    public static List<XMPMetadata> readRawXmp(Path path) throws IOException {
-        try (PDDocument document = XmpUtilReader.loadWithAutomaticDecryption(path)) {
-            return XmpUtilReader.getXmpMetadata(document);
+    public List<XMPMetadata> readRawXmp(Path path) throws IOException {
+        try (PDDocument document = loadWithAutomaticDecryption(path)) {
+            return getXmpMetadata(document);
         }
-    }
-
-    /**
-     * Convenience method for readXMP(File).
-     *
-     * @param filename The filename from which to open the file.
-     * @return BibtexEntryies found in the PDF or an empty list
-     */
-    public static List<BibEntry> readXmp(String filename, XmpPreferences xmpPreferences) throws IOException {
-        return XmpUtilReader.readXmp(Path.of(filename), xmpPreferences);
     }
 
     /**
@@ -67,13 +57,13 @@ public class XmpUtilReader {
      * @throws IOException Throws an IOException if the file cannot be read, so the user than remove a lock or cancel
      *                     the operation.
      */
-    public static List<BibEntry> readXmp(Path path, XmpPreferences xmpPreferences)
+    public List<BibEntry> readXmp(Path path, XmpPreferences xmpPreferences)
             throws IOException {
 
         List<BibEntry> result = new LinkedList<>();
 
         try (PDDocument document = loadWithAutomaticDecryption(path)) {
-            List<XMPMetadata> xmpMetaList = XmpUtilReader.getXmpMetadata(document);
+            List<XMPMetadata> xmpMetaList = getXmpMetadata(document);
 
             if (!xmpMetaList.isEmpty()) {
                 // Only support Dublin Core since JabRef 4.2
@@ -82,7 +72,6 @@ public class XmpUtilReader {
                     if (dcSchema != null) {
                         DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, new BibEntry());
                         Optional<BibEntry> entry = dcExtractor.extractBibtexEntry();
-
                         if (entry.isPresent()) {
                             result.add(entry.get());
                         }
@@ -111,7 +100,7 @@ public class XmpUtilReader {
      *
      * @return empty List if no metadata has been found, or cannot properly find start or end tag in metadata
      */
-    private static List<XMPMetadata> getXmpMetadata(PDDocument document) {
+    private List<XMPMetadata> getXmpMetadata(PDDocument document) {
         PDDocumentCatalog catalog = document.getDocumentCatalog();
         PDMetadata metaRaw = catalog.getMetadata();
         List<XMPMetadata> metaList = new ArrayList<>();
@@ -154,7 +143,7 @@ public class XmpUtilReader {
      * @param path The path to load.
      * @throws IOException from the underlying @link PDDocument#load(File)
      */
-    public static PDDocument loadWithAutomaticDecryption(Path path) throws IOException {
+    public PDDocument loadWithAutomaticDecryption(Path path) throws IOException {
         // try to load the document
         // also uses an empty string as default password
         PDDocument doc = Loader.loadPDF(path.toFile());

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
@@ -25,7 +25,7 @@ public class XmpUtilShared {
     }
 
     protected static XMPMetadata parseXmpMetadata(InputStream is) throws IOException {
-        XMPMetadata meta = null;
+        XMPMetadata meta;
         try {
             DomXmpParser parser = new DomXmpParser();
             meta = parser.parse(is);

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilShared.java
@@ -47,13 +47,13 @@ public class XmpUtilShared {
      */
     public static boolean hasMetadata(Path path, XmpPreferences xmpPreferences) {
         try {
-            List<BibEntry> bibEntries = XmpUtilReader.readXmp(path, xmpPreferences);
+            List<BibEntry> bibEntries = new XmpUtilReader().readXmp(path, xmpPreferences);
             return !bibEntries.isEmpty();
         } catch (EncryptedPdfsNotSupportedException ex) {
             LOGGER.info("Encryption not supported by XMPUtil");
             return false;
         } catch (IOException e) {
-            XmpUtilShared.LOGGER.debug("No metadata was found. Path: " + path.toString());
+            XmpUtilShared.LOGGER.debug("No metadata was found. Path: {}", path.toString());
             return false;
         }
     }

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -35,6 +35,12 @@ import org.apache.xmpbox.xml.XmpSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Writes given BibEntries into the XMP part of a PDF file.
+ *
+ * The conversion of a BibEntry to the XMP data (using Dublin Core) is done at
+ * {@link DublinCoreExtractor#fillDublinCoreSchema()}
+ */
 public class XmpUtilWriter {
 
     private static final String XMP_BEGIN_END_TAG = "?xpacket";

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -7,7 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -9,13 +9,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.xml.transform.TransformerException;
 
-import org.jabref.logic.bibtex.FieldContentFormatter;
 import org.jabref.logic.exporter.EmbeddedBibFilePdfExporter;
 import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.logic.util.io.FileUtil;
@@ -48,7 +46,7 @@ public class XmpUtilWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XmpUtilWriter.class);
 
-    private UnprotectTermsFormatter unprotectTermsFormatter = new UnprotectTermsFormatter();
+    private final UnprotectTermsFormatter unprotectTermsFormatter = new UnprotectTermsFormatter();
 
     /**
      * Try to write the given BibTexEntry in the XMP-stream of the given
@@ -69,8 +67,10 @@ public class XmpUtilWriter {
      * @throws TransformerException If the entry was malformed or unsupported.
      * @throws IOException          If the file could not be written to or could not be found.
      */
-    public void writeXmp(Path file, BibEntry entry,
-                                BibDatabase database, XmpPreferences xmpPreferences)
+    public void writeXmp(Path file,
+                         BibEntry entry,
+                         BibDatabase database,
+                         XmpPreferences xmpPreferences)
         throws IOException, TransformerException {
         writeXmp(file, List.of(entry), database, xmpPreferences);
     }
@@ -85,8 +85,10 @@ public class XmpUtilWriter {
      *                  resolve strings. If the database is null the strings will not be resolved.
      * @param xmpPreferences    The user's xmp preferences.
      */
-    private void writeToDCSchema(DublinCoreSchema dcSchema, BibEntry entry, BibDatabase database,
-                                        XmpPreferences xmpPreferences) {
+    private void writeToDCSchema(DublinCoreSchema dcSchema,
+                                 BibEntry entry,
+                                 BibDatabase database,
+                                 XmpPreferences xmpPreferences) {
         BibEntry resolvedEntry = getDefaultOrDatabaseEntry(entry, database);
         writeToDCSchema(dcSchema, resolvedEntry, xmpPreferences);
     }
@@ -99,7 +101,9 @@ public class XmpUtilWriter {
      * @param entry     The entry, which is added to the dublin core metadata.
      * @param xmpPreferences    The user's xmp preferences.
      */
-    private void writeToDCSchema(DublinCoreSchema dcSchema, BibEntry entry, XmpPreferences xmpPreferences) {
+    private void writeToDCSchema(DublinCoreSchema dcSchema,
+                                 BibEntry entry,
+                                 XmpPreferences xmpPreferences) {
         DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, entry);
         dcExtractor.fillDublinCoreSchema();
     }
@@ -115,7 +119,9 @@ public class XmpUtilWriter {
      *                 resolve strings. If the database is null the strings will not be resolved.
      */
     private void writeDublinCore(PDDocument document,
-                                        List<BibEntry> entries, BibDatabase database, XmpPreferences xmpPreferences)
+                                 List<BibEntry> entries,
+                                 BibDatabase database,
+                                 XmpPreferences xmpPreferences)
         throws IOException, TransformerException {
 
         List<BibEntry> resolvedEntries;
@@ -227,7 +233,9 @@ public class XmpUtilWriter {
      *                 resolve strings. If the database is null the strings will not be resolved.
      */
     private void writeDocumentInformation(PDDocument document,
-                                          BibEntry entry, BibDatabase database, XmpPreferences xmpPreferences) {
+                                          BibEntry entry,
+                                          BibDatabase database,
+                                          XmpPreferences xmpPreferences) {
         PDDocumentInformation di = document.getDocumentInformation();
         BibEntry resolvedEntry = getDefaultOrDatabaseEntry(entry, database);
 
@@ -289,8 +297,9 @@ public class XmpUtilWriter {
      * @throws IOException          If the file could not be written to or could not be found.
      */
     public void writeXmp(Path path,
-                                List<BibEntry> bibtexEntries, BibDatabase database,
-                                XmpPreferences xmpPreferences)
+                         List<BibEntry> bibtexEntries,
+                         BibDatabase database,
+                         XmpPreferences xmpPreferences)
         throws IOException, TransformerException {
         List<BibEntry> resolvedEntries;
         if (database == null) {

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -63,9 +63,7 @@ public class XmpUtilWriter {
     public void writeXmp(Path file, BibEntry entry,
                                 BibDatabase database, XmpPreferences xmpPreferences)
         throws IOException, TransformerException {
-        List<BibEntry> bibEntryList = new ArrayList<>();
-        bibEntryList.add(entry);
-        writeXmp(file, bibEntryList, database, xmpPreferences);
+        writeXmp(file, List.of(entry), database, xmpPreferences);
     }
 
     /**
@@ -80,9 +78,7 @@ public class XmpUtilWriter {
      */
     private void writeToDCSchema(DublinCoreSchema dcSchema, BibEntry entry, BibDatabase database,
                                         XmpPreferences xmpPreferences) {
-
         BibEntry resolvedEntry = getDefaultOrDatabaseEntry(entry, database);
-
         writeToDCSchema(dcSchema, resolvedEntry, xmpPreferences);
     }
 

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -847,7 +847,6 @@ public class BibEntry implements Cloneable {
         return this;
     }
 
-
     /*
      * Returns user comments (arbitrary text before the entry), if they exist. If not, returns the empty String
      */

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -835,6 +835,19 @@ public class BibEntry implements Cloneable {
         return this;
     }
 
+    public BibEntry withDate(Date date) {
+        setDate(date);
+        this.setChanged(false);
+        return this;
+    }
+
+    public BibEntry withMonth(Month parsedMonth) {
+        setMonth(parsedMonth);
+        this.setChanged(false);
+        return this;
+    }
+
+
     /*
      * Returns user comments (arbitrary text before the entry), if they exist. If not, returns the empty String
      */

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -597,7 +597,7 @@ public class BibEntry implements Cloneable {
      */
     public Optional<FieldChange> clearField(Field field, EntriesEventSource eventSource) {
         Optional<String> oldValue = getField(field);
-        if (!oldValue.isPresent()) {
+        if (oldValue.isEmpty()) {
             return Optional.empty();
         }
 
@@ -777,7 +777,8 @@ public class BibEntry implements Cloneable {
         return putKeywords(keywordList, keywordDelimiter);
     }
 
-    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Keyword newValue,
+    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace,
+                                                 Keyword newValue,
                                                  Character keywordDelimiter) {
         KeywordList keywordList = getKeywords(keywordDelimiter);
         keywordList.replaceAll(keywordsToReplace, newValue);

--- a/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
@@ -10,15 +10,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EntryComparatorTest {
 
+    @SuppressWarnings("EqualsWithItself")
     @Test
     void recognizeIdenticalObjectsAsEqual() {
-        BibEntry entry1 = new BibEntry();
-        BibEntry entry2 = entry1;
-        assertEquals(0, new EntryComparator(false, false, StandardField.TITLE).compare(entry1, entry2));
+        BibEntry entry = new BibEntry();
+        assertEquals(0, new EntryComparator(false, false, StandardField.TITLE).compare(entry, entry));
     }
 
     @Test
-    void compareAuthorFieldBiggerAscending() throws Exception {
+    void compareAuthorFieldBiggerAscending() {
         BibEntry entry1 = new BibEntry()
                 .withField(StandardField.AUTHOR, "Stephen King");
         BibEntry entry2 = new BibEntry()
@@ -29,7 +29,7 @@ class EntryComparatorTest {
     }
 
     @Test
-    void bothEntriesHaveNotSetTheFieldToCompareAscending() throws Exception {
+    void bothEntriesHaveNotSetTheFieldToCompareAscending() {
         BibEntry entry1 = new BibEntry()
                 .withField(StandardField.BOOKTITLE, "Stark - The Dark Half (1989)");
         BibEntry entry2 = new BibEntry()
@@ -40,7 +40,7 @@ class EntryComparatorTest {
     }
 
     @Test
-    void secondEntryHasNotSetFieldToCompareAscending() throws Exception {
+    void secondEntryHasNotSetFieldToCompareAscending() {
         BibEntry entry1 = new BibEntry()
                 .withField(StandardField.TITLE, "Stark - The Dark Half (1989)");
         BibEntry entry2 = new BibEntry()
@@ -51,7 +51,7 @@ class EntryComparatorTest {
     }
 
     @Test
-    void firstEntryHasNotSetFieldToCompareAscending() throws Exception {
+    void firstEntryHasNotSetFieldToCompareAscending() {
         BibEntry entry1 = new BibEntry()
                 .withField(StandardField.COMMENTATOR, "Some Commentator");
         BibEntry entry2 = new BibEntry()
@@ -63,7 +63,7 @@ class EntryComparatorTest {
     }
 
     @Test
-    void bothEntriesNumericAscending() throws Exception {
+    void bothEntriesNumericAscending() {
         BibEntry entry1 = new BibEntry()
                 .withField(StandardField.EDITION, "1");
         BibEntry entry2 = new BibEntry()

--- a/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
@@ -10,20 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EntryComparatorTest {
 
-    private BibEntry entry1 = new BibEntry();
-    private BibEntry entry2 = new BibEntry();
-
     @Test
     void recognizeIdenticalObjectsAsEqual() {
-        BibEntry e2 = entry1;
-        assertEquals(0, new EntryComparator(false, false, StandardField.TITLE).compare(entry1, e2));
+        BibEntry entry1 = new BibEntry();
+        BibEntry entry2 = entry1;
+        assertEquals(0, new EntryComparator(false, false, StandardField.TITLE).compare(entry1, entry2));
     }
 
     @Test
     void compareAuthorFieldBiggerAscending() throws Exception {
-        entry1.setField(StandardField.AUTHOR, "Stephen King");
-        entry2.setField(StandardField.AUTHOR, "Henning Mankell");
-
+        BibEntry entry1 = new BibEntry()
+                .withField(StandardField.AUTHOR, "Stephen King");
+        BibEntry entry2 = new BibEntry()
+                .withField(StandardField.AUTHOR, "Henning Mankell");
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.AUTHOR);
 
         assertEquals(-2, entryComparator.compare(entry1, entry2));
@@ -31,9 +30,10 @@ class EntryComparatorTest {
 
     @Test
     void bothEntriesHaveNotSetTheFieldToCompareAscending() throws Exception {
-
-        entry1.setField(StandardField.BOOKTITLE, "Stark - The Dark Half (1989)");
-        entry2.setField(StandardField.COMMENTATOR, "Some Commentator");
+        BibEntry entry1 = new BibEntry()
+                .withField(StandardField.BOOKTITLE, "Stark - The Dark Half (1989)");
+        BibEntry entry2 = new BibEntry()
+                .withField(StandardField.COMMENTATOR, "Some Commentator");
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.TITLE);
 
         assertEquals(-1, entryComparator.compare(entry1, entry2));
@@ -41,9 +41,10 @@ class EntryComparatorTest {
 
     @Test
     void secondEntryHasNotSetFieldToCompareAscending() throws Exception {
-
-        entry1.setField(StandardField.TITLE, "Stark - The Dark Half (1989)");
-        entry2.setField(StandardField.COMMENTATOR, "Some Commentator");
+        BibEntry entry1 = new BibEntry()
+                .withField(StandardField.TITLE, "Stark - The Dark Half (1989)");
+        BibEntry entry2 = new BibEntry()
+                .withField(StandardField.COMMENTATOR, "Some Commentator");
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.TITLE);
 
         assertEquals(-1, entryComparator.compare(entry1, entry2));
@@ -51,9 +52,10 @@ class EntryComparatorTest {
 
     @Test
     void firstEntryHasNotSetFieldToCompareAscending() throws Exception {
-
-        entry1.setField(StandardField.COMMENTATOR, "Some Commentator");
-        entry2.setField(StandardField.TITLE, "Stark - The Dark Half (1989)");
+        BibEntry entry1 = new BibEntry()
+                .withField(StandardField.COMMENTATOR, "Some Commentator");
+        BibEntry entry2 = new BibEntry()
+                .withField(StandardField.TITLE, "Stark - The Dark Half (1989)");
 
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.TITLE);
 
@@ -62,9 +64,10 @@ class EntryComparatorTest {
 
     @Test
     void bothEntriesNumericAscending() throws Exception {
-
-        entry1.setField(StandardField.EDITION, "1");
-        entry2.setField(StandardField.EDITION, "3");
+        BibEntry entry1 = new BibEntry()
+                .withField(StandardField.EDITION, "1");
+        BibEntry entry2 = new BibEntry()
+                .withField(StandardField.EDITION, "3");
 
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.EDITION);
 
@@ -73,29 +76,29 @@ class EntryComparatorTest {
 
     @Test
     void compareObjectsByKeyAscending() {
-        BibEntry e1 = new BibEntry();
-        BibEntry e2 = new BibEntry();
-        e1.setCitationKey("Mayer2019b");
-        e2.setCitationKey("Mayer2019a");
+        BibEntry e1 = new BibEntry()
+                .withCitationKey("Mayer2019b");
+        BibEntry e2 = new BibEntry()
+                .withCitationKey("Mayer2019a");
         assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
         assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }
 
     @Test
     void compareObjectsByKeyWithNull() {
-        BibEntry e1 = new BibEntry();
+        BibEntry e1 = new BibEntry()
+                .withCitationKey("Mayer2019b");
         BibEntry e2 = new BibEntry();
-        e1.setCitationKey("Mayer2019b");
         assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
         assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }
 
     @Test
     void compareObjectsByKeyWithBlank() {
-        BibEntry e1 = new BibEntry();
-        BibEntry e2 = new BibEntry();
-        e1.setCitationKey("Mayer2019b");
-        e2.setCitationKey(" ");
+        BibEntry e1 = new BibEntry()
+                .withCitationKey("Mayer2019b");
+        BibEntry e2 = new BibEntry()
+                .withCitationKey(" ");
         assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
         assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }

--- a/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
@@ -14,7 +14,7 @@ class EntryComparatorTest {
     private BibEntry entry2 = new BibEntry();
 
     @Test
-    void recognizeIdenticObjectsAsEqual() {
+    void recognizeIdenticalObjectsAsEqual() {
         BibEntry e2 = entry1;
         assertEquals(0, new EntryComparator(false, false, StandardField.TITLE).compare(entry1, e2));
     }

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -24,14 +24,12 @@ import static org.mockito.Mockito.when;
 public class XmpExporterTest {
 
     private Exporter exporter;
-    private BibDatabaseContext databaseContext;
+    private BibDatabaseContext databaseContext = new BibDatabaseContext();
     private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
 
     @BeforeEach
     public void setUp() {
         exporter = new XmpExporter(xmpPreferences);
-
-        databaseContext = new BibDatabaseContext();
     }
 
     @Test
@@ -188,21 +186,25 @@ public class XmpExporterTest {
         Path file = testFolder.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(file);
 
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AUTHOR, "Alan Turing");
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.AUTHOR, "Alan Turing");
 
         exporter.export(databaseContext, file, Collections.singletonList(entry));
+
         String actual = String.join("\n", Files.readAllLines(file));
-        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "  </rdf:RDF>";
+        String expected = """
+                  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                      <dc:format>application/pdf</dc:format>
+                      <dc:type>
+                        <rdf:Bag>
+                          <rdf:li>Misc</rdf:li>
+                        </rdf:Bag>
+                      </dc:type>
+                    </rdf:Description>
+                  </rdf:RDF>
+                """;
+
         assertEquals(expected, actual);
     }
 }

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -44,21 +44,21 @@ public class XmpExporterTest {
 
         exporter.export(databaseContext, file, Collections.singletonList(entry));
         String actual = String.join("\n", Files.readAllLines(file)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
-        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:creator>\n" +
-                "        <rdf:Seq>\n" +
-                "          <rdf:li>Alan Turing</rdf:li>\n" +
-                "        </rdf:Seq>\n" +
-                "      </dc:creator>\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "  </rdf:RDF>";
+        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n"
+            + "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n"
+            + "      <dc:format>application/pdf</dc:format>\n"
+            + "      <dc:type>\n"
+            + "        <rdf:Bag>\n"
+            + "          <rdf:li>Misc</rdf:li>\n"
+            + "        </rdf:Bag>\n"
+            + "      </dc:type>\n"
+            + "      <dc:creator>\n"
+            + "        <rdf:Seq>\n"
+            + "          <rdf:li>Alan Turing</rdf:li>\n"
+            + "        </rdf:Seq>\n"
+            + "      </dc:creator>\n"
+            + "    </rdf:Description>\n"
+            + "  </rdf:RDF>";
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -124,19 +124,20 @@ public class XmpExporterTest {
 
         BibEntry entryTuring = new BibEntry()
                 .withField(StandardField.AUTHOR, "Alan Turing");
-
         BibEntry entryArmbrust = new BibEntry()
                 .withField(StandardField.AUTHOR, "Michael Armbrust")
                 .withCitationKey("Armbrust2010");
 
         exporter.export(databaseContext, file, List.of(entryTuring, entryArmbrust));
 
+        // Nothing written in given file
         List<String> lines = Files.readAllLines(file);
         assertEquals(Collections.emptyList(), lines);
 
+        // turing contains the turing entry only
         Path fileTuring = Path.of(file.getParent().toString(), entryTuring.getId() + "_null.xmp");
-        String actualTuring = String.join("\n", Files.readAllLines(fileTuring)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
-
+        // we are using \n to join, so we need it in the expected string as well, \r\n would fail
+        String actualTuring = String.join("\n", Files.readAllLines(fileTuring));
         String expectedTuring = """
                 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                   <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
@@ -156,9 +157,10 @@ public class XmpExporterTest {
               """.stripTrailing();
         assertEquals(expectedTuring, actualTuring);
 
+        // armbrust contains the armbrust entry only
         Path fileArmbrust = Path.of(file.getParent().toString(), entryArmbrust.getId() + "_Armbrust2010.xmp");
-        String actualArmbrust = String.join("\n", Files.readAllLines(fileArmbrust)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
-
+        // we are using \n to join, so we need it in the expected string as well, \r\n would fail
+        String actualArmbrust = String.join("\n", Files.readAllLines(fileArmbrust));
         String expectedArmbrust = """
                   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
                     <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 public class XmpExporterTest {
 
     private Exporter exporter;
-    private BibDatabaseContext databaseContext = new BibDatabaseContext();
+    private final BibDatabaseContext databaseContext = new BibDatabaseContext();
     private final XmpPreferences xmpPreferences = mock(XmpPreferences.class);
 
     @BeforeEach
@@ -42,21 +42,23 @@ public class XmpExporterTest {
 
         exporter.export(databaseContext, file, Collections.singletonList(entry));
         String actual = String.join("\n", Files.readAllLines(file)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
-        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n"
-            + "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n"
-            + "      <dc:format>application/pdf</dc:format>\n"
-            + "      <dc:type>\n"
-            + "        <rdf:Bag>\n"
-            + "          <rdf:li>Misc</rdf:li>\n"
-            + "        </rdf:Bag>\n"
-            + "      </dc:type>\n"
-            + "      <dc:creator>\n"
-            + "        <rdf:Seq>\n"
-            + "          <rdf:li>Alan Turing</rdf:li>\n"
-            + "        </rdf:Seq>\n"
-            + "      </dc:creator>\n"
-            + "    </rdf:Description>\n"
-            + "  </rdf:RDF>";
+        String expected = """
+                  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                      <dc:creator>
+                        <rdf:Seq>
+                          <rdf:li>Alan Turing</rdf:li>
+                        </rdf:Seq>
+                      </dc:creator>
+                      <dc:format>application/pdf</dc:format>
+                      <dc:type>
+                        <rdf:Bag>
+                          <rdf:li>Misc</rdf:li>
+                        </rdf:Bag>
+                      </dc:type>
+                    </rdf:Description>
+                  </rdf:RDF>
+                """.stripTrailing();
         assertEquals(expected, actual);
     }
 
@@ -77,40 +79,40 @@ public class XmpExporterTest {
         String actual = String.join("\n", Files.readAllLines(file)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
         String expected = """
-                      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
-                          <dc:format>application/pdf</dc:format>
-                          <dc:type>
-                            <rdf:Bag>
-                              <rdf:li>Misc</rdf:li>
-                            </rdf:Bag>
-                          </dc:type>
-                          <dc:creator>
-                            <rdf:Seq>
-                              <rdf:li>Alan Turing</rdf:li>
-                            </rdf:Seq>
-                          </dc:creator>
-                        </rdf:Description>
-                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
-                          <dc:format>application/pdf</dc:format>
-                          <dc:type>
-                            <rdf:Bag>
-                              <rdf:li>Misc</rdf:li>
-                            </rdf:Bag>
-                          </dc:type>
-                          <dc:creator>
-                            <rdf:Seq>
-                              <rdf:li>Michael Armbrust</rdf:li>
-                            </rdf:Seq>
-                          </dc:creator>
-                          <dc:relation>
-                            <rdf:Bag>
-                              <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>
-                            </rdf:Bag>
-                          </dc:relation>
-                        </rdf:Description>
-                      </rdf:RDF>
-                    """.stripTrailing();
+                    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                        <dc:creator>
+                          <rdf:Seq>
+                            <rdf:li>Alan Turing</rdf:li>
+                          </rdf:Seq>
+                        </dc:creator>
+                        <dc:format>application/pdf</dc:format>
+                        <dc:type>
+                          <rdf:Bag>
+                            <rdf:li>Misc</rdf:li>
+                          </rdf:Bag>
+                        </dc:type>
+                      </rdf:Description>
+                      <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                        <dc:creator>
+                          <rdf:Seq>
+                            <rdf:li>Michael Armbrust</rdf:li>
+                          </rdf:Seq>
+                        </dc:creator>
+                        <dc:relation>
+                          <rdf:Bag>
+                            <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>
+                          </rdf:Bag>
+                        </dc:relation>
+                        <dc:format>application/pdf</dc:format>
+                        <dc:type>
+                          <rdf:Bag>
+                            <rdf:li>Misc</rdf:li>
+                          </rdf:Bag>
+                        </dc:type>
+                      </rdf:Description>
+                    </rdf:RDF>
+                  """.stripTrailing();
         assertEquals(expected, actual);
     }
 
@@ -135,48 +137,50 @@ public class XmpExporterTest {
         Path fileTuring = Path.of(file.getParent().toString(), entryTuring.getId() + "_null.xmp");
         String actualTuring = String.join("\n", Files.readAllLines(fileTuring)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
-        String expectedTuring = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:creator>\n" +
-                "        <rdf:Seq>\n" +
-                "          <rdf:li>Alan Turing</rdf:li>\n" +
-                "        </rdf:Seq>\n" +
-                "      </dc:creator>\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "  </rdf:RDF>";
-
+        String expectedTuring = """
+                <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                  <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                    <dc:creator>
+                      <rdf:Seq>
+                        <rdf:li>Alan Turing</rdf:li>
+                      </rdf:Seq>
+                    </dc:creator>
+                    <dc:format>application/pdf</dc:format>
+                    <dc:type>
+                      <rdf:Bag>
+                        <rdf:li>Misc</rdf:li>
+                      </rdf:Bag>
+                    </dc:type>
+                  </rdf:Description>
+                </rdf:RDF>
+              """.stripTrailing();
         assertEquals(expectedTuring, actualTuring);
 
         Path fileArmbrust = Path.of(file.getParent().toString(), entryArmbrust.getId() + "_Armbrust2010.xmp");
         String actualArmbrust = String.join("\n", Files.readAllLines(fileArmbrust)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
-        String expectedArmbrust = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:creator>\n" +
-                "        <rdf:Seq>\n" +
-                "          <rdf:li>Michael Armbrust</rdf:li>\n" +
-                "        </rdf:Seq>\n" +
-                "      </dc:creator>\n" +
-                "      <dc:relation>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:relation>\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "  </rdf:RDF>";
-
+        String expectedArmbrust = """
+                  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                      <dc:creator>
+                        <rdf:Seq>
+                          <rdf:li>Michael Armbrust</rdf:li>
+                        </rdf:Seq>
+                      </dc:creator>
+                      <dc:relation>
+                        <rdf:Bag>
+                          <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>
+                        </rdf:Bag>
+                      </dc:relation>
+                      <dc:format>application/pdf</dc:format>
+                      <dc:type>
+                        <rdf:Bag>
+                          <rdf:li>Misc</rdf:li>
+                        </rdf:Bag>
+                      </dc:type>
+                    </rdf:Description>
+                  </rdf:RDF>
+                """.stripTrailing();
         assertEquals(expectedArmbrust, actualArmbrust);
     }
 

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -203,7 +203,7 @@ public class XmpExporterTest {
                       </dc:type>
                     </rdf:Description>
                   </rdf:RDF>
-                """;
+                """.stripTrailing();
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -76,39 +76,41 @@ public class XmpExporterTest {
 
         String actual = String.join("\n", Files.readAllLines(file)); // we are using \n to join, so we need it in the expected string as well, \r\n would fail
 
-        String expected = "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:creator>\n" +
-                "        <rdf:Seq>\n" +
-                "          <rdf:li>Alan Turing</rdf:li>\n" +
-                "        </rdf:Seq>\n" +
-                "      </dc:creator>\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "    <rdf:Description xmlns:dc=\"http://purl.org/dc/elements/1.1/\" rdf:about=\"\">\n" +
-                "      <dc:creator>\n" +
-                "        <rdf:Seq>\n" +
-                "          <rdf:li>Michael Armbrust</rdf:li>\n" +
-                "        </rdf:Seq>\n" +
-                "      </dc:creator>\n" +
-                "      <dc:relation>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:relation>\n" +
-                "      <dc:format>application/pdf</dc:format>\n" +
-                "      <dc:type>\n" +
-                "        <rdf:Bag>\n" +
-                "          <rdf:li>Misc</rdf:li>\n" +
-                "        </rdf:Bag>\n" +
-                "      </dc:type>\n" +
-                "    </rdf:Description>\n" +
-                "  </rdf:RDF>";
+        String expected = """
+                      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                          <dc:format>application/pdf</dc:format>
+                          <dc:type>
+                            <rdf:Bag>
+                              <rdf:li>Misc</rdf:li>
+                            </rdf:Bag>
+                          </dc:type>
+                          <dc:creator>
+                            <rdf:Seq>
+                              <rdf:li>Alan Turing</rdf:li>
+                            </rdf:Seq>
+                          </dc:creator>
+                        </rdf:Description>
+                        <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about="">
+                          <dc:format>application/pdf</dc:format>
+                          <dc:type>
+                            <rdf:Bag>
+                              <rdf:li>Misc</rdf:li>
+                            </rdf:Bag>
+                          </dc:type>
+                          <dc:creator>
+                            <rdf:Seq>
+                              <rdf:li>Michael Armbrust</rdf:li>
+                            </rdf:Seq>
+                          </dc:creator>
+                          <dc:relation>
+                            <rdf:Bag>
+                              <rdf:li>bibtex/citationkey/Armbrust2010</rdf:li>
+                            </rdf:Bag>
+                          </dc:relation>
+                        </rdf:Description>
+                      </rdf:RDF>
+                    """.stripTrailing();
         assertEquals(expected, actual);
     }
 

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
@@ -31,6 +31,7 @@ class XmpUtilReaderTest {
     private XmpPreferences xmpPreferences;
     private BibtexParser parser;
     private BibtexImporter testImporter;
+    private XmpUtilReader xmpUtilReader = new XmpUtilReader();
 
     /**
      * Create a temporary PDF-file with a single empty page.
@@ -53,7 +54,7 @@ class XmpUtilReaderTest {
     @Test
     void testReadArticleDublinCoreReadRawXmp() throws IOException, URISyntaxException {
         Path path = Path.of(XmpUtilShared.class.getResource("article_dublinCore_without_day.pdf").toURI());
-        List<XMPMetadata> meta = XmpUtilReader.readRawXmp(path);
+        List<XMPMetadata> meta = xmpUtilReader.readRawXmp(path);
 
         DublinCoreSchema dcSchema = DublinCoreSchemaCustom.copyDublinCoreSchema(meta.get(0).getDublinCoreSchema());
         DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, new BibEntry());
@@ -71,7 +72,7 @@ class XmpUtilReaderTest {
     @Test
     void testReadArticleDublinCoreReadXmp() throws IOException, URISyntaxException {
         Path pathPdf = Path.of(XmpUtilShared.class.getResource("article_dublinCore.pdf").toURI());
-        List<BibEntry> entries = XmpUtilReader.readXmp(pathPdf, xmpPreferences);
+        List<BibEntry> entries = xmpUtilReader.readXmp(pathPdf, xmpPreferences);
         Path bibFile = Path.of(XmpUtilShared.class.getResource("article_dublinCore.bib").toURI());
         List<BibEntry> expected = testImporter.importDatabase(bibFile).getDatabase().getEntries();
 
@@ -86,7 +87,7 @@ class XmpUtilReaderTest {
     @Test
     void testReadArticleDublinCoreReadXmpPartialDate() throws IOException, URISyntaxException {
         Path pathPdf = Path.of(XmpUtilShared.class.getResource("article_dublinCore_partial_date.pdf").toURI());
-        List<BibEntry> entries = XmpUtilReader.readXmp(pathPdf, xmpPreferences);
+        List<BibEntry> entries = xmpUtilReader.readXmp(pathPdf, xmpPreferences);
         Path bibFile = Path.of(XmpUtilShared.class.getResource("article_dublinCore_partial_date.bib").toURI());
         List<BibEntry> expected = testImporter.importDatabase(bibFile).getDatabase().getEntries();
 
@@ -102,7 +103,7 @@ class XmpUtilReaderTest {
      */
     @Test
     void testReadEmtpyMetadata() throws IOException, URISyntaxException {
-        List<BibEntry> entries = XmpUtilReader.readXmp(Path.of(XmpUtilShared.class.getResource("empty_metadata.pdf").toURI()), xmpPreferences);
+        List<BibEntry> entries = xmpUtilReader.readXmp(Path.of(XmpUtilShared.class.getResource("empty_metadata.pdf").toURI()), xmpPreferences);
         assertEquals(Collections.emptyList(), entries);
     }
 
@@ -112,7 +113,7 @@ class XmpUtilReaderTest {
     @Test
     void testReadPDMetadata() throws IOException, URISyntaxException {
         Path pathPdf = Path.of(XmpUtilShared.class.getResource("PD_metadata.pdf").toURI());
-        List<BibEntry> entries = XmpUtilReader.readXmp(pathPdf, xmpPreferences);
+        List<BibEntry> entries = xmpUtilReader.readXmp(pathPdf, xmpPreferences);
 
         Path bibFile = Path.of(XmpUtilShared.class.getResource("PD_metadata.bib").toURI());
         List<BibEntry> expected = testImporter.importDatabase(bibFile).getDatabase().getEntries();
@@ -129,7 +130,7 @@ class XmpUtilReaderTest {
      */
     @Test
     void testReadNoDescriptionMetadata() throws IOException, URISyntaxException {
-        List<BibEntry> entries = XmpUtilReader.readXmp(Path.of(XmpUtilShared.class.getResource("no_description_metadata.pdf").toURI()), xmpPreferences);
+        List<BibEntry> entries = xmpUtilReader.readXmp(Path.of(XmpUtilShared.class.getResource("no_description_metadata.pdf").toURI()), xmpPreferences);
         assertEquals(Collections.emptyList(), entries);
     }
 }

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
-import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.schema.DublinCoreSchemaCustom;
@@ -29,16 +28,14 @@ import static org.mockito.Mockito.when;
 class XmpUtilReaderTest {
 
     private XmpPreferences xmpPreferences;
-    private BibtexParser parser;
     private BibtexImporter testImporter;
-    private XmpUtilReader xmpUtilReader = new XmpUtilReader();
+    private final XmpUtilReader xmpUtilReader = new XmpUtilReader();
 
     /**
      * Create a temporary PDF-file with a single empty page.
      */
     @BeforeEach
     void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         xmpPreferences = mock(XmpPreferences.class);
         // The code assumes privacy filters to be off
         when(xmpPreferences.shouldUseXmpPrivacyFilter()).thenReturn(false);
@@ -91,7 +88,7 @@ class XmpUtilReaderTest {
         Path bibFile = Path.of(XmpUtilShared.class.getResource("article_dublinCore_partial_date.bib").toURI());
         List<BibEntry> expected = testImporter.importDatabase(bibFile).getDatabase().getEntries();
 
-        expected.forEach(bibEntry -> bibEntry.setFiles(Arrays.asList(
+        expected.forEach(bibEntry -> bibEntry.setFiles(List.of(
                 new LinkedFile("", pathPdf.toAbsolutePath(), "PDF"))
         ));
 
@@ -118,7 +115,7 @@ class XmpUtilReaderTest {
         Path bibFile = Path.of(XmpUtilShared.class.getResource("PD_metadata.bib").toURI());
         List<BibEntry> expected = testImporter.importDatabase(bibFile).getDatabase().getEntries();
 
-        expected.forEach(bibEntry -> bibEntry.setFiles(Arrays.asList(
+        expected.forEach(bibEntry -> bibEntry.setFiles(List.of(
                 new LinkedFile("", pathPdf.toAbsolutePath(), "PDF"))
         ));
 

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -86,7 +86,7 @@ class XmpUtilWriterTest {
     void singleEntryWorks(BibEntry entry) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
 
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entry, null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), entry, null);
 
         List<BibEntry> entriesWritten = new XmpUtilReader().readXmp(pdfFile, xmpPreferences);
 
@@ -116,7 +116,7 @@ class XmpUtilWriterTest {
     void testWriteTwoBibEntries(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeTwo.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, toral2006);
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), entries, null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name
@@ -131,7 +131,7 @@ class XmpUtilWriterTest {
     void testWriteThreeBibEntries(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeThree.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, vapnik2000, toral2006);
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), entries, null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name
@@ -147,7 +147,7 @@ class XmpUtilWriterTest {
         Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
         BibEntry original = new BibEntry()
                 .withField(StandardField.TITLE, "Some {P}rotected {T}erm");
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(original), null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), List.of(original), null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         entryList.forEach(entry -> entry.clearField(StandardField.FILE));
@@ -162,7 +162,7 @@ class XmpUtilWriterTest {
         Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
         BibEntry original = new BibEntry()
                 .withField(StandardField.PAGES, "{55}-{99}");
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(original), null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), List.of(original), null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         entryList.forEach(entry -> entry.clearField(StandardField.FILE));
@@ -175,7 +175,7 @@ class XmpUtilWriterTest {
         Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
         BibEntry original = new BibEntry()
                 .withField(StandardField.PAGES, "2--33");
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(original), null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), List.of(original), null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         entryList.forEach(entry -> entry.clearField(StandardField.FILE));
@@ -186,7 +186,7 @@ class XmpUtilWriterTest {
     @Test
     void singleEntry(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef.pdf", tempDir);
-        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(vapnik2000), null, xmpPreferences);
+        new XmpUtilWriter(xmpPreferences).writeXmp(pdfFile.toAbsolutePath(), List.of(vapnik2000), null);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         vapnik2000.clearField(StandardField.FILE);

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -108,7 +108,7 @@ class XmpUtilWriterTest {
         entry.setId("ID4711");
 
         // write the changed bib entry to the PDF
-        XmpUtilWriter.writeXmp(pdfFile.toAbsolutePath().toString(), entry, null, xmpPreferences);
+        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entry, null, xmpPreferences);
 
         // read entry again
         List<BibEntry> entriesWritten = XmpUtilReader.readXmp(pdfFile.toAbsolutePath().toString(), xmpPreferences);

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -86,7 +86,7 @@ class XmpUtilWriterTest {
     /**
      * Test for writing a PDF file with a single DublinCore metadata entry.
      */
-    void singleEntryWorks(BibEntry entry) throws IOException, TransformerException {
+    void singleEntryWorks(BibEntry entry) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeSingle.pdf", tempDir);
 
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entry, null, xmpPreferences);
@@ -116,7 +116,7 @@ class XmpUtilWriterTest {
     }
 
     @Test
-    void testWriteTwoBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
+    void testWriteTwoBibEntries(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeTwo.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, toral2006);
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
@@ -131,7 +131,7 @@ class XmpUtilWriterTest {
     }
 
     @Test
-    void testWriteThreeBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
+    void testWriteThreeBibEntries(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeThree.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, vapnik2000, toral2006);
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
@@ -146,22 +146,35 @@ class XmpUtilWriterTest {
     }
 
     @Test
-    void proctingBracesAreRemoved(@TempDir Path tempDir) throws IOException, TransformerException {
+    void proctingBracesAreRemovedAtTitle(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
         BibEntry original = new BibEntry()
-                .withField(StandardField.NOTE, "Some {P}rotected {T}erm");
+                .withField(StandardField.TITLE, "Some {P}rotected {T}erm");
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(original), null, xmpPreferences);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         entryList.forEach(entry -> entry.clearField(StandardField.FILE));
 
         BibEntry expected = new BibEntry()
-                .withField(StandardField.NOTE, "Some Protected Term");
+                .withField(StandardField.TITLE, "Some Protected Term");
         assertEquals(List.of(expected), entryList);
     }
 
     @Test
-    void doubleDashAtPageNumberIsKept(@TempDir Path tempDir) throws IOException, TransformerException {
+    void proctingBracesAreKeptAtPages(@TempDir Path tempDir) throws Exception {
+        Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
+        BibEntry original = new BibEntry()
+                .withField(StandardField.PAGES, "{55}-{99}");
+        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(original), null, xmpPreferences);
+        List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
+
+        entryList.forEach(entry -> entry.clearField(StandardField.FILE));
+
+        assertEquals(List.of(original), entryList);
+    }
+
+    @Test
+    void doubleDashAtPageNumberIsKept(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef_writeBraces.pdf", tempDir);
         BibEntry original = new BibEntry()
                 .withField(StandardField.PAGES, "2--33");
@@ -174,7 +187,7 @@ class XmpUtilWriterTest {
     }
 
     @Test
-    void singleEntry(@TempDir Path tempDir) throws IOException, TransformerException {
+    void singleEntry(@TempDir Path tempDir) throws Exception {
         Path pdfFile = this.createDefaultFile("JabRef.pdf", tempDir);
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), List.of(vapnik2000), null, xmpPreferences);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
@@ -187,7 +200,7 @@ class XmpUtilWriterTest {
     /**
      * Creates a temporary PDF-file with a single empty page.
      */
-    private Path createDefaultFile(String fileName, Path tempDir) throws IOException {
+    private Path createDefaultFile(String fileName, Path tempDir) throws Exception {
         // create a default PDF
         Path pdfFile = tempDir.resolve(fileName);
         try (PDDocument pdf = new PDDocument()) {

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -3,6 +3,7 @@ package org.jabref.logic.xmp;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.jabref.logic.exporter.XmpExporterTest;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Date;
 import org.jabref.model.entry.Month;
@@ -23,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * This tests the writing to a PDF. If the creation of the RDF content should be checked, please head to {@link XmpExporterTest}
+ */
 class XmpUtilWriterTest {
 
     @TempDir

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -99,7 +99,7 @@ class XmpUtilWriterTest {
         new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entry, null, xmpPreferences);
 
         // read entry again
-        List<BibEntry> entriesWritten = XmpUtilReader.readXmp(pdfFile.toAbsolutePath().toString(), xmpPreferences);
+        List<BibEntry> entriesWritten = new XmpUtilReader().readXmp(pdfFile, xmpPreferences);
         BibEntry entryWritten = entriesWritten.get(0);
         entryWritten.clearField(StandardField.FILE);
 
@@ -111,7 +111,7 @@ class XmpUtilWriterTest {
         Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, toral2006);
         new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
-        List<BibEntry> entryList = XmpUtilReader.readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
+        List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name
         // thus, we do not need to compare
@@ -126,7 +126,7 @@ class XmpUtilWriterTest {
         Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, vapnik2000, toral2006);
         new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
-        List<BibEntry> entryList = XmpUtilReader.readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
+        List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name
         // thus, we do not need to compare

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -1,10 +1,7 @@
 package org.jabref.logic.xmp;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-
-import javax.xml.transform.TransformerException;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Date;

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -2,11 +2,13 @@ package org.jabref.logic.xmp;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import javax.xml.transform.TransformerException;
 
+import org.jabref.logic.bibtex.comparator.IdComparator;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Date;
 import org.jabref.model.entry.Month;
@@ -29,70 +31,56 @@ import static org.mockito.Mockito.when;
 
 class XmpUtilWriterTest {
 
-    private static BibEntry olly2018;
-    private static BibEntry toral2006;
-    private static BibEntry vapnik2000;
+    private final BibEntry olly2018 = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("Olly2018")
+            .withField(StandardField.AUTHOR, "Olly and Johannes")
+            .withField(StandardField.TITLE, "Stefan's palace")
+            .withField(StandardField.JOURNAL, "Test Journal")
+            .withField(StandardField.VOLUME, "1")
+            .withField(StandardField.NUMBER, "1")
+            .withField(StandardField.PAGES, "1-2")
+            .withMonth(Month.MARCH)
+            .withField(StandardField.ISSN, "978-123-123")
+            .withField(StandardField.NOTE, "NOTE")
+            .withField(StandardField.ABSTRACT, "ABSTRACT")
+            .withField(StandardField.COMMENT, "COMMENT")
+            .withField(StandardField.DOI, "10/3212.3123")
+            .withField(StandardField.FILE, ":article_dublinCore.pdf:PDF")
+            .withField(StandardField.GROUPS, "NO")
+            .withField(StandardField.HOWPUBLISHED, "online")
+            .withField(StandardField.KEYWORDS, "k1, k2")
+            .withField(StandardField.OWNER, "me")
+            .withField(StandardField.REVIEW, "review")
+            .withField(StandardField.URL, "https://www.olly2018.edu");
+    ;
+    private final BibEntry toral2006 = new BibEntry(StandardEntryType.InProceedings)
+            .withField(StandardField.AUTHOR, "Antonio Toral and Rafael Munoz")
+            .withField(StandardField.TITLE, "A proposal to automatically build and maintain gazetteers for Named Entity Recognition by using Wikipedia")
+            .withField(StandardField.BOOKTITLE, "Proceedings of EACL")
+            .withField(StandardField.PAGES, "56--61")
+            .withField(StandardField.EPRINTTYPE, "asdf")
+            .withField(StandardField.OWNER, "Ich")
+            .withField(StandardField.URL, "www.url.de");
+    private final BibEntry vapnik2000 = new BibEntry(StandardEntryType.Book)
+            .withCitationKey("vapnik2000")
+            .withField(StandardField.TITLE, "The Nature of Statistical Learning Theory")
+            .withField(StandardField.PUBLISHER, "Springer Science + Business Media")
+            .withField(StandardField.AUTHOR, "Vladimir N. Vapnik")
+            .withField(StandardField.DOI, "10.1007/978-1-4757-3264-1")
+            .withField(StandardField.OWNER, "Ich")
+            .withField(StandardField.LANGUAGE, "English, Japanese")
+            .withDate(new Date(2000, 5))
+            .withField(new UnknownField(DC_COVERAGE), "coverageField")
+            .withField(new UnknownField((DC_SOURCE)), "JabRef")
+            .withField(new UnknownField(DC_RIGHTS), "Right To X");
     private XmpPreferences xmpPreferences;
 
-    private void initBibEntries() {
-        olly2018 = new BibEntry(StandardEntryType.Article);
-        olly2018.setCitationKey("Olly2018");
-        olly2018.setField(StandardField.AUTHOR, "Olly and Johannes");
-        olly2018.setField(StandardField.TITLE, "Stefan's palace");
-        olly2018.setField(StandardField.JOURNAL, "Test Journal");
-        olly2018.setField(StandardField.VOLUME, "1");
-        olly2018.setField(StandardField.NUMBER, "1");
-        olly2018.setField(StandardField.PAGES, "1-2");
-        olly2018.setMonth(Month.MARCH);
-        olly2018.setField(StandardField.ISSN, "978-123-123");
-        olly2018.setField(StandardField.NOTE, "NOTE");
-        olly2018.setField(StandardField.ABSTRACT, "ABSTRACT");
-        olly2018.setField(StandardField.COMMENT, "COMMENT");
-        olly2018.setField(StandardField.DOI, "10/3212.3123");
-        olly2018.setField(StandardField.FILE, ":article_dublinCore.pdf:PDF");
-        olly2018.setField(StandardField.GROUPS, "NO");
-        olly2018.setField(StandardField.HOWPUBLISHED, "online");
-        olly2018.setField(StandardField.KEYWORDS, "k1, k2");
-        olly2018.setField(StandardField.OWNER, "me");
-        olly2018.setField(StandardField.REVIEW, "review");
-        olly2018.setField(StandardField.URL, "https://www.olly2018.edu");
-
-        toral2006 = new BibEntry(StandardEntryType.InProceedings);
-        toral2006.setField(StandardField.AUTHOR, "Toral, Antonio and Munoz, Rafael");
-        toral2006.setField(StandardField.TITLE, "A proposal to automatically build and maintain gazetteers for Named Entity Recognition by using Wikipedia");
-        toral2006.setField(StandardField.BOOKTITLE, "Proceedings of EACL");
-        toral2006.setField(StandardField.PAGES, "56--61");
-        toral2006.setField(StandardField.EPRINTTYPE, "asdf");
-        toral2006.setField(StandardField.OWNER, "Ich");
-        toral2006.setField(StandardField.URL, "www.url.de");
-
-        vapnik2000 = new BibEntry(StandardEntryType.Book);
-        vapnik2000.setCitationKey("vapnik2000");
-        vapnik2000.setField(StandardField.TITLE, "The Nature of Statistical Learning Theory");
-        vapnik2000.setField(StandardField.PUBLISHER, "Springer Science + Business Media");
-        vapnik2000.setField(StandardField.AUTHOR, "Vladimir N. Vapnik");
-        vapnik2000.setField(StandardField.DOI, "10.1007/978-1-4757-3264-1");
-        vapnik2000.setField(StandardField.OWNER, "Ich");
-        vapnik2000.setField(StandardField.LANGUAGE, "English, Japanese");
-        vapnik2000.setDate(new Date(2000, 5));
-
-        vapnik2000.setField(new UnknownField(DC_COVERAGE), "coverageField");
-        vapnik2000.setField(new UnknownField((DC_SOURCE)), "JabRef");
-        vapnik2000.setField(new UnknownField(DC_RIGHTS), "Right To X");
-    }
-
-    /**
-     * Create a temporary PDF-file with a single empty page.
-     */
     @BeforeEach
     void setUp() {
         xmpPreferences = mock(XmpPreferences.class);
+        when(xmpPreferences.getKeywordSeparator()).thenReturn(',');
         // The code assumes privacy filters to be off
         when(xmpPreferences.shouldUseXmpPrivacyFilter()).thenReturn(false);
-
-        when(xmpPreferences.getKeywordSeparator()).thenReturn(',');
-
-        this.initBibEntries();
     }
 
     /**
@@ -115,25 +103,42 @@ class XmpUtilWriterTest {
         BibEntry entryWritten = entriesWritten.get(0);
         entryWritten.clearField(StandardField.FILE);
 
-        // compare the two entries
-        assertEquals(entry, entryWritten);
+        assertEquals(List.of(entry), entriesWritten);
+    }
+
+    @Test
+    void testWriteTwoBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
+        Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
+        List<BibEntry> entries = List.of(olly2018, toral2006);
+        new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
+        List<BibEntry> entryList = XmpUtilReader.readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
+
+        // the file field is not written - and the read file field contains the PDF file name
+        // thus, we do not need to compare
+        entries.forEach(entry -> entry.clearField(StandardField.FILE));
+        entryList.forEach(entry -> entry.clearField(StandardField.FILE));
+
+        assertEquals(entries, entryList);
+    }
+
+    @Test
+    void testWriteThreeBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
+        Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
+        List<BibEntry> entries = List.of(olly2018, vapnik2000, toral2006);
+        new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
+        List<BibEntry> entryList = XmpUtilReader.readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
+
+        // the file field is not written - and the read file field contains the PDF file name
+        // thus, we do not need to compare
+        entries.forEach(entry -> entry.clearField(StandardField.FILE));
+        entryList.forEach(entry -> entry.clearField(StandardField.FILE));
+
+        assertEquals(entries, entryList);
     }
 
     /**
-     * Test, which writes multiple metadata entries to a PDF and reads them again to test the size.
+     * Creates a temporary PDF-file with a single empty page.
      */
-    @Test
-    void testWriteMultipleBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
-        Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
-
-        List<BibEntry> entries = Arrays.asList(olly2018, vapnik2000, toral2006);
-
-        XmpUtilWriter.writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
-
-        List<BibEntry> entryList = XmpUtilReader.readXmp(Path.of(pdfFile.toAbsolutePath().toString()), xmpPreferences);
-        assertEquals(3, entryList.size());
-    }
-
     private Path createDefaultFile(String fileName, Path tempDir) throws IOException {
         // create a default PDF
         Path pdfFile = tempDir.resolve(fileName);
@@ -142,7 +147,6 @@ class XmpUtilWriterTest {
             pdf.addPage(new PDPage());
             pdf.save(pdfFile.toAbsolutePath().toString());
         }
-
         return pdfFile;
     }
 }

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -18,8 +18,6 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.jabref.logic.xmp.DublinCoreExtractor.DC_COVERAGE;
 import static org.jabref.logic.xmp.DublinCoreExtractor.DC_RIGHTS;

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -107,7 +107,7 @@ class XmpUtilWriterTest {
     void testWriteTwoBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
         Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, toral2006);
-        new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
+        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name
@@ -122,7 +122,7 @@ class XmpUtilWriterTest {
     void testWriteThreeBibEntries(@TempDir Path tempDir) throws IOException, TransformerException {
         Path pdfFile = this.createDefaultFile("JabRef_writeMultiple.pdf", tempDir);
         List<BibEntry> entries = List.of(olly2018, vapnik2000, toral2006);
-        new XmpUtilWriter().writeXmp(Path.of(pdfFile.toAbsolutePath().toString()), entries, null, xmpPreferences);
+        new XmpUtilWriter().writeXmp(pdfFile.toAbsolutePath(), entries, null, xmpPreferences);
         List<BibEntry> entryList = new XmpUtilReader().readXmp(pdfFile.toAbsolutePath(), xmpPreferences);
 
         // the file field is not written - and the read file field contains the PDF file name

--- a/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
+++ b/src/test/java/org/jabref/logic/xmp/XmpUtilWriterTest.java
@@ -3,12 +3,9 @@ package org.jabref.logic.xmp;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import javax.xml.transform.TransformerException;
 
-import org.jabref.logic.bibtex.comparator.IdComparator;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Date;
 import org.jabref.model.entry.Month;


### PR DESCRIPTION
Triggered by https://twitter.com/DrHagva/status/1524096667670171650, I went into the XMP code and tried to understand it. Thereby, I refactored the code to be more modern.

- I also made the XMP test to check for **content** instead of just the amount of entries.
- Removed two obsolete methods (filenames as string instead of Path)

This also fixes https://github.com/JabRef/jabref/issues/8452.

Note that I used the `UnprotectTermsFormatter` instead of `getLatexFreeField`, because with the latter, I get `Ungültiges Byte 3 von 3-Byte-UTF-8-Sequenz.`

The test case is org.jabref.logic.xmp.XmpUtilWriterTest#doubleDashAtPageNumberIsKept.

<details>
WARN: Problem parsing XMP schema. Continuing with other schemas.: java.io.IOException: org.apache.xmpbox.xml.XmpParsingException: Failed to parse
	at org.jabref.logic.xmp.XmpUtilShared.parseXmpMetadata(XmpUtilShared.java:34)
	at org.jabref.logic.xmp.XmpUtilReader.getXmpMetadata(XmpUtilReader.java:132)
	at org.jabref.logic.xmp.XmpUtilReader.readXmp(XmpUtilReader.java:66)
	at org.jabref.logic.xmp.XmpUtilWriterTest.doubleDashAtPageNumberIsKept(XmpUtilWriterTest.java:171)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at jdk.proxy2/jdk.proxy2.$Proxy5.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:133)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
Caused by: org.apache.xmpbox.xml.XmpParsingException: Failed to parse
	at org.apache.xmpbox.xml.DomXmpParser.parse(DomXmpParser.java:126)
	at org.jabref.logic.xmp.XmpUtilShared.parseXmpMetadata(XmpUtilShared.java:31)
	... 84 more
Caused by: org.xml.sax.SAXParseException: Ungültiges Byte 3 von 3-Byte-UTF-8-Sequenz.
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:263)
	at java.xml/com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:342)
	at java.xml/javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:122)
	at org.apache.xmpbox.xml.DomXmpParser.parse(DomXmpParser.java:122)
	... 85 more
Caused by: com.sun.org.apache.xerces.internal.impl.io.MalformedByteSequenceException: Ungültiges Byte 3 von 3-Byte-UTF-8-Sequenz.
	at java.xml/com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.invalidByte(UTF8Reader.java:702)
	at java.xml/com.sun.org.apache.xerces.internal.impl.io.UTF8Reader.read(UTF8Reader.java:436)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1699)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.skipChar(XMLEntityScanner.java:1375)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2762)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:112)
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:542)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:889)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:825)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:247)
	... 88 more
</details>



---

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
