### PR TITLE
Fix path in devs documentation

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-02-software.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-02-software.md
@@ -28,4 +28,4 @@ You can update the IDE after a proper setup to the newest version.
 ## Other Tooling
 
 We collected some other tooling recommendations.
-We invite you to read on at our [tool recommendations](../code-howtos/tools.md).
+We invite you to read on at our [tool recommendations](../../code-howtos/tools.md).


### PR DESCRIPTION
Fixed link's relative path in "Required Software" documentation



```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
