### PR TITLE
Rename 'Close' to 'Cancel' in the External Changes Resolver dialog

### DIFF
--- a/src/main/java/org/jabref/gui/collab/ExternalChangesResolverDialog.fxml
+++ b/src/main/java/org/jabref/gui/collab/ExternalChangesResolverDialog.fxml
@@ -42,5 +42,5 @@
         </AnchorPane>
 
     </content>
-    <ButtonType fx:id="close" text="%Close" buttonData="CANCEL_CLOSE"/>
+    <ButtonType fx:constant="CANCEL"/>
 </DialogPane>


### PR DESCRIPTION

Using 'Cancel' is more accurate since closing the dialog will cancel any resolved changes.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
