### PR TITLE
Try to get auto merge running

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,6 +1,11 @@
 name: Automerge Pull Requests
-on: [pull_request]
-
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 jobs:
   automerge:
     name: Automerge Dependency Updates


### PR DESCRIPTION
Checking https://github.com/JabRef/jabref/pull/9643, I see that the automerge action was skipped_

![image](https://user-images.githubusercontent.com/1366654/230004461-224a8f7a-2059-4ef8-b204-2f59c340889b.png)

I asked ChatGPT, so let's see if this works:

![image](https://user-images.githubusercontent.com/1366654/230004608-8b6015e8-2c72-444c-9187-4874ff614933.png)


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
