### PR TITLE
Add Pubmed/Medline Query Transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - Writing BibTeX data into a PDF (XMP) removes braces. [#8452](https://github.com/JabRef/jabref/issues/8452)
 - Writing BibTeX data into a PDF (XMP) does not write the `file` field.
 - Writing BibTeX data into a PDF (XMP) considers the configured keyword separator (and does not use "," as default any more)
+- The Medline/Pubmed search now also supports the [default fields and operators for searching](https://docs.jabref.org/collect/import-using-online-bibliographic-database#search-syntax). [forum#3554](https://discourse.jabref.org/t/native-pubmed-search/3354)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -154,7 +154,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
         uriBuilder.addParameter("db", "pubmed");
         uriBuilder.addParameter("sort", "relevance");
         uriBuilder.addParameter("retmax", String.valueOf(NUMBER_TO_FETCH));
-        uriBuilder.addParameter("term", query); //already lucene query
+        uriBuilder.addParameter("term", query); // already lucene query
         return uriBuilder.build().toURL();
     }
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -28,7 +28,7 @@ import org.jabref.logic.importer.IdBasedParserFetcher;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.SearchBasedFetcher;
-import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
+import org.jabref.logic.importer.fetcher.transformers.MedlineQueryTransformer;
 import org.jabref.logic.importer.fileformat.MedlineImporter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
@@ -53,16 +53,6 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
     private static final String SEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi";
 
     private int numberOfResultsFound;
-
-    /**
-     * Replaces all commas in a given string with " AND "
-     *
-     * @param query input to remove commas
-     * @return input without commas
-     */
-    private static String replaceCommaWithAND(String query) {
-        return query.replaceAll(", ", " AND ").replaceAll(",", " AND ");
-    }
 
     /**
      * When using 'esearch.fcgi?db=&lt;database>&term=&lt;query>' we will get a list of IDs matching the query.
@@ -164,7 +154,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
         uriBuilder.addParameter("db", "pubmed");
         uriBuilder.addParameter("sort", "relevance");
         uriBuilder.addParameter("retmax", String.valueOf(NUMBER_TO_FETCH));
-        uriBuilder.addParameter("term", replaceCommaWithAND(query));
+        uriBuilder.addParameter("term", query); //already lucene query
         return uriBuilder.build().toURL();
     }
 
@@ -200,7 +190,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
     @Override
     public List<BibEntry> performSearch(QueryNode luceneQuery) throws FetcherException {
         List<BibEntry> entryList;
-        DefaultQueryTransformer transformer = new DefaultQueryTransformer();
+        MedlineQueryTransformer transformer = new MedlineQueryTransformer();
         Optional<String> transformedQuery = transformer.transformLuceneQuery(luceneQuery);
 
         if (transformedQuery.isEmpty() || transformedQuery.get().isBlank()) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/transformers/MedlineQueryTransformer.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/transformers/MedlineQueryTransformer.java
@@ -1,0 +1,54 @@
+package org.jabref.logic.importer.fetcher.transformers;
+
+/**
+ *
+ * Medline/Pubmed specific transformer which uses suffixes for searches
+ * see <a href="https://pubmed.ncbi.nlm.nih.gov/help/#search-tags">Pubmed help</a> for details
+ *
+ */
+public class MedlineQueryTransformer extends AbstractQueryTransformer {
+
+    @Override
+    protected String getLogicalAndOperator() {
+        return " AND ";
+    }
+
+    @Override
+    protected String getLogicalOrOperator() {
+        return " OR ";
+    }
+
+    @Override
+    protected String getLogicalNotOperator() {
+        return "NOT ";
+    }
+
+    @Override
+    protected String handleAuthor(String author) {
+        return author + "[au]";
+    }
+
+    @Override
+    protected String handleTitle(String title) {
+        return title + "[ti]";
+    }
+
+    @Override
+    protected String handleJournal(String journalTitle) {
+        return journalTitle + "[ta]";
+    }
+
+    @Override
+    protected String handleYear(String year) {
+        return year + "[dp]";
+    }
+
+    @Override
+    protected String handleYearRange(String yearRange) {
+        parseYearRange(yearRange);
+        if (endYear == Integer.MAX_VALUE) {
+            return yearRange;
+        }
+        return Integer.toString(startYear) + ":" + Integer.toString(endYear) + "[dp]";
+    }
+}

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -173,6 +173,20 @@ public class MedlineFetcherTest {
     }
 
     @Test
+    public void testWithLuceneQueryAuthorDate() throws Exception {
+        List<BibEntry> entryList = fetcher.performSearch("author:vigmond AND year:2021");
+        entryList.forEach(entry -> entry.clearField(StandardField.ABSTRACT)); // Remove abstract due to copyright);
+        assertEquals(18, entryList.size());
+    }
+
+    @Test
+    public void testWithLuceneQueryAuthorDateRange() throws Exception {
+        List<BibEntry> entryList = fetcher.performSearch("author:vigmond AND year-range:2020-2021");
+        entryList.forEach(entry -> entry.clearField(StandardField.ABSTRACT)); // Remove abstract due to copyright);
+        assertEquals(28, entryList.size());
+    }
+
+    @Test
     public void testInvalidSearchTerm() throws Exception {
         assertEquals(Optional.empty(), fetcher.performSearchById("this.is.a.invalid.search.term.for.the.medline.fetcher"));
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/IEEEQueryTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/IEEEQueryTransformerTest.java
@@ -39,7 +39,7 @@ class IEEEQueryTransformerTest extends InfixTransformerTest<IEEEQueryTransformer
     }
 
     @Override
-    public void convertJournalField() throws Exception {
+    public void convertJournalFieldPrefix() throws Exception {
         IEEEQueryTransformer transformer = getTransformer();
 
         String queryString = "journal:Nature";

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/SuffixTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/SuffixTransformerTest.java
@@ -11,63 +11,51 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test Interface for all transformers that use infix notation for their logical binary operators
  */
-public abstract class InfixTransformerTest<T extends AbstractQueryTransformer> {
+public abstract class SuffixTransformerTest<T extends AbstractQueryTransformer> {
 
     protected abstract T getTransformer();
 
-    /* All prefixes have to include the used separator
-     * Example in the case of ':': <code>"author:"</code>
-     */
+    protected abstract String getAuthorSuffix();
 
-    protected String getAuthorPrefix() {
-        return "";
-    }
+    protected abstract String getUnFieldedSuffix();
 
-    protected String getUnFieldedPrefix() {
-        return "";
-    }
+    protected abstract String getJournalSuffix();
 
-    protected String getJournalPrefix() {
-        return "";
-    }
-
-    protected String getTitlePrefix() {
-        return "";
-    }
+    protected abstract String getTitleSuffix();
 
     @Test
-    public void convertAuthorFieldPrefix() throws Exception {
+    public void convertAuthorFieldSuffix() throws Exception {
         String queryString = "author:\"Igor Steinmacher\"";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getAuthorPrefix() + "\"Igor Steinmacher\"");
+        Optional<String> expected = Optional.of("\"Igor Steinmacher\"" + getAuthorSuffix());
         assertEquals(expected, searchQuery);
     }
 
     @Test
-    public void convertUnFieldedTermPrefix() throws Exception {
+    public void convertUnFieldedTermSuffix() throws Exception {
         String queryString = "\"default value\"";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getUnFieldedPrefix() + queryString);
+        Optional<String> expected = Optional.of(queryString + getUnFieldedSuffix());
         assertEquals(expected, searchQuery);
     }
 
     @Test
-    public void convertExplicitUnFieldedTermPrefix() throws Exception {
+    public void convertExplicitUnFieldedTermSuffix() throws Exception {
         String queryString = "default:\"default value\"";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getUnFieldedPrefix() + "\"default value\"");
+        Optional<String> expected = Optional.of("\"default value\"" + getUnFieldedSuffix());
         assertEquals(expected, searchQuery);
     }
 
     @Test
-    public void convertJournalFieldPrefix() throws Exception {
+    public void convertJournalFieldSuffix() throws Exception {
         String queryString = "journal:Nature";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getJournalPrefix() + "Nature");
+        Optional<String> expected = Optional.of("Nature" + getJournalSuffix());
         assertEquals(expected, searchQuery);
     }
 
@@ -78,29 +66,29 @@ public abstract class InfixTransformerTest<T extends AbstractQueryTransformer> {
     public abstract void convertYearRangeField() throws Exception;
 
     @Test
-    public void convertMultipleValuesWithTheSameFieldPrefix() throws Exception {
+    public void convertMultipleValuesWithTheSameSuffix() throws Exception {
         String queryString = "author:\"Igor Steinmacher\" author:\"Christoph Treude\"";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getAuthorPrefix() + "\"Igor Steinmacher\"" + getTransformer().getLogicalAndOperator() + getAuthorPrefix() + "\"Christoph Treude\"");
+        Optional<String> expected = Optional.of("\"Igor Steinmacher\"" + getAuthorSuffix() + getTransformer().getLogicalAndOperator() + "\"Christoph Treude\"" + getAuthorSuffix());
         assertEquals(expected, searchQuery);
     }
 
     @Test
-    public void groupedOperationsPrefix() throws Exception {
+    public void groupedOperationsSuffix() throws Exception {
         String queryString = "(author:\"Igor Steinmacher\" OR author:\"Christoph Treude\" AND author:\"Christoph Freunde\") AND title:test";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of("(" + getAuthorPrefix() + "\"Igor Steinmacher\"" + getTransformer().getLogicalOrOperator() + "(" + getAuthorPrefix() + "\"Christoph Treude\"" + getTransformer().getLogicalAndOperator() + getAuthorPrefix() + "\"Christoph Freunde\"))" + getTransformer().getLogicalAndOperator() + getTitlePrefix() + "test");
+        Optional<String> expected = Optional.of("(" + "\"Igor Steinmacher\"" + getAuthorSuffix() + getTransformer().getLogicalOrOperator() + "(" + "\"Christoph Treude\"" + getAuthorSuffix() + getTransformer().getLogicalAndOperator() + "\"Christoph Freunde\"" + getAuthorSuffix() + "))" + getTransformer().getLogicalAndOperator() + "test" + getTitleSuffix());
         assertEquals(expected, searchQuery);
     }
 
     @Test
-    public void notOperatorPrefix() throws Exception {
+    public void notOperatorSufix() throws Exception {
         String queryString = "!(author:\"Igor Steinmacher\" OR author:\"Christoph Treude\")";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(queryString, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         Optional<String> searchQuery = getTransformer().transformLuceneQuery(luceneQuery);
-        Optional<String> expected = Optional.of(getTransformer().getLogicalNotOperator() + "(" + getAuthorPrefix() + "\"Igor Steinmacher\"" + getTransformer().getLogicalOrOperator() + getAuthorPrefix() + "\"Christoph Treude\")");
+        Optional<String> expected = Optional.of(getTransformer().getLogicalNotOperator() + "(" + "\"Igor Steinmacher\"" + getAuthorSuffix() + getTransformer().getLogicalOrOperator() + "\"Christoph Treude\")" + getAuthorSuffix());
         assertEquals(expected, searchQuery);
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/transformers/SuffixTransformerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/transformers/SuffixTransformerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Test Interface for all transformers that use infix notation for their logical binary operators
+ * Test Interface for all transformers that use suffix notation for their logical binary operators
  */
 public abstract class SuffixTransformerTest<T extends AbstractQueryTransformer> {
 


### PR DESCRIPTION
Supports the default search fields and boolean operators

The MedlineQueryTransformer is a SuffixTransformer; therefore, I added a new test class. However, I then noticed that the default test cases only over quoted strings whereas Medline uses unquoted strings, so I did not add a test case.
Test class is still useful for future suffix transformers

Fixes https://discourse.jabref.org/t/native-pubmed-search/3354

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
