### PR TITLE
adjust and add testcases for FileAnnotationViewModel

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
@@ -4,7 +4,6 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
 import org.jabref.logic.formatter.bibtexfields.RemoveHyphenatedNewlinesFormatter;
-import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.pdf.FileAnnotation;
 import org.jabref.model.pdf.FileAnnotationType;

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
@@ -33,20 +33,21 @@ public class FileAnnotationViewModel {
             String annotationContent = annotation.getContent();
             String illegibleTextMessage = Localization.lang("The marked area does not contain any legible text!");
             String markingContent = (annotationContent.isEmpty() ? illegibleTextMessage : annotationContent);
-            // remove newlines && hyphens before linebreaks
-            markingContent = markingContent.replaceAll("-" + NEWLINE, "");
-            new RemoveHyphenatedNewlinesFormatter().format(markingContent);
-            // remove new lines not preceded by '.' or ':'
-            markingContent = markingContent.replaceAll("(?<![.|:])" + NEWLINE, " ");
-            this.marking.set(markingContent);
+            this.marking.set(removePunctuationMark(markingContent));
         } else {
             String content = annotation.getContent();
-            // remove newlines && hyphens before linebreaks
-            content = new RemoveHyphenatedNewlinesFormatter().format(content);
-            content = new RemoveNewlinesFormatter().format(content);
-            this.content.set(content);
+            this.content.set(removePunctuationMark(content));
             this.marking.set("");
         }
+    }
+
+    public String removePunctuationMark(String content) {
+        // remove newlines && hyphens before linebreaks
+        content = content.replaceAll("-" + NEWLINE, "");
+        content = new RemoveHyphenatedNewlinesFormatter().format(content);
+        // remove new lines not preceded by '.' or ':'
+        content = content.replaceAll("(?<![.|:])" + NEWLINE, " ");
+        return content;
     }
 
     public String getAuthor() {

--- a/src/test/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModelTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModelTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class FileAnnotationViewModelTest {
 
     private FileAnnotationViewModel annotationViewModel;
+    private FileAnnotationViewModel annotationViewModelWithoutFileAnnotation;
 
     @BeforeEach
     void setup() {
@@ -24,8 +25,9 @@ public class FileAnnotationViewModelTest {
 
         FileAnnotation linkedFileAnnotation = new FileAnnotation("John", LocalDateTime.now(), 3, content, FileAnnotationType.FREETEXT, Optional.empty());
         FileAnnotation annotation = new FileAnnotation("Jaroslav Kucha ˇr", LocalDateTime.parse("2017-07-20T10:11:30"), 1, marking, FileAnnotationType.HIGHLIGHT, Optional.of(linkedFileAnnotation));
-
+        FileAnnotation annotationWithoutFileAnnotation = new FileAnnotation("Jaroslav Kucha ˇr", LocalDateTime.parse("2017-07-20T10:11:30"), 1, marking, FileAnnotationType.HIGHLIGHT, Optional.empty());
         annotationViewModel = new FileAnnotationViewModel(annotation);
+        annotationViewModelWithoutFileAnnotation = new FileAnnotationViewModel(annotationWithoutFileAnnotation);
     }
 
     @Test
@@ -49,11 +51,25 @@ public class FileAnnotationViewModelTest {
     }
 
     @Test
+    public void retrieveCorrectContentWithoutLinkedFileAnnotation() {
+        String expectedMarking = String.format("This is paragraph 1.%n" +
+                "This is paragraph 2, and it crosses several lines, now you can see next paragraph:%n"
+                + "This is paragraph 3.");
+
+        assertEquals(expectedMarking, annotationViewModelWithoutFileAnnotation.getContent());
+    }
+
+    @Test
     public void removeOnlyLineBreaksNotPrecededByPeriodOrColon() {
         String expectedMarking = String.format("This is paragraph 1.%n" +
                 "This is paragraph 2, and it crosses several lines, now you can see next paragraph:%n"
                 + "This is paragraph 3.");
 
         assertEquals(expectedMarking, annotationViewModel.getMarking());
+    }
+
+    @Test
+    public void retrieveCorrectMarkingWithoutLinkedFileAnnotation() {
+        assertEquals("", annotationViewModelWithoutFileAnnotation.getMarking());
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
The code for removing newlines & hyphens before linebreaks is inconsistent and lacks test cases for the part of when annotation doesn't have LinkedFileAnnotation.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
