### PR TITLE
Remove Java Flight Recorder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -560,7 +560,6 @@ jlink {
         requires 'java.transaction.xa'
         requires 'java.rmi'
         requires 'java.xml'
-        requires 'jdk.jfr'
         requires 'jdk.jsobject'
         requires 'jdk.unsupported'
         requires 'jdk.unsupported.desktop'


### PR DESCRIPTION
This removes [Java Flight Recorder](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm#JFRUH170)

> Java Flight Recorder requires a commercial license for use in production.
> [...]
> Java Flight Recorder (JFR) is a tool for collecting diagnostic and profiling data about a running Java application.

I think, we never used it on a user's side, so would remove it for our distribution.

On a case-per-case-basis, we (or some researchers) could include `jdk.jfr` back locally.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
