### PR TITLE
Fix date parser for year/month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - The tab "deprecated fields" is shown in biblatex-mode only. [#7757](https://github.com/JabRef/jabref/issues/7757)
 - We fixed an issue where the last opened libraries were not remembered when a new unsaved libray was open as well [#9190](https://github.com/JabRef/jabref/issues/9190)
 - We fixed an issue where no context menu for the group "All entries" was present [forum#3682](https://discourse.jabref.org/t/how-sort-groups-a-z-not-subgroups/3682)
+- We fixed an issue where entering a date in the format "YYYY/MM" in the entry editor date field caused an exception [#9492](https://github.com/JabRef/jabref/issues/9492)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.fieldeditors;
 
+import java.time.DateTimeException;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
@@ -12,7 +13,12 @@ import org.jabref.model.entry.Date;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.strings.StringUtil;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class DateEditorViewModel extends AbstractEditorViewModel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateEditorViewModel.class);
     private final DateTimeFormatter dateFormatter;
 
     public DateEditorViewModel(Field field, SuggestionProvider<?> suggestionProvider, DateTimeFormatter dateFormatter, FieldCheckers fieldCheckers) {
@@ -25,7 +31,12 @@ public class DateEditorViewModel extends AbstractEditorViewModel {
             @Override
             public String toString(TemporalAccessor date) {
                 if (date != null) {
-                    return dateFormatter.format(date);
+                    try {
+                        return dateFormatter.format(date);
+                    } catch (DateTimeException ex) {
+                        LOGGER.error("Could not format date", ex);
+                        return "";
+                    }
                 } else {
                     return "";
                 }

--- a/src/main/java/org/jabref/model/entry/Date.java
+++ b/src/main/java/org/jabref/model/entry/Date.java
@@ -33,6 +33,7 @@ public class Date {
                 "uuuu-MM-dd'T'H[:ss][xxx][xx][X]",      // covers 2018-10-03T7
                 "uuuu-M-d",                             // covers 2009-1-15
                 "uuuu-M",                               // covers 2009-11
+                "uuuu/M",                               // covers 2020/10
                 "d-M-uuuu",                             // covers 15-1-2012
                 "M-uuuu",                               // covers 1-2012
                 "M/uuuu",                               // covers 9/2015 and 09/2015
@@ -43,7 +44,6 @@ public class Date {
                 "uuuu.M.d",                             // covers 2015.1.15
                 "uuuu",                                 // covers 2015
                 "MMM, uuuu",                            // covers Jan, 2020
-                "uuuu/M",                               // covers 2020/10
                 "uuuu.MM.d"                             // covers 2015.10.15
                 );
 

--- a/src/test/java/org/jabref/model/entry/DateTest.java
+++ b/src/test/java/org/jabref/model/entry/DateTest.java
@@ -44,7 +44,8 @@ class DateTest {
                 Arguments.of(Year.of(2015), "2015"),
                 Arguments.of(YearMonth.of(2020, Month.JANUARY), "Jan, 2020"),
                 Arguments.of(LocalDate.of(2015, Month.OCTOBER, 15), "2015.10.15"),
-                Arguments.of(LocalDate.of(-10000, Month.OCTOBER, 15), "-10000-10-15")
+                Arguments.of(LocalDate.of(-10000, Month.OCTOBER, 15), "-10000-10-15"),
+                Arguments.of(YearMonth.of(2015, Month.NOVEMBER), "2015/11")
                 );
     }
 


### PR DESCRIPTION
Fixes #9492 

Basically moved the uuuu/M up, so the year does not get parsed as month 
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
