### PR TITLE
Fixes koppor/jabref#521 - Allow to drag&drop selected bib entries to other library tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an extra option in the 'Find Unlinked Files' dialog view to ignore unnecessary files like Thumbs.db, DS_Store, etc. [koppor#373](https://github.com/koppor/jabref/issues/373)
 - JabRef now writes log files. Linux: `$home/.cache/jabref/logs/version`, Windows: `%APPDATA%\..\Local\harawata\jabref\version\logs`, Mac: `Users/.../Library/Logs/jabref/version`
 - We added an importer for Citavi backup files, support ".ctv5bak" and ".ctv6bak" file formats. [#8322](https://github.com/JabRef/jabref/issues/8322)
-- We added a feature about allowing drag selected entries and drop them to other opened inactive library tabs.
+- We added a feature to drag selected entries and drop them to other opened inactive library tabs [koppor521](https://github.com/koppor/jabref/issues/521).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an extra option in the 'Find Unlinked Files' dialog view to ignore unnecessary files like Thumbs.db, DS_Store, etc. [koppor#373](https://github.com/koppor/jabref/issues/373)
 - JabRef now writes log files. Linux: `$home/.cache/jabref/logs/version`, Windows: `%APPDATA%\..\Local\harawata\jabref\version\logs`, Mac: `Users/.../Library/Logs/jabref/version`
 - We added an importer for Citavi backup files, support ".ctv5bak" and ".ctv6bak" file formats. [#8322](https://github.com/JabRef/jabref/issues/8322)
+- We added a feature about allowing drag selected entries and drop them to other opened inactive library tabs.
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -222,6 +222,34 @@ public class JabRefFrame extends BorderPane {
                 } else {
                     tabbedPane.getTabs().remove(dndIndicator);
                 }
+                // Accept drag entries from MainTable
+                if (event.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES)) {
+                    event.acceptTransferModes(TransferMode.COPY);
+                    event.consume();
+                }
+            });
+
+            this.getScene().setOnDragEntered(event -> {
+                // It is necessary to setOnDragOver for newly opened tabs
+                tabbedPane.lookupAll(".tab").forEach(t -> {
+                    t.setOnDragOver(tabDragEvent -> {
+                        if(tabDragEvent.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES))
+                        {
+                            tabDragEvent.acceptTransferModes(TransferMode.COPY);
+                            tabDragEvent.consume();
+                        }
+                    });
+                    t.setOnDragDropped(tabDragEvent -> {
+                        for (Tab libraryTab : tabbedPane.getTabs()) {
+                            if (libraryTab.getId().equals(t.getId()) &&
+                                    !tabbedPane.getSelectionModel().getSelectedItem().equals(libraryTab)) {
+                                ((LibraryTab) libraryTab).dropEntry(stateManager.getLocalDragboard().getBibEntries());
+                            }
+                        }
+                        tabDragEvent.consume();
+                    });
+                });
+                event.consume();
             });
 
             this.getScene().setOnDragExited(event -> tabbedPane.getTabs().remove(dndIndicator));

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -231,21 +231,42 @@ public class JabRefFrame extends BorderPane {
 
             this.getScene().setOnDragEntered(event -> {
                 // It is necessary to setOnDragOver for newly opened tabs
+                // drag'n'drop on tabs covered dnd on tabbedPane, so dnd on tabs should contain all dnds on tabbedPane
                 tabbedPane.lookupAll(".tab").forEach(t -> {
                     t.setOnDragOver(tabDragEvent -> {
-                        if(tabDragEvent.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES)) {
+                        if (DragAndDropHelper.hasBibFiles(tabDragEvent.getDragboard())) {
+                            tabDragEvent.acceptTransferModes(TransferMode.ANY);
+                            if (!tabbedPane.getTabs().contains(dndIndicator)) {
+                                tabbedPane.getTabs().add(dndIndicator);
+                            }
+                            event.consume();
+                        } else {
+                            tabbedPane.getTabs().remove(dndIndicator);
+                        }
+
+                        if (tabDragEvent.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES)) {
                             tabDragEvent.acceptTransferModes(TransferMode.COPY);
                             tabDragEvent.consume();
                         }
                     });
+                    t.setOnDragExited(event1 -> tabbedPane.getTabs().remove(dndIndicator));
                     t.setOnDragDropped(tabDragEvent -> {
-                        for (Tab libraryTab : tabbedPane.getTabs()) {
-                            if (libraryTab.getId().equals(t.getId()) &&
-                                    !tabbedPane.getSelectionModel().getSelectedItem().equals(libraryTab)) {
-                                ((LibraryTab) libraryTab).dropEntry(stateManager.getLocalDragboard().getBibEntries());
+                        if (DragAndDropHelper.hasBibFiles(tabDragEvent.getDragboard())) {
+                            tabbedPane.getTabs().remove(dndIndicator);
+                            List<Path> bibFiles = DragAndDropHelper.getBibFiles(tabDragEvent.getDragboard());
+                            OpenDatabaseAction openDatabaseAction = this.getOpenDatabaseAction();
+                            openDatabaseAction.openFiles(bibFiles, true);
+                            tabDragEvent.setDropCompleted(true);
+                            tabDragEvent.consume();
+                        } else {
+                            for (Tab libraryTab : tabbedPane.getTabs()) {
+                                if (libraryTab.getId().equals(t.getId()) &&
+                                        !tabbedPane.getSelectionModel().getSelectedItem().equals(libraryTab)) {
+                                    ((LibraryTab) libraryTab).dropEntry(stateManager.getLocalDragboard().getBibEntries());
+                                }
                             }
+                            tabDragEvent.consume();
                         }
-                        tabDragEvent.consume();
                     });
                 });
                 event.consume();

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -233,8 +233,7 @@ public class JabRefFrame extends BorderPane {
                 // It is necessary to setOnDragOver for newly opened tabs
                 tabbedPane.lookupAll(".tab").forEach(t -> {
                     t.setOnDragOver(tabDragEvent -> {
-                        if(tabDragEvent.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES))
-                        {
+                        if(tabDragEvent.getDragboard().hasContent(DragAndDropDataFormats.ENTRIES)) {
                             tabDragEvent.acceptTransferModes(TransferMode.COPY);
                             tabDragEvent.consume();
                         }

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -2,11 +2,7 @@ package org.jabref.gui;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;
@@ -152,6 +148,10 @@ public class LibraryTab extends Tab {
         this.getDatabase().registerListener(new UpdateTimestampListener(preferencesService));
 
         this.entryEditor = new EntryEditor(this, externalFileTypes);
+
+        // set LibraryTab ID for drag'n'drop
+        // ID content doesn't matter, we only need different tabs to have different ID
+        this.setId(Long.valueOf(new Random().nextLong()).toString());
 
         Platform.runLater(() -> {
             EasyBind.subscribe(changedProperty, this::updateTabTitle);
@@ -756,6 +756,11 @@ public class LibraryTab extends Tab {
 
     public void paste() {
         mainTable.paste();
+    }
+
+    public void dropEntry(List<BibEntry> entriesToAdd)
+    {
+        mainTable.dropEntry(entriesToAdd);
     }
 
     public void cut() {

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -2,7 +2,11 @@ package org.jabref.gui;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -763,8 +763,7 @@ public class LibraryTab extends Tab {
         mainTable.paste();
     }
 
-    public void dropEntry(List<BibEntry> entriesToAdd)
-    {
+    public void dropEntry(List<BibEntry> entriesToAdd) {
         mainTable.dropEntry(entriesToAdd);
     }
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 
 import javafx.animation.PauseTransition;
 import javafx.application.Platform;

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -317,7 +317,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
     public void dropEntry(List<BibEntry> entriesToAdd)
     {
         for (BibEntry entry : entriesToAdd) {
-            importHandler.importEntryWithDuplicateCheck(database, entry);
+            importHandler.importEntryWithDuplicateCheck(database, (BibEntry) entry.clone());
         }
     }
 

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -314,8 +314,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         }
     }
 
-    public void dropEntry(List<BibEntry> entriesToAdd)
-    {
+    public void dropEntry(List<BibEntry> entriesToAdd) {
         for (BibEntry entry : entriesToAdd) {
             importHandler.importEntryWithDuplicateCheck(database, (BibEntry) entry.clone());
         }

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -314,6 +314,13 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         }
     }
 
+    public void dropEntry(List<BibEntry> entriesToAdd)
+    {
+        for (BibEntry entry : entriesToAdd) {
+            importHandler.importEntryWithDuplicateCheck(database, entry);
+        }
+    }
+
     private void handleOnDragOver(TableRow<BibEntryTableViewModel> row, BibEntryTableViewModel item, DragEvent event) {
         if (event.getDragboard().hasFiles()) {
             event.acceptTransferModes(TransferMode.ANY);
@@ -350,8 +357,9 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
         // The following is necesary to initiate the drag and drop in javafx, although we don't need the contents
         // It doesn't work without
+        // Drag'n'drop to other tabs use COPY TransferMode, drop to group sidepane use MOVE
         ClipboardContent content = new ClipboardContent();
-        Dragboard dragboard = startDragAndDrop(TransferMode.MOVE);
+        Dragboard dragboard = startDragAndDrop(TransferMode.COPY_OR_MOVE);
         content.put(DragAndDropDataFormats.ENTRIES, "");
         dragboard.setContent(content);
 


### PR DESCRIPTION
Fixed [https://github.com/koppor/jabref/issues/521](https://github.com/koppor/jabref/issues/521)

by adding a new feature that allows to drag selected entries, and drop them to other opened inactive bib library tabs.

### Behavior Description:

Now when dragging selected entries in main table, JabRef allows user to drop it on another opened library tab, and this item will be copied and added to the dropped library accordingly. Drop to current active tab is disallowed. If there're potential duplicated entries, JabRef will ask user to confirm and choose copy behavior (similar to ctrl-c/v copy and paste).

### Screenshots for UI changes:

[![screenshot.gif](https://s8.gifyu.com/images/screenshot.gif)](https://gifyu.com/image/SKPDF)

### Checklist / TODOs :

- [x] Code implement of this new feature
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
