### PR TITLE
Improve search history attaching change listener

### DIFF
--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -27,6 +27,7 @@ import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.CustomLocalDragboard;
 import org.jabref.gui.util.DialogWindowState;
 import org.jabref.gui.util.OptionalObjectProperty;
+import org.jabref.gui.search.GlobalSearchBar;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -216,8 +217,10 @@ public class StateManager {
     }
 
     public void addSearchHistory(String search) {
-        searchHistory.remove(search);
-        searchHistory.add(search);
+        if (!GlobalSearchBar.searchBoxFocused.get()) {
+            searchHistory.remove(search);
+            searchHistory.add(search);
+        }
     }
 
     public ObservableList<String> getWholeSearchHistory() {

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -107,6 +107,7 @@ public class GlobalSearchBar extends HBox {
     private final DialogService dialogService;
 
     private final BooleanProperty globalSearchActive = new SimpleBooleanProperty(false);
+    public static final BooleanProperty searchBoxFocused = new SimpleBooleanProperty(false);
     private GlobalSearchResultDialog globalSearchResultDialog;
 
     public GlobalSearchBar(JabRefFrame frame, StateManager stateManager, PreferencesService preferencesService, CountingUndoManager undoManager, DialogService dialogService) {
@@ -307,7 +308,12 @@ public class GlobalSearchBar extends HBox {
             informUserAboutInvalidSearchQuery();
             return;
         }
-        this.stateManager.addSearchHistory(searchField.textProperty().get());
+        searchBoxFocused.bind(searchField.focusedProperty());
+        searchBoxFocused.addListener((observable, oldPropertyValue, newPropertyValue) -> {
+            if (!(newPropertyValue || searchField.textProperty().get().isEmpty())) {
+                this.stateManager.addSearchHistory(searchField.textProperty().get());
+            }
+        });
         stateManager.setSearchQuery(searchQuery);
     }
 


### PR DESCRIPTION
Proposes solution for #9685 

Initializing the draft pull request regarding the improvement of search history.

Specifically,  redundant recording of search queries, issued via:
- attachment of a change listener on focusedProperty of search bar textfield, and by
- using unidirectional binding between searcField  and a BooleanPorperty object

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
