### PR TITLE
New tests for NumericFieldComparator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an importer for Citavi backup files, support ".ctv5bak" and ".ctv6bak" file formats. [#8322](https://github.com/JabRef/jabref/issues/8322)
 - We added a feature to drag selected entries and drop them to other opened inactive library tabs [koppor521](https://github.com/koppor/jabref/issues/521).
 - We added support for the [biblatex-apa](https://github.com/plk/biblatex-apa) legal entry types `Legislation`, `Legadminmaterial`, `Jurisdiction`, `Constitution` and `Legal` [#8931](https://github.com/JabRef/jabref/issues/8931)
+- We added tests Implementation of Multiple Condition Coverage (MCC) for isNumber method in [NumericFieldComparator class](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java).
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
+++ b/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
@@ -1,8 +1,8 @@
 package org.jabref.gui.util.comparator;
 
-import java.util.Comparator;
-
 import org.jabref.model.strings.StringUtil;
+
+import java.util.Comparator;
 
 /**
  * Comparator for numeric cases. The purpose of this class is to add the numeric comparison, because values are sorted
@@ -62,4 +62,8 @@ public class NumericFieldComparator implements Comparator<String> {
 
         return true;
     }
+    public boolean isNumberMethodPublic(String number){
+        return isNumber(number);
+    }
+
 }

--- a/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
+++ b/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
@@ -62,6 +62,7 @@ public class NumericFieldComparator implements Comparator<String> {
 
         return true;
     }
+
     public boolean isNumberMethodPublic(String number){
         return isNumber(number);
     }

--- a/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
+++ b/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
@@ -2,7 +2,7 @@ package org.jabref.gui.util.comparator;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NumericFieldComparatorTest {
 
@@ -72,4 +72,53 @@ public class NumericFieldComparatorTest {
     void compareNumericSignalAfterNumber() {
         assertEquals(-2, comparator.compare("5- ", "7+ "));
     }
+
+    // CT1
+    @Test
+    public void numberIsNull(){ assertFalse(comparator.isNumberMethodPublic(null)); }
+
+    // CT2
+    @Test
+    public void numberIsEmpty(){ assertFalse(comparator.isNumberMethodPublic("")); }
+
+    // CT3
+    @Test
+    public void numberIsMinusChar(){ assertFalse(comparator.isNumberMethodPublic("-")); }
+
+    // CT4
+    @Test
+    public void numberIsPlusChar(){ assertFalse(comparator.isNumberMethodPublic("+")); }
+
+    // CT5
+    @Test
+    public void numberIsAOneCharNumber(){ assertTrue(comparator.isNumberMethodPublic("1")); }
+
+    // CT6
+    @Test
+    public void numberIsAOneCharLetter(){ assertFalse(comparator.isNumberMethodPublic("a")); }
+
+    // CT7
+    @Test
+    public void numberBeginsWithMinusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+
+    // CT8
+    @Test
+    public void numberBeginsWithPlusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+
+    // CT9
+    @Test
+    public void numberBeginsWithMinusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("-12a3")); }
+
+    // CT10
+    @Test
+    public void numberBeginsWithPlusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("+12a3")); }
+
+    // CT11
+    @Test
+    public void numberHasDigit(){ assertFalse(comparator.isNumberMethodPublic("12a3")); }
+
+    // CT12
+    @Test
+    public void numberIsNumber(){ assertTrue(comparator.isNumberMethodPublic("11")); }
+
 }

--- a/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
+++ b/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
@@ -75,50 +75,74 @@ public class NumericFieldComparatorTest {
 
     // CT1
     @Test
-    public void numberIsNull(){ assertFalse(comparator.isNumberMethodPublic(null)); }
+    public void numberIsNull(){ 
+        assertFalse(comparator.isNumberMethodPublic(null)); 
+    }
 
     // CT2
     @Test
-    public void numberIsEmpty(){ assertFalse(comparator.isNumberMethodPublic("")); }
+    public void numberIsEmpty(){ 
+        assertFalse(comparator.isNumberMethodPublic("")); 
+    }
 
     // CT3
     @Test
-    public void numberIsMinusChar(){ assertFalse(comparator.isNumberMethodPublic("-")); }
+    public void numberIsMinusChar(){ 
+        assertFalse(comparator.isNumberMethodPublic("-")); 
+    }
 
     // CT4
     @Test
-    public void numberIsPlusChar(){ assertFalse(comparator.isNumberMethodPublic("+")); }
+    public void numberIsPlusChar(){ 
+        assertFalse(comparator.isNumberMethodPublic("+")); 
+    }
 
     // CT5
     @Test
-    public void numberIsAOneCharNumber(){ assertTrue(comparator.isNumberMethodPublic("1")); }
+    public void numberIsAOneCharNumber(){ 
+        assertTrue(comparator.isNumberMethodPublic("1")); 
+    }
 
     // CT6
     @Test
-    public void numberIsAOneCharLetter(){ assertFalse(comparator.isNumberMethodPublic("a")); }
+    public void numberIsAOneCharLetter(){ 
+        assertFalse(comparator.isNumberMethodPublic("a")); 
+    }
 
     // CT7
     @Test
-    public void numberBeginsWithMinusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+    public void numberBeginsWithMinusCharAndIsNumber(){ 
+        assertTrue(comparator.isNumberMethodPublic("-1")); 
+    }
 
     // CT8
     @Test
-    public void numberBeginsWithPlusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+    public void numberBeginsWithPlusCharAndIsNumber(){ 
+        assertTrue(comparator.isNumberMethodPublic("-1")); 
+    }
 
     // CT9
     @Test
-    public void numberBeginsWithMinusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("-12a3")); }
+    public void numberBeginsWithMinusCharAndHasDigit(){ 
+        assertFalse(comparator.isNumberMethodPublic("-12a3")); 
+    }
 
     // CT10
     @Test
-    public void numberBeginsWithPlusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("+12a3")); }
+    public void numberBeginsWithPlusCharAndHasDigit(){ 
+        assertFalse(comparator.isNumberMethodPublic("+12a3")); 
+    }
 
     // CT11
     @Test
-    public void numberHasDigit(){ assertFalse(comparator.isNumberMethodPublic("12a3")); }
+    public void numberHasDigit(){ 
+        assertFalse(comparator.isNumberMethodPublic("12a3"));
+    }
 
     // CT12
     @Test
-    public void numberIsNumber(){ assertTrue(comparator.isNumberMethodPublic("11")); }
+    public void numberIsNumber(){ 
+        assertTrue(comparator.isNumberMethodPublic("11")); 
+    }
 
 }


### PR DESCRIPTION
Implementation of Multiple Condition Coverage (MCC) for isNumber method in NumericFieldComparator class. There is no issue for it.

![image](https://user-images.githubusercontent.com/69814362/184046579-fc17e578-c9fa-40f2-9fd0-8e37d56afea5.png)
![image](https://user-images.githubusercontent.com/69814362/184046257-0e6a06ad-ff66-4bec-a033-15dbbbda6860.png)

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [X] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
