### PR TITLE
Adjust and make tests for BibTex/Biblatex/CSL mapping more accurate by adding Apa 7th edition

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           git subtree pull --prefix buildres/csl/csl-styles csl-styles master --squash || true
           cp buildres/csl/csl-styles/acm-siggraph.csl src/main/resources/csl-styles/
+          cp buildres/csl/csl-styles/apa.csl src/main/resources/csl-styles/
           cp buildres/csl/csl-styles/ieee.csl src/main/resources/csl-styles/
           cp buildres/csl/csl-styles/turabian-author-date.csl src/main/resources/csl-styles/
           git add .

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -104,6 +104,50 @@ public class CSLAdapter {
 
         /**
          * Converts the {@link BibEntry} into {@link CSLItemData}.
+         *
+         *<br>
+         *<table>
+         * <thead>
+         *<tr>
+         *<th style="text-align:left">BibTeX</th>
+         *<th style="text-align:left">BibLaTeX</th>
+         *<th style="text-align:left">EntryPreview/CSL</th>
+         *<th style="text-align:left">proposed logic, conditions and info</th>
+         *</tr>
+         *</thead>
+         *<tbody>
+         *<tr>
+         *<td style="text-align:left">volume</td>
+         *<td style="text-align:left">volume</td>
+         *<td style="text-align:left">volume</td>
+         *<td style="text-align:left"></td>
+         *</tr>
+         *<tr>
+         *<td style="text-align:left">number</td>
+         *<td style="text-align:left">issue</td>
+         *<td style="text-align:left">issue</td>
+         *<td style="text-align:left">For conversion to CSL or BibTeX: BibLaTeX <code>number</code> takes priority and supersedes BibLaTeX <code>issue</code></td>
+         *</tr>
+         *<tr>
+         *<td style="text-align:left">number</td>
+         *<td style="text-align:left">number</td>
+         *<td style="text-align:left">issue</td>
+         *<td style="text-align:left">same as above</td>
+         *</tr>
+         *<tr>
+         *<td style="text-align:left">pages</td>
+         *<td style="text-align:left">eid</td>
+         *<td style="text-align:left">number</td>
+         *<td style="text-align:left">Some journals put the article-number (= eid) into the pages field. If BibLaTeX <code>eid</code> exists, provide csl <code>number</code> to the style. If <code>pages</code> exists, provide csl <code>page</code>.  If <code>eid</code> WITHIN the <code>pages</code> field exists, detect the eid and provide csl <code>number</code>. If both <code>eid</code> and <code>pages</code> exists, ideally provide both csl <code>number</code> and csl <code>page</code>. Ideally the citationstyle should be able to flexibly choose the rendering.</td>
+         *</tr>
+         *<tr>
+         *<td style="text-align:left">pages</td>
+         *<td style="text-align:left">pages</td>
+         *<td style="text-align:left">page</td>
+         *<td style="text-align:left">same as above</td>
+         *</tr>
+         *</tbody>
+         *</table>
          */
         private CSLItemData bibEntryToCSLItemData(BibEntry originalBibEntry, BibDatabaseContext bibDatabaseContext, BibEntryTypesManager entryTypesManager) {
             // We need to make a deep copy, because we modify the entry according to the logic presented at
@@ -129,14 +173,7 @@ public class CSLAdapter {
                             bibEntry.clearField(StandardField.NUMBER);
                         }
                     );
-                /* TODO: fix tests in CitationStyleGeneratorTest.java using APA style, once APA recognizes a "number" field (and thereby will be able to render the "eid" field)
-                 * tracked at https://github.com/citation-style-language/styles/issues/5827
-                 *
-                 * Further info:
-                 * www.zotero.org/styles/apa-6th-edition
-                 * https://docs.citationstyles.org/en/stable/specification.html#number-variables
-                 * https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                 */
+
                   bibEntry.getField(StandardField.EID).ifPresent(eid -> {
                    if (!bibEntry.hasField(StandardField.NUMBER)) {
                        bibEntry.setField(StandardField.NUMBER, eid);

--- a/src/main/resources/csl-styles/apa.csl
+++ b/src/main/resources/csl-styles/apa.csl
@@ -1,0 +1,1917 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+  <info>
+    <title>American Psychological Association 7th edition</title>
+    <title-short>APA</title-short>
+    <id>http://www.zotero.org/styles/apa</id>
+    <link href="http://www.zotero.org/styles/apa" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa-6th-edition" rel="template"/>
+    <link href="https://apastyle.apa.org/style-grammar-guidelines/references/examples" rel="documentation"/>
+    <author>
+      <name>Brenton M. Wiernik</name>
+      <email>zotero@wiernik.org</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="psychology"/>
+    <category field="generic-base"/>
+    <updated>2022-01-31T14:30:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="interviewer" form="short">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="circa" form="short">ca.</term>
+      <term name="bc"> B.C.E.</term>
+      <term name="ad"> C.E.</term>
+      <term name="letter">personal communication</term>
+      <term name="letter" form="short">letter</term>
+      <term name="issue" form="long">
+        <single>issue</single>
+        <multiple>issues</multiple>
+      </term>
+    </terms>
+  </locale>
+  <locale xml:lang="af">
+    <terms>
+      <term name="letter">persoonlike kommunikasie</term>
+      <term name="letter" form="short">brief</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ar">
+    <terms>
+      <term name="letter">اتصال شخصي</term>
+      <term name="letter" form="short">خطاب</term>
+    </terms>
+  </locale>
+  <locale xml:lang="bg">
+    <terms>
+      <term name="letter">лична комуникация</term>
+      <term name="letter" form="short">писмо</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ca">
+    <terms>
+      <term name="letter">comunicació personal</term>
+      <term name="letter" form="short">carta</term>
+    </terms>
+  </locale>
+  <locale xml:lang="cs">
+    <terms>
+      <term name="letter">osobní komunikace</term>
+      <term name="letter" form="short">dopis</term>
+    </terms>
+  </locale>
+  <locale xml:lang="cy">
+    <terms>
+      <term name="letter">cyfathrebu personol</term>
+      <term name="letter" form="short">llythyr</term>
+    </terms>
+  </locale>
+  <locale xml:lang="da">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="letter">personlig kommunikation</term>
+      <term name="letter" form="short">brev</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="letter">persönliche Kommunikation</term>
+      <term name="letter" form="short">Brief</term>
+    </terms>
+  </locale>
+  <locale xml:lang="el">
+    <terms>
+      <term name="letter">προσωπική επικοινωνία</term>
+      <term name="letter" form="short">επιστολή</term>
+    </terms>
+  </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+      <term name="letter">comunicación personal</term>
+      <term name="letter" form="short">carta</term>
+    </terms>
+  </locale>
+  <locale xml:lang="et">
+    <terms>
+      <term name="letter">isiklik suhtlus</term>
+      <term name="letter" form="short">kiri</term>
+    </terms>
+  </locale>
+  <locale xml:lang="eu">
+    <terms>
+      <term name="letter">komunikazio pertsonala</term>
+      <term name="letter" form="short">gutuna</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fa">
+    <terms>
+      <term name="letter">ارتباط شخصی</term>
+      <term name="letter" form="short">نامه</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fi">
+    <terms>
+      <term name="letter">henkilökohtainen viestintä</term>
+      <term name="letter" form="short">kirje</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="letter">communication personnelle</term>
+      <term name="letter" form="short">lettre</term>
+      <term name="editor" form="short">
+        <single>éd.</single>
+        <multiple>éds.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <locale xml:lang="he">
+    <terms>
+      <term name="letter">תקשורת אישית</term>
+      <term name="letter" form="short">מכתב</term>
+    </terms>
+  </locale>
+  <locale xml:lang="hr">
+    <terms>
+      <term name="letter">osobna komunikacija</term>
+      <term name="letter" form="short">pismo</term>
+    </terms>
+  </locale>
+  <locale xml:lang="hu">
+    <terms>
+      <term name="letter">személyes kommunikáció</term>
+      <term name="letter" form="short">levél</term>
+    </terms>
+  </locale>
+  <locale xml:lang="id">
+    <terms>
+      <term name="letter">komunikasi pribadi</term>
+      <term name="letter" form="short">surat</term>
+    </terms>
+  </locale>
+  <locale xml:lang="is">
+    <terms>
+      <term name="letter">persónuleg samskipti</term>
+      <term name="letter" form="short">bréf</term>
+    </terms>
+  </locale>
+  <locale xml:lang="it">
+    <terms>
+      <term name="letter">comunicazione personale</term>
+      <term name="letter" form="short">lettera</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ja">
+    <terms>
+      <term name="letter">個人的なやり取り</term>
+      <term name="letter" form="short">手紙</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ko">
+    <terms>
+      <term name="letter">개인 서신</term>
+      <term name="letter" form="short">편지</term>
+    </terms>
+  </locale>
+  <locale xml:lang="la">
+    <terms>
+      <term name="letter"/>
+      <term name="letter" form="short">epistula</term>
+    </terms>
+  </locale>
+  <locale xml:lang="lt">
+    <terms>
+      <term name="letter">communicationis personalis</term>
+      <term name="letter" form="short"/>
+    </terms>
+  </locale>
+  <locale xml:lang="lv">
+    <terms>
+      <term name="letter">personīga komunikācija</term>
+      <term name="letter" form="short">vēstule</term>
+    </terms>
+  </locale>
+  <locale xml:lang="mn">
+    <terms>
+      <term name="letter">хувийн харилцаа холбоо</term>
+      <term name="letter" form="short">захиа</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nb">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="letter">personlig kommunikasjon</term>
+      <term name="letter" form="short">brev</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="letter">persoonlijke communicatie</term>
+      <term name="letter" form="short">brief</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nn">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="letter">personlig kommunikasjon</term>
+      <term name="letter" form="short">brev</term>
+    </terms>
+  </locale>
+  <locale xml:lang="pl">
+    <terms>
+      <term name="letter">osobista komunikacja</term>
+      <term name="letter" form="short">list</term>
+    </terms>
+  </locale>
+  <locale xml:lang="pt">
+    <terms>
+      <term name="letter">comunicação pessoal</term>
+      <term name="letter" form="short">carta</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ro">
+    <terms>
+      <term name="letter">comunicare personală</term>
+      <term name="letter" form="short">scrisoare</term>
+    </terms>
+  </locale>
+  <locale xml:lang="ru">
+    <terms>
+      <term name="letter">личная переписка</term>
+      <term name="letter" form="short">письмо</term>
+    </terms>
+  </locale>
+  <locale xml:lang="sk">
+    <terms>
+      <term name="letter">osobná komunikácia</term>
+      <term name="letter" form="short">list</term>
+    </terms>
+  </locale>
+  <locale xml:lang="sl">
+    <terms>
+      <term name="letter">osebna komunikacija</term>
+      <term name="letter" form="short">pismo</term>
+    </terms>
+  </locale>
+  <locale xml:lang="sr">
+    <terms>
+      <term name="letter">лична комуникација</term>
+      <term name="letter" form="short">писмо</term>
+    </terms>
+  </locale>
+  <locale xml:lang="sv">
+    <terms>
+      <term name="letter">personlig kommunikation</term>
+      <term name="letter" form="short">brev</term>
+    </terms>
+  </locale>
+  <locale xml:lang="th">
+    <terms>
+      <term name="letter">การสื่อสารส่วนบุคคล</term>
+      <term name="letter" form="short">จดหมาย</term>
+    </terms>
+  </locale>
+  <locale xml:lang="tr">
+    <terms>
+      <term name="letter">kişisel iletişim</term>
+      <term name="letter" form="short">mektup</term>
+    </terms>
+  </locale>
+  <locale xml:lang="uk">
+    <terms>
+      <term name="letter">особисте спілкування</term>
+      <term name="letter" form="short">лист</term>
+    </terms>
+  </locale>
+  <locale xml:lang="vi">
+    <terms>
+      <term name="letter">giao tiếp cá nhân</term>
+      <term name="letter" form="short">thư</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh-CN">
+    <terms>
+      <term name="letter">的私人交流</term>
+      <term name="letter" form="short">信函</term>
+    </terms>
+  </locale>
+  <locale xml:lang="zh-TW">
+    <terms>
+      <term name="letter">私人通訊</term>
+      <term name="letter" form="short">信函</term>
+    </terms>
+  </locale>
+  <!-- General categories of item types:
+       Periodical: article-journal article-magazine article-newspaper post-weblog review review-book
+       Periodical or Booklike: paper-conference
+       Booklike: article book broadcast chapter dataset entry entry-dictionary entry-encyclopedia figure
+                 graphic interview manuscript map motion_picture musical_score pamphlet patent
+                 personal_communication report song speech thesis post webpage
+       Legal: bill legal_case legislation treaty
+  -->
+  <!-- APA references contain four parts: author, date, title, source -->
+  <macro name="author-bib">
+    <names variable="composer" delimiter=", ">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <names variable="director">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if type="book entry entry-dictionary entry-encyclopedia" match="any">
+                <choose>
+                  <if variable="title">
+                    <group delimiter=" ">
+                      <text macro="title"/>
+                      <text macro="parenthetical"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="title-and-descriptions"/>
+                  </else>
+                </choose>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <!-- Test for editortranslator and put that first as that becomes available -->
+        <names variable="editor" delimiter=", ">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="title">
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="parenthetical"/>
+            </group>
+          </if>
+          <else>
+            <text macro="title-and-descriptions"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-intext">
+    <choose>
+      <if type="bill legal_case legislation treaty" match="any">
+        <text macro="title-intext"/>
+      </if>
+      <else-if type="interview personal_communication" match="any">
+        <choose>
+          <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+          <if variable="archive container-title DOI publisher URL" match="none">
+            <group delimiter=", ">
+              <names variable="author">
+                <name and="symbol" delimiter=", " initialize-with=". "/>
+                <substitute>
+                  <text macro="title-intext"/>
+                </substitute>
+              </names>
+              <!-- Replace with term="personal-communication" if that becomes available -->
+              <text term="letter"/>
+            </group>
+          </if>
+          <else>
+            <names variable="author" delimiter=", ">
+              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+              <substitute>
+                <text macro="title-intext"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <names variable="composer" delimiter=", ">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="author"/>
+            <names variable="illustrator"/>
+            <names variable="director"/>
+            <choose>
+              <if variable="container-title">
+                <choose>
+                  <if type="book entry entry-dictionary entry-encyclopedia" match="any">
+                    <text macro="title-intext"/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+            <names variable="editor"/>
+            <names variable="editorial-director"/>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-bib">
+    <group delimiter=" " prefix="(" suffix=")">
+      <choose>
+        <if is-uncertain-date="issued">
+          <text term="circa" form="short"/>
+        </if>
+      </choose>
+      <group>
+        <choose>
+          <if variable="issued">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+            <text variable="year-suffix"/>
+            <choose>
+              <if type="article-magazine article-newspaper broadcast interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <date variable="issued">
+                  <date-part prefix=", " name="month"/>
+                  <date-part prefix=" " name="day"/>
+                </date>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if variable="collection-editor editor editorial-director issue page volume" match="none">
+                    <date variable="issued">
+                      <date-part prefix=", " name="month"/>
+                      <date-part prefix=" " name="day"/>
+                    </date>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic
+                   manuscript map musical_score paper-conference[published] patent report review review-book thesis -->
+            </choose>
+          </if>
+          <else-if variable="status">
+            <group>
+              <text variable="status" text-case="lowercase"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else-if>
+          <else>
+            <text term="no date" form="short"/>
+            <text variable="year-suffix" prefix="-"/>
+          </else>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="date-sort-group">
+    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <choose>
+      <if variable="issued">
+        <text value="1"/>
+      </if>
+      <else-if variable="status">
+        <text value="2"/>
+      </else-if>
+      <else>
+        <text value="0"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-sort-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <group delimiter=" ">
+            <choose>
+              <if is-uncertain-date="original-date">
+                <text term="circa" form="short"/>
+              </if>
+            </choose>
+            <date variable="original-date">
+              <date-part name="year"/>
+            </date>
+          </group>
+          <group delimiter=" ">
+            <choose>
+              <if is-uncertain-date="issued">
+                <text term="circa" form="short"/>
+              </if>
+            </choose>
+            <group>
+              <choose>
+                <if type="interview personal_communication" match="any">
+                  <choose>
+                    <if variable="archive container-title DOI publisher URL" match="none">
+                      <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                      <date variable="issued" form="text"/>
+                    </if>
+                    <else>
+                      <date variable="issued">
+                        <date-part name="year"/>
+                      </date>
+                    </else>
+                  </choose>
+                </if>
+                <else>
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+              <text variable="year-suffix"/>
+            </group>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status" text-case="lowercase"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- APA has two description elements following the title:
+       title (parenthetical) [bracketed]  -->
+  <macro name="title-and-descriptions">
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text macro="title"/>
+          <text macro="parenthetical"/>
+          <text macro="bracketed"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text macro="bracketed"/>
+          <text macro="parenthetical"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="post webpage" match="any">
+        <!-- Webpages are always italicized -->
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if variable="container-title" match="any">
+        <!-- Other types are italicized based on presence of container-title.
+             Assume that review and review-book are published in periodicals/blogs,
+             not just on a web page (ex. 69) -->
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <choose>
+          <if type="article-journal article-magazine article-newspaper post-weblog review review-book" match="any">
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else-if type="paper-conference">
+            <choose>
+              <if variable="collection-editor editor editorial-director" match="any">
+                <group delimiter=": " font-style="italic">
+                  <text variable="title"/>
+                  <!-- Replace with volume-title as that becomes available -->
+                  <choose>
+                    <if is-numeric="volume" match="none">
+                      <group delimiter=" ">
+                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text variable="volume"/>
+                      </group>
+                    </if>
+                  </choose>
+                </group>
+              </if>
+              <else>
+                <text variable="title" font-style="italic"/>
+              </else>
+            </choose>
+          </else-if>
+          <else>
+            <group delimiter=": " font-style="italic">
+              <text variable="title"/>
+              <!-- Replace with volume-title as that becomes available -->
+              <choose>
+                <if is-numeric="volume" match="none">
+                  <group delimiter=" ">
+                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text variable="volume"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext">
+    <choose>
+      <if variable="title" match="none">
+        <text macro="bracketed-intext" prefix="[" suffix="]"/>
+      </if>
+      <else-if type="bill">
+        <!-- If a bill has no number or container-title, assume it is a hearing; italic -->
+        <choose>
+          <if variable="number container-title" match="none">
+            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          </if>
+          <else-if variable="title">
+            <text variable="title" form="short" text-case="title"/>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text variable="genre"/>
+              <group delimiter=" ">
+                <choose>
+                  <if variable="chapter-number container-title" match="none">
+                    <!-- Replace with label variable="number" as that becomes available -->
+                    <text term="issue" form="short"/>
+                  </if>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="legal_case" match="any">
+        <!-- Cases are italicized -->
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else-if type="legislation treaty" match="any">
+        <!-- Legislation and treaties not italicized or quoted -->
+        <text variable="title" form="short" text-case="title"/>
+      </else-if>
+      <else-if type="post webpage" match="any">
+        <!-- Webpages are always italicized -->
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else-if>
+      <else-if variable="container-title" match="any">
+        <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
+        <text variable="title" form="short" quotes="true" text-case="title"/>
+      </else-if>
+      <else>
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="parenthetical">
+    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+    <group prefix="(" suffix=")">
+      <choose>
+        <if type="patent">
+          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+          <group delimiter=" ">
+            <text variable="authority" form="short"/>
+            <choose>
+              <if variable="genre">
+                <text variable="genre" text-case="capitalize-first"/>
+              </if>
+              <else>
+                <!-- This should be localized -->
+                <text value="patent" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <group delimiter=" ">
+              <!-- Replace with label variable="number" if that becomes available -->
+              <text term="issue" form="short" text-case="capitalize-first"/>
+              <text variable="number"/>
+            </group>
+          </group>
+        </if>
+        <else-if type="post webpage" match="any">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <text macro="database-location"/>
+            <text macro="number"/>
+            <text macro="locators-booklike"/>
+          </group>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if type="broadcast graphic map motion_picture song" match="any">
+                <!-- For audiovisual media, number information comes after title, not container-title -->
+                <text macro="number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <text macro="database-location"/>
+            <text macro="number"/>
+            <text macro="locators-booklike"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="parenthetical-container">
+    <choose>
+      <if variable="container-title" match="any">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if type="broadcast graphic map motion_picture song" match="none">
+                <!-- For audiovisual media, number information comes after title, not container-title -->
+                <text macro="number"/>
+              </if>
+            </choose>
+            <text macro="locators-booklike"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="bracketed">
+    <!-- [Descriptive information] -->
+    <!-- If there is a number, genre is already printed in macro="number" -->
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-author reviewed-title" type="review review-book" match="any">
+          <!-- Reviewed item -->
+          <group delimiter="; ">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <!-- Assume that genre is entered as 'Review of the book' or similar -->
+                <choose>
+                  <if variable="number" match="none">
+                    <choose>
+                      <if variable="genre">
+                        <text variable="genre" text-case="capitalize-first"/>
+                      </if>
+                      <else-if variable="medium">
+                        <text variable="medium" text-case="capitalize-first"/>
+                      </else-if>
+                      <else>
+                        <!-- Replace with term="review" as that becomes available -->
+                        <text value="Review of"/>
+                      </else>
+                    </choose>
+                  </if>
+                  <else>
+                    <choose>
+                      <if variable="medium">
+                        <text variable="medium" text-case="capitalize-first"/>
+                      </if>
+                      <else>
+                        <!-- Replace with term="review" as that becomes available -->
+                        <text value="Review of"/>
+                      </else>
+                    </choose>
+                  </else>
+                </choose>
+                <text macro="reviewed-title"/>
+              </group>
+              <names variable="reviewed-author">
+                <label form="verb-short" suffix=" "/>
+                <name and="symbol" initialize-with=". " delimiter=", "/>
+              </names>
+            </group>
+            <choose>
+              <if variable="genre" match="any">
+                <choose>
+                  <if variable="number" match="none">
+                    <text variable="medium" text-case="capitalize-first"/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+          </group>
+        </if>
+        <else-if type="thesis">
+          <!-- Thesis type and institution -->
+          <group delimiter="; ">
+            <choose>
+              <if variable="number" match="none">
+                <group delimiter=", ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <choose>
+                    <if variable="archive DOI URL" match="any">
+                      <!-- Include the university in brackets if thesis is published -->
+                      <text variable="publisher"/>
+                    </if>
+                  </choose>
+                </group>
+              </if>
+            </choose>
+            <text variable="medium" text-case="capitalize-first"/>
+          </group>
+        </else-if>
+        <else-if variable="interviewer" type="interview" match="any">
+          <!-- Interview information -->
+          <choose>
+            <if variable="title">
+              <text macro="format"/>
+            </if>
+            <else-if variable="genre">
+              <group delimiter="; ">
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <group delimiter=" ">
+                    <text term="author" form="verb"/>
+                    <names variable="interviewer">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                    </names>
+                  </group>
+                </group>
+              </group>
+            </else-if>
+            <else-if variable="interviewer">
+              <group delimiter="; ">
+                <names variable="interviewer">
+                  <label form="verb" suffix=" " text-case="capitalize-first"/>
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                </names>
+                <text variable="medium" text-case="capitalize-first"/>
+              </group>
+            </else-if>
+            <else>
+              <text macro="format"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="personal_communication">
+          <!-- Letter information -->
+          <choose>
+            <if variable="recipient">
+              <group delimiter="; ">
+                <group delimiter=" ">
+                  <choose>
+                    <if variable="number" match="none">
+                      <choose>
+                        <if variable="genre">
+                          <text variable="genre" text-case="capitalize-first"/>
+                        </if>
+                        <else-if variable="medium">
+                          <text variable="medium" text-case="capitalize-first"/>
+                        </else-if>
+                        <else>
+                          <text term="letter" form="short" text-case="capitalize-first"/>
+                        </else>
+                      </choose>
+                    </if>
+                    <else>
+                      <choose>
+                        <if variable="medium">
+                          <text variable="medium" text-case="capitalize-first"/>
+                        </if>
+                        <else>
+                          <text term="letter" form="short" text-case="capitalize-first"/>
+                        </else>
+                      </choose>
+                    </else>
+                  </choose>
+                  <names variable="recipient" delimiter=", ">
+                    <label form="verb" suffix=" "/>
+                    <name and="symbol" delimiter=", "/>
+                  </names>
+                </group>
+                <choose>
+                  <if variable="genre" match="any">
+                    <choose>
+                      <if variable="number" match="none">
+                        <text variable="medium" text-case="capitalize-first"/>
+                      </if>
+                    </choose>
+                  </if>
+                </choose>
+              </group>
+            </if>
+            <else>
+              <text macro="format"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="composer" type="song" match="all">
+          <!-- Performer of classical music works -->
+          <group delimiter="; ">
+            <choose>
+              <if variable="number" match="none">
+                <group delimiter=" ">
+                  <choose>
+                    <if variable="genre">
+                      <text variable="genre" text-case="capitalize-first"/>
+                      <!-- Replace prefix with performer label as that becomes available -->
+                      <names variable="author" prefix="recorded by ">
+                        <name and="symbol" initialize-with=". " delimiter=", "/>
+                      </names>
+                    </if>
+                    <else-if variable="medium">
+                      <text variable="medium" text-case="capitalize-first"/>
+                      <!-- Replace prefix with performer label as that becomes available -->
+                      <names variable="author" prefix="recorded by ">
+                        <name and="symbol" initialize-with=". " delimiter=", "/>
+                      </names>
+                    </else-if>
+                    <else>
+                      <!-- Replace prefix with performer label as that becomes available -->
+                      <names variable="author" prefix="Recorded by ">
+                        <name and="symbol" initialize-with=". " delimiter=", "/>
+                      </names>
+                    </else>
+                  </choose>
+                </group>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <choose>
+                    <if variable="medium">
+                      <text variable="medium" text-case="capitalize-first"/>
+                      <!-- Replace prefix with performer label as that becomes available -->
+                      <names variable="author" prefix="recorded by ">
+                        <name and="symbol" initialize-with=". " delimiter=", "/>
+                      </names>
+                    </if>
+                    <else>
+                      <!-- Replace prefix with performer label as that becomes available -->
+                      <names variable="author" prefix="Recorded by ">
+                        <name and="symbol" initialize-with=". " delimiter=", "/>
+                      </names>
+                    </else>
+                  </choose>
+                </group>
+              </else>
+            </choose>
+            <choose>
+              <if variable="genre" match="any">
+                <choose>
+                  <if variable="number" match="none">
+                    <text variable="medium" text-case="capitalize-first"/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else-if variable="container-title" match="none">
+          <!-- Other description -->
+          <text macro="format"/>
+        </else-if>
+        <else>
+          <!-- For conference presentations, chapters in reports, software, place bracketed after the container title -->
+          <choose>
+            <if type="paper-conference speech" match="any">
+              <choose>
+                <if variable="collection-editor editor editorial-director issue page volume" match="any">
+                  <text macro="format"/>
+                </if>
+              </choose>
+            </if>
+            <else-if type="book">
+              <choose>
+                <if variable="version" match="none">
+                  <text macro="format"/>
+                </if>
+              </choose>
+            </else-if>
+            <else-if type="report" match="none">
+              <text macro="format"/>
+            </else-if>
+          </choose>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="bracketed-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-author reviewed-title" type="review review-book" match="any">
+          <!-- This should be localized -->
+          <text macro="reviewed-title-intext" prefix="Review of "/>
+        </if>
+        <else-if variable="interviewer" type="interview" match="any">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <!-- Letter information -->
+          <choose>
+            <if variable="recipient">
+              <group delimiter=" ">
+                <choose>
+                  <if variable="number" match="none">
+                    <text variable="genre" text-case="capitalize-first"/>
+                  </if>
+                  <else>
+                    <text term="letter" form="short" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+                <names variable="recipient" delimiter=", ">
+                  <label form="verb" suffix=" "/>
+                  <name and="symbol" delimiter=", "/>
+                </names>
+              </group>
+            </if>
+            <else>
+              <text macro="format-intext"/>
+            </else>
+          </choose>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="bracketed-container">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if type="paper-conference speech" match="any">
+          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
+          <choose>
+            <if variable="collection-editor editor editorial-director issue page volume" match="none">
+              <text macro="format"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="book" variable="version" match="all">
+          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
+          <text macro="format"/>
+        </else-if>
+        <else-if type="report">
+          <!-- For chapters in reports, place bracketed after the container title -->
+          <text macro="format"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper post-weblog review review-book" match="any">
+        <text macro="secondary-contributors-periodical"/>
+      </if>
+      <else-if type="paper-conference">
+        <choose>
+          <if variable="collection-editor editor editorial-director" match="any">
+            <text macro="secondary-contributors-booklike"/>
+          </if>
+          <else>
+            <text macro="secondary-contributors-periodical"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="secondary-contributors-booklike"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names variable="interviewer" delimiter="; ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names variable="translator" delimiter="; ">
+        <name and="symbol" initialize-with=". " delimiter=", "/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="secondary-contributors-booklike">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names variable="interviewer">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <!-- When editortranslator becomes available, add a test: variable="editortranslator" match="none"; then print translator -->
+      <choose>
+        <if type="post webpage" match="none">
+          <!-- Webpages treat container-title like publisher -->
+          <choose>
+            <if variable="container-title" match="none">
+              <group delimiter="; ">
+                <names variable="container-author">
+                  <label form="verb-short" suffix=" " text-case="title"/>
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                </names>
+                <names variable="editor translator" delimiter="; ">
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <label form="short" prefix=", " text-case="title"/>
+                </names>
+              </group>
+            </if>
+          </choose>
+        </if>
+        <else>
+          <group delimiter="; ">
+            <names variable="container-author">
+              <label form="verb-short" suffix=" " text-case="title"/>
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+            </names>
+            <names variable="editor translator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="database-location">
+    <choose>
+      <if variable="archive-place" match="none">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <!-- Add archive_collection as that becomes available -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text variable="genre" text-case="title"/>
+            <choose>
+              <if is-numeric="number">
+                <!-- Replace with label variable="number" if that becomes available -->
+                <text term="issue" form="short" text-case="capitalize-first"/>
+                <text variable="number"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <!-- Include the university in brackets if thesis is published -->
+                <if variable="archive DOI URL" match="any">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-booklike">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper broadcast interview patent post post-weblog review review-book speech webpage" match="any"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if variable="collection-editor editor editorial-director" match="any">
+            <group delimiter=", ">
+              <text macro="version"/>
+              <text macro="edition"/>
+              <text macro="volume-booklike"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <text macro="version"/>
+          <text macro="edition"/>
+          <text macro="volume-booklike"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="version">
+    <choose>
+      <if is-numeric="version">
+        <group delimiter=" ">
+          <!-- replace with label variable="version" if that becomes available -->
+          <text term="version" text-case="capitalize-first"/>
+          <text variable="version"/>
+        </group>
+      </if>
+      <else>
+        <text variable="version"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series [ex. 52] -->
+      <choose>
+        <if type="report">
+          <group delimiter=" ">
+            <text variable="collection-title" text-case="title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if variable="volume" match="any">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if is-numeric="volume" match="none"/>
+            <else>
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <group>
+            <!-- Replace with label variable="number-of-volumes" if that becomes available -->
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <text term="page-range-delimiter" prefix="1"/>
+            <number variable="number-of-volumes" form="numeric"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <label variable="issue" text-case="capitalize-first"/>
+        <text variable="issue"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="page" form="short" suffix=" "/>
+        <text variable="page"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="reviewed-title">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+              works [Ex. 69] -->
+        <text variable="reviewed-title" font-style="italic"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed works [Ex. 69] -->
+        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="format">
+    <choose>
+      <if variable="genre medium" match="any">
+        <group delimiter="; ">
+          <choose>
+            <if variable="number" match="none">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </if>
+      <!-- Generic labels for specific types -->
+      <!-- These should be localized when possible -->
+      <else-if type="dataset">
+        <text value="Data set"/>
+      </else-if>
+      <else-if type="book" variable="version" match="all">
+        <!-- Replace with type="software" and term="software" as that becomes available -->
+        <text value="Computer software"/>
+      </else-if>
+      <else-if type="interview personal_communication" match="any">
+        <choose>
+          <if variable="archive container-title DOI publisher URL" match="none">
+            <text term="letter" text-case="capitalize-first"/>
+          </if>
+          <else-if type="interview">
+            <text term="interview" text-case="capitalize-first"/>
+          </else-if>
+        </choose>
+      </else-if>
+      <else-if type="map">
+        <text value="Map"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="format-intext">
+    <choose>
+      <if variable="genre" match="any">
+        <text variable="genre" text-case="capitalize-first"/>
+      </if>
+      <else-if variable="medium">
+        <text variable="medium" text-case="capitalize-first"/>
+      </else-if>
+      <!-- Generic labels for specific types -->
+      <!-- These should be localized when possible -->
+      <else-if type="dataset">
+        <text value="Data set"/>
+      </else-if>
+      <else-if type="book" variable="version" match="all">
+        <!-- Replace with type="software" and term="software" as that becomes available -->
+        <text value="Computer software"/>
+      </else-if>
+      <else-if type="interview personal_communication" match="any">
+        <choose>
+          <if variable="archive container-title DOI publisher URL" match="none">
+            <text term="letter" text-case="capitalize-first"/>
+          </if>
+          <else-if type="interview">
+            <text term="interview" text-case="capitalize-first"/>
+          </else-if>
+        </choose>
+      </else-if>
+      <else-if type="map">
+        <text value="Map"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- APA 'source' element contains four parts:
+       container, event, publisher, access -->
+  <macro name="container">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper post-weblog review review-book" match="any">
+        <!-- Periodical items -->
+        <text macro="container-periodical"/>
+      </if>
+      <else-if type="paper-conference">
+        <!-- Determine if paper-conference is a periodical or booklike -->
+        <choose>
+          <if variable="editor editorial-director collection-editor container-author" match="any">
+            <text macro="container-booklike"/>
+          </if>
+          <else>
+            <text macro="container-periodical"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="post webpage" match="none">
+        <!-- post and webpage treat container-title like publisher -->
+        <text macro="container-booklike"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+        <choose>
+          <if variable="volume">
+            <group>
+              <text variable="volume" font-style="italic"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <text variable="issue" font-style="italic"/>
+          </else>
+        </choose>
+        <choose>
+          <if variable="number">
+            <!-- Ex. 6: Journal article with article number or eLocator -->
+            <!-- This should be localized -->
+            <group delimiter=" ">
+              <text term="article-locator" text-case="capitalize-first"/>
+              <text variable="number"/>
+            </group>
+          </if>
+          <else>
+            <text variable="page"/>
+          </else>
+        </choose>
+      </group>
+      <choose>
+        <if variable="issued">
+          <choose>
+            <if variable="issue page volume" match="none">
+              <text variable="status" text-case="capitalize-first"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-booklike">
+    <choose>
+      <if variable="container-title" match="any">
+        <group delimiter=" ">
+          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=", ">
+            <names variable="editor translator" delimiter=", &amp; ">
+              <!-- Change to editortranslator and move editor to substitute as that becomes available -->
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" text-case="title" prefix=" (" suffix=")"/>
+              <substitute>
+                <names variable="editorial-director"/>
+                <names variable="collection-editor"/>
+                <names variable="container-author"/>
+              </substitute>
+            </names>
+            <group delimiter=": " font-style="italic">
+              <text variable="container-title"/>
+              <!-- Replace with volume-title as that becomes available -->
+              <choose>
+                <if is-numeric="volume" match="none">
+                  <group delimiter=" ">
+                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text variable="volume"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </group>
+          <text macro="parenthetical-container"/>
+          <text macro="bracketed-container"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter="; ">
+      <choose>
+        <if type="thesis">
+          <choose>
+            <if variable="archive DOI URL" match="none">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="post webpage" match="any">
+          <!-- For websites, treat container title like publisher -->
+          <group delimiter="; ">
+            <text variable="container-title" text-case="title"/>
+            <text variable="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+          <choose>
+            <if variable="collection-editor editor editorial-director" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="article-journal article-magazine article-newspaper post-weblog" match="none">
+          <text variable="publisher"/>
+        </else-if>
+      </choose>
+      <group delimiter=", ">
+        <choose>
+          <if variable="archive-place">
+            <!-- With `archive-place`: physical archives. Without: online archives. -->
+            <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+            <!-- Split "archive_location" into "archive_collection" and "archive_location" as that becomes available -->
+            <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+            <text variable="archive_location"/>
+          </if>
+        </choose>
+        <text variable="archive"/>
+        <text variable="archive-place"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI" match="any">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if variable="issued status" match="none">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <date variable="accessed" form="text" suffix=","/>
+                <text term="from"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event event-title" match="any">
+        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
+             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+        <choose>
+          <if variable="collection-editor editor editorial-director issue page volume" match="none">
+            <!-- Don't print event info if published in a proceedings -->
+            <group delimiter=", ">
+              <text macro="event-title"/>
+              <text variable="event-place"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-title">
+    <choose>
+      <!-- TODO: We expect "event-title" to be used,
+           but processors and applications may not be updated yet.
+           This macro ensures that either "event" or "event-title" can be accpeted.
+           Remove if procesor logic and application adoption can handle this. -->
+      <if variable="event-title">
+        <text variable="event-title"/>
+      </if>
+      <else>
+        <text variable="event"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description
+                   of publication history, such as full "reprinted" references
+                   (examples 11, 43, 44) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text value="Original work published"/>
+                <choose>
+                  <if is-uncertain-date="original-date">
+                    <text term="circa" form="short"/>
+                  </if>
+                </choose>
+                <date variable="original-date">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Legal citations have their own rules -->
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text macro="container-legal"/>
+              <text macro="date-legal"/>
+            </group>
+            <text variable="references"/>
+          </group>
+          <text macro="access"/>
+        </group>
+      </if>
+      <else-if type="bill">
+        <!-- Currently designed to handle bills, resolutions, hearings, rederal reports. -->
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="number container-title" match="none">
+                <!-- If no number or container-title, then assume it is a hearing -->
+                <text variable="title" font-style="italic"/>
+              </if>
+              <else>
+                <text variable="title"/>
+              </else>
+            </choose>
+            <group delimiter=" ">
+              <text macro="container-legal"/>
+              <text macro="date-legal"/>
+              <choose>
+                <if variable="number container-title" match="none">
+                  <!-- If no number or container-title, then assume it is a hearing -->
+                  <names variable="author" prefix="(testimony of " suffix=")">
+                    <name and="symbol" delimiter=", "/>
+                  </names>
+                </if>
+                <else>
+                  <text variable="status" prefix="(" suffix=")"/>
+                </else>
+              </choose>
+            </group>
+            <text variable="references"/>
+          </group>
+          <text macro="access"/>
+        </group>
+      </else-if>
+      <else-if type="legislation">
+        <!-- Currently designed to handle statutes, codified regulations, executive orders.
+             For uncodified regulations, assume future code section is in status. -->
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text macro="container-legal"/>
+              <text macro="date-legal"/>
+              <text variable="status" prefix="(" suffix=")"/>
+            </group>
+            <text variable="references"/>
+          </group>
+          <text macro="access"/>
+        </group>
+      </else-if>
+      <else-if type="treaty">
+        <!-- APA generally defers to Bluebook for legal citations, but diverges without
+             explanation for treaty items. The Bluebook format that was used in APA 6th
+             ed. is used here. -->
+        <group delimiter=", ">
+          <text variable="title" text-case="title"/>
+          <names variable="author">
+            <name initialize-with="." form="short" delimiter="-"/>
+          </names>
+          <text macro="date-legal"/>
+          <text macro="container-legal"/>
+          <text macro="access"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="legal_case">
+        <group prefix="(" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <choose>
+            <if variable="container-title" match="any">
+              <!-- Print only year for cases published in reporters-->
+              <date variable="issued" form="numeric" date-parts="year"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group prefix="(" suffix=")" delimiter=" ">
+          <group delimiter=" ">
+            <date variable="original-date">
+              <date-part name="year"/>
+            </date>
+            <text term="and" form="symbol"/>
+          </group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="treaty">
+        <date variable="issued" form="text"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <group delimiter=" ">
+                  <!-- Change to label variable="section" as that becomes available -->
+                  <text term="section" form="symbol"/>
+                  <text variable="section"/>
+                </group>
+                <choose>
+                  <if variable="page page-first" match="any">
+                    <text variable="page-first"/>
+                  </if>
+                  <else>
+                    <text value="___"/>
+                  </else>
+                </choose>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <choose>
+                  <if is-numeric="number">
+                    <!-- Replace with label variable="number" if that becomes available -->
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                  </if>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text variable="genre"/>
+            <group delimiter=" ">
+              <choose>
+                <if variable="chapter-number container-title" match="none">
+                  <!-- Replace with label variable="number" as that becomes available -->
+                  <text term="issue" form="short"/>
+                </if>
+              </choose>
+              <text variable="number"/>
+            </group>
+          </group>
+          <text variable="authority"/>
+          <text variable="chapter-number"/>
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text variable="page-first"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legislation">
+        <choose>
+          <if variable="number">
+            <!--There's a public law number-->
+            <group delimiter=", ">
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <choose>
+                <if variable="section">
+                  <group delimiter=" ">
+                    <!-- Change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </if>
+                <else>
+                  <text variable="page-first"/>
+                </else>
+              </choose>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="treaty">
+        <group delimiter=" ">
+          <number variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="page page-first" match="any">
+              <text variable="page-first"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <!-- Replace with label variable="number" if that becomes available -->
+                <text term="issue" form="short" text-case="capitalize-first"/>
+                <text variable="number"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group delimiter=" ">
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+    <sort>
+      <key macro="author-bib" names-min="3" names-use-first="1"/>
+      <key macro="date-sort-group"/>
+      <key macro="date-sort-date" sort="ascending"/>
+      <key variable="status"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="date-intext"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author-bib"/>
+      <key macro="date-sort-group"/>
+      <key macro="date-sort-date" sort="ascending"/>
+      <key variable="status"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="bill legal_case legislation treaty" match="any">
+          <!-- Legal items have different orders and delimiters -->
+          <choose>
+            <if variable="DOI URL" match="any">
+              <text macro="legal-cites"/>
+            </if>
+            <else>
+              <text macro="legal-cites" suffix="."/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=". " suffix=".">
+              <text macro="author-bib"/>
+              <text macro="date-bib"/>
+              <text macro="title-and-descriptions"/>
+              <text macro="container"/>
+              <text macro="event"/>
+              <text macro="publisher"/>
+            </group>
+            <text macro="access"/>
+            <text macro="publication-history"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -430,7 +430,6 @@ class CitationStyleGeneratorTest {
                         "apa.csl"),
 
                 Arguments.of(
-
                         "Foo, B. (n.d.). eid + issue. Bib(La)TeX Journal, 9issue, Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -46,10 +46,10 @@ class CitationStyleGeneratorTest {
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(TestEntry.getTestEntry())));
         context.setMode(BibDatabaseMode.BIBLATEX);
         List<CitationStyle> styleList = CitationStyle.discoverCitationStyles();
-        CitationStyle style = styleList.stream().filter(e -> "American Psychological Association 6th edition".equals(e.getTitle())).findAny().orElse(null);
+        CitationStyle style = styleList.stream().filter(e -> "American Psychological Association 7th edition".equals(e.getTitle())).findAny().orElse(null);
         String citation = CitationStyleGenerator.generateCitation(TestEntry.getTestEntry(), style.getSource(), CitationStyleOutputFormat.HTML, context, new BibEntryTypesManager());
 
-        // if the apa-6th-citation.csl citation style changes this has to be modified
+        // if the apa-7th-citation.csl citation style changes this has to be modified
         String expected = "  <div class=\"csl-entry\">"
                 + "Smith, B., Jones, B., &amp; Williams, J. (2016-07). Title of the test entry. <span style=\"font-style: italic\">BibTeX Journal</span>, <span style=\"font-style: italic\">34</span>(3), 45&ndash;67. https://doi.org/10.1001/bla.blubb"
                 + "</div>\n"
@@ -229,7 +229,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1")
                                 .withField(StandardField.COMMENT, "The issue field does not exist in Bibtex standard, therefore there is no need to render it (The issue field exists in biblatex standard though)")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                         "Foo, B. (n.d.). volume + issue + pages. Bib(La)TeX Journal, 1(9), 45–67.\n",
@@ -242,7 +242,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1")
                                 .withField(StandardField.COMMENT, "The issue field does not exist in Bibtex standard, therefore there is no need to render it (The issue field exists in biblatex standard though.). Since, for this entry, there is no number field present and therefore no data will be overwriten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing.")
                                 .withField(StandardField.ISSUE, "9"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                         "Foo, B. (n.d.). volume + pages. Bib(La)TeX Journal, 1, 45–67.\n",
@@ -253,7 +253,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.TITLE, "volume + pages")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                         "Foo, B. (n.d.). number. Bib(La)TeX Journal, (3number).\n",
@@ -263,7 +263,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.JOURNAL, "Bib(La)TeX Journal")
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.TITLE, "number"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though). Since, for this entry, there is no number field present and therefore no data will be overwriten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing.
                 Arguments.of(
@@ -275,7 +275,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.TITLE, "issue + pages")
                                 .withField(StandardField.ISSUE, "9"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though)
                 Arguments.of(
@@ -287,7 +287,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.TITLE, "issue + number")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though)
                 Arguments.of(
@@ -300,7 +300,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.TITLE, "issue + number + pages")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // "Article number" is not a field that exists in Bibtex standard. Printing the article number in the pages field is a workaround. Some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range. Question: Should it be rendered WITH Article or WITHOUT the Word Article in Front? I guess without?
                 Arguments.of(
@@ -313,7 +313,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "Article 777")
                                 .withField(StandardField.TITLE, "number + pages")
                                 .withField(StandardField.COMMENT, "number + article-number WITH the word article instead of pagerange"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // "The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though). Since, for this entry, there is no number field present and therefore no data will be overwriten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing."
                 Arguments.of(
@@ -324,7 +324,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.JOURNAL, "Bib(La)TeX Journal")
                                 .withField(StandardField.TITLE, "issue")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                         "Foo, B. (n.d.). number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
@@ -335,7 +335,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.TITLE, "number + pages"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // "Article number" is not a field that exists in Bibtex standard. Printing the article number in the pages field is a workaround. Some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range. Question: Should it be rendered WITH Article or WITHOUT the Word Article in Front? I guess without?
                 Arguments.of(
@@ -348,7 +348,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "777e23")
                                 .withField(StandardField.TITLE, "number + pages")
                                 .withField(StandardField.COMMENT, "number + article-number WITHOUT the word article instead of pagerange"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is correct. The "eid" field(short for: electronic identifier) does not exist in Bibtex standard. It exists in Biblatex standard though and is the field, in which the "article number" should be entered into. "Article number" is a field that does not exist in Bibtex and also not in Biblatex standard. As a workaround, some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue (= the "number" field" in Biblatex)  whenever it is in the data and the number (= the "eid" field in Biblatex) when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280). I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition. Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
@@ -362,7 +362,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.TITLE, "eid + issue + number + pages")
                                 .withField(StandardField.EID, "6eid")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 /*
                 Not rendering the "eid" field here, is correct. The "eid" field(= electronic identifier) does not exist in Bibtex standard.
@@ -381,7 +381,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.COMMENT, "")
                                 .withField(StandardField.EID, "Article 6eid")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
         /*
         Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
@@ -400,7 +400,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
@@ -414,7 +414,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
@@ -428,11 +428,11 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                         /*
-                         * Change test once apa-6th-edition.csl supports the CSL "number" field.
+                         * Change test once apa.csl supports the CSL "number" field.
                          * Tracked in https://github.com/citation-style-language/styles/issues/5827
                          * Ideal test: "Foo, B. (n.d.). eid + issue. Bib(La)TeX Journal, (9issue), Article 6eid.\n",
                          * Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
@@ -445,7 +445,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.TITLE, "eid + issue")
                                 .withField(StandardField.EID, "Article 6eid")
                                 .withField(StandardField.ISSUE, "9issue"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
@@ -458,11 +458,11 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "6eid")
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.PAGES, "45--67"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 /*
-                  Change test once apa-6th-edition.csl supports the CSL "number" field.
+                  Change test once apa.csl supports the CSL "number" field.
                   Tracked in https://github.com/citation-style-language/styles/issues/5827
                   Ideal test: "Foo, B. (n.d.). eid + issue + number. Bib(La)TeX Journal, (3number), Article 6eid.\n",
                   Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
@@ -477,7 +477,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "Article 6eid")
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.NUMBER, "3number"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 /*
                     Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
@@ -495,7 +495,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. My personal opinion is that the "eid" (article number) will probably be more helpful to users for finding this article than the page range, if the "number" and "issue" and "volume" are unknown.
                 Arguments.of(
@@ -507,11 +507,11 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.TITLE, "eid + pages")
                                 .withField(StandardField.EID, "6eid")
                                 .withField(StandardField.PAGES, "45--67"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 Arguments.of(
                        /*
-                         Change test once apa-6th-edition.csl supports the CSL "number" field.
+                         Change test once apa.csl supports the CSL "number" field.
                          Tracked in https://github.com/citation-style-language/styles/issues/5827
                          Ideal test: "Foo, B. (n.d.). eid. Bib(La)TeX Journal, Article 6eid.\n",
                          Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
@@ -523,11 +523,11 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.JOURNALTITLE, "Bib(La)TeX Journal")
                                 .withField(StandardField.TITLE, "eid")
                                 .withField(StandardField.EID, "Article 6eid"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // All correct and not controversial, because APA Style (7th edition) recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." (Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2)
                 /*
-                 Change test once apa-6th-edition.csl supports the CSL "number" field.
+                 Change test once apa.csl supports the CSL "number" field.
                  Tracked in https://github.com/citation-style-language/styles/issues/5827
                  Ideal test: "Foo, B. (n.d.). volume + number + eid. Bib(La)TeX Journal, 1(3number), Article 6eid.\n",
                  Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
@@ -542,7 +542,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "Article 6eid")
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
@@ -555,11 +555,11 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "6eid")
                                 .withField(StandardField.PAGES, "45--67")
                                 .withField(StandardField.VOLUME, "1"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." (Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2)
                 /*
-                 Change test once apa-6th-edition.csl supports the CSL "number" field.
+                 Change test once apa.csl supports the CSL "number" field.
                  Tracked in https://github.com/citation-style-language/styles/issues/5827
                  Ideal test: "Foo, B. (n.d.). eid + number. Bib(La)TeX Journal, (3number), Article 6eid.\n",
                  Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
@@ -573,7 +573,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.TITLE, "eid + number")
                                 .withField(StandardField.EID, "Article 6eid")
                                 .withField(StandardField.NUMBER, "3number"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
@@ -586,7 +586,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "6eid")
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "issue" field here is sufficient for APA Style (7th edition). Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
@@ -598,7 +598,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.TITLE, "issue + number")
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.NUMBER, "3number"),
-                        "apa-6th-edition.csl"),
+                        "apa.csl"),
 
                 // Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
@@ -611,7 +611,7 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.ISSUE, "9issue")
                                 .withField(StandardField.NUMBER, "3number")
                                 .withField(StandardField.PAGES, "45--67"),
-                        "apa-6th-edition.csl")
+                        "apa.csl")
         );
     }
 

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -256,7 +256,7 @@ class CitationStyleGeneratorTest {
                         "apa.csl"),
 
                 Arguments.of(
-                        "Foo, B. (n.d.). number. Bib(La)TeX Journal, (3number).\n",
+                        "Foo, B. (n.d.). number. Bib(La)TeX Journal, 3number.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -267,7 +267,7 @@ class CitationStyleGeneratorTest {
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though). Since, for this entry, there is no number field present and therefore no data will be overwriten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing.
                 Arguments.of(
-                        "Foo, B. (n.d.). issue + pages. Bib(La)TeX Journal, (9), 45–67.\n",
+                        "Foo, B. (n.d.). issue + pages. Bib(La)TeX Journal, 9, 45–67.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -279,7 +279,7 @@ class CitationStyleGeneratorTest {
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though)
                 Arguments.of(
-                        "Foo, B. (n.d.). issue + number. Bib(La)TeX Journal, (3number).\n",
+                        "Foo, B. (n.d.). issue + number. Bib(La)TeX Journal, 3number.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -291,7 +291,7 @@ class CitationStyleGeneratorTest {
 
                 // The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though)
                 Arguments.of(
-                        "Foo, B. (n.d.). issue + number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). issue + number + pages. Bib(La)TeX Journal, 3number, 45–67.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -304,7 +304,7 @@ class CitationStyleGeneratorTest {
 
                 // "Article number" is not a field that exists in Bibtex standard. Printing the article number in the pages field is a workaround. Some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range. Question: Should it be rendered WITH Article or WITHOUT the Word Article in Front? I guess without?
                 Arguments.of(
-                        "Foo, B. (n.d.). number + pages. Bib(La)TeX Journal, (3number), Article 777.\n",
+                        "Foo, B. (n.d.). number + pages. Bib(La)TeX Journal, 3number, Article 777.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -317,7 +317,7 @@ class CitationStyleGeneratorTest {
 
                 // "The issue field does not exist in bibtex standard, therefore there is no need to render it (it exists in biblatex standard though). Since, for this entry, there is no number field present and therefore no data will be overwriten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing."
                 Arguments.of(
-                        "Foo, B. (n.d.). issue. Bib(La)TeX Journal, (9issue).\n",
+                        "Foo, B. (n.d.). issue. Bib(La)TeX Journal, 9issue.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -327,7 +327,7 @@ class CitationStyleGeneratorTest {
                         "apa.csl"),
 
                 Arguments.of(
-                        "Foo, B. (n.d.). number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). number + pages. Bib(La)TeX Journal, 3number, 45–67.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -339,7 +339,7 @@ class CitationStyleGeneratorTest {
 
                 // "Article number" is not a field that exists in Bibtex standard. Printing the article number in the pages field is a workaround. Some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range. Question: Should it be rendered WITH Article or WITHOUT the Word Article in Front? I guess without?
                 Arguments.of(
-                        "Foo, B. (n.d.). number + pages. BibTeX Journal, (3number), 777e23.\n",
+                        "Foo, B. (n.d.). number + pages. BibTeX Journal, 3number, 777e23.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -352,7 +352,7 @@ class CitationStyleGeneratorTest {
 
                 // Not rendering the "eid" field here, is correct. The "eid" field(short for: electronic identifier) does not exist in Bibtex standard. It exists in Biblatex standard though and is the field, in which the "article number" should be entered into. "Article number" is a field that does not exist in Bibtex and also not in Biblatex standard. As a workaround, some Journals have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue (= the "number" field" in Biblatex)  whenever it is in the data and the number (= the "eid" field in Biblatex) when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280). I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition. Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + issue + number + pages. BibTeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). eid + issue + number + pages. BibTeX Journal, 3number, 45–67.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -372,7 +372,7 @@ class CitationStyleGeneratorTest {
                         Since, for this entry, there is no number field present and therefore no data will be overwritten, enabling the user to be able to move the data within the issue field to the number field via cleanup action is something worth pursuing.
                  */
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + issue. BibTeX Journal, (9issue), Article 6eid.\n",
+                        "Foo, B. (n.d.). eid + issue. BibTeX Journal, 9issue, Article 6eid.\n",
                         BibDatabaseMode.BIBTEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -389,7 +389,7 @@ class CitationStyleGeneratorTest {
         Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
          */
                 Arguments.of(
-                        "Foo, B. (n.d.). volume + issue + number + pages + eid. Bib(La)TeX Journal, 1(3number), 45–67.\n",
+                        "Foo, B. (n.d.). volume + issue + number + pages + eid. Bib(La)TeX Journal, 1(3number), Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -402,9 +402,9 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
+                // eid field will always be prefixed with article
                 Arguments.of(
-                        "Foo, B. (n.d.). volume + issue + pages + eid. Bib(La)TeX Journal, 1(9issue), 45–67.\n",
+                        "Foo, B. (n.d.). volume + issue + pages + eid. Bib(La)TeX Journal, 1(9issue), Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -416,9 +416,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
-                        "Foo, B. (n.d.). volume + number + pages + eid. Bib(La)TeX Journal, 1(3number), 45–67.\n",
+                        "Foo, B. (n.d.). volume + number + pages + eid. Bib(La)TeX Journal, 1(3number), Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -431,13 +430,8 @@ class CitationStyleGeneratorTest {
                         "apa.csl"),
 
                 Arguments.of(
-                        /*
-                         * Change test once apa.csl supports the CSL "number" field.
-                         * Tracked in https://github.com/citation-style-language/styles/issues/5827
-                         * Ideal test: "Foo, B. (n.d.). eid + issue. Bib(La)TeX Journal, (9issue), Article 6eid.\n",
-                         * Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                         */
-                        "Foo, B. (n.d.). eid + issue. Bib(La)TeX Journal, (9issue).\n",
+
+                        "Foo, B. (n.d.). eid + issue. Bib(La)TeX Journal, 9issue, Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -447,9 +441,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.ISSUE, "9issue"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + issue + pages. Bib(La)TeX Journal, (9issue), 45–67.\n",
+                        "Foo, B. (n.d.). eid + issue + pages. Bib(La)TeX Journal, 9issue, Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -460,15 +453,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "45--67"),
                         "apa.csl"),
 
-                // Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
-                /*
-                  Change test once apa.csl supports the CSL "number" field.
-                  Tracked in https://github.com/citation-style-language/styles/issues/5827
-                  Ideal test: "Foo, B. (n.d.). eid + issue + number. Bib(La)TeX Journal, (3number), Article 6eid.\n",
-                  Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                 */
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + issue + number. Bib(La)TeX Journal, (3number).\n",
+                        "Foo, B. (n.d.). eid + issue + number. Bib(La)TeX Journal, 3number, Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -479,13 +465,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number"),
                         "apa.csl"),
 
-                /*
-                    Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
-
-                    Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
-                */
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + issue + number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). eid + issue + number + pages. Bib(La)TeX Journal, 3number, Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -497,9 +478,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.PAGES, "45--67"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. My personal opinion is that the "eid" (article number) will probably be more helpful to users for finding this article than the page range, if the "number" and "issue" and "volume" are unknown.
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + pages. Bib(La)TeX Journal, 45–67.\n",
+                        "Foo, B. (n.d.). eid + pages. Bib(La)TeX Journal, Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -510,13 +490,7 @@ class CitationStyleGeneratorTest {
                         "apa.csl"),
 
                 Arguments.of(
-                       /*
-                         Change test once apa.csl supports the CSL "number" field.
-                         Tracked in https://github.com/citation-style-language/styles/issues/5827
-                         Ideal test: "Foo, B. (n.d.). eid. Bib(La)TeX Journal, Article 6eid.\n",
-                         Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                       */
-                        "Foo, B. (n.d.). eid. Bib(La)TeX Journal.\n",
+                        "Foo, B. (n.d.). eid. Bib(La)TeX Journal, Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -525,15 +499,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.EID, "Article 6eid"),
                         "apa.csl"),
 
-                // All correct and not controversial, because APA Style (7th edition) recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." (Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2)
-                /*
-                 Change test once apa.csl supports the CSL "number" field.
-                 Tracked in https://github.com/citation-style-language/styles/issues/5827
-                 Ideal test: "Foo, B. (n.d.). volume + number + eid. Bib(La)TeX Journal, 1(3number), Article 6eid.\n",
-                 Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                */
                 Arguments.of(
-                        "Foo, B. (n.d.). volume + number + eid. Bib(La)TeX Journal, 1(3number).\n",
+                        "Foo, B. (n.d.). volume + number + eid. Bib(La)TeX Journal, 1(3number), Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -544,9 +511,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
-                        "Foo, B. (n.d.). volume + pages + eid. Bib(La)TeX Journal, 1, 45–67.\n",
+                        "Foo, B. (n.d.). volume + pages + eid. Bib(La)TeX Journal, 1, Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -557,15 +523,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.VOLUME, "1"),
                         "apa.csl"),
 
-                // APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." (Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2)
-                /*
-                 Change test once apa.csl supports the CSL "number" field.
-                 Tracked in https://github.com/citation-style-language/styles/issues/5827
-                 Ideal test: "Foo, B. (n.d.). eid + number. Bib(La)TeX Journal, (3number), Article 6eid.\n",
-                 Because of https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2
-                */
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + number. Bib(La)TeX Journal, (3number).\n",
+                        "Foo, B. (n.d.). eid + number. Bib(La)TeX Journal, 3number, Article Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -575,9 +534,8 @@ class CitationStyleGeneratorTest {
                                 .withField(StandardField.NUMBER, "3number"),
                         "apa.csl"),
 
-                // Not rendering the "eid" field here, is sufficient, but contested practice. This statement is based on the following reasoning: "eid" (in long: electronic identifier) is the field, which should be used to enter the "article number", when using the Biblatex standard. Both "eid" and "article number" do not exist in the older Bibtex standard. As a workaround, some Journals and publishers have opted to put the article number into the pages field. APA 7th Style recommends following procedure: "If the journal article has an article number instead of a page range, include the word "Article" and then the article number instead of the page range." - Source: https://apastyle.apa.org/style-grammar-guidelines/references/examples/journal-article-references#2. Additionally the APA style (7th edition) created by the CSL community "prints the issue [= the "number" field" in both Biblatex and Bibtex]  whenever it is in the data and the number [= the "eid" field in Biblatex] when no page range is present, entirely independent of the issue number" - Source: https://github.com/citation-style-language/styles/issues/5827#issuecomment-1006011280. I personally think the "eid" field SHOULD be rendered here SOMEWHERE, maybe even IN ADDITION to the page range, because we have the data, right? Why not show it? - But this is just my humble opinion and may not be coherent with the current APA Style 7th edition.
                 Arguments.of(
-                        "Foo, B. (n.d.). eid + number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). eid + number + pages. Bib(La)TeX Journal, 3number, Article 6eid.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -590,7 +548,7 @@ class CitationStyleGeneratorTest {
 
                 // Not rendering the "issue" field here is sufficient for APA Style (7th edition). Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
-                        "Foo, B. (n.d.). issue + number. Bib(La)TeX Journal, (3number).\n",
+                        "Foo, B. (n.d.). issue + number. Bib(La)TeX Journal, 3number.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")
@@ -602,7 +560,7 @@ class CitationStyleGeneratorTest {
 
                 // Not rendering the "issue" field here is sufficient for APA 7th edition. Under current circumstances the "number" field takes priority over the "issue" field (see https://github.com/JabRef/jabref/issues/8372#issuecomment-1023768144). [Keyword: IS RENDERING BOTH VIABLE?]. Ideally, they would coexist: "Roughly speaking number subdivides volume and issue is much closer to subdividing year. I don't think I would want to say that issue is subordinate to number or vice versa. They sort of operate on a similar level." (Source: https://github.com/plk/biblatex/issues/726#issuecomment-1010264258)
                 Arguments.of(
-                        "Foo, B. (n.d.). issue + number + pages. Bib(La)TeX Journal, (3number), 45–67.\n",
+                        "Foo, B. (n.d.). issue + number + pages. Bib(La)TeX Journal, 3number, 45–67.\n",
                         BibDatabaseMode.BIBLATEX,
                         new BibEntry(StandardEntryType.Article)
                                 .withField(StandardField.AUTHOR, "Foo, Bar")


### PR DESCRIPTION
Follow up to  #8607

This follow up was necessary because of https://github.com/citation-style-language/styles/pull/6255

- adds apa.csl for test
- fixes tests
- adds mapping as javadoc comment

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
