### PR TITLE
Switch to "toolchain"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ version = project.findProperty('projVersion') ?: '100.0.0'
 java {
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(19))
+            languageVersion.set(JavaLanguageVersion.of(20))
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,12 @@ group = "org.jabref"
 version = project.findProperty('projVersion') ?: '100.0.0'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_19
-    targetCompatibility = JavaVersion.VERSION_19
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(19))
+        }
+    }
+
     // Workaround needed for Eclipse, probably because of https://github.com/gradle/gradle/issues/16922
     // Should be removed as soon as Gradle 7.0.1 is released ( https://github.com/gradle/gradle/issues/16922#issuecomment-828217060 )
     modularity.inferModulePath.set(false)

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,6 @@ plugins {
 
     id 'idea'
     
-    // enable downloading of JDKs
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
 }
 
 // Enable following for debugging

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ plugins {
     id 'project-report'
 
     id 'idea'
+    
+    // enable downloading of JDKs
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
 }
 
 // Enable following for debugging

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,10 @@ pluginManagement {
     }
 }
 
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
+
 rootProject.name = "JabRef"


### PR DESCRIPTION
There is lots of trouble with gradle to keep up with JDK releases (see e.g., https://github.com/gradle/gradle/issues/23488).

One solution is to switch to the [toolchain feature](https://docs.gradle.org/current/userguide/toolchains.html) of gradle. Instead of providing `sourceCompatibility` and `targetCompatibility`, one specifies the toolchain. According to the docs, Gradle then execute Java compilers newer than the ones Gradle is able to run on.

- We need to think about changing the developer documentation to download one JRE and one JDK.
- The build workflows should work with an updated tooolchain requirement, because gradle downloads the JDK by itself. However, we need to be aware that we should not update the installed JDK at the workflows.
- jpackage will also work with the toolchain "magic": https://github.com/petr-panteleyev/jpackage-gradle-plugin#finding-jpackage

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
