### PR TITLE
Update LinkedIdentifierColumn.java

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/LinkedIdentifierColumn.java
@@ -60,7 +60,7 @@ public class LinkedIdentifierColumn extends MainTableColumn<Map<Field, String>> 
                 .withTooltip(this::createIdentifierTooltip)
                 .withMenu(this::createIdentifierMenu)
                 .withOnMouseClickedEvent((entry, linkedFiles) -> event -> {
-                    if ((event.getButton() == MouseButton.PRIMARY)) {
+                    if ((event.getButton() == MouseButton.SECONDARY)) {
                         new OpenUrlAction(dialogService, stateManager, preferences).execute();
                     }
                 })


### PR DESCRIPTION
<!-- 
"Fixes for issue #8802" --  click and select either doi or url is possible and hyperlinks pops up as well.
Simply changing the Mousebutton.Primary to Mousebutton.Seconday solved the issue
-->
![test](https://user-images.githubusercontent.com/31892050/168788826-b4db8015-002b-4721-9dc8-ffa846a57883.png)


