### PR TITLE
Improve the INSPIREFetcher in "Update with bibliographic information from the web"

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
@@ -94,10 +94,10 @@ public class INSPIREFetcher implements SearchBasedParserFetcher, EntryBasedFetch
         Optional<String> eprint = entry.getField(StandardField.EPRINT);
         String url;
 
-        if (!doi.isEmpty()) {
-            url = INSPIRE_DOI_HOST + doi.get();
-        } else if (archiveprefix.get() == "arXiv" && !eprint.isEmpty()) {
+        if (archiveprefix.get() == "arXiv" && !eprint.isEmpty()) {
             url = INSPIRE_ARXIV_HOST + eprint.get();
+        } else if (!doi.isEmpty()) {
+            url = INSPIRE_DOI_HOST + doi.get();
         } else {
             return results;
         }

--- a/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/INSPIREFetcherTest.java
@@ -66,7 +66,7 @@ class INSPIREFetcherTest {
         BibEntry article = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("Melnikov:1998pr")
                 .withField(StandardField.AUTHOR, "Melnikov, Kirill and Yelkhovsky, Alexander")
-                .withField(StandardField.TITLE, "{Top quark production at threshold with O(alpha-s**2) accuracy}")
+                .withField(StandardField.TITLE, "Top quark production at threshold with O(alpha-s**2) accuracy")
                 .withField(StandardField.DOI, "10.1016/S0550-3213(98)00348-4")
                 .withField(StandardField.JOURNAL, "Nucl. Phys. B")
                 .withField(StandardField.PAGES, "59--72")
@@ -75,7 +75,6 @@ class INSPIREFetcherTest {
                 .withField(StandardField.EPRINT, "hep-ph/9802379")
                 .withField(StandardField.ARCHIVEPREFIX, "arXiv")
                 .withField(new UnknownField("reportnumber"), "BUDKER-INP-1998-7, TTP-98-10");
-
         List<BibEntry> fetchedEntries = fetcher.performSearch(article);
         assertEquals(Collections.singletonList(article), fetchedEntries);
     }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Improve [#9602](https://github.com/JabRef/jabref/pull/9602)

Normally, one can fetch information of new arXiv paper in the INSPIRE database, but this entry doesn't have doi in the INSPIRE database because it is preprint and hasn't been published in journal.
After some time, the paper gets published, if one wants to update the entry through "Update with bibliographic information from the web", then doi is unavailable.
So I added a fetcher with arXiv ID.
In addition, I added the post cleanup to keep the consistency between SearchBasedParserFetcher and EntryBasedFetcher.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
