### PR TITLE
Linked files with an absolute path can be opened again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
-- We fixed an issue where linked fails containing parts of the main file directory could not be opened [#8991](https://github.com/JabRef/jabref/issues/8991)
+- We fixed an issue where linked fails containing parts of the main file directory could not be opened. [#8991](https://github.com/JabRef/jabref/issues/8991)
+- We fixed an issue where linked fails containing parts of the main file directory could not be opened. [#8991](https://github.com/JabRef/jabref/issues/8991)
+- Linked files with an absolute path can be opened again. [#8991](https://github.com/JabRef/jabref/issues/8991)
 - We fixed an issue where the user could not rate an entry in the main table when an entry was not yet ranked. [#5842](https://github.com/JabRef/jabref/issues/5842)
 - We fixed an issue that caused JabRef to sometimes open multiple instances when "Remote Operation" is enabled. [#8653](https://github.com/JabRef/jabref/issues/8653)
 - We fixed an issue where linked files with the filetype "application/pdf" in an entry were not shown with the correct PDF-Icon in the main table [8930](https://github.com/JabRef/jabref/issues/8930)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Fixed
 
 - We fixed an issue where linked fails containing parts of the main file directory could not be opened. [#8991](https://github.com/JabRef/jabref/issues/8991)
-- We fixed an issue where linked fails containing parts of the main file directory could not be opened. [#8991](https://github.com/JabRef/jabref/issues/8991)
 - Linked files with an absolute path can be opened again. [#8991](https://github.com/JabRef/jabref/issues/8991)
 - We fixed an issue where the user could not rate an entry in the main table when an entry was not yet ranked. [#5842](https://github.com/JabRef/jabref/issues/5842)
 - We fixed an issue that caused JabRef to sometimes open multiple instances when "Remote Operation" is enabled. [#8653](https://github.com/JabRef/jabref/issues/8653)

--- a/src/main/java/org/jabref/logic/util/io/FileNameCleaner.java
+++ b/src/main/java/org/jabref/logic/util/io/FileNameCleaner.java
@@ -6,6 +6,8 @@ import org.jabref.model.util.FileHelper;
  * This class is based on http://stackoverflow.com/a/5626340/873282
  * extended with LEFT CURLY BRACE and RIGHT CURLY BRACE
  * Replaces illegal characters in given file paths.
+ *
+ * Regarding the maximum length, see {@link FileUtil#getValidFileName(String)}
  */
 public class FileNameCleaner {
 

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -91,6 +91,8 @@ public class FileUtil {
      * Returns a valid filename for most operating systems.
      * <p>
      * Currently, only the length is restricted to 255 chars, see MAXIMUM_FILE_NAME_LENGTH.
+     *
+     * See also {@link FileHelper#detectBadFileName(String)} and {@link FileNameCleaner#cleanFileName(String)}
      */
     public static String getValidFileName(String fileName) {
         String nameWithoutExtension = getBaseName(fileName);

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -118,9 +118,6 @@ public class LinkedFile implements Serializable {
 
     /**
      * Writes serialized object to ObjectOutputStream, automatically called
-     *
-     * @param out {@link ObjectOutputStream}
-     * @throws IOException
      */
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.writeUTF(getFileType());
@@ -131,9 +128,6 @@ public class LinkedFile implements Serializable {
 
     /**
      * Reads serialized object from ObjectInputStreamm, automatically called
-     *
-     * @param in {@link ObjectInputStream}
-     * @throws IOException
      */
     private void readObject(ObjectInputStream in) throws IOException {
         fileType = new SimpleStringProperty(in.readUTF());

--- a/src/main/java/org/jabref/model/util/FileHelper.java
+++ b/src/main/java/org/jabref/model/util/FileHelper.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +43,7 @@ public class FileHelper {
             20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
             30, 31, 34,
             42,
-            58,
+            58, // ":"
             60, 62, 63,
             123, 124, 125
     };
@@ -133,10 +134,22 @@ public class FileHelper {
     /**
      * Detect illegal characters in given filename.
      *
+     * See also {@link org.jabref.logic.util.io.FileNameCleaner#cleanFileName}
+     *
      * @param fileName the fileName to detect
-     * @return Boolean whether there is a illegal name.
+     * @return Boolean whether there is an illegal name.
      */
     public static boolean detectBadFileName(String fileName) {
+        // fileName could be a path, we want to check the fileName only (and don't care about the path)
+        // Reason: Handling of "c:\temp.pdf" is difficult, because ":" is an illegal character in the file name,
+        //         but a perfectly legal one in the path at this position
+        try {
+            fileName = Path.of(fileName).getFileName().toString();
+        } catch (InvalidPathException e) {
+            // in case the internal method cannot parse the path, it is surely illegal
+            return true;
+        }
+
         for (int i = 0; i < fileName.length(); i++) {
             char c = fileName.charAt(i);
             if (!isCharLegal(c)) {
@@ -161,12 +174,14 @@ public class FileHelper {
     public static Optional<Path> find(String fileName, Path directory) {
         Objects.requireNonNull(fileName);
         Objects.requireNonNull(directory);
-        // Explicitly check for an empty String, as File.exists returns true on that empty path, because it maps to the default jar location
-        // if we then call toAbsoluteDir, it would always return the jar-location folder. This is not what we want here
+
         if (detectBadFileName(fileName)) {
             LOGGER.error("Invalid characters in path for file {} ", fileName);
             return Optional.empty();
         }
+
+        // Explicitly check for an empty string, as File.exists returns true on that empty path, because it maps to the default jar location.
+        // If we then call toAbsoluteDir, it would always return the jar-location folder. This is not what we want here.
         if (fileName.isEmpty()) {
             return Optional.of(directory);
         }

--- a/src/test/java/org/jabref/architecture/MainArchitectureTests.java
+++ b/src/test/java/org/jabref/architecture/MainArchitectureTests.java
@@ -31,7 +31,7 @@ class MainArchitectureTests {
 
     @ArchTest
     public static void doNotUseSwing(JavaClasses classes) {
-        // This checks for all all Swing packages, but not the UndoManager
+        // This checks for all Swing packages, but not the UndoManager
         noClasses().that().areNotAnnotatedWith(AllowedToUseSwing.class)
                    .should().accessClassesThat()
                    .resideInAnyPackage("javax.swing",

--- a/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
@@ -37,7 +37,7 @@ class FileFieldParserTest {
         assertEquals(expected, FileFieldParser.convert(new ArrayList<>(input)));
     }
 
-    private static Stream<Arguments> stringsToParseTestData() throws Exception {
+    private static Stream<Arguments> stringsToParseTest() throws Exception {
         return Stream.of(
                 // null string
                 Arguments.of(
@@ -114,6 +114,18 @@ class FileFieldParserTest {
                         "desc:C\\:\\\\test.pdf:PDF"
                 ),
 
+                // handleNonEscapedFilePath
+                Arguments.of(
+                        Collections.singletonList(new LinkedFile("desc", Path.of("C:\\test.pdf"), "PDF")),
+                        "desc:C:\\test.pdf:PDF"
+                ),
+
+                // Source: https://github.com/JabRef/jabref/issues/8991#issuecomment-1214131042
+                Arguments.of(
+                        Collections.singletonList(new LinkedFile("Boyd2012.pdf", Path.of("C:\\Users\\Literature_database\\Boyd2012.pdf"), "PDF")),
+                        "Boyd2012.pdf:C\\:\\\\Users\\\\Literature_database\\\\Boyd2012.pdf:PDF"
+                ),
+
                 // subsetOfFieldsResultsInFileLink: description only
                 Arguments.of(
                         Collections.singletonList(new LinkedFile("", Path.of("file.pdf"), "")),
@@ -170,8 +182,8 @@ class FileFieldParserTest {
     }
 
     @ParameterizedTest
-    @MethodSource("stringsToParseTestData")
-    public void testParse(List<LinkedFile> expected, String input) {
+    @MethodSource
+    public void stringsToParseTest(List<LinkedFile> expected, String input) {
         assertEquals(expected, FileFieldParser.parse(input));
     }
 }

--- a/src/test/java/org/jabref/model/util/FileHelperTest.java
+++ b/src/test/java/org/jabref/model/util/FileHelperTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FileHelperTest {
 
@@ -64,5 +66,17 @@ class FileHelperTest {
         Path testFile = secondFilesPath.resolve("test.pdf");
         Files.createFile(testFile);
         assertEquals(Optional.of(testFile.toAbsolutePath()), FileHelper.find("files/test.pdf", firstFilesPath));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"c:\\temp.pdf", "/mnt/tmp/test.pdf"})
+    public void legalPaths(String fileName) {
+        assertFalse(FileHelper.detectBadFileName(fileName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"te{}mp.pdf"})
+    public void illegalPaths(String fileName) {
+        assertTrue(FileHelper.detectBadFileName(fileName));
     }
 }

--- a/src/test/java/org/jabref/model/util/FileHelperTest.java
+++ b/src/test/java/org/jabref/model/util/FileHelperTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.util.OS;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@AllowedToUseLogic("Needs access to OS, because of OS-specific tests")
 class FileHelperTest {
 
     @Test

--- a/src/test/java/org/jabref/model/util/FileHelperTest.java
+++ b/src/test/java/org/jabref/model/util/FileHelperTest.java
@@ -4,6 +4,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import org.jabref.logic.util.OS;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,8 +70,17 @@ class FileHelperTest {
         assertEquals(Optional.of(testFile.toAbsolutePath()), FileHelper.find("files/test.pdf", firstFilesPath));
     }
 
+    public void testCTemp() {
+        String fileName = "c:\\temp.pdf";
+        if (OS.WINDOWS) {
+            assertFalse(FileHelper.detectBadFileName(fileName));
+        } else {
+            assertTrue(FileHelper.detectBadFileName(fileName));
+        }
+    }
+
     @ParameterizedTest
-    @ValueSource(strings = {"c:\\temp.pdf", "/mnt/tmp/test.pdf"})
+    @ValueSource(strings = {"/mnt/tmp/test.pdf"})
     public void legalPaths(String fileName) {
         assertFalse(FileHelper.detectBadFileName(fileName));
     }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/8991#issuecomment-1214131042

Follow-up to https://github.com/JabRef/jabref/issues/8786

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
