### PR TITLE
Fix command line export for --exportMatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the browser import would add ' characters before the BibTeX entry on Linux [#9588](https://github.com/JabRef/jabref/issues/9588)
 - We fixed an issue where searching for a specific term with the DOAB fetcher lead to an exception [#9571](https://github.com/JabRef/jabref/issues/9571)
 - We fixed an issue where the "Import" -> "Library to import to" did not show the correct library name if two opened libraries had the same suffix [#9567](https://github.com/JabRef/jabref/issues/9567)
-- We fixe an issue where the rpm-Version of JabRef could not be properly uninstalled and reinstalled [#9558](https://github.com/JabRef/jabref/issues/9558), [#9603](https://github.com/JabRef/jabref/issues/9603)
+- We fixed an issue where the rpm-Version of JabRef could not be properly uninstalled and reinstalled [#9558](https://github.com/JabRef/jabref/issues/9558), [#9603](https://github.com/JabRef/jabref/issues/9603)
+- We fixed an issue where the command line export using `--exportMatches` flag does not create an output bib file [#9581](https://github.com/JabRef/jabref/issues/9581)
 
 
 

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -387,8 +387,8 @@ public class ArgumentProcessor {
             switch (data.length) {
                 case 3 -> formatName = data[2];
                 case 2 ->
-                        // default exporter: HTML table (with Abstract & BibTeX)
-                        formatName = "tablerefsabsbib";
+                        // default exporter: bib file
+                        formatName = "bib";
                 default -> {
                     System.err.println(Localization.lang("Output file missing").concat(". \n \t ")
                                                    .concat(Localization.lang("Usage")).concat(": ") + JabRefCLI.getExportMatchesSyntax());
@@ -397,22 +397,29 @@ public class ArgumentProcessor {
                 }
             }
 
-            // export new database
-            ExporterFactory exporterFactory = ExporterFactory.create(
-                    preferencesService,
-                    Globals.entryTypesManager,
-                    Globals.journalAbbreviationRepository);
-            Optional<Exporter> exporter = exporterFactory.getExporterByName(formatName);
-            if (exporter.isEmpty()) {
-                System.err.println(Localization.lang("Unknown export format") + ": " + formatName);
+            if (formatName.equals("bib")) {
+                // output a bib file as default or if
+                // provided exportFormat is "bib"
+                saveDatabase(new BibDatabase(matches), data[1]);
+                LOGGER.debug("Finished export");
             } else {
-                // We have an TemplateExporter instance:
-                try {
-                    System.out.println(Localization.lang("Exporting") + ": " + data[1]);
-                    exporter.get().export(databaseContext, Path.of(data[1]), matches, Collections.emptyList());
-                } catch (Exception ex) {
-                    System.err.println(Localization.lang("Could not export file") + " '" + data[1] + "': "
-                            + Throwables.getStackTraceAsString(ex));
+                // export new database
+                ExporterFactory exporterFactory = ExporterFactory.create(
+                        preferencesService,
+                        Globals.entryTypesManager,
+                        Globals.journalAbbreviationRepository);
+                Optional<Exporter> exporter = exporterFactory.getExporterByName(formatName);
+                if (exporter.isEmpty()) {
+                    System.err.println(Localization.lang("Unknown export format") + ": " + formatName);
+                } else {
+                    // We have an TemplateExporter instance:
+                    try {
+                        System.out.println(Localization.lang("Exporting") + ": " + data[1]);
+                        exporter.get().export(databaseContext, Path.of(data[1]), matches, Collections.emptyList());
+                    } catch (Exception ex) {
+                        System.err.println(Localization.lang("Could not export file") + " '" + data[1] + "': "
+                                + Throwables.getStackTraceAsString(ex));
+                    }
                 }
             }
         } else {

--- a/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
+++ b/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
@@ -3,10 +3,21 @@ package org.jabref.cli;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
+
+import javafx.collections.FXCollections;
 
 import org.jabref.cli.ArgumentProcessor.Mode;
+import org.jabref.gui.Globals;
+import org.jabref.logic.bibtex.BibEntryAssert;
 import org.jabref.logic.exporter.SavePreferences;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ImporterPreferences;
+import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.metadata.SaveOrderConfig;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.preferences.JabRefPreferences;
 import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -21,13 +32,19 @@ import static org.mockito.Mockito.when;
 class ArgumentProcessorTest {
 
     private ArgumentProcessor processor;
+    private BibtexImporter bibtexImporter;
     private final PreferencesService preferencesService = mock(PreferencesService.class, Answers.RETURNS_DEEP_STUBS);
     private final SavePreferences savePreferences = mock(SavePreferences.class, Answers.RETURNS_DEEP_STUBS);
+    private final ImporterPreferences importerPreferences = mock(ImporterPreferences.class, Answers.RETURNS_DEEP_STUBS);
+    private final ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
 
     @BeforeEach()
     void setup() {
         when(savePreferences.getSaveOrder()).thenReturn(SaveOrderConfig.getDefaultSaveOrder());
         when(preferencesService.getSavePreferences()).thenReturn(savePreferences);
+        when(importerPreferences.getCustomImportList()).thenReturn(FXCollections.emptyObservableSet());
+
+        bibtexImporter = new BibtexImporter(importFormatPreferences, new DummyFileUpdateMonitor());
     }
 
     @Test
@@ -44,5 +61,29 @@ class ArgumentProcessorTest {
         processor = new ArgumentProcessor(args.toArray(String[]::new), Mode.INITIAL_START, preferencesService);
 
         assertTrue(Files.exists(outputBib));
+    }
+
+    @Test
+    void testExportMatches(@TempDir Path tempDir) throws Exception {
+        Globals.IMPORT_FORMAT_READER.resetImportFormats(importerPreferences, importFormatPreferences, new DummyFileUpdateMonitor());
+
+        Path originBib = Path.of(Objects.requireNonNull(ArgumentProcessorTest.class.getResource("origin.bib")).toURI());
+        String originBibFile = originBib.toAbsolutePath().toString();
+
+        Path expectedBib = Path.of(
+                Objects.requireNonNull(ArgumentProcessorTest.class.getResource("ArgumentProcessorTestExportMatches.bib"))
+                       .toURI()
+        );
+        List<BibEntry> expectedEntries = bibtexImporter.importDatabase(expectedBib).getDatabase().getEntries();
+
+        Path outputBib = tempDir.resolve("output.bib").toAbsolutePath();
+        String outputBibFile = outputBib.toAbsolutePath().toString();
+
+        List<String> args = List.of("-n", "--debug", "--exportMatches", "Author=Einstein," + outputBibFile, "-i", originBibFile);
+
+        processor = new ArgumentProcessor(args.toArray(String[]::new), Mode.INITIAL_START, JabRefPreferences.getInstance());
+
+        assertTrue(Files.exists(outputBib));
+        BibEntryAssert.assertEquals(expectedEntries, outputBib, bibtexImporter);
     }
 }

--- a/src/test/resources/org/jabref/cli/ArgumentProcessorTestExportMatches.bib
+++ b/src/test/resources/org/jabref/cli/ArgumentProcessorTestExportMatches.bib
@@ -1,0 +1,10 @@
+% Encoding: UTF-8
+
+@Book{Einstein1920,
+  title =     {Relativity: The special and general theory},
+  publisher = {Penguin},
+  year =      {1920},
+  author =    {Einstein, Albert}
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

This fixes #9581 by creating an export bib file when the `bib` export format is specified, or when there is no specified export format. 

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
