### PR TITLE
Fix for #9068: Fix capitalization after en-dash characters in title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a bug where spaces are trimmed when highlighting differences in the Entries merge dialog. [koppor#371](https://github.com/koppor/jabref/issues/371)
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
+- Title case capitalizes after en-dash in title. [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
@@ -10,30 +10,42 @@ import java.util.stream.Collectors;
 /**
  * Represents a word in a title of a bibtex entry.
  * <p>
- * A word can have protected chars (enclosed in '{' '}') and may be a small (a, an, the, ...) word.
+ * A word can have protected chars (enclosed in '{' '}') and may be a small (a,
+ * an, the, ...) word.
  */
 public final class Word {
     /**
      * Set containing common lowercase function words
      */
     public static final Set<String> SMALLER_WORDS;
+    public static final Set<Character> DASHES_N_HYPHENS;
     private final char[] chars;
     private final boolean[] protectedChars;
 
     static {
         Set<String> smallerWords = new HashSet<>();
+        Set<Character> dashesAndHyphens = new HashSet<>();
 
         // Articles
         smallerWords.addAll(Arrays.asList("a", "an", "the"));
         // Prepositions
-        smallerWords.addAll(Arrays.asList("above", "about", "across", "against", "along", "among", "around", "at", "before", "behind", "below", "beneath", "beside", "between", "beyond", "by", "down", "during", "except", "for", "from", "in", "inside", "into", "like", "near", "of", "off", "on", "onto", "since", "to", "toward", "through", "under", "until", "up", "upon", "with", "within", "without"));
+        smallerWords.addAll(Arrays.asList("above", "about", "across", "against", "along", "among", "around", "at",
+                "before", "behind", "below", "beneath", "beside", "between", "beyond", "by", "down", "during", "except",
+                "for", "from", "in", "inside", "into", "like", "near", "of", "off", "on", "onto", "since", "to",
+                "toward", "through", "under", "until", "up", "upon", "with", "within", "without"));
         // Conjunctions
         smallerWords.addAll(Arrays.asList("and", "but", "for", "nor", "or", "so", "yet"));
 
+        // Dashes and Hyphens
+        dashesAndHyphens.addAll(Arrays.asList('-', '~', '֊', '־', '᐀', '‐', '‑', '‒', '–', '—', '―', '⁓', '⁻', '₋', '−',
+                '⸗', '⸺', '⸻', '〜', '〰', '゠', '︱', '︲', '﹘', '﹣', '－'));
+
         // unmodifiable for thread safety
         SMALLER_WORDS = smallerWords.stream()
-                            .map(word -> word.toLowerCase(Locale.ROOT))
-                            .collect(Collectors.toUnmodifiableSet());
+                .map(word -> word.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
+
+        DASHES_N_HYPHENS = dashesAndHyphens;
     }
 
     public Word(char[] chars, boolean[] protectedChars) {
@@ -46,7 +58,8 @@ public final class Word {
     }
 
     /**
-     * Case-insensitive check against {@link Word#SMALLER_WORDS}. Checks for common function words.
+     * Case-insensitive check against {@link Word#SMALLER_WORDS}. Checks for common
+     * function words.
      */
     public static boolean isSmallerWord(String word) {
         return SMALLER_WORDS.contains(word.toLowerCase(Locale.ROOT));
@@ -77,9 +90,9 @@ public final class Word {
     public void toUpperFirst() {
         for (int i = 0; i < chars.length; i++) {
             if (!protectedChars[i]) {
-                chars[i] = (i == 0) ?
-                        Character.toUpperCase(chars[i]) :
-                        Character.toLowerCase(chars[i]);
+                chars[i] = (i == 0 || DASHES_N_HYPHENS.contains(chars[i - 1]))
+                        ? Character.toUpperCase(chars[i])
+                        : Character.toLowerCase(chars[i]);
             }
         }
     }

--- a/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Tests in addition to the general tests from {@link org.jabref.logic.formatter.FormatterTest}
+ * Tests in addition to the general tests from
+ * {@link org.jabref.logic.formatter.FormatterTest}
  */
 public class CapitalizeFormatterTest {
 
@@ -41,8 +42,47 @@ public class CapitalizeFormatterTest {
             "upper each {NOT} first, Upper Each {NOT} First", // multiple words lower case with {}
             "Upper {E}ach {NOT} First, Upper {E}ach {NOT} First", // multiple words correct with {}
             "UPPER {E}ACH {NOT} FIRST, Upper {E}ach {NOT} First", // multiple words upper case with {}
-            "upper each first {NOT} {this}, Upper Each First {NOT} {this}", // multiple words in lower and upper case with {}
-            "upper each first {N}OT {t}his, Upper Each First {N}ot {t}his", // multiple words in lower and upper case with {} part 2
+            "upper each first {NOT} {this}, Upper Each First {NOT} {this}", // multiple words in lower and upper case
+                                                                            // with {}
+            "upper each first {N}OT {t}his, Upper Each First {N}ot {t}his", // multiple words in lower and upper case
+                                                                            // with {} part 2
+            "first-second USING hypheN, First-Second Using Hyphen", // multiple words in lower and upper case using
+                                                                    // hyphen
+            "breaking Your Next TEST-cASE, Breaking Your Next Test-Case", // multiple words in lower and upper case
+                                                                          // using hyphen
+            "THIS looks〰LIKE a daSH, This Looks〰Like A Dash", // dash-like character
+            "one-dash, One-Dash", // testing all dash-like characters
+            "one~dash, One~Dash",
+            "one֊dash, One֊Dash",
+            "one־dash, One־Dash",
+            "one᐀dash, One᐀Dash",
+            "one‐dash, One‐Dash",
+            "one‑dash, One‑Dash",
+            "one‒dash, One‒Dash",
+            "one–dash, One–Dash",
+            "one—dash, One—Dash",
+            "one―dash, One―Dash",
+            "one⁓dash, One⁓Dash",
+            "one⁻dash, One⁻Dash",
+            "one₋dash, One₋Dash",
+            "one−dash, One−Dash",
+            "one⸗dash, One⸗Dash",
+            "one⸺dash, One⸺Dash",
+            "one⸻dash, One⸻Dash",
+            "one〜dash, One〜Dash",
+            "one〰dash, One〰Dash",
+            "one゠dash, One゠Dash",
+            "one︱dash, One︱Dash",
+            "one︲dash, One︲Dash",
+            "one﹘dash, One﹘Dash",
+            "one﹣dash, One﹣Dash",
+            "one－dash, One－Dash",
+            "--, --", // testing weird cases
+            "--this is one sentence, --This Is One Sentence",
+            "-d-o-i-t right-, -D-O-I-T Right-",
+            "testing hy---------------phen, Testing Hy---------------Phen",
+            "its getting cr--a---z-y, Its Getting Cr--A---Z-Y",
+            "does it wor⸻k with cra゠︱zy dashes?, Does It Wor⸻K With Cra゠︱Zy Dashes?",
     })
     public void testInputs(String input, String expectedResult) {
         String formattedStr = formatter.format(input);

--- a/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
@@ -25,324 +25,329 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IsiImporterTest {
 
-    private static final String FILE_ENDING = ".isi";
-    private final IsiImporter importer = new IsiImporter();
+        private static final String FILE_ENDING = ".isi";
+        private final IsiImporter importer = new IsiImporter();
 
-    private static Stream<String> fileNames() throws IOException {
-        Predicate<String> fileName = name -> name.startsWith("IsiImporterTest")
-                && !name.contains("Empty")
-                && name.endsWith(FILE_ENDING);
-        return ImporterTestEngine.getTestFiles(fileName).stream();
-    }
-
-    private static Stream<String> invalidFileNames() throws IOException {
-        Predicate<String> fileName = name -> !name.startsWith("IsiImporterTest");
-        return ImporterTestEngine.getTestFiles(fileName).stream();
-    }
-
-    @Test
-    public void testParseMonthException() {
-        IsiImporter.parseMonth("20l06 06-07");
-    }
-
-    @Test
-    public void testGetFormatName() {
-        assertEquals("ISI", importer.getName());
-    }
-
-    @Test
-    public void testGetCLIId() {
-        assertEquals("isi", importer.getId());
-    }
-
-    @Test
-    public void testsGetExtensions() {
-        assertEquals(StandardFileType.ISI, importer.getFileType());
-    }
-
-    @Test
-    public void testGetDescription() {
-        assertEquals("Importer for the ISI Web of Science, INSPEC and Medline format.",
-                importer.getDescription());
-    }
-
-    @ParameterizedTest
-    @MethodSource("fileNames")
-    public void testIsRecognizedFormatAccepted(String fileName) throws IOException {
-        ImporterTestEngine.testIsRecognizedFormat(importer, fileName);
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidFileNames")
-    public void testIsRecognizedFormatRejected(String fileName) throws IOException {
-        ImporterTestEngine.testIsNotRecognizedFormat(importer, fileName);
-    }
-
-    @Test
-    public void testProcessSubSup() {
-        HashMap<Field, String> subs = new HashMap<>();
-
-        subs.put(StandardField.TITLE, "/sub 3/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_3$", subs.get(StandardField.TITLE));
-
-        subs.put(StandardField.TITLE, "/sub   3   /");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_3$", subs.get(StandardField.TITLE));
-
-        subs.put(StandardField.TITLE, "/sub 31/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_{31}$", subs.get(StandardField.TITLE));
-
-        subs.put(StandardField.ABSTRACT, "/sub 3/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_3$", subs.get(StandardField.ABSTRACT));
-
-        subs.put(StandardField.REVIEW, "/sub 31/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_{31}$", subs.get(StandardField.REVIEW));
-
-        subs.put(StandardField.TITLE, "/sup 3/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$^3$", subs.get(StandardField.TITLE));
-
-        subs.put(StandardField.TITLE, "/sup 31/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$^{31}$", subs.get(StandardField.TITLE));
-
-        subs.put(StandardField.ABSTRACT, "/sup 3/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$^3$", subs.get(StandardField.ABSTRACT));
-
-        subs.put(StandardField.REVIEW, "/sup 31/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$^{31}$", subs.get(StandardField.REVIEW));
-
-        subs.put(StandardField.TITLE, "/sub $Hello/");
-        IsiImporter.processSubSup(subs);
-        assertEquals("$_{\\$Hello}$", subs.get(StandardField.TITLE));
-    }
-
-    @Test
-    public void testImportEntries1() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTest1.isi").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
-        BibEntry entry = entries.get(0);
-
-        assertEquals(1, entries.size());
-        assertEquals(Optional.of("Optical properties of MgO doped LiNbO$_3$ single crystals"),
-                entry.getField(StandardField.TITLE));
-        assertEquals(
-                Optional.of(
-                        "James Brown and James Marc Brown and Brown, J. M. and Brown, J. and Brown, J. M. and Brown, J."),
-                entry.getField(StandardField.AUTHOR));
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("Optical Materials"), entry.getField(StandardField.JOURNAL));
-        assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
-        assertEquals(Optional.of("28"), entry.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("5"), entry.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("467--72"), entry.getField(StandardField.PAGES));
-    }
-
-    @Test
-    public void testImportEntries2() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTest2.isi").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
-        BibEntry entry = entries.get(0);
-
-        assertEquals(3, entries.size());
-        assertEquals(Optional.of("Optical properties of MgO doped LiNbO$_3$ single crystals"),
-                entry.getField(StandardField.TITLE));
-        assertEquals(StandardEntryType.Misc, entry.getType());
-        assertEquals(Optional.of("Optical Materials"), entry.getField(StandardField.JOURNAL));
-        assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
-        assertEquals(Optional.of("28"), entry.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("5"), entry.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("467-72"), entry.getField(StandardField.PAGES));
-    }
-
-    @Test
-    public void testImportEntriesINSPEC() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestInspec.isi").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
-
-        BibEntry first = entries.get(0);
-        BibEntry second = entries.get(1);
-
-        if (first.getField(StandardField.TITLE).equals(
-                Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn$_2$P$_2$S$_6$ crystals"))) {
-            BibEntry tmp = first;
-            first = second;
-            second = tmp;
+        private static Stream<String> fileNames() throws IOException {
+                Predicate<String> fileName = name -> name.startsWith("IsiImporterTest")
+                                && !name.contains("Empty")
+                                && name.endsWith(FILE_ENDING);
+                return ImporterTestEngine.getTestFiles(fileName).stream();
         }
 
-        assertEquals(2, entries.size());
-        assertEquals(
-                Optional.of(
-                        "Second harmonic generation of continuous wave ultraviolet light and production of beta -BaB$_2$O$_4$ optical waveguides"),
-                first.getField(StandardField.TITLE));
-        assertEquals(StandardEntryType.Article, first.getType());
+        private static Stream<String> invalidFileNames() throws IOException {
+                Predicate<String> fileName = name -> !name.startsWith("IsiImporterTest");
+                return ImporterTestEngine.getTestFiles(fileName).stream();
+        }
 
-        assertEquals(Optional.of("Degl'Innocenti, R. and Guarino, A. and Poberaj, G. and Gunter, P."),
-                first.getField(StandardField.AUTHOR));
-        assertEquals(Optional.of("Applied Physics Letters"), first.getField(StandardField.JOURNAL));
-        assertEquals(Optional.of("2006"), first.getField(StandardField.YEAR));
-        assertEquals(Optional.of(Month.JULY), first.getMonth());
-        assertEquals(Optional.of("89"), first.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("4"), first.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("Lorem ipsum abstract"), first.getField(StandardField.ABSTRACT));
-        assertEquals(Optional.of("Aip"), first.getField(StandardField.PUBLISHER));
-        assertEquals(
-                Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn$_2$P$_2$S$_6$ crystals"),
-                second.getField(StandardField.TITLE));
-        assertEquals(StandardEntryType.Article, second.getType());
-    }
+        @Test
+        public void testParseMonthException() {
+                IsiImporter.parseMonth("20l06 06-07");
+        }
 
-    @Test
-    public void testImportEntriesWOS() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestWOS.isi").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        @Test
+        public void testGetFormatName() {
+                assertEquals("ISI", importer.getName());
+        }
 
-        BibEntry first = entries.get(0);
-        BibEntry second = entries.get(1);
+        @Test
+        public void testGetCLIId() {
+                assertEquals("isi", importer.getId());
+        }
 
-        assertEquals(2, entries.size());
+        @Test
+        public void testsGetExtensions() {
+                assertEquals(StandardFileType.ISI, importer.getFileType());
+        }
 
-        assertEquals(Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn2P2S6 crystals"),
-                first.getField(StandardField.TITLE));
-        assertEquals(Optional.of("Optical waveguides in Sn2P2S6 by low fluence MeV He+ ion implantation"),
-                second.getField(StandardField.TITLE));
+        @Test
+        public void testGetDescription() {
+                assertEquals("Importer for the ISI Web of Science, INSPEC and Medline format.",
+                                importer.getDescription());
+        }
 
-        assertEquals(Optional.of("Journal of Physics-condensed Matter"), first.getField(StandardField.JOURNAL));
-    }
+        @ParameterizedTest
+        @MethodSource("fileNames")
+        public void testIsRecognizedFormatAccepted(String fileName) throws IOException {
+                ImporterTestEngine.testIsRecognizedFormat(importer, fileName);
+        }
 
-    @Test
-    public void testIsiAuthorsConvert() {
-        assertEquals(
-                "James Brown and James Marc Brown and Brown, J. M. and Brown, J. and Brown, J. M. and Brown, J.",
-                IsiImporter.isiAuthorsConvert(
-                        "James Brown and James Marc Brown and Brown, J.M. and Brown, J. and Brown, J.M. and Brown, J."));
+        @ParameterizedTest
+        @MethodSource("invalidFileNames")
+        public void testIsRecognizedFormatRejected(String fileName) throws IOException {
+                ImporterTestEngine.testIsNotRecognizedFormat(importer, fileName);
+        }
 
-        assertEquals(
-                "Joffe, Hadine and Hall, Janet E. and Gruber, Staci and Sarmiento, Ingrid A. and Cohen, Lee S. and Yurgelun-Todd, Deborah and Martin, Kathryn A.",
-                IsiImporter.isiAuthorsConvert(
-                        "Joffe, Hadine; Hall, Janet E; Gruber, Staci; Sarmiento, Ingrid A; Cohen, Lee S; Yurgelun-Todd, Deborah; Martin, Kathryn A"));
-    }
+        @Test
+        public void testProcessSubSup() {
+                HashMap<Field, String> subs = new HashMap<>();
 
-    @Test
-    public void testMonthConvert() {
-        assertEquals("#jun#", IsiImporter.parseMonth("06"));
-        assertEquals("#jun#", IsiImporter.parseMonth("JUN"));
-        assertEquals("#jun#", IsiImporter.parseMonth("jUn"));
-        assertEquals("#may#", IsiImporter.parseMonth("MAY-JUN"));
-        assertEquals("#jun#", IsiImporter.parseMonth("2006 06"));
-        assertEquals("#jun#", IsiImporter.parseMonth("2006 06-07"));
-        assertEquals("#jul#", IsiImporter.parseMonth("2006 07 03"));
-        assertEquals("#may#", IsiImporter.parseMonth("2006 May-Jun"));
-    }
+                subs.put(StandardField.TITLE, "/sub 3/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_3$", subs.get(StandardField.TITLE));
 
-    @Test
-    public void testIsiAuthorConvert() {
-        assertEquals("James Brown", IsiImporter.isiAuthorConvert("James Brown"));
-        assertEquals("James Marc Brown", IsiImporter.isiAuthorConvert("James Marc Brown"));
-        assertEquals("Brown, J. M.", IsiImporter.isiAuthorConvert("Brown, J.M."));
-        assertEquals("Brown, J.", IsiImporter.isiAuthorConvert("Brown, J."));
-        assertEquals("Brown, J. M.", IsiImporter.isiAuthorConvert("Brown, JM"));
-        assertEquals("Brown, J.", IsiImporter.isiAuthorConvert("Brown, J"));
-        assertEquals("Brown, James", IsiImporter.isiAuthorConvert("Brown, James"));
-        assertEquals("Hall, Janet E.", IsiImporter.isiAuthorConvert("Hall, Janet E"));
-        assertEquals("", IsiImporter.isiAuthorConvert(""));
-    }
+                subs.put(StandardField.TITLE, "/sub   3   /");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_3$", subs.get(StandardField.TITLE));
 
-    @Test
-    public void testImportIEEEExport() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IEEEImport1.txt").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
-        BibEntry entry = entries.get(0);
+                subs.put(StandardField.TITLE, "/sub 31/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_{31}$", subs.get(StandardField.TITLE));
 
-        assertEquals(1, entries.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("Geoscience and Remote Sensing Letters, IEEE"), entry.getField(StandardField.JOURNAL));
-        assertEquals(Optional.of("Improving Urban Road Extraction in High-Resolution "
-                        + "Images Exploiting Directional Filtering, Perceptual " + "Grouping, and Simple Topological Concepts"),
-                entry.getField(StandardField.TITLE));
-        assertEquals(Optional.of("4"), entry.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("3"), entry.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("1545-598X"), entry.getField(new UnknownField("SN")));
-        assertEquals(Optional.of("387--391"), entry.getField(StandardField.PAGES));
-        assertEquals(Optional.of("Gamba, P. and Dell'Acqua, F. and Lisini, G."), entry.getField(StandardField.AUTHOR));
-        assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
-        assertEquals(Optional.of("Perceptual grouping, street extraction, urban remote sensing"),
-                entry.getField(StandardField.KEYWORDS));
-        assertEquals(Optional.of("Lorem ipsum abstract"), entry.getField(StandardField.ABSTRACT));
-    }
+                subs.put(StandardField.ABSTRACT, "/sub 3/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_3$", subs.get(StandardField.ABSTRACT));
 
-    @Test
-    public void testIEEEImport() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IEEEImport1.txt").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
-        BibEntry entry = entries.get(0);
+                subs.put(StandardField.REVIEW, "/sub 31/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_{31}$", subs.get(StandardField.REVIEW));
 
-        assertEquals(1, entries.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("Geoscience and Remote Sensing Letters, IEEE"), entry.getField(StandardField.JOURNAL));
-        assertEquals(
-                Optional.of(
-                        "Improving Urban Road Extraction in High-Resolution Images Exploiting Directional Filtering, Perceptual Grouping, and Simple Topological Concepts"),
-                entry.getField(StandardField.TITLE));
-        assertEquals(Optional.of("4"), entry.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("3"), entry.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("1545-598X"), entry.getField(new UnknownField("SN")));
-        assertEquals(Optional.of("387--391"), entry.getField(StandardField.PAGES));
-        assertEquals(Optional.of("Gamba, P. and Dell'Acqua, F. and Lisini, G."), entry.getField(StandardField.AUTHOR));
-        assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
-        assertEquals(Optional.of("Perceptual grouping, street extraction, urban remote sensing"),
-                entry.getField(StandardField.KEYWORDS));
-        assertEquals(Optional.of("Lorem ipsum abstract"), entry.getField(StandardField.ABSTRACT));
-    }
+                subs.put(StandardField.TITLE, "/sup 3/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$^3$", subs.get(StandardField.TITLE));
 
-    @Test
-    public void testImportEntriesMedline() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestMedline.isi").toURI());
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+                subs.put(StandardField.TITLE, "/sup 31/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$^{31}$", subs.get(StandardField.TITLE));
 
-        BibEntry first = entries.get(0);
-        BibEntry second = entries.get(1);
+                subs.put(StandardField.ABSTRACT, "/sup 3/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$^3$", subs.get(StandardField.ABSTRACT));
 
-        assertEquals(2, entries.size());
-        assertEquals(
-                Optional.of("Effects of modafinil on cognitive performance and alertness during sleep deprivation."),
-                first.getField(StandardField.TITLE));
-        assertEquals(Optional.of("Wesensten, Nancy J."), first.getField(StandardField.AUTHOR));
-        assertEquals(Optional.of("Curr Pharm Des"), first.getField(StandardField.JOURNAL));
-        assertEquals(Optional.of("2006"), first.getField(StandardField.YEAR));
-        assertEquals(Optional.empty(), first.getField(StandardField.MONTH));
-        assertEquals(Optional.of("12"), first.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("20"), first.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("2457--71"), first.getField(StandardField.PAGES));
-        assertEquals(StandardEntryType.Article, first.getType());
-        assertEquals(
-                Optional.of(
-                        "Estrogen therapy selectively enhances prefrontal cognitive processes: a randomized, double-blind, placebo-controlled study with functional magnetic resonance imaging in perimenopausal and recently postmenopausal women."),
-                second.getField(StandardField.TITLE));
-        assertEquals(
-                Optional.of(
-                        "Joffe, Hadine and Hall, Janet E. and Gruber, Staci and Sarmiento, Ingrid A. and Cohen, Lee S. and Yurgelun-Todd, Deborah and Martin, Kathryn A."),
-                second.getField(StandardField.AUTHOR));
-        assertEquals(Optional.of("2006"), second.getField(StandardField.YEAR));
-        assertEquals(Optional.of(Month.MAY), second.getMonth());
-        assertEquals(Optional.of("13"), second.getField(StandardField.VOLUME));
-        assertEquals(Optional.of("3"), second.getField(StandardField.NUMBER));
-        assertEquals(Optional.of("411--22"), second.getField(StandardField.PAGES));
-        assertEquals(StandardEntryType.Article, second.getType());
-    }
+                subs.put(StandardField.REVIEW, "/sup 31/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$^{31}$", subs.get(StandardField.REVIEW));
 
-    @Test
-    public void testImportEntriesEmpty() throws IOException, URISyntaxException {
-        Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestEmpty.isi").toURI());
+                subs.put(StandardField.TITLE, "/sub $Hello/");
+                IsiImporter.processSubSup(subs);
+                assertEquals("$_{\\$Hello}$", subs.get(StandardField.TITLE));
+        }
 
-        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        @Test
+        public void testImportEntries1() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTest1.isi").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+                BibEntry entry = entries.get(0);
 
-        assertEquals(1, entries.size());
-    }
+                assertEquals(1, entries.size());
+                assertEquals(Optional.of("Optical properties of MgO doped LiNbO$_3$ single crystals"),
+                                entry.getField(StandardField.TITLE));
+                assertEquals(
+                                Optional.of(
+                                                "James Brown and James Marc Brown and Brown, J. M. and Brown, J. and Brown, J. M. and Brown, J."),
+                                entry.getField(StandardField.AUTHOR));
+                assertEquals(StandardEntryType.Article, entry.getType());
+                assertEquals(Optional.of("Optical Materials"), entry.getField(StandardField.JOURNAL));
+                assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
+                assertEquals(Optional.of("28"), entry.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("5"), entry.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("467--72"), entry.getField(StandardField.PAGES));
+        }
+
+        @Test
+        public void testImportEntries2() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTest2.isi").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+                BibEntry entry = entries.get(0);
+
+                assertEquals(3, entries.size());
+                assertEquals(Optional.of("Optical properties of MgO doped LiNbO$_3$ single crystals"),
+                                entry.getField(StandardField.TITLE));
+                assertEquals(StandardEntryType.Misc, entry.getType());
+                assertEquals(Optional.of("Optical Materials"), entry.getField(StandardField.JOURNAL));
+                assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
+                assertEquals(Optional.of("28"), entry.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("5"), entry.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("467-72"), entry.getField(StandardField.PAGES));
+        }
+
+        @Test
+        public void testImportEntriesINSPEC() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestInspec.isi").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+
+                BibEntry first = entries.get(0);
+                BibEntry second = entries.get(1);
+
+                if (first.getField(StandardField.TITLE).equals(
+                                Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn$_2$P$_2$S$_6$ crystals"))) {
+                        BibEntry tmp = first;
+                        first = second;
+                        second = tmp;
+                }
+
+                assertEquals(2, entries.size());
+                assertEquals(
+                                Optional.of(
+                                                "Second harmonic generation of continuous wave ultraviolet light and production of beta -BaB$_2$O$_4$ optical waveguides"),
+                                first.getField(StandardField.TITLE));
+                assertEquals(StandardEntryType.Article, first.getType());
+
+                assertEquals(Optional.of("Degl'Innocenti, R. and Guarino, A. and Poberaj, G. and Gunter, P."),
+                                first.getField(StandardField.AUTHOR));
+                assertEquals(Optional.of("Applied Physics Letters"), first.getField(StandardField.JOURNAL));
+                assertEquals(Optional.of("2006"), first.getField(StandardField.YEAR));
+                assertEquals(Optional.of(Month.JULY), first.getMonth());
+                assertEquals(Optional.of("89"), first.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("4"), first.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("Lorem ipsum abstract"), first.getField(StandardField.ABSTRACT));
+                assertEquals(Optional.of("Aip"), first.getField(StandardField.PUBLISHER));
+                assertEquals(
+                                Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn$_2$P$_2$S$_6$ crystals"),
+                                second.getField(StandardField.TITLE));
+                assertEquals(StandardEntryType.Article, second.getType());
+        }
+
+        @Test
+        public void testImportEntriesWOS() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestWOS.isi").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+
+                BibEntry first = entries.get(0);
+                BibEntry second = entries.get(1);
+
+                assertEquals(2, entries.size());
+
+                assertEquals(Optional.of("Optical and photoelectric spectroscopy of photorefractive Sn2P2S6 crystals"),
+                                first.getField(StandardField.TITLE));
+                assertEquals(Optional.of("Optical waveguides in Sn2P2S6 by low fluence MeV He+ ion implantation"),
+                                second.getField(StandardField.TITLE));
+
+                assertEquals(Optional.of("Journal of Physics-Condensed Matter"), first.getField(StandardField.JOURNAL));
+        }
+
+        @Test
+        public void testIsiAuthorsConvert() {
+                assertEquals(
+                                "James Brown and James Marc Brown and Brown, J. M. and Brown, J. and Brown, J. M. and Brown, J.",
+                                IsiImporter.isiAuthorsConvert(
+                                                "James Brown and James Marc Brown and Brown, J.M. and Brown, J. and Brown, J.M. and Brown, J."));
+
+                assertEquals(
+                                "Joffe, Hadine and Hall, Janet E. and Gruber, Staci and Sarmiento, Ingrid A. and Cohen, Lee S. and Yurgelun-Todd, Deborah and Martin, Kathryn A.",
+                                IsiImporter.isiAuthorsConvert(
+                                                "Joffe, Hadine; Hall, Janet E; Gruber, Staci; Sarmiento, Ingrid A; Cohen, Lee S; Yurgelun-Todd, Deborah; Martin, Kathryn A"));
+        }
+
+        @Test
+        public void testMonthConvert() {
+                assertEquals("#jun#", IsiImporter.parseMonth("06"));
+                assertEquals("#jun#", IsiImporter.parseMonth("JUN"));
+                assertEquals("#jun#", IsiImporter.parseMonth("jUn"));
+                assertEquals("#may#", IsiImporter.parseMonth("MAY-JUN"));
+                assertEquals("#jun#", IsiImporter.parseMonth("2006 06"));
+                assertEquals("#jun#", IsiImporter.parseMonth("2006 06-07"));
+                assertEquals("#jul#", IsiImporter.parseMonth("2006 07 03"));
+                assertEquals("#may#", IsiImporter.parseMonth("2006 May-Jun"));
+        }
+
+        @Test
+        public void testIsiAuthorConvert() {
+                assertEquals("James Brown", IsiImporter.isiAuthorConvert("James Brown"));
+                assertEquals("James Marc Brown", IsiImporter.isiAuthorConvert("James Marc Brown"));
+                assertEquals("Brown, J. M.", IsiImporter.isiAuthorConvert("Brown, J.M."));
+                assertEquals("Brown, J.", IsiImporter.isiAuthorConvert("Brown, J."));
+                assertEquals("Brown, J. M.", IsiImporter.isiAuthorConvert("Brown, JM"));
+                assertEquals("Brown, J.", IsiImporter.isiAuthorConvert("Brown, J"));
+                assertEquals("Brown, James", IsiImporter.isiAuthorConvert("Brown, James"));
+                assertEquals("Hall, Janet E.", IsiImporter.isiAuthorConvert("Hall, Janet E"));
+                assertEquals("", IsiImporter.isiAuthorConvert(""));
+        }
+
+        @Test
+        public void testImportIEEEExport() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IEEEImport1.txt").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+                BibEntry entry = entries.get(0);
+
+                assertEquals(1, entries.size());
+                assertEquals(StandardEntryType.Article, entry.getType());
+                assertEquals(Optional.of("Geoscience and Remote Sensing Letters, IEEE"),
+                                entry.getField(StandardField.JOURNAL));
+                assertEquals(Optional.of("Improving Urban Road Extraction in High-Resolution "
+                                + "Images Exploiting Directional Filtering, Perceptual "
+                                + "Grouping, and Simple Topological Concepts"),
+                                entry.getField(StandardField.TITLE));
+                assertEquals(Optional.of("4"), entry.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("3"), entry.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("1545-598X"), entry.getField(new UnknownField("SN")));
+                assertEquals(Optional.of("387--391"), entry.getField(StandardField.PAGES));
+                assertEquals(Optional.of("Gamba, P. and Dell'Acqua, F. and Lisini, G."),
+                                entry.getField(StandardField.AUTHOR));
+                assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
+                assertEquals(Optional.of("Perceptual grouping, street extraction, urban remote sensing"),
+                                entry.getField(StandardField.KEYWORDS));
+                assertEquals(Optional.of("Lorem ipsum abstract"), entry.getField(StandardField.ABSTRACT));
+        }
+
+        @Test
+        public void testIEEEImport() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IEEEImport1.txt").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+                BibEntry entry = entries.get(0);
+
+                assertEquals(1, entries.size());
+                assertEquals(StandardEntryType.Article, entry.getType());
+                assertEquals(Optional.of("Geoscience and Remote Sensing Letters, IEEE"),
+                                entry.getField(StandardField.JOURNAL));
+                assertEquals(
+                                Optional.of(
+                                                "Improving Urban Road Extraction in High-Resolution Images Exploiting Directional Filtering, Perceptual Grouping, and Simple Topological Concepts"),
+                                entry.getField(StandardField.TITLE));
+                assertEquals(Optional.of("4"), entry.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("3"), entry.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("1545-598X"), entry.getField(new UnknownField("SN")));
+                assertEquals(Optional.of("387--391"), entry.getField(StandardField.PAGES));
+                assertEquals(Optional.of("Gamba, P. and Dell'Acqua, F. and Lisini, G."),
+                                entry.getField(StandardField.AUTHOR));
+                assertEquals(Optional.of("2006"), entry.getField(StandardField.YEAR));
+                assertEquals(Optional.of("Perceptual grouping, street extraction, urban remote sensing"),
+                                entry.getField(StandardField.KEYWORDS));
+                assertEquals(Optional.of("Lorem ipsum abstract"), entry.getField(StandardField.ABSTRACT));
+        }
+
+        @Test
+        public void testImportEntriesMedline() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestMedline.isi").toURI());
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+
+                BibEntry first = entries.get(0);
+                BibEntry second = entries.get(1);
+
+                assertEquals(2, entries.size());
+                assertEquals(
+                                Optional.of("Effects of modafinil on cognitive performance and alertness during sleep deprivation."),
+                                first.getField(StandardField.TITLE));
+                assertEquals(Optional.of("Wesensten, Nancy J."), first.getField(StandardField.AUTHOR));
+                assertEquals(Optional.of("Curr Pharm Des"), first.getField(StandardField.JOURNAL));
+                assertEquals(Optional.of("2006"), first.getField(StandardField.YEAR));
+                assertEquals(Optional.empty(), first.getField(StandardField.MONTH));
+                assertEquals(Optional.of("12"), first.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("20"), first.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("2457--71"), first.getField(StandardField.PAGES));
+                assertEquals(StandardEntryType.Article, first.getType());
+                assertEquals(
+                                Optional.of(
+                                                "Estrogen therapy selectively enhances prefrontal cognitive processes: a randomized, double-blind, placebo-controlled study with functional magnetic resonance imaging in perimenopausal and recently postmenopausal women."),
+                                second.getField(StandardField.TITLE));
+                assertEquals(
+                                Optional.of(
+                                                "Joffe, Hadine and Hall, Janet E. and Gruber, Staci and Sarmiento, Ingrid A. and Cohen, Lee S. and Yurgelun-Todd, Deborah and Martin, Kathryn A."),
+                                second.getField(StandardField.AUTHOR));
+                assertEquals(Optional.of("2006"), second.getField(StandardField.YEAR));
+                assertEquals(Optional.of(Month.MAY), second.getMonth());
+                assertEquals(Optional.of("13"), second.getField(StandardField.VOLUME));
+                assertEquals(Optional.of("3"), second.getField(StandardField.NUMBER));
+                assertEquals(Optional.of("411--22"), second.getField(StandardField.PAGES));
+                assertEquals(StandardEntryType.Article, second.getType());
+        }
+
+        @Test
+        public void testImportEntriesEmpty() throws IOException, URISyntaxException {
+                Path file = Path.of(IsiImporterTest.class.getResource("IsiImporterTestEmpty.isi").toURI());
+
+                List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+
+                assertEquals(1, entries.size());
+        }
 }


### PR DESCRIPTION
Fixes #9068

Title case capitalizes after en-dash in title.

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
