### PR TITLE
Fix split multiline localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ src/main/gen/
 src/main/generated/
 src-gen/
 
+structure101-settings.java.hsw
+
 # private data
 /buildres/jabref-cert-2016.p12
 

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -54,16 +54,9 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         mainFileDirValidator = new FunctionBasedValidator<>(
                 mainFileDirectoryProperty,
                 mainDirectoryPath -> {
-                    ValidationMessage error = ValidationMessage.error(String.format(
-                            "%s%n%s%n%n%s%n%n%s > %s > %s",
-                            Localization.lang("Main directory not found"),
-                            mainDirectoryPath,
-                            Localization.lang("Please select a valid main directory under"),
-                            Localization.lang("Linked files"),
-                            Localization.lang("File directory"),
-                            Localization.lang("Main file directory")
-                    ));
-
+                    ValidationMessage error = ValidationMessage.error(
+                            Localization.lang("Main file directory %0 not found.\nCheck the preferences (linked files) or the library properties.", mainDirectoryPath)
+                    );
                     try {
                         Path path = Path.of(mainDirectoryPath);
                         if (!(Files.exists(path) && Files.isDirectory(path))) {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -507,8 +507,6 @@ Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\
 
 Show\ advanced\ hints\ (i.e.\ helpful\ tooltips,\ suggestions\ and\ explanation)=Show advanced hints (i.e. helpful tooltips, suggestions and explanation)
 
-Main\ file\ directory=Main file directory
-
 Manage\ custom\ exports=Manage custom exports
 
 Manage\ custom\ imports=Manage custom imports
@@ -1508,7 +1506,11 @@ Does\ nothing.=Does nothing.
 Identity=Identity
 Clears\ the\ field\ completely.=Clears the field completely.
 Directory\ not\ found=Directory not found
+
+Main\ file\ directory=Main file directory
 Main\ file\ directory\ not\ set.\ Check\ the\ preferences\ (linked\ files)\ or\ the\ library\ properties.=Main file directory not set. Check the preferences (linked files) or the library properties.
+Main\ file\ directory\ %0\ not\ found.\nCheck\ the\ preferences\ (linked\ files)\ or\ the\ library\ properties.=Main file directory %0 not found.\nCheck the preferences (linked files) or the library properties.
+
 This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=This operation requires exactly one item to be selected.
 Opening\ large\ number\ of\ files=Opening large number of files
 You\ are\ about\ to\ open\ %0\ files.\ Continue?=You are about to open %0 files. Continue?
@@ -2532,12 +2534,10 @@ Multiline=Multiline
 
 Unable\ to\ open\ linked\ eprint.\ Please\ set\ the\ eprinttype\ field=Unable to open linked eprint. Please set the eprinttype field
 Unable\ to\ open\ linked\ eprint.\ Please\ verify\ that\ the\ eprint\ field\ has\ a\ valid\ '%0'\ id=Unable to open linked eprint. Please verify that the eprint field has a valid '%0' id
-Main\ directory\ not\ found=Main directory not found
-Please\ select\ a\ valid\ main\ directory\ under=Please select a valid main directory under
 
 Search\ from\ history...=Search from history...
 your\ search\ history\ is\ empty=your search history is empty
-Clear\ history =Clear history
+Clear\ history=Clear history
 
 Delete\ %0\ files=Delete %0 files
 Delete\ %0\ files\ permanently\ from\ disk,\ or\ just\ remove\ the\ files\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ files\ permanently\ from\ disk.=Delete %0 files permanently from disk, or just remove the files from the entry? Pressing Delete will delete the files permanently from disk.


### PR DESCRIPTION
While checking https://github.com/JabRef/jabref/pull/9811, I found a very strange translation key. I fixed that (using our `\n` possibility) and made the string consistent to an existing one.

Also removed a space at the end of a localization key. Not sure whether I should create a test case for that?

I also ignored a file created by the tool https://structure101.com/.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
