### PR TITLE
"Capitalize" capitalizes words after hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue about selecting the save order in the preferences. [#9175](https://github.com/JabRef/jabref/issues/9147)
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
 - We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
+- We fixed an issue where Capitalize didn't capitalize words after hyphen characters. [#9157](https://github.com/JabRef/jabref/issues/9157)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
@@ -22,7 +22,7 @@ public class CapitalizeFormatter extends Formatter {
     public String format(String input) {
         Title title = new Title(input);
 
-        title.getWords().stream().forEach(Word::toUpperFirst);
+        title.getWords().stream().forEach(Word::toUpperFirstIgnoreHyphen);
 
         return title.toString();
     }

--- a/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/Word.java
@@ -102,6 +102,16 @@ public final class Word {
         }
     }
 
+    public void toUpperFirstIgnoreHyphen() {
+        for (int i = 0; i < chars.length; i++) {
+            if (!protectedChars[i]) {
+                chars[i] = (i == 0 || (DASHES.contains(chars[i - 1]))) ?
+                        Character.toUpperCase(chars[i]) :
+                        Character.toLowerCase(chars[i]);
+            }
+        }
+    }
+
     public void toUpperFirstTitle() {
         for (int i = 0; i < chars.length; i++) {
             if (!protectedChars[i]) {

--- a/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -43,6 +43,13 @@ public class CapitalizeFormatterTest {
             "UPPER {E}ACH {NOT} FIRST, Upper {E}ach {NOT} First", // multiple words upper case with {}
             "upper each first {NOT} {this}, Upper Each First {NOT} {this}", // multiple words in lower and upper case with {}
             "upper each first {N}OT {t}his, Upper Each First {N}ot {t}his", // multiple words in lower and upper case with {} part 2
+            "upper-each-first, Upper-Each-First", // multiple words lower case with -
+            "Upper-Each-First, Upper-Each-First", // multiple words correct with -
+            "Upper-each-First, Upper-Each-First", // multiple words in lower and upper case with -
+            "UPPER-EACH-FIRST, Upper-Each-First", // multiple words upper case with -
+            "{u}pper-each-{f}irst, {u}pper-Each-{f}irst", // multiple words lower case with {} and -
+            "-upper, -Upper", // single word with -
+            "-{u}pper, -{u}pper", // single word with {} and -
     })
     public void testInputs(String input, String expectedResult) {
         String formattedStr = formatter.format(input);


### PR DESCRIPTION
Fixes #9157

Added to a new method to Word (toUpperFirstIgnoreHyphen) that is called in CapitalizeFormatter to capitalize first letter of every word, including words after hyphen characters.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
