### PR TITLE
Remove BibTeXML from StandardFileType

### DIFF
--- a/src/main/java/org/jabref/logic/util/StandardFileType.java
+++ b/src/main/java/org/jabref/logic/util/StandardFileType.java
@@ -10,7 +10,6 @@ import org.jabref.model.util.OptionalUtil;
  */
 public enum StandardFileType implements FileType {
 
-    BIBTEXML("BibTeXML", "bibx", "xml"),
     ENDNOTE("Endnote", "ref", "enw"),
     ISI("Isi", "isi", "txt"),
     MEDLINE("Medline", "nbib", "xml"),


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/9583. 

Thank @morgantec for the hint - https://github.com/JabRef/jabref/issues/9372#issuecomment-1518549405

![image](https://user-images.githubusercontent.com/1366654/234092367-6c3c063c-d312-4c8a-85a8-23d3d1c4a256.png)


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
