### PR TITLE
 Opening a file removes duplicate keywords and triggers lib changed

### DIFF
--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -773,8 +773,20 @@ public class BibEntry implements Cloneable {
 
     public Optional<FieldChange> removeKeywords(KeywordList keywordsToRemove, Character keywordDelimiter) {
         KeywordList keywordList = getKeywords(keywordDelimiter);
+
+        // We need to fix "file has changed on disk" for duplicate keywords
+        // The input of the set may contain duplicate keywords (which are present as single keyword in the set)
+        // Even if no "keywordsToRemove" is contained, the method "putKeywords" will return a change, because the duplicate keywords will have been removed
+        int oldSize = keywordList.size();
         keywordList.removeAll(keywordsToRemove);
-        return putKeywords(keywordList, keywordDelimiter);
+        // claim 1: The size of a set is the same, if no element is removed
+        // claim 2: The size of a set is different if an element was removed
+        // With claim 1, we can assume no change if there is no change on the size
+        if (oldSize == keywordList.size()) {
+            return Optional.empty();
+        } else {
+            return putKeywords(keywordList, keywordDelimiter);
+        }
     }
 
     public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace,

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -158,6 +158,21 @@ public class BibtexDatabaseWriterTest {
     }
 
     @Test
+    void writeEntryWithDuplicateKeywords() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setType(StandardEntryType.Article);
+        entry.setField(StandardField.KEYWORDS, "asdf,asdf,asdf");
+        database.insertEntry(entry);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
+
+        assertEquals("@Article{," + OS.NEWLINE
+                     + "  keywords = {asdf,asdf,asdf}," + OS.NEWLINE
+                     + "}" + OS.NEWLINE,
+                stringWriter.toString());
+    }
+
+    @Test
     void writeEncodingAndEntry() throws Exception {
         BibEntry entry = new BibEntry();
         entry.setType(StandardEntryType.Article);
@@ -239,6 +254,7 @@ public class BibtexDatabaseWriterTest {
                 +
                 "@Comment{jabref-meta: keypatterndefault:test;}" + OS.NEWLINE, stringWriter.toString());
     }
+
 
     @Test
     void writeGroups() throws Exception {

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -271,7 +271,6 @@ public class BibtexDatabaseWriterTest {
                 "@Comment{jabref-meta: keypatterndefault:test;}" + OS.NEWLINE, stringWriter.toString());
     }
 
-
     @Test
     void writeGroups() throws Exception {
         GroupTreeNode groupRoot = GroupTreeNode.fromGroup(new AllEntriesGroup(""));

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -173,7 +173,7 @@ public class BibtexDatabaseWriterTest {
     }
 
     @Test
-    void writeEntryWithDuplicateKeywordsFromPutKeyword() throws Exception {
+    void putKeyWordsRemovesDuplicateKeywordsIsVisibleDuringWrite() throws Exception {
         BibEntry entry = new BibEntry();
         entry.setType(StandardEntryType.Article);
         entry.putKeywords(List.of("asdf", "asdf", "asdf"), ',');
@@ -183,7 +183,7 @@ public class BibtexDatabaseWriterTest {
         databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
 
         assertEquals("@Article{," + OS.NEWLINE
-                     + "  keywords = {asdf,asdf,asdf}," + OS.NEWLINE
+                     + "  keywords = {asdf}," + OS.NEWLINE
                      + "}" + OS.NEWLINE,
                 stringWriter.toString());
     }

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -173,6 +173,22 @@ public class BibtexDatabaseWriterTest {
     }
 
     @Test
+    void writeEntryWithDuplicateKeywordsFromPutKeyword() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setType(StandardEntryType.Article);
+        entry.putKeywords(List.of("asdf", "asdf", "asdf"), ',');
+
+        database.insertEntry(entry);
+
+        databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
+
+        assertEquals("@Article{," + OS.NEWLINE
+                     + "  keywords = {asdf,asdf,asdf}," + OS.NEWLINE
+                     + "}" + OS.NEWLINE,
+                stringWriter.toString());
+    }
+
+    @Test
     void writeEncodingAndEntry() throws Exception {
         BibEntry entry = new BibEntry();
         entry.setType(StandardEntryType.Article);

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1923,4 +1923,17 @@ class BibtexParserTest {
 
         assertEquals(Optional.of("#apr#"), result.get().getField(StandardField.MONTH));
     }
+
+    @Test
+    void parseDuplicateKeywords() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{,\n"
+            + "  keywords     = {asdf, asdf, asdf},\n"
+            + "}\n"
+            + "");
+
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Misc)
+            .withField(StandardField.KEYWORDS, "asdf, asdf, asdf");
+
+        assertEquals(expectedEntry, result);
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1939,7 +1939,6 @@ class BibtexParserTest {
 
     @Test
     void parseDuplicateKeywordsWithTwoEntries() throws Exception {
-
         BibEntry expectedEntryFirst = new BibEntry(StandardEntryType.Article)
             .withField(StandardField.KEYWORDS, "bbb")
             .withCitationKey("Test2017");

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1925,15 +1925,38 @@ class BibtexParserTest {
     }
 
     @Test
-    void parseDuplicateKeywords() throws ParseException {
-        Optional<BibEntry> result = parser.parseSingleEntry("@Misc{,\n"
-            + "  keywords     = {asdf, asdf, asdf},\n"
+    void parseDuplicateKeywordsWithOnlyOneEntry() throws ParseException {
+        Optional<BibEntry> result = parser.parseSingleEntry("@Article{,\n"
+            + "Keywords={asdf,asdf,asdf},\n"
             + "}\n"
             + "");
 
-        BibEntry expectedEntry = new BibEntry(StandardEntryType.Misc)
-            .withField(StandardField.KEYWORDS, "asdf, asdf, asdf");
+        BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
+            .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
 
-        assertEquals(expectedEntry, result);
+        assertEquals(Optional.of(expectedEntry), result);
+    }
+
+    @Test
+    void parseDuplicateKeywordsWithTwoEntries() throws Exception {
+
+        BibEntry expectedEntryFirst = new BibEntry(StandardEntryType.Article)
+            .withField(StandardField.KEYWORDS, "bbb")
+            .withCitationKey("Test2017");
+
+        BibEntry expectedEntrySecond = new BibEntry(StandardEntryType.Article)
+            .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
+
+        String entries = """
+            @Article{Test2017,
+              keywords = {bbb},
+            }
+
+            @Article{,
+              keywords = {asdf,asdf,asdf},
+            },
+            """;
+        ParserResult result = parser.parse(new StringReader(entries));
+        assertEquals(List.of(expectedEntryFirst, expectedEntrySecond), result.getDatabase().getEntries());
     }
 }

--- a/src/test/java/org/jabref/migrations/SpecialFieldsToSeparateFieldsTest.java
+++ b/src/test/java/org/jabref/migrations/SpecialFieldsToSeparateFieldsTest.java
@@ -39,9 +39,8 @@ class SpecialFieldsToSeparateFieldsTest {
         assertEquals(expected, entry);
     }
 
-    // This test fails because we call entry removeKeywords which operates on a set of keywords
     @Test
-    public void noKewordToMigrateButDuplicateKeywords() {
+    public void noKeywordToMigrateButDuplicateKeywords() {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "JabRef")
                                        .withField(StandardField.KEYWORDS, "asdf, asdf, asdf");
         BibEntry expected = new BibEntry().withField(StandardField.AUTHOR, "JabRef")

--- a/src/test/java/org/jabref/migrations/SpecialFieldsToSeparateFieldsTest.java
+++ b/src/test/java/org/jabref/migrations/SpecialFieldsToSeparateFieldsTest.java
@@ -39,6 +39,19 @@ class SpecialFieldsToSeparateFieldsTest {
         assertEquals(expected, entry);
     }
 
+    // This test fails because we call entry removeKeywords which operates on a set of keywords
+    @Test
+    public void noKewordToMigrateButDuplicateKeywords() {
+        BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "JabRef")
+                                       .withField(StandardField.KEYWORDS, "asdf, asdf, asdf");
+        BibEntry expected = new BibEntry().withField(StandardField.AUTHOR, "JabRef")
+                                          .withField(StandardField.KEYWORDS, "asdf, asdf, asdf");
+
+        new SpecialFieldsToSeparateFields(',').performMigration(new ParserResult(List.of(entry)));
+
+        assertEquals(expected, entry);
+    }
+
     @Test
     public void migrateMultipleSpecialFields() {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "JabRef")

--- a/src/test/java/org/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseTest.java
@@ -478,5 +478,4 @@ class BibDatabaseTest {
         database.setPreamble("Oh yeah!");
         assertEquals(Optional.of("Oh yeah!"), database.getPreamble());
     }
-
 }

--- a/src/test/java/org/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BibDatabaseTest {
 
     private BibDatabase database;
-    private BibtexString bibtexString = new BibtexString("DSP", "Digital Signal Processing");
+    private final BibtexString bibtexString = new BibtexString("DSP", "Digital Signal Processing");
 
     @BeforeEach
     void setUp() {
@@ -478,4 +478,5 @@ class BibDatabaseTest {
         database.setPreamble("Oh yeah!");
         assertEquals(Optional.of("Oh yeah!"), database.getPreamble());
     }
+
 }


### PR DESCRIPTION
Refs and I will hopefully find a way to fixes #9187 

After a while debugging and adding tests everywhere I finally found the culprit. The keyword special field migration calls 
removeKeywords on an entry and that internally calls getKeywords which returns only a Set and readds those
=> As this is now a Set: Poof our duplicate keywords are gone and the library has changed 

Questions to decide: Remove duplicate keywords on save? Probably easiest solution
Refactor migration to keep duplicates?


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
