### PR TITLE
Fix text color in the event log console when applying dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We resolved an issue that cut off the number of group entries when it exceedet four digits. [#8797](https://github.com/JabRef/jabref/issues/8797)
 - We fixed an issue where the Global Search UI preview is still white in dark theme. [#9362](https://github.com/JabRef/jabref/issues/9362)
 - We fixed the double paste issue when <kbd>Cmd</kbd> + <kbd>v</kbd> is pressed on 'New entry from plaintext' dialog. [#9367](https://github.com/JabRef/jabref/issues/9367)
-- We fixed the log text color in the event log console when using dark mode
+- We fixed the log text color in the event log console when using dark mode. [#9732](https://github.com/JabRef/jabref/issues/9732)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We resolved an issue that cut off the number of group entries when it exceedet four digits. [#8797](https://github.com/JabRef/jabref/issues/8797)
 - We fixed an issue where the Global Search UI preview is still white in dark theme. [#9362](https://github.com/JabRef/jabref/issues/9362)
 - We fixed the double paste issue when <kbd>Cmd</kbd> + <kbd>v</kbd> is pressed on 'New entry from plaintext' dialog. [#9367](https://github.com/JabRef/jabref/issues/9367)
-
+- We fixed the log text color in the event log console when using dark mode
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the double paste issue when <kbd>Cmd</kbd> + <kbd>v</kbd> is pressed on 'New entry from plaintext' dialog. [#9367](https://github.com/JabRef/jabref/issues/9367)
 - We fixed the log text color in the event log console when using dark mode
 
+
 ### Removed
 
 - We removed the support of BibTeXML. [#9540](https://github.com/JabRef/jabref/issues/9540)

--- a/src/main/java/org/jabref/gui/errorconsole/ErrorConsole.css
+++ b/src/main/java/org/jabref/gui/errorconsole/ErrorConsole.css
@@ -16,6 +16,11 @@
     -fx-fill: -jr-error;
 }
 
+.output .glyph-icon {
+    -fx-font-size: 18.0;
+    -fx-fill: -jr-warn;
+}
+
 .log .glyph-icon {
     -fx-font-size: 18.0;
     -fx-fill: -jr-info;
@@ -24,3 +29,16 @@
 .custom-buttons {
     -fx-padding: 5px;
 }
+
+.exception {
+    -fx-text-fill: -fx-text-base-color;
+}
+
+.output {
+    -fx-text-fill: -fx-text-base-color;
+}
+
+.log {
+    -fx-text-fill: -fx-text-base-color;
+}
+


### PR DESCRIPTION
Fix text color in the event log console when applying dark mode by setting text color to `-fx-text-base-color`. Also, fix the font size of icons before warning logs.

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixes #9732

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
Fixed event log console:
Dark mode:
![JabRef-9732-t1](https://user-images.githubusercontent.com/129295755/230113520-079c4e1b-9f00-449a-8dc4-7bf710d8a22f.png)
Light Mode:
![JabRef-9732-t2](https://user-images.githubusercontent.com/129295755/230113869-91eb6c5c-785b-4014-9add-c9efa77885ea.png)
