### PR TITLE
Fix issue: Auto-linking files with safe character replacements #9267

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
 - We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
+- We fixed an issue when using an unsafe character in the citation key, the auto-linking feature fails to link files. [#9267](https://github.com/JabRef/jabref/issues/9267)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
+++ b/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
@@ -65,13 +65,8 @@ class CitationKeyBasedFileFinder implements FileFinder {
         return result.stream().sorted().collect(Collectors.toList());
     }
 
-    public static String getSafeCiteKey(String citeKey) {
-        // replace the unsafe character with the underscore.
-        return citeKey.replaceAll("[:/*?<>|]", "_");
-    }
-
     private boolean matches(String filename, String citeKey) {
-        boolean startsWithKey = filename.startsWith(getSafeCiteKey(citeKey));
+        boolean startsWithKey = filename.startsWith(FileNameCleaner.cleanFileName(citeKey));
         if (startsWithKey) {
             // The file name starts with the key, that's already a good start
             // However, we do not want to match "JabRefa" for "JabRef" since this is probably a file belonging to another entry published in the same time / same name

--- a/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
+++ b/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
@@ -65,8 +65,13 @@ class CitationKeyBasedFileFinder implements FileFinder {
         return result.stream().sorted().collect(Collectors.toList());
     }
 
+    private static String getSafeCiteKey(String citeKey) {
+        // replace the unsafe character with the underscore.
+        return citeKey.replaceAll("[:/*?<>|]", "_");
+    }
+
     private boolean matches(String filename, String citeKey) {
-        boolean startsWithKey = filename.startsWith(citeKey);
+        boolean startsWithKey = filename.startsWith(getSafeCiteKey(citeKey));
         if (startsWithKey) {
             // The file name starts with the key, that's already a good start
             // However, we do not want to match "JabRefa" for "JabRef" since this is probably a file belonging to another entry published in the same time / same name

--- a/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
+++ b/src/main/java/org/jabref/logic/util/io/CitationKeyBasedFileFinder.java
@@ -65,7 +65,7 @@ class CitationKeyBasedFileFinder implements FileFinder {
         return result.stream().sorted().collect(Collectors.toList());
     }
 
-    private static String getSafeCiteKey(String citeKey) {
+    public static String getSafeCiteKey(String citeKey) {
         // replace the unsafe character with the underscore.
         return citeKey.replaceAll("[:/*?<>|]", "_");
     }

--- a/src/test/java/org/jabref/logic/util/io/CitationKeyBasedFileFinderTest.java
+++ b/src/test/java/org/jabref/logic/util/io/CitationKeyBasedFileFinderTest.java
@@ -99,4 +99,17 @@ class CitationKeyBasedFileFinderTest {
 
         assertEquals(Collections.emptyList(), results);
     }
+
+    @Test
+    void findAssociatedFilesWithUnsafeCharacters() throws Exception {
+        BibEntry entryWithUnsafeCitationKey = new BibEntry(StandardEntryType.Article);
+        entryWithUnsafeCitationKey.setCitationKey("test:test/*test?");
+
+        Path testFile = Files.createFile(pdfsDir.resolve("test_test__test_.pdf"));
+        FileFinder fileFinder = new CitationKeyBasedFileFinder(false);
+
+        List<Path> results = fileFinder.findAssociatedFiles(entryWithUnsafeCitationKey, Collections.singletonList(pdfsDir), Collections.singletonList("pdf"));
+
+        assertEquals(Collections.singletonList(testFile), results);
+    }
 }

--- a/src/test/java/org/jabref/logic/util/io/CitationKeyBasedFileFinderTest.java
+++ b/src/test/java/org/jabref/logic/util/io/CitationKeyBasedFileFinderTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class CitationKeyBasedFileFinderTest {
 
@@ -101,15 +102,28 @@ class CitationKeyBasedFileFinderTest {
     }
 
     @Test
-    void findAssociatedFilesWithUnsafeCharacters() throws Exception {
+    void findAssociatedFilesWithUnsafeCharactersStartWithSearch() throws Exception {
         BibEntry entryWithUnsafeCitationKey = new BibEntry(StandardEntryType.Article);
-        entryWithUnsafeCitationKey.setCitationKey("test:test/*test?");
+        entryWithUnsafeCitationKey.setCitationKey("?test");
 
-        Path testFile = Files.createFile(pdfsDir.resolve("test_test__test_.pdf"));
+        Path testFile = Files.createFile(pdfsDir.resolve("_test_file.pdf"));
         FileFinder fileFinder = new CitationKeyBasedFileFinder(false);
 
         List<Path> results = fileFinder.findAssociatedFiles(entryWithUnsafeCitationKey, Collections.singletonList(pdfsDir), Collections.singletonList("pdf"));
 
         assertEquals(Collections.singletonList(testFile), results);
+    }
+
+    @Test
+    void findAssociatedFilesWithUnsafeCharactersExactSearch() throws Exception {
+        BibEntry entryWithUnsafeCitationKey = new BibEntry(StandardEntryType.Article);
+        entryWithUnsafeCitationKey.setCitationKey("test:test/*test?");
+
+        Path testFile = Files.createFile(pdfsDir.resolve("test_test__test_.pdf"));
+        FileFinder fileFinder = new CitationKeyBasedFileFinder(true);
+
+        List<Path> results = fileFinder.findAssociatedFiles(entryWithUnsafeCitationKey, Collections.singletonList(pdfsDir), Collections.singletonList("pdf"));
+
+        assertNotEquals(Collections.singletonList(testFile), results);
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #9267 

### Short Description
This aims to fix the issue where it is impossible to find the related file when the citation key involves some characters (e.g. `:`) that cannot be contained in the file name. 
We fix this issue by searching the related file with the citation key where its unsafe characters are replaced with underscores `_`. (See [#9267](https://github.com/JabRef/jabref/issues/9267))

### UI changes
- Input a citation key with an unsafe character (colon ":")   
   
![313210096_495396219314658_7636164207235418215_n](https://user-images.githubusercontent.com/109927532/198224384-dbec1eb8-5536-4ad5-84fb-67a10629e51c.png)
- Before  
  
![312984263_535109675291077_2673210671895727303_n](https://user-images.githubusercontent.com/109927532/198224619-dbaacd33-38b7-4f9c-ae64-e2902f34fdc2.png)
- After  
  
![312436604_797747644827893_4867990044154713722_n](https://user-images.githubusercontent.com/109927532/198224755-f6368445-3e13-464b-9da6-7d1dbfdbee70.png)
**Note: The user should reopen the library to see the attachment**

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
