### PR TITLE
Reviewdoc: Comment on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Run check style reporter
         uses: nikitasavinov/checkstyle-action@master
         with:
-          reporter: github-pr-check
+          reporter: github-pr-review
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           checkstyle_config: 'config/checkstyle/checkstyle_reviewdog.xml'
-          checkstyle_version: '10.1'
+          checkstyle_version: '10.3'
       - name: Run checkstyle gradle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
       - name: Run markdown-lint

--- a/docs/adr/0025-reviewdog-reviews.md
+++ b/docs/adr/0025-reviewdog-reviews.md
@@ -24,9 +24,11 @@ How to quickly provide feedback to contributors that checkstyle was not matched?
 
 * Use [Reviewdog's PullRequest review reporter](https://github.com/reviewdog/reviewdog#reporter-github-pullrequest-review-comment--reportergithub-pr-review)
 * Use [Reviewdog's check reporter](https://github.com/reviewdog/reviewdog#reporter-github-checks--reportergithub-check)
+* Use [comment-failure-action](https://github.com/quipper/comment-failure-action)
 
 ## Decision Outcome
 
 Chosen option: "Use Reviewdog's PullRequest review reporter", because resolves force to provide fast feedback.
+We do not want to use `comment-failure-action`, because [it might procude too much comments](https://github.com/quipper/comment-failure-action/issues/224).
 We accept that newcomers might be annoyed if quick automatic feedback by a bot is given:
 We value the time of our maintainers and want to keep them focused on the real challanges of the code changes.

--- a/docs/adr/0025-reviewdog-reviews.md
+++ b/docs/adr/0025-reviewdog-reviews.md
@@ -1,0 +1,32 @@
+---
+parent: Architectural Decisions
+nav_order: 24
+---
+# Reviewdog findings are code reviews
+
+## Context and Problem Statement
+
+JabRef offers [guidelines to setup the local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
+There is also a section on [JabRef's code style](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace#using-jabrefs-code-style).
+There are pull requests by newcomers, which do not follow that style guide.
+
+How to quickly provide feedback to contributors that checkstyle was not matched?
+
+## Decision Drivers
+
+* Be friendly to newcomers
+* Provide fast feedback to contributors
+* Lower the workload of maintainers
+* Keep maintainers focused on the "real" challanges of the code changes
+
+## Considered Options
+
+
+* Use [Reviewdog's PullRequest review reporter](https://github.com/reviewdog/reviewdog#reporter-github-pullrequest-review-comment--reportergithub-pr-review)
+* Use [Reviewdog's check reporter](https://github.com/reviewdog/reviewdog#reporter-github-checks--reportergithub-check)
+
+## Decision Outcome
+
+Chosen option: "Use Reviewdog's PullRequest review reporter", because resolves force to provide fast feedback.
+We accept that newcomers might be annoyed if quick automatic feedback by a bot is given:
+We value the time of our maintainers and want to keep them focused on the real challanges of the code changes.

--- a/docs/adr/0025-reviewdog-reviews.md
+++ b/docs/adr/0025-reviewdog-reviews.md
@@ -1,6 +1,6 @@
 ---
 parent: Architectural Decisions
-nav_order: 24
+nav_order: 25
 ---
 # Reviewdog findings are code reviews
 


### PR DESCRIPTION
There are more and more pull requests coming in JabRef. A significant number of them does not follow our guidelines to setup a workspace.

The contributors do not check our failing tests and they should get instant feedback.

I checked [comment-failure-action](https://github.com/quipper/comment-failure-action).
It will produce lots of similar comments at each run (https://github.com/quipper/comment-failure-action/issues/224).
Therefore, I did not use it.

The solution is to let reviewdog create a review.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
