### PR TITLE
Fix libraries not being remembered when an unsaved library is discarded upon closing JabRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
+- We fixed an issue where JabRef forgets opened libraries [#9190](https://github.com/JabRef/jabref/issues/9190)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -408,6 +408,14 @@ public class JabRefFrame extends BorderPane {
                                                              .getDatabasePath()
                                                              .orElse(null);
 
+                int i = 0;
+                while (focusedDatabase == null && i < tabbedPane.getTabs().size()) {
+                    focusedDatabase = getLibraryTabAt(i).getBibDatabaseContext()
+                                                        .getDatabasePath()
+                                                        .orElse(null);
+                    i++;
+                }
+
                 prefs.getGuiPreferences().setLastFilesOpened(filenames);
                 prefs.getGuiPreferences().setLastFocusedFile(focusedDatabase);
             }

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -407,6 +407,15 @@ public class JabRefFrame extends BorderPane {
                 Path focusedDatabase = getCurrentLibraryTab().getBibDatabaseContext()
                                                              .getDatabasePath()
                                                              .orElse(null);
+
+                int i = 0;
+                while (focusedDatabase == null && i < tabbedPane.getTabs().size()) {
+                    focusedDatabase = getLibraryTabAt(i).getBibDatabaseContext()
+                                                        .getDatabasePath()
+                                                        .orElse(null);
+                    i++;
+                }
+
                 prefs.getGuiPreferences().setLastFilesOpened(filenames);
                 prefs.getGuiPreferences().setLastFocusedFile(focusedDatabase);
             }

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -408,14 +408,6 @@ public class JabRefFrame extends BorderPane {
                                                              .getDatabasePath()
                                                              .orElse(null);
 
-                int i = 0;
-                while (focusedDatabase == null && i < tabbedPane.getTabs().size()) {
-                    focusedDatabase = getLibraryTabAt(i).getBibDatabaseContext()
-                                                        .getDatabasePath()
-                                                        .orElse(null);
-                    i++;
-                }
-
                 prefs.getGuiPreferences().setLastFilesOpened(filenames);
                 prefs.getGuiPreferences().setLastFocusedFile(focusedDatabase);
             }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2573,7 +2573,9 @@ public class JabRefPreferences implements PreferencesService {
             if (newValue != null) {
                 put(LAST_FOCUSED, newValue.toAbsolutePath().toString());
             } else {
-                remove(LAST_EDITED);
+                if (guiPreferences.getLastFilesOpened().isEmpty()) {
+                    remove(LAST_EDITED);
+                }
             }
         });
         guiPreferences.getFileHistory().addListener((InvalidationListener) change -> storeFileHistory(guiPreferences.getFileHistory()));

--- a/src/test/resources/testbib/jabref-authors.bib
+++ b/src/test/resources/testbib/jabref-authors.bib
@@ -39,7 +39,7 @@
   bibsource  = {dblp computer science bibliography, http://dblp.org},
   biburl     = {http://dblp.uni-trier.de/rec/bib/conf/icdsp/JohanssonG15a},
   groups     = {By rating},
-  keywords   = {rank4},
+  ranking    = {rank4},
   readstatus = {read},
   timestamp  = {Tue, 22 Sep 2015 18:08:19 +0200},
   year       = {2015},
@@ -1174,8 +1174,8 @@
   pages     = {120--128},
   address   = {Oxford, UK},
   file      = {:geiger2016evolution.pdf:PDF},
-  keywords  = {rank4},
   month     = mar,
+  ranking   = {rank4},
   year      = {2016},
 }
 
@@ -1222,8 +1222,8 @@
   address      = {San Francisco Bay, CA, USA},
   file         = {:Harrer2015ImprovingStaticAnalysis.pdf:PDF},
   groups       = {By rating},
-  keywords     = {rank5},
   month        = mar,
+  ranking      = {rank5},
   year         = {2015},
 }
 
@@ -1237,8 +1237,8 @@
   address   = {Cleveland, Ohio, USA},
   file      = {:Harrer2014AutomatedandIsolated.pdf:PDF},
   groups    = {By rating},
-  keywords  = {rank2},
   month     = apr,
+  ranking   = {rank2},
   year      = {2014},
 }
 
@@ -1591,7 +1591,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/fgcs/WettingerBKL16},
   journal   = {Future Generation Comp. Syst.},
-  keywords  = {rank4},
+  ranking   = {rank4},
   timestamp = {Thu, 31 Mar 2016 01:00:00 +0200},
   year      = {2016},
 }
@@ -1624,7 +1624,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/conf/closer/BreitenbucherBK15},
   groups    = {My papers},
-  keywords  = {rank3},
+  ranking   = {rank3},
   timestamp = {Tue, 04 Aug 2015 09:17:34 +0200},
   year      = {2015},
 }
@@ -1706,7 +1706,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/tsc/EshuisNKP15},
   journal   = {{IEEE} Trans. Services Computing},
-  keywords  = {rank2},
+  ranking   = {rank2},
   timestamp = {Wed, 09 Mar 2016 00:00:00 +0100},
   year      = {2015},
 }

--- a/src/test/resources/testbib/jabref-authors.bib
+++ b/src/test/resources/testbib/jabref-authors.bib
@@ -39,7 +39,7 @@
   bibsource  = {dblp computer science bibliography, http://dblp.org},
   biburl     = {http://dblp.uni-trier.de/rec/bib/conf/icdsp/JohanssonG15a},
   groups     = {By rating},
-  ranking    = {rank4},
+  keywords   = {rank4},
   readstatus = {read},
   timestamp  = {Tue, 22 Sep 2015 18:08:19 +0200},
   year       = {2015},
@@ -1175,7 +1175,7 @@
   address   = {Oxford, UK},
   file      = {:geiger2016evolution.pdf:PDF},
   month     = mar,
-  ranking   = {rank4},
+  keywords  = {rank4},
   year      = {2016},
 }
 
@@ -1223,7 +1223,7 @@
   file         = {:Harrer2015ImprovingStaticAnalysis.pdf:PDF},
   groups       = {By rating},
   month        = mar,
-  ranking      = {rank5},
+  keywords     = {rank5},
   year         = {2015},
 }
 
@@ -1238,7 +1238,7 @@
   file      = {:Harrer2014AutomatedandIsolated.pdf:PDF},
   groups    = {By rating},
   month     = apr,
-  ranking   = {rank2},
+  keywords  = {rank2},
   year      = {2014},
 }
 
@@ -1591,7 +1591,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/fgcs/WettingerBKL16},
   journal   = {Future Generation Comp. Syst.},
-  ranking   = {rank4},
+  keywords  = {rank4},
   timestamp = {Thu, 31 Mar 2016 01:00:00 +0200},
   year      = {2016},
 }
@@ -1624,7 +1624,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/conf/closer/BreitenbucherBK15},
   groups    = {My papers},
-  ranking   = {rank3},
+  keywords  = {rank3},
   timestamp = {Tue, 04 Aug 2015 09:17:34 +0200},
   year      = {2015},
 }
@@ -1706,7 +1706,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/tsc/EshuisNKP15},
   journal   = {{IEEE} Trans. Services Computing},
-  ranking   = {rank2},
+  keywords  = {rank2},
   timestamp = {Wed, 09 Mar 2016 00:00:00 +0100},
   year      = {2015},
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #9190 

Made it so that when closing the app if the focused database is not saved look for the first saved open database to set as focused.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
