### PR TITLE
Fix parsing of save actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#9067](https://github.com/JabRef/jabref/pull/9067), [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
 - We fixed issues with save actions not correctly loaded when opening the library. [#9122](https://github.com/JabRef/jabref/pull/9122)
-- We fixed an issue where title case didn't capitalize words after en-dash characters [#9068](https://github.com/JabRef/jabref/pull/9068)
-- We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
+- We fixed an issue where title case didn't capitalize words after en-dash characters. [#9068](https://github.com/JabRef/jabref/pull/9068)
+- We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open. [#9075](https://github.com/JabRef/jabref/issues/9075)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed some visual glitches with the linked files editor field in the entry editor and increased its height. [#8823](https://github.com/JabRef/jabref/issues/8823)
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#9067](https://github.com/JabRef/jabref/pull/9067), [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
+- We fixed issues with save actions not correctly loaded when opening the library
 - We fixed an issue where title case didn't capitalize words after en-dash characters [#9068]
 - We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed some visual glitches with the linked files editor field in the entry editor and increased its height. [#8823](https://github.com/JabRef/jabref/issues/8823)
 - We fixed several bugs regarding the manual and the autosave of library files that sometimes lead to exceptions or data loss. [#9067](https://github.com/JabRef/jabref/pull/9067), [#8448](https://github.com/JabRef/jabref/issues/8484), [#8746](https://github.com/JabRef/jabref/issues/8746), [#6684](https://github.com/JabRef/jabref/issues/6684), [#6644](https://github.com/JabRef/jabref/issues/6644), [#6102](https://github.com/JabRef/jabref/issues/6102), [#6002](https://github.com/JabRef/jabref/issues/6000)
 - We fixed an issue where applied save actions on saving the library file would lead to the dialog "The libary has been modified by another program" popping up [#4877](https://github.com/JabRef/jabref/issues/4877)
-- We fixed issues with save actions not correctly loaded when opening the library
-- We fixed an issue where title case didn't capitalize words after en-dash characters [#9068]
+- We fixed issues with save actions not correctly loaded when opening the library. [#9122](https://github.com/JabRef/jabref/pull/9122)
+- We fixed an issue where title case didn't capitalize words after en-dash characters [#9068](https://github.com/JabRef/jabref/pull/9068)
 - We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open [#9075](https://github.com/JabRef/jabref/issues/9075)
 
 ### Removed

--- a/src/main/java/org/jabref/logic/cleanup/Cleanups.java
+++ b/src/main/java/org/jabref/logic/cleanup/Cleanups.java
@@ -30,6 +30,17 @@ public class Cleanups {
     public static final FieldFormatterCleanups RECOMMEND_BIBTEX_ACTIONS;
     public static final FieldFormatterCleanups RECOMMEND_BIBLATEX_ACTIONS;
 
+    /**
+     * This parses the key/list map of fields and clean up actions for the field.
+     *
+     * General format for one key/list map: <code>...[...]</code> - <code>field[formatter1,formatter2,...]</code>
+     * Multiple are written as <code>...[...]...[...]...[...]</code>
+     *   <code>field1[formatter1,formatter2,...]field2[formatter3,formatter4,...]</code>
+     *
+     * The idea is that characters are field names until <code>[</code> is reached and that formatter lists are terminated by <code>]</code>
+     *
+     * Example: <code>pages[normalize_page_numbers]title[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]</code>
+     */
     private static final Pattern FIELD_FORMATTER_CLEANUP_PATTERN = Pattern.compile("([^\\[]+)\\[([^\\]]+)\\]");
 
     static {

--- a/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
+++ b/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
@@ -27,6 +27,9 @@ public class FieldFormatterCleanups {
         this.actions = Objects.requireNonNull(actions);
     }
 
+    /**
+     * Note: String parsing is done at {@link Cleanups#parse(String)}
+     */
     private static String getMetaDataString(List<FieldFormatterCleanup> actionList, String newLineSeparator) {
         // first, group all formatters by the field for which they apply
         Map<Field, List<String>> groupedByField = new TreeMap<>(Comparator.comparing(Field::getName));
@@ -52,7 +55,7 @@ public class FieldFormatterCleanups {
 
             StringJoiner joiner = new StringJoiner(",", "[", "]" + newLineSeparator);
             entry.getValue().forEach(joiner::add);
-            result.append(joiner.toString());
+            result.append(joiner);
         }
 
         return result.toString();

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -288,14 +288,13 @@ public class BibtexParser implements Parser {
     }
 
     private void parseJabRefComment(Map<String, String> meta) {
-        StringBuilder buffer = null;
+        StringBuilder buffer;
         try {
             buffer = parseBracketedTextExactly();
         } catch (IOException e) {
-            /* if we get an IO Exception here, than we have an unbracketed comment,
-             * which means that we should just return and the comment will be picked up as arbitrary text
-             *  by the parser
-             */
+            // if we get an IO Exception here, then we have an unbracketed comment,
+            // which means that we should just return and the comment will be picked up as arbitrary text
+            // by the parser
             LOGGER.info("Found unbracketed comment");
             return;
         }

--- a/src/test/java/org/jabref/logic/cleanup/CleanupsTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/CleanupsTest.java
@@ -1,0 +1,183 @@
+package org.jabref.logic.cleanup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jabref.logic.formatter.bibtexfields.EscapeAmpersandsFormatter;
+import org.jabref.logic.formatter.bibtexfields.EscapeDollarSignFormatter;
+import org.jabref.logic.formatter.bibtexfields.EscapeUnderscoresFormatter;
+import org.jabref.logic.formatter.bibtexfields.LatexCleanupFormatter;
+import org.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
+import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CleanupsTest {
+
+    @Test
+    void parserKeepsSaveActions() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                month[normalize_month]
+                pages[normalize_page_numbers]
+                title[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                publisher[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                journal[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                abstract[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                """);
+
+        List<FieldFormatterCleanup> expected = new ArrayList<>(30);
+        expected.add(new FieldFormatterCleanup(StandardField.MONTH, new NormalizeMonthFormatter()));
+        expected.add(new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()));
+        for (Field field : List.of(StandardField.TITLE, StandardField.BOOKTITLE, StandardField.PUBLISHER, StandardField.JOURNAL, StandardField.ABSTRACT)) {
+            expected.add(new FieldFormatterCleanup(field, new EscapeAmpersandsFormatter()));
+            expected.add(new FieldFormatterCleanup(field, new EscapeDollarSignFormatter()));
+            expected.add(new FieldFormatterCleanup(field, new EscapeUnderscoresFormatter()));
+            expected.add(new FieldFormatterCleanup(field, new LatexCleanupFormatter()));
+        }
+
+        assertEquals(expected, fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesLatexCleanupFormatter() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[latex_cleanup]
+                """);
+        assertEquals(
+                List.of(new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter())),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesTwoFormatters() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeUnderscores,latex_cleanup]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesFourFormatters() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeDollarSignFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesTwoFormattersWithCommas() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,escapeDollarSign]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeDollarSignFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesTwoFormattersOneWithComma() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                pages[normalize_page_numbers]
+                booktitle[escapeAmpersands,escapeDollarSign]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeDollarSignFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserParsesThreeFormattersTwoWithComma() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                pages[normalize_page_numbers]
+                title[escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,escapeDollarSign]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeDollarSignFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserWithTwoAndThree() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeAmpersands,escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,escapeUnderscores,latex_cleanup]
+                """);
+
+        List<FieldFormatterCleanup> expected = new ArrayList<>(30);
+        for (Field field : List.of(StandardField.TITLE, StandardField.BOOKTITLE)) {
+            expected.add(new FieldFormatterCleanup(field, new EscapeAmpersandsFormatter()));
+            expected.add(new FieldFormatterCleanup(field, new EscapeUnderscoresFormatter()));
+            expected.add(new FieldFormatterCleanup(field, new LatexCleanupFormatter()));
+        }
+
+        assertEquals(expected, fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserWithFourEntries() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,escapeUnderscores,latex_cleanup]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new LatexCleanupFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+
+    @Test
+    void parserTest() {
+        List<FieldFormatterCleanup> fieldFormatterCleanups = Cleanups.parse("""
+                title[escapeAmpersands,escapeUnderscores,latex_cleanup]
+                booktitle[escapeAmpersands,latex_cleanup]
+                """);
+        assertEquals(
+                List.of(
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new EscapeUnderscoresFormatter()),
+                        new FieldFormatterCleanup(StandardField.TITLE, new LatexCleanupFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new EscapeAmpersandsFormatter()),
+                        new FieldFormatterCleanup(StandardField.BOOKTITLE, new LatexCleanupFormatter())
+                ),
+                fieldFormatterCleanups);
+    }
+}

--- a/src/test/java/org/jabref/logic/exporter/FieldFormatterCleanupsTest.java
+++ b/src/test/java/org/jabref/logic/exporter/FieldFormatterCleanupsTest.java
@@ -27,17 +27,16 @@ public class FieldFormatterCleanupsTest {
 
     @BeforeEach
     public void setUp() {
-        entry = new BibEntry();
-        entry.setType(StandardEntryType.InProceedings);
-        entry.setCitationKey("6055279");
-        entry.setField(StandardField.TITLE, "Educational session 1");
-        entry.setField(StandardField.BOOKTITLE, "Custom Integrated Circuits Conference (CICC), 2011 IEEE");
-        entry.setField(StandardField.YEAR, "2011");
-        entry.setField(StandardField.MONTH, "Sept.");
-        entry.setField(StandardField.PAGES, "1-7");
-        entry.setField(StandardField.ABSTRACT, "Start of the above-titled section of the conference proceedings record.");
-        entry.setField(StandardField.DOI, "10.1109/CICC.2011.6055279");
-        entry.setField(StandardField.ISSN, "0886-5930");
+        entry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("6055279")
+                .withField(StandardField.TITLE, "Educational session 1")
+                .withField(StandardField.BOOKTITLE, "Custom Integrated Circuits Conference (CICC), 2011 IEEE")
+                .withField(StandardField.YEAR, "2011")
+                .withField(StandardField.MONTH, "Sept.")
+                .withField(StandardField.PAGES, "1-7")
+                .withField(StandardField.ABSTRACT, "Start of the above-titled section of the conference proceedings record.")
+                .withField(StandardField.DOI, "10.1109/CICC.2011.6055279")
+                .withField(StandardField.ISSN, "0886-5930");
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -139,12 +139,9 @@ class BibtexParserTest {
     @Test
     void singleFromStringRecognizesEntryInMultiple() throws ParseException {
         Optional<BibEntry> parsed = BibtexParser.singleFromString("""
-                        @article{canh05,
-                            author = {Crowston, K. and Annabi, H.},
-                            title = {Title A}
-                            }
-                        @inProceedings{foo,  author={Norton Bar}}
-                        """,
+                        @article{canh05, author = {Crowston, K. and Annabi, H.},
+                            title = {Title A}}
+                        @inProceedings{foo,  author={Norton Bar}}""",
                 importFormatPreferences, fileMonitor);
 
         assertTrue(parsed.get().getCitationKey().equals(Optional.of("canh05"))

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -114,7 +114,10 @@ class BibtexParserTest {
     @Test
     void singleFromStringRecognizesEntry() throws ParseException {
         Optional<BibEntry> parsed = BibtexParser.singleFromString(
-                "@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n",
+                """
+                        @article{canh05,  author = {Crowston, K. and Annabi, H.},
+                          title = {Title A}}
+                        """,
                 importFormatPreferences, fileMonitor);
 
         BibEntry expected = new BibEntry();
@@ -129,8 +132,10 @@ class BibtexParserTest {
     @Test
     void singleFromStringRecognizesEntryInMultiple() throws ParseException {
         Optional<BibEntry> parsed = BibtexParser.singleFromString(
-                "@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n"
-                        + "@inProceedings{foo," + "  author={Norton Bar}}",
+                """
+                        @article{canh05,  author = {Crowston, K. and Annabi, H.},
+                          title = {Title A}}
+                        @inProceedings{foo,  author={Norton Bar}}""",
                 importFormatPreferences, fileMonitor);
 
         assertTrue(parsed.get().getCitationKey().equals(Optional.of("canh05"))
@@ -285,8 +290,11 @@ class BibtexParserTest {
 
     @Test
     void parseRecognizesEntryWithBigNumbers() throws IOException {
-        ParserResult result = parser.parse(new StringReader("@article{canh05," + "isbn = 1234567890123456789,\n"
-                + "isbn2 = {1234567890123456789},\n" + "small = 1234,\n" + "}"));
+        ParserResult result = parser.parse(new StringReader("""
+                @article{canh05,isbn = 1234567890123456789,
+                isbn2 = {1234567890123456789},
+                small = 1234,
+                }"""));
 
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
         BibEntry entry = parsed.iterator().next();
@@ -374,8 +382,10 @@ class BibtexParserTest {
         expected.add(secondEntry);
 
         ParserResult result = parser.parse(
-                new StringReader("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
-                        + "  title = {Title A}}\n" + "@inProceedings{foo," + "  author={Norton Bar}}"));
+                new StringReader("""
+                        @article{canh05,  author = {Crowston, K. and Annabi, H.},
+                          title = {Title A}}
+                        @inProceedings{foo,  author={Norton Bar}}"""));
         List<BibEntry> parsed = result.getDatabase().getEntries();
 
         assertEquals(expected, parsed);
@@ -466,13 +476,19 @@ class BibtexParserTest {
 
     @Test
     void parseRecognizesHeaderButIgnoresEncoding() throws IOException {
-        ParserResult result = parser.parse(new StringReader("This file was created with JabRef 2.1 beta 2." + "\n"
-                + "Encoding: Cp1252" + "\n" + "" + "\n" + "@INPROCEEDINGS{CroAnnHow05," + "\n"
-                + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.}," + "\n"
-                + "  title = {Effective work practices for floss development: A model and propositions}," + "\n"
-                + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)}," + "\n"
-                + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n" + "  timestamp = {2006.05.29}," + "\n"
-                + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"));
+        ParserResult result = parser.parse(new StringReader("""
+                This file was created with JabRef 2.1 beta 2.
+                Encoding: Cp1252
+
+                @INPROCEEDINGS{CroAnnHow05,
+                  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},
+                  title = {Effective work practices for floss development: A model and propositions},
+                  booktitle = {Hawaii International Conference On System Sciences (HICSS)},
+                  year = {2005},
+                  owner = {oezbek},
+                  timestamp = {2006.05.29},
+                  url = {http://james.howison.name/publications.html}
+                }))"""));
 
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
         BibEntry entry = parsed.iterator().next();
@@ -496,12 +512,16 @@ class BibtexParserTest {
     @Test
     void parseRecognizesFormatedEntry() throws IOException {
         ParserResult result = parser.parse(
-                new StringReader("" + "@INPROCEEDINGS{CroAnnHow05," + "\n"
-                        + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.}," + "\n"
-                        + "  title = {Effective work practices for floss development: A model and propositions}," + "\n"
-                        + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)}," + "\n"
-                        + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n" + "  timestamp = {2006.05.29},"
-                        + "\n" + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"));
+                new StringReader("""
+                        @INPROCEEDINGS{CroAnnHow05,
+                          author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},
+                          title = {Effective work practices for floss development: A model and propositions},
+                          booktitle = {Hawaii International Conference On System Sciences (HICSS)},
+                          year = {2005},
+                          owner = {oezbek},
+                          timestamp = {2006.05.29},
+                          url = {http://james.howison.name/publications.html}
+                        }))"""));
 
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
         BibEntry entry = parsed.iterator().next();
@@ -599,11 +619,15 @@ class BibtexParserTest {
     @Test
     void parseReturnsEmptyListIfNoEntryRecognized() throws IOException {
         ParserResult result = parser.parse(
-                new StringReader("  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.}," + "\n"
-                        + "  title = {Effective work practices for floss development: A model and propositions}," + "\n"
-                        + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)}," + "\n"
-                        + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n" + "  timestamp = {2006.05.29},"
-                        + "\n" + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"));
+                new StringReader("""
+                          author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},
+                          title = {Effective work practices for floss development: A model and propositions},
+                          booktitle = {Hawaii International Conference On System Sciences (HICSS)},
+                          year = {2005},
+                          owner = {oezbek},
+                          timestamp = {2006.05.29},
+                          url = {http://james.howison.name/publications.html}
+                        }))"""));
 
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
 
@@ -613,7 +637,10 @@ class BibtexParserTest {
     @Test
     void parseReturnsEmptyListIfNoEntryExistent() throws IOException {
         ParserResult result = parser
-                .parse(new StringReader("This was created with JabRef 2.1 beta 2." + "\n" + "Encoding: Cp1252" + "\n"));
+                .parse(new StringReader("""
+                        This was created with JabRef 2.1 beta 2.
+                        Encoding: Cp1252
+                        """));
 
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
 
@@ -1287,14 +1314,19 @@ class BibtexParserTest {
     @Test
     void parseRecognizesSaveActionsAfterEntry() throws IOException {
         ParserResult parserResult = parser.parse(
-                new StringReader("@InProceedings{6055279,\n" + "  Title                    = {Educational session 1},\n"
-                        + "  Booktitle                = {Custom Integrated Circuits Conference (CICC), 2011 IEEE},\n"
-                        + "  Year                     = {2011},\n" + "  Month                    = {Sept},\n"
-                        + "  Pages                    = {1-7},\n"
-                        + "  Abstract                 = {Start of the above-titled section of the conference proceedings record.},\n"
-                        + "  DOI                      = {10.1109/CICC.2011.6055279},\n"
-                        + "  ISSN                     = {0886-5930}\n" + "}\n" + "\n"
-                        + "@comment{jabref-meta: saveActions:enabled;title[lower_case]}"));
+                new StringReader("""
+                        @InProceedings{6055279,
+                          Title                    = {Educational session 1},
+                          Booktitle                = {Custom Integrated Circuits Conference (CICC), 2011 IEEE},
+                          Year                     = {2011},
+                          Month                    = {Sept},
+                          Pages                    = {1-7},
+                          Abstract                 = {Start of the above-titled section of the conference proceedings record.},
+                          DOI                      = {10.1109/CICC.2011.6055279},
+                          ISSN                     = {0886-5930}
+                        }
+
+                        @comment{jabref-meta: saveActions:enabled;title[lower_case]}"""));
 
         FieldFormatterCleanups saveActions = parserResult.getMetaData().getSaveActions().get();
 
@@ -1403,11 +1435,13 @@ class BibtexParserTest {
 
     @Test
     void integrationTestGroupTree() throws IOException, ParseException {
-        ParserResult result = parser.parse(new StringReader("@comment{jabref-meta: groupsversion:3;}" + OS.NEWLINE
-                + "@comment{jabref-meta: groupstree:" + OS.NEWLINE + "0 AllEntriesGroup:;" + OS.NEWLINE
-                + "1 KeywordGroup:Fréchet\\;0\\;keywords\\;FrechetSpace\\;0\\;1\\;;" + OS.NEWLINE
-                + "1 KeywordGroup:Invariant theory\\;0\\;keywords\\;GIT\\;0\\;0\\;;" + OS.NEWLINE
-                + "1 ExplicitGroup:TestGroup\\;0\\;Key1\\;Key2\\;;" + "}"));
+        ParserResult result = parser.parse(new StringReader("""
+                @comment{jabref-meta: groupsversion:3;}
+                @comment{jabref-meta: groupstree:
+                0 AllEntriesGroup:;
+                1 KeywordGroup:Fréchet\\;0\\;keywords\\;FrechetSpace\\;0\\;1\\;;
+                1 KeywordGroup:Invariant theory\\;0\\;keywords\\;GIT\\;0\\;0\\;;
+                1 ExplicitGroup:TestGroup\\;0\\;Key1\\;Key2\\;;}"""));
 
         GroupTreeNode root = result.getMetaData().getGroups().get();
 
@@ -1475,9 +1509,10 @@ class BibtexParserTest {
 
     @Test
     void parseReallyUnknownType() throws Exception {
-        String bibtexEntry = "@ReallyUnknownType{test," + OS.NEWLINE +
-                " Comment                  = {testentry}" + OS.NEWLINE +
-                "}";
+        String bibtexEntry = """
+                @ReallyUnknownType{test,
+                 Comment                  = {testentry}
+                }""";
 
         Collection<BibEntry> entries = parser.parseEntries(bibtexEntry);
         BibEntry expectedEntry = new BibEntry();
@@ -1490,9 +1525,10 @@ class BibtexParserTest {
 
     @Test
     void parseOtherTypeTest() throws Exception {
-        String bibtexEntry = "@Other{test," + OS.NEWLINE +
-                " Comment                  = {testentry}" + OS.NEWLINE +
-                "}";
+        String bibtexEntry = """
+                @Other{test,
+                 Comment                  = {testentry}
+                }""";
 
         Collection<BibEntry> entries = parser.parseEntries(bibtexEntry);
         BibEntry expectedEntry = new BibEntry();
@@ -1562,22 +1598,24 @@ class BibtexParserTest {
         expected.add(third);
 
         ParserResult result = parser
-                .parse(new StringReader("@article{a}" + OS.NEWLINE + "@article{b}" + OS.NEWLINE + "@inProceedings{c}"));
+                .parse(new StringReader("""
+                        @article{a}
+                        @article{b}
+                        @inProceedings{c}"""));
 
         assertEquals(expected, result.getDatabase().getEntries());
     }
 
     @Test
     void parsePrecedingComment() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + OS.NEWLINE +
-                "@Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                % Some random comment that should stay here
+                @Article{test,
+                  Author                   = {Foo Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         // read in bibtex string
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
@@ -1594,14 +1632,13 @@ class BibtexParserTest {
 
     @Test
     void parseCommentAndEntryInOneLine() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "Some random comment that should stay here @Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                Some random comment that should stay here @Article{test,
+                  Author                   = {Foo Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         // read in bibtex string
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
@@ -1640,15 +1677,14 @@ class BibtexParserTest {
 
     @Test
     void parseRegularCommentBeforeEntry() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "@Comment{someComment} " + OS.NEWLINE +
-                "@Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                @Comment{someComment}
+                @Article{test,
+                  Author                   = {Foo Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
         Collection<BibEntry> entries = result.getDatabase().getEntries();
@@ -1668,15 +1704,14 @@ class BibtexParserTest {
 
     @Test
     void parseCommentWithoutBracketsBeforeEntry() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "@Comment someComment  " + OS.NEWLINE +
-                "@Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                @Comment someComment
+                @Article{test,
+                  Author                   = {Foo Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
         Collection<BibEntry> entries = result.getDatabase().getEntries();
@@ -1687,17 +1722,16 @@ class BibtexParserTest {
 
     @Test
     void parseCommentContainingEntries() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "@Comment{@article{myarticle,}" + OS.NEWLINE +
-                "@inproceedings{blabla, title={the proceedings of blabla}; }" + OS.NEWLINE +
-                "} " + OS.NEWLINE +
-                "@Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                @Comment{@article{myarticle,}
+                @inproceedings{blabla, title={the proceedings of blabla}; }
+                }
+                @Article{test,
+                  Author                   = {Foo Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
         Collection<BibEntry> entries = result.getDatabase().getEntries();
@@ -1708,17 +1742,16 @@ class BibtexParserTest {
 
     @Test
     void parseCommentContainingEntriesAndAtSymbols() throws IOException {
-        // @formatter:off
-        String bibtexEntry = "@Comment{@article{myarticle,}" + OS.NEWLINE +
-                "@inproceedings{blabla, title={the proceedings of bl@bl@}; }" + OS.NEWLINE +
-                "} " + OS.NEWLINE +
-                "@Article{test," + OS.NEWLINE +
-                "  Author                   = {Foo@Bar}," + OS.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
-                "  Note                     = {some note}," + OS.NEWLINE +
-                "  Number                   = {1}" + OS.NEWLINE +
-                "}";
-        // @formatter:on
+        String bibtexEntry = """
+                @Comment{@article{myarticle,}
+                @inproceedings{blabla, title={the proceedings of bl@bl@}; }
+                }
+                @Article{test,
+                  Author                   = {Foo@Bar},
+                  Journal                  = {International Journal of Something},
+                  Note                     = {some note},
+                  Number                   = {1}
+                }""";
 
         ParserResult result = parser.parse(new StringReader(bibtexEntry));
         Collection<BibEntry> entries = result.getDatabase().getEntries();

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -91,7 +91,7 @@ class BibtexParserTest {
         expected.setCitationKey("test");
         expected.setField(StandardField.AUTHOR, "Ed von Test");
 
-        assertEquals(Collections.singletonList(expected), parsed);
+        assertEquals(List.of(expected), parsed);
     }
 
     @Test
@@ -345,7 +345,7 @@ class BibtexParserTest {
         BibEntry expected = new BibEntry(StandardEntryType.Article).withField(InternalField.KEY_FIELD, "test")
                                                                    .withField(StandardField.AUTHOR, "Ed von T@st");
 
-        assertEquals(Collections.singletonList(expected), parsed);
+        assertEquals(List.of(expected), parsed);
     }
 
     @Test
@@ -361,7 +361,7 @@ class BibtexParserTest {
         ParserResult result = parser.parse(new StringReader(entryWithComment));
         List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        assertEquals(Collections.singletonList(expected), parsed);
+        assertEquals(List.of(expected), parsed);
         assertEquals(expected.getUserComments(), parsed.get(0).getUserComments());
     }
 
@@ -658,7 +658,7 @@ class BibtexParserTest {
         Collection<BibEntry> parsed = result.getDatabase().getEntries();
 
         assertFalse(result.hasWarnings());
-        assertEquals(Collections.singletonList(expected), parsed);
+        assertEquals(List.of(expected), parsed);
     }
 
     @Test
@@ -1124,7 +1124,7 @@ class BibtexParserTest {
     @Test
     void parsePreservesMultipleSpacesInNonWrappableField() throws IOException {
         when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields())
-                .thenReturn(Collections.singletonList(StandardField.FILE));
+                .thenReturn(List.of(StandardField.FILE));
         BibtexParser parser = new BibtexParser(importFormatPreferences, fileMonitor);
         ParserResult result = parser
                 .parse(new StringReader("@article{canh05,file = {ups  sala}}"));
@@ -1331,7 +1331,7 @@ class BibtexParserTest {
         FieldFormatterCleanups saveActions = parserResult.getMetaData().getSaveActions().get();
 
         assertTrue(saveActions.isEnabled());
-        assertEquals(Collections.singletonList(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())),
+        assertEquals(List.of(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())),
                 saveActions.getConfiguredActions());
     }
 
@@ -1369,7 +1369,7 @@ class BibtexParserTest {
         FieldFormatterCleanups saveActions = parserResult.getMetaData().getSaveActions().get();
 
         assertTrue(saveActions.isEnabled());
-        assertEquals(Collections.singletonList(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())),
+        assertEquals(List.of(new FieldFormatterCleanup(StandardField.TITLE, new LowerCaseFormatter())),
                 saveActions.getConfiguredActions());
     }
 
@@ -1520,7 +1520,7 @@ class BibtexParserTest {
         expectedEntry.setCitationKey("test");
         expectedEntry.setField(StandardField.COMMENT, "testentry");
 
-        assertEquals(Collections.singletonList(expectedEntry), entries);
+        assertEquals(List.of(expectedEntry), entries);
     }
 
     @Test
@@ -1536,7 +1536,7 @@ class BibtexParserTest {
         expectedEntry.setCitationKey("test");
         expectedEntry.setField(StandardField.COMMENT, "testentry");
 
-        assertEquals(Collections.singletonList(expectedEntry), entries);
+        assertEquals(List.of(expectedEntry), entries);
     }
 
     @Test
@@ -1663,7 +1663,7 @@ class BibtexParserTest {
         List<BibEntry> parsed = parser
                 .parseEntries("@article{test,author={" + SavePreferences.ENCODING_PREFIX + "}}");
 
-        assertEquals(Collections.singletonList(expected), parsed);
+        assertEquals(List.of(expected), parsed);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1171,7 +1171,7 @@ class BibtexParserTest {
     }
 
     /**
-     * Test for #669
+     * Test for <a href="https://github.com/JabRef/jabref/issues/669">#669</a>
      */
     @Test
     void parsePreambleAndEntryWithoutNewLine() throws IOException {

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1152,7 +1152,7 @@ class BibtexParserTest {
         Collection<BibEntry> parsedEntries = result.getDatabase().getEntries();
         BibEntry parsedEntry = parsedEntries.iterator().next();
 
-        assertEquals(Optional.of("ups " + OS.NEWLINE + "sala"), parsedEntry.getField(StandardField.ABSTRACT));
+        assertEquals(Optional.of("ups \nsala"), parsedEntry.getField(StandardField.ABSTRACT));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -138,11 +138,13 @@ class BibtexParserTest {
 
     @Test
     void singleFromStringRecognizesEntryInMultiple() throws ParseException {
-        Optional<BibEntry> parsed = BibtexParser.singleFromString(
-                """
-                        @article{canh05,  author = {Crowston, K. and Annabi, H.},
-                          title = {Title A}}
-                        @inProceedings{foo,  author={Norton Bar}}""",
+        Optional<BibEntry> parsed = BibtexParser.singleFromString("""
+                        @article{canh05,
+                            author = {Crowston, K. and Annabi, H.},
+                            title = {Title A}
+                            }
+                        @inProceedings{foo,  author={Norton Bar}}
+                        """,
                 importFormatPreferences, fileMonitor);
 
         assertTrue(parsed.get().getCitationKey().equals(Optional.of("canh05"))


### PR DESCRIPTION
During crafting tests for the syntax, we noticed that save actions were not correctly parsed in some cases.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
