### PR TITLE
Remove support for Markdown syntax for strikethrough and task lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Removed
 
 - We removed the support of BibTeXML.[#9540](https://github.com/JabRef/jabref/issues/9540)
-
+- We removed support for Markdown syntax for strikethrough and task lists in comment fields. 
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Removed
 
 - We removed the support of BibTeXML.[#9540](https://github.com/JabRef/jabref/issues/9540)
-- We removed support for Markdown syntax for strikethrough and task lists in comment fields. 
+- We removed support for Markdown syntax for strikethrough and task lists in comment fields. [#9726](https://github.com/JabRef/jabref/pull/9726)
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -198,8 +198,6 @@ dependencies {
     }
 
     implementation 'com.vladsch.flexmark:flexmark:0.64.0'
-    implementation 'com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:0.64.0'
-    implementation 'com.vladsch.flexmark:flexmark-ext-gfm-tasklist:0.64.0'
 
     implementation group: 'net.harawata', name: 'appdirs', version: '1.2.1'
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -94,8 +94,6 @@ open module org.jabref {
     requires com.ibm.icu;
 
     requires flexmark;
-    requires flexmark.ext.gfm.strikethrough;
-    requires flexmark.ext.gfm.tasklist;
     requires flexmark.util.ast;
     requires flexmark.util.data;
     requires com.h2database.mvstore;

--- a/src/main/java/org/jabref/logic/layout/format/MarkdownFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/MarkdownFormatter.java
@@ -1,12 +1,9 @@
 package org.jabref.logic.layout.format;
 
-import java.util.List;
 import java.util.Objects;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
-import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.ast.Node;
@@ -19,12 +16,6 @@ public class MarkdownFormatter implements LayoutFormatter {
 
     public MarkdownFormatter() {
         MutableDataSet options = new MutableDataSet();
-        // in case a new extension is added here, the depedency has to be added to build.gradle, too.
-        options.set(Parser.EXTENSIONS, List.of(
-                StrikethroughExtension.create(),
-                TaskListExtension.create()
-        ));
-
         parser = Parser.builder(options).build();
         renderer = HtmlRenderer.builder(options).build();
     }

--- a/src/test/java/org/jabref/logic/layout/format/MarkdownFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/MarkdownFormatterTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MarkdownFormatterTest {
 
@@ -36,22 +35,5 @@ class MarkdownFormatterTest {
     void formatWhenFormattingNullThenThrowsException() {
         Exception exception = assertThrows(NullPointerException.class, () -> markdownFormatter.format(null));
         assertEquals("Field Text should not be null, when handed to formatter", exception.getMessage());
-    }
-
-    @Test
-    void formatWhenMarkupContainingStrikethroughThenContainsMatchingDel() {
-        // Only test strikethrough extension
-        assertTrue(markdownFormatter.format("a ~~b~~ b").contains("<del>b</del>"));
-    }
-
-    @Test
-    void formatWhenMarkupContainingTaskListThenContainsFormattedTaskList() {
-        String actual = markdownFormatter.format("Some text\n" +
-                "* [ ] open task\n" +
-                "* [x] closed task\n\n" +
-                "some other text");
-        // Only test list items
-        assertTrue(actual.contains("<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;open task</li>"));
-        assertTrue(actual.contains("<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"checked\" disabled=\"disabled\" readonly=\"readonly\" />&nbsp;closed task</li>"));
     }
 }


### PR DESCRIPTION
To reduce the number of dependencies (due to [JDK-8240567](https://bugs.openjdk.org/browse/JDK-8240567); refs https://github.com/JabRef/jabref/issues/5226), I removed two dependencies IMHO used very seldom.

In the current JabRef, if you select the build-in preview, you get a markdown rendering. This changes now a bit.

Before:

![image](https://user-images.githubusercontent.com/1366654/229291056-e91204a7-3701-4fa5-9c3d-a4f78b157fc2.png)

After:

![image](https://user-images.githubusercontent.com/1366654/229291104-8db082e7-2c98-4891-887e-375780fac7e0.png)


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
