### PR TITLE
SLR Remove "last-search-date"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We call backup files `.bak` and temporary writing files now `.sav`.
 - JabRef keeps 10 older versions of a `.bib` file in the [user data dir](https://github.com/harawata/appdirs#supported-directories) (instead of a single `.sav` (now: `.bak`) file in the directory of the `.bib` file)
 - We changed the button label from "Return to JabRef" to "Return to library" to better indicate the purpose of the action.
+- We removed "last-search-date" from the SLR feature, because the last-search-date can be detucted from the git logs.
 - We reworked the External Changes Resolver dialog. [#9021](https://github.com/JabRef/jabref/pull/9021)
 
 
@@ -39,7 +40,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
 
 ### Removed
-
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We call backup files `.bak` and temporary writing files now `.sav`.
 - JabRef keeps 10 older versions of a `.bib` file in the [user data dir](https://github.com/harawata/appdirs#supported-directories) (instead of a single `.sav` (now: `.bak`) file in the directory of the `.bib` file)
 - We changed the button label from "Return to JabRef" to "Return to library" to better indicate the purpose of the action.
-- We removed "last-search-date" from the SLR feature, because the last-search-date can be detucted from the git logs.
+- We removed "last-search-date" from the SLR feature, because the last-search-date can be deducted from the git logs.
 - We reworked the External Changes Resolver dialog. [#9021](https://github.com/JabRef/jabref/pull/9021)
 
 

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -6,7 +6,6 @@ import java.io.Writer;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -119,7 +118,7 @@ class StudyRepository {
             gitHandler.createCommitOnCurrentBranch("Setup/Update Repository Structure", false);
             gitHandler.checkoutBranch(SEARCH_BRANCH);
             // If study definition does not exist on this branch or was changed on work branch, copy it from work
-            boolean studyDefinitionDoesNotExistOrChanged = !(Files.exists(studyDefinitionFile) && new StudyYamlParser().parseStudyYamlFile(studyDefinitionFile).equalsBesideLastSearchDate(study));
+            boolean studyDefinitionDoesNotExistOrChanged = !(Files.exists(studyDefinitionFile) && new StudyYamlParser().parseStudyYamlFile(studyDefinitionFile).equals(study));
             if (studyDefinitionDoesNotExistOrChanged) {
                 new StudyYamlParser().writeStudyYamlFile(study, studyDefinitionFile);
             }
@@ -218,15 +217,13 @@ class StudyRepository {
      */
     public void persist(List<QueryResult> crawlResults) throws IOException, GitAPIException, SaveException {
         updateWorkAndSearchBranch();
-        study.setLastSearchDate(LocalDate.now());
         persistStudy();
         gitHandler.createCommitOnCurrentBranch("Update search date", true);
         gitHandler.checkoutBranch(SEARCH_BRANCH);
         persistResults(crawlResults);
-        study.setLastSearchDate(LocalDate.now());
         persistStudy();
         try {
-            // First commit changes to search branch branch and update remote
+            // First commit changes to search branch and update remote
             String commitMessage = "Conducted search: " + LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
             boolean newSearchResults = gitHandler.createCommitOnCurrentBranch(commitMessage, false);
             gitHandler.checkoutBranch(WORK_BRANCH);

--- a/src/main/java/org/jabref/model/study/Study.java
+++ b/src/main/java/org/jabref/model/study/Study.java
@@ -1,6 +1,5 @@
 package org.jabref.model.study;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -12,16 +11,17 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *
  * This class defines all aspects of a scientific study relevant to the application. It is a proxy for the file based study definition.
  */
-
-@JsonPropertyOrder({"authors", "title", "last-search-date", "research-questions", "queries", "databases"})
+@JsonPropertyOrder({"authors", "title", "research-questions", "queries", "databases"})
 public class Study {
     private List<String> authors;
+
     private String title;
-    @JsonProperty("last-search-date")
-    private LocalDate lastSearchDate;
+
     @JsonProperty("research-questions")
     private List<String> researchQuestions;
+
     private List<StudyQuery> queries;
+
     private List<StudyDatabase> databases;
 
     public Study(List<String> authors, String title, List<String> researchQuestions, List<StudyQuery> queryEntries, List<StudyDatabase> databases) {
@@ -54,14 +54,6 @@ public class Study {
         this.queries = queries;
     }
 
-    public LocalDate getLastSearchDate() {
-        return lastSearchDate;
-    }
-
-    public void setLastSearchDate(LocalDate date) {
-        lastSearchDate = date;
-    }
-
     public List<StudyDatabase> getDatabases() {
         return databases;
     }
@@ -91,7 +83,6 @@ public class Study {
         return "Study{" +
                 "authors=" + authors +
                 ", studyName='" + title + '\'' +
-                ", lastSearchDate=" + lastSearchDate +
                 ", researchQuestions=" + researchQuestions +
                 ", queries=" + queries +
                 ", libraries=" + databases +
@@ -99,57 +90,21 @@ public class Study {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
 
-        Study study = (Study) o;
+        Study otherStudy = (Study) other;
 
-        if (getAuthors() != null ? !getAuthors().equals(study.getAuthors()) : study.getAuthors() != null) {
-            return false;
-        }
-        if (getTitle() != null ? !getTitle().equals(study.getTitle()) : study.getTitle() != null) {
-            return false;
-        }
-        if (getLastSearchDate() != null ? !getLastSearchDate().equals(study.getLastSearchDate()) : study.getLastSearchDate() != null) {
-            return false;
-        }
-        if (getResearchQuestions() != null ? !getResearchQuestions().equals(study.getResearchQuestions()) : study.getResearchQuestions() != null) {
-            return false;
-        }
-        if (getQueries() != null ? !getQueries().equals(study.getQueries()) : study.getQueries() != null) {
-            return false;
-        }
-        return getDatabases() != null ? getDatabases().equals(study.getDatabases()) : study.getDatabases() == null;
-    }
-
-    public boolean equalsBesideLastSearchDate(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        Study study = (Study) o;
-
-        if (getAuthors() != null ? !getAuthors().equals(study.getAuthors()) : study.getAuthors() != null) {
-            return false;
-        }
-        if (getTitle() != null ? !getTitle().equals(study.getTitle()) : study.getTitle() != null) {
-            return false;
-        }
-        if (getResearchQuestions() != null ? !getResearchQuestions().equals(study.getResearchQuestions()) : study.getResearchQuestions() != null) {
-            return false;
-        }
-        if (getQueries() != null ? !getQueries().equals(study.getQueries()) : study.getQueries() != null) {
-            return false;
-        }
-        return getDatabases() != null ? getDatabases().equals(study.getDatabases()) : study.getDatabases() == null;
+        return Objects.equals(authors, otherStudy.authors) &&
+                Objects.equals(title, otherStudy.title) &&
+                Objects.equals(researchQuestions, otherStudy.researchQuestions) &&
+                Objects.equals(queries, otherStudy.queries) &&
+                Objects.equals(databases, otherStudy.databases);
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -163,15 +162,6 @@ class StudyRepositoryTest {
         // All Springer results are duplicates for "Quantum"
         assertEquals(expected, getTestStudyRepository().getQueryResultEntries("Quantum").getEntries());
         assertEquals(getSpringerCloudComputingMockResults(), getTestStudyRepository().getQueryResultEntries("Cloud Computing").getEntries());
-    }
-
-    @Test
-    void setsLastSearchDatePersistedCorrectly() throws Exception {
-        List<QueryResult> mockResults = getMockResults();
-
-        studyRepository.persist(mockResults);
-
-        assertEquals(LocalDate.now(), getTestStudyRepository().getStudy().getLastSearchDate());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -40,6 +40,7 @@ import org.mockito.Answers;
 
 import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -123,9 +124,9 @@ class StudyRepositoryTest {
         assertTrue(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeQuantum + " - Quantum", "Springer.bib")));
         assertTrue(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeCloudComputing + " - Cloud Computing", "Springer.bib")));
         assertTrue(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeSoftwareEngineering + " - Software Engineering", "Springer.bib")));
-        assertTrue(Files.notExists(Path.of(tempRepositoryDirectory.toString(), hashCodeQuantum + " - Quantum", "IEEEXplore.bib")));
-        assertTrue(Files.notExists(Path.of(tempRepositoryDirectory.toString(), hashCodeCloudComputing + " - Cloud Computing", "IEEEXplore.bib")));
-        assertTrue(Files.notExists(Path.of(tempRepositoryDirectory.toString(), hashCodeSoftwareEngineering + " - Software Engineering", "IEEEXplore.bib")));
+        assertFalse(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeQuantum + " - Quantum", "IEEEXplore.bib")));
+        assertFalse(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeCloudComputing + " - Cloud Computing", "IEEEXplore.bib")));
+        assertFalse(Files.exists(Path.of(tempRepositoryDirectory.toString(), hashCodeSoftwareEngineering + " - Software Engineering", "IEEEXplore.bib")));
     }
 
     /**
@@ -167,9 +168,7 @@ class StudyRepositoryTest {
     @Test
     void studyResultsPersistedCorrectly() throws Exception {
         List<QueryResult> mockResults = getMockResults();
-
         studyRepository.persist(mockResults);
-
         assertEquals(new HashSet<>(getNonDuplicateBibEntryResult().getEntries()), new HashSet<>(getTestStudyRepository().getStudyResultEntries().getEntries()));
     }
 

--- a/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.crawler;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.util.List;
 
 import org.jabref.logic.util.io.FileUtil;
@@ -35,22 +34,18 @@ class StudyYamlParserTest {
                 new StudyDatabase("Medline/PubMed", true), new StudyDatabase("IEEEXplore", false));
 
         expectedStudy = new Study(authors, studyName, researchQuestions, queryEntries, libraryEntries);
-        expectedStudy.setLastSearchDate(LocalDate.parse("2020-11-26"));
     }
 
     @Test
     public void parseStudyFileSuccessfully() throws Exception {
         Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve("study.yml"));
-
         assertEquals(expectedStudy, study);
     }
 
     @Test
     public void writeStudyFileSuccessfully() throws Exception {
         new StudyYamlParser().writeStudyYamlFile(expectedStudy, testDirectory.resolve("study.yml"));
-
         Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve("study.yml"));
-
         assertEquals(expectedStudy, study);
     }
 }

--- a/src/test/resources/org/jabref/logic/crawler/study.yml
+++ b/src/test/resources/org/jabref/logic/crawler/study.yml
@@ -1,7 +1,6 @@
 authors:
   - Jab Ref
 title: TestStudyName
-last-search-date: 2020-11-26
 research-questions:
   - Question1
   - Question2


### PR DESCRIPTION
We removed "last-search-date" from the SLR feature, because the last-search-date can be detucted from the git logs.

Ports one change of https://github.com/koppor/jabref/pull/559 to here.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
