### PR TITLE
Searching for an entry on the web shouldn't take forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
 - We fixed an issue where Capitalize didn't capitalize words after hyphen characters. [#9157](https://github.com/JabRef/jabref/issues/9157)
 - We fixed an issue with the message that is displayed when fetcher returns an empty list of entries for given query. [#9195](https://github.com/JabRef/jabref/issues/9195)
+
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
 - We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
 - We fixed an issue where Capitalize didn't capitalize words after hyphen characters. [#9157](https://github.com/JabRef/jabref/issues/9157)
-
+- We fixed an issue with the message that is displayed when fetcher returns an empty list of entries for given query. [#9195](https://github.com/JabRef/jabref/issues/9195)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -38,7 +38,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImportAction.class);
 
-    private StringProperty message;
+    private final StringProperty message;
     private final TaskExecutor taskExecutor;
     private final BibDatabaseContext databaseContext;
     private final DialogService dialogService;

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -38,7 +38,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImportAction.class);
 
-    private final StringProperty message;
+    private StringProperty message;
     private final TaskExecutor taskExecutor;
     private final BibDatabaseContext databaseContext;
     private final DialogService dialogService;
@@ -80,6 +80,9 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             this.parserResult = parserResult;
             // fill in the list for the user, where one can select the entries to import
             entries.addAll(parserResult.getDatabase().getEntries());
+            if (entries.isEmpty()) {
+               task.updateMessage("No entries corresponding to given query");
+            }
         }).onFailure(ex -> {
             LOGGER.error("Error importing", ex);
             dialogService.showErrorDialogAndWait(ex);

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -81,7 +81,7 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             // fill in the list for the user, where one can select the entries to import
             entries.addAll(parserResult.getDatabase().getEntries());
             if (entries.isEmpty()) {
-               task.updateMessage("No entries corresponding to given query");
+               task.updateMessage(Localization.lang("No entries corresponding to given query"));
             }
         }).onFailure(ex -> {
             LOGGER.error("Error importing", ex);

--- a/src/main/java/org/jabref/gui/util/BackgroundTask.java
+++ b/src/main/java/org/jabref/gui/util/BackgroundTask.java
@@ -257,7 +257,7 @@ public abstract class BackgroundTask<V> {
         updateProgress(new BackgroundProgress(workDone, max));
     }
 
-    protected void updateMessage(String newMessage) {
+    public void updateMessage(String newMessage) {
         message.setValue(newMessage);
     }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2508,3 +2508,5 @@ The\ %0s\ are\ the\ same.\ However,\ the\ order\ of\ field\ content\ differs=The
 Keep\ from\ import=Keep from import
 Keep\ merged=Keep merged
 Keep\ old\ entry=Keep old entry
+
+No\ entries\ corresponding\ to\ given\ query=No entries corresponding to given query


### PR DESCRIPTION
Fixes [#9195](https://github.com/JabRef/jabref/issues/9195)

Updated message when fetcher returns an empty list of entries.

![fix_issue](https://user-images.githubusercontent.com/94762087/193426945-5115ac68-bbcd-41c4-aed9-93130d9dbd0c.png)


- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
