### PR TITLE
Fix for resizing cleanup entries dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed the Cleanup entries dialog is partially visible [#9223](https://github.com/JabRef/jabref/issues/9223)
 - We fixed the display of the "Customize Entry Types" dialogue title [#9198](https://github.com/JabRef/jabref/issues/9198)
 - We fixed an issue where author names with tilde accents (for example ñ) were marked as "Names are not in the standard BibTex format" [#8071](https://github.com/JabRef/jabref/issues/8071)
 - We fixed an issue where the possibility to generate a subdatabase from an aux file was writing empty files when called from the commandline [#9115](https://github.com/JabRef/jabref/issues/9115), [forum#3516](https://discourse.jabref.org/t/export-subdatabase-from-aux-file-on-macos-command-line/3516)

--- a/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
@@ -10,14 +10,12 @@ import org.jabref.preferences.CleanupPreferences;
 import org.jabref.preferences.FilePreferences;
 
 public class CleanupDialog extends BaseDialog<CleanupPreferences> {
-
     public CleanupDialog(BibDatabaseContext databaseContext, CleanupPreferences initialPreset, FilePreferences filePreferences) {
         setTitle(Localization.lang("Cleanup entries"));
         getDialogPane().setPrefSize(600, 650);
         getDialogPane().getButtonTypes().setAll(ButtonType.OK, ButtonType.CANCEL);
 
         CleanupPresetPanel presetPanel = new CleanupPresetPanel(databaseContext, initialPreset, filePreferences);
-
 
         // placing the content of the presetPanel in a scroll pane
         ScrollPane scrollPane = new ScrollPane();

--- a/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
@@ -1,8 +1,8 @@
 package org.jabref.gui.cleanup;
 
 import javafx.scene.control.ButtonType;
-
 import javafx.scene.control.ScrollPane;
+
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;

--- a/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
@@ -2,6 +2,7 @@ package org.jabref.gui.cleanup;
 
 import javafx.scene.control.ButtonType;
 
+import javafx.scene.control.ScrollPane;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
@@ -12,11 +13,19 @@ public class CleanupDialog extends BaseDialog<CleanupPreferences> {
 
     public CleanupDialog(BibDatabaseContext databaseContext, CleanupPreferences initialPreset, FilePreferences filePreferences) {
         setTitle(Localization.lang("Cleanup entries"));
-        getDialogPane().setPrefSize(600, 600);
+        getDialogPane().setPrefSize(600, 650);
         getDialogPane().getButtonTypes().setAll(ButtonType.OK, ButtonType.CANCEL);
 
         CleanupPresetPanel presetPanel = new CleanupPresetPanel(databaseContext, initialPreset, filePreferences);
-        getDialogPane().setContent(presetPanel);
+
+
+        // placing the content of the presetPanel in a scroll pane
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+        scrollPane.setContent(presetPanel);
+
+        getDialogPane().setContent(scrollPane);
         setResultConverter(button -> {
             if (button == ButtonType.OK) {
                 return presetPanel.getCleanupPreset();


### PR DESCRIPTION
Fixes #9223 
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


## Issue description
The content of the dialog for the cleanup entries becomes partially visible when resizing the 
dialog (decreasing the size) vertically or horizontally.

## Solution description
I added a *ScrollPane* and put the content of the *presetPanel* inside this ScrollPane in order to
be able to scroll and view the rest of the content when needed (when the dialog is resized).

**Note:** I put the name of the ScrollPane Object as `scrollPane` but I believe the name can be more significant and coherent 
with the project structure.

I also changed the preferred height to 650, so when the dialog opens, it displays all the initial information without the need 
to display the scroll bar.

### The new CleanupDialog

![Screenshot from 2022-10-11 23-43-07](https://user-images.githubusercontent.com/82417779/195213288-241e62f3-2173-422c-bb7c-e94d58f9feb5.png)

## Other possible enhancements
While fixing this issue, i noticed that the *CleanupDialog* can be resized with no limits. In other words the size of the dialog 
can be reduced to 0 or extended to infinity, as show the pictures below: 

![Screenshot from 2022-10-12 00-00-43](https://user-images.githubusercontent.com/82417779/195213816-bee2e86d-d263-4b84-bcf0-156101f4f086.png)

![Screenshot from 2022-10-12 00-07-17](https://user-images.githubusercontent.com/82417779/195214432-1719620f-5d3f-42b4-981e-4cc5a7dc41ee.png)

So we can add *min-width* and *min-height* for the Dialog.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- / Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
