### PR TITLE
Release v5.9 preparation - set "GitVersion" explicitely

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -45,12 +45,15 @@ jobs:
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - uses: actions/checkout@v3
+      - name: Fetch all history for all tags and branches
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Run GitVersion
         id: gitversion
         shell: bash
         run: |
-          echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
+          echo "AssemblySemVer=5.9.`git rev-list v5.8..HEAD --count`" >> $GITHUB_OUTPUT
           echo "InformationalVersion=5.9--`git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git log -1 --format=%h`" >> $GITHUB_OUTPUT
           echo "Major=5" >> $GITHUB_OUTPUT
           echo "Minor=9" >> $GITHUB_OUTPUT

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -45,17 +45,14 @@ jobs:
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - name: Fetch all history for all tags and branches
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.15
-        with:
-          versionSpec: "5.x"
+      - uses: actions/checkout@v3
       - name: Run GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.15
+        run: |
+          echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
+          echo "InformationalVersion=5.9--2023-01-06" >> $GITHUB_OUTPUT
+          echo "Major=5" >> $GITHUB_OUTPUT
+          echo "Minor=9" >> $GITHUB_OUTPUT
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -48,9 +48,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run GitVersion
         id: gitversion
+        shell: bash
         run: |
           echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
-          echo "InformationalVersion=5.9--2023-01-06" >> $GITHUB_OUTPUT
+          echo "InformationalVersion=5.9--`git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git log -1 --format=%h`" >> $GITHUB_OUTPUT
           echo "Major=5" >> $GITHUB_OUTPUT
           echo "Minor=9" >> $GITHUB_OUTPUT
       - name: Set up JDK

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -61,17 +61,14 @@ jobs:
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - name: Fetch all history for all tags and branches
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.15
-        with:
-          versionSpec: "5.x"
+      - uses: actions/checkout@v3
       - name: Run GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.15
+        run: |
+          echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
+          echo "InformationalVersion=5.9--2023-01-06" >> $GITHUB_OUTPUT
+          echo "Major=5" >> $GITHUB_OUTPUT
+          echo "Minor=9" >> $GITHUB_OUTPUT
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -61,12 +61,15 @@ jobs:
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - uses: actions/checkout@v3
+      - name: Fetch all history for all tags and branches
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Run GitVersion
         id: gitversion
         shell: bash
         run: |
-          echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
+          echo "AssemblySemVer=5.9.`git rev-list v5.8..HEAD --count`" >> $GITHUB_OUTPUT
           echo "InformationalVersion=5.9--`git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git log -1 --format=%h`" >> $GITHUB_OUTPUT
           echo "Major=5" >> $GITHUB_OUTPUT
           echo "Minor=9" >> $GITHUB_OUTPUT

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -66,7 +66,7 @@ jobs:
         id: gitversion
         run: |
           echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
-          echo "InformationalVersion=5.9--2023-01-06" >> $GITHUB_OUTPUT
+          echo "InformationalVersion=5.9--` git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git show -s --format=%H`" >> $GITHUB_OUTPUT
           echo "Major=5" >> $GITHUB_OUTPUT
           echo "Minor=9" >> $GITHUB_OUTPUT
       - name: Set up JDK

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -64,9 +64,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run GitVersion
         id: gitversion
+        shell: bash
         run: |
           echo "AssemblySemVer=5.9.0" >> $GITHUB_OUTPUT
-          echo "InformationalVersion=5.9--` git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git show -s --format=%H`" >> $GITHUB_OUTPUT
+          echo "InformationalVersion=5.9--`git log -1 --pretty='format:%cd' --date=format:'%Y-%m-%d'`--`git log -1 --format=%h`" >> $GITHUB_OUTPUT
           echo "Major=5" >> $GITHUB_OUTPUT
           echo "Minor=9" >> $GITHUB_OUTPUT
       - name: Set up JDK

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 5.9
 assembly-versioning-format: '{major}.{minor}.{WeightedPreReleaseNumber}'
 assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{CommitDate}--{ShortSha}'
 mode: ContinuousDeployment

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-next-version: 5.9
 assembly-versioning-format: '{major}.{minor}.{WeightedPreReleaseNumber}'
 assembly-informational-format: '{major}.{minor}{PreReleaseTagWithDash}--{CommitDate}--{ShortSha}'
 mode: ContinuousDeployment


### PR DESCRIPTION
We set the new major version to 6 directly after the last release (https://github.com/JabRef/jabref/commit/e586da37ffec97d44d1a2209988fb5ced0b6f0c4). However, we decided to release version 5.9 inbetween. Thus, we need to rool back.

Possibilities:

- Open a separate branch, cherry-pick all commits but leave out the semver commit. -- I tried with `git rebase -i v5.8`, but that was not good
- Manually set the version

This PR implements the second approach. Note that this will NOT re-open https://github.com/JabRef/jabref/issues/5399 and https://github.com/JabRef/jabref/issues/5657 (linked from 
https://github.com/JabRef/jabref/pull/5682), because the patch number is increased by using the number of commits since the last (hard-coded) release v5.8.

Resulting about dialog:

![grafik](https://user-images.githubusercontent.com/1366654/210647482-c0b0dd9f-effd-48da-9ef0-6af8fa944324.png)

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
