### PR TITLE
Fix for issue: right click menu 6601

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -189,8 +189,15 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
         database.getDatabase().registerListener(this);
 
+        MainTableColumnFactory rightClickMenuFactory = new MainTableColumnFactory(
+                database,
+                preferencesService,
+                preferencesService.getColumnPreferences(),
+                libraryTab.getUndoManager(),
+                dialogService,
+                stateManager);
         // Enable the header right-click menu.
-        new MainTableHeaderContextMenu(this).show(true);
+        new MainTableHeaderContextMenu(this, rightClickMenuFactory).show(true);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -142,8 +142,6 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
         this.getSortOrder().clear();
 
-        new MainTableHeaderContextMenu().show(this);
-
         /* KEEP for debugging purposes
         for (var colModel : mainTablePreferences.getColumnPreferences().getColumnSortOrder()) {
             for (var col : this.getColumns()) {
@@ -190,6 +188,9 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         });
 
         database.getDatabase().registerListener(this);
+
+        // Enable the header right-click menu.
+        new MainTableHeaderContextMenu(this).show(true);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -142,6 +142,8 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
         this.getSortOrder().clear();
 
+        new MainTableHeaderContextMenu().show(this);
+
         /* KEEP for debugging purposes
         for (var colModel : mainTablePreferences.getColumnPreferences().getColumnSortOrder()) {
             for (var col : this.getColumns()) {

--- a/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -74,50 +74,55 @@ public class MainTableColumnFactory {
         this.stateManager = stateManager;
     }
 
+    public TableColumn<BibEntryTableViewModel, ?> createColumn(MainTableColumnModel column) {
+        TableColumn<BibEntryTableViewModel, ?> returnColumn = null;
+        switch (column.getType()) {
+            case INDEX:
+                returnColumn = createIndexColumn(column);
+                break;
+            case GROUPS:
+                returnColumn = createGroupColumn(column);
+                break;
+            case FILES:
+                returnColumn = createFilesColumn(column);
+                break;
+            case LINKED_IDENTIFIER:
+                returnColumn = createIdentifierColumn(column);
+                break;
+            case LIBRARY_NAME:
+                returnColumn = createLibraryColumn(column);
+                break;
+            case EXTRAFILE:
+                if (!column.getQualifier().isBlank()) {
+                    returnColumn = createExtraFileColumn(column);
+                }
+                break;
+            case SPECIALFIELD:
+                if (!column.getQualifier().isBlank()) {
+                    Field field = FieldFactory.parseField(column.getQualifier());
+                    if (field instanceof SpecialField) {
+                        returnColumn = createSpecialFieldColumn(column);
+                    } else {
+                        LOGGER.warn("Special field type '{}' is unknown. Using normal column type.", column.getQualifier());
+                        returnColumn = createFieldColumn(column);
+                    }
+                }
+                break;
+            default:
+            case NORMALFIELD:
+                if (!column.getQualifier().isBlank()) {
+                    returnColumn = createFieldColumn(column);
+                }
+                break;
+        }
+        return returnColumn;
+    }
+
     public List<TableColumn<BibEntryTableViewModel, ?>> createColumns() {
         List<TableColumn<BibEntryTableViewModel, ?>> columns = new ArrayList<>();
 
         columnPreferences.getColumns().forEach(column -> {
-
-            switch (column.getType()) {
-                case INDEX:
-                    columns.add(createIndexColumn(column));
-                    break;
-                case GROUPS:
-                    columns.add(createGroupColumn(column));
-                    break;
-                case FILES:
-                    columns.add(createFilesColumn(column));
-                    break;
-                case LINKED_IDENTIFIER:
-                    columns.add(createIdentifierColumn(column));
-                    break;
-                case LIBRARY_NAME:
-                    columns.add(createLibraryColumn(column));
-                    break;
-                case EXTRAFILE:
-                    if (!column.getQualifier().isBlank()) {
-                        columns.add(createExtraFileColumn(column));
-                    }
-                    break;
-                case SPECIALFIELD:
-                    if (!column.getQualifier().isBlank()) {
-                        Field field = FieldFactory.parseField(column.getQualifier());
-                        if (field instanceof SpecialField) {
-                            columns.add(createSpecialFieldColumn(column));
-                        } else {
-                            LOGGER.warn("Special field type '{}' is unknown. Using normal column type.", column.getQualifier());
-                            columns.add(createFieldColumn(column));
-                        }
-                    }
-                    break;
-                default:
-                case NORMALFIELD:
-                    if (!column.getQualifier().isBlank()) {
-                        columns.add(createFieldColumn(column));
-                    }
-                    break;
-            }
+            columns.add(createColumn(column));
         });
 
         return columns;

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TableColumn;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
@@ -38,9 +39,9 @@ public class MainTableHeaderContextMenu extends ContextMenu {
             }
             event.consume();
         });
-        // Cancels right-click menu when double-clicked
+        // Cancels right-click menu when middle mouse button clicked
         mainTable.setOnMouseClicked(event -> {
-            if (event.getButton() != MouseButton.SECONDARY && !event.isControlDown()) {
+            if (event.getButton() != MouseButton.MIDDLE && !event.isControlDown()) {
                 this.hide();
             }
         });
@@ -58,6 +59,9 @@ public class MainTableHeaderContextMenu extends ContextMenu {
             RadioMenuItem itemToAdd = createMenuItem(tableColumn);
             this.getItems().add(itemToAdd);
         }
+
+        SeparatorMenuItem separator = new SeparatorMenuItem();
+        this.getItems().add(separator);
 
         // Append to the menu the current remaining columns in the table.
         for (TableColumn<BibEntryTableViewModel, ?> column :mainTable.getColumns()

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -1,0 +1,57 @@
+package org.jabref.gui.maintable;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.RadioMenuItem;
+import javafx.scene.layout.StackPane;
+
+public class MainTableHeaderContextMenu extends ContextMenu {
+
+    //MainTable mainTable;
+
+
+    public MainTableHeaderContextMenu(){
+        super();
+        //this.mainTable = mainTable;
+        //Obtain the most commonly used fields and the current fields in header.
+        // place in list - need method of updating.
+        constructItems();
+
+    }
+
+    private void constructItems() {
+        String entryTypeLabel = "Entrytype";
+        String authorEditorLabel = "Author/Editor";
+        String titleLabel = "Title";
+        String yearLabel = "Year";
+        String journalLabel = "Journal/Booktitle";
+
+//        RadioMenuItem groupColor = new RadioMenuItem("Group color");
+//        RadioMenuItem linkedFile = new RadioMenuItem("Linked file");
+//        RadioMenuItem linkedId = new RadioMenuItem("Linked id");
+
+        RadioMenuItem entryType = new RadioMenuItem(entryTypeLabel);
+        RadioMenuItem author = new RadioMenuItem(authorEditorLabel);
+        RadioMenuItem title = new RadioMenuItem(titleLabel);
+        RadioMenuItem year = new RadioMenuItem(yearLabel);
+        RadioMenuItem journal = new RadioMenuItem(journalLabel);
+        MenuItem randomButton = new MenuItem("Click me");
+        randomButton.setOnAction(event -> {
+            //new columnDialog
+            RadioMenuItem addTestItem = new RadioMenuItem("test");
+            this.getItems().add(addTestItem);
+        });
+
+        this.getItems().addAll(entryType, author, title, year, journal, randomButton);
+    }
+
+    //Handles showing the menu in the cursors position when right clicked.
+    public void show(MainTable mainTable) {
+        mainTable.setOnContextMenuRequested(event -> {
+            if (!(event.getTarget() instanceof StackPane)) {
+                this.show(mainTable, event.getScreenX(), event.getScreenY());
+            }
+            event.consume();
+        });
+    }
+}

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -48,7 +48,9 @@ public class MainTableHeaderContextMenu extends ContextMenu {
 
     /**
      * Creates an item for the menu constructed with the name/visibility of the table column.
+     *
      */
+    @SuppressWarnings("rawtypes")
     private RadioMenuItem createMenuItem(TableColumn<BibEntryTableViewModel, ?> column) {
         // Construct initial menuItem and flag if item is visible in main table
         String itemName = ((MainTableColumn<?>) column).getDisplayName();

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -1,57 +1,91 @@
 package org.jabref.gui.maintable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.TableColumn;
 import javafx.scene.layout.StackPane;
+
+import org.jabref.gui.maintable.columns.MainTableColumn;
 
 public class MainTableHeaderContextMenu extends ContextMenu {
 
-    //MainTable mainTable;
-
-
-    public MainTableHeaderContextMenu(){
+    public MainTableHeaderContextMenu() {
         super();
-        //this.mainTable = mainTable;
-        //Obtain the most commonly used fields and the current fields in header.
-        // place in list - need method of updating.
-        constructItems();
-
     }
 
-    private void constructItems() {
+    /**
+     * Handles showing the menu in the cursors position when right-clicked.
+     */
+    public void show(MainTable mainTable) {
+        mainTable.setOnContextMenuRequested(event -> {
+            if (!(event.getTarget() instanceof StackPane)) {
+                // Main table columns
+                constructItems(mainTable);
+                this.show(mainTable, event.getScreenX(), event.getScreenY());
+            }
+            event.consume();
+        });
+    }
+
+    /**
+     * Constructs the items for the list and places them in the menu.
+     */
+    private void constructItems(MainTable mainTable) {
+        // Reset the right-click menu and
+        this.getItems().clear();
+        // Obtain the most commonly used fields and the current fields in header.
+        // TODO: 17/10/2022 implement most commonly used fields
+        // Populate the menu with the current columns in the table.
+        for (TableColumn<BibEntryTableViewModel, ?> column :mainTable.getColumns()
+        ) {
+            RadioMenuItem itemToAdd = createMenuItem(column);
+            this.getItems().add(itemToAdd);
+        }
+    }
+
+    /**
+     * Creates an item for the menu constructed with the name/visibility of the table column.
+     */
+    private RadioMenuItem createMenuItem(TableColumn<BibEntryTableViewModel, ?> column) {
+        // Construct initial menuItem and flag if item is visible in main table
+        String itemName = ((MainTableColumn<?>) column).getDisplayName();
+        MainTableColumn tableColumn = (MainTableColumn) column;
+
+        RadioMenuItem returnItem = new RadioMenuItem(itemName);
+
+        returnItem.setSelected(tableColumn.isVisible());
+
+        // Set action to toggle visibility from main table when item is clicked
+        returnItem.setOnAction(event -> tableColumn.setVisible(!tableColumn.isVisible()));
+
+        return returnItem;
+    }
+
+    private List<RadioMenuItem> commonColumns() {
+        // TODO: 17/10/2022 obtain list of common columns
+        List<RadioMenuItem> items = new ArrayList<>();
         String entryTypeLabel = "Entrytype";
         String authorEditorLabel = "Author/Editor";
         String titleLabel = "Title";
         String yearLabel = "Year";
         String journalLabel = "Journal/Booktitle";
 
-//        RadioMenuItem groupColor = new RadioMenuItem("Group color");
-//        RadioMenuItem linkedFile = new RadioMenuItem("Linked file");
-//        RadioMenuItem linkedId = new RadioMenuItem("Linked id");
+        // add special items
 
         RadioMenuItem entryType = new RadioMenuItem(entryTypeLabel);
         RadioMenuItem author = new RadioMenuItem(authorEditorLabel);
         RadioMenuItem title = new RadioMenuItem(titleLabel);
         RadioMenuItem year = new RadioMenuItem(yearLabel);
         RadioMenuItem journal = new RadioMenuItem(journalLabel);
-        MenuItem randomButton = new MenuItem("Click me");
-        randomButton.setOnAction(event -> {
-            //new columnDialog
-            RadioMenuItem addTestItem = new RadioMenuItem("test");
-            this.getItems().add(addTestItem);
-        });
+        items.add(entryType);
+        items.add(author);
+        items.add(title);
+        items.add(year);
+        items.add(journal);
 
-        this.getItems().addAll(entryType, author, title, year, journal, randomButton);
-    }
-
-    //Handles showing the menu in the cursors position when right clicked.
-    public void show(MainTable mainTable) {
-        mainTable.setOnContextMenuRequested(event -> {
-            if (!(event.getTarget() instanceof StackPane)) {
-                this.show(mainTable, event.getScreenX(), event.getScreenY());
-            }
-            event.consume();
-        });
+        return items;
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -7,7 +7,6 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TableColumn;
-import javafx.scene.input.MouseButton;
 import javafx.scene.layout.StackPane;
 
 import org.jabref.gui.maintable.columns.MainTableColumn;
@@ -34,16 +33,13 @@ public class MainTableHeaderContextMenu extends ContextMenu {
     public void show(boolean show) {
         // TODO: 20/10/2022 unknown bug where issue does not show unless parameter is passed through this method.
         mainTable.setOnContextMenuRequested(event -> {
+            // Display the menu if header is clicked, otherwise, remove from display.
             if (!(event.getTarget() instanceof StackPane) && show) {
                 this.show(mainTable, event.getScreenX(), event.getScreenY());
-            }
-            event.consume();
-        });
-        // Cancels right-click menu when middle mouse button clicked
-        mainTable.setOnMouseClicked(event -> {
-            if (event.getButton() != MouseButton.MIDDLE && !event.isControlDown()) {
+            } else if (this.isShowing()) {
                 this.hide();
             }
+            event.consume();
         });
     }
 

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -15,16 +15,18 @@ import org.jabref.gui.maintable.columns.MainTableColumn;
 public class MainTableHeaderContextMenu extends ContextMenu {
 
     MainTable mainTable;
-    Set<TableColumn<BibEntryTableViewModel, ?>> columnSet;
+    Set<TableColumn<BibEntryTableViewModel, ?>> mainTableColumnSet;
+    MainTableColumnFactory factory;
     /**
      * Constructor for the right click menu
      *
      */
-    public MainTableHeaderContextMenu(MainTable mainTable) {
+    public MainTableHeaderContextMenu(MainTable mainTable, MainTableColumnFactory factory) {
         super();
-        columnSet = new HashSet<>();
-        constructItems(mainTable);
         this.mainTable = mainTable;
+        this.factory = factory;
+        mainTableColumnSet = new HashSet<>();
+        constructItems(mainTable);
     }
 
     /**
@@ -49,12 +51,16 @@ public class MainTableHeaderContextMenu extends ContextMenu {
         this.getItems().clear();
         // Obtain the most commonly used fields and the current fields in header.
         // TODO: 17/10/2022 implement most commonly used fields
+        mainTableColumnSet.addAll(commonColumns());
+
         // Populate the menu with the current columns in the table.
         for (TableColumn<BibEntryTableViewModel, ?> column :mainTable.getColumns()
         ) {
-            RadioMenuItem itemToAdd = createMenuItem(column);
-            this.getItems().add(itemToAdd);
-            this.columnSet.add(column);
+            if (!isInTable((MainTableColumn) column, mainTableColumnSet.stream().toList())) {
+                this.mainTableColumnSet.add(column);
+                RadioMenuItem itemToAdd = createMenuItem(column);
+                this.getItems().add(itemToAdd);
+            }
         }
     }
 
@@ -64,18 +70,21 @@ public class MainTableHeaderContextMenu extends ContextMenu {
      */
     @SuppressWarnings("rawtypes")
     private RadioMenuItem createMenuItem(TableColumn<BibEntryTableViewModel, ?> column) {
-        // Construct initial menuItem and flag if item is visible in main table
-        String itemName = ((MainTableColumn<?>) column).getDisplayName();
+        // Construct initial menuItem
         MainTableColumn tableColumn = (MainTableColumn) column;
+        String itemName = tableColumn.getDisplayName();
 
         RadioMenuItem returnItem = new RadioMenuItem(itemName);
 
-        returnItem.setSelected(tableColumn.isVisible());
+        // Flag item as selected if the item is already in the main table.
+        returnItem.setSelected(isInTable(tableColumn, mainTable.getColumns()));
 
         // Set action to toggle visibility from main table when item is clicked
         returnItem.setOnAction(event -> {
-            if (tableColumn.isVisible()) {
+            if (isInTable(tableColumn, mainTable.getColumns())) {
                 removeColumn(tableColumn);
+                System.out.println(tableColumn.getModel().getType());
+                System.out.println(tableColumn.getModel().getQualifier());
             } else {
                 addColumn(tableColumn);
             }
@@ -90,8 +99,7 @@ public class MainTableHeaderContextMenu extends ContextMenu {
     @SuppressWarnings("rawtypes")
     private void addColumn(MainTableColumn tableColumn) {
         // Do not add duplicate if table column is already within the table.
-        if (!mainTable.getColumns().contains(tableColumn)) {
-            // noinspection unchecked
+        if (!isInTable(tableColumn, mainTable.getColumns())) {
             mainTable.getColumns().add(tableColumn);
             tableColumn.setVisible(true);
         }
@@ -106,28 +114,59 @@ public class MainTableHeaderContextMenu extends ContextMenu {
         mainTable.getColumns().removeIf(tableCol -> tableCol == tableColumn);
     }
 
-    private List<RadioMenuItem> commonColumns() {
+    private boolean isInTable(MainTableColumn tableColumn, List<TableColumn<BibEntryTableViewModel, ?>> tableColumns) {
+        for (TableColumn<BibEntryTableViewModel, ?> column:
+        tableColumns) {
+            MainTableColumnModel model = ((MainTableColumn) column).getModel();
+            if (tableColumn.getModel().getQualifier().equals(model.getQualifier()) || tableColumn.getModel().getType().equals(model.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void refreshMenu() {
+        for (TableColumn<BibEntryTableViewModel, ?> column :mainTableColumnSet) {
+            RadioMenuItem itemToAdd = createMenuItem(column);
+            this.getItems().add(itemToAdd);
+        }
+    }
+
+    private Set<TableColumn<BibEntryTableViewModel, ?>> commonColumns() {
         // TODO: 17/10/2022 obtain list of common columns
-        List<RadioMenuItem> items = new ArrayList<>();
-        String entryTypeLabel = "Entrytype";
-        String authorEditorLabel = "Author/Editor";
-        String titleLabel = "Title";
-        String yearLabel = "Year";
-        String journalLabel = "Journal/Booktitle";
 
-        // add special items
+        String entryTypeQualifier = "entrytype";
+        String authorEditQualifier = "author/editor";
+        String titleQualifier = "title";
+        String yearQualifier = "year";
+        String journalBookQualifier = "journal/booktitle";
+        String rankQualifier = "ranking";
+        String readStatusQualifier = "readstatus";
+        String priorityQualifier = "priority";
 
-        RadioMenuItem entryType = new RadioMenuItem(entryTypeLabel);
-        RadioMenuItem author = new RadioMenuItem(authorEditorLabel);
-        RadioMenuItem title = new RadioMenuItem(titleLabel);
-        RadioMenuItem year = new RadioMenuItem(yearLabel);
-        RadioMenuItem journal = new RadioMenuItem(journalLabel);
-        items.add(entryType);
-        items.add(author);
-        items.add(title);
-        items.add(year);
-        items.add(journal);
+        // Create the MainTableColumn Models from qualifiers + types.
+        List<MainTableColumnModel> commonColumns = new ArrayList<>();
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.GROUPS));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.FILES));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.LINKED_IDENTIFIER));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.NORMALFIELD, entryTypeQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.NORMALFIELD, authorEditQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.NORMALFIELD, titleQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.NORMALFIELD, yearQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.NORMALFIELD, journalBookQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.SPECIALFIELD, rankQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.SPECIALFIELD, readStatusQualifier));
+        commonColumns.add(new MainTableColumnModel(MainTableColumnModel.Type.SPECIALFIELD, priorityQualifier));
 
-        return items;
+        // Create the Table Columns from the models.
+        Set<TableColumn<BibEntryTableViewModel, ?>> commonTableColumns = new HashSet<>();
+        for (MainTableColumnModel columnModel: commonColumns
+             ) {
+            TableColumn<BibEntryTableViewModel, ?> tableColumn = factory.createColumn(columnModel);
+            commonTableColumns.add(tableColumn);
+            this.getItems().add(createMenuItem(tableColumn));
+        }
+
+        return commonTableColumns;
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -176,8 +176,7 @@ public class MainTableHeaderContextMenu extends ContextMenu {
 
         // Create the Table Columns from the models using factory methods.
         List<TableColumn<BibEntryTableViewModel, ?>> commonTableColumns = new ArrayList<>();
-        for (MainTableColumnModel columnModel: commonColumns
-             ) {
+        for (MainTableColumnModel columnModel: commonColumns) {
             TableColumn<BibEntryTableViewModel, ?> tableColumn = factory.createColumn(columnModel);
             commonTableColumns.add(tableColumn);
         }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

Fixes #6601 **[WIP]**

**The user is able to right-click on the header of a maintable, to toggle the each column(field) visibility. This is also updated in the Entry Table in preferences. This is intended to improve the efficiency of using the program/UI as it will give users one less step from toggling the visibility of fields, instead of clicking through the preferences menus.**

Inspired from #7729, #8762

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

**Demonstration (Screenshots):**

1. When the user right clicks on the Main Table header, a context menu appears with the most commonly used fields based on the default preferences), and the other currently used fields. A tick next to the item shows whether the column is visible in the table. The seperator in the table distinguishes between commonly and currently used fields. 
![screenshotA](https://user-images.githubusercontent.com/57881310/197105891-23dc2a56-9242-4bb7-93bd-e6a787ce5d59.PNG)

2. When an item is clicked, its visibility gets toggled. This process either removes the column from the MainTable, or adds it back into view, which is reflected in the preferences. In this scenario, I have clicked the Author/Editor and the Chapter fields, both are now removed from the MainTable, and their ticks show they are not visible.
![screenShotB](https://user-images.githubusercontent.com/57881310/197105915-70877c95-2e90-4ffa-9e40-c90f73651a98.PNG)

3. After clicking on "Author/Editor" it is placed back into the table, and its tick is present, showing that is indeed back in the table with its original contents.
![screenShotC](https://user-images.githubusercontent.com/57881310/197105927-cc2c05a7-f8a3-41a6-b023-cb9340ab0d3a.PNG)

**TO-DO:**

- Currently considering adding the Show Preferences button, but thought I would push this draft pull request to get some feedback to make sure this is going in the right direction.
- Aware that checking the column is present in the current maintable is inefficient, beleive a boolean property within the MainTableColumn could be added to make it constant, and only have to check once.


