### PR TITLE
Add 'More' option to the table column context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added "Attach file from URL" to right-click context menu to download and store a file with the reference library. [#9646](https://github.com/JabRef/jabref/issues/9646)
 - We enabled updating an existing entry with data from InspireHEP. [#9351](https://github.com/JabRef/jabref/issues/9351)
 - We added a fetcher for the Bibliotheksverbund Bayern (experimental). [#9641](https://github.com/JabRef/jabref/pull/9641)
-
+- We added a "More" option to the context menu that appears when a table columns is right-clicked. This enables for easier adding of new columns. [#9432](https://github.com/JabRef/jabref/issues/9432)
 
 
 

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -5,12 +5,17 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TableColumn;
 import javafx.scene.layout.StackPane;
 
+import org.jabref.gui.Globals;
+import org.jabref.gui.JabRefGUI;
 import org.jabref.gui.maintable.columns.MainTableColumn;
+import org.jabref.gui.preferences.ShowPreferencesAction;
+import org.jabref.gui.preferences.table.TableTab;
 
 public class MainTableHeaderContextMenu extends ContextMenu {
 
@@ -75,6 +80,11 @@ public class MainTableHeaderContextMenu extends ContextMenu {
             RightClickMenuItem itemToAdd = createMenuItem(tableColumn, false);
             this.getItems().add(itemToAdd);
         }
+
+        this.getItems().add(separator);
+
+        RightClickMenuMoreItem itemToAdd = new RightClickMenuMoreItem("More");
+        this.getItems().add(itemToAdd);
     }
 
     /**
@@ -222,6 +232,22 @@ public class MainTableHeaderContextMenu extends ContextMenu {
 
         public boolean isVisibleInTable() {
             return visibleInTable;
+        }
+    }
+
+    /**
+     * RightClickMenuMoreItem: A special menu item that opens the Preferences > Entry table window
+     *
+     */
+    private class RightClickMenuMoreItem extends MenuItem {
+
+        RightClickMenuMoreItem(String displayName) {
+            super(displayName);
+
+            // Set action to open the Preferences > Entry table window
+            this.setOnAction(event -> {
+                new ShowPreferencesAction(JabRefGUI.getMainFrame(), Globals.TASK_EXECUTOR, new TableTab()).execute();
+            });
         }
     }
 }

--- a/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableHeaderContextMenu.java
@@ -81,9 +81,10 @@ public class MainTableHeaderContextMenu extends ContextMenu {
             this.getItems().add(itemToAdd);
         }
 
+        separator = new SeparatorMenuItem();
         this.getItems().add(separator);
 
-        RightClickMenuMoreItem itemToAdd = new RightClickMenuMoreItem("More");
+        RightClickMenuMoreItem itemToAdd = new RightClickMenuMoreItem("More...");
         this.getItems().add(itemToAdd);
     }
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -43,8 +43,31 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
     private final JabRefFrame frame;
     private PreferencesDialogViewModel viewModel;
 
+    private PreferencesTab tabToBeFound;
+
     public PreferencesDialogView(JabRefFrame frame) {
         this.frame = frame;
+        this.setTitle(Localization.lang("JabRef preferences"));
+
+        ViewLoader.view(this)
+                  .load()
+                  .setAsDialogPane(this);
+
+        ControlHelper.setAction(saveButton, getDialogPane(), event -> savePreferencesAndCloseDialog());
+
+        // Stop the default button from firing when the user hits enter within the search box
+        searchBox.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                event.consume();
+            }
+        });
+
+        themeManager.updateFontStyle(getDialogPane().getScene());
+    }
+
+    public PreferencesDialogView(JabRefFrame frame, PreferencesTab tabToBeFound) {
+        this.frame = frame;
+        this.tabToBeFound = tabToBeFound;
         this.setTitle(Localization.lang("JabRef preferences"));
 
         ViewLoader.view(this)
@@ -100,12 +123,26 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
             }
         });
 
-        preferenceTabList.getSelectionModel().selectFirst();
+        if (this.tabToBeFound != null) {
+            preferenceTabList.getSelectionModel().select(findPreferencesTab(this.tabToBeFound));
+        } else {
+            preferenceTabList.getSelectionModel().selectFirst();
+        }
         new ViewModelListCellFactory<PreferencesTab>()
                 .withText(PreferencesTab::getTabName)
                 .install(preferenceTabList);
 
         viewModel.setValues();
+    }
+
+    PreferencesTab findPreferencesTab(PreferencesTab tabToBeFound) {
+        for (int i = 0; i < viewModel.getPreferenceTabs().size(); i++) {
+            boolean isTabFound = viewModel.getPreferenceTabs().get(i).getTabName().equals(tabToBeFound.getTabName());
+            if (isTabFound) {
+                return viewModel.getPreferenceTabs().get(i);
+            }
+        }
+        return null;
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.preferences;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
@@ -124,7 +125,8 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         });
 
         if (this.tabToBeFound != null) {
-            preferenceTabList.getSelectionModel().select(findPreferencesTab(this.tabToBeFound));
+            Optional<PreferencesTab> foundPreferenceTab = findPreferencesTab(this.tabToBeFound);
+            foundPreferenceTab.ifPresent(preferencesTab -> preferenceTabList.getSelectionModel().select(preferencesTab));
         } else {
             preferenceTabList.getSelectionModel().selectFirst();
         }
@@ -135,14 +137,15 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         viewModel.setValues();
     }
 
-    PreferencesTab findPreferencesTab(PreferencesTab tabToBeFound) {
+    Optional<PreferencesTab> findPreferencesTab(PreferencesTab tabToBeFound) {
+        Optional<PreferencesTab> foundTab = Optional.empty();
         for (int i = 0; i < viewModel.getPreferenceTabs().size(); i++) {
             boolean isTabFound = viewModel.getPreferenceTabs().get(i).getTabName().equals(tabToBeFound.getTabName());
             if (isTabFound) {
-                return viewModel.getPreferenceTabs().get(i);
+                foundTab = Optional.ofNullable(viewModel.getPreferenceTabs().get(i));
             }
         }
-        return null;
+        return foundTab;
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/preferences/ShowPreferencesAction.java
+++ b/src/main/java/org/jabref/gui/preferences/ShowPreferencesAction.java
@@ -18,9 +18,15 @@ public class ShowPreferencesAction extends SimpleCommand {
         this.taskExecutor = taskExecutor;
     }
 
-    public ShowPreferencesAction(JabRefFrame jabRefFrame, TaskExecutor taskExecutor, PreferencesTab tab) {
+    /**
+     * Creates an action to open a preferences window at a specific tab
+     * @param jabRefFrame
+     * @param taskExecutor
+     * @param preferencesTab Tab in the preferences window to be shown
+     */
+    public ShowPreferencesAction(JabRefFrame jabRefFrame, TaskExecutor taskExecutor, PreferencesTab preferencesTab) {
         this(jabRefFrame, taskExecutor);
-        this.preferencesTab = tab;
+        this.preferencesTab = preferencesTab;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/preferences/ShowPreferencesAction.java
+++ b/src/main/java/org/jabref/gui/preferences/ShowPreferencesAction.java
@@ -11,15 +11,26 @@ public class ShowPreferencesAction extends SimpleCommand {
 
     private final JabRefFrame jabRefFrame;
     private final TaskExecutor taskExecutor;
+    private PreferencesTab preferencesTab;
 
     public ShowPreferencesAction(JabRefFrame jabRefFrame, TaskExecutor taskExecutor) {
         this.jabRefFrame = jabRefFrame;
         this.taskExecutor = taskExecutor;
     }
 
+    public ShowPreferencesAction(JabRefFrame jabRefFrame, TaskExecutor taskExecutor, PreferencesTab tab) {
+        this(jabRefFrame, taskExecutor);
+        this.preferencesTab = tab;
+    }
+
     @Override
     public void execute() {
         DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
-        dialogService.showCustomDialog(new PreferencesDialogView(jabRefFrame));
+
+        if (this.preferencesTab != null) {
+            dialogService.showCustomDialog(new PreferencesDialogView(jabRefFrame, this.preferencesTab));
+        } else {
+            dialogService.showCustomDialog(new PreferencesDialogView(jabRefFrame));
+        }
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Fixes #9432 

This PR adds a "More" option to the context menu that appears when a table column is right-clicked. The idea is to ease the addition of new columns. When the "More" option is selected, the Preferences window opens at the "Entry table" tab, so that the existing functionality for managing the table columns shown can be reused.

![image](https://user-images.githubusercontent.com/50246663/229247347-ff207ea9-d3f7-4618-b186-b7c2177d4c4a.png)
![image](https://user-images.githubusercontent.com/50246663/229247408-4c4c8c74-7496-4b99-a476-7048c4e319cb.png)


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
