### PR TITLE
Add support for fjournal in abbreviation and unabbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - An SLR can now be started from the SLR itself. [#9131](https://github.com/JabRef/jabref/pull/9131), [koppor#601](https://github.com/koppor/jabref/issues/601)
 - Implement a new ISBN Fetcher ([doi-to-bibtex-converter.herokuapp.com](http://doi-to-bibtex-converter.herokuapp.com) as source). [#9145](https://github.com/JabRef/jabref/pull/9145)
 - We added support for the Ukrainian and Arabic languages. [#9236](https://github.com/JabRef/jabref/pull/9236), [#9243](https://github.com/JabRef/jabref/pull/9243)
+- We added integrate `fjournal` support in article to abbreviation and unabbreviation functionalities. [#321](https://github.com/JabRef/jabref/pull/321) 
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/journals/UndoableAbbreviator.java
+++ b/src/main/java/org/jabref/gui/journals/UndoableAbbreviator.java
@@ -8,6 +8,8 @@ import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldProperty;
+import org.jabref.model.entry.field.StandardField;
 
 public class UndoableAbbreviator {
 
@@ -43,10 +45,17 @@ public class UndoableAbbreviator {
             return false; // Unknown, cannot abbreviate anything.
         }
 
-        String newText = getAbbreviatedName(journalAbbreviationRepository.get(text).get());
+        Abbreviation abbreviation = journalAbbreviationRepository.get(text).get();
+        String newText = getAbbreviatedName(abbreviation);
 
         if (newText.equals(origText)) {
             return false;
+        }
+
+        // Store full name into fjournal
+        if (fieldName.equals(StandardField.JOURNAL)) {
+            entry.setField(StandardField.FJOURNAL, abbreviation.getName());
+            ce.addEdit(new UndoableFieldChange(entry, StandardField.FJOURNAL, null, abbreviation.getName()));
         }
 
         entry.setField(fieldName, newText);

--- a/src/main/java/org/jabref/gui/journals/UndoableUnabbreviator.java
+++ b/src/main/java/org/jabref/gui/journals/UndoableUnabbreviator.java
@@ -8,6 +8,7 @@ import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
 
 public class UndoableUnabbreviator {
 
@@ -30,6 +31,10 @@ public class UndoableUnabbreviator {
             return false;
         }
 
+        if (restoreFromFjournal(entry, field, ce)) {
+            return true;
+        }
+
         String text = entry.getField(field).get();
         String origText = text;
         if (database != null) {
@@ -48,6 +53,23 @@ public class UndoableUnabbreviator {
         String newText = abbreviation.getName();
         entry.setField(field, newText);
         ce.addEdit(new UndoableFieldChange(entry, field, origText, newText));
+        return true;
+    }
+
+    public boolean restoreFromFjournal(BibEntry entry, Field field, CompoundEdit ce) {
+        if (!(field.equals(StandardField.JOURNAL) && entry.hasField(StandardField.FJOURNAL))) {
+            return false;
+        }
+
+        String origText = entry.getField(field).get();
+        String newText = entry.getField(StandardField.FJOURNAL).get().trim();
+
+        entry.setField(StandardField.FJOURNAL, "");
+        ce.addEdit(new UndoableFieldChange(entry, StandardField.FJOURNAL, newText, ""));
+
+        entry.setField(field, newText);
+        ce.addEdit(new UndoableFieldChange(entry, field, origText, newText));
+
         return true;
     }
 }

--- a/src/main/java/org/jabref/model/entry/field/StandardField.java
+++ b/src/main/java/org/jabref/model/entry/field/StandardField.java
@@ -56,6 +56,7 @@ public enum StandardField implements Field {
     EVENTTITLE("eventtitle"),
     EVENTTITLEADDON("eventtitleaddon"),
     FILE("file", FieldProperty.FILE_EDITOR, FieldProperty.VERBATIM),
+    FJOURNAL("fjournal"),
     FOREWORD("foreword", FieldProperty.PERSON_NAMES),
     FOLDER("folder"),
     GENDER("gender", FieldProperty.GENDER),


### PR DESCRIPTION
Fixes

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

## Short Description
This adds the feature of storing and using `journal` in abbreviation and unabbreviation for the `journal` field in articles. A detailed description is described by @koppor in [koppor/jabref#321](https://github.com/koppor/jabref).

## Checklist
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

## Behaviour
* abbreviate: `fjournal` will store the full name of `journal` (no matter whether `journal` is already abbreviated in some level)

![1](https://user-images.githubusercontent.com/64695351/198862897-a74b0a80-a91d-4a6d-9a5b-8d7cc2c2cc1b.gif)

* unabbreviate with `fjournal` unexists: use the previous abbreviation method

![2](https://user-images.githubusercontent.com/64695351/198862949-c996ef6e-032c-438a-9bc3-2a6fc8eb34e0.gif)

* unabbreviate with 'fjournal' exists: move `fjounral` to `journal` and delete `fjournal`

![3](https://user-images.githubusercontent.com/64695351/198862982-c3cd884d-b77e-4eb3-8f65-938d9a1718f3.gif)


