### PR TITLE
EventFilter for CLOSE events in BaseDialog closes dialogs regardless of focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
-- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
+- We fixed an issue where the 'close dialog' key binding was not closing dialogs when lists were selected. [#8888](https://github.com/jabref/jabref/issues/8888)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
-- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/koppor/jabref/issues/8888)
+- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
+- We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/koppor/jabref/issues/8888)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -11,7 +11,6 @@ import javafx.scene.input.KeyCode;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.icon.IconTheme;
-import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
@@ -72,13 +71,6 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         viewModel = new PreferencesDialogViewModel(dialogService, preferencesService, frame);
 
         preferenceTabList.itemsProperty().setValue(viewModel.getPreferenceTabs());
-
-        // The list view does not respect the listener for the dialog and needs its own
-        preferenceTabList.setOnKeyReleased(key -> {
-            if (preferencesService.getKeyBindingRepository().checkKeyCombinationEquality(KeyBinding.CLOSE, key)) {
-                this.closeDialog();
-            }
-        });
 
         PreferencesSearchHandler searchHandler = new PreferencesSearchHandler(viewModel.getPreferenceTabs());
         preferenceTabList.itemsProperty().bindBidirectional(searchHandler.filteredPreferenceTabsProperty());

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -11,6 +11,7 @@ import javafx.scene.input.KeyCode;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
@@ -71,6 +72,13 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         viewModel = new PreferencesDialogViewModel(dialogService, preferencesService, frame);
 
         preferenceTabList.itemsProperty().setValue(viewModel.getPreferenceTabs());
+
+        // The list view does not respect the listener for the dialog and needs its own
+        preferenceTabList.setOnKeyReleased(key -> {
+            if (preferencesService.getKeyBindingRepository().checkKeyCombinationEquality(KeyBinding.CLOSE, key)) {
+                this.closeDialog();
+            }
+        });
 
         PreferencesSearchHandler searchHandler = new PreferencesSearchHandler(viewModel.getPreferenceTabs());
         preferenceTabList.itemsProperty().bindBidirectional(searchHandler.filteredPreferenceTabsProperty());

--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -7,6 +7,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 
 import org.jabref.gui.Globals;
@@ -17,6 +18,13 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 public class BaseDialog<T> extends Dialog<T> implements org.jabref.gui.Dialog<T> {
 
     protected BaseDialog() {
+        getDialogPane().getScene().addEventFilter(KeyEvent.KEY_RELEASED, event -> {
+            KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
+            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
+                close();
+            }
+        });
+
         getDialogPane().getScene().setOnKeyPressed(event -> {
             KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
             if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {


### PR DESCRIPTION
Fixes #8888

My initial solution to this issue (#9268) was to add an event handler specifically to the ListView in the Preferences dialog. As very rightly pointed out by @k3KAW8Pnf7mkmdSMPHz27, however, this was only a partial fix and the issue persisted in other ListViews throughout JabRef dialogs. 

As stated in [this](https://docs.oracle.com/javafx/2/events/processing.htm#CEGJAAFD) documentation on event handling, the event propagates up from the main stage during the event capturing phase. I therefore hypothesized that the event was being consumed somewhere in the dispatch chain before it could make it to the ListViews. 

My new solution filters for CLOSE events deeper in the event dispatch chain, namely, within the BaseDialog constructor. This ensures that custom dialogs always react to a CLOSE event, regardless of where the focus currently is in the dialog pane. 

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
