### PR TITLE
Fixes spelling of compliant

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -183,7 +183,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
                     PosixFilePermission.OTHERS_READ);
             if (Files.exists(targetFile)) {
                 Files.copy(targetFile, backupFile, StandardCopyOption.REPLACE_EXISTING);
-                if (FileUtil.IS_POSIX_COMPILANT) {
+                if (FileUtil.IS_POSIX_COMPLIANT) {
                     try {
                         oldFilePermissions = Files.getPosixFilePermissions(targetFile);
                     } catch (IOException exception) {
@@ -196,7 +196,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
             Files.move(temporaryFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 
             // Restore file permissions
-            if (FileUtil.IS_POSIX_COMPILANT) {
+            if (FileUtil.IS_POSIX_COMPLIANT) {
                 try {
                     Files.setPosixFilePermissions(targetFile, oldFilePermissions);
                 } catch (IOException exception) {

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class FileUtil {
 
-    public static final boolean IS_POSIX_COMPILANT = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    public static final boolean IS_POSIX_COMPLIANT = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
     public static final int MAXIMUM_FILE_NAME_LENGTH = 255;
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtil.class);
 


### PR DESCRIPTION
Fixes spelling of compliant in FileUtil.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
