### PR TITLE
add: add test cases for Date formats

### DIFF
--- a/src/test/java/org/jabref/model/entry/DateTest.java
+++ b/src/test/java/org/jabref/model/entry/DateTest.java
@@ -23,6 +23,18 @@ class DateTest {
     }
 
     @Test
+    void parseCorrectlyDayMonthYearPeriodSeparatorDate() throws Exception {
+        Date expected = new Date(LocalDate.of(2015, 1, 15));
+        assertEquals(Optional.of(expected), Date.parse("15.1.2015"));
+    }
+
+    @Test
+    void parseCorrectlyMonthWordDayYearDate() throws Exception {
+        Date expected = new Date(LocalDate.of(2015, 9, 1));
+        assertEquals(Optional.of(expected), Date.parse("September 1, 2015"));
+    }
+
+    @Test
     void parseCorrectlyDayMonthYearDate() throws Exception {
         Date expected = new Date(LocalDate.of(2014, 6, 19));
         assertEquals(Optional.of(expected), Date.parse("19-06-2014"));
@@ -32,6 +44,18 @@ class DateTest {
     void parseCorrectlyMonthYearDate() throws Exception {
         Date expected = new Date(YearMonth.of(2014, 6));
         assertEquals(Optional.of(expected), Date.parse("06-2014"));
+    }
+
+    @Test
+    void parseCorrectlyYearMonthDayDate() throws Exception{
+        Date expected = new Date(LocalDate.of(2014, 6, 7));
+        assertEquals(Optional.of(expected), Date.parse("2014-6-7"));
+    }
+
+    @Test
+    void parseCorrectlyMonthWordYearDate() throws Exception {
+        Date expected = new Date(YearMonth.of(2020, 6));
+        assertEquals(Optional.of(expected), Date.parse("Jun, 2020"));
     }
 
     @Test

--- a/src/test/java/org/jabref/model/entry/DateTest.java
+++ b/src/test/java/org/jabref/model/entry/DateTest.java
@@ -47,7 +47,7 @@ class DateTest {
     }
 
     @Test
-    void parseCorrectlyYearMonthDayDate() throws Exception{
+    void parseCorrectlyYearMonthDayDate() throws Exception {
         Date expected = new Date(LocalDate.of(2014, 6, 7));
         assertEquals(Optional.of(expected), Date.parse("2014-6-7"));
     }


### PR DESCRIPTION
Added test cases for the below date formats in the Date class to make sure different date formats get parsed properly:
 - uuuu.M.d
 - MMMM d, uuuu
 - uuuu-M-d
 - MMM, uuuu

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
