### PR TITLE
Update Readme.md for early contributor guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Check out the ways you can contribute, below:
 
 We view pull requests as a collaborative process.
 Submit a pull request early to get feedback from the team on work in progress.
-We will discuss improvements with you and agree to merge them once the [developers](https://github.com/JabRef/jabref/blob/main/MAINTAINERS) approve.
+We will discuss improvements with you and agree to merge them once the [developers](https://github.com/JabRef/jabref/blob/main/MAINTAINERS) approve. Please also remember to discuss bigger changes early with the core developers to avoid a waste of time and work. Some fundamental design decisions can be found within our list of [Architectural Decision Records](https://devdocs.jabref.org/adr.html).
 
 If you want a step-by-step walk-through on how to set-up your workspace, please check [this guideline](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
 


### PR DESCRIPTION
In the past we had some PRs which were not mergable for fundamental design changes we could not accept. This change to the readme tries to prevent contributors to waste time and work.