### PR TITLE
Update MacOS jabrefHost.py to find local installs

### DIFF
--- a/buildres/mac/jabrefHost.py
+++ b/buildres/mac/jabrefHost.py
@@ -11,11 +11,11 @@ import sys
 from pathlib import Path
 
 # We assume that this python script is located in "jabref/lib" while the executable is "jabref/bin/JabRef"
-# Note that the `which` command does not work as intended on MacOs, so the path must be hardcoded.
+# Note that the package structure is different when installed as a .app bundle on MacOs, so the path must be altered.
 script_dir = Path(__file__).resolve().parent.parent
 JABREF_PATH = script_dir / "bin/JabRef"
 if not JABREF_PATH.exists():
-    JABREF_PATH = Path( "/Applications/JabRef.app/Contents/MacOS/JabRef")
+    JABREF_PATH = script_dir / "MacOS/JabRef"
 
 if not JABREF_PATH.exists():
     logging.error("Could not determine JABREF_PATH")


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #9474

The previous MacOS hardcoded path fails if JabRef is installed to a users local applications directory rather than the system one (e.g. if the user doesn't have admin permissions). On my version of MacOS (12.6.1) and python (3.9.6) this change works correctly for local installs as well as global. The Mac app bundle is structured differently so an alternate path is still required.

If the difference in `which` behaviour is still a problem (maybe on older versions/different python versions?) the original hardcoded fallback could also be included as a final option. If that is still necessary the explanatory comment should be updated too, as should the docs to detail when the hardcoded fallback is needed and therefore when users may need to manually update it.

As mentioned on the issue thread the python script path in the browser extension JSON would still need to be updated for local installs, so I will submit a separate [PR](https://github.com/allydunham/user-documentation/tree/fix-for-issue-9474) to the docs with notes on the process. If this script can't be updated I can expand the docs update to detail the hardcoded path change required to make the browser extension work for local app installs.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
