### PR TITLE
Streamline AppDirs paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 - 'Get full text' now also checks the file url. [#568](https://github.com/koppor/jabref/issues/568)
 - We refined the 'main directory not found' error message. [#9625](https://github.com/JabRef/jabref/pull/9625)
+- We streamlined the paths for logs and backups: The parent path fragement is always `logs` or `backups`.
+- Backups of libraries are not stored per JabRef version, but collected together.
 - We modified the `Add Group` dialog to use the most recently selected group hierarchical context [#9141](https://github.com/JabRef/jabref/issues/9141)
 
 

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -22,6 +22,7 @@ import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
 import org.jabref.logic.util.BuildInfo;
+import org.jabref.logic.util.OS;
 import org.jabref.migrations.PreferencesMigrations;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -90,10 +91,12 @@ public class Launcher {
      * the log configuration programmatically anymore.
      */
     private static void addLogToDisk() {
-        Path directory = Path.of(AppDirsFactory.getInstance().getUserLogDir(
-                "jabref",
-                new BuildInfo().version.toString(),
-                "org.jabref"));
+        Path directory = Path.of(AppDirsFactory.getInstance()
+                                               .getUserDataDir(
+                OS.APP_DIR_APP_NAME,
+                "logs",
+                OS.APP_DIR_APP_AUTHOR))
+                .resolve(new BuildInfo().version.toString());
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
+++ b/src/main/java/org/jabref/gui/backup/BackupResolverDialog.java
@@ -32,7 +32,7 @@ public class BackupResolverDialog extends FXDialog {
         getDialogPane().setMinHeight(180);
         getDialogPane().getButtonTypes().setAll(RESTORE_FROM_BACKUP, REVIEW_BACKUP, IGNORE_BACKUP);
 
-        Optional<Path> backupPathOpt = BackupFileUtil.getPathOfLatestExisingBackupFile(originalPath, BackupFileType.BACKUP);
+        Optional<Path> backupPathOpt = BackupFileUtil.getPathOfLatestExistingBackupFile(originalPath, BackupFileType.BACKUP);
         String backupFilename = backupPathOpt.map(Path::getFileName).map(Path::toString).orElse(Localization.lang("File not found"));
         String content = new StringBuilder()
                 .append(Localization.lang("A backup file for '%0' was found at [%1]",

--- a/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -63,7 +63,7 @@ public class BackupUIManager {
             // This will be modified by using the `DatabaseChangesResolverDialog`.
             BibDatabaseContext originalDatabase = originalParserResult.getDatabaseContext();
 
-            Path backupPath = BackupFileUtil.getPathOfLatestExisingBackupFile(originalPath, BackupFileType.BACKUP).orElseThrow();
+            Path backupPath = BackupFileUtil.getPathOfLatestExistingBackupFile(originalPath, BackupFileType.BACKUP).orElseThrow();
             BibDatabaseContext backupDatabase = OpenDatabase.loadDatabase(backupPath, importFormatPreferences, new DummyFileUpdateMonitor()).getDatabaseContext();
 
             DatabaseChangeResolverFactory changeResolverFactory = new DatabaseChangeResolverFactory(dialogService, originalDatabase, preferencesService.getBibEntryPreferences());

--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -87,7 +87,7 @@ public class BackupManager {
      * Determines the most recent existing backup file name
      */
     static Optional<Path> getLatestBackupPath(Path originalPath) {
-        return BackupFileUtil.getPathOfLatestExisingBackupFile(originalPath, BackupFileType.BACKUP);
+        return BackupFileUtil.getPathOfLatestExistingBackupFile(originalPath, BackupFileType.BACKUP);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/util/OS.java
+++ b/src/main/java/org/jabref/logic/util/OS.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 public class OS {
     public static final String NEWLINE = System.lineSeparator();
 
-    public static final String APP_DIR_APP_NAME = "JabRef";
+    public static final String APP_DIR_APP_NAME = "jabref";
     public static final String APP_DIR_APP_AUTHOR = "org.jabref";
 
     // File separator obtained from system

--- a/src/main/java/org/jabref/logic/util/io/BackupFileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/BackupFileUtil.java
@@ -10,7 +10,6 @@ import java.util.HexFormat;
 import java.util.Optional;
 
 import org.jabref.logic.util.BackupFileType;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.OS;
 
 import net.harawata.appdirs.AppDirsFactory;
@@ -25,11 +24,11 @@ public class BackupFileUtil {
     }
 
     public static Path getAppDataBackupDir() {
-        Path directory = Path.of(AppDirsFactory.getInstance().getUserDataDir(
-                                     OS.APP_DIR_APP_NAME,
-                                     new BuildInfo().version.toString(),
-                                     OS.APP_DIR_APP_AUTHOR))
-                             .resolve("backups");
+        Path directory = Path.of(AppDirsFactory.getInstance()
+                                               .getUserDataDir(
+                                                       OS.APP_DIR_APP_NAME,
+                                                       "backups",
+                                                       OS.APP_DIR_APP_AUTHOR));
         return directory;
     }
 
@@ -72,7 +71,7 @@ public class BackupFileUtil {
      *
      * @param targetFile the full path of the file to backup
      */
-    public static Optional<Path> getPathOfLatestExisingBackupFile(Path targetFile, BackupFileType fileType) {
+    public static Optional<Path> getPathOfLatestExistingBackupFile(Path targetFile, BackupFileType fileType) {
         // The code is similar to "getPathForNewBackupFileAndCreateDirectory"
 
         String extension = "." + fileType.getExtensions().get(0);

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -530,7 +530,10 @@ public class JabRefPreferences implements PreferencesService {
 
         // SSL
         defaults.put(TRUSTSTORE_PATH, Path.of(AppDirsFactory.getInstance()
-                                                            .getUserDataDir(OS.APP_DIR_APP_NAME, "ssl", OS.APP_DIR_APP_AUTHOR))
+                                                            .getUserDataDir(
+                                                                    OS.APP_DIR_APP_NAME,
+                                                                    "ssl",
+                                                                    OS.APP_DIR_APP_AUTHOR))
                                           .resolve("truststore.jks").toString());
 
         defaults.put(POS_X, 0);


### PR DESCRIPTION
While discussing the backup path with @ThiloteE, I found, we are inconsistent.

Before:

```
├───100.0.0
│   └───backups
├───Logs
│   ├───100.0.0
│   ├───5.7--2022-08-05--73c111c
│   ├───5.8--2022-11-21--f7ea169
│   ├───5.8--2022-12-18--b7fae4b
│   ├───5.9--2023-01-04--bc3b9892f
│   ├───6.0--2023-01-01--b06ec3f
│   ├───6.0--2023-01-04--06771c8
│   └───unknown
├───lucene94
│   ├───-1446191503
│   ├───-1525049150
│   ├───-1981152844
│   ├───-2018577075
│   ├───-271657575
│   ├───-404722334
│   ├───-911001257
│   ├───1750725641
│   ├───1907816293
│   ├───647714185
│   ├───762261717
│   └───unsaved
└───ssl
```

After:

```
├───backups
├───logs
│   └───100.0.0
├───lucene94
│   ├───-1446191503
│   ├───-1981152844
│   ├───-2018577075
│   └───-404722334
└───ssl
```

Note that `logs` is spelled with lower-case `l`. This is consistent to `ssl` and `lucene94`. - We could discuss if we should introduce another level of hierarchy for `lucene`: `lucene/94` to be consistent to `logs`.

Backups still work (checked by modifing a backup)

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
