### PR TITLE
Fixes issue #9031 - Failed attempt 1

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
@@ -92,9 +92,15 @@ public class SpecialFieldColumn extends MainTableColumn<Optional<SpecialFieldVal
 
     private Rating createSpecialRating(BibEntryTableViewModel entry, Optional<SpecialFieldValueViewModel> value) {
         Rating ranking = new Rating();
-        System.out.println("Ranking was: " + entry.getEntry().getField(SpecialField.RANKING));
+
+        // rank is get from the new value
         int rank = value.map(specialFieldValueViewModel -> specialFieldValueViewModel.getValue().toRating()).orElse(0);
+
+        // set the rating as rank
         ranking.setRating(rank);
+
+        // Following code attempts to get the value of the rank (i.e., keyword) from the entry.
+        // However, the argument 'entry' was already updated, so it seems impossible to get the old value of ranking from updated entry.
 
 //        String keyword = "";
 //        switch (rank) {
@@ -105,29 +111,30 @@ public class SpecialFieldColumn extends MainTableColumn<Optional<SpecialFieldVal
 //            case 4 -> keyword = "rank4";
 //            case 5 -> keyword = "rank5";
 //        }
-
 //        String finalKeyword = keyword;
 
         ranking.addEventFilter(MouseEvent.MOUSE_CLICKED, event -> {
             if (event.getButton().equals(MouseButton.PRIMARY)
+                    // ClickCount modified from 2 to 1, and it behaves like this:
+                    // When the rank is already set, clicking any of stars in the field will clear the current ranking.
                     && event.getClickCount() == 1
+                    // The following two conditions checks if the old value (which actually is the new value) is the
+                    // same as the new value.
                     && entry.getEntry().hasField(SpecialField.RANKING)
+                    // Since both the values are the new value and are the same, following condition does not work.
                     // && String.valueOf(entry.getEntry().getField(SpecialField.RANKING)).equals(finalKeyword)
                     ) {
                 ranking.setRating(0);
-                System.out.println("IF 0");
                 event.consume();
             } else if (event.getButton().equals(MouseButton.SECONDARY)) {
-                System.out.println("IF 1");
                 event.consume();
             }
         });
-        System.out.println("FINISHED.");
-        System.out.println("value was" + rank);
+
         EasyBind.subscribe(ranking.ratingProperty(), rating ->
                 new SpecialFieldViewModel(SpecialField.RANKING, preferencesService, undoManager)
                         .setSpecialFieldValue(entry.getEntry(), SpecialFieldValue.getRating(rating.intValue())));
-        System.out.println("Ranking now is: " + entry.getEntry().getField(SpecialField.RANKING));
+
         return ranking;
     }
 

--- a/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
@@ -92,26 +92,42 @@ public class SpecialFieldColumn extends MainTableColumn<Optional<SpecialFieldVal
 
     private Rating createSpecialRating(BibEntryTableViewModel entry, Optional<SpecialFieldValueViewModel> value) {
         Rating ranking = new Rating();
+        System.out.println("Ranking was: " + entry.getEntry().getField(SpecialField.RANKING));
+        int rank = value.map(specialFieldValueViewModel -> specialFieldValueViewModel.getValue().toRating()).orElse(0);
+        ranking.setRating(rank);
 
-        if (value.isPresent()) {
-            ranking.setRating(value.get().getValue().toRating());
-        } else {
-            ranking.setRating(0);
-        }
+//        String keyword = "";
+//        switch (rank) {
+//            case 0 -> keyword = "CLEAR_RANK";
+//            case 1 -> keyword = "rank1";
+//            case 2 -> keyword = "rank2";
+//            case 3 -> keyword = "rank3";
+//            case 4 -> keyword = "rank4";
+//            case 5 -> keyword = "rank5";
+//        }
+
+//        String finalKeyword = keyword;
 
         ranking.addEventFilter(MouseEvent.MOUSE_CLICKED, event -> {
-            if (event.getButton().equals(MouseButton.PRIMARY) && event.getClickCount() == 2) {
+            if (event.getButton().equals(MouseButton.PRIMARY)
+                    && event.getClickCount() == 1
+                    && entry.getEntry().hasField(SpecialField.RANKING)
+                    // && String.valueOf(entry.getEntry().getField(SpecialField.RANKING)).equals(finalKeyword)
+                    ) {
                 ranking.setRating(0);
+                System.out.println("IF 0");
                 event.consume();
             } else if (event.getButton().equals(MouseButton.SECONDARY)) {
+                System.out.println("IF 1");
                 event.consume();
             }
         });
-
+        System.out.println("FINISHED.");
+        System.out.println("value was" + rank);
         EasyBind.subscribe(ranking.ratingProperty(), rating ->
                 new SpecialFieldViewModel(SpecialField.RANKING, preferencesService, undoManager)
                         .setSpecialFieldValue(entry.getEntry(), SpecialFieldValue.getRating(rating.intValue())));
-
+        System.out.println("Ranking now is: " + entry.getEntry().getField(SpecialField.RANKING));
         return ranking;
     }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Please note this is a **failed** attempt tried to fix #9031. The PR is opened for recording the attempt.

**Positioning the problem**
We thought the issue is related to createSpecialColumn method in SpecialFieldColumn.java, because we found a listener which listen double click of primary button of mouse and single click of secondary button. This listener looks quite relevant to the issue. 

**Attempt**
We then modified the method, tried to get the past value (which actually does not exist in the method) of ranking field and compare it with the new value of ranking field in the method. What's more, we also only changed the number of required click to perform clear ranking from 2 to 1. This seems could fix the issue (but actually it did not). 

**Actual behavior**
Per the issue description, the expected behavior of the modified application is: if the single click on the same ranking as past ranking is detected, then the ranking is cleared, per the issue description.
The actual behavior is: while single-clicking on any of five stars (even when clicking the not same ranking star as the past ranking), the ranking will be cleared. The below gif animation provides a direct view of the actual behavior:

![recording](https://user-images.githubusercontent.com/64069894/198863619-c7add867-7629-48df-bcba-354d176c925a.gif)

Actions performed in the animation: 
Single-click on the third star individually twice, 
Single-click on the fourth star individually twice,
Single-click on the third star once, then single-click on the fifth star once.

**Testing**
We did not perform any kind of automatic testing. Only the above manual testing was performed.
There might be potential influence (bug) to other part of the code.

**Analyzing the attempt**
From the attempt, we can see that the modified application did not performed as the expected behavior indicated in the issue description.
The main problem we found in this attempt is that we can't find the past value of ranking of that entry. The argument 'entry', after our testing, we found it is always already updated its ranking value, so we can't see any way to only modify the createSpecialColumn method to fix the issue.
We asked questions about this issue, and Carl replied that the createSpecialColumn method is this method 'should only be called once on initialization of the table and the ranking control', 'createSpecialRating delivers the JavaFX node to be displayed in the TableView' and is just a draw method.

**What's next?**
 There are several ways to continue working on this issue:
1. Research 'TableView' mentioned above,
2. When we single-click on a star on a clear-rank, the ranking is being set. Finding this listener might be helpful.
3. RatingSkin.java seems worth to have a look at.


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
