### PR TITLE
Fix javafx version not displayed in About Dialog

### DIFF
--- a/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.help;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -57,8 +58,11 @@ public class AboutDialogViewModel extends AbstractViewModel {
         maintainers.set(buildInfo.maintainers);
         license.set(Localization.lang("License") + ":");
         changelogUrl = buildInfo.version.getChangelogUrl();
+
+        String javafx_version = System.getProperty("javafx.runtime.version", BuildInfo.UNKNOWN_VERSION).toLowerCase(Locale.ROOT);
+
         versionInfo = String.format("JabRef %s%n%s %s %s %nJava %s %nJavaFX %s", buildInfo.version, BuildInfo.OS,
-                BuildInfo.OS_VERSION, BuildInfo.OS_ARCH, BuildInfo.JAVA_VERSION, BuildInfo.JAVAFX_VERSION);
+                BuildInfo.OS_VERSION, BuildInfo.OS_ARCH, BuildInfo.JAVA_VERSION, javafx_version);
     }
 
     public String getDevelopmentVersion() {

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -16,8 +16,6 @@ public final class BuildInfo {
     public static final String OS_VERSION = System.getProperty("os.version", UNKNOWN_VERSION).toLowerCase(Locale.ROOT);
     public static final String OS_ARCH = System.getProperty("os.arch", UNKNOWN_VERSION).toLowerCase(Locale.ROOT);
     public static final String JAVA_VERSION = System.getProperty("java.version", UNKNOWN_VERSION).toLowerCase(Locale.ROOT);
-    public static final String JAVAFX_VERSION = System.getProperty("javafx.runtime.version", UNKNOWN_VERSION).toLowerCase(Locale.ROOT);
-
 
     public final Version version;
     public final String maintainers;


### PR DESCRIPTION
It seems that the property is null when javafx is not yet loaded; therefore, we check that in the about dialog as well



<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

<img width="535" alt="Bildschirmfoto 2022-06-21 um 21 53 13" src="https://user-images.githubusercontent.com/320228/174886537-907fa6a2-7198-44f9-82b1-2c6fc65ef0f8.png">

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
