### PR TITLE
Improve startup-behavior of pdf indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where JabRef would not exit when a connection to a LibreOffice document was established previously and the document is still open. [#9075](https://github.com/JabRef/jabref/issues/9075)
 - We fixed an issue about selecting the save order in the preferences. [#9175](https://github.com/JabRef/jabref/issues/9147)
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
+- We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -888,16 +888,6 @@ public class LibraryTab extends Tab {
 
     private class IndexUpdateListener {
 
-        public IndexUpdateListener() {
-            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
-                try {
-                    indexingTaskManager.updateIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
-                } catch (IOException e) {
-                    LOGGER.error("Cannot access lucene index", e);
-                }
-            }
-        }
-
         @Subscribe
         public void listen(EntriesAddedEvent addedEntryEvent) {
             if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -48,9 +48,9 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.util.FileFieldParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.pdf.FileAnnotationCache;
+import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
+import org.jabref.logic.pdf.search.indexing.PdfIndexer;
 import org.jabref.logic.search.SearchQuery;
-import org.jabref.logic.search.indexing.IndexingTaskManager;
-import org.jabref.logic.search.indexing.LuceneIndexer;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.util.UpdateField;
 import org.jabref.logic.util.io.FileUtil;
@@ -219,11 +219,12 @@ public class LibraryTab extends Tab {
 
         feedData(context);
 
-        try {
-            indexingTaskManager.manageFulltextIndexAccordingToPrefs(LuceneIndexer.of(bibDatabaseContext, preferencesService, preferencesService.getFilePreferences()));
-            indexingTaskManager.updateIndex(LuceneIndexer.of(bibDatabaseContext, preferencesService, preferencesService.getFilePreferences()));
-        } catch (IOException e) {
-            LOGGER.error("Cannot access lucene index", e);
+        if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+            try {
+                indexingTaskManager.updateIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
+            } catch (IOException e) {
+                LOGGER.error("Cannot access lucene index", e);
+            }
         }
 
         // a temporary workaround to update groups pane
@@ -369,7 +370,9 @@ public class LibraryTab extends Tab {
             setTooltip(new Tooltip(toolTipText.toString()));
         });
 
-        indexingTaskManager.updateDatabaseName(tabTitle.toString());
+        if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+            indexingTaskManager.updateDatabaseName(tabTitle.toString());
+        }
     }
 
     private List<String> collectAllDatabasePaths() {
@@ -847,7 +850,7 @@ public class LibraryTab extends Tab {
 
             // Automatically add new entries to the selected group (or set of groups)
             if (preferencesService.getGroupsPreferences().shouldAutoAssignGroup()) {
-                stateManager.getSelectedGroups(bibDatabaseContext).forEach(
+                stateManager.getSelectedGroup(bibDatabaseContext).forEach(
                         selectedGroup -> selectedGroup.addEntriesToGroup(addedEntriesEvent.getBibEntries()));
             }
         }
@@ -885,43 +888,62 @@ public class LibraryTab extends Tab {
 
     private class IndexUpdateListener {
 
+        public IndexUpdateListener() {
+            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+                try {
+                    indexingTaskManager.updateIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), bibDatabaseContext);
+                } catch (IOException e) {
+                    LOGGER.error("Cannot access lucene index", e);
+                }
+            }
+        }
+
         @Subscribe
         public void listen(EntriesAddedEvent addedEntryEvent) {
-            try {
-                LuceneIndexer luceneIndexer = LuceneIndexer.of(bibDatabaseContext, preferencesService, preferencesService.getFilePreferences());
-                for (BibEntry addedEntry : addedEntryEvent.getBibEntries()) {
-                    indexingTaskManager.addToIndex(luceneIndexer, addedEntry);
+            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+                try {
+                    PdfIndexer pdfIndexer = PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences());
+                    for (BibEntry addedEntry : addedEntryEvent.getBibEntries()) {
+                        indexingTaskManager.addToIndex(pdfIndexer, addedEntry, bibDatabaseContext);
+                    }
+                } catch (IOException e) {
+                    LOGGER.error("Cannot access lucene index", e);
                 }
-            } catch (IOException e) {
-                LOGGER.error("Cannot access lucene index", e);
             }
         }
 
         @Subscribe
         public void listen(EntriesRemovedEvent removedEntriesEvent) {
-            try {
-                LuceneIndexer luceneIndexer = LuceneIndexer.of(bibDatabaseContext, preferencesService, preferencesService.getFilePreferences());
-                for (BibEntry removedEntry : removedEntriesEvent.getBibEntries()) {
-                    indexingTaskManager.removeFromIndex(luceneIndexer, removedEntry);
+            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+                try {
+                    PdfIndexer pdfIndexer = PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences());
+                    for (BibEntry removedEntry : removedEntriesEvent.getBibEntries()) {
+                        indexingTaskManager.removeFromIndex(pdfIndexer, removedEntry);
+                    }
+                } catch (IOException e) {
+                    LOGGER.error("Cannot access lucene index", e);
                 }
-            } catch (IOException e) {
-                LOGGER.error("Cannot access lucene index", e);
             }
         }
 
         @Subscribe
         public void listen(FieldChangedEvent fieldChangedEvent) {
-            for (BibEntry bibEntry : fieldChangedEvent.getBibEntries()) {
-                try {
-                    List<LinkedFile> removedFiles = new ArrayList<>();
-                    if (fieldChangedEvent.getField().equals(StandardField.FILE)) {
-                        List<LinkedFile> oldFileList = FileFieldParser.parse(fieldChangedEvent.getOldValue());
-                        List<LinkedFile> newFileList = FileFieldParser.parse(fieldChangedEvent.getNewValue());
-                        removedFiles.remove(newFileList);
+            if (preferencesService.getFilePreferences().shouldFulltextIndexLinkedFiles()) {
+                if (fieldChangedEvent.getField().equals(StandardField.FILE)) {
+                    List<LinkedFile> oldFileList = FileFieldParser.parse(fieldChangedEvent.getOldValue());
+                    List<LinkedFile> newFileList = FileFieldParser.parse(fieldChangedEvent.getNewValue());
+
+                    List<LinkedFile> addedFiles = new ArrayList<>(newFileList);
+                    addedFiles.remove(oldFileList);
+                    List<LinkedFile> removedFiles = new ArrayList<>(oldFileList);
+                    removedFiles.remove(newFileList);
+
+                    try {
+                        indexingTaskManager.addToIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), fieldChangedEvent.getBibEntry(), addedFiles, bibDatabaseContext);
+                        indexingTaskManager.removeFromIndex(PdfIndexer.of(bibDatabaseContext, preferencesService.getFilePreferences()), fieldChangedEvent.getBibEntry(), removedFiles);
+                    } catch (IOException e) {
+                        LOGGER.warn("I/O error when writing lucene index", e);
                     }
-                    indexingTaskManager.updateIndex(LuceneIndexer.of(bibDatabaseContext, preferencesService, preferencesService.getFilePreferences()), bibEntry, removedFiles);
-                } catch (IOException e) {
-                    LOGGER.warn("I/O error when writing lucene index", e);
                 }
             }
         }

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/DocumentReader.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/DocumentReader.java
@@ -100,12 +100,12 @@ public final class DocumentReader {
                     try {
                         addContentIfNotEmpty(pdfDocument, newDocument, pageNumber);
                     } catch (IOException e) {
-                        LOGGER.warn("Could not read page " + pageNumber + " of " + resolvedPdfPath.toAbsolutePath(), e);
+                        LOGGER.warn("Could not read page {} of  {}", pageNumber, resolvedPdfPath.toAbsolutePath(), e);
                     }
                     pages.add(newDocument);
                 }
         } catch (IOException e) {
-            LOGGER.warn("Could not read " + resolvedPdfPath.toAbsolutePath(), e);
+            LOGGER.warn("Could not read {}", resolvedPdfPath.toAbsolutePath(), e);
         }
         if (pages.isEmpty()) {
             Document newDocument = new Document();

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/DocumentReader.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/DocumentReader.java
@@ -71,11 +71,7 @@ public final class DocumentReader {
     public Optional<List<Document>> readLinkedPdf(BibDatabaseContext databaseContext, LinkedFile pdf) {
         Optional<Path> pdfPath = pdf.findIn(databaseContext, filePreferences);
         if (pdfPath.isPresent()) {
-            try {
-                return Optional.of(readPdfContents(pdf, pdfPath.get()));
-            } catch (IOException e) {
-                LOGGER.error("Could not read pdf file {}!", pdf.getLink(), e);
-            }
+            return Optional.of(readPdfContents(pdf, pdfPath.get()));
         }
         return Optional.empty();
     }
@@ -94,19 +90,30 @@ public final class DocumentReader {
                     .collect(Collectors.toList());
     }
 
-    private List<Document> readPdfContents(LinkedFile pdf, Path resolvedPdfPath) throws IOException {
+    private List<Document> readPdfContents(LinkedFile pdf, Path resolvedPdfPath) {
+        List<Document> pages = new ArrayList<>();
         try (PDDocument pdfDocument = Loader.loadPDF(resolvedPdfPath.toFile())) {
-            List<Document> pages = new ArrayList<>();
-
-            for (int pageNumber = 0; pageNumber < pdfDocument.getNumberOfPages(); pageNumber++) {
-                Document newDocument = new Document();
-                addIdentifiers(newDocument, pdf.getLink());
-                addMetaData(newDocument, resolvedPdfPath, pageNumber);
-                addContentIfNotEmpty(pdfDocument, newDocument, pageNumber);
-                pages.add(newDocument);
-            }
-            return pages;
+                for (int pageNumber = 0; pageNumber < pdfDocument.getNumberOfPages(); pageNumber++) {
+                    Document newDocument = new Document();
+                    addIdentifiers(newDocument, pdf.getLink());
+                    addMetaData(newDocument, resolvedPdfPath, pageNumber);
+                    try {
+                        addContentIfNotEmpty(pdfDocument, newDocument, pageNumber);
+                    } catch (IOException e) {
+                        LOGGER.warn("Could not read page " + pageNumber + " of " + resolvedPdfPath.toAbsolutePath(), e);
+                    }
+                    pages.add(newDocument);
+                }
+        } catch (IOException e) {
+            LOGGER.warn("Could not read " + resolvedPdfPath.toAbsolutePath(), e);
         }
+        if (pages.isEmpty()) {
+            Document newDocument = new Document();
+            addIdentifiers(newDocument, pdf.getLink());
+            addMetaData(newDocument, resolvedPdfPath, 0);
+            pages.add(newDocument);
+        }
+        return pages;
     }
 
     private void addMetaData(Document newDocument, Path resolvedPdfPath, int pageNumber) {
@@ -135,24 +142,20 @@ public final class DocumentReader {
         return LINEBREAK_WITHOUT_PERIOD_PATTERN.matcher(mergedHyphenNewlines).replaceAll("$1 ");
     }
 
-    private void addContentIfNotEmpty(PDDocument pdfDocument, Document newDocument, int pageNumber) {
-        try {
-            PDFTextStripper pdfTextStripper = new PDFTextStripper();
-            pdfTextStripper.setLineSeparator("\n");
-            pdfTextStripper.setStartPage(pageNumber);
-            pdfTextStripper.setEndPage(pageNumber);
+    private void addContentIfNotEmpty(PDDocument pdfDocument, Document newDocument, int pageNumber) throws IOException {
+        PDFTextStripper pdfTextStripper = new PDFTextStripper();
+        pdfTextStripper.setLineSeparator("\n");
+        pdfTextStripper.setStartPage(pageNumber);
+        pdfTextStripper.setEndPage(pageNumber);
 
-            String pdfContent = pdfTextStripper.getText(pdfDocument);
-            if (StringUtil.isNotBlank(pdfContent)) {
-                newDocument.add(new TextField(CONTENT, mergeLines(pdfContent), Field.Store.YES));
-            }
-            PDPage page = pdfDocument.getPage(pageNumber);
-            List<String> annotations = page.getAnnotations().stream().filter((annotation) -> annotation.getContents() != null).map(PDAnnotation::getContents).collect(Collectors.toList());
-            if (annotations.size() > 0) {
-                newDocument.add(new TextField(ANNOTATIONS, annotations.stream().collect(Collectors.joining("\n")), Field.Store.YES));
-            }
-        } catch (IOException e) {
-            LOGGER.info("Could not read contents of PDF document \"{}\"", pdfDocument.toString(), e);
+        String pdfContent = pdfTextStripper.getText(pdfDocument);
+        if (StringUtil.isNotBlank(pdfContent)) {
+            newDocument.add(new TextField(CONTENT, mergeLines(pdfContent), Field.Store.YES));
+        }
+        PDPage page = pdfDocument.getPage(pageNumber);
+        List<String> annotations = page.getAnnotations().stream().filter((annotation) -> annotation.getContents() != null).map(PDAnnotation::getContents).collect(Collectors.toList());
+        if (annotations.size() > 0) {
+            newDocument.add(new TextField(ANNOTATIONS, annotations.stream().collect(Collectors.joining("\n")), Field.Store.YES));
         }
     }
 


### PR DESCRIPTION
PdfIndexing is improved in two ways:
- fix a bug that caused re-indexing on each start of JabRef
- add an empty entry to the index for files JabRef was not able to read (happens a lot due to missing fonts). This way JabRef knows the file was already read and will not try again on the next start (assuming the read would fail again).

Fixes #8420

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
