### PR TITLE
Fulltext fetcher for IACR eprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - We added a field showing the BibTeX/biblatex source for added and deleted entries in the "External Changes Resolver" dialog. [#9509](https://github.com/JabRef/jabref/issues/9509)
 - We added a full text fetcher for IACR eprints.
-- Add "Attach file from URL" to right-click context menu which downloads file from URL and stores it with reference library.
+- We added "Attach file from URL" to right-click context menu to download and store a file with the reference library.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Added
 
 - We added a field showing the BibTeX/biblatex source for added and deleted entries in the "External Changes Resolver" dialog. [#9509](https://github.com/JabRef/jabref/issues/9509)
-- We added a full text fetcher for IACR eprints.
-- We added "Attach file from URL" to right-click context menu to download and store a file with the reference library.
+- We added a full text fetcher for IACR eprints. [#9651](https://github.com/JabRef/jabref/pull/9651)
+- We added "Attach file from URL" to right-click context menu to download and store a file with the reference library. [#9646](https://github.com/JabRef/jabref/issues/9646)
+- We enabled updating an existing entry with data from InspireHEP. [#9351](https://github.com/JabRef/jabref/issues/9351)
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Added
 
 - We added a field showing the BibTeX/biblatex source for added and deleted entries in the "External Changes Resolver" dialog. [#9509](https://github.com/JabRef/jabref/issues/9509)
-
+- We added a full text fetcher for IACR eprints.
 
 
 

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -196,6 +196,7 @@ public class WebFetchers {
         fetchers.add(new ArXivFetcher(importFormatPreferences));
         fetchers.add(new IEEE(importFormatPreferences, importerPreferences));
         fetchers.add(new ApsFetcher());
+        fetchers.add(new IacrEprintFetcher(importFormatPreferences));
 
         // Meta search
         // fetchers.add(new JstorFetcher(importFormatPreferences));

--- a/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
@@ -25,7 +25,7 @@ public class IacrEprintFetcher implements FulltextFetcher, IdBasedFetcher {
     private static final Predicate<String> IDENTIFIER_PREDICATE = Pattern.compile("\\d{4}/\\d{3,5}").asPredicate();
     private static final String CITATION_URL_PREFIX = "https://eprint.iacr.org/";
     private static final String DESCRIPTION_URL_PREFIX = "https://eprint.iacr.org/";
-    private static final String FULLTEXT_URL_PREFIX = "https://eprint.iacr.org/archive/";
+    private static final String FULLTEXT_URL_PREFIX = "https://eprint.iacr.org/";
     private static final String VERSION_URL_PREFIX = "https://eprint.iacr.org/archive/versions/";
 
     private final ImportFormatPreferences prefs;
@@ -142,7 +142,7 @@ public class IacrEprintFetcher implements FulltextFetcher, IdBasedFetcher {
             String fulltextLinkAsInHtml = getRequiredValueBetween(startOfFulltextLink, ".pdf", descriptiveHtml);
             // There is an additional "\n           href=\"/archive/" we have to remove - and for some reason,
             // getRequiredValueBetween refuses to match across the line break.
-            fulltextLinkAsInHtml = fulltextLinkAsInHtml.replaceFirst(".*href=\"/archive/", "").trim();
+            fulltextLinkAsInHtml = fulltextLinkAsInHtml.replaceFirst(".*href=\"/", "").trim();
             String fulltextLink = FULLTEXT_URL_PREFIX + fulltextLinkAsInHtml + ".pdf";
             return Optional.of(new URL(fulltextLink));
         }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
@@ -1,14 +1,13 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.importer.FetcherException;
-import org.jabref.logic.importer.IdBasedFetcher;
-import org.jabref.logic.importer.ImportFormatPreferences;
-import org.jabref.logic.importer.ParseException;
+import org.jabref.logic.importer.*;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLDownload;
@@ -17,7 +16,7 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
-public class IacrEprintFetcher implements IdBasedFetcher {
+public class IacrEprintFetcher implements FulltextFetcher, IdBasedFetcher {
 
     public static final String NAME = "IACR eprints";
 
@@ -26,6 +25,7 @@ public class IacrEprintFetcher implements IdBasedFetcher {
     private static final Predicate<String> IDENTIFIER_PREDICATE = Pattern.compile("\\d{4}/\\d{3,5}").asPredicate();
     private static final String CITATION_URL_PREFIX = "https://eprint.iacr.org/";
     private static final String DESCRIPTION_URL_PREFIX = "https://eprint.iacr.org/";
+    private static final String FULLTEXT_URL_PREFIX = "https://eprint.iacr.org/archive/";
     private static final String VERSION_URL_PREFIX = "https://eprint.iacr.org/archive/versions/";
 
     private final ImportFormatPreferences prefs;
@@ -129,5 +129,28 @@ public class IacrEprintFetcher implements IdBasedFetcher {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    @Override
+    public Optional<URL> findFullText(BibEntry entry) throws IOException, FetcherException {
+        Objects.requireNonNull(entry);
+
+        Optional<String> urlField = entry.getField(StandardField.URL);
+        if (urlField.isPresent()) {
+            String descriptiveHtml = getHtml(urlField.get());
+            String startOfFulltextLink = "<a class=\"btn btn-sm btn-outline-dark\"";
+            String fulltextLinkAsInHtml = getRequiredValueBetween(startOfFulltextLink, ".pdf", descriptiveHtml);
+            // There is an additional "\n           href=\"/archive/" we have to remove - and for some reason,
+            // getRequiredValueBetween refuses to match across the line break.
+            fulltextLinkAsInHtml = fulltextLinkAsInHtml.replaceFirst(".*href=\"/archive/", "").trim();
+            String fulltextLink = FULLTEXT_URL_PREFIX + fulltextLinkAsInHtml + ".pdf";
+            return Optional.of(new URL(fulltextLink));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public TrustLevel getTrustLevel() {
+        return TrustLevel.PREPRINT;
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
@@ -7,7 +7,11 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.importer.*;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.FulltextFetcher;
+import org.jabref.logic.importer.IdBasedFetcher;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLDownload;

--- a/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
@@ -200,7 +200,6 @@ public class IacrEprintFetcherTest {
         return ids.stream();
     }
 
-
     @Test
     public void getFulltextWithVersion() throws FetcherException, IOException {
         Optional<URL> pdfUrl = fetcher.findFullText(abram2017);

--- a/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
@@ -203,15 +203,13 @@ public class IacrEprintFetcherTest {
     @Test
     public void getFulltextWithVersion() throws FetcherException, IOException {
         Optional<URL> pdfUrl = fetcher.findFullText(abram2017);
-        assertTrue(pdfUrl.isPresent());
-        assertEquals("https://eprint.iacr.org/archive/2017/1118/1511505927.pdf", pdfUrl.get().toString());
+        assertEquals(Optional.of("https://eprint.iacr.org/archive/2017/1118/1511505927.pdf"), pdfUrl.map(URL::toString));
     }
 
     @Test
     public void getFulltextWithoutVersion() throws FetcherException, IOException {
         Optional<URL> pdfUrl = fetcher.findFullText(abram2017noVersion);
-        assertTrue(pdfUrl.isPresent());
-        assertEquals("https://eprint.iacr.org/2017/1118.pdf", pdfUrl.get().toString());
+        assertEquals(Optional.of("https://eprint.iacr.org/2017/1118.pdf"), pdfUrl.map(URL::toString));
     }
 
     @Test
@@ -219,11 +217,11 @@ public class IacrEprintFetcherTest {
         BibEntry abram2017WithoutUrl = abram2017;
         abram2017WithoutUrl.clearField(StandardField.URL);
         Optional<URL> pdfUrl = fetcher.findFullText(abram2017WithoutUrl);
-        assertTrue(pdfUrl.isEmpty());
+        assertEquals(Optional.empty(), pdfUrl);
     }
 
     @Test
-    public void getFulltextWithNonIACRUrl() throws FetcherException, IOException {
+    public void getFulltextWithNonIACRUrl() throws IOException {
         BibEntry abram2017WithNonIACRUrl = abram2017;
         abram2017WithNonIACRUrl.setField(StandardField.URL, "https://example.com");
         assertThrows(FetcherException.class, () -> fetcher.findFullText(abram2017WithNonIACRUrl));

--- a/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,6 +38,7 @@ public class IacrEprintFetcherTest {
 
     private IacrEprintFetcher fetcher;
     private BibEntry abram2017;
+    private BibEntry abram2017noVersion;
     private BibEntry beierle2016;
     private BibEntry delgado2017;
 
@@ -53,6 +56,17 @@ public class IacrEprintFetcherTest {
                 .withField(StandardField.TITLE, "Solida: A Blockchain Protocol Based on Reconfigurable Byzantine Consensus")
                 .withField(StandardField.URL, "https://eprint.iacr.org/2017/1118/20171124:064527")
                 .withField(StandardField.VERSION, "20171124:064527")
+                .withField(StandardField.YEAR, "2017");
+
+        abram2017noVersion = new BibEntry(StandardEntryType.Misc)
+                .withCitationKey("cryptoeprint:2017/1118")
+                .withField(StandardField.ABSTRACT, "dummy")
+                .withField(StandardField.AUTHOR, "Ittai Abraham and Dahlia Malkhi and Kartik Nayak and Ling Ren and Alexander Spiegelman")
+                .withField(StandardField.DATE, "2017-11-24")
+                .withField(StandardField.HOWPUBLISHED, "Cryptology ePrint Archive, Paper 2017/1118")
+                .withField(StandardField.NOTE, "\\url{https://eprint.iacr.org/2017/1118}")
+                .withField(StandardField.TITLE, "Solida: A Blockchain Protocol Based on Reconfigurable Byzantine Consensus")
+                .withField(StandardField.URL, "https://eprint.iacr.org/2017/1118")
                 .withField(StandardField.YEAR, "2017");
 
         beierle2016 = new BibEntry(StandardEntryType.Misc)
@@ -184,5 +198,35 @@ public class IacrEprintFetcherTest {
         ids.addAll(getIdsFor(1999, 24));
         ids.removeAll(withdrawnIds);
         return ids.stream();
+    }
+
+
+    @Test
+    public void getFulltextWithVersion() throws FetcherException, IOException {
+        Optional<URL> pdfUrl = fetcher.findFullText(abram2017);
+        assertTrue(pdfUrl.isPresent());
+        assertEquals("https://eprint.iacr.org/archive/2017/1118/1511505927.pdf", pdfUrl.get().toString());
+    }
+
+    @Test
+    public void getFulltextWithoutVersion() throws FetcherException, IOException {
+        Optional<URL> pdfUrl = fetcher.findFullText(abram2017noVersion);
+        assertTrue(pdfUrl.isPresent());
+        assertEquals("https://eprint.iacr.org/2017/1118.pdf", pdfUrl.get().toString());
+    }
+
+    @Test
+    public void getFulltextWithoutUrl() throws FetcherException, IOException {
+        BibEntry abram2017WithoutUrl = abram2017;
+        abram2017WithoutUrl.clearField(StandardField.URL);
+        Optional<URL> pdfUrl = fetcher.findFullText(abram2017WithoutUrl);
+        assertTrue(pdfUrl.isEmpty());
+    }
+
+    @Test
+    public void getFulltextWithNonIACRUrl() throws FetcherException, IOException {
+        BibEntry abram2017WithNonIACRUrl = abram2017;
+        abram2017WithNonIACRUrl.setField(StandardField.URL, "https://example.com");
+        assertThrows(FetcherException.class, () -> fetcher.findFullText(abram2017WithNonIACRUrl));
     }
 }


### PR DESCRIPTION
Adds fulltext fetching for IACR eprint PDFs.

My Java skills are a bit rusty, and while the code works, I'm happy to make additional changes if there are more elegant ways to do things.

I am unsure about whether to add anything to the developer docs on fetchers, as they seem to only cover a subset of all fetchers anyway (so far, the IACR fetcher isn't mentioned at all).

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable) 
- [x] Tests created for changes (if applicable) 
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
  - (not applicable)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
  - There does not seem to be fetcher-specific documentation for users (regarding fulltext fetching)
