### PR TITLE
Change default File Chooser to show supported files extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where searching for unlinked files would include the current library's .bib file [#9735](https://github.com/JabRef/jabref/issues/9735)
 - We fixed an issue where it was no longer possible to connect to a shared mysql database due to an exception [#9761](https://github.com/JabRef/jabref/issues/9761)
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
+- We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/util/FileFilterConverter.java
+++ b/src/main/java/org/jabref/gui/util/FileFilterConverter.java
@@ -27,7 +27,8 @@ public class FileFilterConverter {
     }
 
     public static FileChooser.ExtensionFilter toExtensionFilter(FileType fileType) {
-        String description = Localization.lang("%0 file", fileType.toString());
+        String fileList = String.join(", ", fileType.getExtensionsWithAsteriskAndDot());
+        String description = Localization.lang("%0 file (%1)", fileType.getName(), fileList);
         return new FileChooser.ExtensionFilter(description, fileType.getExtensionsWithAsteriskAndDot());
     }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1725,6 +1725,7 @@ Cannot\ cite\ entries\ without\ citation\ keys.\ Generate\ keys\ now?=Cannot cit
 New\ technical\ report=New technical report
 
 %0\ file=%0 file
+%0\ file\ (%1)=%0 file (%1)
 Custom\ layout\ file=Custom layout file
 Protected\ terms\ file=Protected terms file
 Style\ file=Style file


### PR DESCRIPTION
Fixes #9372 
Change default File Chooser to show supported files extensions

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
![Schermata del 2023-04-27 21-53-46](https://user-images.githubusercontent.com/11558228/235157761-44ada3e1-a6f5-4db4-b3a8-cc18e73a9f5d.png)


