### PR TITLE
Enhance "file" field in General Tab of Entry-Editor

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -9,7 +9,7 @@
 <?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.LinkedFilesEditor">
-    <ListView fx:id="listView" prefHeight="0" HBox.hgrow="ALWAYS" maxHeight="100" />
+    <ListView fx:id="listView" HBox.hgrow="ALWAYS"/>
     <Button onAction="#addNewFile"
             styleClass="icon-button">
         <graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -236,7 +236,16 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
     @FXML
     private void addNewFile() {
-        viewModel.addNewFile();
+//        System.out.println(listView.getPrefHeight());
+        int number = viewModel.addNewFile();
+        if(number < 3)
+            return;
+        else{
+            listView.setMinHeight(number*20);
+//            listView.setPrefHeight(number*5);
+            System.out.println(listView.getPrefHeight());
+        }
+//
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -135,7 +135,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
         return files;
     }
 
-    public void addNewFile() {
+    public int addNewFile() {
         Path workingDirectory = databaseContext.getFirstExistingFileDir(preferences.getFilePreferences())
                                                .orElse(preferences.getFilePreferences().getWorkingDirectory());
 
@@ -155,6 +155,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
                     preferences,
                     externalFileTypes));
         });
+        return files.size();
     }
 
     @Override


### PR DESCRIPTION
Fixes #8823

Hello, we are a group of students and interested in ui design, and we also think user experience is the most important, in the origin version, user can not quickly find which file he/she select. I want to use setPrefHeight to dynamically update the height of list. But also, there are some issues with other fields` height, maybe we should still make sure every box consist. Also, we hope continue to try to improve this problem!

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
