### PR TITLE
Default path for ssl key store is nested inside "JabRef" directory

### DIFF
--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -527,7 +527,10 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(PROXY_PASSWORD, "");
 
         // SSL
-        defaults.put(TRUSTSTORE_PATH, Path.of(AppDirsFactory.getInstance().getUserDataDir("ssl", SearchFieldConstants.VERSION, "org.jabref")).resolveSibling("truststore.jks").toString());
+        defaults.put(TRUSTSTORE_PATH, Path.of(AppDirsFactory.getInstance()
+                                                            .getUserDataDir("JabRef", SearchFieldConstants.VERSION, "org.jabref"))
+                                          .resolve("ssl")
+                                          .resolve("truststore.jks").toString());
 
         defaults.put(POS_X, 0);
         defaults.put(POS_Y, 0);

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -528,8 +528,7 @@ public class JabRefPreferences implements PreferencesService {
 
         // SSL
         defaults.put(TRUSTSTORE_PATH, Path.of(AppDirsFactory.getInstance()
-                                                            .getUserDataDir("JabRef", SearchFieldConstants.VERSION, "org.jabref"))
-                                          .resolve("ssl")
+                                                            .getUserDataDir("JabRef", "ssl", "org.jabref"))
                                           .resolve("truststore.jks").toString());
 
         defaults.put(POS_X, 0);


### PR DESCRIPTION
While discussing https://github.com/JabRef/jabref/pull/8791, it was sawn, that there is a two-level nesting of application data:

Selected examples:

![grafik](https://user-images.githubusercontent.com/1366654/168475281-8406fb3f-dec1-44b2-a202-134ec8f7cf07.png)

![grafik](https://user-images.githubusercontent.com/1366654/168475295-56621525-986f-4163-9bec-56b6899b361b.png)

Full path

    C:\Users\koppor\AppData\Local\Mozilla\Firefox

For JabRef, it currently looks as follows:

![grafik](https://user-images.githubusercontent.com/1366654/168475335-1c97213a-2754-4c69-be8c-b510e09a6791.png)

![grafik](https://user-images.githubusercontent.com/1366654/168475342-b5d97c35-2722-49ae-96d8-f5dc1f9c4f9a.png)

Interpretation: The ssl trust store is stored one level too high. This PR fixes i. This PR is a follow-up to #8583.

Result:

![grafik](https://user-images.githubusercontent.com/1366654/168476366-4350dac4-3d38-4249-8a71-8d55a5ac6cb9.png)

---

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
