### PR TITLE
Add Nemo file manager

### DIFF
--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -94,9 +94,13 @@ public class Linux implements NativeDesktop {
         if (desktopSession != null) {
             desktopSession = desktopSession.toLowerCase(Locale.ROOT);
             if (desktopSession.contains("gnome")) {
-                cmd = "nautilus" + filePath.toString().replace(" ", "\\ ");
-            } else if (desktopSession.contains("kde")) {
+                cmd = "nautilus --select " + filePath.toString().replace(" ", "\\ ");
+            } else if (desktopSession.contains("kde") || desktopSession.contains("plasma")) {
                 cmd = "dolphin --select " + filePath.toString().replace(" ", "\\ ");
+            } else if (desktopSession.contains("mate")) {
+                cmd = "caja --select " + filePath.toString().replace(" ", "\\ ");
+            } else if (desktopSession.contains("cinnamon")) {
+                cmd = "nemo --select " + filePath.toString().replace(" ", "\\ ");
             }
         }
         Runtime.getRuntime().exec(cmd);


### PR DESCRIPTION
This should fix #8679 for unconfined packages.
I simply updated nautilus to the proper command (it changed at some point) and added caja and nemo.
We still need a better solution for the snap and/or flatpak, but that is more complex, unless the dbus command mentioned in #8679  is added.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
