### PR TITLE
Maximize the duplicate entries dialog

### DIFF
--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
@@ -1,10 +1,12 @@
 package org.jabref.gui.duplicationFinder;
 
+import javafx.geometry.Rectangle2D;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.BorderPane;
+import javafx.stage.Screen;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
@@ -55,6 +57,12 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
     }
 
     private void init(BibEntry one, BibEntry two, DuplicateResolverType type) {
+        Rectangle2D primaryScreenBounds = Screen.getPrimary().getVisualBounds();
+        this.setX(primaryScreenBounds.getMinX());
+        this.setY(primaryScreenBounds.getMinY());
+        this.setWidth(primaryScreenBounds.getWidth());
+        this.setHeight(primaryScreenBounds.getHeight());
+
         ButtonType cancel = ButtonType.CANCEL;
         ButtonType merge = new ButtonType(Localization.lang("Keep merged"), ButtonData.OK_DONE);
 


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/9055

I think this issue is asking to make the merge dialog as large as possible but within the size of the screen. Initially, when the main window of Jabref is placed in the top left-hand corner of the screen, the merge pop-up is off-screen. My solution is to get
the primary screen bound first, then set the initial size of the dialog based on the primary screen bound. So after the first run of the new dialog, it will show all the merge information with no part of it out-of-screen, although it's not a full-screen show.  It has the maximum width, but not the highest height.

I kept it able to retrieve the previous window state and set the new dialog window size and position to match it. Since it's initially set to maximum, running it again without changing its size will keep the dialog large.

<img width="1080" alt="dialog" src="https://user-images.githubusercontent.com/110883617/197321814-77ff8ebe-2cd1-4914-a101-a9bfabb13300.png">





<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
