### PR TITLE
Switch from set-output to environment files

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -13,10 +13,10 @@ jobs:
         id: checksecrets
         shell: bash
         run: |
-          if [ -z "$BUILDJABREFPRIVATEKEY" ]; then
-            echo ::set-output name=secretspresent::false
+          if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
+            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=secretspresent::true
+            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -24,7 +24,7 @@ jobs:
         id: extract_branch
         if: ${{ steps.checksecrets.outputs.secretspresent }}
         run: |
-          echo "##[set-output name=branch;]$(echo ${{ github.event.pull_request.head.ref }})"
+          echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
       - name: Delete folder on builds.jabref.org
         if: ${{ steps.checksecrets.outputs.secretspresent }}
         uses: appleboy/ssh-action@v0.1.5

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -14,9 +14,9 @@ jobs:
         shell: bash
         run: |
           if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
+            echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
+            echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             displayName: linux
@@ -44,7 +44,7 @@ jobs:
           - os: windows-latest
             displayName: windows
             archivePortable: 7z a -r build/distribution/JabRef-portable_windows.zip ./build/distribution/JabRef && rm -R build/distribution/JabRef
-          - os: macOS-latest
+          - os: macos-latest
             displayName: macOS
             archivePortable: brew install pigz && tar -c -C build/distribution JabRef.app | pigz --rsyncable > build/distribution/JabRef-portable_macos.tar.gz && rm -R build/distribution/JabRef.app
     runs-on: ${{ matrix.os }}
@@ -55,9 +55,9 @@ jobs:
         shell: bash
         run: |
           if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            echo ::set-output name=secretspresent::false
+            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=secretspresent::true
+            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -158,9 +158,9 @@ jobs:
         shell: bash
         run: |
           if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            echo ::set-output name=secretspresent::false
+            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=secretspresent::true
+            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -55,9 +55,9 @@ jobs:
         shell: bash
         run: |
           if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
+            echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
+            echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -158,9 +158,9 @@ jobs:
         shell: bash
         run: |
           if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
+            echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
+            echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}

--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Determine dates
         id: dates
         run: |
-          echo ::set-output name=start_date::`date -d "$(date +%Y-%m-01) -3 months" +%Y-%m-%d`
-          echo ::set-output name=stop_date::`date -d "$(date +%Y-%m-01) -1 day" +%Y-%m-%d`
-          echo ::set-output name=quarter::`date -d "$(date +%Y-%m-01) -1 day" +%Y`-Q$(( ((`date -d "$(date +%Y-%m-01) -1 day" +%m`)-1)/3+1 ))
+          echo "start_date=`date -d "$(date +%Y-%m-01) -3 months" +%Y-%m-%d`" >> $GITHUB_STATE
+          echo "stop_date=`date -d "$(date +%Y-%m-01) -1 day" +%Y-%m-%d`" >> $GITHUB_STATE
+          echo "quarter=`date -d "$(date +%Y-%m-01) -1 day" +%Y`-Q$(( ((`date -d "$(date +%Y-%m-01) -1 day" +%m`)-1)/3+1 ))" >> $GITHUB_STATE
       - name: 'Development history of last quarter'
         uses: nbprojekt/gource-action@v1
         with:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -22,10 +22,10 @@ jobs:
         id: checksecrets
         shell: bash
         run: |
-          if [ "SNAPCRAFT_LOGIN_FILE" == "" ]; then
-            echo ::set-output name=secretspresent::false
+          if [ "$SNAPCRAFT_LOGIN_FILE" == "" ]; then
+            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=secretspresent::true
+            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -23,9 +23,9 @@ jobs:
         shell: bash
         run: |
           if [ "$SNAPCRAFT_LOGIN_FILE" == "" ]; then
-            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
+            echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
+            echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.SNAPCRAFT_LOGIN_FILE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,10 +149,10 @@ jobs:
         id: checksecrets
         shell: bash
         run: |
-          if [ "CODECOV_TOKEN" == "" ]; then
-            echo ::set-output name=secretspresent::false
+          if [ "$CODECOV_TOKEN" == "" ]; then
+            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=secretspresent::true
+            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,9 +150,9 @@ jobs:
         shell: bash
         run: |
           if [ "$CODECOV_TOKEN" == "" ]; then
-            run: echo "secretspresent=false" >> $GITHUB_OUTPUT
+            echo "secretspresent=false" >> $GITHUB_OUTPUT
           else
-            run: echo "secretspresent=true" >> $GITHUB_OUTPUT
+            echo "secretspresent=true" >> $GITHUB_OUTPUT
           fi
         env:
           SNAPCRAFT_LOGIN_FILE: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Implements https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also fixes casing "macos-latest" so that the Mac OS binary should not be build any more for "external" PRs.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
