### PR TITLE
Open event log when clicking on collapsed notification

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -13,8 +13,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javafx.concurrent.Task;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.print.PrinterJob;
 import javafx.scene.Group;
@@ -350,12 +348,10 @@ public class JabRefDialogService implements DialogService {
                                               .text(
                                                     "(" + Localization.lang("Check the event log to see all notifications") + ")"
                                                      + "\n\n" + message)
-                                              .onAction(new EventHandler<ActionEvent>() {
-                                                @Override
-                                                public void handle(ActionEvent a) {
-                                                    ErrorConsoleAction ec = new ErrorConsoleAction();
-                                                    ec.execute();
-                                                }}))
+                                              .onAction((e)-> {
+                                                     ErrorConsoleAction ec = new ErrorConsoleAction();
+                                                     ec.execute();
+                                                 }))
                          .hideCloseButton()
                          .show();
         });

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -13,6 +13,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javafx.concurrent.Task;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.print.PrinterJob;
 import javafx.scene.Group;
@@ -35,6 +37,7 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 import javafx.util.Duration;
 
+import org.jabref.gui.help.ErrorConsoleAction;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BackgroundTask;
@@ -343,9 +346,16 @@ public class JabRefDialogService implements DialogService {
                          .threshold(5,
                                  Notifications.create()
                                               .title(Localization.lang("Last notification"))
+                                              // TODO: Change to a notification overview instead of event log when that is available. The event log is not that user friendly (different purpose).
                                               .text(
                                                     "(" + Localization.lang("Check the event log to see all notifications") + ")"
-                                                     + "\n\n" + message))
+                                                     + "\n\n" + message)
+                                              .onAction(new EventHandler<ActionEvent>() {
+                                                @Override
+                                                public void handle(ActionEvent a) {
+                                                    ErrorConsoleAction ec = new ErrorConsoleAction();
+                                                    ec.execute();
+                                                }}))
                          .hideCloseButton()
                          .show();
         });


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

In https://github.com/JabRef/jabref/pull/8775#discussion_r870153000, I suggested a change for collapsed notifications to improve their UX. Since this has not been implemented there, I went ahead with my own approach.

The collapsed notifications contain a hint to the event log. However, for users, it is likely tiresome to find the menu entry and open the event log from there. Thus, when clicking the collapsed notification, the event log opens now.

Not sure, whether the way I did it is clean, so open for feedback.

An additional thing I noticed is that the event log is empty for me (not the case on the stable build). Probably not related, possibly, an issue should be created for it.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
