### PR TITLE
Fix for issue 8747: date field change causes an uncaught exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
 - We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
+- We fixed an issue where editing entry's "date" field in library mode "biblatex" causes an uncaught exception. [#8747][https://github.com/JabRef/jabref/issues/8747]
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
@@ -11,9 +11,9 @@ import org.jabref.gui.util.component.TemporalAccessorPicker;
 import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.preferences.PreferencesService;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import org.jabref.preferences.PreferencesService;
 
 public class DateEditor extends HBox implements FieldEditorFX {
 

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
@@ -13,13 +13,14 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
+import org.jabref.preferences.PreferencesService;
 
 public class DateEditor extends HBox implements FieldEditorFX {
 
     @FXML private DateEditorViewModel viewModel;
     @FXML private TemporalAccessorPicker datePicker;
 
-    public DateEditor(Field field, DateTimeFormatter dateFormatter, SuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+    public DateEditor(Field field, DateTimeFormatter dateFormatter, SuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers, PreferencesService preferences) {
         this.viewModel = new DateEditorViewModel(field, suggestionProvider, dateFormatter, fieldCheckers);
 
         ViewLoader.view(this)
@@ -28,6 +29,8 @@ public class DateEditor extends HBox implements FieldEditorFX {
 
         datePicker.setStringConverter(viewModel.getDateToStringConverter());
         datePicker.getEditor().textProperty().bindBidirectional(viewModel.textProperty());
+
+        new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), datePicker.getEditor());
     }
 
     public DateEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
@@ -36,7 +36,7 @@ public class DateEditorViewModel extends AbstractEditorViewModel {
                 if (StringUtil.isNotBlank(string)) {
                     try {
                         return dateFormatter.parse(string);
-                    } catch (DateTimeParseException exception) {
+                    } catch (Exception exception) {
                         // We accept all kinds of dates (not just in the format specified)
                         return Date.parse(string).map(Date::toTemporalAccessor).orElse(null);
                     }

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -55,9 +55,9 @@ public class FieldEditors {
         boolean isMultiLine = FieldFactory.isMultiLineField(field, preferences.getFieldContentParserPreferences().getNonWrappableFields());
 
         if (preferences.getTimestampPreferences().getTimestampField().equals(field)) {
-            return new DateEditor(field, DateTimeFormatter.ofPattern(preferences.getTimestampPreferences().getTimestampFormat()), suggestionProvider, fieldCheckers);
+            return new DateEditor(field, DateTimeFormatter.ofPattern(preferences.getTimestampPreferences().getTimestampFormat()), suggestionProvider, fieldCheckers, preferences);
         } else if (fieldProperties.contains(FieldProperty.DATE)) {
-            return new DateEditor(field, DateTimeFormatter.ofPattern("[uuuu][-MM][-dd]"), suggestionProvider, fieldCheckers);
+            return new DateEditor(field, DateTimeFormatter.ofPattern("[uuuu][-MM][-dd]"), suggestionProvider, fieldCheckers, preferences);
         } else if (fieldProperties.contains(FieldProperty.EXTERNAL)) {
             return new UrlEditor(field, dialogService, suggestionProvider, fieldCheckers, preferences);
         } else if (fieldProperties.contains(FieldProperty.JOURNAL_NAME)) {

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -76,7 +76,6 @@ public class TemporalAccessorPicker extends DatePicker {
 
     private static LocalDate getLocalDate(TemporalAccessor dateTime) {
         // Try to get as much information from the temporal accessor
-        if (dateTime == null) return null;
         LocalDate date = dateTime.query(TemporalQueries.localDate());
         if (date != null) {
             return date;
@@ -140,7 +139,7 @@ public class TemporalAccessorPicker extends DatePicker {
 
             TemporalAccessor dateTime = getStringConverter().fromString(value);
             temporalAccessorValue.set(dateTime);
-            return dateTime == null ? null : getLocalDate(dateTime);
+            return getLocalDate(dateTime);
         }
     }
 }

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -75,6 +75,11 @@ public class TemporalAccessorPicker extends DatePicker {
     }
 
     private static LocalDate getLocalDate(TemporalAccessor dateTime) {
+        // Return null when dateTime is null pointer
+        if (dateTime == null) {
+            return null;
+        }
+
         // Try to get as much information from the temporal accessor
         LocalDate date = dateTime.query(TemporalQueries.localDate());
         if (date != null) {
@@ -127,7 +132,7 @@ public class TemporalAccessorPicker extends DatePicker {
         @Override
         public String toString(LocalDate object) {
             TemporalAccessor value = getTemporalAccessorValue();
-            return (value != null) ? getStringConverter().toString(value) : "";
+            return (value != null) ? getStringConverter().toString(value) : getEditor().getText();
         }
 
         @Override
@@ -139,7 +144,7 @@ public class TemporalAccessorPicker extends DatePicker {
 
             TemporalAccessor dateTime = getStringConverter().fromString(value);
             temporalAccessorValue.set(dateTime);
-            return getLocalDate(dateTime);
+            return (dateTime != null) ? getLocalDate(dateTime) : null;
         }
     }
 }

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -76,6 +76,7 @@ public class TemporalAccessorPicker extends DatePicker {
 
     private static LocalDate getLocalDate(TemporalAccessor dateTime) {
         // Try to get as much information from the temporal accessor
+        if (dateTime == null) return null;
         LocalDate date = dateTime.query(TemporalQueries.localDate());
         if (date != null) {
             return date;
@@ -139,7 +140,7 @@ public class TemporalAccessorPicker extends DatePicker {
 
             TemporalAccessor dateTime = getStringConverter().fromString(value);
             temporalAccessorValue.set(dateTime);
-            return getLocalDate(dateTime);
+            return dateTime == null ? null : getLocalDate(dateTime);
         }
     }
 }

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 import java.time.Year;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.util.Objects;
@@ -21,6 +22,8 @@ import org.jabref.gui.Globals;
 import org.jabref.gui.fieldeditors.TextInputControlBehavior;
 import org.jabref.gui.fieldeditors.contextmenu.EditorContextAction;
 import org.jabref.gui.util.BindingsHelper;
+import org.jabref.model.entry.Date;
+import org.jabref.model.strings.StringUtil;
 
 /**
  * A date picker with configurable datetime format where both date and time can be changed via the text field and the
@@ -106,7 +109,16 @@ public class TemporalAccessorPicker extends DatePicker {
 
             @Override
             public TemporalAccessor fromString(String value) {
-                return LocalDateTime.parse(value, defaultFormatter);
+                if (StringUtil.isNotBlank(value)) {
+                    try {
+                        return defaultFormatter.parse(value);
+                    } catch (
+                            DateTimeParseException exception) {
+                        return Date.parse(value).map(Date::toTemporalAccessor).orElse(null);
+                    }
+                } else {
+                    return null;
+                }
             }
         };
         return Objects.requireNonNullElseGet(stringConverterProperty().get(), () -> newConverter);

--- a/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
+++ b/src/main/java/org/jabref/gui/util/component/TemporalAccessorPicker.java
@@ -132,6 +132,8 @@ public class TemporalAccessorPicker extends DatePicker {
         @Override
         public String toString(LocalDate object) {
             TemporalAccessor value = getTemporalAccessorValue();
+
+            // Keeps the original text when it is an invalid date
             return (value != null) ? getStringConverter().toString(value) : getEditor().getText();
         }
 
@@ -144,7 +146,8 @@ public class TemporalAccessorPicker extends DatePicker {
 
             TemporalAccessor dateTime = getStringConverter().fromString(value);
             temporalAccessorValue.set(dateTime);
-            return (dateTime != null) ? getLocalDate(dateTime) : null;
+
+            return getLocalDate(dateTime);
         }
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

Fixes #8747

## Short Description

In library mode "biblatex", when user edits the entry's "date" field with an invalid input and clicks somewhere, an uncaught exception of null pointer occurs.

## Checklist
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

## UI changes (takes time to load gif images)
* Before
 * Type invalid inputs: nothing happen
 * Click somewhere: an exception occured;
 * Press Enter: input disappears
![312775146_691460315939346_8658484514782598519_n](https://user-images.githubusercontent.com/110649463/198204638-4d140731-8e34-4f3d-976c-1869e09c01a3.gif)

* After
 * Type invalid inputs: show warning icon
 * Click somewhere: nothing happens
 * Press Enter: input disappears
![313129752_1170515957176323_7279031655860662192_n](https://user-images.githubusercontent.com/110649463/198204182-50daecbf-6ecc-4c2e-b520-7908b77bd521.gif)

![312829199_3262902150588889_342121938428642385_n](https://user-images.githubusercontent.com/110649463/198204236-facfa543-b514-468f-a463-32b4644f8615.png)
