### PR TITLE
"study.yml" is static now

### DIFF
--- a/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
+++ b/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
@@ -8,6 +8,7 @@ import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.crawler.StudyRepository;
 import org.jabref.logic.crawler.StudyYamlParser;
 import org.jabref.model.study.Study;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -25,7 +26,7 @@ public class StartNewStudyAction extends ExistingStudySearchAction {
     @Override
     protected void setupRepository(Path studyRepositoryRoot) throws IOException, GitAPIException {
         StudyYamlParser studyYAMLParser = new StudyYamlParser();
-        studyYAMLParser.writeStudyYamlFile(newStudy, studyRepositoryRoot.resolve("study.yml"));
+        studyYAMLParser.writeStudyYamlFile(newStudy, studyRepositoryRoot.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME));
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -217,11 +217,8 @@ class StudyRepository {
      */
     public void persist(List<QueryResult> crawlResults) throws IOException, GitAPIException, SaveException {
         updateWorkAndSearchBranch();
-        persistStudy();
-        gitHandler.createCommitOnCurrentBranch("Update search date", true);
         gitHandler.checkoutBranch(SEARCH_BRANCH);
         persistResults(crawlResults);
-        persistStudy();
         try {
             // First commit changes to search branch and update remote
             String commitMessage = "Conducted search: " + LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
@@ -245,10 +242,15 @@ class StudyRepository {
      */
     private void updateRemoteSearchAndWorkBranch() throws IOException, GitAPIException {
         String currentBranch = gitHandler.getCurrentlyCheckedOutBranch();
+
+        // update remote search branch
         gitHandler.checkoutBranch(SEARCH_BRANCH);
         gitHandler.pushCommitsToRemoteRepository();
+
+        // update remote work branch
         gitHandler.checkoutBranch(WORK_BRANCH);
         gitHandler.pushCommitsToRemoteRepository();
+
         gitHandler.checkoutBranch(currentBranch);
     }
 
@@ -258,15 +260,16 @@ class StudyRepository {
      */
     private void updateWorkAndSearchBranch() throws IOException, GitAPIException {
         String currentBranch = gitHandler.getCurrentlyCheckedOutBranch();
+
+        // update search branch
         gitHandler.checkoutBranch(SEARCH_BRANCH);
         gitHandler.pullOnCurrentBranch();
+
+        // update work branch
         gitHandler.checkoutBranch(WORK_BRANCH);
         gitHandler.pullOnCurrentBranch();
-        gitHandler.checkoutBranch(currentBranch);
-    }
 
-    private void persistStudy() throws IOException {
-        new StudyYamlParser().writeStudyYamlFile(study, studyDefinitionFile);
+        gitHandler.checkoutBranch(currentBranch);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -48,9 +48,10 @@ import org.slf4j.LoggerFactory;
  * the structured persistence of the crawling results for the study within the file based repository,
  * as well as the sharing, and versioning of results using git.
  */
-class StudyRepository {
+public class StudyRepository {
     // Tests work with study.yml
-    private static final String STUDY_DEFINITION_FILE_NAME = "study.yml";
+    public static final String STUDY_DEFINITION_FILE_NAME = "study.yml";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(StudyRepository.class);
     private static final Pattern MATCHCOLON = Pattern.compile(":");
     private static final Pattern MATCHILLEGALCHARACTERS = Pattern.compile("[^A-Za-z0-9_.\\s=-]");

--- a/src/main/java/org/jabref/logic/git/SlrGitHandler.java
+++ b/src/main/java/org/jabref/logic/git/SlrGitHandler.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 
+import org.jabref.logic.crawler.StudyRepository;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
@@ -101,7 +103,7 @@ public class SlrGitHandler extends GitHandler {
             if (currentToken.startsWith("diff --git a/")) {
                 // If the diff is related to a different file, save the diff for the previous file
                 if (!(Objects.isNull(relativePath) || Objects.isNull(joiner))) {
-                    if (!relativePath.contains("study.yml")) {
+                    if (!relativePath.contains(StudyRepository.STUDY_DEFINITION_FILE_NAME)) {
                         diffsPerFile.put(Path.of(repositoryPath.toString(), relativePath), joiner.toString());
                     }
                 }

--- a/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
+++ b/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
@@ -120,8 +120,8 @@ class CrawlerTest {
     }
 
     private void setUpTestStudyDefinitionFile() throws Exception {
-        Path destination = tempRepositoryDirectory.resolve("study.yml");
-        URL studyDefinition = this.getClass().getResource("study.yml");
+        Path destination = tempRepositoryDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME);
+        URL studyDefinition = this.getClass().getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, false);
     }
 }

--- a/src/test/java/org/jabref/logic/crawler/StudyDatabaseToFetcherConverterTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyDatabaseToFetcherConverterTest.java
@@ -58,7 +58,7 @@ class StudyDatabaseToFetcherConverterTest {
 
     @Test
     public void getActiveFetcherInstances() throws Exception {
-        Path studyDefinition = tempRepositoryDirectory.resolve("study.yml");
+        Path studyDefinition = tempRepositoryDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         copyTestStudyDefinitionFileIntoDirectory(studyDefinition);
 
         StudyRepository studyRepository = new StudyRepository(
@@ -83,7 +83,7 @@ class StudyDatabaseToFetcherConverterTest {
     }
 
     private void copyTestStudyDefinitionFileIntoDirectory(Path destination) throws Exception {
-        URL studyDefinition = this.getClass().getResource("study.yml");
+        URL studyDefinition = this.getClass().getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, false);
     }
 }

--- a/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -190,8 +190,8 @@ class StudyRepositoryTest {
      * Copies the study definition file into the test repository
      */
     private void setUpTestStudyDefinitionFile() throws Exception {
-        Path destination = tempRepositoryDirectory.resolve("study.yml");
-        URL studyDefinition = this.getClass().getResource("study.yml");
+        Path destination = tempRepositoryDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME);
+        URL studyDefinition = this.getClass().getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, false);
     }
 

--- a/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -23,8 +23,8 @@ class StudyYamlParserTest {
 
     @BeforeEach
     void setupStudy() throws Exception {
-        Path destination = testDirectory.resolve("study.yml");
-        URL studyDefinition = StudyYamlParser.class.getResource("study.yml");
+        Path destination = testDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME);
+        URL studyDefinition = StudyYamlParser.class.getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, true);
 
         List<String> authors = List.of("Jab Ref");
@@ -39,14 +39,14 @@ class StudyYamlParserTest {
 
     @Test
     public void parseStudyFileSuccessfully() throws Exception {
-        Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve("study.yml"));
+        Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME));
         assertEquals(expectedStudy, study);
     }
 
     @Test
     public void writeStudyFileSuccessfully() throws Exception {
-        new StudyYamlParser().writeStudyYamlFile(expectedStudy, testDirectory.resolve("study.yml"));
-        Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve("study.yml"));
+        new StudyYamlParser().writeStudyYamlFile(expectedStudy, testDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME));
+        Study study = new StudyYamlParser().parseStudyYamlFile(testDirectory.resolve(StudyRepository.STUDY_DEFINITION_FILE_NAME));
         assertEquals(expectedStudy, study);
     }
 


### PR DESCRIPTION
Follow-up on https://github.com/JabRef/jabref/pull/9116 

`study.yml` is not modified any more during a call.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
