### PR TITLE
Fix right clicking a group and choosing "remove selected entries from this group" leads to error when Bibtex source tab is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where deprecated fields tab is shown when the fields don't contain any values. [#8396](https://github.com/JabRef/jabref/issues/8396)
 - We fixed an issue which allow us to select and open identifiers from a popup list in the maintable [#8758](https://github.com/JabRef/jabref/issues/8758), [8802](https://github.com/JabRef/jabref/issues/8802)
 - We fixed an issue where the escape button had no functionality within the "Filter groups" textfield. [koppor#562](https://github.com/koppor/jabref/issues/562)
+- We fixed an issue where right clicking a group and choose "remove selected entries from this group" leads to error when Bibtex source tab is selected. [#8012](https://github.com/JabRef/jabref/issues/8012)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -306,7 +306,9 @@ public class SourceTab extends EntryEditorTab {
                     new FieldWriter(fieldWriterPreferences).write(fieldName, newValue);
 
                     compound.addEdit(new UndoableFieldChange(outOfFocusEntry, fieldName, oldValue, newValue));
-                    outOfFocusEntry.setField(fieldName, newValue);
+                    if (outOfFocusEntry.getField(fieldName).isPresent()) {
+                        outOfFocusEntry.setField(fieldName, newValue);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Previous discussion about right clicking a group and choosing "remove selected entries from this group" leads to error when Bibtex source tab is selected #8012
Big thank you to @ThiloteE and @Siedlerchr for all the provided information in #8012 that help me to find the root of this issue.

## Root of issue #8012
1. We have a entry with only `author` and `groups` as fields.
![111](https://user-images.githubusercontent.com/49628911/168956444-1c3097c1-0edd-49db-9e20-a003241ab219.png)
2. When we right click on group `111` and click on "Remove selected entries from this group", this entry will be deleted and still stay in `previousEntry` and `outOfFocusBound` variables.
3. However, `previousEntry` or `outOfFocusBound` only have `author` as field after "Remove selected entries from this group".
![111](https://user-images.githubusercontent.com/49628911/168956728-cfb198d2-90f5-4255-a622-6535aa12f3a0.png)
4. In the image below, we are iterating through all fields in `newEntry` which has keys `author` and `groups`.
![222](https://user-images.githubusercontent.com/49628911/168957351-55eb1c8d-f4d4-4331-84a1-cd3e40e5e94f.png)
6. Since `outOfFocusBound` does not have `groups` field, assigning value to a null result in error.
![222](https://user-images.githubusercontent.com/49628911/168957457-4b1c0c91-d634-4ba0-98c6-12e927779d56.png)

## Proposed solution
Fixes #8012
Add a validation before setting value to a field.
```
if (outOfFocusEntry.getField(fieldName).isPresent()) {
            outOfFocusEntry.setField(fieldName, newValue);
}
```

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
