### PR TITLE
Improve installation of java 18 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
         }
     },
 
-    "onCreateCommand": "yes | sdk install java 18.0.2-tem && gradle assemble",
+    "onCreateCommand": "gradle assemble",
 
     // Need to connect as root otherwise we run into issues with gradle.
     // default option is "vscode". More info: https://aka.ms/vscode-remote/containers/non-root.
@@ -28,10 +28,11 @@
         // Adds a lightweight desktop that can be accessed using a VNC viewer or the web
         "desktop-lite": "latest",
 
-        // Install java 17 (java 18 is not yet available from ms)
+        // Install java
         "java": {
-            "version": "17",
-            "installGradle": true
+            "version": "18",
+            "installGradle": true,
+            "jdkDistro": "sem"
         }
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

For some reason java 18 is no longer available through the "tem" distro. Thus using "sem" now and using the latest improvements to the java-feature to directly install java 18: https://github.com/devcontainers/features/pull/172

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
