### PR TITLE
Additional code to handle discarded changes

### DIFF
--- a/File not found
+++ b/File not found
@@ -1,0 +1,7 @@
+@Article{,
+  author = {Test1-abc},
+  title  = {Test1},
+  month  = may,
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
Fix #9361


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
