### PR TITLE
Increase the network connection timeout and improve error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The Medline/Pubmed search now also supports the [default fields and operators for searching](https://docs.jabref.org/collect/import-using-online-bibliographic-database#search-syntax). [forum#3554](https://discourse.jabref.org/t/native-pubmed-search/3354)
 - We improved group expansion arrow that prevent it from activating group when expanding or collapsing. [#7982](https://github.com/JabRef/jabref/issues/7982), [#3176](https://github.com/JabRef/jabref/issues/3176)
 - When configured SSL certificates changed, JabRef warns the user to restart to apply the configuration.
+- We fixed an issue that caused JabRef to sometimes open multiple instances when "Remote Operation" is enabled. [#8653](https://github.com/JabRef/jabref/issues/8653)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
+++ b/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
@@ -18,7 +18,7 @@ public class RemoteClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoteClient.class);
 
-    private static final int TIMEOUT = 200;
+    private static final int TIMEOUT = 1000;
     private final int port;
 
     public RemoteClient(int port) {

--- a/src/main/java/org/jabref/logic/remote/server/RemoteListenerServerLifecycle.java
+++ b/src/main/java/org/jabref/logic/remote/server/RemoteListenerServerLifecycle.java
@@ -43,7 +43,8 @@ public class RemoteListenerServerLifecycle implements AutoCloseable {
         try {
             result = new RemoteListenerServerThread(messageHandler, port, preferencesService);
         } catch (BindException e) {
-            LOGGER.warn("Port is blocked", e);
+            LOGGER.warn("There was an error opening the configured network port {}. Please ensure there isn't another" +
+                    " application already using that port.", port);
             result = null;
         } catch (IOException e) {
             result = null;


### PR DESCRIPTION
In some instances, connecting to an existing JabRef instance may take longer
than the original 200ms timeout. Here we increase that timeout to a full
second. If it takes longer than that to connect to an existing instance,
chances are something else bad is going on.

Additionally, in a case where we attempt a ping but it fails for some reason,
but we're also unable to bind the port to listen ourselves, we give the
user a more informative error message about the potential cause of that
problem, and offer two possible solutions: figure out what other process
is already binding the port, or file a bug if that process happens to be
JabRef (since that would indicate that a 1s timeout isn't sufficient).

Fixes #8653.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
