### PR TITLE
Update sorting of entries in maintable by special fields immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed that sorting of entries in the maintable by special fields is updated immediately [#9334](https://github.com/JabRef/jabref/issues/9334)
 - We fixed the Cleanup entries dialog is partially visible [#9223](https://github.com/JabRef/jabref/issues/9223)
 - We fixed the display of the "Customize Entry Types" dialogue title [#9198](https://github.com/JabRef/jabref/issues/9198)
 - We fixed an issue where author names with tilde accents (for example ñ) were marked as "Names are not in the standard BibTex format" [#8071](https://github.com/JabRef/jabref/issues/8071)

--- a/src/main/java/org/jabref/gui/maintable/BibEntryTableViewModel.java
+++ b/src/main/java/org/jabref/gui/maintable/BibEntryTableViewModel.java
@@ -104,13 +104,25 @@ public class BibEntryTableViewModel {
 
     public ObservableValue<Optional<SpecialFieldValueViewModel>> getSpecialField(SpecialField field) {
         OptionalBinding<SpecialFieldValueViewModel> value = specialFieldValues.get(field);
+        // Fetch possibly updated value from BibEntry entry
+        Optional<String> currentValue = this.entry.getField(field);
         if (value != null) {
-            return value;
+            if (currentValue.isEmpty() && value.getValue().isEmpty()) {
+                var zeroValue = getField(field).flatMapOpt(fieldValue -> field.parseValue("CLEAR_RANK").map(SpecialFieldValueViewModel::new));
+                specialFieldValues.put(field, zeroValue);
+                return zeroValue;
+            } else if (value.getValue().isEmpty() || !value.getValue().get().getValue().getFieldValue().equals(currentValue)) {
+                // specialFieldValues value and BibEntry value differ => Set specialFieldValues value to BibEntry value
+                value = getField(field).flatMapOpt(fieldValue -> field.parseValue(fieldValue).map(SpecialFieldValueViewModel::new));
+                specialFieldValues.put(field, value);
+                return value;
+            }
+            // END WORKAROUND
         } else {
             value = getField(field).flatMapOpt(fieldValue -> field.parseValue(fieldValue).map(SpecialFieldValueViewModel::new));
             specialFieldValues.put(field, value);
-            return value;
         }
+        return value;
     }
 
     public ObservableValue<String> getFields(OrFields fields) {

--- a/src/main/java/org/jabref/gui/maintable/BibEntryTableViewModel.java
+++ b/src/main/java/org/jabref/gui/maintable/BibEntryTableViewModel.java
@@ -117,7 +117,6 @@ public class BibEntryTableViewModel {
                 specialFieldValues.put(field, value);
                 return value;
             }
-            // END WORKAROUND
         } else {
             value = getField(field).flatMapOpt(fieldValue -> field.parseValue(fieldValue).map(SpecialFieldValueViewModel::new));
             specialFieldValues.put(field, value);


### PR DESCRIPTION

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Once applied, entries in the maintable sorted by a special field value are getting updated immediately after their value has changed.

The workaround is necessary because specialFieldValues and entry.fields get updated separately (entry.fields before speicalFieldValues). This lead to the behaviour that when sorting for a special field in the maintaible (like ranking or read status), the sorting does not get updated properly on change.

Closes #9334. (See also the issue for a more detailed description of the underlying problem)

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
