### PR TITLE
Respect OS language at NativeDesktop#getDefaultFileChooserDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where it was no longer possible to connect to a shared mysql database due to an exception [#9761](https://github.com/JabRef/jabref/issues/9761)
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
+- We fixed the default main file directory for non-English Linux and macOS users. [#8010](https://github.com/JabRef/jabref/issues/8010)
 
 ### Removed
 

--- a/docs/decisions/0026-use-jna-to-determine-default-directory.md
+++ b/docs/decisions/0026-use-jna-to-determine-default-directory.md
@@ -34,6 +34,7 @@ Swing's FileChooser implemented a very decent directory determination algorithm.
 It thereby uses `sun.awt.shell.ShellFolder`.
 
 * Good, because provides best results on most platforms.
+* Good, because also supports localization of the folder name. E.g., `~/Dokumente` in Germany.
 * Bad, because introduces a dependency on Swing and thereby contradicts the second decision driver.
 * Bad, because GraalVM's support Swing is experimental
 

--- a/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/DefaultDesktop.java
@@ -45,9 +45,4 @@ public class DefaultDesktop implements NativeDesktop {
     public Path getApplicationDirectory() {
         return getUserDirectory();
     }
-
-    @Override
-    public Path getDefaultFileChooserDirectory() {
-        return Path.of(System.getProperty("user.home"));
-    }
 }

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import javax.swing.filechooser.FileSystemView;
 
 import org.jabref.architecture.AllowedToUseAwt;
+import org.jabref.architecture.AllowedToUseSwing;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefExecutorService;
@@ -26,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @AllowedToUseAwt("Requires AWT to open a file with the native method")
+@AllowedToUseSwing("Uses getFileSystemView to get the default documents directory")
 public class Linux implements NativeDesktop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Linux.class);

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -11,6 +11,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.swing.filechooser.FileSystemView;
+
 import org.jabref.architecture.AllowedToUseAwt;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
@@ -173,7 +175,6 @@ public class Linux implements NativeDesktop {
     public Path getDefaultFileChooserDirectory() {
         return Path.of(Objects.requireNonNullElse(
                 System.getenv("XDG_DOCUMENTS_DIR"),
-                System.getProperty("user.home") + "/Documents")
-        );
+                FileSystemView.getFileSystemView().getDefaultDirectory().getPath()));
     }
 }

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -5,8 +5,10 @@ import java.nio.file.Path;
 
 import javax.swing.filechooser.FileSystemView;
 
+import org.jabref.architecture.AllowedToUseSwing;
 import org.jabref.gui.DialogService;
 
+@AllowedToUseSwing("Uses getFileSystemView to get the default documents directory")
 public interface NativeDesktop {
 
     void openFile(String filePath, String fileType) throws IOException;

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -3,6 +3,8 @@ package org.jabref.gui.desktop.os;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import javax.swing.filechooser.FileSystemView;
+
 import org.jabref.gui.DialogService;
 
 public interface NativeDesktop {
@@ -35,7 +37,9 @@ public interface NativeDesktop {
      *
      * @return The path to the directory
      */
-     Path getDefaultFileChooserDirectory();
+     default Path getDefaultFileChooserDirectory() {
+         return Path.of(FileSystemView.getFileSystemView().getDefaultDirectory().getPath());
+     }
 
     /**
      * Returns the path to the system's user directory.

--- a/src/main/java/org/jabref/gui/desktop/os/OSX.java
+++ b/src/main/java/org/jabref/gui/desktop/os/OSX.java
@@ -52,9 +52,4 @@ public class OSX implements NativeDesktop {
     public Path getApplicationDirectory() {
         return Path.of("/Applications");
     }
-
-    @Override
-    public Path getDefaultFileChooserDirectory() {
-        return Path.of(System.getProperty("user.home") + "/Documents");
-    }
 }


### PR DESCRIPTION
Fixes #8010 - especially https://github.com/JabRef/jabref/issues/8010#issuecomment-1531526339

In Germany, the default "documents" folder is `~/Dokumente`. Either we mirror all translations in JabRef - or we use `FileSystemView.getFileSystemView().getDefaultDirectory().getPath()`. (Source: https://stackoverflow.com/a/32914568/873282)

This partially reverts https://github.com/JabRef/jabref/pull/9222.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
