### PR TITLE
Global Search UI preview is dark in dark theme when no entry is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the password is saved locally if user wants to use proxy with authentication [#8055](https://github.com/JabRef/jabref/issues/8055)
 - JabRef is now more relaxed when parsing field content: In case a field content ended with `\`, the combination `\}` was treated as plain `}`. [#9668](https://github.com/JabRef/jabref/issues/9668)
 - We resolved an issue that cut off the number of group entries when it exceedet four digits. [#8797](https://github.com/JabRef/jabref/issues/8797)
-
+- We fixed an issue where the Global Search UI preview is still white in dark theme. [#9362](https://github.com/JabRef/jabref/issues/9362)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -244,7 +244,8 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
 
     private void update() {
         if (entry.isEmpty() || (layout == null)) {
-            // Nothing to do
+            // Make sure that the preview panel is not completely white, especially with dark theme on
+            setPreviewText("");
             return;
         }
 

--- a/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
@@ -58,6 +58,11 @@ public class GlobalSearchResultDialog extends BaseDialog<Void> {
 
         resultsTable.getColumns().removeIf(col -> col instanceof SpecialFieldColumn);
         resultsTable.getSelectionModel().selectFirst();
+
+        if (resultsTable.getSelectionModel().getSelectedItem() != null) {
+            previewViewer.setEntry(resultsTable.getSelectionModel().getSelectedItem().getEntry());
+        }
+
         resultsTable.getSelectionModel().selectedItemProperty().addListener((obs, old, newValue) -> {
             if (newValue != null) {
                 previewViewer.setEntry(newValue.getEntry());


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes https://github.com/JabRef/jabref/issues/9362
![test](https://user-images.githubusercontent.com/72476774/229155854-47409765-6914-4307-bf38-ef3a101f0a05.png)
When nothing has been selected in the Global Search dialog, the preview screen will remain black on dark mode instead of being white.

![test2](https://user-images.githubusercontent.com/72476774/229156369-a191af57-0b0a-43ce-a2d5-b9ba947459f5.png)
Moreover when there is an entry in the table, the first entry will also be shown in the preview instead of only being selected on the table.


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```