### PR TITLE
Fixes issue #9281: Let right-click menu more accurately represent selected (sub-)group(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We modified the Directory of Open Access Books (DOAB) fetcher so that it will now also fetch the ISBN when possible. [#8708](https://github.com/JabRef/jabref/issues/8708)
 
 ### Fixed
+
+
 - We fixed the clicked group removal option present, but actions are taken on all selected groups [#9281](https://github.com/JabRef/jabref/issues/9281)
 - We fixed the Cleanup entries dialog is partially visible [#9223](https://github.com/JabRef/jabref/issues/9223)
 - We fixed the display of the "Customize Entry Types" dialogue title [#9198](https://github.com/JabRef/jabref/issues/9198)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We modified the Directory of Open Access Books (DOAB) fetcher so that it will now also fetch the ISBN when possible. [#8708](https://github.com/JabRef/jabref/issues/8708)
 
 ### Fixed
-
+- We fixed the clicked group removal option present, but actions are taken on all selected groups [#9281](https://github.com/JabRef/jabref/issues/9281)
 - We fixed the Cleanup entries dialog is partially visible [#9223](https://github.com/JabRef/jabref/issues/9223)
 - We fixed the display of the "Customize Entry Types" dialogue title [#9198](https://github.com/JabRef/jabref/issues/9198)
 - We fixed an issue where author names with tilde accents (for example ñ) were marked as "Names are not in the standard BibTex format" [#8071](https://github.com/JabRef/jabref/issues/8071)

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -399,14 +399,12 @@ public class GroupTreeViewModel extends AbstractViewModel {
 
     public void removeGroupKeepSubgroups(GroupNodeViewModel group) {
         boolean confirmed;
-        //check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
+        // check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
         if (!selectedGroups.contains(group)) {
             selectedGroups.clear();
             selectedGroups.add(group);
         }
-
         if (selectedGroups.size() <= 1) {
-
             confirmed = dialogService.showConfirmationDialogAndWait(
                     Localization.lang("Remove group"),
                     Localization.lang("Remove group \"%0\" and keep its subgroups?", group.getDisplayName()),
@@ -439,7 +437,6 @@ public class GroupTreeViewModel extends AbstractViewModel {
             }
             writeGroupChangesToMetaData();
         }
-
     }
 
     /**
@@ -447,7 +444,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
      */
     public void removeGroupAndSubgroups(GroupNodeViewModel group) {
         boolean confirmed;
-        //check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
+        // check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
         if (!selectedGroups.contains(group)) {
             selectedGroups.clear();
             selectedGroups.add(group);

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -399,39 +399,43 @@ public class GroupTreeViewModel extends AbstractViewModel {
 
     public void removeGroupKeepSubgroups(GroupNodeViewModel group) {
         boolean confirmed;
-        if (selectedGroups.size() <= 1) {
-            confirmed = dialogService.showConfirmationDialogAndWait(
-                    Localization.lang("Remove group"),
-                    Localization.lang("Remove group \"%0\" and keep its subgroups?", group.getDisplayName()),
-                    Localization.lang("Remove"));
-        } else {
-            confirmed = dialogService.showConfirmationDialogAndWait(
-                    Localization.lang("Remove groups"),
-                    Localization.lang("Remove all selected groups and keep their subgroups?"),
-                    Localization.lang("Remove all"));
-        }
+        if (selectedGroups.contains(group)) {
+            if (selectedGroups.size() <= 1) {
 
-        if (confirmed) {
-            // TODO: Add undo
-            // final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(groupsRoot, node, UndoableAddOrRemoveGroup.REMOVE_NODE_KEEP_CHILDREN);
-            // panel.getUndoManager().addEdit(undo);
-
-            List<GroupNodeViewModel> selectedGroupNodes = new ArrayList<>(selectedGroups);
-            selectedGroupNodes.forEach(eachNode -> {
-                GroupTreeNode groupNode = eachNode.getGroupNode();
-
-                groupNode.getParent()
-                         .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
-                groupNode.removeFromParent();
-            });
-
-            if (selectedGroupNodes.size() > 1) {
-                dialogService.notify(Localization.lang("Removed all selected groups."));
+                confirmed = dialogService.showConfirmationDialogAndWait(
+                        Localization.lang("Remove group"),
+                        Localization.lang("Remove group \"%0\" and keep its subgroups?", group.getDisplayName()),
+                        Localization.lang("Remove"));
             } else {
-                dialogService.notify(Localization.lang("Removed group \"%0\".", group.getDisplayName()));
+                confirmed = dialogService.showConfirmationDialogAndWait(
+                        Localization.lang("Remove groups"),
+                        Localization.lang("Remove all selected groups and keep their subgroups?"),
+                        Localization.lang("Remove all"));
             }
-            writeGroupChangesToMetaData();
+
+            if (confirmed) {
+                // TODO: Add undo
+                // final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(groupsRoot, node, UndoableAddOrRemoveGroup.REMOVE_NODE_KEEP_CHILDREN);
+                // panel.getUndoManager().addEdit(undo);
+
+                List<GroupNodeViewModel> selectedGroupNodes = new ArrayList<>(selectedGroups);
+                selectedGroupNodes.forEach(eachNode -> {
+                    GroupTreeNode groupNode = eachNode.getGroupNode();
+
+                    groupNode.getParent()
+                             .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
+                    groupNode.removeFromParent();
+                });
+
+                if (selectedGroupNodes.size() > 1) {
+                    dialogService.notify(Localization.lang("Removed all selected groups."));
+                } else {
+                    dialogService.notify(Localization.lang("Removed group \"%0\".", group.getDisplayName()));
+                }
+                writeGroupChangesToMetaData();
+            }
         }
+
     }
 
     /**

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -399,41 +399,45 @@ public class GroupTreeViewModel extends AbstractViewModel {
 
     public void removeGroupKeepSubgroups(GroupNodeViewModel group) {
         boolean confirmed;
-        if (selectedGroups.contains(group)) {
-            if (selectedGroups.size() <= 1) {
+        //check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
+        if (!selectedGroups.contains(group)) {
+            selectedGroups.clear();
+            selectedGroups.add(group);
+        }
 
-                confirmed = dialogService.showConfirmationDialogAndWait(
-                        Localization.lang("Remove group"),
-                        Localization.lang("Remove group \"%0\" and keep its subgroups?", group.getDisplayName()),
-                        Localization.lang("Remove"));
+        if (selectedGroups.size() <= 1) {
+
+            confirmed = dialogService.showConfirmationDialogAndWait(
+                    Localization.lang("Remove group"),
+                    Localization.lang("Remove group \"%0\" and keep its subgroups?", group.getDisplayName()),
+                    Localization.lang("Remove"));
+        } else {
+            confirmed = dialogService.showConfirmationDialogAndWait(
+                    Localization.lang("Remove groups"),
+                    Localization.lang("Remove all selected groups and keep their subgroups?"),
+                    Localization.lang("Remove all"));
+        }
+
+        if (confirmed) {
+            // TODO: Add undo
+            // final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(groupsRoot, node, UndoableAddOrRemoveGroup.REMOVE_NODE_KEEP_CHILDREN);
+            // panel.getUndoManager().addEdit(undo);
+
+            List<GroupNodeViewModel> selectedGroupNodes = new ArrayList<>(selectedGroups);
+            selectedGroupNodes.forEach(eachNode -> {
+                GroupTreeNode groupNode = eachNode.getGroupNode();
+
+                groupNode.getParent()
+                         .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
+                groupNode.removeFromParent();
+            });
+
+            if (selectedGroupNodes.size() > 1) {
+                dialogService.notify(Localization.lang("Removed all selected groups."));
             } else {
-                confirmed = dialogService.showConfirmationDialogAndWait(
-                        Localization.lang("Remove groups"),
-                        Localization.lang("Remove all selected groups and keep their subgroups?"),
-                        Localization.lang("Remove all"));
+                dialogService.notify(Localization.lang("Removed group \"%0\".", group.getDisplayName()));
             }
-
-            if (confirmed) {
-                // TODO: Add undo
-                // final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(groupsRoot, node, UndoableAddOrRemoveGroup.REMOVE_NODE_KEEP_CHILDREN);
-                // panel.getUndoManager().addEdit(undo);
-
-                List<GroupNodeViewModel> selectedGroupNodes = new ArrayList<>(selectedGroups);
-                selectedGroupNodes.forEach(eachNode -> {
-                    GroupTreeNode groupNode = eachNode.getGroupNode();
-
-                    groupNode.getParent()
-                             .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
-                    groupNode.removeFromParent();
-                });
-
-                if (selectedGroupNodes.size() > 1) {
-                    dialogService.notify(Localization.lang("Removed all selected groups."));
-                } else {
-                    dialogService.notify(Localization.lang("Removed group \"%0\".", group.getDisplayName()));
-                }
-                writeGroupChangesToMetaData();
-            }
+            writeGroupChangesToMetaData();
         }
 
     }
@@ -443,6 +447,12 @@ public class GroupTreeViewModel extends AbstractViewModel {
      */
     public void removeGroupAndSubgroups(GroupNodeViewModel group) {
         boolean confirmed;
+        //check whether the group is in selectedGroups, if not, we clear all selected group and add the current group into it by default
+        if (!selectedGroups.contains(group)) {
+            selectedGroups.clear();
+            selectedGroups.add(group);
+        }
+
         if (selectedGroups.size() <= 1) {
             confirmed = dialogService.showConfirmationDialogAndWait(
                     Localization.lang("Remove group and subgroups"),


### PR DESCRIPTION
Fixes #9281

### Previous discussion about "Remove group" options are presented for clicked group, but actions are taken on all selected groups.
> The group passed to `removeGroupKeepSubgroups` and `removeGroupAndSubgroups` is only used for dialog text, `selectedGroups` is used for all actual removals.
----
### Proposed solution 
---
We assume that the user would like to apply removal only to the current clicked group if the clicked group is not in `selectedGroups`  
- When `removeGroupKeepSubgroups()` or `removeGroupAndSubgroups()` are called, check whether the clicked group is presented in `selectedGroupds` 
  - if yes, we do not take anything actions 
  - if no, clear `selectedGroups` and add the current clicked group into `selectedGroups`

### Single group in `selectedGroup` but does not contain `group` removal
before `removeGroupKeepSubgroups()` or `removeGroupAndSubgroups()`:
`selectedGroups`: test2
`group`: test3 
#### Steps:

![image](https://user-images.githubusercontent.com/61769268/198757095-d36d7aa6-a010-4f5f-a943-06dd2a86dba8.png)
![image](https://user-images.githubusercontent.com/61769268/198757641-6df43ad6-8537-48d4-b082-571f0a3823b5.png)
![image](https://user-images.githubusercontent.com/61769268/198757885-6d343eff-a59f-46a0-a82b-3dbc2e6fe82e.png)

### Multi group in `seletedGroup` but does not contain `group`
before `removeGroupKeepSubgroups()` or `removeGroupAndSubgroups()`:
`selectedGroups`: test1, test2,test3
`group`: test4
#### Steps:
![image](https://user-images.githubusercontent.com/61769268/198759904-f0ea4678-0c42-4bbb-afdc-f0c5e6df1ea9.png)
![image](https://user-images.githubusercontent.com/61769268/198760069-ca2e191f-c4c7-4b96-86c3-ff7119709fa0.png)
![image](https://user-images.githubusercontent.com/61769268/198760230-3498b249-acac-4831-a02a-d59bad6be100.png)

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
