### PR TITLE
Add comments to == usage instead of equals

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -578,6 +578,7 @@ public class LibraryTab extends Tab {
     public void showAndEdit(BibEntry entry) {
         showBottomPane(BasePanelMode.SHOWING_EDITOR);
 
+        // We use != instead of equals because of performance reasons
         if (entry != getShowing()) {
             entryEditor.setEntry(entry);
             showing = entry;

--- a/src/main/java/org/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -135,7 +135,7 @@ public class BibtexDatabaseWriter extends BibDatabaseWriter {
         //   - it is provided (!= null)
         //   - explicitly set in the .bib file OR not equal to UTF_8
         // Otherwise, we do not write anything and return
-        if ((encoding == null) || (!bibDatabaseContext.getMetaData().getEncodingExplicitlySupplied() && (encoding == StandardCharsets.UTF_8))) {
+        if ((encoding == null) || (!bibDatabaseContext.getMetaData().getEncodingExplicitlySupplied() && (encoding.equals(StandardCharsets.UTF_8)))) {
             return;
         }
 

--- a/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
+++ b/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
@@ -59,6 +59,7 @@ public class FieldChangedEvent extends EntryChangedEvent {
     }
 
     private int computeMajorCharacterChange(String oldValue, String newValue) {
+        // We do == because of performance reasons
         if (oldValue == newValue) {
             return 0;
         } else if ((oldValue == null) && (newValue != null)) {


### PR DESCRIPTION
Sometimes, we use `==` instead of `equals`.

I think, all cases are fine. Nevertheless, the places deserve code comments.

Triggered by applying https://docs.openrewrite.org/recipes/java/cleanup/referentialequalitytoobjectequals

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
