### PR TITLE
Improved dialog for deletion of multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - `log.txt` does not contain entries for non-found files during PDF indexing. [#9678](https://github.com/JabRef/jabref/pull/9678)
 - We improved the Medline importer to correctly import ISO dates for `revised`. [#9536](https://github.com/JabRef/jabref/issues/9536)
 - To avoid cluttering of the directory, We always delete the `.sav` file upon successful write. [#9675](https://github.com/JabRef/jabref/pull/9675)
-
+- We improved the unlinking/deletion of multiple linked files of an entry using the <kbd>Delete</kbd> key [#9473](https://github.com/JabRef/jabref/issues/9473)
 
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -385,7 +385,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
 
         if (file.isEmpty()) {
-            LOGGER.warn("Could not find file " + linkedFile.getLink());
+            LOGGER.warn("Could not find file {}", linkedFile.getLink());
             return true;
         }
 
@@ -407,7 +407,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                     return true;
                 } catch (IOException ex) {
                     dialogService.showErrorDialogAndWait(Localization.lang("Cannot delete file"), Localization.lang("File permission error"));
-                    LOGGER.warn("File permission error while deleting: " + linkedFile, ex);
+                    LOGGER.warn("File permission error while deleting: {}", linkedFile, ex);
                 }
             }
         }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.fieldeditors;
 
-import java.util.List;
 import java.util.Optional;
 
 import javafx.beans.binding.Bindings;
@@ -41,6 +40,7 @@ import org.jabref.gui.copyfiles.CopySingleFileAction;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.importer.GrobidOptInDialogHelper;
 import org.jabref.gui.keyboard.KeyBinding;
+import org.jabref.gui.linkedfile.DeleteFileAction;
 import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.gui.util.ViewModelListCellFactory;
@@ -218,10 +218,8 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
             if (keyBinding.isPresent()) {
                 switch (keyBinding.get()) {
                     case DELETE_ENTRY:
-                        List<LinkedFileViewModel> toBeDeleted = List.copyOf(listView.getSelectionModel().getSelectedItems());
-                        for (LinkedFileViewModel selectedItem : toBeDeleted) {
-                            viewModel.deleteFile(selectedItem);
-                        }
+                        new DeleteFileAction(dialogService, preferencesService, databaseContext,
+                                viewModel, listView).execute();
                         event.consume();
                         break;
                     default:

--- a/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -1,0 +1,136 @@
+package org.jabref.gui.linkedfile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ListView;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.fieldeditors.LinkedFileViewModel;
+import org.jabref.gui.fieldeditors.LinkedFilesEditorViewModel;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.preferences.PreferencesService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteFileAction extends SimpleCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteFileAction.class);
+
+    private final DialogService dialogService;
+    private final PreferencesService preferences;
+    private final BibDatabaseContext databaseContext;
+    private final LinkedFilesEditorViewModel viewModel;
+    private final ListView<LinkedFileViewModel> listView;
+
+    public DeleteFileAction(DialogService dialogService,
+                            PreferencesService preferences,
+                            BibDatabaseContext databaseContext,
+                            LinkedFilesEditorViewModel viewModel,
+                            ListView<LinkedFileViewModel> listView) {
+        this.dialogService = dialogService;
+        this.preferences = preferences;
+        this.databaseContext = databaseContext;
+        this.viewModel = viewModel;
+        this.listView = listView;
+    }
+
+    @Override
+    public void execute() {
+        List<LinkedFileViewModel> toBeDeleted = List.copyOf(listView.getSelectionModel().getSelectedItems());
+
+        if (toBeDeleted.isEmpty()) {
+            dialogService.notify(Localization.lang("This operation requires selected linked files."));
+            return;
+        }
+
+        String dialogTitle;
+        String dialogContent;
+
+        if (toBeDeleted.size() != 1) {
+            dialogTitle = Localization.lang("Delete %0 files", toBeDeleted.size());
+            dialogContent = Localization.lang("Delete %0 files permanently from disk, or just remove the files from the entry? " +
+                    "Pressing Delete will delete the files permanently from disk.", toBeDeleted.size());
+        } else {
+            Optional<Path> file = toBeDeleted.get(0).getFile().findIn(databaseContext, preferences.getFilePreferences());
+
+            if (file.isPresent()) {
+                dialogTitle = Localization.lang("Delete '%0'", file.get().getFileName().toString());
+                dialogContent = Localization.lang("Delete '%0' permanently from disk, or just remove the file from the entry? " +
+                        "Pressing Delete will delete the file permanently from disk.", file.get().toString());
+            } else {
+                dialogService.notify(Localization.lang("Error accessing file '%0'.", toBeDeleted.get(0).getFile().getLink()));
+                return;
+            }
+        }
+
+        ButtonType removeFromEntry = new ButtonType(Localization.lang("Remove from entry"), ButtonBar.ButtonData.YES);
+        ButtonType deleteFromEntry = new ButtonType(Localization.lang("Delete from disk"));
+        Optional<ButtonType> buttonType = dialogService.showCustomButtonDialogAndWait(Alert.AlertType.INFORMATION,
+                dialogTitle, dialogContent, removeFromEntry, deleteFromEntry, ButtonType.CANCEL);
+
+        if (buttonType.isPresent()) {
+            if (buttonType.get().equals(removeFromEntry)) {
+                deleteFiles(toBeDeleted, false);
+            }
+
+            if (buttonType.get().equals(deleteFromEntry)) {
+                deleteFiles(toBeDeleted, true);
+            }
+        }
+    }
+
+    /**
+     * Deletes the files from the entry and optionally from disk.
+     *
+     * @param toBeDeleted the files to be deleted
+     * @param deleteFromDisk if true, the files are deleted from disk, otherwise they are only removed from the entry
+     */
+    private void deleteFiles(List<LinkedFileViewModel> toBeDeleted, boolean deleteFromDisk) {
+        for (LinkedFileViewModel fileViewModel : toBeDeleted) {
+            if (fileViewModel.getFile().isOnlineLink()) {
+                viewModel.removeFileLink(fileViewModel);
+            } else {
+                if (deleteFromDisk) {
+                    deleteFileFromDisk(fileViewModel);
+                }
+                viewModel.getFiles().remove(fileViewModel);
+            }
+        }
+    }
+
+    /**
+     * Deletes the file from disk without asking the user for confirmation.
+     *
+     * @param fileViewModel the file to be deleted
+     */
+    public void deleteFileFromDisk(LinkedFileViewModel fileViewModel) {
+        LinkedFile linkedFile = fileViewModel.getFile();
+
+        Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
+
+        if (file.isEmpty()) {
+            LOGGER.warn("Could not find file " + linkedFile.getLink());
+        }
+
+        if (file.isPresent()) {
+            try {
+                Files.delete(file.get());
+            } catch (
+                    IOException ex) {
+                dialogService.showErrorDialogAndWait(Localization.lang("Cannot delete file"), Localization.lang("File permission error"));
+                LOGGER.warn("File permission error while deleting: " + linkedFile, ex);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -120,7 +120,7 @@ public class DeleteFileAction extends SimpleCommand {
         Optional<Path> file = linkedFile.findIn(databaseContext, preferences.getFilePreferences());
 
         if (file.isEmpty()) {
-            LOGGER.warn("Could not find file " + linkedFile.getLink());
+            LOGGER.warn("Could not find file {}", linkedFile.getLink());
         }
 
         if (file.isPresent()) {
@@ -129,8 +129,10 @@ public class DeleteFileAction extends SimpleCommand {
             } catch (
                     IOException ex) {
                 dialogService.showErrorDialogAndWait(Localization.lang("Cannot delete file"), Localization.lang("File permission error"));
-                LOGGER.warn("File permission error while deleting: " + linkedFile, ex);
+                LOGGER.warn("File permission error while deleting: {}", linkedFile, ex);
             }
+        } else {
+            dialogService.notify(Localization.lang("Error accessing file '%0'.", linkedFile.getLink()));
         }
     }
 }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2539,3 +2539,8 @@ Please\ select\ a\ valid\ main\ directory\ under=Please select a valid main dire
 Search\ from\ history...=Search from history...
 your\ search\ history\ is\ empty=your search history is empty
 Clear\ history =Clear history
+
+Delete\ %0\ files=Delete %0 files
+Delete\ %0\ files\ permanently\ from\ disk,\ or\ just\ remove\ the\ files\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ files\ permanently\ from\ disk.=Delete %0 files permanently from disk, or just remove the files from the entry? Pressing Delete will delete the files permanently from disk.
+Error\ accessing\ file\ '%0'.=Error accessing file '%0'.
+This\ operation\ requires\ selected\ linked\ files.=This operation requires selected linked files.


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #9473

Created `DeleteFileAction` class that extends `SimpleCommand`. This class handles both the creation of the dialog that either shows a file name or the amount of files, depending on the selection in the `LinkedFileViewModel`, as well as the unlinking/deletion itself. Also changed the call in `LinkedFilesEditor` when <kbd>Delete</kbd> is pressed to use this new `DeleteFileAction` class.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
---
Deletion of a single file:
![image](https://user-images.githubusercontent.com/64023154/228277820-0b50be98-ae7c-4f9f-93b0-ebf1ddeb020f.png)
Deletion of multiple files:
![image](https://user-images.githubusercontent.com/64023154/228278203-daa327e1-9a8d-446f-b31a-e2a62c79dd89.png)


