### PR TITLE
Adds missing "requires" statement

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -114,6 +114,7 @@ open module org.jabref {
     requires com.fasterxml.jackson.dataformat.yaml;
     requires com.fasterxml.jackson.datatype.jsr310;
     requires net.harawata.appdirs;
+    requires com.sun.jna;
     requires com.sun.jna.platform;
 
     requires org.eclipse.jgit;


### PR DESCRIPTION
When compiling JabRef in IntelliJ, I got following error message:

```
...src\main\java\org\jabref\gui\desktop\os\Windows.java:84:9
java: cannot access com.sun.jna.LastErrorException
  class file for com.sun.jna.LastErrorException not found
```

We had the libraries in the classpath since the usage of AppDirs:

```
\--- net.harawata:appdirs:1.2.1
     \--- net.java.dev.jna:jna-platform:5.6.0
          \--- net.java.dev.jna:jna:5.6.0
```

Direct JNA usage was introduced at https://github.com/JabRef/jabref/pull/9222.
Seems, simply, a `requires` statement was missing:

```java
requires com.sun.jna;
```

This PR adds this statement.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
