### PR TITLE
Add HTTP server for MS Office Word integration

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -118,4 +118,6 @@ open module org.jabref {
     requires org.eclipse.jgit;
     uses org.eclipse.jgit.transport.SshSessionFactory;
     uses org.eclipse.jgit.lib.GpgSigner;
+
+    requires jdk.httpserver;
 }

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -2,7 +2,9 @@ package org.jabref.cli;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.Authenticator;
+import java.net.InetSocketAddress;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +32,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.preferences.JabRefPreferences;
 import org.jabref.preferences.PreferencesService;
 
+//import com.sun.net.httpserver.HttpServer;
 import net.harawata.appdirs.AppDirsFactory;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
@@ -48,6 +51,25 @@ public class Launcher {
 
     public static void main(String[] args) {
         addLogToDisk();
+
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
+            server.createContext("/applications/myapp", httpExchange -> {
+                    String response = "This is the response";
+                    httpExchange.getResponseHeaders().add("Content-Type", "text/plain; charset=UTF-8");
+                    httpExchange.sendResponseHeaders(200, response.length());
+                    OutputStream out = httpExchange.getResponseBody();
+                    out.write(response.getBytes());
+                    out.close();
+                }
+            );
+            server.setExecutor(null); // creates a default executor
+            server.start();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         try {
             // Init preferences
             final JabRefPreferences preferences = JabRefPreferences.getInstance();

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -32,7 +32,7 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.preferences.JabRefPreferences;
 import org.jabref.preferences.PreferencesService;
 
-//import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpServer;
 import net.harawata.appdirs.AppDirsFactory;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Adds HTTP server for Office integration. At the moment, it's only a prototype showing that we do have enough space in our module list to include the jdk.httpserver (which is unfortunatly not as dev-friendly as other solutions, but works fine).

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
