### PR TITLE
Fix for issue 9304

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -429,7 +429,7 @@ public class GroupTreeView extends BorderPane {
             viewModel.removeSubgroups(group);
         });
 
-        MenuItem sortSubgroups = new MenuItem(Localization.lang("Sort subgroups"));
+        MenuItem sortSubgroups = new MenuItem(Localization.lang("Sort subgroups A-Z"));
         sortSubgroups.setOnAction(event -> viewModel.sortAlphabeticallyRecursive(group.getGroupNode()));
 
         MenuItem addEntries = new MenuItem(Localization.lang("Add selected entries to this group"));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -867,7 +867,7 @@ Please\ check\ your\ library\ file\ for\ wrong\ syntax.=Please check your librar
 SourceTab\ error=SourceTab error
 User\ input\ via\ entry-editor\ in\ `{}bibtex\ source`\ tab\ led\ to\ failure.=User input via entry-editor in `{}bibtex source` tab led to failure.
 
-Sort\ subgroups=Sort subgroups
+Sort\ subgroups=Sort subgroups A-Z
 
 source\ edit=source edit
 Special\ name\ formatters=Special name formatters

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -867,7 +867,7 @@ Please\ check\ your\ library\ file\ for\ wrong\ syntax.=Please check your librar
 SourceTab\ error=SourceTab error
 User\ input\ via\ entry-editor\ in\ `{}bibtex\ source`\ tab\ led\ to\ failure.=User input via entry-editor in `{}bibtex source` tab led to failure.
 
-Sort\ subgroups=Sort subgroups A-Z
+Sort\ subgroups\ A-Z=Sort subgroups A-Z
 
 source\ edit=source edit
 Special\ name\ formatters=Special name formatters


### PR DESCRIPTION
Fixes Issue: #9304 

Added A-Z to the translation key in the GroupTreeView.java and JabRef_en.properties files


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
