### PR TITLE
Fix no context menu with sorting on all entries group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - The tab "deprecated fields" is shown in biblatex-mode only. [#7757](https://github.com/JabRef/jabref/issues/7757)
 - We fixed an issue where the last opened libraries were not remembered when a new unsaved libray was open as well [#9190](https://github.com/JabRef/jabref/issues/9190)
-
+- We fixed an issue where no context menu for the group "All entries" was present [forum#3682](https://discourse.jabref.org/t/how-sort-groups-a-z-not-subgroups/3682)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -447,7 +447,7 @@ public class GroupTreeView extends BorderPane {
             menu.getItems().clear();
             if (viewModel.isEditable(group)) {
                 menu.getItems().add(editGroup);
-                if (group.getChildren().size() > 0 && viewModel.canAddGroupsIn(group)) {
+                if ((group.getChildren().size() > 0) && viewModel.canAddGroupsIn(group)) {
                     menu.getItems().add(removeGroupWithSubgroups);
                     menu.getItems().add(new SeparatorMenuItem());
                     menu.getItems().add(addSubgroup);
@@ -460,6 +460,11 @@ public class GroupTreeView extends BorderPane {
                         menu.getItems().add(addSubgroup);
                     }
                 }
+            }
+            if (group.isRoot()) {
+                menu.getItems().add(addSubgroup);
+                menu.getItems().add(removeSubgroups);
+                menu.getItems().add(sortSubgroups);
             }
 
             if (viewModel.canAddEntriesIn(group)) {


### PR DESCRIPTION
Regression that was introduced in #9286  
https://discourse.jabref.org/t/how-sort-groups-a-z-not-subgroups/3682

<img width="439" alt="grafik" src="https://user-images.githubusercontent.com/320228/209451760-eebd218d-7b74-4193-9553-0a5cef877019.png">


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
