### PR TITLE
Make autosave tick in shared database opening dialog active

### DIFF
--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseLoginDialogViewModel.java
@@ -161,7 +161,7 @@ public class SharedDatabaseLoginDialogViewModel extends AbstractViewModel {
             LibraryTab libraryTab = manager.openNewSharedDatabaseTab(connectionProperties);
             setPreferences();
 
-            if (!folder.getValue().isEmpty()) {
+            if (!folder.getValue().isEmpty() && autosave.get()) {
                 try {
                     new SaveDatabaseAction(libraryTab, preferencesService, Globals.entryTypesManager).saveAs(Path.of(folder.getValue()));
                 } catch (Throwable e) {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Follow-up of  #9000. The problem was that if the folder was set, the autosave tick did not make any difference. Now the tick is "active", i.e. synchronizing to a local database is deactivated even if the folder is set.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Manually tested changed features in running JabRef (always required)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
