### PR TITLE
Fixed ZBMathTest and extracted keyWordSeparator

### DIFF
--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -385,7 +385,7 @@ public class StudyRepository {
      * @param crawlResults The results that shall be persisted.
      */
     private void persistResults(List<QueryResult> crawlResults) throws IOException, SaveException {
-        DatabaseMerger merger = new DatabaseMerger(importFormatPreferences.getKeywordSeparator());
+        DatabaseMerger merger = new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
         BibDatabase newStudyResultEntries = new BibDatabase();
 
         for (QueryResult result : crawlResults) {

--- a/src/main/java/org/jabref/logic/importer/ImportFormatPreferences.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatPreferences.java
@@ -1,8 +1,5 @@
 package org.jabref.logic.importer;
 
-import javafx.beans.property.ReadOnlyObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-
 import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.importer.fetcher.GrobidPreferences;
@@ -10,62 +7,11 @@ import org.jabref.logic.preferences.DOIPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.preferences.BibEntryPreferences;
 
-public class ImportFormatPreferences {
-
-    private final ReadOnlyObjectProperty<BibEntryPreferences> bibEntryPreferences;
-    private final CitationKeyPatternPreferences citationKeyPatternPreferences;
-    private final FieldContentFormatterPreferences fieldContentFormatterPreferences;
-    private final XmpPreferences xmpPreferences;
-    private final DOIPreferences doiPreferences;
-    private final GrobidPreferences grobidPreferences;
-
-    public ImportFormatPreferences(BibEntryPreferences bibEntryPreferences,
-                                   CitationKeyPatternPreferences citationKeyPatternPreferences,
-                                   FieldContentFormatterPreferences fieldContentFormatterPreferences,
-                                   XmpPreferences xmpPreferences,
-                                   DOIPreferences doiPreferences,
-                                   GrobidPreferences grobidPreferences) {
-        this.bibEntryPreferences = new SimpleObjectProperty<>(bibEntryPreferences);
-        this.citationKeyPatternPreferences = citationKeyPatternPreferences;
-        this.fieldContentFormatterPreferences = fieldContentFormatterPreferences;
-        this.xmpPreferences = xmpPreferences;
-        this.doiPreferences = doiPreferences;
-        this.grobidPreferences = grobidPreferences;
-    }
-
-    public DOIPreferences getDoiPreferences() {
-        return doiPreferences;
-    }
-
-    public ReadOnlyObjectProperty<BibEntryPreferences> bibEntryPreferencesProperty() {
-        return bibEntryPreferences;
-    }
-
-    public BibEntryPreferences getBibEntryPreferences() {
-        return bibEntryPreferences.getValue();
-    }
-
-    /**
-     * @deprecated use {@link BibEntryPreferences#getKeywordSeparator} instead.
-     */
-    @Deprecated
-    public Character getKeywordSeparator() {
-        return bibEntryPreferencesProperty().getValue().getKeywordSeparator();
-    }
-
-    public CitationKeyPatternPreferences getCitationKeyPatternPreferences() {
-        return citationKeyPatternPreferences;
-    }
-
-    public FieldContentFormatterPreferences getFieldContentFormatterPreferences() {
-        return fieldContentFormatterPreferences;
-    }
-
-    public XmpPreferences getXmpPreferences() {
-        return xmpPreferences;
-    }
-
-    public GrobidPreferences getGrobidPreferences() {
-        return grobidPreferences;
-    }
+public record ImportFormatPreferences(
+        BibEntryPreferences bibEntryPreferences,
+        CitationKeyPatternPreferences citationKeyPatternPreferences,
+        FieldContentFormatterPreferences fieldContentFormatterPreferences,
+        XmpPreferences xmpPreferences,
+        DOIPreferences doiPreferences,
+        GrobidPreferences grobidPreferences) {
 }

--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -73,10 +73,10 @@ public class ImportFormatReader {
         formats.add(new PdfVerbatimBibTextImporter(importFormatPreferences));
         formats.add(new PdfContentImporter(importFormatPreferences));
         formats.add(new PdfEmbeddedBibFileImporter(importFormatPreferences));
-        if (importFormatPreferences.getGrobidPreferences().isGrobidEnabled()) {
+        if (importFormatPreferences.grobidPreferences().isGrobidEnabled()) {
             formats.add(new PdfGrobidImporter(importFormatPreferences));
         }
-        formats.add(new PdfXmpImporter(importFormatPreferences.getXmpPreferences()));
+        formats.add(new PdfXmpImporter(importFormatPreferences.xmpPreferences()));
         formats.add(new RepecNepImporter(importFormatPreferences));
         formats.add(new RisImporter());
         formats.add(new SilverPlatterImporter());

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -12,12 +12,7 @@ import org.jabref.migrations.PostOpenMigration;
 import org.jabref.migrations.SpecialFieldsToSeparateFields;
 import org.jabref.model.util.FileUpdateMonitor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class OpenDatabase {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenDatabase.class);
 
     private OpenDatabase() {
     }
@@ -32,7 +27,7 @@ public class OpenDatabase {
             throws IOException {
         ParserResult result = new BibtexImporter(importFormatPreferences, fileMonitor).importDatabase(fileToOpen);
 
-        performLoadDatabaseMigrations(result, importFormatPreferences.getKeywordSeparator());
+        performLoadDatabaseMigrations(result, importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
 
         return result;
     }

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -186,7 +186,7 @@ public class WebFetchers {
         Set<FulltextFetcher> fetchers = new HashSet<>();
 
         // Original
-        fetchers.add(new DoiResolution(importFormatPreferences.getDoiPreferences()));
+        fetchers.add(new DoiResolution(importFormatPreferences.doiPreferences()));
 
         // Publishers
         fetchers.add(new ScienceDirect(importerPreferences));

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -148,7 +148,10 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                 allKeywords = Optional.of(allKeywords.get().replaceAll(entry.getKey(), entry.getValue()));
             }
 
-            String filteredKeywords = KeywordList.merge(allKeywords.get(), "", importFormatPreferences.getKeywordSeparator()).toString();
+            String filteredKeywords = KeywordList.merge(
+                    allKeywords.get(),
+                    "",
+                    importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).toString();
             bibEntry.setField(StandardField.KEYWORDS, filteredKeywords);
         }
     }
@@ -596,9 +599,10 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
         public Page<BibEntry> performSearchPaged(QueryNode luceneQuery, int pageNumber) throws FetcherException {
             ArXivQueryTransformer transformer = new ArXivQueryTransformer();
             String transformedQuery = transformer.transformLuceneQuery(luceneQuery).orElse("");
-            List<BibEntry> searchResult = searchForEntries(transformedQuery, pageNumber).stream()
-                                                                                        .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.getKeywordSeparator()))
-                                                                                        .collect(Collectors.toList());
+            List<BibEntry> searchResult = searchForEntries(transformedQuery, pageNumber)
+                    .stream()
+                    .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()))
+                    .collect(Collectors.toList());
             return new Page<>(transformedQuery, pageNumber, filterYears(searchResult, transformer));
         }
 
@@ -624,7 +628,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
         @Override
         public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
             return searchForEntryById(identifier)
-                    .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.getKeywordSeparator()));
+                    .map((arXivEntry) -> arXivEntry.toBibEntry(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()));
         }
 
         @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/DOAJFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DOAJFetcher.java
@@ -211,7 +211,7 @@ public class DOAJFetcher implements SearchBasedParserFetcher {
                 JSONArray results = jsonObject.getJSONArray("results");
                 for (int i = 0; i < results.length(); i++) {
                     JSONObject bibJsonEntry = results.getJSONObject(i).getJSONObject("bibjson");
-                    BibEntry entry = parseBibJSONtoBibtex(bibJsonEntry, preferences.getKeywordSeparator());
+                    BibEntry entry = parseBibJSONtoBibtex(bibJsonEntry, preferences.bibEntryPreferences().getKeywordSeparator());
                     entries.add(entry);
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -214,7 +214,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
                 JSONArray results = jsonObject.getJSONArray("articles");
                 for (int i = 0; i < results.length(); i++) {
                     JSONObject jsonEntry = results.getJSONObject(i);
-                    BibEntry entry = parseJsonResponse(jsonEntry, importFormatPreferences.getKeywordSeparator());
+                    BibEntry entry = parseJsonResponse(jsonEntry, importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
                     boolean addEntry;
                     // In case entry has no year, add it
                     // In case an entry has a year, check if its in the year range

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -83,7 +83,7 @@ public class BibtexParser implements Parser {
 
     public BibtexParser(ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) {
         this.importFormatPreferences = Objects.requireNonNull(importFormatPreferences);
-        fieldContentFormatter = new FieldContentFormatter(importFormatPreferences.getFieldContentFormatterPreferences());
+        fieldContentFormatter = new FieldContentFormatter(importFormatPreferences.fieldContentFormatterPreferences());
         metaDataParser = new MetaDataParser(fileMonitor);
     }
 
@@ -228,7 +228,7 @@ public class BibtexParser implements Parser {
 
         // Instantiate meta data
         try {
-            parserResult.setMetaData(metaDataParser.parse(meta, importFormatPreferences.getBibEntryPreferences().getKeywordSeparator()));
+            parserResult.setMetaData(metaDataParser.parse(meta, importFormatPreferences.bibEntryPreferences().getKeywordSeparator()));
         } catch (ParseException exception) {
             parserResult.addException(exception);
         }
@@ -611,7 +611,7 @@ public class BibtexParser implements Parser {
                     entry.setField(field, entry.getField(field).get() + " and " + content);
                 } else if (StandardField.KEYWORDS.equals(field)) {
                     // multiple keywords fields should be combined to one
-                    entry.addKeyword(content, importFormatPreferences.getBibEntryPreferences().getKeywordSeparator());
+                    entry.addKeyword(content, importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
                 }
             } else {
                 entry.setField(field, content);

--- a/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporter.java
@@ -28,6 +28,7 @@ import org.jabref.logic.importer.fileformat.endnote.Contributors;
 import org.jabref.logic.importer.fileformat.endnote.Dates;
 import org.jabref.logic.importer.fileformat.endnote.ElectronicResourceNum;
 import org.jabref.logic.importer.fileformat.endnote.Isbn;
+import org.jabref.logic.importer.fileformat.endnote.Keyword;
 import org.jabref.logic.importer.fileformat.endnote.Keywords;
 import org.jabref.logic.importer.fileformat.endnote.Label;
 import org.jabref.logic.importer.fileformat.endnote.Notes;
@@ -212,7 +213,7 @@ public class EndnoteXmlImporter extends Importer implements Parser {
                 .ifPresent(value -> entry.setField(StandardField.NOTE, value.trim()));
         getUrl(endNoteRecord)
                 .ifPresent(value -> entry.setField(StandardField.URL, value));
-        entry.putKeywords(getKeywords(endNoteRecord), preferences.getKeywordSeparator());
+        entry.putKeywords(getKeywords(endNoteRecord), preferences.bibEntryPreferences().getKeywordSeparator());
         Optional.ofNullable(endNoteRecord.getAbstract())
                 .map(Abstract::getStyle)
                 .map(Style::getContent)
@@ -307,9 +308,9 @@ public class EndnoteXmlImporter extends Importer implements Parser {
         if (keywords != null) {
             return keywords.getKeyword()
                            .stream()
-                           .map(keyword -> keyword.getStyle())
+                           .map(Keyword::getStyle)
                            .filter(Objects::nonNull)
-                           .map(style -> style.getContent())
+                           .map(Style::getContent)
                            .collect(Collectors.toList());
         } else {
             return Collections.emptyList();

--- a/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
@@ -81,7 +81,7 @@ public class ModsImporter extends Importer implements Parser {
     private JAXBContext context;
 
     public ModsImporter(ImportFormatPreferences importFormatPreferences) {
-        keywordSeparator = importFormatPreferences.getKeywordSeparator() + " ";
+        keywordSeparator = importFormatPreferences.bibEntryPreferences().getKeywordSeparator() + " ";
     }
 
     @Override
@@ -179,7 +179,7 @@ public class ModsImporter extends Importer implements Parser {
             nameDefinition.ifPresent(name -> handleAuthorsInNamePart(name, authors, fields));
 
             originInfoDefinition.ifPresent(originInfo -> originInfo
-                    .getPlaceOrPublisherOrDateIssued().stream()
+                    .getPlaceOrPublisherOrDateIssued()
                     .forEach(element -> putPlaceOrPublisherOrDate(fields, element.getName().getLocalPart(),
                             element.getValue())));
 
@@ -229,7 +229,7 @@ public class ModsImporter extends Importer implements Parser {
 
     private void parseIdentifier(Map<Field, String> fields, IdentifierDefinition identifier, BibEntry entry) {
         String type = identifier.getType();
-        if ("citekey".equals(type) && !entry.getCitationKey().isPresent()) {
+        if ("citekey".equals(type) && entry.getCitationKey().isEmpty()) {
             entry.setCitationKey(identifier.getValue());
         } else if (!"local".equals(type) && !"citekey".equals(type)) {
             // put all identifiers (doi, issn, isbn,...) except of local and citekey
@@ -381,8 +381,8 @@ public class ModsImporter extends Importer implements Parser {
 
         List<String> places = new ArrayList<>();
         placeDefinition
-                .ifPresent(place -> place.getPlaceTerm().stream().filter(placeTerm -> placeTerm.getValue() != null)
-                                         .map(PlaceTermDefinition::getValue).forEach(element -> places.add(element)));
+                .ifPresent(place -> place.getPlaceTerm().stream().map(PlaceTermDefinition::getValue)
+                                         .filter(Objects::nonNull).forEach(places::add));
         putIfListIsNotEmpty(fields, places, StandardField.ADDRESS, ", ");
 
         dateDefinition.ifPresent(date -> putDate(fields, elementName, date));

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfGrobidImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfGrobidImporter.java
@@ -25,7 +25,7 @@ public class PdfGrobidImporter extends Importer {
     private final ImportFormatPreferences importFormatPreferences;
 
     public PdfGrobidImporter(ImportFormatPreferences importFormatPreferences) {
-        this.grobidService = new GrobidService(importFormatPreferences.getGrobidPreferences());
+        this.grobidService = new GrobidService(importFormatPreferences.grobidPreferences());
         this.importFormatPreferences = importFormatPreferences;
     }
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -46,10 +46,10 @@ public class PdfMergeMetadataImporter extends Importer {
         this.metadataImporters = new ArrayList<>();
         this.metadataImporters.add(new PdfVerbatimBibTextImporter(importFormatPreferences));
         this.metadataImporters.add(new PdfEmbeddedBibFileImporter(importFormatPreferences));
-        if (importFormatPreferences.getGrobidPreferences().isGrobidEnabled()) {
+        if (importFormatPreferences.grobidPreferences().isGrobidEnabled()) {
             this.metadataImporters.add(new PdfGrobidImporter(importFormatPreferences));
         }
-        this.metadataImporters.add(new PdfXmpImporter(importFormatPreferences.getXmpPreferences()));
+        this.metadataImporters.add(new PdfXmpImporter(importFormatPreferences.xmpPreferences()));
         this.metadataImporters.add(new PdfContentImporter(importFormatPreferences));
     }
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -332,7 +332,7 @@ public class RepecNepImporter extends Importer {
                 String content = readMultipleLines(in);
                 String[] keywords = content.split("[,;]");
                 be.addKeywords(Arrays.asList(keywords),
-                        importFormatPreferences.getKeywordSeparator());
+                        importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
             } else if ("JEL".equals(keyword)) {
                 // parse JEL field
                 be.setField(new UnknownField("jel"), readMultipleLines(in));

--- a/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
+++ b/src/test/java/org/jabref/gui/entryeditor/SourceTabTest.java
@@ -22,12 +22,12 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.util.DummyFileUpdateMonitor;
-import org.jabref.preferences.BibEntryPreferences;
 import org.jabref.testutils.category.GUITest;
 
 import org.fxmisc.richtext.CodeArea;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
@@ -52,12 +52,8 @@ class SourceTabTest {
         StateManager stateManager = mock(StateManager.class);
         when(stateManager.activeSearchQueryProperty()).thenReturn(OptionalObjectProperty.empty());
         KeyBindingRepository keyBindingRepository = new KeyBindingRepository(Collections.emptyList(), Collections.emptyList());
-        BibEntryPreferences bibEntryPreferences = mock(BibEntryPreferences.class);
-        when(bibEntryPreferences.getKeywordSeparator()).thenReturn(',');
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences())
-                .thenReturn(mock(FieldContentFormatterPreferences.class));
-        when(importFormatPreferences.getBibEntryPreferences()).thenReturn(bibEntryPreferences);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
 
         sourceTab = new SourceTab(new BibDatabaseContext(), new CountingUndoManager(), fieldWriterPreferences, importFormatPreferences, new DummyFileUpdateMonitor(), mock(DialogService.class), stateManager, keyBindingRepository);

--- a/src/test/java/org/jabref/gui/slr/ManageStudyDefinitionViewModelTest.java
+++ b/src/test/java/org/jabref/gui/slr/ManageStudyDefinitionViewModelTest.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.jabref.gui.DialogService;
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.model.study.Study;
@@ -17,7 +16,6 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ManageStudyDefinitionViewModelTest {
     private ImportFormatPreferences importFormatPreferences;
@@ -29,8 +27,6 @@ class ManageStudyDefinitionViewModelTest {
         // code taken from org.jabref.logic.importer.WebFetchersTest.setUp
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         importerPreferences = mock(ImporterPreferences.class);
-        FieldContentFormatterPreferences fieldContentFormatterPreferences = mock(FieldContentFormatterPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(fieldContentFormatterPreferences);
         dialogService = mock(DialogService.class);
     }
 

--- a/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
+++ b/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
 import org.jabref.logic.exporter.SavePreferences;
@@ -100,8 +99,8 @@ class CrawlerTest {
         when(savePreferences.takeMetadataSaveOrderInAccount()).thenReturn(true);
         when(savePreferences.getCitationKeyPatternPreferences()).thenReturn(citationKeyPatternPreferences);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(new FieldContentFormatterPreferences());
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         entryTypesManager = new BibEntryTypesManager();
     }
 

--- a/src/test/java/org/jabref/logic/crawler/StudyDatabaseToFetcherConverterTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyDatabaseToFetcherConverterTest.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.exporter.SavePreferences;
 import org.jabref.logic.git.SlrGitHandler;
 import org.jabref.logic.importer.ImportFormatPreferences;
@@ -49,8 +48,7 @@ class StudyDatabaseToFetcherConverterTest {
         timestampPreferences = mock(TimestampPreferences.class);
         when(savePreferences.getSaveOrder()).thenReturn(new SaveOrderConfig());
         when(savePreferences.takeMetadataSaveOrderInAccount()).thenReturn(true);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(new FieldContentFormatterPreferences());
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
         entryTypesManager = new BibEntryTypesManager();
         gitHandler = mock(SlrGitHandler.class, Answers.RETURNS_DEFAULTS);

--- a/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -87,8 +87,8 @@ class StudyRepositoryTest {
         when(savePreferences.takeMetadataSaveOrderInAccount()).thenReturn(true);
         when(savePreferences.getCitationKeyPatternPreferences()).thenReturn(citationKeyPatternPreferences);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(new FieldContentFormatterPreferences());
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(new FieldContentFormatterPreferences());
         when(timestampPreferences.getTimestampField()).then(invocation -> StandardField.TIMESTAMP);
         entryTypesManager = new BibEntryTypesManager();
         getTestStudyRepository();
@@ -211,7 +211,7 @@ class StudyRepositoryTest {
 
     private BibDatabase getNonDuplicateBibEntryResult() {
         BibDatabase mockResults = new BibDatabase(getSpringerCloudComputingMockResults());
-        DatabaseMerger merger = new DatabaseMerger(importFormatPreferences.getKeywordSeparator());
+        DatabaseMerger merger = new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
         merger.merge(mockResults, new BibDatabase(getSpringerQuantumMockResults()));
         merger.merge(mockResults, new BibDatabase(getArXivQuantumMockResults()));
         return mockResults;

--- a/src/test/java/org/jabref/logic/database/DatabaseMergerTest.java
+++ b/src/test/java/org/jabref/logic/database/DatabaseMergerTest.java
@@ -20,6 +20,7 @@ import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -30,8 +31,8 @@ class DatabaseMergerTest {
 
     @BeforeEach
     void setUp() {
-        importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
     }
 
     @Test
@@ -49,7 +50,7 @@ class DatabaseMergerTest {
 
         BibDatabase database = new BibDatabase(List.of(entry1));
         BibDatabase other = new BibDatabase(List.of(entry2, entry3));
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).merge(database, other);
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).merge(database, other);
 
         assertEquals(List.of(entry1, entry3), database.getEntries());
     }
@@ -80,7 +81,7 @@ class DatabaseMergerTest {
 
         BibDatabase database = new BibDatabase(List.of(entry1, entry4));
         BibDatabase other = new BibDatabase(List.of(entry2, entry3));
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).merge(database, other);
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).merge(database, other);
         assertEquals(List.of(entry1, entry4), database.getEntries());
     }
 
@@ -103,8 +104,8 @@ class DatabaseMergerTest {
         source1.addString(sourceString1);
         source2.addString(sourceString2);
 
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).mergeStrings(target, source1);
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).mergeStrings(target, source2);
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeStrings(target, source1);
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeStrings(target, source2);
         // Use string representation to compare since the id will not match
         List<String> resultStringsSorted = target.getStringValues()
                 .stream()
@@ -132,7 +133,7 @@ class DatabaseMergerTest {
         source.addString(sourceString1);
         source.addString(sourceString2);
 
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).mergeStrings(target, source);
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeStrings(target, source);
         List<BibtexString> resultStringsSorted = target.getStringValues()
                 .stream()
                 .sorted((s1, s2) -> new BibtexStringComparator(false).compare(s1, s2))
@@ -155,7 +156,7 @@ class DatabaseMergerTest {
                 List.of(new ContentSelector(StandardField.AUTHOR, List.of("Test Author")),
                         new ContentSelector(StandardField.TITLE, List.of("Test Title")));
 
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).mergeMetaData(target, other, "unknown", List.of());
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeMetaData(target, other, "unknown", List.of());
 
         // Assert that content selectors are all merged
         assertEquals(expectedContentSelectors, target.getContentSelectorList());
@@ -181,7 +182,7 @@ class DatabaseMergerTest {
                         new ContentSelector(StandardField.TITLE, List.of("Test Title")));
         GroupTreeNode expectedImportedGroupNode = new GroupTreeNode(new ExplicitGroup("Imported unknown", GroupHierarchyType.INDEPENDENT, ';'));
 
-        new DatabaseMerger(importFormatPreferences.getKeywordSeparator()).mergeMetaData(target, other, "unknown", List.of());
+        new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeMetaData(target, other, "unknown", List.of());
 
         // Assert that groups of other are children of root node of target
         assertEquals(targetRootGroup, target.getGroups().get());

--- a/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
@@ -1,16 +1,13 @@
 package org.jabref.logic.exporter;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
 import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtex.FieldWriterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
-import org.jabref.logic.importer.fileformat.PdfEmbeddedBibFileImporter;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -40,17 +37,14 @@ class EmbeddedBibFilePdfExporterTest {
 
     @TempDir static Path tempDir;
 
-    private static BibEntry olly2018 = new BibEntry(StandardEntryType.Article);
-    private static BibEntry toral2006 = new BibEntry(StandardEntryType.Article);
-    private static BibEntry vapnik2000 = new BibEntry(StandardEntryType.Article);
+    private static final BibEntry olly2018 = new BibEntry(StandardEntryType.Article);
+    private static final BibEntry toral2006 = new BibEntry(StandardEntryType.Article);
+    private static final BibEntry vapnik2000 = new BibEntry(StandardEntryType.Article);
 
-    private PdfEmbeddedBibFileImporter importer;
     private EmbeddedBibFilePdfExporter exporter;
     private ImportFormatPreferences importFormatPreferences;
     private BibDatabaseMode bibDatabaseMode;
     private BibEntryTypesManager bibEntryTypesManager;
-    private FieldWriterPreferences fieldWriterPreferences;
-    private Charset encoding;
 
     private BibDatabaseContext databaseContext;
     private BibDatabase dataBase;
@@ -79,7 +73,7 @@ class EmbeddedBibFilePdfExporterTest {
         olly2018.setField(StandardField.URL, "https://www.olly2018.edu");
 
         LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
-        olly2018.setFiles(Arrays.asList(linkedFile));
+        olly2018.setFiles(List.of(linkedFile));
 
         toral2006.setField(StandardField.AUTHOR, "Toral, Antonio and Munoz, Rafael");
         toral2006.setField(StandardField.TITLE, "A proposal to automatically build and maintain gazetteers for Named Entity Recognition by using Wikipedia");
@@ -89,7 +83,7 @@ class EmbeddedBibFilePdfExporterTest {
         toral2006.setField(StandardField.OWNER, "Ich");
         toral2006.setField(StandardField.URL, "www.url.de");
 
-        toral2006.setFiles(Arrays.asList(new LinkedFile("non-existing", "path/to/nowhere.pdf", "PDF")));
+        toral2006.setFiles(List.of(new LinkedFile("non-existing", "path/to/nowhere.pdf", "PDF")));
 
         vapnik2000.setCitationKey("vapnik2000");
         vapnik2000.setField(StandardField.TITLE, "The Nature of Statistical Learning Theory");
@@ -104,20 +98,20 @@ class EmbeddedBibFilePdfExporterTest {
      */
     @BeforeEach
     void setUp() throws IOException {
-        encoding = Charset.defaultCharset();
-
         filePreferences = mock(FilePreferences.class);
         when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
 
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
+        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
 
         bibDatabaseMode = BibDatabaseMode.BIBTEX;
         bibEntryTypesManager = new BibEntryTypesManager();
-        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(true, List.of(StandardField.MONTH), new FieldContentFormatterPreferences());
+        FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(
+                true,
+                List.of(StandardField.MONTH),
+                new FieldContentFormatterPreferences());
 
-        importer = new PdfEmbeddedBibFileImporter(importFormatPreferences);
         exporter = new EmbeddedBibFilePdfExporter(bibDatabaseMode, bibEntryTypesManager, fieldWriterPreferences);
 
         databaseContext = new BibDatabaseContext();
@@ -132,13 +126,13 @@ class EmbeddedBibFilePdfExporterTest {
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithValidPdfFileLinks")
     void successfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, Arrays.asList(olly2018)));
+        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
     }
 
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithInvalidPdfFileLinks")
     void unsuccessfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, Arrays.asList(olly2018)));
+        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
     }
 
     public static Stream<Arguments> provideBibEntriesWithValidPdfFileLinks() {
@@ -180,8 +174,6 @@ class EmbeddedBibFilePdfExporterTest {
             pdf.save(pdfFile.toAbsolutePath().toString());
         }
 
-        LinkedFile linkedFile = new LinkedFile("A linked pdf", pdfFile, "PDF");
-
-        return linkedFile;
+        return new LinkedFile("A linked pdf", pdfFile, "PDF");
     }
 }

--- a/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
@@ -7,7 +7,6 @@ import java.util.stream.Stream;
 
 import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.bibtex.FieldWriterPreferences;
-import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,14 +35,11 @@ class EmbeddedBibFilePdfExporterTest {
 
     @TempDir static Path tempDir;
 
-    private static final BibEntry olly2018 = new BibEntry(StandardEntryType.Article);
-    private static final BibEntry toral2006 = new BibEntry(StandardEntryType.Article);
-    private static final BibEntry vapnik2000 = new BibEntry(StandardEntryType.Article);
+    private static BibEntry olly2018 = new BibEntry(StandardEntryType.Article);
+    private static BibEntry toral2006 = new BibEntry(StandardEntryType.Article);
+    private static BibEntry vapnik2000 = new BibEntry(StandardEntryType.Article);
 
     private EmbeddedBibFilePdfExporter exporter;
-    private ImportFormatPreferences importFormatPreferences;
-    private BibDatabaseMode bibDatabaseMode;
-    private BibEntryTypesManager bibEntryTypesManager;
 
     private BibDatabaseContext databaseContext;
     private BibDatabase dataBase;
@@ -102,11 +97,8 @@ class EmbeddedBibFilePdfExporterTest {
         when(filePreferences.getUser()).thenReturn(tempDir.toAbsolutePath().toString());
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
 
-        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
-
-        bibDatabaseMode = BibDatabaseMode.BIBTEX;
-        bibEntryTypesManager = new BibEntryTypesManager();
+        BibDatabaseMode bibDatabaseMode = BibDatabaseMode.BIBTEX;
+        BibEntryTypesManager bibEntryTypesManager = new BibEntryTypesManager();
         FieldWriterPreferences fieldWriterPreferences = new FieldWriterPreferences(
                 true,
                 List.of(StandardField.MONTH),

--- a/src/test/java/org/jabref/logic/exporter/ModsExportFormatFilesTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ModsExportFormatFilesTest.java
@@ -14,18 +14,19 @@ import org.jabref.logic.importer.fileformat.ModsImporter;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.preferences.BibEntryPreferences;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ModsExportFormatFilesTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModsExportFormatFilesTest.class);
@@ -52,16 +53,19 @@ public class ModsExportFormatFilesTest {
 
     @BeforeEach
     public void setUp(@TempDir Path testFolder) throws Exception {
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences()).thenReturn(mock(BibEntryPreferences.class));
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
         exporter = new ModsExporter();
+        bibtexImporter = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor());
+        modsImporter = new ModsImporter(importFormatPreferences);
+
         Path path = testFolder.resolve("ARandomlyNamedFile.tmp");
         Files.createFile(path);
         exportedFile = path.toAbsolutePath();
-        ImportFormatPreferences mock = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        bibtexImporter = new BibtexImporter(mock, new DummyFileUpdateMonitor());
-        Mockito.when(mock.getKeywordSeparator()).thenReturn(',');
-        modsImporter = new ModsImporter(mock);
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/logic/importer/ImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImporterTest.java
@@ -27,6 +27,7 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -105,7 +106,8 @@ public class ImporterTest {
         // all classes implementing {@link Importer}
         // sorted alphabetically
 
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         XmpPreferences xmpPreferences = mock(XmpPreferences.class);
         // @formatter:off
         return Stream.of(

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.fetcher.AbstractIsbnFetcher;
 import org.jabref.logic.importer.fetcher.CiteSeer;
 import org.jabref.logic.importer.fetcher.GoogleScholar;
@@ -30,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class WebFetchersTest {
 
@@ -45,8 +43,6 @@ class WebFetchersTest {
     void setUp() {
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         importerPreferences = mock(ImporterPreferences.class);
-        FieldContentFormatterPreferences fieldContentFormatterPreferences = mock(FieldContentFormatterPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(fieldContentFormatterPreferences);
     }
 
     private Set<Class<?>> getIgnoredInaccessibleClasses() {
@@ -56,7 +52,7 @@ class WebFetchersTest {
                          try {
                              return Class.forName(classPath);
                          } catch (ClassNotFoundException e) {
-                             LOGGER.error("Some of the ignored classes were not found {}", e);
+                             LOGGER.error("Some of the ignored classes were not found", e);
                              return null;
                          }
                      }).filter(Objects::nonNull).collect(Collectors.toSet());

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,10 +54,10 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
 
     @BeforeAll
     static void setUp() {
-        importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         // Used during DOI fetch process
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(
                 new FieldContentFormatterPreferences(
                         Arrays.stream("pdf;ps;url;doi;file;isbn;issn".split(";"))
                               .map(fieldName -> StandardField.fromName(fieldName).isPresent() ? StandardField.fromName(fieldName).get() : new UnknownField(fieldName))
@@ -104,6 +105,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
                 .withField(StandardField.DOI, "10.48550/ARXIV.1811.10364");
 
         // Example of a robust result, with information from both ArXiv-assigned and user-assigned DOIs
+        // FixMe: Test this BibEntry
         completePaper = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Büscher, Tobias and Diez, Angel L. and Gompper, Gerhard and Elgeti, Jens")
                 .withField(StandardField.TITLE, "Instability and fingering of interfaces in growing tissue")

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 
 import javafx.collections.FXCollections;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedFetcher;
@@ -17,6 +16,7 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,11 +37,10 @@ public class AstrophysicsDataSystemTest implements PagedSearchFetcherTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(
-                mock(FieldContentFormatterPreferences.class));
+
         fetcher = new AstrophysicsDataSystem(importFormatPreferences, importerPreferences);
 
         diezSliceTheoremEntry = new BibEntry(StandardEntryType.Article)

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -40,7 +40,7 @@ public class AstrophysicsDataSystemTest implements PagedSearchFetcherTest {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(
                 mock(FieldContentFormatterPreferences.class));
         fetcher = new AstrophysicsDataSystem(importFormatPreferences, importerPreferences);
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/CollectionOfComputerScienceBibliographiesFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CollectionOfComputerScienceBibliographiesFetcherTest.java
@@ -34,7 +34,7 @@ class CollectionOfComputerScienceBibliographiesFetcherTest {
     @BeforeEach
     public void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         fetcher = new CollectionOfComputerScienceBibliographiesFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/CollectionOfComputerScienceBibliographiesParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CollectionOfComputerScienceBibliographiesParserTest.java
@@ -39,7 +39,7 @@ public class CollectionOfComputerScienceBibliographiesParserTest {
 
     private void parseXmlAndCheckResults(String xmlName, List<String> resourceNames) throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
 
         InputStream is = CollectionOfComputerScienceBibliographiesParserTest.class.getResourceAsStream(xmlName);
         CollectionOfComputerScienceBibliographiesParser parser = new CollectionOfComputerScienceBibliographiesParser(importFormatPreferences);

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.CompositeIdFetcher;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
@@ -19,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -104,11 +104,9 @@ class CompositeIdFetcherTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        FieldContentFormatterPreferences fieldContentFormatterPreferences = mock(FieldContentFormatterPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(fieldContentFormatterPreferences);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         // Needed for ArXiv Fetcher keyword processing
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         compositeIdFetcher = new CompositeIdFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import javafx.collections.FXCollections;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportCleanup;
 import org.jabref.logic.importer.ImportFormatPreferences;
@@ -25,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,11 +92,9 @@ public class CompositeSearchBasedFetcherTest {
      * @return A stream of Arguments wrapping set of fetchers.
      */
     static Stream<Arguments> performSearchParameters() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        when(importFormatPreferences.getFieldContentFormatterPreferences())
-                .thenReturn(mock(FieldContentFormatterPreferences.class));
         List<Set<SearchBasedFetcher>> fetcherParameters = new ArrayList<>();
 
         List<SearchBasedFetcher> list = List.of(

--- a/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
@@ -14,10 +13,10 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @FetcherTest
 public class DBLPFetcherTest {
@@ -27,10 +26,7 @@ public class DBLPFetcherTest {
 
     @BeforeEach
     public void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences())
-                .thenReturn(mock(FieldContentFormatterPreferences.class));
-        dblpFetcher = new DBLPFetcher(importFormatPreferences);
+        dblpFetcher = new DBLPFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
         entry = new BibEntry();
 
         entry.setType(StandardEntryType.Article);

--- a/src/test/java/org/jabref/logic/importer/fetcher/DOAJFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DOAJFetcherTest.java
@@ -14,6 +14,7 @@ import kong.unirest.json.JSONObject;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -26,8 +27,8 @@ class DOAJFetcherTest {
 
     @BeforeEach
     void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         fetcher = new DOAJFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.PagedSearchBasedFetcher;
@@ -19,10 +18,10 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @FetcherTest
 @DisabledOnCIServer("CI server is blocked by Google")
@@ -33,9 +32,7 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
 
     @BeforeEach
     void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
-                mock(FieldContentFormatterPreferences.class));
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         finder = new GoogleScholar(importFormatPreferences);
         entry = new BibEntry();
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
@@ -18,6 +18,7 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -48,10 +49,12 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
 
     @BeforeEach
     void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
+
         fetcher = new IEEE(importFormatPreferences, importerPreferences);
         entry = new BibEntry();
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.importer.fetcher;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -13,10 +12,10 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @FetcherTest
 class INSPIREFetcherTest {
@@ -25,8 +24,7 @@ class INSPIREFetcherTest {
 
     @BeforeEach
     void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(mock(FieldContentFormatterPreferences.class));
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         fetcher = new INSPIREFetcher(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/LibraryOfCongressTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/LibraryOfCongressTest.java
@@ -7,6 +7,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
+import org.jabref.preferences.BibEntryPreferences;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,9 +25,11 @@ public class LibraryOfCongressTest {
 
     @BeforeEach
     public void setUp() {
-        ImportFormatPreferences prefs = mock(ImportFormatPreferences.class);
-        when(prefs.getKeywordSeparator()).thenReturn(',');
-        fetcher = new LibraryOfCongress(prefs);
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
+        when(importFormatPreferences.bibEntryPreferences()).thenReturn(mock(BibEntryPreferences.class));
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
+        fetcher = new LibraryOfCongress(importFormatPreferences);
     }
 
     @Test
@@ -55,7 +58,7 @@ public class LibraryOfCongressTest {
     }
 
     @Test
-    public void performSearchByInvalidId() throws Exception {
+    public void performSearchByInvalidId() {
         assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("xxx"));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
@@ -29,7 +29,7 @@ class MathSciNetTest {
     @BeforeEach
     void setUp() throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
+        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(
                 mock(FieldContentFormatterPreferences.class));
         fetcher = new MathSciNet(importFormatPreferences);
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MathSciNetTest.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -14,6 +13,7 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -28,9 +28,9 @@ class MathSciNetTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.fieldContentFormatterPreferences()).thenReturn(
-                mock(FieldContentFormatterPreferences.class));
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         fetcher = new MathSciNet(importFormatPreferences);
 
         ratiuEntry = new BibEntry();

--- a/src/test/java/org/jabref/logic/importer/fetcher/ZbMATHTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ZbMATHTest.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.bibtex.FieldContentFormatterPreferences;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -14,6 +13,7 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -26,9 +26,9 @@ class ZbMATHTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getFieldContentFormatterPreferences()).thenReturn(
-                mock(FieldContentFormatterPreferences.class));
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         fetcher = new ZbMATH(importFormatPreferences);
 
         donaldsonEntry = new BibEntry();

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -54,7 +54,6 @@ import org.jabref.model.groups.WordKeywordGroup;
 import org.jabref.model.metadata.SaveOrderConfig;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.model.util.FileUpdateMonitor;
-import org.jabref.preferences.BibEntryPreferences;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,10 +77,7 @@ class BibtexParserTest {
     @BeforeEach
     void setUp() {
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        BibEntryPreferences bibEntryPreferences = mock(BibEntryPreferences.class);
-
-        when(importFormatPreferences.getBibEntryPreferences()).thenReturn(bibEntryPreferences);
-        when(importFormatPreferences.getBibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         parser = new BibtexParser(importFormatPreferences, new DummyFileUpdateMonitor());
     }
 
@@ -1133,7 +1129,7 @@ class BibtexParserTest {
 
     @Test
     void parsePreservesMultipleSpacesInNonWrappableField() throws IOException {
-        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields())
+        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields())
                 .thenReturn(List.of(StandardField.FILE));
         BibtexParser parser = new BibtexParser(importFormatPreferences, fileMonitor);
         ParserResult result = parser

--- a/src/test/java/org/jabref/logic/importer/fileformat/CitaviXmlImporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/CitaviXmlImporterTestFiles.java
@@ -4,21 +4,13 @@ import java.io.IOException;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.jabref.logic.importer.ImportFormatPreferences;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CitaviXmlImporterTestFiles {
 
     private static final String FILE_ENDING = ".ctv6bak";
     private final CitaviXmlImporter citaviXmlImporter = new CitaviXmlImporter();
-
-    private ImportFormatPreferences preferences;
 
     private static Stream<String> fileNames() throws IOException {
         Predicate<String> fileName = name -> name.startsWith("CitaviXmlImporterTest") && name.endsWith(FILE_ENDING);
@@ -28,12 +20,6 @@ public class CitaviXmlImporterTestFiles {
     private static Stream<String> invalidFileNames() throws IOException {
         Predicate<String> fileName = name -> !name.startsWith("CitaviXmlImporterTest");
         return ImporterTestEngine.getTestFiles(fileName).stream();
-    }
-
-    @BeforeEach
-    void setUp() {
-        preferences = mock(ImportFormatPreferences.class);
-        when(preferences.getKeywordSeparator()).thenReturn(';');
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/EndnoteXmlImporterTestFiles.java
@@ -9,6 +9,7 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -16,7 +17,7 @@ import static org.mockito.Mockito.when;
 public class EndnoteXmlImporterTestFiles {
 
     private static final String FILE_ENDING = ".xml";
-    private ImportFormatPreferences preferences;
+    private ImportFormatPreferences importFormatPreferences;
 
     private static Stream<String> fileNames() throws IOException {
         Predicate<String> fileName = name -> name.startsWith("EndnoteXmlImporterTest") && name.endsWith(FILE_ENDING);
@@ -30,25 +31,25 @@ public class EndnoteXmlImporterTestFiles {
 
     @BeforeEach
     void setUp() {
-        preferences = mock(ImportFormatPreferences.class);
-        when(preferences.getKeywordSeparator()).thenReturn(';');
+        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(';');
     }
 
     @ParameterizedTest
     @MethodSource("fileNames")
     void testIsRecognizedFormat(String fileName) throws IOException {
-        ImporterTestEngine.testIsRecognizedFormat(new EndnoteXmlImporter(preferences), fileName);
+        ImporterTestEngine.testIsRecognizedFormat(new EndnoteXmlImporter(importFormatPreferences), fileName);
     }
 
     @ParameterizedTest
     @MethodSource("invalidFileNames")
     void testIsNotRecognizedFormat(String fileName) throws IOException {
-        ImporterTestEngine.testIsNotRecognizedFormat(new EndnoteXmlImporter(preferences), fileName);
+        ImporterTestEngine.testIsNotRecognizedFormat(new EndnoteXmlImporter(importFormatPreferences), fileName);
     }
 
     @ParameterizedTest
     @MethodSource("fileNames")
     void testImportEntries(String fileName) throws Exception {
-        ImporterTestEngine.testImportEntries(new EndnoteXmlImporter(preferences), fileName, FILE_ENDING);
+        ImporterTestEngine.testImportEntries(new EndnoteXmlImporter(importFormatPreferences), fileName, FILE_ENDING);
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ModsImporterTestFiles.java
@@ -27,7 +27,7 @@ class ModsImporterTestFiles {
     @BeforeEach
     void setUp() {
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfEmbeddedBibFileImporterTest.java
@@ -21,12 +21,11 @@ import static org.mockito.Mockito.when;
 class PdfEmbeddedBibFileImporterTest {
 
     private PdfEmbeddedBibFileImporter importer;
-    private ImportFormatPreferences importFormatPreferences;
 
     @BeforeEach
     void setUp() {
-        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
         importer = new PdfEmbeddedBibFileImporter(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfGrobidImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfGrobidImporterTest.java
@@ -35,8 +35,8 @@ public class PdfGrobidImporterTest {
         when(grobidPreferences.getGrobidURL()).thenReturn("http://grobid.jabref.org:8070");
 
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
-        when(importFormatPreferences.getGrobidPreferences()).thenReturn(grobidPreferences);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.grobidPreferences()).thenReturn(grobidPreferences);
 
         importer = new PdfGrobidImporter(importFormatPreferences);
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java
@@ -35,8 +35,8 @@ class PdfMergeMetadataImporterTest {
         when(grobidPreferences.getGrobidURL()).thenReturn("http://grobid.jabref.org:8070");
 
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
-        when(importFormatPreferences.getGrobidPreferences()).thenReturn(grobidPreferences);
+        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
+        when(importFormatPreferences.grobidPreferences()).thenReturn(grobidPreferences);
 
         importer = new PdfMergeMetadataImporter(importFormatPreferences);
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfVerbatimBibTextImporterTest.java
@@ -22,12 +22,11 @@ import static org.mockito.Mockito.when;
 class PdfVerbatimBibTextImporterTest {
 
     private PdfVerbatimBibTextImporter importer;
-    private ImportFormatPreferences importFormatPreferences;
 
     @BeforeEach
     void setUp() {
-        importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getFieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.fieldContentFormatterPreferences().getNonWrappableFields()).thenReturn(List.of());
         importer = new PdfVerbatimBibTextImporter(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/RepecNepImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RepecNepImporterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -24,8 +25,9 @@ public class RepecNepImporterTest {
 
     @BeforeEach
     public void setUp() {
-        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
         testImporter = new RepecNepImporter(importFormatPreferences);
     }
 

--- a/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
@@ -30,17 +30,18 @@ import static org.mockito.Mockito.when;
 public class GrobidServiceTest {
 
     private static GrobidService grobidService;
-    private static GrobidPreferences grobidPreferences = new GrobidPreferences(
-            true,
-            false,
-            "http://grobid.jabref.org:8070");
     private static ImportFormatPreferences importFormatPreferences;
 
     @BeforeAll
     public static void setup() {
-        grobidService = new GrobidService(grobidPreferences);
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
+        when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
+
+        GrobidPreferences grobidPreferences = new GrobidPreferences(
+                true,
+                false,
+                "http://grobid.jabref.org:8070");
+        grobidService = new GrobidService(grobidPreferences);
     }
 
     @Test


### PR DESCRIPTION
Follow up to #9442 

... also cleaned up tests, made ImportFormatPreferences a record and applied simple ide suggestions

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
