### PR TITLE
Down to JDK19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ group = "org.jabref"
 version = project.findProperty('projVersion') ?: '100.0.0'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_20
-    targetCompatibility = JavaVersion.VERSION_20
+    sourceCompatibility = JavaVersion.VERSION_19
+    targetCompatibility = JavaVersion.VERSION_19
     // Workaround needed for Eclipse, probably because of https://github.com/gradle/gradle/issues/16922
     // Should be removed as soon as Gradle 7.0.1 is released ( https://github.com/gradle/gradle/issues/16922#issuecomment-828217060 )
     modularity.inferModulePath.set(false)


### PR DESCRIPTION
Switch to Java 19 for gradle build

It seems that the toolset around VS Code does not support Java 20. See https://github.com/redhat-developer/vscode-java/issues/3043#issuecomment-1517991699.

I think, we do not use [new features of JDK 20](https://www.infoworld.com/article/3676699/jdk-20-the-new-features-in-java-20.html) yet, thus I propose the downgrade.

JabRef can still be compiled with JDK 20.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
