### PR TITLE
Remove empty javadoc comments

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/newmergedialog/cell/ThreeWayMergeCell.java
+++ b/src/main/java/org/jabref/gui/mergeentries/newmergedialog/cell/ThreeWayMergeCell.java
@@ -6,9 +6,6 @@ import javafx.scene.layout.HBox;
 
 import com.tobiasdiez.easybind.EasyBind;
 
-/**
- *
- */
 public abstract class ThreeWayMergeCell extends HBox {
     public static final String ODD_PSEUDO_CLASS = "odd";
     public static final String EVEN_PSEUDO_CLASS = "even";

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLF_FF.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLF_FF.java
@@ -3,9 +3,6 @@ package org.jabref.logic.layout.format;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.entry.AuthorList;
 
-/**
- *
- */
 public class AuthorLF_FF implements LayoutFormatter {
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLF_FFAbbr.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLF_FFAbbr.java
@@ -3,9 +3,6 @@ package org.jabref.logic.layout.format;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.entry.AuthorList;
 
-/**
- *
- */
 public class AuthorLF_FFAbbr implements LayoutFormatter {
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/475

Deleted three empty javadoc comments.



```[tasklist]
### Compulsory checks
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (for UI changes)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
