### PR TITLE
Fixed controls outgrow preferences dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue that JabRef displayed the wrong group tree after loading. [koppor#637](https://github.com/koppor/jabref/issues/637)
 - We fixed an issue when using an unsafe character in the citation key, the auto-linking feature fails to link files. [#9267](https://github.com/JabRef/jabref/issues/9267)
 - We fixed an issue where a known journal's medline/dot-less abbreviation does not switch to the full name. [#9370](https://github.com/JabRef/jabref/issues/9370)
+- We fixed an issue where controls in the preferences dialog could outgrow the window. [#9017](https://github.com/JabRef/jabref/issues/9017)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -93,7 +93,7 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         EasyBind.subscribe(preferenceTabList.getSelectionModel().selectedItemProperty(), tab -> {
             if (tab instanceof AbstractPreferenceTabView<?> preferencesTab) {
                 preferencesContainer.setContent(preferencesTab.getBuilder());
-                preferencesTab.prefWidthProperty().bind(preferencesContainer.widthProperty());
+                preferencesTab.prefWidthProperty().bind(preferencesContainer.widthProperty().subtract(10d));
                 preferencesTab.getStyleClass().add("preferencesTab");
             } else {
                 preferencesContainer.setContent(null);


### PR DESCRIPTION
Fixed #9017 
Closes #9242 

Just a little bit more space to breathe (10 px)

before:

<img width="513" alt="JabRef_lrfBF3mFV6" src="https://user-images.githubusercontent.com/23321102/182543335-c1ac5a70-cf67-402d-8f1b-b069ef4a9ee1.png">

after:

![grafik](https://user-images.githubusercontent.com/50491877/208193589-4ea962a6-0bf2-4801-a6eb-18cb822ad768.png)



- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
