### PR TITLE
Workaround for buildSrc:jar issue

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -18,3 +18,10 @@ sourceSets{
         }
     }
 }
+
+/**
+ * This is a workaround for Entry org/jabref/build/JournalAbbreviationConverter$_convert_closure1$_closure2.class is a duplicate but no duplicate handling strategy has been set.
+ *
+ * Source: https://github.com/gradle/gradle/issues/17236#issuecomment-923074298
+ */
+tasks.getByName("jar").setProperty("duplicatesStrategy", DuplicatesStrategy.EXCLUDE);

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace.md
@@ -351,10 +351,11 @@ If that does not help:
 4. Execute `./gradlew run`
 5. Start IntelliJ and try again.
 
-### Issue with org/jabref/build/JournalAbbreviationConverter$\_convert\_closure1$\_closure2.class is a duplicate but no duplicate handling strategy has been set
+### Issue with `_closure2.class is a duplicate but no duplicate handling strategy has been set`
 
 After changing the contents of `build.gradle`, on might get following error:
 
-`Entry org/jabref/build/JournalAbbreviationConverter$_convert_closure1$_closure2.class is a duplicate but no duplicate handling strategy has been set.`
+    Entry org/jabref/build/JournalAbbreviationConverter$_convert_closure1$_closure2.class is a duplicate but no duplicate handling strategy has been set.
 
-Currently, no "real" solution is known. One has to start from scratch (`git clean -xdf`, ...).
+Please update to the latest development code.
+We applied the workaround from <https://github.com/gradle/gradle/issues/17236#issuecomment-923074298>.


### PR DESCRIPTION
At https://github.com/gradle/gradle/issues/17236#issuecomment-923074298 I finally found a workaround for followwing gradle issue:

```
Execution failed for task ':buildSrc:jar'.
> Entry org/jabref/build/JournalAbbreviationConverter$_convert_closure1$_closure2.class is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
