### PR TITLE
Fix missing clear action on pressing esc within the "Filter groups" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the notification bar message, icon and actions appeared to be invisible. [#8761](https://github.com/JabRef/jabref/issues/8761)
 - We fixed an issue where deprecated fields tab is shown when the fields don't contain any values. [#8396](https://github.com/JabRef/jabref/issues/8396)
 - We fixed an issue which allow us to select and open identifiers from a popup list in the maintable [#8758](https://github.com/JabRef/jabref/issues/8758), [8802](https://github.com/JabRef/jabref/issues/8802)
+- We fixed an issue where the escape button had no functionality within the "Filter groups" textfield. [koppor#562](https://github.com/koppor/jabref/issues/562)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/keyboard/TextInputKeyBindings.java
+++ b/src/main/java/org/jabref/gui/keyboard/TextInputKeyBindings.java
@@ -90,6 +90,10 @@ public class TextInputKeyBindings {
                         focusedTextField.positionCaret(res.caretPosition);
                         event.consume();
                     }
+                    case CLOSE -> {
+                        focusedTextField.clear();
+                        event.consume();
+                    }
                 }
             });
         }


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/562

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
