### PR TITLE
FIx Preferences window cannot 'outgrow' scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
 - We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
 - We fixed an issue where Capitalize didn't capitalize words after hyphen characters. [#9157](https://github.com/JabRef/jabref/issues/9157)
+- We fixed an issue where preferences window cannot 'outgrow' horizontal scrollbar. [#9017](https://github.com/JabRef/jabref/issues/9017)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/importexport/ImportExportTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/importexport/ImportExportTab.fxml
@@ -21,23 +21,23 @@
     <Label styleClass="sectionHeader" text="%Custom DOI URI"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <CheckBox fx:id="useCustomDOI" text="%Use custom DOI base URI for article access"/>
-        <TextField fx:id="useCustomDOIName" HBox.hgrow="ALWAYS"/>
+        <TextField fx:id="useCustomDOIName"/>
     </HBox>
 
     <Label styleClass="sectionHeader" text="%Export sort order"/>
     <SaveOrderConfigPanel fx:id="exportOrderPanel"/>
 
     <Label styleClass="sectionHeader" text="%Remote services"/>
-    <CheckBox fx:id="grobidEnabled" text="%Allow sending PDF files and raw citation strings to a JabRef online service (Grobid) to determine Metadata. This produces better results."/>
+    <CheckBox fx:id="grobidEnabled" text="%Allow sending PDF files and raw citation strings to a JabRef online service (Grobid) to determine Metadata. This produces better results." wrapText="true"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <Label text="%Grobid URL" />
-        <TextField fx:id="grobidURL" HBox.hgrow="ALWAYS"/>
+        <TextField fx:id="grobidURL" prefWidth="200.0"/>
     </HBox>
 
     <Label styleClass="sectionHeader" text="%Custom API key"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <ComboBox fx:id="apiKeySelector" prefWidth="200.0" GridPane.columnIndex="1"/>
-        <TextField fx:id="customApiKey" HBox.hgrow="ALWAYS"/>
+        <TextField fx:id="customApiKey" prefWidth="400.0"/>
         <CheckBox fx:id="useCustomApiKey" text="%Custom">
         </CheckBox>
     </HBox>


### PR DESCRIPTION


Fixes #9017 Preferences window cannot 'outgrow' horizontal scrollbar #9017, a UI bug
And the changing result screen shot is provided in the issue 
link: https://github.com/JabRef/jabref/issues/9017



<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
