### PR TITLE
Return absolute path in case an absolute one is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with the message that is displayed when fetcher returns an empty list of entries for given query. [#9195](https://github.com/JabRef/jabref/issues/9195)
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
+- We fixed an issue where a user could not open an attached file. [#9386](https://github.com/JabRef/jabref/issues/9386)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
 - We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
 - We fixed an issue where editing entry's "date" field in library mode "biblatex" causes an uncaught exception. [#8747](https://github.com/JabRef/jabref/issues/8747)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue with the message that is displayed when fetcher returns an empty list of entries for given query. [#9195](https://github.com/JabRef/jabref/issues/9195)
 - We fixed an issue where an exception was not logged correctly. [koppor#627](https://github.com/JabRef/koppor/issues/627)
 - We fixed an issue where hitting enter on the search field within the preferences dialog closed the dialog. [koppor#630](https://github.com/koppor/jabref/issues/630)
-- We fixed an issue where a user could not open an attached file. [#9386](https://github.com/JabRef/jabref/issues/9386)
+- We fixed an issue where a user could not open an attached file in a new unsaved library. [#9386](https://github.com/JabRef/jabref/issues/9386)
 - We fixed a typo within a connection error message. [koppor#625](https://github.com/koppor/jabref/issues/625)
 - We fixed an issue where the 'close dialog' key binding was not closing the Preferences dialog. [#8888](https://github.com/jabref/jabref/issues/8888)
 - We fixed an issue where editing entry's "date" field in library mode "biblatex" causes an uncaught exception. [#8747](https://github.com/JabRef/jabref/issues/8747)

--- a/src/main/java/org/jabref/model/util/FileHelper.java
+++ b/src/main/java/org/jabref/model/util/FileHelper.java
@@ -115,6 +115,7 @@ public class FileHelper {
      * @param fileName        The filename, may also be a relative path to the file
      */
     public static Optional<Path> find(final BibDatabaseContext databaseContext, String fileName, FilePreferences filePreferences) {
+        Objects.requireNonNull(fileName, "fileName");
         return find(fileName, databaseContext.getFileDirectories(filePreferences));
     }
 
@@ -126,6 +127,16 @@ public class FileHelper {
      * returning the first found file to match if any.
      */
     public static Optional<Path> find(String fileName, List<Path> directories) {
+        if (directories.isEmpty()) {
+            // Fallback, if no directories to resolve are passed
+            Path path = Path.of(fileName);
+            if (path.isAbsolute()) {
+                return Optional.of(path);
+            } else {
+                return Optional.empty();
+            }
+        }
+
         return directories.stream()
                           .flatMap(directory -> find(fileName, directory).stream())
                           .findFirst();


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/9386

The user created a new library, but did not save the library. Thus, we had no path to resolve the (absolute) filename.

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
