### PR TITLE
Remove overquoting in jabrefHost on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where the browser import would add ' characters before the BibTeX entry on Linux [#9588](https://github.com/JabRef/jabref/issues/9588)
 - We fixed an issue where searching for a specific term with the DOAB fetcher lead to an exception [#9571](https://github.com/JabRef/jabref/issues/9571)
 - We fixed an issue where the "Import" -> "Library to import to" did not show the correct library name if two opened libraries had the same suffix [#9567](https://github.com/JabRef/jabref/issues/9567)
 

--- a/buildres/linux/jabrefHost.py
+++ b/buildres/linux/jabrefHost.py
@@ -96,7 +96,7 @@ def send_message(message):
 
 def add_jabref_entry(data):
     """Send string via cli as literal to preserve special characters"""
-    cmd = str(JABREF_PATH).split() + ["--importBibtex", r"'{}'".format(data)]
+    cmd = str(JABREF_PATH).split() + ["--importBibtex", r"{}".format(data)]
     logging.info("Try to execute command {}".format(cmd))
     response = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     logging.info("Called JabRef and got: {}".format(response))


### PR DESCRIPTION
Remove overquoting in jabrefHost.py, fixing #9588. On Linux (not MacOS), the script wraps the BibTeX passed to JabRef via CLI parameter in an extra set of ' quotes. Since the data is never evaluated by a shell script, the quotes are passed to JabRef and are stored in the database. This may be the cause for the garbage charactes observed in #9582; however, this fix does not address that issue.

Fixes #9588 

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
