### PR TITLE
add: add test cases for FileUtil

### DIFF
--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -383,4 +383,23 @@ class FileUtilTest {
         Path bibFile = Files.createFile(rootDir.resolve("test.pdf"));
         assertFalse(FileUtil.isBibFile(bibFile));
     }
+
+    @Test
+    void testFindinPath() {
+        Optional<Path> resultPath1 = FileUtil.find("existingTestFile.txt", rootDir);
+        assertEquals(resultPath1.get().toString(), existingTestFile.toString());
+        Optional<Path> resultPath2 = FileUtil.find("otherExistingTestFile.txt", rootDir);
+        assertEquals(resultPath2.get().toString(), otherExistingTestFile.toString());
+    }
+
+    @Test
+    void testFindinListofPath() {
+        Path[] pathArr = {existingTestFile, otherExistingTestFile, rootDir};
+        List<Path> paths = Arrays.asList(pathArr);
+        Path[] resultArr = {existingTestFile, existingTestFile};
+        List<Path> resultPaths = Arrays.asList(resultArr);
+        List<Path> result = FileUtil.find("existingTestFile.txt", paths);
+        System.out.println(result.toString());
+        assertEquals(resultPaths, result);
+    }
 }

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -393,11 +393,10 @@ class FileUtilTest {
     @Test
     void testFindinListofPath() {
         Path[] pathArr = {existingTestFile, otherExistingTestFile, rootDir};
-        List<Path> paths = Arrays.asList(pathArr);
+        List<Path> paths = List.of(pathArr);
         Path[] resultArr = {existingTestFile, existingTestFile};
-        List<Path> resultPaths = Arrays.asList(resultArr);
+        List<Path> resultPaths = List.of(resultArr);
         List<Path> result = FileUtil.find("existingTestFile.txt", paths);
-        System.out.println(result.toString());
         assertEquals(resultPaths, result);
     }
 }

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -388,8 +388,6 @@ class FileUtilTest {
     void testFindinPath() {
         Optional<Path> resultPath1 = FileUtil.find("existingTestFile.txt", rootDir);
         assertEquals(resultPath1.get().toString(), existingTestFile.toString());
-        Optional<Path> resultPath2 = FileUtil.find("otherExistingTestFile.txt", rootDir);
-        assertEquals(resultPath2.get().toString(), otherExistingTestFile.toString());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -392,10 +392,8 @@ class FileUtilTest {
 
     @Test
     void testFindinListofPath() {
-        Path[] pathArr = {existingTestFile, otherExistingTestFile, rootDir};
-        List<Path> paths = List.of(pathArr);
-        Path[] resultArr = {existingTestFile, existingTestFile};
-        List<Path> resultPaths = List.of(resultArr);
+        List<Path> paths = List.of(existingTestFile, otherExistingTestFile, rootDir);
+        List<Path> resultPaths = List.of(existingTestFile, existingTestFile);
         List<Path> result = FileUtil.find("existingTestFile.txt", paths);
         assertEquals(resultPaths, result);
     }


### PR DESCRIPTION

After running the coverage test, I find two methods are not tested.
<img width="945" alt="image" src="https://user-images.githubusercontent.com/39109002/168735624-f7749324-c734-4113-beac-227c8edffa69.png">
So I added two test cases for this feature and they all passed.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
