### PR TITLE
Close OO connection on JabRef exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a bug where spaces are trimmed when highlighting differences in the Entries merge dialog. [koppor#371](https://github.com/koppor/jabref/issues/371)
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
+- We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/JabRefMain.java
+++ b/src/main/java/org/jabref/gui/JabRefMain.java
@@ -15,6 +15,7 @@ import javafx.stage.Stage;
 
 import org.jabref.cli.ArgumentProcessor;
 import org.jabref.cli.JabRefCLI;
+import org.jabref.gui.openoffice.OOBibBaseConnect;
 import org.jabref.gui.remote.JabRefMessageHandler;
 import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -131,6 +132,7 @@ public class JabRefMain extends Application {
 
     @Override
     public void stop() {
+        OOBibBaseConnect.closeOfficeConnection();
         Globals.stopBackgroundTasks();
         Globals.shutdownThreadPools();
     }

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
@@ -79,7 +79,7 @@ public class OOBibBaseConnect {
     }
 
     /**
-     *  Close any open office connection, if none exists does nothing
+     * Close any open office connection, if none exists does nothing
      */
     public static void closeOfficeConnection() {
         try {

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
@@ -95,7 +95,7 @@ public class OOBibBaseConnect {
                 }
             }
         } catch (Exception ex) {
-            LOGGER.error("Exception disposing office process connection bridge:", ex);
+            LOGGER.error("Exception disposing office process connection bridge", ex);
         }
     }
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.sun.star.uno.UnoRuntime.queryInterface;
+
 /**
  * Establish connection to a document opened in OpenOffice or LibreOffice.
  */

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
@@ -15,6 +15,8 @@ import org.jabref.model.openoffice.uno.UnoCast;
 import org.jabref.model.openoffice.uno.UnoTextDocument;
 import org.jabref.model.openoffice.util.OOResult;
 
+import com.sun.star.bridge.XBridge;
+import com.sun.star.bridge.XBridgeFactory;
 import com.sun.star.comp.helper.BootstrapException;
 import com.sun.star.container.NoSuchElementException;
 import com.sun.star.container.XEnumeration;
@@ -25,11 +27,16 @@ import com.sun.star.lang.XComponent;
 import com.sun.star.lang.XMultiComponentFactory;
 import com.sun.star.text.XTextDocument;
 import com.sun.star.uno.XComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import static com.sun.star.uno.UnoRuntime.queryInterface;
 /**
  * Establish connection to a document opened in OpenOffice or LibreOffice.
  */
-class OOBibBaseConnect {
+public class OOBibBaseConnect {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OOBibBaseConnect.class);
 
     private final DialogService dialogService;
     private final XDesktop xDesktop;
@@ -68,6 +75,27 @@ class OOBibBaseConnect {
             throw new CreationException(e.getMessage());
         }
         return UnoCast.cast(XDesktop.class, desktop).get();
+    }
+
+    /**
+     *  Close any open office connection, if none exists does nothing
+     */
+    public static void closeOfficeConnection() {
+        try {
+            // get the bridge factory from the local service manager
+            XBridgeFactory bridgeFactory = queryInterface(XBridgeFactory.class,
+                                                          org.jabref.gui.openoffice.Bootstrap.createSimpleServiceManager()
+                    .createInstance("com.sun.star.bridge.BridgeFactory"));
+
+            if (bridgeFactory != null) {
+                for (XBridge bridge : bridgeFactory.getExistingBridges()) {
+                    // dispose of this bridge after closing its connection
+                    queryInterface(XComponent.class, bridge).dispose();
+                }
+            }
+        } catch (Exception ex) {
+            LOGGER.error("Exception disposing office process connection bridge:", ex);
+        }
     }
 
     private static List<XTextDocument> getTextDocuments(XDesktop desktop)
@@ -125,15 +153,15 @@ class OOBibBaseConnect {
         // auto-detecting instances, so we need to show dialog in FX
         // thread
         Optional<DocumentTitleViewModel> selectedDocument =
-                (dialogService
+                dialogService
                         .showChoiceDialogAndWait(Localization.lang("Select document"),
                                 Localization.lang("Found documents:"),
                                 Localization.lang("Use selected document"),
-                                viewModel));
+                                viewModel);
 
-        return (selectedDocument
+        return selectedDocument
                 .map(DocumentTitleViewModel::getXtextDocument)
-                .orElse(null));
+                .orElse(null);
     }
 
     /**
@@ -157,7 +185,7 @@ class OOBibBaseConnect {
         List<XTextDocument> textDocumentList = getTextDocuments(this.xDesktop);
         if (textDocumentList.isEmpty()) {
             throw new NoDocumentFoundException("No Writer documents found");
-        } else if (textDocumentList.size() == 1 && autoSelectForSingle) {
+        } else if ((textDocumentList.size() == 1) && autoSelectForSingle) {
             selected = textDocumentList.get(0); // Get the only one
         } else { // Bring up a dialog
             selected = OOBibBaseConnect.selectDocumentDialog(textDocumentList,
@@ -233,4 +261,4 @@ class OOBibBaseConnect {
             return UnoTextDocument.getFrameTitle(this.xTextDocument);
         }
     }
-} // end of OOBibBaseConnect
+}


### PR DESCRIPTION
Fixes #9075 

Closes the OO-Bridge when JabRef exits. If none is open, nothing happens. Otherwise the bridge is closed, JabRef exits but the LO document stays open

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
