### PR TITLE
DOAB Fetcher now fetches ISBN and imprint fields where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We reworked the Define study parameters dialog. [#9123](https://github.com/JabRef/jabref/pull/9123)
 - We simplified the actions to fast-resolve duplicates to 'Keep Left', 'Keep Right', 'Keep Both' and 'Keep Merged'. [#9056](https://github.com/JabRef/jabref/issues/9056)
 - We fixed an issue where a message about changed metadata would occur on saving although nothing changed. [#9159](https://github.com/JabRef/jabref/issues/9159)
+- We modified the Directory of Open Access Books (DOAB) fetcher so that it will now also fetch the ISBN when possible. [#8708](https://github.com/JabRef/jabref/issues/8708)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DOABFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DOABFetcher.java
@@ -18,6 +18,7 @@ import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.strings.StringUtil;
 
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONException;
@@ -160,7 +161,7 @@ public class DOABFetcher implements SearchBasedParserFetcher {
 
         // Special condition to check if publisher field is empty. If so, retrieve imprint (if available)
         if (entry.getField(StandardField.PUBLISHER).isEmpty()) {
-            if (!publisherImprint.equals("")) {
+            if (!StringUtil.isNullOrEmpty(publisherImprint)) {
                 entry.setField(StandardField.PUBLISHER, publisherImprint);
             }
         }

--- a/src/test/java/org/jabref/logic/importer/fetcher/DOABFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DOABFetcherTest.java
@@ -45,6 +45,7 @@ public class DOABFetcherTest {
                 ),
                 Arguments.of(
                         new BibEntry(StandardEntryType.Book)
+                                .withField(StandardField.ISBN, "9789085551201")
                                 .withField(StandardField.AUTHOR, "Ronald Snijder")
                                 .withField(StandardField.TITLE, "The deliverance of open access books")
                                 .withField(StandardField.SUBTITLE, "Examining usage and dissemination")


### PR DESCRIPTION
Fixes #8708.

Previously, the DOAB Fetcher could not obtain the ISBN of a DOAB entry. This PR modifies the URL for DOAB query to include `BITSTREAM` data (where ISBN information can be found). 

Below is an example of the previous and updated URL's for DOAB queries (note the ",bitstreams" suffix)

`PREVIOUS`: https://directory.doabooks.org/rest/search?query=handle:%2220.500.12854/26303%22&expand=metadata

`UPDATED`: https://directory.doabooks.org/rest/search?query=handle:%2220.500.12854/26303%22&expand=metadata,bitstreams

The fetcher can then obtain the ISBN and add the field to the entry accordingly. I am creating this Draft PR to discuss with maintainers that it seems like **_many_** DOAB entries do not have ISBN metadata or `BITSTREAM` objects and so the ISBN may perhaps be unobtainable in these instances. So I am wondering if there is anything more can be done or if (under the assumption that this PR is accepted firstly) #8708 should be closed?


- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.