### PR TITLE
Autosave folder and checkbox is remembered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed "Error while sending to JabRef" when the browser extension interacts with JabRef. [JabRef-Browser-Extension#479](https://github.com/JabRef/JabRef-Browser-Extension/issues/479)
 - We fixed a bug where updating group view mode (intersection or union) requires re-selecting groups to take effect. [#6998](https://github.com/JabRef/jabref/issues/6998)
 - We fixed a bug that prevented external group metadata changes from being merged. [#8873](https://github.com/JabRef/jabref/issues/8873)
+- We fixed the shared database opening dialog to remember autosave folder and tick. [#7516](https://github.com/JabRef/jabref/issues/7516)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
@@ -212,6 +212,9 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
         }
 
         sharedDatabasePreferences.setRememberPassword(rememberPassword.get());
+
+        sharedDatabasePreferences.setFolder(folder.getValue());
+        sharedDatabasePreferences.setAutosave(autosave.get());
     }
 
     /**
@@ -225,6 +228,8 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
         Optional<String> sharedDatabaseUser = sharedDatabasePreferences.getUser();
         Optional<String> sharedDatabasePassword = sharedDatabasePreferences.getPassword();
         boolean sharedDatabaseRememberPassword = sharedDatabasePreferences.getRememberPassword();
+        Optional<String> sharedDatabaseFolder = sharedDatabasePreferences.getFolder();
+        boolean sharedDatabaseAutosave = sharedDatabasePreferences.getAutosave();
         Optional<String> sharedDatabaseKeystoreFile = sharedDatabasePreferences.getKeyStoreFile();
 
         if (sharedDatabaseType.isPresent()) {
@@ -248,6 +253,9 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
         }
 
         rememberPassword.set(sharedDatabaseRememberPassword);
+        
+        sharedDatabaseFolder.ifPresent(folder::set);
+        autosave.set(sharedDatabaseAutosave);
     }
 
     private boolean isSharedDatabaseAlreadyPresent(DBMSConnectionProperties connectionProperties) {

--- a/src/main/java/org/jabref/logic/shared/prefs/SharedDatabasePreferences.java
+++ b/src/main/java/org/jabref/logic/shared/prefs/SharedDatabasePreferences.java
@@ -25,6 +25,8 @@ public class SharedDatabasePreferences {
     private static final String SHARED_DATABASE_NAME = "sharedDatabaseName";
     private static final String SHARED_DATABASE_USER = "sharedDatabaseUser";
     private static final String SHARED_DATABASE_PASSWORD = "sharedDatabasePassword";
+    private static final String SHARED_DATABASE_FOLDER = "sharedDatabaseFolder";
+    private static final String SHARED_DATABASE_AUTOSAVE = "sharedDatabaseAutosave";
     private static final String SHARED_DATABASE_REMEMBER_PASSWORD = "sharedDatabaseRememberPassword";
     private static final String SHARED_DATABASE_USE_SSL = "sharedDatabaseUseSSL";
     private static final String SHARED_DATABASE_KEYSTORE_FILE = "sharedDatabaseKeyStoreFile";
@@ -77,6 +79,14 @@ public class SharedDatabasePreferences {
         return internalPrefs.getBoolean(SHARED_DATABASE_REMEMBER_PASSWORD, false);
     }
 
+    public Optional<String> getFolder() {
+        return getOptionalValue(SHARED_DATABASE_FOLDER);
+    }
+
+    public boolean getAutosave() {
+        return internalPrefs.getBoolean(SHARED_DATABASE_AUTOSAVE, false);
+    }
+
     public boolean isUseSSL() {
         return internalPrefs.getBoolean(SHARED_DATABASE_USE_SSL, false);
     }
@@ -107,6 +117,14 @@ public class SharedDatabasePreferences {
 
     public void setRememberPassword(boolean rememberPassword) {
         internalPrefs.putBoolean(SHARED_DATABASE_REMEMBER_PASSWORD, rememberPassword);
+    }
+
+    public void setFolder(String folder) {
+        internalPrefs.put(SHARED_DATABASE_FOLDER, folder);
+    }
+
+    public void setAutosave(boolean autosave) {
+        internalPrefs.putBoolean(SHARED_DATABASE_AUTOSAVE, autosave);
     }
 
     public void setUseSSL(boolean useSSL) {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

With this changes, the autosave folder and tick in the shared database opening dialog is remembered for the next time. I introduced these two things as new attributes of `SharedDatabasePreferences`.

Fixes  #7516.

Please check if this changes are as intended. I have seen that there are preference attributes for all other elements of the shared database opening dialog, but not for these two. Maybe there is a reason for that. But I think the new changes more convenient when you frequently open the shared database and want to synchronize the same BIB file everytime.


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
