### PR TITLE
disable conversions for empty fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Changed
 
+- We disabled the conversion menu for empty fields [#9200](https://github.com/JabRef/jabref/issues/9200)
 - Genres are now mapped correctly to entry types when importing MODS files. [#9185](https://github.com/JabRef/jabref/issues/9185)
 - We improved the Citavi Importer to also import so called Knowledge-items into the field `comment` of the corresponding entry [#9025](https://github.com/JabRef/jabref/issues/9025)
 - We removed wrapping of string constants when writing to a `.bib` file.

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
@@ -15,6 +15,9 @@ import javafx.scene.control.Tooltip;
 import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.formatter.Formatters;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
+
+import com.tobiasdiez.easybind.EasyBind;
 
 public class DefaultMenu implements Supplier<List<MenuItem>> {
 
@@ -62,7 +65,7 @@ public class DefaultMenu implements Supplier<List<MenuItem>> {
             CustomMenuItem menuItem = new CustomMenuItem(new Label(converter.getName()));
             Tooltip toolTip = new Tooltip(converter.getDescription());
             Tooltip.install(menuItem.getContent(), toolTip);
-            menuItem.setDisable(textInputControl.textProperty().get() == null);
+            EasyBind.subscribe(textInputControl.textProperty(), value -> menuItem.setDisable(StringUtil.isNullOrEmpty(value)));
             menuItem.setOnAction(event ->
                     textInputControl.textProperty().set(converter.format(textInputControl.textProperty().get())));
             submenu.getItems().add(menuItem);

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
@@ -62,6 +62,7 @@ public class DefaultMenu implements Supplier<List<MenuItem>> {
             CustomMenuItem menuItem = new CustomMenuItem(new Label(converter.getName()));
             Tooltip toolTip = new Tooltip(converter.getDescription());
             Tooltip.install(menuItem.getContent(), toolTip);
+            menuItem.setDisable(textInputControl.textProperty().get() == null);
             menuItem.setOnAction(event ->
                     textInputControl.textProperty().set(converter.format(textInputControl.textProperty().get())));
             submenu.getItems().add(menuItem);


### PR DESCRIPTION
Converting fields that were empty led to a Nullpointer Exception. This PR checks for null strings and replaces the return value with a blank String.

Fixes #9200 

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
