### PR TITLE
Add MergeLibraries functionality 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a warning message next to the authors field in the merge dialog to warn users when the authors are the same but formatted differently. [#8745](https://github.com/JabRef/jabref/issues/8745)
 - The properties of an existing systematic literature review can be edited. [koppor#604](https://github.com/koppor/jabref/issues/604)
 - An SLR can now be started from the SLR itself. [#9131](https://github.com/JabRef/jabref/pull/9131), [koppor#601](https://github.com/koppor/jabref/issues/601)
+- Added functionality that allows users to merge pre-existing libraries into the current library. [#295](https://github.com/koppor/jabref/issues/295)
 
 ### Changed
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,8 @@ dependencies {
 
     implementation 'io.github.java-diff-utils:java-diff-utils:4.12'
     implementation 'info.debatty:java-string-similarity:2.0.0'
+    implementation 'com.google.jimfs:jimfs:1.2'
+    implementation 'com.google.jimfs:jimfs-parent:1.2'
 
     antlr4 'org.antlr:antlr4:4.9.3'
     implementation 'org.antlr:antlr4-runtime:4.9.3'
@@ -221,6 +223,8 @@ dependencies {
     // xjc needs the runtime as well for the ant task, otherwise it fails
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '3.0.2'
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.2'
+
+
 }
 
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,8 @@ dependencies {
     implementation 'info.debatty:java-string-similarity:2.0.0'
     implementation 'com.google.jimfs:jimfs:1.2'
     implementation 'com.google.jimfs:jimfs-parent:1.2'
+    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 
     antlr4 'org.antlr:antlr4:4.9.3'
     implementation 'org.antlr:antlr4-runtime:4.9.3'

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -98,6 +98,7 @@ import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.libraryproperties.LibraryPropertiesAction;
 import org.jabref.gui.menus.FileHistoryMenu;
+import org.jabref.gui.mergeLibraries.MergeCommand;
 import org.jabref.gui.mergeentries.MergeEntriesAction;
 import org.jabref.gui.preferences.ShowPreferencesAction;
 import org.jabref.gui.preview.CopyCitationAction;
@@ -748,6 +749,7 @@ public class JabRefFrame extends BorderPane {
                 factory.createSubMenu(StandardActions.IMPORT,
                         factory.createMenuItem(StandardActions.IMPORT_INTO_CURRENT_LIBRARY, new ImportCommand(this, false, prefs, stateManager)),
                         factory.createMenuItem(StandardActions.IMPORT_INTO_NEW_LIBRARY, new ImportCommand(this, true, prefs, stateManager))),
+                        factory.createMenuItem(StandardActions.MERGE_LIBRARIES_INTO_CURRENT_LIBRARY, new MergeCommand(this, prefs, stateManager)),
 
                 factory.createSubMenu(StandardActions.EXPORT,
                         factory.createMenuItem(StandardActions.EXPORT_ALL, new ExportCommand(ExportCommand.ExportMethod.EXPORT_ALL, this, stateManager, dialogService, prefs)),

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -128,6 +128,8 @@ public enum StandardActions implements Action {
 
     NEW_ENTRY(Localization.lang("New entry"), IconTheme.JabRefIcons.ADD_ENTRY, KeyBinding.NEW_ENTRY),
     NEW_ARTICLE(Localization.lang("New article"), IconTheme.JabRefIcons.ADD_ARTICLE),
+
+    MERGE_LIBRARIES_INTO_CURRENT_LIBRARY(Localization.lang("Merge libraries into current library")),
     NEW_ENTRY_FROM_PLAIN_TEXT(Localization.lang("New entry from plain text"), IconTheme.JabRefIcons.NEW_ENTRY_FROM_PLAIN_TEXT, KeyBinding.NEW_ENTRY_FROM_PLAIN_TEXT),
     LIBRARY_PROPERTIES(Localization.lang("Library properties")),
     FIND_DUPLICATES(Localization.lang("Find duplicates"), IconTheme.JabRefIcons.FIND_DUPLICATES),

--- a/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
+++ b/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
@@ -77,9 +77,8 @@ public class MergeCommand extends SimpleCommand {
     }
 
     public BibDatabase doMerge(Path path, BibDatabase database) throws IOException {
-        SortedSet<Importer> importers = Globals.IMPORT_FORMAT_READER.getImportFormats();
         //find all the .lib files by crawling in doMerge and merge them
-        Set<BibEntry> toAdd = new HashSet<>();
+        List<BibEntry> toAdd = new ArrayList<>();
         for(Path f : getAllFiles(path)) {
             ParserResult result;
 
@@ -105,7 +104,6 @@ public class MergeCommand extends SimpleCommand {
                 boolean addFlag = true;
                 for (BibEntry dbEntry : database.getEntries()) {
 
-                    System.out.println("------" + dbEntry.getCitationKey());
                     if (entry.equals(dbEntry)) {
                         addFlag = false;
                         break;

--- a/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
+++ b/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
@@ -1,22 +1,46 @@
 package org.jabref.gui.mergeLibraries;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.dialogs.BackupUIManager;
+import org.jabref.gui.importer.actions.OpenDatabaseAction;
+import org.jabref.gui.shared.SharedDatabaseUIManager;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
+
+import org.jabref.logic.autosaveandbackup.BackupManager;
+import org.jabref.logic.database.DuplicateCheck;
+import org.jabref.logic.importer.Importer;
+import org.jabref.logic.importer.OpenDatabase;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.shared.DatabaseNotSupportedException;
+import org.jabref.logic.shared.exception.InvalidDBMSConnectionPropertiesException;
+import org.jabref.logic.shared.exception.NotASharedDatabaseException;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.PreferencesService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.jabref.logic.database.DuplicateCheck.*;
 
+import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Optional;
+import java.sql.SQLException;
+import java.util.*;
+
 
 public class MergeCommand extends SimpleCommand {
     private final JabRefFrame frame;
     private final DialogService dialogService;
     private final PreferencesService preferences;
     private final StateManager stateManager;
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenDatabaseAction.class);
 
     public MergeCommand(JabRefFrame frame,PreferencesService preferences, StateManager stateManager) {
 
@@ -42,10 +66,108 @@ public class MergeCommand extends SimpleCommand {
             doMerge(path.get(), database.get().getDatabase());
     }
 
-    public BibDatabase doMerge(Path filepath, BibDatabase database){
+    public BibDatabase doMerge(Path path, BibDatabase database){
+        SortedSet<Importer> importers = Globals.IMPORT_FORMAT_READER.getImportFormats();
         //find all the .lib files by crawling in doMerge and merge them
+        for(File f : getAllFiles(path)){
+            System.out.println(f.toString());
+            ParserResult result;
+
+            //try to convert the .bib file to a database
+            try {
+                result = loadDatabase(f.toPath());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            /*then go through each entry in the current database and check
+              against the following rules for merging:
+              1. if the entry is equal to any in the main database then ignore the new entry
+              2. if the entry has the same key as any in the main database then ignore the new entry
+              3. if the entry is a duplicate of any in the main database then ignore the new entry
+            */
+            for(BibEntry entry : result.getDatabase().getEntries()){
+                for(BibEntry dbEntry : database.getEntries()){
+//                    if(!entry.equals(dbEntry) && !(entry.getCiteKeyBinding().equals(dbEntry.getCiteKeyBinding()))
+//                            && !(DuplicateCheck()))
+                }
+            }
+        }
+
+
         //then add the database to the StateManager's activeDatabase
 
         return null;
+    }
+
+    /**
+     *  getAllFiles: Recursively crawls through a directory to find all .bib files
+     *
+     * @param path the path to a directory containing the .bib files we are looking
+     *             to merge
+     * @return all the .bib files in a given directory and subdirectories
+     */
+    private List<File> getAllFiles(Path path){
+        List<File> files = new ArrayList<>();
+
+        // Get all the .bib files in this directory
+        List currentFile = List.of(path.toFile().listFiles((dir, name) -> name.endsWith(".bib")));
+        if(currentFile != null)
+            files.addAll(currentFile);
+
+        // Get all the directories in the directory
+        File[] directories = path.toFile().listFiles(File::isDirectory);
+        if(directories == null) return files;
+
+        //crawl through all the files in the directory and add them to the files
+        for(File f : directories){
+            Path p = f.toPath();
+            files.addAll(getAllFiles(p));
+        }
+
+        return files;
+    }
+
+    /**
+     * This method is taken from the loadDatabase method in {@link OpenDatabaseAction}.
+     */
+    private ParserResult loadDatabase(Path file) throws Exception {
+        Path fileToLoad = file.toAbsolutePath();
+
+        preferences.getFilePreferences().setWorkingDirectory(fileToLoad.getParent());
+
+        if (BackupManager.backupFileDiffers(fileToLoad)) {
+            BackupUIManager.showRestoreBackupDialog(dialogService, fileToLoad);
+        }
+
+        ParserResult result;
+        try {
+            result = OpenDatabase.loadDatabase(fileToLoad,
+                    preferences.getImportFormatPreferences(),
+                    Globals.getFileUpdateMonitor());
+            if (result.hasWarnings()) {
+                String content = Localization.lang("Please check your library file for wrong syntax.")
+                        + "\n\n" + result.getErrorMessage();
+                DefaultTaskExecutor.runInJavaFXThread(() ->
+                        dialogService.showWarningDialogAndWait(Localization.lang("Open library error"), content));
+            }
+        } catch (IOException e) {
+            result = ParserResult.fromError(e);
+            LOGGER.error("Error opening file '{}'", fileToLoad, e);
+        }
+
+        if (result.getDatabase().isShared()) {
+            try {
+                new SharedDatabaseUIManager(frame).openSharedDatabaseFromParserResult(result);
+            } catch (SQLException | DatabaseNotSupportedException | InvalidDBMSConnectionPropertiesException |
+                     NotASharedDatabaseException e) {
+                result.getDatabaseContext().clearDatabasePath(); // do not open the original file
+                result.getDatabase().clearSharedDatabaseID();
+                LOGGER.error("Connection error", e);
+
+                throw e;
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
+++ b/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
@@ -96,30 +96,29 @@ public class MergeCommand extends SimpleCommand {
             */
             BibEntryTypesManager entryTypesManager = new BibEntryTypesManager();
 
+
             for (BibEntry entry : result.getDatabase().getEntries()) {
-                System.out.println(entry.getCitationKey());
+                boolean addFlag = true;
                 for (BibEntry dbEntry : database.getEntries()) {
+
                     System.out.println("------" + dbEntry.getCitationKey());
                     if (entry.equals(dbEntry)) {
-                        System.out.println("equals");
+                        addFlag = false;
+                        break;
                     }
 
                     if (entry.getCitationKey().equals(dbEntry.getCitationKey())) {
-                        System.out.println("same key");
+                        addFlag = false;
+                        break;
                     }
 
                     if (new DuplicateCheck(entryTypesManager).isDuplicate(entry, dbEntry, BibDatabaseMode.BIBTEX)){
-                        System.out.println("duplicate");
+                        addFlag = false;
+                        break;
                     }
-
-
-                    if (!entry.equals(dbEntry) &&
-                        !(entry.getCiteKeyBinding().equals(dbEntry.getCiteKeyBinding())) &&
-                        !(new DuplicateCheck(entryTypesManager).isDuplicate(entry, dbEntry, BibDatabaseMode.BIBTEX))) {
-
-                        System.out.println(entry.getCitationKey() + " added");
-                        toAdd.add(entry);
-                    }
+                }
+                if (addFlag) {
+                    toAdd.add(entry);
                 }
             }
         }

--- a/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
+++ b/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
@@ -4,35 +4,48 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefFrame;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
-import org.jabref.gui.util.OptionalObjectProperty;
+import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.preferences.PreferencesService;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 public class MergeCommand extends SimpleCommand {
     private final JabRefFrame frame;
     private final DialogService dialogService;
     private final PreferencesService preferences;
+    private final StateManager stateManager;
+
     public MergeCommand(JabRefFrame frame,PreferencesService preferences, StateManager stateManager) {
 
         this.preferences = preferences;
         this.frame = frame;
         this.dialogService = frame.getDialogService();
+        this.stateManager = stateManager;
     }
 
     @Override
     public void execute() {
         //TODO: write the execute method
+
+        //construct a configuration with the current directory
+        //(this really could have just been a constructor so think of it like that)
+        DirectoryDialogConfiguration.Builder config = new DirectoryDialogConfiguration.Builder().withInitialDirectory(preferences.getFilePreferences().getWorkingDirectory());
         //open dialog box using the dialog service which will return a path to a directory
-        //find all the .lib files by crawling in doMerge and merge them
-        //then add the database to the StateManager's activeDatabase
+        Optional<Path> path = dialogService.showDirectorySelectionDialog(config.build());
 
 
+        Optional<BibDatabaseContext> database = stateManager.getActiveDatabase();
+        if(path.isPresent() && database.isPresent())
+            doMerge(path.get(), database.get().getDatabase());
     }
 
     public BibDatabase doMerge(Path filepath, BibDatabase database){
+        //find all the .lib files by crawling in doMerge and merge them
+        //then add the database to the StateManager's activeDatabase
+
         return null;
     }
 }

--- a/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
+++ b/src/main/java/org/jabref/gui/mergeLibraries/MergeCommand.java
@@ -1,0 +1,38 @@
+package org.jabref.gui.mergeLibraries;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.util.OptionalObjectProperty;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.preferences.PreferencesService;
+
+import java.nio.file.Path;
+
+public class MergeCommand extends SimpleCommand {
+    private final JabRefFrame frame;
+    private final DialogService dialogService;
+    private final PreferencesService preferences;
+    public MergeCommand(JabRefFrame frame,PreferencesService preferences, StateManager stateManager) {
+
+        this.preferences = preferences;
+        this.frame = frame;
+        this.dialogService = frame.getDialogService();
+    }
+
+    @Override
+    public void execute() {
+        //TODO: write the execute method
+        //open dialog box using the dialog service which will return a path to a directory
+        //find all the .lib files by crawling in doMerge and merge them
+        //then add the database to the StateManager's activeDatabase
+
+
+    }
+
+    public BibDatabase doMerge(Path filepath, BibDatabase database){
+        return null;
+    }
+}

--- a/src/test/java/org/jabref/logic/mergelibraries/MergeCommandTest.java
+++ b/src/test/java/org/jabref/logic/mergelibraries/MergeCommandTest.java
@@ -20,6 +20,8 @@ import org.jabref.preferences.FilePreferences;
 import org.jabref.preferences.PreferencesService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.jabref.gui.Globals.entryTypesManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -60,14 +62,13 @@ public class MergeCommandTest {
         BibDatabase db = new BibDatabase();
 
         // For a simple file system with Unix-style paths and behavior:
-        FileSystem fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform());
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
         Path foo = fs.getPath("/foo");
-
         Files.createDirectory(foo);
 
         Path a = foo.resolve("a.bib"); // /foo/hello.txt
         Files.write(a, ImmutableList.of(
-                        "@Book{Leon2009,\n" +
+                        "@misc{Leon2009,\n" +
                         "  author    = {Leon},\n" +
                         "  editor    = {Qingxuan},\n" +
                         "  publisher = {Liu inc.},\n" +
@@ -79,7 +80,7 @@ public class MergeCommandTest {
 
         Path b = foo.resolve("b.bib"); // /foo/hello.txt
         Files.write(b, ImmutableList.of(
-                        "@Book{Brown2001,\n" +
+                        "@misc{Brown2001,\n" +
                         "  author    = {Jimmy Brown},\n" +
                         "  editor    = {Brian Smith},\n" +
                         "  publisher = {Liu inc.},\n" +
@@ -114,14 +115,12 @@ public class MergeCommandTest {
         entry2.setField(StandardField.KEY,"Leon2009");
         testDB.insertEntry(entry2);
 
-//        assertEquals(db, testDB);
-
         for (BibEntry dbEntry : db.getEntries()) {
             boolean equalFlag = false;
             System.out.println("dbEntry: " + dbEntry);
             for (BibEntry testDbEntry : testDB.getEntries()) {
                 System.out.println("---- testDbEntry: " + testDbEntry);
-                if (dbEntry.equals(testDbEntry)) {
+                if (new DuplicateCheck(entryTypesManager).isDuplicate(testDbEntry, dbEntry, BibDatabaseMode.BIBTEX)) {
                     equalFlag = true;
                     break;
                 }

--- a/src/test/java/org/jabref/logic/mergelibraries/MergeCommandTest.java
+++ b/src/test/java/org/jabref/logic/mergelibraries/MergeCommandTest.java
@@ -1,0 +1,100 @@
+package org.jabref.logic.mergelibraries;
+
+import com.google.common.collect.ImmutableList;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.LibraryTab;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.importer.NewEntryAction;
+import org.jabref.gui.mergeLibraries.MergeCommand;
+import org.jabref.logic.importer.fileformat.bibtexml.Entry;
+import org.jabref.logic.importer.fileformat.endnote.Database;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.preferences.PreferencesService;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import scala.sys.process.ProcessBuilderImpl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+public class MergeCommandTest {
+    private JabRefFrame jabRefFrame = mock(JabRefFrame.class);
+    private PreferencesService preferencesService = mock(PreferencesService.class);
+    private StateManager stateManager = mock(StateManager.class);
+
+    @Test
+    public void testDoMerge() throws IOException {
+        MergeCommand command = new MergeCommand(jabRefFrame, preferencesService, stateManager);
+        BibDatabase db = new BibDatabase();
+
+        // For a simple file system with Unix-style paths and behavior:
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path foo = fs.getPath("/foo");
+
+        Files.createDirectory(foo);
+
+        Path a = foo.resolve("a.bib"); // /foo/hello.txt
+        Files.write(a, ImmutableList.of(
+                        "@Book{Leon2009,\n" +
+                        "  author    = {Leon},\n" +
+                        "  editor    = {Qingxuan},\n" +
+                        "  publisher = {Liu inc.},\n" +
+                        "  title     = {Crazy Mind},\n" +
+                        "  year      = {2009},\n" +
+                        "}\n" +
+                        "\n" +
+                        "@Comment{jabref-meta: databaseType:bibtex;}"), StandardCharsets.UTF_8);
+
+        Path b = foo.resolve("b.bib"); // /foo/hello.txt
+        Files.write(b, ImmutableList.of(
+                        "@Book{Brown2001,\n" +
+                        "  author    = {Jimmy Brown},\n" +
+                        "  editor    = {Brian Smith},\n" +
+                        "  publisher = {Liu inc.},\n" +
+                        "  title     = {Jimmy's Normal Adventures},\n" +
+                        "  year      = {2001},\n" +
+                        "}\n" +
+                        "\n" +
+                        "@Comment{jabref-meta: databaseType:bibtex;}"), StandardCharsets.UTF_8);
+
+        command.doMerge(foo, db);
+
+        BibDatabase testDB = new BibDatabase();
+
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE,"Jimmy's Normal Adventures");
+        entry.setField(StandardField.AUTHOR,"Jimmy Brown");
+        entry.setField(StandardField.EDITOR,"Brian Smith");
+        entry.setField(StandardField.PUBLISHER,"Smith inc.");
+        entry.setField(StandardField.YEAR,"2001");
+        entry.setField(StandardField.KEY,"Brown2001");
+        testDB.insertEntry(entry);
+
+        BibEntry entry2 = new BibEntry();
+        entry2.setField(StandardField.TITLE,"Crazy Mind");
+        entry2.setField(StandardField.AUTHOR,"Leon");
+        entry2.setField(StandardField.EDITOR,"Qingxuan");
+        entry2.setField(StandardField.PUBLISHER,"Liu inc.");
+        entry2.setField(StandardField.YEAR,"2009");
+        entry2.setField(StandardField.KEY,"Leon2009");
+        testDB.insertEntry(entry2);
+
+        assertEquals(db, testDB);
+    }
+
+}


### PR DESCRIPTION
- Added UI element to create user friendly way of interacting with the feature
- Added a command that merges any libraries within a given directory in to the current active library according to the rules specifies in the issue #295 so that users with many .lib files that wish to compile them into one .lib file may do so.

Fixes https://github.com/koppor/jabref/issues/295

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
