### PR TITLE
Add unit tests for BibStringDiff Class

### DIFF
--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibStringDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibStringDiffTest.java
@@ -31,4 +31,48 @@ public class BibStringDiffTest {
         List<BibStringDiff> result = BibStringDiff.compare(originalDataBase, newDataBase);
         assertEquals(List.of(diff), result);
     }
+
+    @Test
+    void compareTestDefault() throws Exception {
+
+        BibtexString BibStringDiff_that  = new BibtexString("name1", "content1");
+        BibtexString BibStringDiff_other  = new BibtexString("name2", "content2");
+
+        Boolean result = BibStringDiff_that .equals(BibStringDiff_other);
+
+        assertEquals(true, result);
+    }
+    @Test
+    void compareTestNull() throws Exception {
+
+        BibtexString BibStringDiff_that  = new BibtexString("name1", "content1");
+        BibtexString BibStringDiff_other = null;
+
+        Boolean result = BibStringDiff_that.equals(BibStringDiff_other);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    void compareDiferentTestDefault() throws Exception {
+
+        BibtexString BibStringDiff_that  = new BibtexString("name1", "content1");
+        String BibStringDiff_other = "bora";
+
+        Boolean result = BibStringDiff_that.equals(BibStringDiff_other);
+
+        assertEquals(false, result);
+    }
+
+    @Test
+    void compareSameTestDefault() throws Exception {
+
+      
+        BibtexString BibStringDiff_that  = new BibtexString("name1", "content1");
+        BibtexString BibStringDiff_other  = new BibtexString("name2", "content2");
+
+        Boolean result = BibStringDiff_that.equals(BibStringDiff_other);
+
+        assertEquals(false, result);
+    }
 }


### PR DESCRIPTION
Implementation of Multiple Condition Coverage (MCC) for isNumber method in BibStringDiff class. There is no issue for it. Done to Study and Pratice Test Covarage and Unity Testing




- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
