### PR TITLE
Add config for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java
+{
+	"name": "Java",
+	"image": "mcr.microsoft.com/vscode/devcontainers/base:bullseye",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"vscjava.vscode-java-pack"
+			]
+		}
+	},
+
+	"onCreateCommand": "yes | sdk install java 18.0.2-tem && gradle assemble",
+
+	// Need to connect as root otherwise we run into issues with gradle.
+	// default option is "vscode". More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "root",
+	"features": {
+		// Adds a lightweight desktop that can be accessed using a VNC viewer or the web
+		"desktop-lite": "latest",
+
+		// Install java 17 (java 18 is not yet available from ms)
+		"java": {
+            "version": "17",
+			"installGradle": true
+        }
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,37 +1,37 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/java
 {
-	"name": "Java",
-	"image": "mcr.microsoft.com/vscode/devcontainers/base:bullseye",
+    "name": "Java",
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:bullseye",
 
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": { 
-			},
-			
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"vscjava.vscode-java-pack"
-			]
-		}
-	},
-
-	"onCreateCommand": "yes | sdk install java 18.0.2-tem && gradle assemble",
-
-	// Need to connect as root otherwise we run into issues with gradle.
-	// default option is "vscode". More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "root",
-	"features": {
-		// Adds a lightweight desktop that can be accessed using a VNC viewer or the web
-		"desktop-lite": "latest",
-
-		// Install java 17 (java 18 is not yet available from ms)
-		"java": {
-            "version": "17",
-			"installGradle": true
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": { 
+            },
+            
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "vscjava.vscode-java-pack"
+            ]
         }
-	}
+    },
+
+    "onCreateCommand": "yes | sdk install java 18.0.2-tem && gradle assemble",
+
+    // Need to connect as root otherwise we run into issues with gradle.
+    // default option is "vscode". More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "root",
+    "features": {
+        // Adds a lightweight desktop that can be accessed using a VNC viewer or the web
+        "desktop-lite": "latest",
+
+        // Install java 17 (java 18 is not yet available from ms)
+        "java": {
+            "version": "17",
+            "installGradle": true
+        }
+    }
 }


### PR DESCRIPTION
Similar to the config for gitpod, we add a config for Github's codespaces. Compilation works. Moreover, one can run the compiled version (in the browser) buy following the steps at https://github.com/devcontainers/features/blob/main/src/desktop-lite/NOTES.md#connecting-to-the-desktop and then opening a terminal, and running jabref via `gradle run`.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
