### PR TITLE
Disable ResearchGateTest on CI

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @FetcherTest
+@DisabledOnCIServer("Blocked by Cloudflare")
 public class ResearchGateTest {
 
     private static final String URL_PDF = "https://www.researchgate.net/profile/Abdurrazzak-Gehani/publication/4207355_Paranoid_a_global_secure_file_access_control_system/links/5457747d0cf2cf516480995e/Paranoid-a-global-secure-file-access-control-system.pdf";


### PR DESCRIPTION
"Fixes"

```
ResearchGateTest > performSearchWithBibEntry() FAILED
    org.jabref.logic.importer.FetcherException: ResearchGate server unavailable
```

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
