### PR TITLE
Fix title case capitalization after en-dash characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed a bug where spaces are trimmed when highlighting differences in the Entries merge dialog. [koppor#371](https://github.com/koppor/jabref/issues/371)
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
-
+- We fixed an issue where title case didn't capitalize words after en-dash characters [#9068]
 ### Removed
 
 

--- a/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
@@ -17,11 +17,13 @@ public final class Word {
      * Set containing common lowercase function words
      */
     public static final Set<String> SMALLER_WORDS;
+    public static final Set<Character> DASHES;
     private final char[] chars;
     private final boolean[] protectedChars;
 
     static {
         Set<String> smallerWords = new HashSet<>();
+        Set<Character> dashes = new HashSet<>();
 
         // Articles
         smallerWords.addAll(Arrays.asList("a", "an", "the"));
@@ -30,10 +32,20 @@ public final class Word {
         // Conjunctions
         smallerWords.addAll(Arrays.asList("and", "but", "for", "nor", "or", "so", "yet"));
 
+        // Dashes
+        dashes.addAll(Arrays.asList(
+                '-', '~', '⸗', '〰', '᐀', '֊', '־', '‐', '‑', '‒',
+                '–', '—', '―', '⁓', '⁻', '₋', '−', '⸺', '⸻',
+                '〜', '゠', '︱', '︲', '﹘', '﹣', '－'
+        ));
+
+        // unmodifiable for thread safety
+        DASHES = dashes;
+
         // unmodifiable for thread safety
         SMALLER_WORDS = smallerWords.stream()
-                            .map(word -> word.toLowerCase(Locale.ROOT))
-                            .collect(Collectors.toUnmodifiableSet());
+                                    .map(word -> word.toLowerCase(Locale.ROOT))
+                                    .collect(Collectors.toUnmodifiableSet());
     }
 
     public Word(char[] chars, boolean[] protectedChars) {
@@ -77,7 +89,7 @@ public final class Word {
     public void toUpperFirst() {
         for (int i = 0; i < chars.length; i++) {
             if (!protectedChars[i]) {
-                chars[i] = (i == 0) ?
+                chars[i] = (i == 0 || DASHES.contains(chars[i - 1])) ?
                         Character.toUpperCase(chars[i]) :
                         Character.toLowerCase(chars[i]);
             }

--- a/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
@@ -55,6 +55,7 @@ public class TitleCaseFormatterTest {
                         "⁻⁻test−ing dash⸻like characters"),
                 Arguments.of("--Test〰Ing M-U~L゠T︱I⁓P︲L--~~︲E Dash⸻-Like Characters",
                         "--test〰ing M-u~l゠t︱i⁓p︲l--~~︲e dASH⸻-likE charACTErs"),
+                Arguments.of("Kinetic Studies on Enzyme-Catalyzed Reactions: Oxidation of Glucose, Decomposition of Hydrogen Peroxide and Their Combination","kinetic studies on enzyme-catalyzed reactions: oxidation of glucose, decomposition of hydrogen peroxide and their combination"),
                 Arguments.of("{BPMN} Conformance in Open Source Engines",
                         new TitleCaseFormatter().getExampleInput()));
     }

--- a/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
@@ -45,6 +45,16 @@ public class TitleCaseFormatterTest {
                         "bibliographic software. a comparison."),
                 Arguments.of("Bibliographic Software. {A COMPARISON.}",
                         "bibliographic software. {A COMPARISON.}"),
+                Arguments.of("--Test~Ing Dash--Like Characters",
+                        "--test~ing dash--like characters"),
+                Arguments.of("-⸗Test⸗Ing Dash〰Like Cha᐀᐀Racters",
+                        "-⸗test⸗ing dash〰like cha᐀᐀racters"),
+                Arguments.of("︲︲Test־Ing Dash⁓⁓Like Characters",
+                        "︲︲test־ing dash⁓⁓like characters"),
+                Arguments.of("⁻⁻Test−Ing Dash⸻Like Characters",
+                        "⁻⁻test−ing dash⸻like characters"),
+                Arguments.of("--Test〰Ing M-U~L゠T︱I⁓P︲L--~~︲E Dash⸻-Like Characters",
+                        "--test〰ing M-u~l゠t︱i⁓p︲l--~~︲e dASH⸻-likE charACTErs"),
                 Arguments.of("{BPMN} Conformance in Open Source Engines",
                         new TitleCaseFormatter().getExampleInput()));
     }

--- a/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
@@ -55,7 +55,8 @@ public class TitleCaseFormatterTest {
                         "⁻⁻test−ing dash⸻like characters"),
                 Arguments.of("--Test〰Ing M-U~L゠T︱I⁓P︲L--~~︲E Dash⸻-Like Characters",
                         "--test〰ing M-u~l゠t︱i⁓p︲l--~~︲e dASH⸻-likE charACTErs"),
-                Arguments.of("Kinetic Studies on Enzyme-Catalyzed Reactions: Oxidation of Glucose, Decomposition of Hydrogen Peroxide and Their Combination","kinetic studies on enzyme-catalyzed reactions: oxidation of glucose, decomposition of hydrogen peroxide and their combination"),
+                Arguments.of("Kinetic Studies on Enzyme-Catalyzed Reactions: Oxidation of Glucose, Decomposition of Hydrogen Peroxide and Their Combination",
+                        "kinetic studies on enzyme-catalyzed reactions: oxidation of glucose, decomposition of hydrogen peroxide and their combination"),
                 Arguments.of("{BPMN} Conformance in Open Source Engines",
                         new TitleCaseFormatter().getExampleInput()));
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
@@ -213,7 +213,7 @@ public class IsiImporterTest {
         assertEquals(Optional.of("Optical waveguides in Sn2P2S6 by low fluence MeV He+ ion implantation"),
                 second.getField(StandardField.TITLE));
 
-        assertEquals(Optional.of("Journal of Physics-condensed Matter"), first.getField(StandardField.JOURNAL));
+        assertEquals(Optional.of("Journal of Physics-Condensed Matter"), first.getField(StandardField.JOURNAL));
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #9068 


Closes #9101 
Closes #9100 
Closes #9099

What: I implemented a change to the Word.java file so that it can capitalize any part of a title that follows one of the characters from the en-dash list, like "-", "~" or "〰" on the Title Case method. For example, the title "test-driven software" becomes "Test-Driven Software" instead of the previous result "Test-driven Software".

Why: Following the issue #9068  discussion, there was a need to solve such a problem.

Context:  This change was incentivized by the University that I'm a part of at the moment. On its course, I ended up studying Test-Driven Development (TDD), where this project (JabRef) was one of the options to work on using the TDD method. Therefore, i chose this issue to work on.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
