### PR TITLE
Add Check if groups drag and drop allowed

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -320,14 +320,14 @@ public class GroupTreeView extends BorderPane {
                 Dragboard dragboard = event.getDragboard();
                 boolean success = false;
 
-                if (dragboard.hasContent(DragAndDropDataFormats.GROUP)) {
+                if (dragboard.hasContent(DragAndDropDataFormats.GROUP) && viewModel.canAddGroupsIn(row.getItem())) {
                     List<String> pathToSources = (List<String>) dragboard.getContent(DragAndDropDataFormats.GROUP);
                     List<GroupNodeViewModel> changedGroups = new LinkedList<>();
                     for (String pathToSource : pathToSources) {
                         Optional<GroupNodeViewModel> source = viewModel
                                 .rootGroupProperty().get()
                                 .getChildByPath(pathToSource);
-                        if (source.isPresent()) {
+                        if (source.isPresent() && viewModel.canBeDragged(source.get())) {
                             source.get().draggedOn(row.getItem(), ControlHelper.getDroppingMouseLocation(row, event));
                             changedGroups.add(source.get());
                             success = true;
@@ -335,6 +335,9 @@ public class GroupTreeView extends BorderPane {
                     }
                     groupTree.getSelectionModel().clearSelection();
                     changedGroups.forEach(value -> selectNode(value, true));
+                    if (success) {
+                        viewModel.writeGroupChangesToMetaData();
+                    }
                 }
 
                 if (localDragboard.hasBibEntries()) {
@@ -442,21 +445,28 @@ public class GroupTreeView extends BorderPane {
 
         menu.setOnShown(event -> {
             menu.getItems().clear();
-            menu.getItems().add(editGroup);
-            if (group.getChildren().size() > 0) {
-                menu.getItems().add(removeGroupWithSubgroups);
-                menu.getItems().add(new SeparatorMenuItem());
-                menu.getItems().add(addSubgroup);
-                menu.getItems().add(removeSubgroups);
-                menu.getItems().add(sortSubgroups);
-            } else {
-                menu.getItems().add(removeGroupNoSubgroups);
-                menu.getItems().add(new SeparatorMenuItem());
-                menu.getItems().add(addSubgroup);
+            if (viewModel.isEditable(group)) {
+                menu.getItems().add(editGroup);
+                if (group.getChildren().size() > 0 && viewModel.canAddGroupsIn(group)) {
+                    menu.getItems().add(removeGroupWithSubgroups);
+                    menu.getItems().add(new SeparatorMenuItem());
+                    menu.getItems().add(addSubgroup);
+                    menu.getItems().add(removeSubgroups);
+                    menu.getItems().add(sortSubgroups);
+                } else {
+                    menu.getItems().add(removeGroupNoSubgroups);
+                    if (viewModel.canAddGroupsIn(group)) {
+                        menu.getItems().add(new SeparatorMenuItem());
+                        menu.getItems().add(addSubgroup);
+                    }
+                }
             }
-            menu.getItems().add(new SeparatorMenuItem());
-            menu.getItems().add(addEntries);
-            menu.getItems().add(removeEntries);
+
+            if (viewModel.canAddEntriesIn(group)) {
+                menu.getItems().add(new SeparatorMenuItem());
+                menu.getItems().add(addEntries);
+                menu.getItems().add(removeEntries);
+            }
         });
 
         menu.getItems().add(new Menu());

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -641,10 +641,10 @@ public class GroupTreeViewModel extends AbstractViewModel {
             return false;
         } else if (group instanceof ExplicitGroup) {
             return true;
-        } else if (group instanceof LastNameGroup || group instanceof KeywordGroup || group instanceof RegexKeywordGroup) {
+        } else if (group instanceof LastNameGroup || group instanceof RegexKeywordGroup) {
             if (groupnode.getParent().isPresent()) {
                 AbstractGroup groupParent = groupnode.getParent().get().getGroup();
-                if (group instanceof KeywordGroup && groupParent instanceof AutomaticKeywordGroup) {
+                if (groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup) {
                     return true;
                 } else {
                     return false;
@@ -652,8 +652,10 @@ public class GroupTreeViewModel extends AbstractViewModel {
             } else {
                 return false;
             }
-        } else if (group instanceof SearchGroup) {
+        } else if (group instanceof KeywordGroup) {
             return true;
+        } else if (group instanceof SearchGroup) {
+            return false;
         } else if (group instanceof AutomaticKeywordGroup) {
             return false;
         } else if (group instanceof AutomaticPersonsGroup) {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -631,7 +631,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
         } else if (group instanceof TexGroup) {
             return true;
         } else {
-            throw new UnsupportedOperationException("AllowDragInto method not yet implemented in group: " + group.getClass().getName());
+            throw new UnsupportedOperationException("canAddGroupsIn method not yet implemented in group: " + group.getClass().getName());
         }
     }
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -30,10 +30,13 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.AllEntriesGroup;
 import org.jabref.model.groups.AutomaticKeywordGroup;
 import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.groups.KeywordGroup;
+import org.jabref.model.groups.LastNameGroup;
 import org.jabref.model.groups.RegexKeywordGroup;
 import org.jabref.model.groups.SearchGroup;
 import org.jabref.model.groups.TexGroup;
@@ -184,7 +187,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
         });
     }
 
-    private void writeGroupChangesToMetaData() {
+    public void writeGroupChangesToMetaData() {
         currentDatabase.ifPresent(database -> database.getMetaData().setGroups(rootGroup.get().getGroupNode()));
     }
 
@@ -570,5 +573,125 @@ public class GroupTreeViewModel extends AbstractViewModel {
 
     public void sortAlphabeticallyRecursive(GroupTreeNode group) {
         group.sortChildren(compAlphabetIgnoreCase, true);
+    }
+
+    public boolean canBeDragged(GroupNodeViewModel groupnode) {
+        AbstractGroup group = groupnode.getGroupNode().getGroup();
+        if (group instanceof AllEntriesGroup) {
+            return false;
+        } else if (group instanceof ExplicitGroup) {
+            return true;
+        } else if (group instanceof LastNameGroup || group instanceof KeywordGroup || group instanceof RegexKeywordGroup) {
+            if (groupnode.getParent().isPresent()) {
+                AbstractGroup groupParent = groupnode.getParent().get().getGroup();
+                if (groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup) {
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        } else if (group instanceof SearchGroup) {
+            return true;
+        } else if (group instanceof AutomaticKeywordGroup) {
+            return true;
+        } else if (group instanceof AutomaticPersonsGroup) {
+            return true;
+        } else if (group instanceof TexGroup) {
+            return true;
+        } else {
+            throw new UnsupportedOperationException("canBeDragged method not yet implemented in group: " + group.getClass().getName());
+        }
+    }
+
+    public boolean canAddGroupsIn(GroupNodeViewModel groupnode) {
+        AbstractGroup group = groupnode.getGroupNode().getGroup();
+        if (group instanceof AllEntriesGroup) {
+            return true;
+        } else if (group instanceof ExplicitGroup) {
+            return true;
+        } else if (group instanceof LastNameGroup || group instanceof KeywordGroup || group instanceof RegexKeywordGroup) {
+            if (groupnode.getParent().isPresent()) {
+                AbstractGroup groupParent = groupnode.getParent().get().getGroup();
+                if (groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup) {
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        } else if (group instanceof SearchGroup) {
+            return true;
+        } else if (group instanceof AutomaticKeywordGroup) {
+            return false;
+        } else if (group instanceof AutomaticPersonsGroup) {
+            return false;
+        } else if (group instanceof TexGroup) {
+            return true;
+        } else {
+            throw new UnsupportedOperationException("AllowDragInto method not yet implemented in group: " + group.getClass().getName());
+        }
+    }
+
+    public boolean canAddEntriesIn(GroupNodeViewModel groupnode) {
+        AbstractGroup group = groupnode.getGroupNode().getGroup();
+        if (group instanceof AllEntriesGroup) {
+            return false;
+        } else if (group instanceof ExplicitGroup) {
+            return true;
+        } else if (group instanceof LastNameGroup || group instanceof KeywordGroup || group instanceof RegexKeywordGroup) {
+            if (groupnode.getParent().isPresent()) {
+                AbstractGroup groupParent = groupnode.getParent().get().getGroup();
+                if (group instanceof KeywordGroup && groupParent instanceof AutomaticKeywordGroup) {
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else if (group instanceof SearchGroup) {
+            return true;
+        } else if (group instanceof AutomaticKeywordGroup) {
+            return false;
+        } else if (group instanceof AutomaticPersonsGroup) {
+            return false;
+        } else if (group instanceof TexGroup) {
+            return false;
+        } else {
+            throw new UnsupportedOperationException("canAddEntriesIn method not yet implemented in group: " + group.getClass().getName());
+        }
+    }
+
+    public boolean isEditable(GroupNodeViewModel groupnode) {
+        AbstractGroup group = groupnode.getGroupNode().getGroup();
+        if (group instanceof AllEntriesGroup) {
+            return false;
+        } else if (group instanceof ExplicitGroup) {
+            return true;
+        } else if (group instanceof LastNameGroup || group instanceof KeywordGroup || group instanceof RegexKeywordGroup) {
+            if (groupnode.getParent().isPresent()) {
+                AbstractGroup groupParent = groupnode.getParent().get().getGroup();
+                if (groupParent instanceof AutomaticKeywordGroup || groupParent instanceof AutomaticPersonsGroup) {
+                    return false;
+                } else {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        } else if (group instanceof SearchGroup) {
+            return true;
+        } else if (group instanceof AutomaticKeywordGroup) {
+            return true;
+        } else if (group instanceof AutomaticPersonsGroup) {
+            return true;
+        } else if (group instanceof TexGroup) {
+            return true;
+        } else {
+            throw new UnsupportedOperationException("isEditable method not yet implemented in group: " + group.getClass().getName());
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #9368
Fixes #9360

Briefly, the solution is to add four methods to the various types of groups: **AllowDragInto**, **CanBeDragged**, **isEditable** and **AllowActionOnSelectedEntry**.

**AllowDragInto**, **CanBeDragged**  should solve the problem of authorizaztion to Drag and Drop: during drag and drop, the GroupTreeView queries these methods to know what is allowed to do.

If the drag and drop is successful, in **shared database**, update grouping in the MetaData table.

Adding **isEditable** and **AllowActionOnSelectedEntry**, we can establish which menu items to display for each type of group.

**Note**: I have not tested the TexGroup group.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.