### PR TITLE
Cleanup index when opening a library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where removing several groups deletes only one of them. [#8390](https://github.com/JabRef/jabref/issues/8390)
 - We fixed an issue where the Sidepane (groups, web search and open office) width is not remembered after restarting JabRef. [#8907](https://github.com/JabRef/jabref/issues/8907)
 - We fixed a bug where switching between themes will cause an error/exception. [#8939](https://github.com/JabRef/jabref/pull/8939)
+- We fixed a bug where files that were deleted in the source bibtex file were kept in the index. [8962](https://github.com/JabRef/jabref/pull/8962)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -857,7 +857,7 @@ public class LibraryTab extends Tab {
         public IndexUpdateListener() {
             if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
                 try {
-                    indexingTaskManager.addToIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
+                    indexingTaskManager.updateIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
                 } catch (IOException e) {
                     LOGGER.error("Cannot access lucene index", e);
                 }

--- a/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
+++ b/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
@@ -69,7 +69,7 @@ public class RebuildFulltextSearchIndexAction extends SimpleCommand {
         }
         try {
             currentLibraryTab.get().getIndexingTaskManager().createIndex(PdfIndexer.of(databaseContext, filePreferences));
-            currentLibraryTab.get().getIndexingTaskManager().addToIndex(PdfIndexer.of(databaseContext, filePreferences), databaseContext);
+            currentLibraryTab.get().getIndexingTaskManager().updateIndex(PdfIndexer.of(databaseContext, filePreferences), databaseContext);
         } catch (IOException e) {
             dialogService.notify(Localization.lang("Failed to access fulltext search index"));
             LOGGER.error("Failed to access fulltext search index", e);

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -2,6 +2,7 @@ package org.jabref.logic.pdf.search.indexing;
 
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.jabref.gui.util.BackgroundTask;
@@ -88,11 +89,18 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         enqueueTask(() -> indexer.createIndex());
     }
 
-    public void addToIndex(PdfIndexer indexer, BibDatabaseContext databaseContext) {
+    public void updateIndex(PdfIndexer indexer, BibDatabaseContext databaseContext) {
+        Set<String> pathsToRemove = indexer.getListOfFilePaths();
         for (BibEntry entry : databaseContext.getEntries()) {
             for (LinkedFile file : entry.getFiles()) {
+                System.out.println("Adding file " + file.getLink());
                 enqueueTask(() -> indexer.addToIndex(entry, file, databaseContext));
+                pathsToRemove.remove(file.getLink());
             }
+        }
+        for (String pathToRemove : pathsToRemove) {
+            System.out.println("Removing file " + pathToRemove);
+            enqueueTask(() -> indexer.removeFromIndex(pathToRemove));
         }
     }
 
@@ -108,7 +116,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
 
     public void removeFromIndex(PdfIndexer indexer, BibEntry entry, List<LinkedFile> linkedFiles) {
         for (LinkedFile file : linkedFiles) {
-            enqueueTask(() -> indexer.removeFromIndex(entry, file));
+            enqueueTask(() -> indexer.removeFromIndex(file.getLink()));
         }
     }
 

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -93,13 +93,11 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         Set<String> pathsToRemove = indexer.getListOfFilePaths();
         for (BibEntry entry : databaseContext.getEntries()) {
             for (LinkedFile file : entry.getFiles()) {
-                System.out.println("Adding file " + file.getLink());
                 enqueueTask(() -> indexer.addToIndex(entry, file, databaseContext));
                 pathsToRemove.remove(file.getLink());
             }
         }
         for (String pathToRemove : pathsToRemove) {
-            System.out.println("Removing file " + pathToRemove);
             enqueueTask(() -> indexer.removeFromIndex(pathToRemove));
         }
     }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.jabref.gui.LibraryTab;
@@ -25,6 +27,8 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -110,19 +114,16 @@ public class PdfIndexer {
     }
 
     /**
-     * Removes a pdf file linked to one entry in the database from the index
+     * Removes a pdf file identified by its path from the index
      *
-     * @param entry the entry the file is linked to
-     * @param linkedFile the link to the file to be removed
+     * @param linkedFilePath the path to the file to be removed
      */
-    public void removeFromIndex(BibEntry entry, LinkedFile linkedFile) {
+    public void removeFromIndex(String linkedFilePath) {
         try (IndexWriter indexWriter = new IndexWriter(
                 directoryToIndex,
                 new IndexWriterConfig(
                         new EnglishStemAnalyzer()).setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND))) {
-            if (!entry.getFiles().isEmpty()) {
-                indexWriter.deleteDocuments(new Term(SearchFieldConstants.PATH, linkedFile.getLink()));
-            }
+            indexWriter.deleteDocuments(new Term(SearchFieldConstants.PATH, linkedFilePath));
             indexWriter.commit();
         } catch (IOException e) {
             LOGGER.warn("Could not initialize the IndexWriter!", e);
@@ -145,7 +146,7 @@ public class PdfIndexer {
      */
     public void removeFromIndex(BibEntry entry, List<LinkedFile> linkedFiles) {
         for (LinkedFile linkedFile : linkedFiles) {
-            removeFromIndex(entry, linkedFile);
+            removeFromIndex(linkedFile.getLink());
         }
     }
 
@@ -223,5 +224,26 @@ public class PdfIndexer {
         } catch (IOException e) {
             LOGGER.warn("Could not add the document {} to the index!", linkedFile.getLink(), e);
         }
+    }
+
+    /**
+     * Lists the paths of all the files that are stored in the index
+     *
+     * @return all file paths
+     */
+    public Set<String> getListOfFilePaths() {
+        Set<String> paths = new HashSet<>();
+        try (IndexReader reader = DirectoryReader.open(directoryToIndex)) {
+            IndexSearcher searcher = new IndexSearcher(reader);
+            MatchAllDocsQuery query = new MatchAllDocsQuery();
+            TopDocs allDocs = searcher.search(query, Integer.MAX_VALUE);
+            for (ScoreDoc scoreDoc : allDocs.scoreDocs) {
+                Document doc = reader.document(scoreDoc.doc);
+                paths.add(doc.getField(SearchFieldConstants.PATH).stringValue());
+            }
+        } catch (IOException e) {
+            return paths;
+        }
+        return paths;
     }
 }


### PR DESCRIPTION
A user might have deleted a link to a fulltext-file in the source tex
file and we need to reflect that change in the index as well.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
