### PR TITLE
Don't show the info button when the authors field content is identical

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/newmergedialog/PersonsNameFieldRowView.java
+++ b/src/main/java/org/jabref/gui/mergeentries/newmergedialog/PersonsNameFieldRowView.java
@@ -21,7 +21,7 @@ public class PersonsNameFieldRowView extends FieldRowView {
         leftEntryNames = authorsParser.parse(viewModel.getLeftFieldValue());
         rightEntryNames = authorsParser.parse(viewModel.getRightFieldValue());
 
-        if (!leftEntry.equals(rightEntry) && leftEntryNames.equals(rightEntryNames)) {
+        if (!viewModel.hasEqualLeftAndRightValues() && leftEntryNames.equals(rightEntryNames)) {
             showPersonsNamesAreTheSameInfo();
             shouldShowDiffs.set(false);
         }


### PR DESCRIPTION
- Followup to #9088 
![image](https://user-images.githubusercontent.com/21198231/188285608-2683aff1-e51d-4a30-86cd-bdbfd85a1f7d.png)


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
