### PR TITLE
Fixing capitalization in words with any dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an importer for Citavi backup files, support ".ctv5bak" and ".ctv6bak" file formats. [#8322](https://github.com/JabRef/jabref/issues/8322)
 - We added a feature to drag selected entries and drop them to other opened inactive library tabs [koppor521](https://github.com/koppor/jabref/issues/521).
 - We added support for the [biblatex-apa](https://github.com/plk/biblatex-apa) legal entry types `Legislation`, `Legadminmaterial`, `Jurisdiction`, `Constitution` and `Legal` [#8931](https://github.com/JabRef/jabref/issues/8931)
+- We added the capitalization of words with any dashes characters in title. [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Changed
 
@@ -40,6 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the preferences option "Warn about duplicates on import" option from the tab "File" to the tab "Import and Export". [koppor#570](https://github.com/koppor/jabref/issues/570)
 - When JabRef encounters `% Encoding: UTF-8` header, it is kept during writing (and not removed). [#8964](https://github.com/JabRef/jabref/pull/8964)
 - We replace characters which cannot be decoded using the specified encoding by a (probably another) valid character. This happens if JabRef detects the wrong charset (e.g., UTF-8 instead of Windows 1252). One can use the [Integrity Check](https://docs.jabref.org/finding-sorting-and-cleaning-entries/checkintegrity) to find those characters.
+- We changed the file Word.java to solve the issue [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Fixed
 
@@ -63,6 +65,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a bug where updating group view mode (intersection or union) requires re-selecting groups to take effect. [#6998](https://github.com/JabRef/jabref/issues/6998)
 - We fixed a bug that prevented external group metadata changes from being merged. [#8873](https://github.com/JabRef/jabref/issues/8873)
 - We fixed the shared database opening dialog to remember autosave folder and tick. [#7516](https://github.com/JabRef/jabref/issues/7516)
+- We fixed an issue where capitalization did not work for words with dashes and covered the zero width spaces. [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an importer for Citavi backup files, support ".ctv5bak" and ".ctv6bak" file formats. [#8322](https://github.com/JabRef/jabref/issues/8322)
 - We added a feature to drag selected entries and drop them to other opened inactive library tabs [koppor521](https://github.com/koppor/jabref/issues/521).
 - We added support for the [biblatex-apa](https://github.com/plk/biblatex-apa) legal entry types `Legislation`, `Legadminmaterial`, `Jurisdiction`, `Constitution` and `Legal` [#8931](https://github.com/JabRef/jabref/issues/8931)
-- We added the capitalization of words with any dashes characters in title. [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Changed
 
@@ -41,7 +40,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the preferences option "Warn about duplicates on import" option from the tab "File" to the tab "Import and Export". [koppor#570](https://github.com/koppor/jabref/issues/570)
 - When JabRef encounters `% Encoding: UTF-8` header, it is kept during writing (and not removed). [#8964](https://github.com/JabRef/jabref/pull/8964)
 - We replace characters which cannot be decoded using the specified encoding by a (probably another) valid character. This happens if JabRef detects the wrong charset (e.g., UTF-8 instead of Windows 1252). One can use the [Integrity Check](https://docs.jabref.org/finding-sorting-and-cleaning-entries/checkintegrity) to find those characters.
-- We changed the file Word.java to solve the issue [#9068](https://github.com/JabRef/jabref/issues/9068)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
+++ b/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
@@ -1,8 +1,8 @@
 package org.jabref.gui.util.comparator;
 
-import java.util.Comparator;
-
 import org.jabref.model.strings.StringUtil;
+
+import java.util.Comparator;
 
 /**
  * Comparator for numeric cases. The purpose of this class is to add the numeric comparison, because values are sorted
@@ -62,4 +62,8 @@ public class NumericFieldComparator implements Comparator<String> {
 
         return true;
     }
+    public boolean isNumberMethodPublic(String number){
+        return isNumber(number);
+    }
+
 }

--- a/src/main/java/org/jabref/logic/formatter/casechanger/TitleParser.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/TitleParser.java
@@ -15,6 +15,14 @@ public final class TitleParser {
     public List<Word> parse(String title) {
         List<Word> words = new LinkedList<>();
 
+        /**
+         * Remove possible zero width unicode characters
+         */
+        title = title.replaceAll("\u200B", "");
+        title = title.replaceAll("\u200C", "");
+        title = title.replaceAll("\u200D", "");
+        title = title.replaceAll("\uFEFF", "");
+
         boolean[] isProtected = determineProtectedChars(title);
 
         reset();

--- a/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
@@ -1,10 +1,8 @@
 package org.jabref.logic.formatter.casechanger;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
+import com.sun.star.lang.IllegalArgumentException;
+
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -77,9 +75,16 @@ public final class Word {
     public void toUpperFirst() {
         for (int i = 0; i < chars.length; i++) {
             if (!protectedChars[i]) {
-                chars[i] = (i == 0) ?
-                        Character.toUpperCase(chars[i]) :
-                        Character.toLowerCase(chars[i]);
+                if (i == 0) {
+                    chars[i] = Character.toUpperCase(chars[i]);
+                }
+                else if (hasAnyDash(chars[i])) {
+                    chars[i+1] = Character.toUpperCase(chars[i+1]);
+                    i++;
+                }
+                else {
+                    chars[i] = Character.toLowerCase(chars[i]);
+                }
             }
         }
     }
@@ -100,5 +105,19 @@ public final class Word {
 
     public boolean endsWithColon() {
         return this.toString().endsWith(":");
+    }
+
+    public boolean hasAnyDash(char c) {
+        char[] dashes = {'\u002D', '\u058A', '\u05BE', '\u1400', '\u1806', '\u2010',
+                '\u2011', '\u2012', '\u2013', '\u2014', '\u2015', '\u2E17',
+                '\u2E1A', '\u2E3A', '\u2E3B', '\u2E40', '\u301C', '\u3030',
+                '\u30A0', '\uFE31', '\uFE32', '\uFE58', '\uFE63', '\uFF0D'};
+
+        for (char x : dashes) {
+            if (x == c) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
+++ b/src/test/java/org/jabref/gui/util/comparator/NumericFieldComparatorTest.java
@@ -2,7 +2,7 @@ package org.jabref.gui.util.comparator;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NumericFieldComparatorTest {
 
@@ -72,4 +72,53 @@ public class NumericFieldComparatorTest {
     void compareNumericSignalAfterNumber() {
         assertEquals(-2, comparator.compare("5- ", "7+ "));
     }
+
+    // CT1
+    @Test
+    public void numberIsNull(){ assertFalse(comparator.isNumberMethodPublic(null)); }
+
+    // CT2
+    @Test
+    public void numberIsEmpty(){ assertFalse(comparator.isNumberMethodPublic("")); }
+
+    // CT3
+    @Test
+    public void numberIsMinusChar(){ assertFalse(comparator.isNumberMethodPublic("-")); }
+
+    // CT4
+    @Test
+    public void numberIsPlusChar(){ assertFalse(comparator.isNumberMethodPublic("+")); }
+
+    // CT5
+    @Test
+    public void numberIsAOneCharNumber(){ assertTrue(comparator.isNumberMethodPublic("1")); }
+
+    // CT6
+    @Test
+    public void numberIsAOneCharLetter(){ assertFalse(comparator.isNumberMethodPublic("a")); }
+
+    // CT7
+    @Test
+    public void numberBeginsWithMinusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+
+    // CT8
+    @Test
+    public void numberBeginsWithPlusCharAndIsNumber(){ assertTrue(comparator.isNumberMethodPublic("-1")); }
+
+    // CT9
+    @Test
+    public void numberBeginsWithMinusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("-12a3")); }
+
+    // CT10
+    @Test
+    public void numberBeginsWithPlusCharAndHasDigit(){ assertFalse(comparator.isNumberMethodPublic("+12a3")); }
+
+    // CT11
+    @Test
+    public void numberHasDigit(){ assertFalse(comparator.isNumberMethodPublic("12a3")); }
+
+    // CT12
+    @Test
+    public void numberIsNumber(){ assertTrue(comparator.isNumberMethodPublic("11")); }
+
 }

--- a/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -59,30 +59,30 @@ public class CapitalizeFormatterTest {
             "multiple-{words} with-{h}yphen right-now {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words lower case with hyphen and {}
             "Multiple-{words} With-{h}yphen Right-Now {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words correct with hyphen and {}
             "MULTIPLE-{words} WITH-{h}yphen RIGHT-NOW {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words upper case with hyphen and {}
-            "with\u002Dother dashes, With\u002DOther Dashes", // words with hyphen-minus
-            "with\u058Aother dashes, With\u058AOther Dashes", // words with armenian hyphen
-            "with\u05BEother dashes, With\u05BEOther Dashes", // words with hebrew punctuation maqaf
-            "with\u1400other dashes, With\u1400Other Dashes", // words with canadian syllabics hyphen
-            "with\u1806other dashes, With\u1806Other Dashes", // words with mongolian todo soft hyphen
-            "with\u2010other dashes, With\u2010Other Dashes", // words with hyphen
-            "with\u2011other dashes, With\u2011Other Dashes", // words with non-breaking hyphen
-            "with\u2012other dashes, With\u2012Other Dashes", // words with figure dash
-            "with\u2013other dashes, With\u2013Other Dashes", // words with en dash
-            "with\u2014other dashes, With\u2014Other Dashes", // words with em dash
-            "with\u2015other dashes, With\u2015Other Dashes", // words with horizontal bar
-            "with\u2E17other dashes, With\u2E17Other Dashes", // words with double oblique hyphen
-            "with\u2E1Aother dashes, With\u2E1AOther Dashes", // words with hyphen with diaeresis
-            "with\u2E3Aother dashes, With\u2E3AOther Dashes", // words with two-em dash
-            "with\u2E3Bother dashes, With\u2E3BOther Dashes", // words with three-em dash
-            "with\u2E40other dashes, With\u2E40Other Dashes", // words with double hyphen
-            "with\u301Cother dashes, With\u301COther Dashes", // words with wave dash
-            "with\u3030other dashes, With\u3030Other Dashes", // words with wavy dash
-            "with\u30A0other dashes, With\u30A0Other Dashes", // words with katakana-hiraga double hyphen
-            "with\uFE31other dashes, With\uFE31Other Dashes", // words with vertical em dash
-            "with\uFE32other dashes, With\uFE32Other Dashes", // words with vertical en dash
-            "with\uFE58other dashes, With\uFE58Other Dashes", // words with small em dash
-            "with\uFE63other dashes, With\uFE63Other Dashes", // words with small hyphen-minus
-            "with\uFF0Dother dashes, With\uFF0DOther Dashes", // words with fullwidth hyphen-minus
+            "with-other dashes, With-Other Dashes", // words with hyphen-minus
+            "with֊other dashes, With֊Other Dashes", // words with armenian hyphen
+            "with־other dashes, With־Other Dashes", // words with hebrew punctuation maqaf
+            "with᐀other dashes, With᐀Other Dashes", // words with canadian syllabics hyphen
+            "with᠆other dashes, With᠆Other Dashes", // words with mongolian todo soft hyphen
+            "with‐other dashes, With‐Other Dashes", // words with hyphen
+            "with‑other dashes, With‑Other Dashes", // words with non-breaking hyphen
+            "with‒other dashes, With‒Other Dashes", // words with figure dash
+            "with–other dashes, With–Other Dashes", // words with en dash
+            "with—other dashes, With—Other Dashes", // words with em dash
+            "with―other dashes, With―Other Dashes", // words with horizontal bar
+            "with⸗other dashes, With⸗Other Dashes", // words with double oblique hyphen
+            "with⸚other dashes, With⸚Other Dashes", // words with hyphen with diaeresis
+            "with⸺other dashes, With⸺Other Dashes", // words with two-em dash
+            "with⸻other dashes, With⸻Other Dashes", // words with three-em dash
+            "with⹀other dashes, With⹀Other Dashes", // words with double hyphen
+            "with〜other dashes, With〜Other Dashes", // words with wave dash
+            "with〰other dashes, With〰Other Dashes", // words with wavy dash
+            "with゠other dashes, With゠Other Dashes", // words with katakana-hiraga double hyphen
+            "with︱other dashes, With︱Other Dashes", // words with vertical em dash
+            "with︲other dashes, With︲Other Dashes", // words with vertical en dash
+            "with﹘other dashes, With﹘Other Dashes", // words with small em dash
+            "with﹣other dashes, With﹣Other Dashes", // words with small hyphen-minus
+            "with－other dashes, With－Other Dashes", // words with fullwidth hyphen-minus
             "remove\u200Bzero\u200Bwidth\u200Bspaces\u200B, Removezerowidthspaces", // words with unwelcome zero width spaces
             "remove\u200Czero\u200Cwidth\u200Cspaces\u200C, Removezerowidthspaces", // words with unwelcome zero width spaces
             "remove\u200Dzero\u200Dwidth\u200Dspaces\u200D, Removezerowidthspaces", // words with unwelcome zero width spaces

--- a/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -43,6 +43,50 @@ public class CapitalizeFormatterTest {
             "UPPER {E}ACH {NOT} FIRST, Upper {E}ach {NOT} First", // multiple words upper case with {}
             "upper each first {NOT} {this}, Upper Each First {NOT} {this}", // multiple words in lower and upper case with {}
             "upper each first {N}OT {t}his, Upper Each First {N}ot {t}his", // multiple words in lower and upper case with {} part 2
+            "{with-hyphen, {with-hyphen", // unmatched braces with hyphen
+            "with-hyphen, With-Hyphen", // single word with hyphen
+            "With-hyphen, With-Hyphen", // single word with hyphen
+            "With-Hyphen, With-Hyphen", // single word with hyphen correct
+            "WITH-HYPHEN, With-Hyphen", // single word upper case with hyphen
+            "multiple-words with-hyphen right-now people, Multiple-Words With-Hyphen Right-Now People", // multiple words lower case with hyphen
+            "Multiple-words With-hyphen Right-now people, Multiple-Words With-Hyphen Right-Now People", // multiple words in upper and lower case with hyphen
+            "Multiple-Words With-Hyphen Right-Now People, Multiple-Words With-Hyphen Right-Now People", // multiple words with hyphen correct
+            "MULTIPLE-WORDS WITH-HYPHEN RIGHT-NOW PEOPLE, Multiple-Words With-Hyphen Right-Now People", // multiple words upper case with hyphen
+            "{w}ith-hyphen, {w}ith-Hyphen", // single word lower case with hyphen and {}
+            "{W}ith-hyphen, {W}ith-Hyphen", // single word with hyphen and {}
+            "{W}ith-Hyphen, {W}ith-Hyphen", // single word correct with hyphen and {}
+            "{W}ITH-HYPH{E}N, {W}ith-Hyph{E}n", // single word upper case with hyphen and {}
+            "multiple-{words} with-{h}yphen right-now {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words lower case with hyphen and {}
+            "Multiple-{words} With-{h}yphen Right-Now {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words correct with hyphen and {}
+            "MULTIPLE-{words} WITH-{h}yphen RIGHT-NOW {people}, Multiple-{words} With-{h}yphen Right-Now {people}", // multiple words upper case with hyphen and {}
+            "with\u002Dother dashes, With\u002DOther Dashes", // words with hyphen-minus
+            "with\u058Aother dashes, With\u058AOther Dashes", // words with armenian hyphen
+            "with\u05BEother dashes, With\u05BEOther Dashes", // words with hebrew punctuation maqaf
+            "with\u1400other dashes, With\u1400Other Dashes", // words with canadian syllabics hyphen
+            "with\u1806other dashes, With\u1806Other Dashes", // words with mongolian todo soft hyphen
+            "with\u2010other dashes, With\u2010Other Dashes", // words with hyphen
+            "with\u2011other dashes, With\u2011Other Dashes", // words with non-breaking hyphen
+            "with\u2012other dashes, With\u2012Other Dashes", // words with figure dash
+            "with\u2013other dashes, With\u2013Other Dashes", // words with en dash
+            "with\u2014other dashes, With\u2014Other Dashes", // words with em dash
+            "with\u2015other dashes, With\u2015Other Dashes", // words with horizontal bar
+            "with\u2E17other dashes, With\u2E17Other Dashes", // words with double oblique hyphen
+            "with\u2E1Aother dashes, With\u2E1AOther Dashes", // words with hyphen with diaeresis
+            "with\u2E3Aother dashes, With\u2E3AOther Dashes", // words with two-em dash
+            "with\u2E3Bother dashes, With\u2E3BOther Dashes", // words with three-em dash
+            "with\u2E40other dashes, With\u2E40Other Dashes", // words with double hyphen
+            "with\u301Cother dashes, With\u301COther Dashes", // words with wave dash
+            "with\u3030other dashes, With\u3030Other Dashes", // words with wavy dash
+            "with\u30A0other dashes, With\u30A0Other Dashes", // words with katakana-hiraga double hyphen
+            "with\uFE31other dashes, With\uFE31Other Dashes", // words with vertical em dash
+            "with\uFE32other dashes, With\uFE32Other Dashes", // words with vertical en dash
+            "with\uFE58other dashes, With\uFE58Other Dashes", // words with small em dash
+            "with\uFE63other dashes, With\uFE63Other Dashes", // words with small hyphen-minus
+            "with\uFF0Dother dashes, With\uFF0DOther Dashes", // words with fullwidth hyphen-minus
+            "remove\u200Bzero\u200Bwidth\u200Bspaces\u200B, Removezerowidthspaces", // words with unwelcome zero width spaces
+            "remove\u200Czero\u200Cwidth\u200Cspaces\u200C, Removezerowidthspaces", // words with unwelcome zero width spaces
+            "remove\u200Dzero\u200Dwidth\u200Dspaces\u200D, Removezerowidthspaces", // words with unwelcome zero width spaces
+            "remove\uFEFFzero\uFEFFwidth\uFEFFspaces\uFEFF, Removezerowidthspaces", // words with unwelcome zero width spaces
     })
     public void testInputs(String input, String expectedResult) {
         String formattedStr = formatter.format(input);


### PR DESCRIPTION
Fixes [#9068 ](https://github.com/JabRef/jabref/issues/9068)

What: Fixing capitalization after dashes. Also covering zero width spaces. Tests were implemented too.

Why: To solve the issue #9068 

Context: I'm having some classes about TDD (Test-Driven Development) and we were asked to solve an issue from JabRef. I chose to work on this one.

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
