### PR TITLE
Keep EOL setting at backups

### DIFF
--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -228,11 +228,13 @@ public class SaveDatabaseAction {
     }
 
     private boolean saveDatabase(Path file, boolean selectedOnly, Charset encoding, SavePreferences.DatabaseSaveType saveType) throws SaveException {
+        // if this code is adapted, please also adapt org.jabref.logic.autosaveandbackup.BackupManager.performBackup
+
         GeneralPreferences generalPreferences = this.preferences.getGeneralPreferences();
         SavePreferences savePreferences = this.preferences.getSavePreferences()
                                                       .withSaveType(saveType);
+        BibDatabaseContext bibDatabaseContext = libraryTab.getBibDatabaseContext();
         try (AtomicFileWriter fileWriter = new AtomicFileWriter(file, encoding, savePreferences.shouldMakeBackup())) {
-            BibDatabaseContext bibDatabaseContext = libraryTab.getBibDatabaseContext();
             BibWriter bibWriter = new BibWriter(fileWriter, bibDatabaseContext.getDatabase().getNewLineSeparator());
             BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(bibWriter, generalPreferences, savePreferences, entryTypesManager);
 

--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.autosaveandbackup;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -20,7 +19,6 @@ import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SavePreferences;
 import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.logic.util.DelayTaskThrottler;
-import org.jabref.logic.util.OS;
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.event.BibDatabaseContextChangedEvent;

--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -57,7 +57,7 @@ public class BackupManager {
         this.bibDatabaseContext = bibDatabaseContext;
         this.entryTypesManager = entryTypesManager;
         this.preferences = preferences;
-        this.throttler = new DelayTaskThrottler(15000);
+        this.throttler = new DelayTaskThrottler(15_000);
 
         changeFilter = new CoarseChangeFilter(bibDatabaseContext);
         changeFilter.registerListener(this);
@@ -134,13 +134,13 @@ public class BackupManager {
     }
 
     private void performBackup(Path backupPath) {
-        try {
-            Charset charset = bibDatabaseContext.getMetaData().getEncoding().orElse(StandardCharsets.UTF_8);
-            GeneralPreferences generalPreferences = preferences.getGeneralPreferences();
-            SavePreferences savePreferences = preferences.getSavePreferences()
-                                                         .withMakeBackup(false);
-            Writer writer = new AtomicFileWriter(backupPath, charset);
-            BibWriter bibWriter = new BibWriter(writer, OS.NEWLINE);
+        // code similar to org.jabref.gui.exporter.SaveDatabaseAction.saveDatabase
+        GeneralPreferences generalPreferences = preferences.getGeneralPreferences();
+        SavePreferences savePreferences = preferences.getSavePreferences()
+                                                     .withMakeBackup(false);
+        Charset encoding = bibDatabaseContext.getMetaData().getEncoding().orElse(StandardCharsets.UTF_8);
+        try (AtomicFileWriter fileWriter = new AtomicFileWriter(backupPath, encoding)) {
+            BibWriter bibWriter = new BibWriter(fileWriter, bibDatabaseContext.getDatabase().getNewLineSeparator());
             new BibtexDatabaseWriter(bibWriter, generalPreferences, savePreferences, entryTypesManager)
                     .saveDatabase(bibDatabaseContext);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -157,7 +157,7 @@ public class BackupManager {
 
         // do not print errors in field values into the log during autosave
         if (!isErrorInField) {
-            LOGGER.error("Error while saving to file" + backupPath, e);
+            LOGGER.error("Error while saving to file {}", backupPath, e);
         }
     }
 

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -193,7 +193,7 @@ public class FileUtil {
      *
      * @param fromFile The source filename to rename
      * @param toFile   The target fileName
-     * @return True if the rename was successful, false if an exception occurred
+     * @return True if rename was successful, false if an exception occurred
      */
     public static boolean renameFile(Path fromFile, Path toFile) {
         return renameFile(fromFile, toFile, false);
@@ -204,8 +204,8 @@ public class FileUtil {
      *
      * @param fromFile        The source filename to rename
      * @param toFile          The target fileName
-     * @param replaceExisting Wether to replace existing files or not
-     * @return True if the rename was successful, false if an exception occurred
+     * @param replaceExisting Whether to replace existing files or not
+     * @return True if rename was successful, false if an exception occurred
      * @deprecated Use {@link Files#move(Path, Path, CopyOption...)} instead and handle exception properly
      */
     @Deprecated


### PR DESCRIPTION
The BackupManager did not honor the EOL setting of the library. It could be that users hit strange messages when starting JabRef. This PR fixes that.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
