### PR TITLE
Update PDFBox to the snapshot version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue about selecting the save order in the preferences. [#9175](https://github.com/JabRef/jabref/issues/9147)
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
 - We fixed an issue where pdfs were re-indexed on each startup. [#9166](https://github.com/JabRef/jabref/pull/9166)
+- We fixed an issue when reading malformed PDF. [#9204](https://github.com/JabRef/jabref/issues/9204)
 - We fixed an issue where Capitalize didn't capitalize words after hyphen characters. [#9157](https://github.com/JabRef/jabref/issues/9157)
 - We fixed an issue with the message that is displayed when fetcher returns an empty list of entries for given query. [#9195](https://github.com/JabRef/jabref/issues/9195)
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/groups/public' }
+    maven { url 'https://repository.apache.org/content/groups/snapshots/' }
     maven { url 'https://jitpack.io' }
 }
 
@@ -111,9 +112,9 @@ dependencies {
     // Include all jar-files in the 'lib' folder as dependencies
     implementation fileTree(dir: 'lib', includes: ['*.jar'])
 
-    implementation 'org.apache.pdfbox:pdfbox:3.0.0-RC1'
-    implementation 'org.apache.pdfbox:fontbox:3.0.0-RC1'
-    implementation 'org.apache.pdfbox:xmpbox:3.0.0-RC1'
+    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.0-SNAPSHOT', changing: true
+    implementation group: 'org.apache.pdfbox', name: 'fontbox', version: '3.0.0-SNAPSHOT', changing: true
+    implementation group: 'org.apache.pdfbox', name: 'xmpbox', version: '3.0.0-SNAPSHOT', changing: true
 
     implementation 'org.apache.lucene:lucene-core:9.4.0'
     implementation 'org.apache.lucene:lucene-queryparser:9.4.0'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -89,8 +89,8 @@ open module org.jabref {
     requires org.fxmisc.flowless;
     requires org.apache.tika.core;
     uses org.apache.tika.detect.AutoDetectReader;
-    requires pdfbox;
-    requires xmpbox;
+    requires org.apache.pdfbox;
+    requires org.apache.xmpbox;
     requires com.ibm.icu;
 
     requires flexmark;


### PR DESCRIPTION
This fixes https://github.com/JabRef/jabref/issues/9204 by pulling-in the latest development version of Apache PDFBox.

I could not add a test case, because the linked PDF does not conform to the definition "open source":

![grafik](https://user-images.githubusercontent.com/1366654/195950918-85833585-9904-4854-b71c-48d5751cc3aa.png)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
