### PR TITLE
Add restart warning on SSL configuration change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - Writing BibTeX data into a PDF (XMP) considers the configured keyword separator (and does not use "," as default any more)
 - The Medline/Pubmed search now also supports the [default fields and operators for searching](https://docs.jabref.org/collect/import-using-online-bibliographic-database#search-syntax). [forum#3554](https://discourse.jabref.org/t/native-pubmed-search/3354)
 - We improved group expansion arrow that prevent it from activating group when expanding or collapsing. [#7982](https://github.com/JabRef/jabref/issues/7982), [#3176](https://github.com/JabRef/jabref/issues/3176)
+- When configured SSL certificates changed, JabRef warns the user to restart to apply the configuration.
 
 ### Fixed
 
@@ -30,11 +31,11 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the unnecessary horizontal scroll bar in group panel [#8467](https://github.com/JabRef/jabref/issues/8467)
 - We fixed an issue where the notification bar message, icon and actions appeared to be invisible. [#8761](https://github.com/JabRef/jabref/issues/8761)
 - We fixed an issue where deprecated fields tab is shown when the fields don't contain any values. [#8396](https://github.com/JabRef/jabref/issues/8396)
-- We fixed an issue where an exception for DOI search occured when the DOI contained urlencoded characters. [#8787](https://github.com/JabRef/jabref/issues/8787)
+- We fixed an issue where an exception for DOI search occurred when the DOI contained urlencoded characters. [#8787](https://github.com/JabRef/jabref/issues/8787)
 - We fixed an issue which allow us to select and open identifiers from a popup list in the maintable [#8758](https://github.com/JabRef/jabref/issues/8758), [8802](https://github.com/JabRef/jabref/issues/8802)
 - We fixed an issue where the escape button had no functionality within the "Filter groups" textfield. [koppor#562](https://github.com/koppor/jabref/issues/562)
 - We fixed an issue where right clicking a group and choose "remove selected entries from this group" leads to error when Bibtex source tab is selected. [#8012](https://github.com/JabRef/jabref/issues/8012)
-- When the proxy configuration removed the proxy user/password, this change is applied immediatly.
+- When the proxy configuration removed the proxy user/password, this change is applied immediately.
 
 ### Removed
 
@@ -66,7 +67,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Changed
 
 - We upgraded to Lucene 9.1 for the fulltext search.
-  Thus, the now created search index cannot be read from older versions of JabRef anylonger.
+  Thus, the now created search index cannot be read from older versions of JabRef any longer.
   ⚠️ JabRef will recreate the index in a new folder for new files and this will take a long time for a huge library.
   Moreover, switching back and forth JabRef versions and meanwhile adding PDFs also requires rebuilding the index now and then.
   [#8362](https://github.com/JabRef/jabref/pull/8362)
@@ -93,7 +94,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where "Copy DOI url" in the right-click menu of the Entry List would just copy the DOI and not the DOI url. [#8389](https://github.com/JabRef/jabref/issues/8389)
 - We fixed an issue where opening the console from the drop-down menu would cause an exception. [#8466](https://github.com/JabRef/jabref/issues/8466)
 - We fixed an issue when reading non-UTF-8 encoded. When no encoding header is present, the encoding is now detected from the file content (and the preference option is disregarded). [#8417](https://github.com/JabRef/jabref/issues/8417)
-- We fixed an issue where pasting a URL was replacing + signs by spaces making the URL unreachable. [#8448](https://github.com/JabRef/jabref/issues/8448)
+- We fixed an issue where pasting a URL was replacing `+` signs by spaces making the URL unreachable. [#8448](https://github.com/JabRef/jabref/issues/8448)
 - We fixed an issue where creating subsidiary files from aux files created with some versions of biblatex would produce incorrect results. [#8513](https://github.com/JabRef/jabref/issues/8513)
 - We fixed an issue where opening the changelog from withing JabRef led to a 404 error. [#8563](https://github.com/JabRef/jabref/issues/8563)
 - We fixed an issue where not all found unlinked local files were imported correctly due to some race condition. [#8444](https://github.com/JabRef/jabref/issues/8444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue which allow us to select and open identifiers from a popup list in the maintable [#8758](https://github.com/JabRef/jabref/issues/8758), [8802](https://github.com/JabRef/jabref/issues/8802)
 - We fixed an issue where the escape button had no functionality within the "Filter groups" textfield. [koppor#562](https://github.com/koppor/jabref/issues/562)
 - We fixed an issue where right clicking a group and choose "remove selected entries from this group" leads to error when Bibtex source tab is selected. [#8012](https://github.com/JabRef/jabref/issues/8012)
+- When the proxy configuration removed the proxy user/password, this change is applied immediatly.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the unnecessary horizontal scroll bar in group panel [#8467](https://github.com/JabRef/jabref/issues/8467)
 - We fixed an issue where the notification bar message, icon and actions appeared to be invisible. [#8761](https://github.com/JabRef/jabref/issues/8761)
 - We fixed an issue where deprecated fields tab is shown when the fields don't contain any values. [#8396](https://github.com/JabRef/jabref/issues/8396)
-- We fixed an issue where an exxception for DOI search occured when the DOI contained urlencoded characters. [#8787](https://github.com/JabRef/jabref/issues/8787)
+- We fixed an issue where an exception for DOI search occured when the DOI contained urlencoded characters. [#8787](https://github.com/JabRef/jabref/issues/8787)
 - We fixed an issue which allow us to select and open identifiers from a popup list in the maintable [#8758](https://github.com/JabRef/jabref/issues/8758), [8802](https://github.com/JabRef/jabref/issues/8802)
 - We fixed an issue where the escape button had no functionality within the "Filter groups" textfield. [koppor#562](https://github.com/koppor/jabref/issues/562)
 - We fixed an issue where right clicking a group and choose "remove selected entries from this group" leads to error when Bibtex source tab is selected. [#8012](https://github.com/JabRef/jabref/issues/8012)

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
@@ -227,7 +227,7 @@ public class PreferencesDialogViewModel extends AbstractViewModel {
     }
 
     /**
-     * Inserts the preference values into the the Properties of the ViewModel
+     * Inserts the preference values into the Properties of the ViewModel
      */
     public void setValues() {
         for (PreferencesTab preferencesTab : preferenceTabs) {

--- a/src/main/java/org/jabref/gui/preferences/network/NetworkTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/network/NetworkTabViewModel.java
@@ -4,6 +4,7 @@ import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javafx.beans.property.BooleanProperty;
@@ -69,7 +70,7 @@ public class NetworkTabViewModel implements PreferenceTabViewModel {
     private final ProxyPreferences backupProxyPreferences;
     private final SSLPreferences sslPreferences;
 
-    private final List<String> restartWarning = new ArrayList<>();
+    private final List<String> restartWarnings = new ArrayList<>();
 
     private final TrustStoreManager trustStoreManager;
 
@@ -208,9 +209,12 @@ public class NetworkTabViewModel implements PreferenceTabViewModel {
     }
 
     private void storeProxySettings(ProxyPreferences newProxyPreferences) {
-        if (!newProxyPreferences.equals(proxyPreferences)) {
-            ProxyRegisterer.register(newProxyPreferences);
+        if (Objects.equals(newProxyPreferences, proxyPreferences)) {
+            // nothing changed; thus, nothing to store
+            return;
         }
+
+        ProxyRegisterer.register(newProxyPreferences);
 
         proxyPreferences.setUseProxy(newProxyPreferences.shouldUseProxy());
         proxyPreferences.setHostname(newProxyPreferences.getHostname());
@@ -318,7 +322,7 @@ public class NetworkTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public List<String> getRestartWarnings() {
-        return restartWarning;
+        return restartWarnings;
     }
 
     public BooleanProperty remoteServerProperty() {

--- a/src/main/java/org/jabref/logic/net/ProxyRegisterer.java
+++ b/src/main/java/org/jabref/logic/net/ProxyRegisterer.java
@@ -21,10 +21,15 @@ public class ProxyRegisterer {
 
                 System.setProperty("https.proxyUser", proxyPrefs.getUsername());
                 System.setProperty("https.proxyPassword", proxyPrefs.getPassword());
+            } else {
+                System.clearProperty("http.proxyUser");
+                System.clearProperty("http.proxyPassword");
+
+                System.clearProperty("https.proxyUser");
+                System.clearProperty("https.proxyPassword");
             }
         } else {
-            // The following two lines signal that the system proxy settings
-            // should be used:
+            // The following two lines signal that the system proxy settings should be used:
             System.setProperty("java.net.useSystemProxies", "true");
             System.setProperty("proxySet", "true");
         }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1250,6 +1250,12 @@ Check\ connection=Check connection
 Connection\ failed\!=Connection failed\!
 Connection\ successful\!=Connection successful\!
 
+SSL\ Configuration=SSL Configuration
+SSL\ configuration\ changed=SSL configuration changed
+SSL\ certificate\ file=SSL certificate file
+Duplicate\ Certificates=Duplicate Certificates
+You\ already\ added\ this\ certificate=You already added this certificate
+
 Open\ folder=Open folder
 Export\ sort\ order=Export sort order
 Save\ sort\ order=Save sort order
@@ -2474,10 +2480,6 @@ Valid\ from=Valid from
 Valid\ to=Valid to
 Signature\ algorithm=Signature algorithm
 Version=Version
-SSL\ Configuration=SSL Configuration
-SSL\ certificate\ file=SSL certificate file
-Duplicate\ Certificates=Duplicate Certificates
-You\ already\ added\ this\ certificate=You already added this certificate
 
 Error\ downloading=Error downloading
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1245,6 +1245,10 @@ Use\ custom\ proxy\ configuration=Use custom proxy configuration
 Proxy\ requires\ authentication=Proxy requires authentication
 Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Attention: Password is stored in plain text!
 Clear\ connection\ settings=Clear connection settings
+Check\ Proxy\ Setting=Check Proxy Setting
+Check\ connection=Check connection
+Connection\ failed\!=Connection failed\!
+Connection\ successful\!=Connection successful\!
 
 Open\ folder=Open folder
 Export\ sort\ order=Export sort order
@@ -2328,10 +2332,6 @@ Removes\ digits.=Removes digits.
 
 Presets=Presets
 
-Check\ Proxy\ Setting=Check Proxy Setting
-Check\ connection=Check connection
-Connection\ failed\!=Connection failed\!
-Connection\ successful\!=Connection successful\!
 Generate\ groups\ from\ keywords\ in\ the\ following\ field=Generate groups from keywords in the following field
 Generate\ groups\ for\ author\ last\ names=Generate groups for author last names
 Regular\ expression=Regular expression

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
@@ -20,69 +20,54 @@ import static org.mockito.Mockito.mock;
 @FetcherTest
 public class DoiFetcherTest {
 
-    private DoiFetcher fetcher;
-    private BibEntry bibEntryBurd2011;
-    private BibEntry bibEntryDecker2007;
-    private BibEntry bibEntryIannarelli2019;
-    private BibEntry bibEntryStenzel2020;
+    private DoiFetcher fetcher = new DoiFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
 
-    @BeforeEach
-    public void setUp() {
-        fetcher = new DoiFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
-
-        bibEntryBurd2011 = new BibEntry();
-        bibEntryBurd2011.setType(StandardEntryType.Book);
-        bibEntryBurd2011.setCitationKey("Burd_2011");
-        bibEntryBurd2011.setField(StandardField.TITLE, "Java{\\textregistered} For Dummies{\\textregistered}");
-        bibEntryBurd2011.setField(StandardField.PUBLISHER, "Wiley");
-        bibEntryBurd2011.setField(StandardField.YEAR, "2011");
-        bibEntryBurd2011.setField(StandardField.AUTHOR, "Barry Burd");
-        bibEntryBurd2011.setField(StandardField.MONTH, "jul");
-        bibEntryBurd2011.setField(StandardField.DOI, "10.1002/9781118257517");
-
-        bibEntryDecker2007 = new BibEntry();
-        bibEntryDecker2007.setType(StandardEntryType.InProceedings);
-        bibEntryDecker2007.setCitationKey("Decker_2007");
-        bibEntryDecker2007.setField(StandardField.AUTHOR, "Gero Decker and Oliver Kopp and Frank Leymann and Mathias Weske");
-        bibEntryDecker2007.setField(StandardField.BOOKTITLE, "{IEEE} International Conference on Web Services ({ICWS} 2007)");
-        bibEntryDecker2007.setField(StandardField.MONTH, "jul");
-        bibEntryDecker2007.setField(StandardField.PUBLISHER, "{IEEE}");
-        bibEntryDecker2007.setField(StandardField.TITLE, "{BPEL}4Chor: Extending {BPEL} for Modeling Choreographies");
-        bibEntryDecker2007.setField(StandardField.YEAR, "2007");
-        bibEntryDecker2007.setField(StandardField.DOI, "10.1109/icws.2007.59");
-
-        // mEDRA BibEntry
-        bibEntryIannarelli2019 = new BibEntry(StandardEntryType.Article)
-                                                                        .withField(StandardField.AUTHOR,
-                                                                                   ""
-                                                                                                         + "Iannarelli Riccardo  and "
-                                                                                                         + "Novello Anna  and "
-                                                                                                         + "Stricker Damien  and "
-                                                                                                         + "Cisternino Marco  and "
-                                                                                                         + "Gallizio Federico  and "
-                                                                                                         + "Telib Haysam  and "
-                                                                                                         + "Meyer Thierry ")
-                                                                        .withField(StandardField.PUBLISHER, "AIDIC: Italian Association of Chemical Engineering")
-                                                                        .withField(StandardField.TITLE, "Safety in research institutions: how to better communicate the risks using numerical simulations")
-                                                                        .withField(StandardField.YEAR, "2019")
-                                                                        .withField(StandardField.DOI, "10.3303/CET1977146")
-                                                                        .withField(StandardField.JOURNAL, "Chemical Engineering Transactions")
-                                                                        .withField(StandardField.PAGES, "871-876")
-                                                                        .withField(StandardField.VOLUME, "77");
-        bibEntryStenzel2020 = new BibEntry();
-        bibEntryStenzel2020.setType(StandardEntryType.Article);
-        bibEntryStenzel2020.setCitationKey("Stenzel_2020");
-        bibEntryStenzel2020.setField(StandardField.AUTHOR, "L. Stenzel and A. L. C. Hayward and U. Schollwöck and F. Heidrich-Meisner");
-        bibEntryStenzel2020.setField(StandardField.JOURNAL, "Physical Review A");
-        bibEntryStenzel2020.setField(StandardField.TITLE, "Topological phases in the Fermi-Hofstadter-Hubbard model on hybrid-space ladders");
-        bibEntryStenzel2020.setField(StandardField.YEAR, "2020");
-        bibEntryStenzel2020.setField(StandardField.MONTH, "aug");
-        bibEntryStenzel2020.setField(StandardField.VOLUME, "102");
-        bibEntryStenzel2020.setField(StandardField.DOI, "10.1103/physreva.102.023315");
-        bibEntryStenzel2020.setField(StandardField.PUBLISHER, "American Physical Society ({APS})");
-        bibEntryStenzel2020.setField(StandardField.PAGES, "023315");
-        bibEntryStenzel2020.setField(StandardField.NUMBER, "2");
-    }
+    private BibEntry bibEntryBurd2011 = new BibEntry(StandardEntryType.Book)
+            .withCitationKey("Burd_2011")
+            .withField(StandardField.TITLE, "Java{\\textregistered} For Dummies{\\textregistered}")
+            .withField(StandardField.PUBLISHER, "Wiley")
+            .withField(StandardField.YEAR, "2011")
+            .withField(StandardField.AUTHOR, "Barry Burd")
+            .withField(StandardField.MONTH, "jul")
+            .withField(StandardField.DOI, "10.1002/9781118257517");
+    private BibEntry bibEntryDecker2007 = new BibEntry(StandardEntryType.InProceedings)
+            .withCitationKey("Decker_2007")
+            .withField(StandardField.AUTHOR, "Gero Decker and Oliver Kopp and Frank Leymann and Mathias Weske")
+            .withField(StandardField.BOOKTITLE, "{IEEE} International Conference on Web Services ({ICWS} 2007)")
+            .withField(StandardField.MONTH, "jul")
+            .withField(StandardField.PUBLISHER, "{IEEE}")
+            .withField(StandardField.TITLE, "{BPEL}4Chor: Extending {BPEL} for Modeling Choreographies")
+            .withField(StandardField.YEAR, "2007")
+            .withField(StandardField.DOI, "10.1109/icws.2007.59");
+    private BibEntry bibEntryIannarelli2019 = new BibEntry(StandardEntryType.Article)
+            .withField(StandardField.AUTHOR,
+                    ""
+                            + "Iannarelli Riccardo  and "
+                            + "Novello Anna  and "
+                            + "Stricker Damien  and "
+                            + "Cisternino Marco  and "
+                            + "Gallizio Federico  and "
+                            + "Telib Haysam  and "
+                            + "Meyer Thierry ")
+            .withField(StandardField.PUBLISHER, "AIDIC: Italian Association of Chemical Engineering")
+            .withField(StandardField.TITLE, "Safety in research institutions: how to better communicate the risks using numerical simulations")
+            .withField(StandardField.YEAR, "2019")
+            .withField(StandardField.DOI, "10.3303/CET1977146")
+            .withField(StandardField.JOURNAL, "Chemical Engineering Transactions")
+            .withField(StandardField.PAGES, "871-876")
+            .withField(StandardField.VOLUME, "77");
+    private BibEntry bibEntryStenzel2020 = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("Stenzel_2020")
+            .withField(StandardField.AUTHOR, "L. Stenzel and A. L. C. Hayward and U. Schollwöck and F. Heidrich-Meisner")
+            .withField(StandardField.JOURNAL, "Physical Review A")
+            .withField(StandardField.TITLE, "Topological phases in the Fermi-Hofstadter-Hubbard model on hybrid-space ladders")
+            .withField(StandardField.YEAR, "2020")
+            .withField(StandardField.MONTH, "aug")
+            .withField(StandardField.VOLUME, "102")
+            .withField(StandardField.DOI, "10.1103/physreva.102.023315")
+            .withField(StandardField.PUBLISHER, "American Physical Society ({APS})")
+            .withField(StandardField.PAGES, "023315")
+            .withField(StandardField.NUMBER, "2");
 
     @Test
     public void testGetName() {

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
@@ -9,7 +9,6 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -40,7 +40,7 @@ class DoiResolutionTest {
         );
     }
 
-    @Disabled("Cannot fetch due to Cloudfare protection")
+    @Disabled("Cannot fetch due to Cloudflare protection")
     @Test
     void linkWithPdfStringLeadsToFulltext() throws IOException {
         entry.setField(StandardField.DOI, "10.1002/acr2.11101");
@@ -61,7 +61,7 @@ class DoiResolutionTest {
 
     @Test
     void returnAnythingWhenBehindSpringerPayWall() throws IOException {
-        // Springer returns a HTML page instead of an empty page,
+        // Springer returns an HTML page instead of an empty page,
         // even if the user does not have access
         // We cannot easily handle this case, because other publisher return the wrong media type.
         entry.setField(StandardField.DOI, "10.1007/978-3-319-62594-2_12");


### PR DESCRIPTION
Follow up to https://github.com/JabRef/jabref/pull/8583

I did following:

1. fetch DOI
2. see SSL error
3. add custom SSL certificate
4. fetch DOI
5. see SSL error
6. restart JabRef
7. fetch DOI
8. see DOI

To prevent WTFs at users, I added a restart warning:

![image](https://user-images.githubusercontent.com/1366654/171064368-93f46888-0981-4832-a9ed-2d85a2461b7d.png)

I digged in the code for URLDownload, but could not find the place for ssl certficate handling. I would assume, Java does some caching...

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
