### PR TITLE
Disable DoiToBibtexConverterComIsbnFetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added a warning message next to the authors field in the merge dialog to warn users when the authors are the same but formatted differently. [#8745](https://github.com/JabRef/jabref/issues/8745)
 - The properties of an existing systematic literature review can be edited. [koppor#604](https://github.com/koppor/jabref/issues/604)
 - An SLR can now be started from the SLR itself. [#9131](https://github.com/JabRef/jabref/pull/9131), [koppor#601](https://github.com/koppor/jabref/issues/601)
-- Implement a new ISBN Fetcher ([doi-to-bibtex-converter.herokuapp.com](http://doi-to-bibtex-converter.herokuapp.com) as source). [#9145](https://github.com/JabRef/jabref/pull/9145)
 - We added support for the Ukrainian and Arabic languages. [#9236](https://github.com/JabRef/jabref/pull/9236), [#9243](https://github.com/JabRef/jabref/pull/9243)
 - The default file directory of a library is used as default directory for [unlinked file lookup](https://docs.jabref.org/collect/findunlinkedfiles#link-the-pdfs-to-your-bib-library). [koppor#546](https://github.com/koppor/jabref/issues/546)
 - We added support for the field `fjournal` (in `@article`) for abbreviation and unabbreviation functionalities. [#321](https://github.com/JabRef/jabref/pull/321)
@@ -102,7 +101,6 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Removed
 
 - We removed "last-search-date" from the SLR feature, because the last-search-date can be deducted from the git logs. [#9116](https://github.com/JabRef/jabref/pull/9116)
-- We removed the doi-to-bibtex fetcher based on <https://doi-to-bibtex-converter.herokuapp.com>, because the site is down.
 - We removed the [CiteseerX](https://docs.jabref.org/collect/import-using-online-bibliographic-database#citeseerx) fetcher, because the API used by JabRef is sundowned.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Removed
 
 - We removed "last-search-date" from the SLR feature, because the last-search-date can be deducted from the git logs. [#9116](https://github.com/JabRef/jabref/pull/9116)
-
+- We removed the doi-to-bibtex fetcher based on <https://doi-to-bibtex-converter.herokuapp.com>, because the site is down.
 
 
 

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import org.jabref.logic.importer.fetcher.ArXivFetcher;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
-import org.jabref.logic.importer.fetcher.isbntobibtex.DoiToBibtexConverterComIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.EbookDeIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
 import org.jabref.model.entry.BibEntry;

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -33,7 +33,7 @@ public class CompositeIdFetcher {
         if (isbn.isPresent()) {
             return new IsbnFetcher(importFormatPreferences)
                     .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences))
-                    .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences))
+                    // .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences))
                     .performSearchById(isbn.get().getNormalized());
         }
         /* TODO: IACR is currently disabled, because it needs to be reworked: https://github.com/JabRef/jabref/issues/8876

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -41,7 +41,6 @@ import org.jabref.logic.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fetcher.SpringerLink;
 import org.jabref.logic.importer.fetcher.TitleFetcher;
 import org.jabref.logic.importer.fetcher.ZbMATH;
-import org.jabref.logic.importer.fetcher.isbntobibtex.DoiToBibtexConverterComIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.EbookDeIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
 import org.jabref.logic.importer.fileformat.PdfMergeMetadataImporter;
@@ -67,8 +66,8 @@ public class WebFetchers {
             fetcher = new DoiFetcher(importFormatPreferences);
         } else if (field == ISBN) {
             fetcher = new IsbnFetcher(importFormatPreferences)
-                    .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences))
-                    .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences));
+                    .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences));
+                    // .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences));
         } else if (field == EPRINT) {
             fetcher = new ArXivFetcher(importFormatPreferences);
         } else {
@@ -132,8 +131,8 @@ public class WebFetchers {
         set.add(new ArXivFetcher(importFormatPreferences));
         set.add(new AstrophysicsDataSystem(importFormatPreferences, importerPreferences));
         set.add(new IsbnFetcher(importFormatPreferences)
-                .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences))
-                .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences)));
+                .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences)));
+                // .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences)));
         set.add(new DiVA(importFormatPreferences));
         set.add(new DoiFetcher(importFormatPreferences));
         set.add(new MedlineFetcher());
@@ -160,8 +159,8 @@ public class WebFetchers {
         set.add(new AstrophysicsDataSystem(importFormatPreferences, importerPreferences));
         set.add(new DoiFetcher(importFormatPreferences));
         set.add(new IsbnFetcher(importFormatPreferences)
-                .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences))
-                .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences)));
+                .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences)));
+                // .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences)));
         set.add(new MathSciNet(importFormatPreferences));
         set.add(new CrossRef());
         set.add(new ZbMATH(importFormatPreferences));

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -13,7 +13,6 @@ import org.jabref.logic.importer.fetcher.ApsFetcher;
 import org.jabref.logic.importer.fetcher.ArXivFetcher;
 import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
 import org.jabref.logic.importer.fetcher.BiodiversityLibrary;
-import org.jabref.logic.importer.fetcher.CiteSeer;
 import org.jabref.logic.importer.fetcher.CollectionOfComputerScienceBibliographiesFetcher;
 import org.jabref.logic.importer.fetcher.CompositeSearchBasedFetcher;
 import org.jabref.logic.importer.fetcher.CrossRef;

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -17,7 +17,6 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.Importer;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
-import org.jabref.logic.importer.fetcher.isbntobibtex.DoiToBibtexConverterComIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.EbookDeIsbnFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
 import org.jabref.logic.importer.util.FileFieldParser;
@@ -100,7 +99,7 @@ public class PdfMergeMetadataImporter extends Importer {
                 try {
                     new IsbnFetcher(importFormatPreferences)
                             .addRetryFetcher(new EbookDeIsbnFetcher(importFormatPreferences))
-                            .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences))
+                            // .addRetryFetcher(new DoiToBibtexConverterComIsbnFetcher(importFormatPreferences))
                             .performSearchById(candidate.getField(StandardField.ISBN).get()).ifPresent(fetchedCandidates::add);
                 } catch (FetcherException e) {
                     LOGGER.error("Fetching failed for ISBN \"{}\".", candidate.getField(StandardField.ISBN).get(), e);

--- a/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SemanticScholarTest.java
@@ -175,4 +175,11 @@ public class SemanticScholarTest implements PagedSearchFetcherTest {
         actual.clearField(StandardField.ABSTRACT);
         assertEquals(barrosEntry, actual);
     }
+
+    @Test
+    @Override
+    @DisabledOnCIServer("Unstable on CI")
+    public void pageSearchReturnsUniqueResultsPerPage() throws Exception {
+        // Implementation is done in the interface
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/DoiToBibtexConverterComIsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/DoiToBibtexConverterComIsbnFetcherTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+@Disabled("Page https://doi-to-bibtex-converter.herokuapp.com is down")
 @FetcherTest
 public class DoiToBibtexConverterComIsbnFetcherTest extends AbstractIsbnFetcherTest {
 


### PR DESCRIPTION
The DoiToBibtexConverterComIsbnFetcher fetcher bases on https://doi-to-bibtex-converter.herokuapp.com/. That page is sort of 404:

![grafik](https://user-images.githubusercontent.com/1366654/208266031-801451c7-8daf-453a-b096-bdd3c87fc109.png)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
