### PR TITLE
Refine JsorFetcherTest#searchById to ignore urlDate

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
@@ -64,8 +64,10 @@ public class JstorFetcherTest implements SearchBasedFetcherCapabilityTest {
 
     @Test
     void searchById() throws Exception {
-        bibEntry.setField(StandardField.URLDATE, LocalDate.now().format(DateTimeFormatter.ISO_DATE));
-        assertEquals(Optional.of(bibEntry), fetcher.performSearchById("90002164"));
+        Optional<BibEntry> actual = fetcher.performSearchById("90002164");
+        // The URL date is always the current date in the US. No need to properly check it.
+        actual.ifPresent(entry -> entry.clearField(StandardField.URLDATE));
+        assertEquals(Optional.of(bibEntry), actual);
     }
 
     @Test


### PR DESCRIPTION
Tests executed locally around midnight in Europe - and they failed. This PR fixes it.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
