### PR TITLE
Changed the color of light-color-text and highlighted text in …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - In the context of a systematic literature review (SLR), we reworked the "Define study" parameters dialog. [#9123](https://github.com/JabRef/jabref/pull/9123)
 - We upgraded to Lucene 9.4 for the fulltext search. The search index will be rebuild. [#9213](https://github.com/JabRef/jabref/pull/9213)
 - We disabled the "change case" menu for empty fields. [#9214](https://github.com/JabRef/jabref/issues/9214)
-- We disabled the conversion menu for empty fields. [#9200](https://github.com/JabRef/jabref/issues/9200) 
+- We disabled the conversion menu for empty fields. [#9200](https://github.com/JabRef/jabref/issues/9200)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - In the context of a systematic literature review (SLR), we reworked the "Define study" parameters dialog. [#9123](https://github.com/JabRef/jabref/pull/9123)
 - We upgraded to Lucene 9.4 for the fulltext search. The search index will be rebuild. [#9213](https://github.com/JabRef/jabref/pull/9213)
 - We disabled the "change case" menu for empty fields. [#9214](https://github.com/JabRef/jabref/issues/9214)
-- We disabled the conversion menu for empty fields. [#9200](https://github.com/JabRef/jabref/issues/9200)
+- We disabled the conversion menu for empty fields. [#9200](https://github.com/JabRef/jabref/issues/9200) 
 
 ### Fixed
 
@@ -134,6 +134,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the display of the "Customize Entry Types" dialog title. [#9198](https://github.com/JabRef/jabref/issues/9198)
 - We fixed an issue where the CSS styles are missing in some dialogs. [#9150](https://github.com/JabRef/jabref/pull/9150)
 - We fixed an issue where controls in the preferences dialog could outgrow the window. [#9017](https://github.com/JabRef/jabref/issues/9017)
+- We fixed an issue where highlighted text color for entry merge dialogue was not clearly visible. [#9192](https://github.com/JabRef/jabref/issues/9192)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -9,10 +9,12 @@
     -jr-accent-alt: -jr-accent;
 
     -jr-red: #b71c1f;
+    -jr-dull-red: #db1d2b;
     -jr-light-red: #db1d2b;
     -jr-green: #1cb631;
     -jr-light-green: #28d93c;
     -jr-blue: #2c2cb7;
+    -jr-sky-blue: #006dff;
     -jr-light-blue: #3a3ad9;
     -jr-purple: #b72486;
     -jr-light-purple: #d927a8;
@@ -36,7 +38,7 @@
 
     -fx-dark-text-color: black;
     -fx-mid-text-color: #7d8591;
-    -fx-light-text-color: #9aa3af;
+    -fx-light-text-color: #e5e7ea;
     -jr-separator: #333744;
     -fx-outer-border: #424758;
 
@@ -68,11 +70,11 @@
 }
 
 .addition {
-    -rtfx-background-color: -jr-green;
+    -rtfx-background-color: -jr-dull-red;
 }
 
 .deletion {
-    -rtfx-background-color: -jr-red;
+    -rtfx-background-color: -jr-sky-blue;
 }
 
 #previewBody {

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -9,12 +9,10 @@
     -jr-accent-alt: -jr-accent;
 
     -jr-red: #b71c1f;
-    -jr-dull-red: #db1d2b;
     -jr-light-red: #db1d2b;
     -jr-green: #1cb631;
     -jr-light-green: #28d93c;
     -jr-blue: #2c2cb7;
-    -jr-sky-blue: #006dff;
     -jr-light-blue: #3a3ad9;
     -jr-purple: #b72486;
     -jr-light-purple: #d927a8;
@@ -70,11 +68,13 @@
 }
 
 .addition {
-    -rtfx-background-color: -jr-dull-red;
+    -fx-text-background-color: black;
+    -rtfx-background-color: #FDAF56;
 }
 
 .deletion {
-    -rtfx-background-color: -jr-sky-blue;
+    -fx-text-background-color: black;
+    -rtfx-background-color: #ECD58E;
 }
 
 #previewBody {

--- a/src/main/java/org/jabref/gui/Dark.css
+++ b/src/main/java/org/jabref/gui/Dark.css
@@ -74,7 +74,7 @@
 
 .deletion {
     -fx-text-background-color: black;
-    -rtfx-background-color: #ECD58E;
+    -rtfx-background-color: #FFEECC;
 }
 
 #previewBody {


### PR DESCRIPTION
…entry merge dialogue

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #9192

**Before:**

![grafik](https://user-images.githubusercontent.com/73715071/193327675-78c73e64-f732-4bac-9f3d-4b1cf62f5994.png)
![grafik](https://user-images.githubusercontent.com/73715071/193331700-62d2ac77-0ef8-4858-8791-c9296ff6592c.png)

**After:**
![Screenshot 2023-01-14 235730](https://user-images.githubusercontent.com/56410265/212492654-0c1f0ffd-1659-4468-a882-e929196c772e.png)
![Screenshot 2023-01-15 004947](https://user-images.githubusercontent.com/56410265/212492651-2bab857c-4655-4fcd-a1ee-7ae753cc0363.png)
![Screenshot 2023-01-15 005014](https://user-images.githubusercontent.com/56410265/212492652-95589764-9594-4a4c-a541-a3f0c1334f3b.png)
![Screenshot 2023-01-15 005032](https://user-images.githubusercontent.com/56410265/212492653-045b8405-e0f8-409f-bdd6-e70d9038190e.png)






<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
