### PR TITLE
Fixes citation key generation when authors list has "and others" at t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the custom entry types dialog into the preferences dialog. [#9760](https://github.com/JabRef/jabref/pull/9760)
 - We moved the manage content selectors dialog to the library properties. [#9768](https://github.com/JabRef/jabref/pull/9768)
 - We moved the preferences menu command from the options menu to the file menu. [#9768](https://github.com/JabRef/jabref/pull/9768)
-
+- We changed the handling of an "overflow" of authors at `[authIniN]`: JabRef uses `+` to indicate an overflow. Example: `[authIni2]` produces `A+` (instead of `AB`) for `Aachen and Berlin and Chemnitz`. [#9703](https://github.com/JabRef/jabref/pull/9703)
 
 
 ### Fixed
@@ -65,6 +65,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the log text color in the event log console when using dark mode. [#9732](https://github.com/JabRef/jabref/issues/9732)
 - We fixed an issue where searching for unlinked files would include the current library's .bib file [#9735](https://github.com/JabRef/jabref/issues/9735)
 - We fixed an issue where it was no longer possible to connect to a shared mysql database due to an exception [#9761](https://github.com/JabRef/jabref/issues/9761)
+- We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -39,10 +39,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The BracketedExpressionExpander provides methods to expand bracketed expressions, such as
- * [year]_[author]_[firstpage], using information from a provided BibEntry. The above-mentioned expression would yield
- * 2017_Kitsune_123 when expanded using the BibTeX entry "@Article{ authors = {O. Kitsune}, year = {2017},
- * pages={123-6}}".
+ * This class provides methods to expand bracketed expressions, such as
+ * <code>[year]_[author]_[firstpage]</code>, using information from a provided BibEntry. The above-mentioned expression would yield
+ * <code>2017_Kitsune_123</code> when expanded using the BibTeX entry <code>@Article{ authors = {O. Kitsune}, year = {2017},
+ * pages={123-6}}</code>.
+ * <p>
+ * The embedding in JabRef is explained at <a href="https://docs.jabref.org/setup/citationkeypattern">Customize the citation key generator</a>.
+ * </p>
  */
 public class BracketedPattern {
     private static final Logger LOGGER = LoggerFactory.getLogger(BracketedPattern.class);
@@ -51,6 +54,7 @@ public class BracketedPattern {
      * The maximum number of characters in the first author's last name.
      */
     private static final int CHARS_OF_FIRST = 5;
+
     /**
      * The maximum number of name abbreviations that can be used. If there are more authors, {@code MAX_ALPHA_AUTHORS -
      * 1} name abbreviations will be displayed, and a + sign will be appended at the end.
@@ -61,18 +65,23 @@ public class BracketedPattern {
      * Matches everything that is not a unicode decimal digit.
      */
     private static final Pattern NOT_DECIMAL_DIGIT = Pattern.compile("\\P{Nd}");
+
     /**
      * Matches everything that is not an uppercase ASCII letter. The intended use is to remove all lowercase letters
      */
     private static final Pattern NOT_CAPITAL_CHARACTER = Pattern.compile("[^A-Z]");
+
     /**
      * Matches uppercase english letters between "({" and "})", which should be used to abbreviate the name of an institution
      */
+
     private static final Pattern INLINE_ABBREVIATION = Pattern.compile("(?<=\\(\\{)[A-Z]+(?=}\\))");
+
     /**
-     * Matches with "dep"/"dip", case insensitive
+     * Matches with "dep"/"dip", case-insensitive
      */
     private static final Pattern DEPARTMENTS = Pattern.compile("^d[ei]p.*", Pattern.CASE_INSENSITIVE);
+
     private static final Pattern WHITESPACE = Pattern.compile("\\p{javaWhitespace}");
 
     private enum Institution {
@@ -85,10 +94,12 @@ public class BracketedPattern {
          * Matches "uni" followed by "v" or "b", at the start of a string or after a space, case insensitive
          */
         private static final Pattern UNIVERSITIES = Pattern.compile("^uni(v|b|$).*", Pattern.CASE_INSENSITIVE);
+
         /**
-         * Matches with "tech", case insensitive
+         * Matches with "tech", case-insensitive
          */
         private static final Pattern TECHNOLOGICAL_INSTITUTES = Pattern.compile("^tech.*", Pattern.CASE_INSENSITIVE);
+
         /**
          * Matches with "dep"/"dip"/"lab", case insensitive
          */
@@ -357,7 +368,7 @@ public class BracketedPattern {
                     case "authEtAl":
                         return authEtal(authorList, "", "EtAl");
                     case "authshort":
-                        return authshort(authorList);
+                        return authShort(authorList);
                 }
 
                 if (pattern.matches("authIni[\\d]+")) {
@@ -400,7 +411,7 @@ public class BracketedPattern {
                     case "edtr.edtr.ea":
                         return authAuthEa(editorList);
                     case "edtrshort":
-                        return authshort(editorList);
+                        return authShort(editorList);
                 }
 
                 if (pattern.matches("edtrIni[\\d]+")) {
@@ -542,9 +553,9 @@ public class BracketedPattern {
     /**
      * Applies modifiers to a label generated based on a field marker.
      *
-     * @param label  The generated label.
-     * @param parts  String array containing the modifiers.
-     * @param offset The number of initial items in the modifiers array to skip.
+     * @param label                The generated label.
+     * @param parts                String array containing the modifiers.
+     * @param offset               The number of initial items in the modifiers array to skip.
      * @param expandBracketContent a function to expand the content in the parentheses.
      * @return The modified label.
      */
@@ -777,13 +788,17 @@ public class BracketedPattern {
     }
 
     /**
-     * Gets the last name of all authors/editors
+     * Gets the last name of all authors/editors.
+     * Pattern <code>[authors]</code>.
+     * <p>
+     * <code>and others</code> is converted to <code>EtAl</code>
+     * </p>
      *
      * @param authorList an {@link AuthorList}
-     * @return the sur name of all authors/editors
+     * @return the surname of all authors/editors
      */
-    private static String allAuthors(AuthorList authorList) {
-        return joinAuthorsOnLastName(authorList, authorList.getNumberOfAuthors(), "", "");
+    static String allAuthors(AuthorList authorList) {
+        return joinAuthorsOnLastName(authorList, authorList.getNumberOfAuthors(), "", "EtAl");
     }
 
     /**
@@ -792,10 +807,17 @@ public class BracketedPattern {
      * @param authorList an {@link AuthorList}
      * @return the initials of all authors' names
      */
-    private static String authorsAlpha(AuthorList authorList) {
+    static String authorsAlpha(AuthorList authorList) {
         StringBuilder alphaStyle = new StringBuilder();
-        int maxAuthors = authorList.getNumberOfAuthors() <= MAX_ALPHA_AUTHORS ?
-                authorList.getNumberOfAuthors() : (MAX_ALPHA_AUTHORS - 1);
+        int maxAuthors;
+        final boolean maxAuthorsExceeded;
+        if (authorList.getNumberOfAuthors() <= MAX_ALPHA_AUTHORS) {
+            maxAuthors = authorList.getNumberOfAuthors();
+            maxAuthorsExceeded = false;
+        } else {
+            maxAuthors = MAX_ALPHA_AUTHORS - 1;
+            maxAuthorsExceeded = true;
+        }
 
         if (authorList.getNumberOfAuthors() == 1) {
             String[] firstAuthor = authorList.getAuthor(0).getLastOnly()
@@ -808,8 +830,13 @@ public class BracketedPattern {
             alphaStyle.append(firstAuthor[firstAuthor.length - 1], 0,
                     Math.min(3, firstAuthor[firstAuthor.length - 1].length()));
         } else {
+            boolean andOthersPresent = authorList.getAuthor(maxAuthors - 1).equals(Author.OTHERS);
+            if (andOthersPresent) {
+                maxAuthors--;
+            }
             List<String> vonAndLastNames = authorList.getAuthors().stream()
-                                                     .limit(maxAuthors).map(Author::getLastOnly)
+                                                     .limit(maxAuthors)
+                                                     .map(Author::getLastOnly)
                                                      .collect(Collectors.toList());
             for (String vonAndLast : vonAndLastNames) {
                 // replace all whitespaces by " "
@@ -820,7 +847,7 @@ public class BracketedPattern {
                     alphaStyle.append(part, 0, 1);
                 }
             }
-            if (authorList.getNumberOfAuthors() > MAX_ALPHA_AUTHORS) {
+            if (andOthersPresent || maxAuthorsExceeded) {
                 alphaStyle.append("+");
             }
         }
@@ -834,15 +861,27 @@ public class BracketedPattern {
      * @param authorList the list of authors
      * @param maxAuthors the maximum number of authors in the string
      * @param delimiter  delimiter separating the last names of the authors
-     * @param suffix     to replace excess authors with
+     * @param suffix     to replace excess authors with. Also used to replace <code>and others</code>.
      * @return a string consisting of authors' last names separated by a `delimiter` and with any authors excess of
      * `maxAuthors` replaced with `suffix`
      */
-    private static String joinAuthorsOnLastName(AuthorList authorList, int maxAuthors, String delimiter, String suffix) {
-        suffix = authorList.getNumberOfAuthors() > maxAuthors ? suffix : "";
+    private static String joinAuthorsOnLastName(AuthorList authorList, int maxAuthors, String delimiter, final String suffix) {
+        final String finalSuffix = authorList.getNumberOfAuthors() > maxAuthors ? suffix : "";
         return authorList.getAuthors().stream()
-                         .map(Author::getLast).flatMap(Optional::stream)
-                         .limit(maxAuthors).collect(Collectors.joining(delimiter, "", suffix));
+                         .map(author -> {
+                             if (author.equals(Author.OTHERS)) {
+                                 if (suffix.startsWith(delimiter)) {
+                                     return Optional.of(suffix.substring(delimiter.length()));
+                                 } else {
+                                     return Optional.of(suffix);
+                                 }
+                             } else {
+                                 return author.getLast();
+                             }
+                         })
+                         .flatMap(Optional::stream)
+                         .limit(maxAuthors)
+                         .collect(Collectors.joining(delimiter, "", finalSuffix));
     }
 
     /**
@@ -877,46 +916,21 @@ public class BracketedPattern {
         return authorSB.toString();
     }
 
-    /**
-     * auth.auth.ea format:
-     * <ol>
-     * <li>Isaac Newton and James Maxwell and Albert Einstein (1960)</li>
-     * <li>Isaac Newton and James Maxwell (1960)</li>
-     * </ol>
-     * give:
-     * <ol>
-     * <li>Newton.Maxwell.ea</li>
-     * <li>Newton.Maxwell</li>
-     * </ol>
-     */
-    private static String authAuthEa(AuthorList authorList) {
+    static String authAuthEa(AuthorList authorList) {
         return joinAuthorsOnLastName(authorList, 2, ".", ".ea");
     }
 
     /**
-     * auth.etal, authEtAl, ... format:
-     * <ol>
-     * <li>Isaac Newton and James Maxwell and Albert Einstein (1960)</li>
-     * <li>Isaac Newton and James Maxwell (1960)</li>
-     * </ol>
-     * <p>
-     * auth.etal give (delim=".", append=".etal"):
-     * <ol>
-     * <li>Newton.etal</li>
-     * <li>Newton.Maxwell</li>
-     * </ol>
-     * </p>
-     * <p>
-     * authEtAl give (delim="", append="EtAl"):
-     * <ol>
-     * <li>NewtonEtAl</li>
-     * <li>NewtonMaxwell</li>
-     * </ol>
-     * </p>
-     * Note that [authEtAl] equals [authors2]
+     * auth.etal, authEtAl, ... format
      */
-    private static String authEtal(AuthorList authorList, String delim, String append) {
-        if (authorList.getNumberOfAuthors() <= 2) {
+    static String authEtal(AuthorList authorList, String delim, String append) {
+        if (authorList.isEmpty()) {
+            return "";
+        }
+        if ((authorList.getNumberOfAuthors() <= 2)
+                && ((authorList.getNumberOfAuthors() == 1) || !authorList.getAuthor(1).equals(Author.OTHERS))) {
+            // in case 1 or two authors, just name them
+            // exception: If the second author is "and others", then do the appendix handling (in the other branch)
             return joinAuthorsOnLastName(authorList, 2, delim, "");
         } else {
             return authorList.getAuthor(0).getLast().orElse("") + append;
@@ -924,7 +938,8 @@ public class BracketedPattern {
     }
 
     /**
-     * The first N characters of the Mth author's or editor's last name. M starts counting from 1
+     * The first N characters of the Mth author's or editor's last name. M starts counting from 1.
+     * In case the Mth author is {@link Author#OTHERS}, <code>+</code> is returned.
      */
     private static String authNofMth(AuthorList authorList, int n, int m) {
         // have m counting from 0
@@ -934,7 +949,11 @@ public class BracketedPattern {
             return "";
         }
 
-        String lastName = authorList.getAuthor(mminusone).getLast()
+        Author lastAuthor = authorList.getAuthor(mminusone);
+        if (lastAuthor.equals(Author.OTHERS)) {
+            return "+";
+        }
+        String lastName = lastAuthor.getLast()
                                     .map(CitationKeyGenerator::removeDefaultUnwantedCharacters).orElse("");
         return lastName.length() > n ? lastName.substring(0, n) : lastName;
     }
@@ -947,21 +966,9 @@ public class BracketedPattern {
     }
 
     /**
-     * authshort format:
-     * <p>
-     * given author names
-     * <ol><li>Isaac Newton and James Maxwell and Albert Einstein and N. Bohr</li>
-     * <li>Isaac Newton and James Maxwell and Albert Einstein</li>
-     * <li>Isaac Newton and James Maxwell</li>
-     * <li>Isaac Newton</li></ol>
-     * yield
-     * <ol><li>NME+</li>
-     * <li>NME</li>
-     * <li>NM</li>
-     * <li>Newton</li></ol></p>
-     * {@author added by Kolja Brix, kbx@users.sourceforge.net}
+     * authshort format
      */
-    private static String authshort(AuthorList authorList) {
+    static String authShort(AuthorList authorList) {
         StringBuilder author = new StringBuilder();
         final int numberOfAuthors = authorList.getNumberOfAuthors();
 
@@ -980,37 +987,32 @@ public class BracketedPattern {
     }
 
     /**
-     * authIniN format:
-     * <p>
-     * Each author gets (N div #authors) chars, the remaining (N mod #authors) chars are equally distributed to the
-     * authors first in the row. If (N < #authors), only the first N authors get mentioned.
-     * <p>
-     * For example if
-     * <ol>
-     * <li> I. Newton and J. Maxwell and A. Einstein and N. Bohr (..) </li>
-     * <li> I. Newton and J. Maxwell and A. Einstein </li>
-     * <li> I. Newton and J. Maxwell </li>
-     * <li> I. Newton </li>
-     * </ol>
-     * authIni4 gives:
-     * <ol>
-     * <li> NMEB </li>
-     * <li> NeME </li>
-     * <li> NeMa </li>
-     * <li> Newt </li>
-     * </ol>
+     * authIniN format
      *
      * @param authorList The authors to format.
      * @param n          The maximum number of characters this string will be long. A negative number or zero will lead
      *                   to "" be returned.
      */
-    private static String authIniN(AuthorList authorList, int n) {
+    static String authIniN(AuthorList authorList, int n) {
         if ((n <= 0) || authorList.isEmpty()) {
             return "";
         }
 
-        StringBuilder author = new StringBuilder();
         final int numberOfAuthors = authorList.getNumberOfAuthors();
+        final boolean lastAuthorIsOthers = authorList.getAuthor(numberOfAuthors - 1).equals(Author.OTHERS);
+        if ((n > 1) && ((n < numberOfAuthors) || lastAuthorIsOthers)) {
+            final int limit = Math.min(n - 1, numberOfAuthors - 1);
+            // special handling if the last author is "Others"
+            // This gets the single char "+" only
+            AuthorList allButOthers = AuthorList.of(
+                    authorList.getAuthors()
+                              .stream()
+                              .limit(limit)
+                              .toList());
+            return authIniN(allButOthers, n - 1) + "+";
+        }
+
+        StringBuilder author = new StringBuilder();
 
         int charsAll = n / numberOfAuthors;
         for (int i = 0; i < numberOfAuthors; i++) {

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -21,14 +21,23 @@ import org.slf4j.LoggerFactory;
  * This is the utility class of the LabelPattern package.
  */
 public class CitationKeyGenerator extends BracketedPattern {
-    /*
+    /**
      * All single characters that we can use for extending a key to make it unique.
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
-    public static final String DEFAULT_UNWANTED_CHARACTERS = "-`ʹ:!;?^+";
+
+    /**
+     * List of unwanted characters. These will be removed at the end.
+     * Note that <code>+</code> is a wanted character to indicate "et al." in authorsAlpha.
+     * Example: "ABC+". See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
+     */
+    public static final String DEFAULT_UNWANTED_CHARACTERS = "-`ʹ:!;?^";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
+
     // Source of disallowed characters : https://tex.stackexchange.com/a/408548/9075
     private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
+
     private final AbstractCitationKeyPattern citeKeyPattern;
     private final BibDatabase database;
     private final CitationKeyPatternPreferences citationKeyPatternPreferences;

--- a/src/main/java/org/jabref/logic/importer/AuthorListParser.java
+++ b/src/main/java/org/jabref/logic/importer/AuthorListParser.java
@@ -97,8 +97,17 @@ public class AuthorListParser {
     public AuthorList parse(String listOfNames) {
         Objects.requireNonNull(listOfNames);
 
-        // Handle the statement "and others" at the end, removing it
-        listOfNames = StringUtil.removeStringAtTheEnd(listOfNames.trim(), " and others");
+        // Handling of "and others"
+        // Remove it from the list; it will be added at the very end of this method as special Author.OTHERS
+        listOfNames = listOfNames.trim();
+        final String andOthersSuffix = " and others";
+        final boolean andOthersPresent;
+        if (StringUtil.endsWithIgnoreCase(listOfNames, andOthersSuffix)) {
+            andOthersPresent = true;
+            listOfNames = StringUtil.removeStringAtTheEnd(listOfNames, " and others");
+        } else {
+            andOthersPresent = false;
+        }
 
         // Handle case names in order lastname, firstname and separated by ","
         // E.g., Ali Babar, M., Dingsøyr, T., Lago, P., van der Vliet, H.
@@ -154,6 +163,11 @@ public class AuthorListParser {
         while (tokenStart < original.length()) {
             getAuthor().ifPresent(authors::add);
         }
+
+        if (andOthersPresent) {
+            authors.add(Author.OTHERS);
+        }
+
         return AuthorList.of(authors);
     }
 

--- a/src/main/java/org/jabref/logic/importer/AuthorListParser.java
+++ b/src/main/java/org/jabref/logic/importer/AuthorListParser.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
+import org.jabref.model.strings.StringUtil;
 
 public class AuthorListParser {
 
@@ -95,6 +96,9 @@ public class AuthorListParser {
      */
     public AuthorList parse(String listOfNames) {
         Objects.requireNonNull(listOfNames);
+
+        // Handle the statement "and others" at the end, removing it
+        listOfNames = StringUtil.removeStringAtTheEnd(listOfNames.trim(), " and others");
 
         // Handle case names in order lastname, firstname and separated by ","
         // E.g., Ali Babar, M., Dingsøyr, T., Lago, P., van der Vliet, H.

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -12,6 +12,14 @@ import org.jabref.model.strings.StringUtil;
  * Current usage: only methods <code>getLastOnly</code>, <code>getFirstLast</code>, and <code>getLastFirst</code> are used; all other methods are provided for completeness.
  */
 public class Author {
+
+    /**
+     * Object indicating the <code>others</code> author. This is a BibTeX feature mostly rendered in "et al." in LaTeX.
+     * Example: <code>authors = {Oliver Kopp and others}</code>. This is then appearing as "Oliver Kopp et al.".
+     * In the context of BibTeX key generation, this is "Kopp+" (<code>+</code> for "et al.") and not "KO".
+     */
+    public static final Author OTHERS = new Author("", "", null, "others", null);
+
     private final String firstPart;
     private final String firstAbbr;
     private final String vonPart;

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -766,4 +766,9 @@ public class StringUtil {
     public static String removeStringAtTheEnd(String string, String stringToBeRemoved) {
         return StringUtils.removeEndIgnoreCase(string, stringToBeRemoved);
     }
+
+    @ApacheCommonsLang3Allowed("No Guava equivalent existing")
+    public static boolean endsWithIgnoreCase(String string, String suffix) {
+        return StringUtils.endsWithIgnoreCase(string, suffix);
+    }
 }

--- a/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -761,4 +761,9 @@ public class StringUtil {
     public static boolean containsWhitespace(String s) {
         return s.chars().anyMatch(Character::isWhitespace);
     }
+
+    @ApacheCommonsLang3Allowed("No Guava equivalent existing - see https://stackoverflow.com/a/23825984")
+    public static String removeStringAtTheEnd(String string, String stringToBeRemoved) {
+        return StringUtils.removeEndIgnoreCase(string, stringToBeRemoved);
+    }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -3,6 +3,7 @@ package org.jabref.logic.citationkeypattern;
 import java.util.stream.Stream;
 
 import org.jabref.model.database.BibDatabase;
+import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.field.StandardField;
@@ -18,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+/**
+ * Tests based on a BibEntry are contained in {@link CitationKeyGeneratorTest}
+ */
 class BracketedPatternTest {
 
     private BibEntry bibentry;
@@ -46,6 +50,209 @@ class BracketedPatternTest {
 
         database = new BibDatabase();
         database.insertEntry(dbentry);
+    }
+
+    static Stream<Arguments> allAuthors() {
+        return Stream.of(
+                Arguments.of("ArtemenkoEtAl", "Alexander Artemenko and others"),
+                Arguments.of("AachenEtAl", "Aachen and others"),
+                Arguments.of("AachenBerlinEtAl", "Aachen and Berlin and others"),
+                Arguments.of("AachenBerlinChemnitzEtAl", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("AachenBerlinChemnitzDüsseldorf", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("AachenBerlinChemnitzDüsseldorfEtAl", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("AachenBerlinChemnitzDüsseldorfEssen", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("AachenBerlinChemnitzDüsseldorfEssenEtAl", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void allAuthors(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.allAuthors(list));
+    }
+
+    static Stream<Arguments> authorsAlpha() {
+        return Stream.of(
+                Arguments.of("A+", "Alexander Artemenko and others"),
+                Arguments.of("A+", "Aachen and others"),
+                Arguments.of("AB+", "Aachen and Berlin and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authorsAlpha(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authorsAlpha(list));
+    }
+
+    static Stream<Arguments> authShort() {
+        return Stream.of(
+                Arguments.of("Newton", "Isaac Newton"),
+                Arguments.of("NM", "Isaac Newton and James Maxwell"),
+                Arguments.of("NME", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("NME+", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aachen", "Aachen"),
+                Arguments.of("A+", "Aachen and others"),
+                Arguments.of("AB", "Aachen and Berlin"),
+                Arguments.of("AB+", "Aachen and Berlin and others"),
+                Arguments.of("ABC", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authIni1(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 1));
+    }
+
+    static Stream<Arguments> authIni1() {
+        return Stream.of(
+                Arguments.of("N", "Isaac Newton"),
+                Arguments.of("N", "Isaac Newton and James Maxwell"),
+                Arguments.of("N", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("N", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("A", "Aachen"),
+                Arguments.of("A", "Aachen and others"),
+                Arguments.of("A", "Aachen and Berlin"),
+                Arguments.of("A", "Aachen and Berlin and others"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authIni2(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 2));
+    }
+
+    static Stream<Arguments> authIni2() {
+        return Stream.of(
+                Arguments.of("Ne", "Isaac Newton"),
+                Arguments.of("NM", "Isaac Newton and James Maxwell"),
+                Arguments.of("N+", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("N+", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aa", "Aachen"),
+                Arguments.of("A+", "Aachen and others"),
+                Arguments.of("AB", "Aachen and Berlin"),
+                Arguments.of("A+", "Aachen and Berlin and others"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("D+", "John Doe and Donald Smith and Will Wonder"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("A+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authIni4(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 4));
+    }
+
+    static Stream<Arguments> authIni4() {
+        return Stream.of(
+                Arguments.of("Newt", "Isaac Newton"),
+                Arguments.of("NeMa", "Isaac Newton and James Maxwell"),
+                Arguments.of("NeME", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("NMEB", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aach", "Aachen"),
+                Arguments.of("Aac+", "Aachen and others"),
+                Arguments.of("AaBe", "Aachen and Berlin"),
+                Arguments.of("AaB+", "Aachen and Berlin and others"),
+                Arguments.of("AaBC", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authEtAlDotDotEal(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authEtal(list, ".", ".etal"));
+    }
+
+    static Stream<Arguments> authEtAlDotDotEal() {
+        return Stream.of(
+                Arguments.of("Newton", "Isaac Newton"),
+                Arguments.of("Newton.Maxwell", "Isaac Newton and James Maxwell"),
+                Arguments.of("Newton.etal", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("Newton.etal", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aachen", "Aachen"),
+                Arguments.of("Aachen.etal", "Aachen and others"),
+                Arguments.of("Aachen.Berlin", "Aachen and Berlin"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and others"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authAuthEa(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authAuthEa(list));
+    }
+
+    static Stream<Arguments> authAuthEa() {
+        return Stream.of(
+                Arguments.of("Newton", "Isaac Newton"),
+                Arguments.of("Newton.Maxwell", "Isaac Newton and James Maxwell"),
+                Arguments.of("Newton.Maxwell.ea", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("Newton.Maxwell.ea", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aachen", "Aachen"),
+                Arguments.of("Aachen.ea", "Aachen and others"),
+                Arguments.of("Aachen.Berlin", "Aachen and Berlin"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and others"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authShort(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authShort(list));
+    }
+
+    private static Stream<Arguments> expandBracketsWithFallback() {
+        return Stream.of(
+                Arguments.of("auth", "[title:(auth)]"),
+                Arguments.of("auth2021", "[title:(auth[YEAR])]"),
+                Arguments.of("not2021", "[title:(not[YEAR])]"),
+                Arguments.of("", "[title:([YEAR)]"),
+                Arguments.of(")]", "[title:(YEAR])]"),
+                Arguments.of("2105.02891", "[title:([EPRINT:([YEAR])])]"),
+                Arguments.of("2021", "[title:([auth:([YEAR])])]")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource()
+    void expandBracketsWithFallback(String expandResult, String pattern) {
+        BibEntry bibEntry = new BibEntry()
+                .withField(StandardField.YEAR, "2021").withField(StandardField.EPRINT, "2105.02891");
+        BracketedPattern bracketedPattern = new BracketedPattern(pattern);
+
+        assertEquals(expandResult, bracketedPattern.expand(bibEntry));
     }
 
     @Test
@@ -348,18 +555,19 @@ class BracketedPatternTest {
 
     @Test
     void expandBracketsWithTestCasesFromRegExpBasedFileFinder() {
-        BibEntry entry = new BibEntry(StandardEntryType.Article).withCitationKey("HipKro03");
-        entry.setField(StandardField.AUTHOR, "Eric von Hippel and Georg von Krogh");
-        entry.setField(StandardField.TITLE, "Open Source Software and the \"Private-Collective\" Innovation Model: Issues for Organization Science");
-        entry.setField(StandardField.JOURNAL, "Organization Science");
-        entry.setField(StandardField.YEAR, "2003");
-        entry.setField(StandardField.VOLUME, "14");
-        entry.setField(StandardField.PAGES, "209--223");
-        entry.setField(StandardField.NUMBER, "2");
-        entry.setField(StandardField.ADDRESS, "Institute for Operations Research and the Management Sciences (INFORMS), Linthicum, Maryland, USA");
-        entry.setField(StandardField.DOI, "http://dx.doi.org/10.1287/orsc.14.2.209.14992");
-        entry.setField(StandardField.ISSN, "1526-5455");
-        entry.setField(StandardField.PUBLISHER, "INFORMS");
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("HipKro03")
+                .withField(StandardField.AUTHOR, "Eric von Hippel and Georg von Krogh")
+                .withField(StandardField.TITLE, "Open Source Software and the \"Private-Collective\" Innovation Model: Issues for Organization Science")
+                .withField(StandardField.JOURNAL, "Organization Science")
+                .withField(StandardField.YEAR, "2003")
+                .withField(StandardField.VOLUME, "14")
+                .withField(StandardField.PAGES, "209--223")
+                .withField(StandardField.NUMBER, "2")
+                .withField(StandardField.ADDRESS, "Institute for Operations Research and the Management Sciences (INFORMS), Linthicum, Maryland, USA")
+                .withField(StandardField.DOI, "http://dx.doi.org/10.1287/orsc.14.2.209.14992")
+                .withField(StandardField.ISSN, "1526-5455")
+                .withField(StandardField.PUBLISHER, "INFORMS");
 
         BibDatabase database = new BibDatabase();
         database.insertEntry(entry);
@@ -391,27 +599,5 @@ class BracketedPatternTest {
         BibEntry bibEntry = new BibEntry()
                 .withField(StandardField.JOURNAL, "{ACS} Medicinal Chemistry Letters");
         assertEquals("ACS Medicinal Chemistry Letters", BracketedPattern.expandBrackets("[JOURNAL:unprotect_terms]", null, bibEntry, null));
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideArgumentsForFallback")
-    void expandBracketsWithFallback(String expandResult, String pattern) {
-        BibEntry bibEntry = new BibEntry()
-                .withField(StandardField.YEAR, "2021").withField(StandardField.EPRINT, "2105.02891");
-        BracketedPattern bracketedPattern = new BracketedPattern(pattern);
-
-        assertEquals(expandResult, bracketedPattern.expand(bibEntry));
-    }
-
-    private static Stream<Arguments> provideArgumentsForFallback() {
-        return Stream.of(
-                Arguments.of("auth", "[title:(auth)]"),
-                Arguments.of("auth2021", "[title:(auth[YEAR])]"),
-                Arguments.of("not2021", "[title:(not[YEAR])]"),
-                Arguments.of("", "[title:([YEAR)]"),
-                Arguments.of(")]", "[title:(YEAR])]"),
-                Arguments.of("2105.02891", "[title:([EPRINT:([YEAR])])]"),
-                Arguments.of("2021", "[title:([auth:([YEAR])])]")
-        );
     }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1150,4 +1150,11 @@ class CitationKeyGeneratorTest {
         entry.setField(StandardField.YEAR, "2021");
         assertEquals("Brekel2021", generateKey(entry, "[auth][year]"));
     }
+
+    @Test
+    void generateKeyCorrectKeyWithAndOthersAtTheEnd() {
+        BibEntry entry = createABibEntryAuthor("Alexander Artemenko and others");
+        entry.setField(StandardField.YEAR, "2019");
+        assertEquals("Artemenko2019", generateKey(entry, "[auth][year]"));
+    }
 }

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.citationkeypattern;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParseException;
@@ -13,6 +14,9 @@ import org.jabref.model.util.FileUpdateMonitor;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 
 import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
@@ -20,15 +24,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests whole citation key patterns such as <code>[authorsAlpha][year]</code>.
+ * The concrete patterns such as <code>authorsAlpha</code> should better be tested at {@link BracketedPatternTest}.
+ */
 class CitationKeyGeneratorTest {
 
     private static final BibEntry AUTHOR_EMPTY = createABibEntryAuthor("");
 
     private static final String AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1 = "Isaac Newton";
-    private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1 = createABibEntryAuthor("Isaac Newton");
+    private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1 = createABibEntryAuthor(AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1);
+
     private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_2 = createABibEntryAuthor("Isaac Newton and James Maxwell");
+
     private static final String AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_3 = "Isaac Newton and James Maxwell and Albert Einstein";
-    private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_3 = createABibEntryAuthor("Isaac Newton and James Maxwell and Albert Einstein");
+    private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_3 = createABibEntryAuthor(AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_3);
+
+    private static final String AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3 = "Isaac Newton and James Maxwell and others";
+    private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3 = createABibEntryAuthor(AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3);
 
     private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1 = createABibEntryAuthor("Wil van der Aalst");
     private static final BibEntry AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2 = createABibEntryAuthor("Wil van der Aalst and Tammo van Lessen");
@@ -486,12 +499,12 @@ class CitationKeyGeneratorTest {
 
     @Test
     void testAuthIniN() {
-        assertEquals("NMEB", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, "[authIni4]"));
-        assertEquals("NMEB", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, "[authIni4]"));
-        assertEquals("NeME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, "[authIni4]"));
-        assertEquals("NeMa", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, "[authIni4]"));
-        assertEquals("Newt", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, "[authIni4]"));
         assertEquals("", generateKey(AUTHOR_EMPTY, "[authIni4]"));
+        assertEquals("Newt", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, "[authIni4]"));
+        assertEquals("NeMa", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, "[authIni4]"));
+        assertEquals("NeME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, "[authIni4]"));
+        assertEquals("NMEB", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, "[authIni4]"));
+        assertEquals("NME+", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, "[authIni4]"));
 
         assertEquals("N", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, "[authIni1]"));
         assertEquals("", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, "[authIni0]"));
@@ -542,7 +555,7 @@ class CitationKeyGeneratorTest {
     @Test
     void testAuthShort() {
         // tests taken from the comments
-        assertEquals("NME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHSHORT));
+        assertEquals("NME+", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHSHORT));
         assertEquals("NME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHSHORT));
         assertEquals("NM", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHSHORT));
         assertEquals("Newton", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHSHORT));
@@ -606,19 +619,23 @@ class CitationKeyGeneratorTest {
         assertEquals("NewtonMaxwellEinstein", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORS));
     }
 
-    /**
-     * Tests [authorsAlpha]
-     */
-    @Test
-    void authorsAlpha() {
-        assertEquals("New", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORSALPHA));
-        assertEquals("NM", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORSALPHA));
-        assertEquals("NME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORSALPHA));
-        assertEquals("NMEB", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHORSALPHA));
-        assertEquals("NME", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORSALPHA));
+    static Stream<Arguments> testAuthorsAlpha() {
+        return Stream.of(
+                Arguments.of("New", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORSALPHA),
+                Arguments.of("NM", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORSALPHA),
+                Arguments.of("NME", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORSALPHA),
+                Arguments.of("NMEB", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHORSALPHA),
+                Arguments.of("NME+", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORSALPHA),
+                Arguments.of("vdAal", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORSALPHA),
+                Arguments.of("vdAvL", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORSALPHA),
+                Arguments.of("NM+", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3, AUTHORSALPHA)
+        );
+    }
 
-        assertEquals("vdAal", generateKey(AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORSALPHA));
-        assertEquals("vdAvL", generateKey(AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORSALPHA));
+    @ParameterizedTest
+    @MethodSource
+    void testAuthorsAlpha(String expected, BibEntry entry, String pattern) {
+        assertEquals(expected, generateKey(entry, pattern));
     }
 
     /**

--- a/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
@@ -446,7 +446,7 @@ class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[authIni2]");
         entry.setField(StandardField.AUTHOR, "John Doe and Donald Smith and Will Wonder");
         new CitationKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("DS"), entry.getCitationKey());
+        assertEquals(Optional.of("D+"), entry.getCitationKey());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -5,8 +5,6 @@ import java.util.stream.Stream;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,7 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AuthorListParserTest {
 
-    private static Stream<Arguments> data() {
+    AuthorListParser parser = new AuthorListParser();
+
+    private static Stream<Arguments> parseSingleAuthorCorrectly() {
         return Stream.of(
                 Arguments.of("王, 军", new Author("军", "军.", null, "王", null)),
                 Arguments.of("Doe, John", new Author("John", "J.", null, "Doe", null)),
@@ -27,21 +27,31 @@ class AuthorListParserTest {
                 Arguments.of("{K}ent-{B}oswell, E. S.", new Author("E. S.", "E. S.", null, "{K}ent-{B}oswell", null)),
                 Arguments.of("Uhlenhaut, N Henriette", new Author("N Henriette", "N. H.", null, "Uhlenhaut", null)),
                 Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null)),
-                Arguments.of("Alexander Artemenko and others", new Author("Alexander", "A.", null, "Artemenko", null))
+                // parseAuthorWithFirstNameAbbreviationContainingUmlaut
+                Arguments.of("{\\OE}rjan Umlauts", new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null))
         );
     }
 
     @ParameterizedTest
-    @MethodSource("data")
-    void parseCorrectly(String authorsString, Author authorsParsed) {
-        AuthorListParser parser = new AuthorListParser();
-        Assertions.assertEquals(AuthorList.of(authorsParsed), parser.parse(authorsString));
+    @MethodSource
+    void parseSingleAuthorCorrectly(String authorsString, Author authorsParsed) {
+        assertEquals(AuthorList.of(authorsParsed), parser.parse(authorsString));
     }
 
-    @Test
-    public void parseAuthorWithFirstNameAbbreviationContainingUmlaut() {
-        assertEquals(AuthorList.of(
-                new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
-                new AuthorListParser().parse("{\\OE}rjan Umlauts"));
+    private static Stream<Arguments> parseMultipleCorrectly() {
+        return Stream.of(
+                Arguments.of(
+                        AuthorList.of(
+                                new Author("Alexander", "A.", null, "Artemenko", null),
+                                Author.OTHERS
+                        ),
+                        "Alexander Artemenko and others")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseMultipleCorrectly(AuthorList expected, String authorsString) {
+        assertEquals(expected, parser.parse(authorsString));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -26,7 +26,8 @@ class AuthorListParserTest {
                 Arguments.of("de la Vallée Poussin, J. C. G.", new Author("J. C. G.", "J. C. G.", "de la", "Vallée Poussin", null)),
                 Arguments.of("{K}ent-{B}oswell, E. S.", new Author("E. S.", "E. S.", null, "{K}ent-{B}oswell", null)),
                 Arguments.of("Uhlenhaut, N Henriette", new Author("N Henriette", "N. H.", null, "Uhlenhaut", null)),
-                Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null))
+                Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null)),
+                Arguments.of("Alexander Artemenko and others", new Author("Alexander", "A.", null, "Artemenko", null))
         );
     }
 

--- a/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -24,7 +24,7 @@ class StringUtilTest {
         Path path = Path.of("src", "main", "java", StringUtil.class.getName().replace('.', '/') + ".java");
         int lineCount = Files.readAllLines(path, StandardCharsets.UTF_8).size();
 
-        assertTrue(lineCount <= 765, "StringUtil increased in size to " + lineCount + ". "
+        assertTrue(lineCount <= 769, "StringUtil increased in size to " + lineCount + ". "
                 + "We try to keep this class as small as possible. "
                 + "Thus think twice if you add something to StringUtil.");
     }

--- a/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -24,7 +24,7 @@ class StringUtilTest {
         Path path = Path.of("src", "main", "java", StringUtil.class.getName().replace('.', '/') + ".java");
         int lineCount = Files.readAllLines(path, StandardCharsets.UTF_8).size();
 
-        assertTrue(lineCount <= 769, "StringUtil increased in size to " + lineCount + ". "
+        assertTrue(lineCount <= 774, "StringUtil increased in size to " + lineCount + ". "
                 + "We try to keep this class as small as possible. "
                 + "Thus think twice if you add something to StringUtil.");
     }


### PR DESCRIPTION
…he end

Fixes koppor/jabref#626
Remove the statement "and others" at the end of authors list in order to generate a correct citation key.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
