### PR TITLE
Fix issue 9068 - Fixing letter capitalization after hyphen or dash between 2 terms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,15 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Added
 
-- In case a backup is found, the filename of the backup is shown.
-- On startup, JabRef notifies the user if there were parsing errors during opening.
-- We integrated a new three-way merge UI for merging entries in the Entries Merger Dialog, the Duplicate Resolver Dialog, the Entry Importer Dialog, and the External Changes Resolver Dialog. [#8945](https://github.com/JabRef/jabref/pull/8945)
-- We added the ability to merge groups, keywords, comments and files when merging entries. [#9022](https://github.com/JabRef/jabref/pull/9022)
+- We added the possibility of capitalizing after en-dash characters in title. [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Changed
 
-- We improved the Citavi Importer to also import so called Knowledge-items into the field `comment` of the corresponding entry [#9025](https://github.com/JabRef/jabref/issues/9025)
-- We removed wrapping of string constants when writing to a `.bib` file.
-- We call backup files `.bak` and temporary writing files now `.sav`.
-- JabRef keeps 10 older versions of a `.bib` file in the [user data dir](https://github.com/harawata/appdirs#supported-directories) (instead of a single `.sav` (now: `.bak`) file in the directory of the `.bib` file)
-- We changed the button label from "Return to JabRef" to "Return to library" to better indicate the purpose of the action.
+- We Changed the Word.java file located in src/main/java/org/jabref/logic/formatter/casechanger/Word.java to solve the issue [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Fixed
 
-- The [HtmlToLaTeXFormatter](https://docs.jabref.org/finding-sorting-and-cleaning-entries/saveactions#html-to-latex) keeps single `<` characters.
-- We fixed a performance regression when opening large libraries [#9041](https://github.com/JabRef/jabref/issues/9041)
-- We fixed a bug where spaces are trimmed when highlighting differences in the Entries merge dialog. [koppor#371](https://github.com/koppor/jabref/issues/371)
-- We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
-- We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
-- We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
+- We fixed an issue where JabRef could not capitalize a character after a dash or hyphen inside a word. Issue [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/formatter/casechanger/TitleParser.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/TitleParser.java
@@ -21,9 +21,9 @@ public final class TitleParser {
 
         int index = 0;
         for (char c : title.toCharArray()) {
-            if (Character.isWhitespace(c)) {
+            if (Character.isWhitespace(c)){
                 createWord(isProtected).ifPresent(words::add);
-            } else {
+            }else {
                 if (wordStart == -1) {
                     wordStart = index;
                 }

--- a/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
@@ -75,14 +75,28 @@ public final class Word {
     }
 
     public void toUpperFirst() {
+        int dash_sentinela = 0;
         for (int i = 0; i < chars.length; i++) {
             if (!protectedChars[i]) {
-                chars[i] = (i == 0) ?
-                        Character.toUpperCase(chars[i]) :
-                        Character.toLowerCase(chars[i]);
+                if(i == 0){
+                    chars[i] = Character.toUpperCase(chars[i]);
+                }
+                else {
+                        if (chars[i] == '—' || chars[i] == '-') {
+                            dash_sentinela = 1;
+                            chars[i] = Character.toUpperCase(chars[i]);
+                            continue;
+                        }
+                        if (dash_sentinela == 1) {
+                            chars[i] = Character.toUpperCase(chars[i]);
+                            dash_sentinela = 0;
+                            continue;
+                        }
+                        chars[i] = Character.toLowerCase(chars[i]);
+                    }
+                }
             }
         }
-    }
 
     public boolean isSmallerWord() {
         // "word:" is still a small "word"

--- a/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -43,6 +43,12 @@ public class CapitalizeFormatterTest {
             "UPPER {E}ACH {NOT} FIRST, Upper {E}ach {NOT} First", // multiple words upper case with {}
             "upper each first {NOT} {this}, Upper Each First {NOT} {this}", // multiple words in lower and upper case with {}
             "upper each first {N}OT {t}his, Upper Each First {N}ot {t}his", // multiple words in lower and upper case with {} part 2
+            "upper each first including-this,Upper Each First Including-This", //multiple words in lower including words with a - inside
+            "upper each first including—this,Upper Each First Including—This", //multiple words in lower including words with a — (dash) inside
+            "upper Each first-including-this,Upper Each First-Including-This", // multiple words in lower and upper with multiple hifen and dash in
+            "upper Each first-including—this,Upper Each First-Including—This", // multiple words in lower and upper with multiple hifen and dash in
+            "UPPER Each first-INCLUDING-THIS,Upper Each First-Including-This", // multiple words in lower and upper with multiple dash in
+
     })
     public void testInputs(String input, String expectedResult) {
         String formattedStr = formatter.format(input);


### PR DESCRIPTION
What : 
I implemented a change in the Word.java file so that I can capitalize titles, with the capitalize function, that have a hyphen or a dash inside two terms. Like enzyme-catalyzed.

Why :
To solve the  issue [#9068].

Context:
I am currently studying tests in University and the Professor proposed a TDD application in JabRef.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
