### PR TITLE
Hide diffs when one of the field values is blank a.k.a no conflict

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowView.java
+++ b/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowView.java
@@ -21,6 +21,7 @@ import org.jabref.gui.mergeentries.newmergedialog.fieldsmerger.FieldMergerFactor
 import org.jabref.gui.mergeentries.newmergedialog.toolbar.ThreeWayMergeToolbar;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.strings.StringUtil;
 
 import com.tobiasdiez.easybind.EasyBind;
 import org.fxmisc.richtext.StyleClassedTextArea;
@@ -150,7 +151,7 @@ public class FieldRowView {
     }
 
     public void showDiff(ShowDiffConfig diffConfig) {
-        if (!rightValueCell.isVisible()) {
+        if (!rightValueCell.isVisible() || StringUtil.isNullOrEmpty(viewModel.getLeftFieldValue()) || StringUtil.isNullOrEmpty(viewModel.getRightFieldValue())) {
             return;
         }
         LOGGER.debug("Showing diffs...");


### PR DESCRIPTION
context: Show Diff: Split View: I would think again of the colors: red means removal in my experience - can another color be used? -- I would see both first two columns as input for the Merged Entry. Thus, I am a bit confused by using red as color at the "Original Entry"
*Originally posted by @koppor*
![image](https://user-images.githubusercontent.com/21198231/187734954-d0fb3f82-d032-4431-88b0-f5d08da9bc78.png)

## Screenshots
![image](https://user-images.githubusercontent.com/21198231/187735395-b91c9036-6681-46b1-846e-e408e41a5261.png)


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
