### PR TITLE
Moved position of add group button to HBox in groups panel UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the preferences option "Warn about duplicates on import" option from the tab "File" to the tab "Import and Export". [koppor#570](https://github.com/koppor/jabref/issues/570)
 - When JabRef encounters `% Encoding: UTF-8` header, it is kept during writing (and not removed). [#8964](https://github.com/JabRef/jabref/pull/8964)
 - We replace characters which cannot be decoded using the specified encoding by a (probably another) valid character. This happens if JabRef detects the wrong charset (e.g., UTF-8 instead of Windows 1252). One can use the [Integrity Check](https://docs.jabref.org/finding-sorting-and-cleaning-entries/checkintegrity) to find those characters.
+- We moved the "add group" button from the bottom of the groups UI panel to the horizontal row of icon buttons at the top [koppor#529](https://github.com/koppor/jabref/issues/529)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/groups/GroupModeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupModeViewModel.java
@@ -14,6 +14,14 @@ public class GroupModeViewModel {
         this.mode = mode;
     }
 
+    public Node getAddGroupGraphic() {
+        return JabRefIcons.ADD.getGraphicNode();
+    }
+
+    public Tooltip getAddGroupTooltip() {
+        return new Tooltip(Localization.lang("Add group"));
+    }
+
     public Node getUnionIntersectionGraphic() {
         if (mode == GroupViewMode.UNION) {
             return JabRefIcons.GROUP_UNION.getGraphicNode();

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -68,7 +68,6 @@ public class GroupTreeView extends BorderPane {
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> numberColumn;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> expansionNodeColumn;
     private CustomTextField searchField;
-    private Button addNewGroup;
 
     private final StateManager stateManager;
     private final DialogService dialogService;
@@ -133,17 +132,6 @@ public class GroupTreeView extends BorderPane {
         this.setCenter(groupTree);
 
         mainColumn.prefWidthProperty().bind(groupTree.widthProperty().subtract(60d).subtract(15));
-
-        addNewGroup = new Button(Localization.lang("Add group"));
-        addNewGroup.setId("addNewGroup");
-        addNewGroup.setMaxWidth(Double.MAX_VALUE);
-        HBox.setHgrow(addNewGroup, Priority.ALWAYS);
-        addNewGroup.setTooltip(new Tooltip(Localization.lang("New group")));
-        addNewGroup.setOnAction(event -> addNewGroup());
-
-        HBox groupBar = new HBox(addNewGroup);
-        groupBar.setId("groupBar");
-        this.setBottom(groupBar);
     }
 
     private void initialize() {
@@ -467,10 +455,6 @@ public class GroupTreeView extends BorderPane {
         // removeSubgroupsPopupAction.setEnabled(!node.isLeaf());
 
         return menu;
-    }
-
-    private void addNewGroup() {
-        viewModel.addNewGroupToRoot();
     }
 
     /**

--- a/src/main/java/org/jabref/gui/sidepane/GroupsSidePaneComponent.java
+++ b/src/main/java/org/jabref/gui/sidepane/GroupsSidePaneComponent.java
@@ -3,40 +3,64 @@ package org.jabref.gui.sidepane;
 import javafx.scene.control.Button;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.groups.GroupModeViewModel;
+import org.jabref.gui.groups.GroupTreeViewModel;
 import org.jabref.gui.groups.GroupViewMode;
 import org.jabref.gui.groups.GroupsPreferences;
 import org.jabref.gui.icon.IconTheme;
+import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 
 import com.tobiasdiez.easybind.EasyBind;
+import org.jabref.preferences.PreferencesService;
 
 public class GroupsSidePaneComponent extends SidePaneComponent {
     private final GroupsPreferences groupsPreferences;
     private final DialogService dialogService;
+
+    private final GroupTreeViewModel viewModel;
     private final Button intersectionUnionToggle = IconTheme.JabRefIcons.GROUP_INTERSECTION.asButton();
+
+    private final Button addGroup = IconTheme.JabRefIcons.ADD.asButton();
 
     public GroupsSidePaneComponent(SimpleCommand closeCommand,
                                    SimpleCommand moveUpCommand,
                                    SimpleCommand moveDownCommand,
                                    SidePaneContentFactory contentFactory,
                                    GroupsPreferences groupsPreferences,
+                                   TaskExecutor taskExecutor,
+                                   StateManager stateManager,
+                                   PreferencesService preferencesService,
                                    DialogService dialogService) {
         super(SidePaneType.GROUPS, closeCommand, moveUpCommand, moveDownCommand, contentFactory);
         this.groupsPreferences = groupsPreferences;
         this.dialogService = dialogService;
+        this.viewModel = new GroupTreeViewModel(stateManager, dialogService, preferencesService, taskExecutor, stateManager.getLocalDragboard());
+        setupAddGroupButton();
         setupIntersectionUnionToggle();
 
         EasyBind.subscribe(groupsPreferences.groupViewModeProperty(), mode -> {
             GroupModeViewModel modeViewModel = new GroupModeViewModel(mode);
+            addGroup.setGraphic(modeViewModel.getAddGroupGraphic());
+            addGroup.setTooltip(modeViewModel.getAddGroupTooltip());
             intersectionUnionToggle.setGraphic(modeViewModel.getUnionIntersectionGraphic());
             intersectionUnionToggle.setTooltip(modeViewModel.getUnionIntersectionTooltip());
         });
     }
 
+    private void setupAddGroupButton() {
+        addExtraButtonToHeader(addGroup, 0);
+        addGroup.setOnAction(event -> addNewGroup());
+    }
+
+    private void addNewGroup() {
+        viewModel.addNewGroupToRoot();
+    }
+
     private void setupIntersectionUnionToggle() {
-        addExtraButtonToHeader(intersectionUnionToggle, 0);
+        addExtraButtonToHeader(intersectionUnionToggle, 1);
         intersectionUnionToggle.setOnAction(event -> new ToggleUnionIntersectionAction().execute());
     }
 

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
@@ -33,6 +33,7 @@ public class SidePaneViewModel extends AbstractViewModel {
     private final StateManager stateManager;
     private final SidePaneContentFactory sidePaneContentFactory;
     private final DialogService dialogService;
+    private final TaskExecutor taskExecutor;
 
     public SidePaneViewModel(PreferencesService preferencesService,
                              StateManager stateManager,
@@ -41,6 +42,7 @@ public class SidePaneViewModel extends AbstractViewModel {
                              UndoManager undoManager) {
         this.preferencesService = preferencesService;
         this.stateManager = stateManager;
+        this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;
         this.sidePaneContentFactory = new SidePaneContentFactory(
                 preferencesService,
@@ -71,6 +73,9 @@ public class SidePaneViewModel extends AbstractViewModel {
                         new MoveDownAction(pane),
                         sidePaneContentFactory,
                         preferencesService.getGroupsPreferences(),
+                        taskExecutor,
+                        stateManager,
+                        preferencesService,
                         dialogService);
                 case WEB_SEARCH, OPEN_OFFICE -> new SidePaneComponent(pane,
                         new ClosePaneAction(pane),


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/529
Would fix #8398 if the community were to decide to take this proposal over its competing alternatives.

**Description:**

Moves the "add group" button previously at the bottom of the groups GUI panel into the horizontal icon menu at the top.

Proposed change:
![propchange](https://user-images.githubusercontent.com/54055631/198870130-a1e5b780-c195-413b-a181-b6eaa6716c5f.png)

Implementation:
![Screenshot from 2022-10-30 19-45-46](https://user-images.githubusercontent.com/54055631/198870148-e45ad3fc-e599-4feb-9bec-4884def15c45.png)



- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
