### PR TITLE
Detect more cases of an entry modified in the external changes resolver dialog

### DIFF
--- a/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
@@ -68,9 +68,7 @@ public class BibDatabaseDiff {
         }
 
         // Now we've found all exact matches, look through the remaining entries, looking for close matches.
-        for (Iterator<BibEntry> iteratorNotMatched = notMatched.iterator(); iteratorNotMatched.hasNext(); ) {
-            BibEntry originalEntry = iteratorNotMatched.next();
-
+        for (BibEntry originalEntry : notMatched) {
             // These two variables will keep track of which entry most closely matches the one we're looking at.
             double bestMatch = 0;
             int bestMatchIndex = -1;
@@ -86,7 +84,6 @@ public class BibDatabaseDiff {
 
             if (bestMatch > MATCH_THRESHOLD) {
                 used.add(bestMatchIndex);
-                iteratorNotMatched.remove();
                 differences.add(new BibEntryDiff(originalEntry, newEntries.get(bestMatchIndex)));
             } else {
                 differences.add(new BibEntryDiff(originalEntry, null));

--- a/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
@@ -15,14 +15,14 @@ import org.jabref.model.entry.field.StandardField;
 public class BibDatabaseDiff {
 
     private static final double MATCH_THRESHOLD = 0.4;
-    private final Optional<MetaDataDiff> metaDataDiff;
-    private final Optional<PreambleDiff> preambleDiff;
+    private final MetaDataDiff metaDataDiff;
+    private final PreambleDiff preambleDiff;
     private final List<BibStringDiff> bibStringDiffs;
     private final List<BibEntryDiff> entryDiffs;
 
     private BibDatabaseDiff(BibDatabaseContext originalDatabase, BibDatabaseContext newDatabase) {
-        metaDataDiff = MetaDataDiff.compare(originalDatabase.getMetaData(), newDatabase.getMetaData());
-        preambleDiff = PreambleDiff.compare(originalDatabase, newDatabase);
+        metaDataDiff = MetaDataDiff.compare(originalDatabase.getMetaData(), newDatabase.getMetaData()).orElse(null);
+        preambleDiff = PreambleDiff.compare(originalDatabase, newDatabase).orElse(null);
         bibStringDiffs = BibStringDiff.compare(originalDatabase.getDatabase(), newDatabase.getDatabase());
 
         // Sort both databases according to a common sort key.
@@ -108,11 +108,11 @@ public class BibDatabaseDiff {
     }
 
     public Optional<MetaDataDiff> getMetaDataDifferences() {
-        return metaDataDiff;
+        return Optional.ofNullable(metaDataDiff);
     }
 
     public Optional<PreambleDiff> getPreambleDifferences() {
-        return preambleDiff;
+        return Optional.ofNullable(preambleDiff);
     }
 
     public List<BibStringDiff> getBibStringDifferences() {

--- a/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
@@ -106,7 +106,7 @@ public class BibDatabaseDiff {
     }
 
     private static boolean hasEqualCitationKey(BibEntry oneEntry, BibEntry twoEntry) {
-        return oneEntry.getCitationKey().equals(twoEntry.getCitationKey());
+        return oneEntry.hasCitationKey() && twoEntry.hasCitationKey() && oneEntry.getCitationKey().equals(twoEntry.getCitationKey());
     }
 
     public static BibDatabaseDiff compare(BibDatabaseContext base, BibDatabaseContext changed) {

--- a/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiff.java
@@ -6,11 +6,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.jabref.gui.Globals;
 import org.jabref.logic.database.DuplicateCheck;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 
 public class BibDatabaseDiff {
@@ -69,7 +69,7 @@ public class BibDatabaseDiff {
         }
 
         // Now we've found all exact matches, look through the remaining entries, looking for close matches.
-        DuplicateCheck duplicateCheck = new DuplicateCheck(Globals.entryTypesManager);
+        DuplicateCheck duplicateCheck = new DuplicateCheck(new BibEntryTypesManager());
         for (BibEntry originalEntry : notMatched) {
             // These two variables will keep track of which entry most closely matches the one we're looking at.
             double bestMatch = 0;

--- a/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/BibDatabaseDiffTest.java
@@ -29,10 +29,8 @@ class BibDatabaseDiffTest {
     @Test
     void compareOfSameEntryReportsNoDifferences() throws Exception {
         BibEntry entry = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entry)));
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entry)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entry, entry);
 
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
@@ -41,10 +39,8 @@ class BibDatabaseDiffTest {
     void compareOfDifferentEntriesWithSameDataReportsNoDifferences() throws Exception {
         BibEntry entryOne = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
         BibEntry entryTwo = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
 
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
@@ -52,12 +48,9 @@ class BibDatabaseDiffTest {
     @Test
     void compareOfTwoEntriesWithSameContentAndLfEndingsReportsNoDifferences() throws Exception {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
-
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
 
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
@@ -65,12 +58,9 @@ class BibDatabaseDiffTest {
     @Test
     void compareOfTwoEntriesWithSameContentAndCrLfEndingsReportsNoDifferences() throws Exception {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
-
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
 
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
@@ -78,12 +68,9 @@ class BibDatabaseDiffTest {
     @Test
     void compareOfTwoEntriesWithSameContentAndMixedLineEndingsReportsNoDifferences() throws Exception {
         BibEntry entryOne = new BibEntry().withField(StandardField.COMMENT, "line1\n\nline3\n\nline5");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
-
         BibEntry entryTwo = new BibEntry().withField(StandardField.COMMENT, "line1\r\n\r\nline3\r\n\r\nline5");
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
 
         assertEquals(Collections.emptyList(), diff.getEntryDifferences());
     }
@@ -92,10 +79,8 @@ class BibDatabaseDiffTest {
     void compareOfTwoDifferentEntriesWithDifferentDataReportsDifferences() throws Exception {
         BibEntry entryOne = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "test");
         BibEntry entryTwo = new BibEntry(BibEntry.DEFAULT_TYPE).withField(StandardField.TITLE, "another test");
-        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
-        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
 
-        BibDatabaseDiff diff = BibDatabaseDiff.compare(databaseOne, databaseTwo);
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
 
         // two different entries between the databases
         assertEquals(2, diff.getEntryDifferences().size(), "incorrect amount of different entries");
@@ -125,5 +110,34 @@ class BibDatabaseDiffTest {
         assertNull(diff.getEntryDifferences().get(1).getOriginalEntry(), "originalEntry is not null");
         assertEquals(entryThree, diff.getEntryDifferences().get(2).getNewEntry(), "there is another value as newEntry [2]");
         assertNull(diff.getEntryDifferences().get(2).getOriginalEntry(), "originalEntry is not null [2]");
+    }
+
+    @Test
+    void compareOfTwoEntriesWithEqualCitationKeysShouldReportsOneDifference() {
+        BibEntry entryOne = new BibEntry(BibEntry.DEFAULT_TYPE)
+                .withField(StandardField.TITLE, "test")
+                .withField(StandardField.AUTHOR, "author")
+                .withField(StandardField.YEAR, "2001")
+                .withCitationKey("key");
+        BibEntry entryTwo = new BibEntry(BibEntry.DEFAULT_TYPE)
+                .withField(StandardField.TITLE, "test1")
+                .withField(StandardField.AUTHOR, "writer")
+                .withField(StandardField.YEAR, "1899")
+                .withCitationKey("key");
+
+        BibDatabaseDiff diff = compareEntries(entryOne, entryTwo);
+
+        // two different entries between the databases
+        assertEquals(1, diff.getEntryDifferences().size(), "incorrect amount of different entries");
+
+        assertEquals(entryOne, diff.getEntryDifferences().get(0).getOriginalEntry(), "there is another value as originalEntry");
+        assertEquals(entryTwo, diff.getEntryDifferences().get(0).getNewEntry(), "there is another value as newEntry");
+    }
+
+    private BibDatabaseDiff compareEntries(BibEntry entryOne, BibEntry entryTwo) {
+        BibDatabaseContext databaseOne = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryOne)));
+        BibDatabaseContext databaseTwo = new BibDatabaseContext(new BibDatabase(Collections.singletonList(entryTwo)));
+
+        return BibDatabaseDiff.compare(databaseOne, databaseTwo);
     }
 }


### PR DESCRIPTION
**Context**
When an external change in the database occurs, JabRef loads the new version of the database and parses it. Then it compares the list of entries on JabRef and the list of entries loaded from the new version. In the comparison logic, JabRef tries to predict what entries were added, deleted, or modified. The logic is straightforward:
- If an entry exists in JabRef's memory but not in the external database then it's **deleted** from outside
- If an entry exists in the external database but not in JabRef's memory then it's **added** from outside
- If an entry exists in both places then it is **modified** from outside

**So how does JabRef know when an entry is modified?**
JabRef doesn't know for sure when an entry is modified but it can make some decent predictions. To decide if "entry A" was modified JabRef compares "entry A" against all entries in the external database and tries to find the most similar entry. After finding the most similar entry, it compares the similarity score against a threshold, and only when the similarity score is above that threshold then it can predict that "entry A" was modified.

**Why this PR?**
The aim of this pr is to detect more cases of an entry modified that the current similarity detection algorithm can't detect. The pr addresses two main cases:
- When you add or modify many fields of an entry without altering the citation key value.
- When you add or modify many fields of an entry (Citation key included) but the entry is still identifiable using other fields *(ISBN, DOI, etc)*.
____
The issue was first reported in https://github.com/JabRef/jabref-issue-melting-pot/issues/18
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
