### PR TITLE
Add: Add test cases for non-default styles in CitationStyleTest

### DIFF
--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -22,6 +22,40 @@ class CitationStyleGeneratorTest {
     private final BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
 
     @Test
+    void testACMCitation() {
+        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
+        context.setMode(BibDatabaseMode.BIBLATEX);
+        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
+        CitationStyle style = styleList.stream().filter(e -> "ACM SIGGRAPH".equals(e.getTitle())).findAny().orElse(null);
+        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
+
+        // if the acm-siggraph.csl citation style changes this has to be modified
+        String expected = "  <div class=\"csl-entry\">"
+                + "<span style=\"font-variant: small-caps\">Smith, B., Jones, B., and Williams, J.</span> 2016-07. Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span> <span style=\"font-style: italic\">34</span>, 7, 45&ndash;67."
+                + "</div>\n"
+                + "";
+
+        assertEquals(expected, citation);
+    }
+
+    @Test
+    void testAPACitation() {
+        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
+        context.setMode(BibDatabaseMode.BIBLATEX);
+        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
+        CitationStyle style = styleList.stream().filter(e -> "American Psychological Association 6th edition".equals(e.getTitle())).findAny().orElse(null);
+        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
+
+        // if the apa-6th-citation.csl citation style changes this has to be modified
+        String expected = "  <div class=\"csl-entry\">"
+                + "Smith, B., Jones, B., &amp; Williams, J. (2016-07). Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span>, <span style=\"font-style: italic\">34</span>(7), 45&ndash;67. https://doi.org/10.1001/bla.blubb"
+                + "</div>\n"
+                + "";
+
+        assertEquals(expected, citation);
+    }
+
+    @Test
     void testIgnoreNewLine() {
         BibEntry entry = new BibEntry();
         entry.setField(StandardField.AUTHOR, "Last, First and\nDoe, Jane");

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
@@ -36,7 +36,7 @@ class CitationStyleTest {
     }
 
     @Test
-    void testDiscoverCitationStylesNotNull() {
+    void testDiscoverCitationStylesNotNull() throws Exception {
         List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
         assertNotNull(styleList);
     }
@@ -74,5 +74,4 @@ class CitationStyleTest {
 
         assertEquals(expected, citation);
     }
-
 }

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
@@ -40,38 +40,4 @@ class CitationStyleTest {
         List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
         assertNotNull(styleList);
     }
-
-    @Test
-    void testACMCitation() {
-        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
-        context.setMode(BibDatabaseMode.BIBLATEX);
-        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
-        CitationStyle style = styleList.stream().filter(e -> "ACM SIGGRAPH".equals(e.getTitle())).findAny().orElse(null);
-        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
-
-        // if the acm-siggraph.csl citation style changes this has to be modified
-        String expected = "  <div class=\"csl-entry\">"
-                + "<span style=\"font-variant: small-caps\">Smith, B., Jones, B., and Williams, J.</span> 2016-07. Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span> <span style=\"font-style: italic\">34</span>, 7, 45&ndash;67."
-                + "</div>\n"
-                + "";
-
-        assertEquals(expected, citation);
-    }
-
-    @Test
-    void testAPACitation() {
-        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
-        context.setMode(BibDatabaseMode.BIBLATEX);
-        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
-        CitationStyle style = styleList.stream().filter(e -> "American Psychological Association 6th edition".equals(e.getTitle())).findAny().orElse(null);
-        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
-
-        // if the apa-6th-citation.csl citation style changes this has to be modified
-        String expected = "  <div class=\"csl-entry\">"
-                + "Smith, B., Jones, B., &amp; Williams, J. (2016-07). Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span>, <span style=\"font-style: italic\">34</span>(7), 45&ndash;67. https://doi.org/10.1001/bla.blubb"
-                + "</div>\n"
-                + "";
-
-        assertEquals(expected, citation);
-    }
 }

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
@@ -34,4 +34,45 @@ class CitationStyleTest {
 
         assertEquals(expected, citation);
     }
+
+    @Test
+    void testDiscoverCitationStylesNotNull() {
+        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
+        assertNotNull(styleList);
+    }
+
+    @Test
+    void testACMCitation() {
+        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
+        context.setMode(BibDatabaseMode.BIBLATEX);
+        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
+        CitationStyle style = styleList.stream().filter(e -> "ACM SIGGRAPH".equals(e.getTitle())).findAny().orElse(null);
+        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
+
+        // if the acm-siggraph.csl citation style changes this has to be modified
+        String expected = "  <div class=\"csl-entry\">"
+                + "<span style=\"font-variant: small-caps\">Smith, B., Jones, B., and Williams, J.</span> 2016-07. Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span> <span style=\"font-style: italic\">34</span>, 7, 45&ndash;67."
+                + "</div>\n"
+                + "";
+
+        assertEquals(expected, citation);
+    }
+
+    @Test
+    void testAPACitation() {
+        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
+        context.setMode(BibDatabaseMode.BIBLATEX);
+        List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
+        CitationStyle style = styleList.stream().filter(e -> "American Psychological Association 6th edition".equals(e.getTitle())).findAny().orElse(null);
+        String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
+
+        // if the apa-6th-citation.csl citation style changes this has to be modified
+        String expected = "  <div class=\"csl-entry\">"
+                + "Smith, B., Jones, B., &amp; Williams, J. (2016-07). Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span>, <span style=\"font-style: italic\">34</span>(7), 45&ndash;67. https://doi.org/10.1001/bla.blubb"
+                + "</div>\n"
+                + "";
+
+        assertEquals(expected, citation);
+    }
+
 }


### PR DESCRIPTION
Adding test cases to help improve testing for the citation styles.

Added two test cases to check citation styles non-default (IEEE) styles as the other styles were not being tested. Added testACMCitation and testAPACitation to cover the corresponding citation styles, which are imported from (build/resources/main/csl-styles/acm-siggraph.csl) and (build/resources/main/csl-styles/apa-6th-edition.csl). Also, added a test case for discoverCitationStyles to improve code coverage for the CitationStyle class.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
