### PR TITLE
Lucene search backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where removing several groups deletes only one of them. [#8390](https://github.com/JabRef/jabref/issues/8390)
 - We fixed an issue where the Sidepane (groups, web search and open office) width is not remembered after restarting JabRef. [#8907](https://github.com/JabRef/jabref/issues/8907)
 - We fixed a bug where switching between themes will cause an error/exception. [#8939](https://github.com/JabRef/jabref/pull/8939)
+- We fixed a bug where files that were deleted in the source bibtex file were kept in the index. [8962](https://github.com/JabRef/jabref/pull/8962)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -855,12 +855,13 @@ public class LibraryTab extends Tab {
     private class IndexUpdateListener {
 
         public IndexUpdateListener() {
-            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
-                try {
-                    indexingTaskManager.updateIndex(LuceneIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()));
-                } catch (IOException e) {
-                    LOGGER.error("Cannot access lucene index", e);
+            try {
+                indexingTaskManager.manageFulltextIndexAccordingToPrefs(LuceneIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()));
+                if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+                        indexingTaskManager.updateIndex(LuceneIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()));
                 }
+            } catch (IOException e) {
+                LOGGER.error("Cannot access lucene index", e);
             }
         }
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -857,7 +857,7 @@ public class LibraryTab extends Tab {
         public IndexUpdateListener() {
             if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
                 try {
-                    indexingTaskManager.addToIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
+                    indexingTaskManager.updateIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
                 } catch (IOException e) {
                     LOGGER.error("Cannot access lucene index", e);
                 }

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
@@ -28,7 +28,7 @@ import org.jabref.gui.util.TooltipTextUtil;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
-import org.jabref.model.pdf.search.PdfSearchResults;
+import org.jabref.model.pdf.search.LuceneSearchResults;
 import org.jabref.model.pdf.search.SearchResult;
 import org.jabref.model.search.rules.SearchRules;
 import org.jabref.preferences.PreferencesService;
@@ -83,7 +83,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
             documentViewerView = new DocumentViewerView();
         }
         this.entry = entry;
-        PdfSearchResults searchResults = stateManager.activeSearchQueryProperty().get().get().getRule().getFulltextResults(stateManager.activeSearchQueryProperty().get().get().getQuery(), entry);
+        LuceneSearchResults searchResults = stateManager.activeSearchQueryProperty().get().get().getRule().getLuceneResults(stateManager.activeSearchQueryProperty().get().get().getQuery(), entry);
 
         content.getChildren().clear();
 

--- a/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -12,7 +12,7 @@ import org.jabref.gui.externalfiletype.UnknownExternalFileType;
 import org.jabref.logic.cleanup.MoveFilesCleanup;
 import org.jabref.logic.cleanup.RenamePdfCleanup;
 import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
-import org.jabref.logic.pdf.search.indexing.PdfIndexer;
+import org.jabref.logic.pdf.search.indexing.LuceneIndexer;
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -81,7 +81,7 @@ public class ExternalFilesEntryLinker {
         }
 
         try {
-            indexingTaskManager.addToIndex(PdfIndexer.of(bibDatabaseContext, filePreferences), entry, bibDatabaseContext);
+            indexingTaskManager.addToIndex(LuceneIndexer.of(bibDatabaseContext, filePreferences), entry);
         } catch (IOException e) {
             LOGGER.error("Could not access Fulltext-Index", e);
         }
@@ -99,7 +99,7 @@ public class ExternalFilesEntryLinker {
         }
 
         try {
-            indexingTaskManager.addToIndex(PdfIndexer.of(bibDatabaseContext, filePreferences), entry, bibDatabaseContext);
+            indexingTaskManager.addToIndex(LuceneIndexer.of(bibDatabaseContext, filePreferences), entry);
         } catch (IOException e) {
             LOGGER.error("Could not access Fulltext-Index", e);
         }

--- a/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
+++ b/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
@@ -9,7 +9,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.pdf.search.indexing.PdfIndexer;
+import org.jabref.logic.pdf.search.indexing.LuceneIndexer;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.preferences.FilePreferences;
 
@@ -68,8 +68,8 @@ public class RebuildFulltextSearchIndexAction extends SimpleCommand {
             return;
         }
         try {
-            currentLibraryTab.get().getIndexingTaskManager().createIndex(PdfIndexer.of(databaseContext, filePreferences));
-            currentLibraryTab.get().getIndexingTaskManager().updateIndex(PdfIndexer.of(databaseContext, filePreferences), databaseContext);
+            currentLibraryTab.get().getIndexingTaskManager().createIndex(LuceneIndexer.of(databaseContext, filePreferences));
+            currentLibraryTab.get().getIndexingTaskManager().updateIndex(LuceneIndexer.of(databaseContext, filePreferences));
         } catch (IOException e) {
             dialogService.notify(Localization.lang("Failed to access fulltext search index"));
             LOGGER.error("Failed to access fulltext search index", e);

--- a/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
+++ b/src/main/java/org/jabref/gui/search/RebuildFulltextSearchIndexAction.java
@@ -69,7 +69,7 @@ public class RebuildFulltextSearchIndexAction extends SimpleCommand {
         }
         try {
             currentLibraryTab.get().getIndexingTaskManager().createIndex(PdfIndexer.of(databaseContext, filePreferences));
-            currentLibraryTab.get().getIndexingTaskManager().addToIndex(PdfIndexer.of(databaseContext, filePreferences), databaseContext);
+            currentLibraryTab.get().getIndexingTaskManager().updateIndex(PdfIndexer.of(databaseContext, filePreferences), databaseContext);
         } catch (IOException e) {
             dialogService.notify(Localization.lang("Failed to access fulltext search index"));
             LOGGER.error("Failed to access fulltext search index", e);

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -2,6 +2,7 @@ package org.jabref.logic.pdf.search.indexing;
 
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.jabref.gui.util.BackgroundTask;
@@ -88,11 +89,18 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         enqueueTask(() -> indexer.createIndex());
     }
 
-    public void addToIndex(PdfIndexer indexer, BibDatabaseContext databaseContext) {
+    public void updateIndex(PdfIndexer indexer, BibDatabaseContext databaseContext) {
+        Set<String> pathsToRemove = indexer.getListOfFilePaths();
         for (BibEntry entry : databaseContext.getEntries()) {
             for (LinkedFile file : entry.getFiles()) {
+                System.out.println("Adding file " + file.getLink());
                 enqueueTask(() -> indexer.addToIndex(entry, file, databaseContext));
+                pathsToRemove.remove(file.getLink());
             }
+        }
+        for (String pathToRemove : pathsToRemove) {
+            System.out.println("Removing file " + pathToRemove);
+            enqueueTask(() -> indexer.removeFromIndex(pathToRemove));
         }
     }
 
@@ -108,7 +116,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
 
     public void removeFromIndex(PdfIndexer indexer, BibEntry entry, List<LinkedFile> linkedFiles) {
         for (LinkedFile file : linkedFiles) {
-            enqueueTask(() -> indexer.removeFromIndex(entry, file));
+            enqueueTask(() -> indexer.removeFromIndex(file.getLink()));
         }
     }
 

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -89,6 +89,16 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         enqueueTask(() -> indexer.createIndex());
     }
 
+    public void manageFulltextIndexAccordingToPrefs(LuceneIndexer indexer) {
+        indexer.getFilePreferences().fulltextIndexLinkedFilesProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue.booleanValue()) {
+                enqueueTask(() -> indexer.updateIndex());
+            } else {
+                enqueueTask(() -> indexer.deleteLinkedFilesIndex());
+            }
+        });
+    }
+
     public void updateIndex(LuceneIndexer indexer) {
         Set<String> pathsToRemove = indexer.getListOfFilePaths();
         Set<Integer> hashesOfEntriesToRemove = indexer.getDatabaseContext().getEntries().stream().map(BibEntry::updateAndGetIndexHash).collect(Collectors.toSet());

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.pdf.search.indexing;
 
-import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -102,21 +101,15 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
     }
 
     public void addToIndex(LuceneIndexer indexer, BibEntry entry) {
-        enqueueTask(() -> addToIndex(indexer, entry));
-    }
-
-    public void removeFromIndex(LuceneIndexer indexer, List<LinkedFile> linkedFiles) {
-        for (LinkedFile file : linkedFiles) {
-            enqueueTask(() -> indexer.removeFromIndex(file.getLink()));
-        }
+        enqueueTask(() -> indexer.addToIndex(entry));
     }
 
     public void removeFromIndex(LuceneIndexer indexer, BibEntry entry) {
-        enqueueTask(() -> removeFromIndex(indexer, entry));
+        enqueueTask(() -> indexer.removeFromIndex(entry));
     }
 
     public void updateIndex(LuceneIndexer indexer, BibEntry entry) {
-        enqueueTask(() -> updateIndex(indexer, entry));
+        enqueueTask(() -> indexer.updateIndex(entry));
     }
 
     public void updateDatabaseName(String name) {

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -93,13 +93,11 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
         Set<String> pathsToRemove = indexer.getListOfFilePaths();
         for (BibEntry entry : databaseContext.getEntries()) {
             for (LinkedFile file : entry.getFiles()) {
-                System.out.println("Adding file " + file.getLink());
                 enqueueTask(() -> indexer.addToIndex(entry, file, databaseContext));
                 pathsToRemove.remove(file.getLink());
             }
         }
         for (String pathToRemove : pathsToRemove) {
-            System.out.println("Removing file " + pathToRemove);
             enqueueTask(() -> indexer.removeFromIndex(pathToRemove));
         }
     }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -92,7 +92,9 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
     public void manageFulltextIndexAccordingToPrefs(LuceneIndexer indexer) {
         indexer.getFilePreferences().fulltextIndexLinkedFilesProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue.booleanValue()) {
-                enqueueTask(() -> indexer.updateIndex());
+                for (BibEntry bibEntry : indexer.getDatabaseContext().getEntries()) {
+                    enqueueTask(() -> indexer.updateIndex(bibEntry, List.of()));
+                }
             } else {
                 enqueueTask(() -> indexer.deleteLinkedFilesIndex());
             }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/LuceneIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/LuceneIndexer.java
@@ -224,12 +224,6 @@ public class LuceneIndexer {
         }
     }
 
-    public void updateIndex() {
-        for (BibEntry bibEntry : databaseContext.getEntries()) {
-            updateIndex(bibEntry, List.of());
-        }
-    }
-
     public void updateIndex(BibEntry entry, List<LinkedFile> removedFiles) {
         int oldHash = entry.getLastIndexHash();
         int newHash = entry.updateAndGetIndexHash();

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/PdfIndexer.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.jabref.gui.LibraryTab;
@@ -25,6 +27,8 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -110,19 +114,16 @@ public class PdfIndexer {
     }
 
     /**
-     * Removes a pdf file linked to one entry in the database from the index
+     * Removes a pdf file identified by its path from the index
      *
-     * @param entry the entry the file is linked to
-     * @param linkedFile the link to the file to be removed
+     * @param linkedFilePath the path to the file to be removed
      */
-    public void removeFromIndex(BibEntry entry, LinkedFile linkedFile) {
+    public void removeFromIndex(String linkedFilePath) {
         try (IndexWriter indexWriter = new IndexWriter(
                 directoryToIndex,
                 new IndexWriterConfig(
                         new EnglishStemAnalyzer()).setOpenMode(IndexWriterConfig.OpenMode.CREATE_OR_APPEND))) {
-            if (!entry.getFiles().isEmpty()) {
-                indexWriter.deleteDocuments(new Term(SearchFieldConstants.PATH, linkedFile.getLink()));
-            }
+            indexWriter.deleteDocuments(new Term(SearchFieldConstants.PATH, linkedFilePath));
             indexWriter.commit();
         } catch (IOException e) {
             LOGGER.warn("Could not initialize the IndexWriter!", e);
@@ -145,7 +146,7 @@ public class PdfIndexer {
      */
     public void removeFromIndex(BibEntry entry, List<LinkedFile> linkedFiles) {
         for (LinkedFile linkedFile : linkedFiles) {
-            removeFromIndex(entry, linkedFile);
+            removeFromIndex(linkedFile.getLink());
         }
     }
 
@@ -223,5 +224,26 @@ public class PdfIndexer {
         } catch (IOException e) {
             LOGGER.warn("Could not add the document {} to the index!", linkedFile.getLink(), e);
         }
+    }
+
+    /**
+     * Lists the paths of all the files that are stored in the index
+     *
+     * @return all file paths
+     */
+    public Set<String> getListOfFilePaths() {
+        Set<String> paths = new HashSet<>();
+        try (IndexReader reader = DirectoryReader.open(directoryToIndex)) {
+            IndexSearcher searcher = new IndexSearcher(reader);
+            MatchAllDocsQuery query = new MatchAllDocsQuery();
+            TopDocs allDocs = searcher.search(query, Integer.MAX_VALUE);
+            for (ScoreDoc scoreDoc : allDocs.scoreDocs) {
+                Document doc = reader.document(scoreDoc.doc);
+                paths.add(doc.getField(SearchFieldConstants.PATH).stringValue());
+            }
+        } catch (IOException e) {
+            return paths;
+        }
+        return paths;
     }
 }

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -230,8 +230,9 @@ public class BibDatabaseContext {
         Path appData = getFulltextIndexBasePath();
 
         if (getDatabasePath().isPresent()) {
-            LOGGER.info("Index path for {} is {}", getDatabasePath().get(), appData);
-            return appData.resolve(String.valueOf(this.getDatabasePath().get().hashCode()));
+            Path databasePath = appData.resolve(String.valueOf(this.getDatabasePath().get().hashCode()));
+            LOGGER.info("Index path for {} is {}", getDatabasePath().get(), databasePath);
+            return databasePath;
         }
 
         return appData.resolve("unsaved");

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -57,6 +57,7 @@ public class BibEntry implements Cloneable {
     public static final EntryType DEFAULT_TYPE = StandardEntryType.Misc;
     private static final Logger LOGGER = LoggerFactory.getLogger(BibEntry.class);
     private final SharedBibEntryData sharedBibEntryData;
+    private int lastIndexHash;
 
     /**
      * Map to store the words in every field
@@ -815,6 +816,15 @@ public class BibEntry implements Cloneable {
     @Override
     public int hashCode() {
         return Objects.hash(type.getValue(), fields);
+    }
+
+    public int getLastIndexHash() {
+        return lastIndexHash;
+    }
+
+    public int updateAndGetIndexHash() {
+        lastIndexHash = hashCode();
+        return lastIndexHash;
     }
 
     public void registerListener(Object object) {

--- a/src/main/java/org/jabref/model/pdf/search/LuceneSearchResults.java
+++ b/src/main/java/org/jabref/model/pdf/search/LuceneSearchResults.java
@@ -5,15 +5,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-public final class PdfSearchResults {
+public final class LuceneSearchResults {
 
     private final List<SearchResult> searchResults;
 
-    public PdfSearchResults(List<SearchResult> search) {
+    public LuceneSearchResults(List<SearchResult> search) {
         this.searchResults = Collections.unmodifiableList(search);
     }
 
-    public PdfSearchResults() {
+    public LuceneSearchResults() {
         this.searchResults = Collections.emptyList();
     }
 

--- a/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
+++ b/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
@@ -1,9 +1,14 @@
 package org.jabref.model.pdf.search;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public class SearchFieldConstants {
 
     public static final String BIB_FIELDS_PREFIX = "bfp_";
     public static final String FILE_FIELDS_PREFIX = "f_";
+    public static final String BIB_ENTRY_ID_HASH = "id";
 
     public static final String PATH = FILE_FIELDS_PREFIX + "path";
     public static final String CONTENT = FILE_FIELDS_PREFIX + "content";
@@ -11,7 +16,8 @@ public class SearchFieldConstants {
     public static final String ANNOTATIONS = FILE_FIELDS_PREFIX + "annotations";
     public static final String MODIFIED = FILE_FIELDS_PREFIX + "modified";
 
-    public static final String[] PDF_FIELDS = new String[]{PATH, CONTENT, PAGE_NUMBER, MODIFIED, ANNOTATIONS};
+    public static final String[] PDF_FIELDS = new String[]{PATH, CONTENT, ANNOTATIONS};
+    public static Set<String> all_searchable_fields = Arrays.stream(PDF_FIELDS).collect(Collectors.toSet());
 
     public static final String VERSION = "lucene92_jabref0";
 }

--- a/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
+++ b/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
@@ -2,13 +2,16 @@ package org.jabref.model.pdf.search;
 
 public class SearchFieldConstants {
 
-    public static final String PATH = "path";
-    public static final String CONTENT = "content";
-    public static final String PAGE_NUMBER = "pageNumber";
-    public static final String ANNOTATIONS = "annotations";
-    public static final String MODIFIED = "modified";
+    public static final String BIB_FIELDS_PREFIX = "bfp_";
+    public static final String FILE_FIELDS_PREFIX = "f_";
+
+    public static final String PATH = FILE_FIELDS_PREFIX + "path";
+    public static final String CONTENT = FILE_FIELDS_PREFIX + "content";
+    public static final String PAGE_NUMBER = FILE_FIELDS_PREFIX + "pageNumber";
+    public static final String ANNOTATIONS = FILE_FIELDS_PREFIX + "annotations";
+    public static final String MODIFIED = FILE_FIELDS_PREFIX + "modified";
 
     public static final String[] PDF_FIELDS = new String[]{PATH, CONTENT, PAGE_NUMBER, MODIFIED, ANNOTATIONS};
 
-    public static final String VERSION = "lucene92";
+    public static final String VERSION = "lucene92_jabref0";
 }

--- a/src/main/java/org/jabref/model/pdf/search/SearchResult.java
+++ b/src/main/java/org/jabref/model/pdf/search/SearchResult.java
@@ -19,6 +19,7 @@ import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
 import org.apache.lucene.search.highlight.TextFragment;
 
 import static org.jabref.model.pdf.search.SearchFieldConstants.ANNOTATIONS;
+import static org.jabref.model.pdf.search.SearchFieldConstants.BIB_ENTRY_ID_HASH;
 import static org.jabref.model.pdf.search.SearchFieldConstants.CONTENT;
 import static org.jabref.model.pdf.search.SearchFieldConstants.MODIFIED;
 import static org.jabref.model.pdf.search.SearchFieldConstants.PAGE_NUMBER;
@@ -30,34 +31,44 @@ public final class SearchResult {
 
     private final int pageNumber;
     private final long modified;
+    private final int hash;
 
     private final float luceneScore;
     private List<String> contentResultStringsHtml;
     private List<String> annotationsResultStringsHtml;
 
     public SearchResult(IndexSearcher searcher, Query query, ScoreDoc scoreDoc) throws IOException {
-        this.path = getFieldContents(searcher, scoreDoc, PATH);
-        this.pageNumber = Integer.parseInt(getFieldContents(searcher, scoreDoc, PAGE_NUMBER));
-        this.modified = Long.parseLong(getFieldContents(searcher, scoreDoc, MODIFIED));
         this.luceneScore = scoreDoc.score;
+        this.path = getFieldContents(searcher, scoreDoc, PATH);
+        if (this.path.length() > 0) {
+            // pdf result
+            this.pageNumber = Integer.parseInt(getFieldContents(searcher, scoreDoc, PAGE_NUMBER));
+            this.modified = Long.parseLong(getFieldContents(searcher, scoreDoc, MODIFIED));
+            this.hash = 0;
 
-        String content = getFieldContents(searcher, scoreDoc, CONTENT);
-        String annotations = getFieldContents(searcher, scoreDoc, ANNOTATIONS);
+            String content = getFieldContents(searcher, scoreDoc, CONTENT);
+            String annotations = getFieldContents(searcher, scoreDoc, ANNOTATIONS);
 
-        Highlighter highlighter = new Highlighter(new SimpleHTMLFormatter("<b>", "</b>"), new QueryScorer(query));
+            Highlighter highlighter = new Highlighter(new SimpleHTMLFormatter("<b>", "</b>"), new QueryScorer(query));
 
-        try (TokenStream contentStream = new EnglishStemAnalyzer().tokenStream(CONTENT, content)) {
-            TextFragment[] frags = highlighter.getBestTextFragments(contentStream, content, true, 10);
-            this.contentResultStringsHtml = Arrays.stream(frags).map(TextFragment::toString).collect(Collectors.toList());
-        } catch (InvalidTokenOffsetsException e) {
-            this.contentResultStringsHtml = List.of();
-        }
+            try (TokenStream contentStream = new EnglishStemAnalyzer().tokenStream(CONTENT, content)) {
+                TextFragment[] frags = highlighter.getBestTextFragments(contentStream, content, true, 10);
+                this.contentResultStringsHtml = Arrays.stream(frags).map(TextFragment::toString).collect(Collectors.toList());
+            } catch (InvalidTokenOffsetsException e) {
+                this.contentResultStringsHtml = List.of();
+            }
 
-        try (TokenStream annotationStream = new EnglishStemAnalyzer().tokenStream(ANNOTATIONS, annotations)) {
-            TextFragment[] frags = highlighter.getBestTextFragments(annotationStream, annotations, true, 10);
-            this.annotationsResultStringsHtml = Arrays.stream(frags).map(TextFragment::toString).collect(Collectors.toList());
-        } catch (InvalidTokenOffsetsException e) {
-            this.annotationsResultStringsHtml = List.of();
+            try (TokenStream annotationStream = new EnglishStemAnalyzer().tokenStream(ANNOTATIONS, annotations)) {
+                TextFragment[] frags = highlighter.getBestTextFragments(annotationStream, annotations, true, 10);
+                this.annotationsResultStringsHtml = Arrays.stream(frags).map(TextFragment::toString).collect(Collectors.toList());
+            } catch (InvalidTokenOffsetsException e) {
+                this.annotationsResultStringsHtml = List.of();
+            }
+        } else {
+            // Found somewhere in the bib entry
+            this.hash = Integer.parseInt(getFieldContents(searcher, scoreDoc, BIB_ENTRY_ID_HASH));
+            this.pageNumber = -1;
+            this.modified = -1;
         }
     }
 
@@ -69,8 +80,11 @@ public final class SearchResult {
         return indexableField.stringValue();
     }
 
-    public boolean isResultFor(BibEntry entry) {
-        return entry.getFiles().stream().anyMatch(linkedFile -> path.equals(linkedFile.getLink()));
+    public float getSearchScoreFor(BibEntry entry) {
+        if (this.path != null) {
+            return entry.getFiles().stream().anyMatch(linkedFile -> path.equals(linkedFile.getLink())) ? luceneScore : 0;
+        }
+        return entry.getLastIndexHash() == hash ? luceneScore : 0;
     }
 
     public String getPath() {

--- a/src/main/java/org/jabref/model/search/rules/ContainsBasedSearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/ContainsBasedSearchRule.java
@@ -54,6 +54,6 @@ public class ContainsBasedSearchRule extends FullTextSearchRule {
             }
         }
 
-        return getFulltextResults(query, bibEntry).numSearchResults() > 0; // Didn't match all words.
+        return getLuceneResults(query, bibEntry).numSearchResults() > 0; // Didn't match all words.
     }
 }

--- a/src/main/java/org/jabref/model/search/rules/GrammarBasedSearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/GrammarBasedSearchRule.java
@@ -14,13 +14,13 @@ import java.util.stream.Collectors;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.gui.Globals;
-import org.jabref.logic.pdf.search.retrieval.PdfSearcher;
+import org.jabref.logic.pdf.search.retrieval.LuceneSearcher;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Keyword;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
-import org.jabref.model.pdf.search.PdfSearchResults;
+import org.jabref.model.pdf.search.LuceneSearchResults;
 import org.jabref.model.pdf.search.SearchResult;
 import org.jabref.model.search.rules.SearchRules.SearchFlags;
 import org.jabref.model.strings.StringUtil;
@@ -105,8 +105,8 @@ public class GrammarBasedSearchRule implements SearchRule {
             return;
         }
         try {
-            PdfSearcher searcher = PdfSearcher.of(databaseContext);
-            PdfSearchResults results = searcher.search(query, 5);
+            LuceneSearcher searcher = LuceneSearcher.of(databaseContext);
+            LuceneSearchResults results = searcher.search(query, 5);
             searchResults = results.getSortedByScore();
         } catch (IOException e) {
             LOGGER.error("Could not retrieve search results!", e);
@@ -119,13 +119,13 @@ public class GrammarBasedSearchRule implements SearchRule {
             return new BibtexSearchVisitor(searchFlags, bibEntry).visit(tree);
         } catch (Exception e) {
             LOGGER.debug("Search failed", e);
-            return getFulltextResults(query, bibEntry).numSearchResults() > 0;
+            return getLuceneResults(query, bibEntry).numSearchResults() > 0;
         }
     }
 
     @Override
-    public PdfSearchResults getFulltextResults(String query, BibEntry bibEntry) {
-        return new PdfSearchResults(searchResults.stream().filter(searchResult -> searchResult.isResultFor(bibEntry)).collect(Collectors.toList()));
+    public LuceneSearchResults getLuceneResults(String query, BibEntry bibEntry) {
+        return new LuceneSearchResults(searchResults.stream().filter(searchResult -> searchResult.getSearchScoreFor(bibEntry) > 0).collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/org/jabref/model/search/rules/RegexBasedSearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/RegexBasedSearchRule.java
@@ -57,6 +57,6 @@ public class RegexBasedSearchRule extends FullTextSearchRule {
                 }
             }
         }
-        return getFulltextResults(query, bibEntry).numSearchResults() > 0;
+        return getLuceneResults(query, bibEntry).numSearchResults() > 0;
     }
 }

--- a/src/main/java/org/jabref/model/search/rules/SearchRule.java
+++ b/src/main/java/org/jabref/model/search/rules/SearchRule.java
@@ -1,13 +1,13 @@
 package org.jabref.model.search.rules;
 
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.pdf.search.PdfSearchResults;
+import org.jabref.model.pdf.search.LuceneSearchResults;
 
 public interface SearchRule {
 
     boolean applyRule(String query, BibEntry bibEntry);
 
-    PdfSearchResults getFulltextResults(String query, BibEntry bibEntry);
+    LuceneSearchResults getLuceneResults(String query, BibEntry bibEntry);
 
     boolean validateSearchStrings(String query);
 }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -468,7 +468,7 @@ I\ Agree=I Agree
 
 Indexing\ pdf\ files=Indexing pdf files
 Indexing\ for\ %0=Indexing for %0
-%0\ of\ %1\ linked\ files\ added\ to\ the\ index=%0 of %1 linked files added to the index
+%0\ of\ %1\ entries\ added\ to\ the\ index=%0 of %1 entries added to the index
 
 Invalid\ citation\ key=Invalid citation key
 

--- a/src/test/java/org/jabref/logic/pdf/search/indexing/LuceneIndexerTest.java
+++ b/src/test/java/org/jabref/logic/pdf/search/indexing/LuceneIndexerTest.java
@@ -25,9 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PdfIndexerTest {
+public class LuceneIndexerTest {
 
-    private PdfIndexer indexer;
+    private LuceneIndexer indexer;
     private BibDatabase database;
     private BibDatabaseContext context = mock(BibDatabaseContext.class);
 
@@ -42,7 +42,7 @@ public class PdfIndexerTest {
         when(context.getFulltextIndexPath()).thenReturn(indexDir);
         when(context.getDatabase()).thenReturn(database);
         when(context.getEntries()).thenReturn(database.getEntries());
-        this.indexer = PdfIndexer.of(context, filePreferences);
+        this.indexer = LuceneIndexer.of(context, filePreferences);
     }
 
     @Test
@@ -54,7 +54,9 @@ public class PdfIndexerTest {
 
         // when
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -71,7 +73,9 @@ public class PdfIndexerTest {
 
         // when
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -88,7 +92,9 @@ public class PdfIndexerTest {
 
         // when
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -106,7 +112,9 @@ public class PdfIndexerTest {
 
         // when
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -124,7 +132,9 @@ public class PdfIndexerTest {
 
         // when
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -141,7 +151,9 @@ public class PdfIndexerTest {
         database.insertEntry(entry);
 
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
         // index actually exists
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
             assertEquals(33, reader.numDocs());
@@ -164,7 +176,9 @@ public class PdfIndexerTest {
         exampleThesis.setFiles(Collections.singletonList(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
         database.insertEntry(exampleThesis);
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
 
         // index with first entry
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {
@@ -176,7 +190,7 @@ public class PdfIndexerTest {
         metadata.setFiles(Collections.singletonList(new LinkedFile("Metadata file", "metaData.pdf", StandardFileType.PDF.getName())));
 
         // when
-        indexer.addToIndex(metadata, null);
+        indexer.addToIndex(metadata);
 
         // then
         try (IndexReader reader = DirectoryReader.open(new NIOFSDirectory(context.getFulltextIndexPath()))) {

--- a/src/test/java/org/jabref/logic/pdf/search/retrieval/LuceneSearcherTest.java
+++ b/src/test/java/org/jabref/logic/pdf/search/retrieval/LuceneSearcherTest.java
@@ -11,7 +11,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.model.pdf.search.PdfSearchResults;
+import org.jabref.model.pdf.search.LuceneSearchResults;
 import org.jabref.preferences.FilePreferences;
 
 import org.apache.lucene.queryparser.classic.ParseException;
@@ -25,9 +25,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PdfSearcherTest {
+public class LuceneSearcherTest {
 
-    private PdfSearcher search;
+    private LuceneSearcher search;
 
     @BeforeEach
     public void setUp(@TempDir Path indexDir) throws IOException {
@@ -54,7 +54,7 @@ public class PdfSearcherTest {
         database.insertEntry(exampleThesis);
 
         LuceneIndexer indexer = LuceneIndexer.of(context, filePreferences);
-        search = PdfSearcher.of(context);
+        search = LuceneSearcher.of(context);
 
         indexer.createIndex();
         for (BibEntry bibEntry : context.getEntries()) {
@@ -64,37 +64,37 @@ public class PdfSearcherTest {
 
     @Test
     public void searchForTest() throws IOException, ParseException {
-        PdfSearchResults result = search.search("test", 10);
+        LuceneSearchResults result = search.search("test", 10);
         assertEquals(8, result.numSearchResults());
     }
 
     @Test
     public void searchForUniversity() throws IOException, ParseException {
-        PdfSearchResults result = search.search("University", 10);
+        LuceneSearchResults result = search.search("University", 10);
         assertEquals(1, result.numSearchResults());
     }
 
     @Test
     public void searchForStopWord() throws IOException, ParseException {
-        PdfSearchResults result = search.search("and", 10);
+        LuceneSearchResults result = search.search("and", 10);
         assertEquals(0, result.numSearchResults());
     }
 
     @Test
     public void searchForSecond() throws IOException, ParseException {
-        PdfSearchResults result = search.search("second", 10);
+        LuceneSearchResults result = search.search("second", 10);
         assertEquals(4, result.numSearchResults());
     }
 
     @Test
     public void searchForAnnotation() throws IOException, ParseException {
-        PdfSearchResults result = search.search("annotation", 10);
+        LuceneSearchResults result = search.search("annotation", 10);
         assertEquals(2, result.numSearchResults());
     }
 
     @Test
     public void searchForEmptyString() throws IOException {
-        PdfSearchResults result = search.search("", 10);
+        LuceneSearchResults result = search.search("", 10);
         assertEquals(0, result.numSearchResults());
     }
 

--- a/src/test/java/org/jabref/logic/pdf/search/retrieval/PdfSearcherTest.java
+++ b/src/test/java/org/jabref/logic/pdf/search/retrieval/PdfSearcherTest.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 
-import org.jabref.logic.pdf.search.indexing.PdfIndexer;
+import org.jabref.logic.pdf.search.indexing.LuceneIndexer;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -53,11 +53,13 @@ public class PdfSearcherTest {
         exampleThesis.setCitationKey("ExampleThesis");
         database.insertEntry(exampleThesis);
 
-        PdfIndexer indexer = PdfIndexer.of(context, filePreferences);
+        LuceneIndexer indexer = LuceneIndexer.of(context, filePreferences);
         search = PdfSearcher.of(context);
 
         indexer.createIndex();
-        indexer.addToIndex(context);
+        for (BibEntry bibEntry : context.getEntries()) {
+            indexer.addToIndex(bibEntry);
+        }
     }
 
     @Test


### PR DESCRIPTION
First draft of the switch to the Lucene Search Backend

Whats working:
- Added all bib-fields to the index
- BibEntry hash is used as an identifier in the index
- Both fulltext and bib-fields are indexed together, in the same index, in the background
- Can see in the code that searches in bib-fields are working as expected

Todo:
- Switch current search to use the lucene backend
- Deal with search-groups (can they be migrated?)
- Add the option to sort search-results by lucene score

Follow-ups:
- Improve fulltext-search-results display
- Improve query-entry (like #8356?)

Fixes #8857 
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
