### PR TITLE
Preferences dialog now closes on CLOSE DIALOG key binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
-- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/koppor/jabref/issues/8888)
+- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
+- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/koppor/jabref/issues/8888)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -11,6 +11,7 @@ import javafx.scene.input.KeyCode;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
@@ -71,6 +72,13 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         viewModel = new PreferencesDialogViewModel(dialogService, preferencesService, frame);
 
         preferenceTabList.itemsProperty().setValue(viewModel.getPreferenceTabs());
+
+        // The list view does not respect the listener for the dialog and needs its own
+        preferenceTabList.setOnKeyReleased(key -> {
+            if (preferencesService.getKeyBindingRepository().checkKeyCombinationEquality(KeyBinding.CLOSE, key)) {
+                this.closeDialog();
+            }
+        });
 
         PreferencesSearchHandler searchHandler = new PreferencesSearchHandler(viewModel.getPreferenceTabs());
         preferenceTabList.itemsProperty().bindBidirectional(searchHandler.filteredPreferenceTabsProperty());


### PR DESCRIPTION
Fixes #8888 

The Preferences dialog was not closing when the CLOSE DIALOG key binding was pressed. This was because when the user changed the tab, they needed to click the Preference Tab List. This ListView was not respecting the event handlers that were present on the dialog. To resolve this, an 'onKeyReleased' event was added to the ListView. The Preferences tab now closes when the CLOSE DIALOG key binding is pressed.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
