### PR TITLE
Open last connected shared DBs at startup preference

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -129,6 +129,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.shared.DatabaseLocation;
+import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.undo.AddUndoableActionEvent;
 import org.jabref.logic.undo.UndoChangeEvent;
 import org.jabref.logic.undo.UndoRedoEvent;
@@ -422,7 +423,7 @@ public class JabRefFrame extends BorderPane {
      * @param filenames the filenames of all currently opened files - used for storing them if prefs openLastEdited is
      *                  set to true
      */
-    private void tearDownJabRef(List<String> filenames) {
+    private void tearDownJabRef(List<String> filenames, List<String> sharedDBs) {
         if (prefs.getImportExportPreferences().shouldOpenLastEdited()) {
             // Here we store the names of all current files. If there is no current file, we remove any
             // previously stored filename.
@@ -434,6 +435,13 @@ public class JabRefFrame extends BorderPane {
                                                              .orElse(null);
                 prefs.getGuiPreferences().setLastFilesOpened(filenames);
                 prefs.getGuiPreferences().setLastFocusedFile(focusedDatabase);
+            }
+        }
+        if (prefs.getExternalApplicationsPreferences().shouldAutoConnectToLastSharedDatabases()) {
+            if (sharedDBs.isEmpty()) {
+                prefs.getExternalApplicationsPreferences().getLastConnectedSharedDatabases().clear();
+            } else {
+                prefs.getExternalApplicationsPreferences().setLastConnectedSharedDatabases(sharedDBs);
             }
         }
 
@@ -469,6 +477,7 @@ public class JabRefFrame extends BorderPane {
 
         // Then ask if the user really wants to close, if the library has not been saved since last save.
         List<String> filenames = new ArrayList<>();
+        List<String> sharedDBs = new ArrayList<>();
         for (int i = 0; i < tabbedPane.getTabs().size(); i++) {
             LibraryTab libraryTab = getLibraryTabAt(i);
             final BibDatabaseContext context = libraryTab.getBibDatabaseContext();
@@ -485,6 +494,10 @@ public class JabRefFrame extends BorderPane {
                     return false;
                 }
             } else if (context.getLocation() == DatabaseLocation.SHARED) {
+                new SharedDatabasePreferences(context.getDatabase().generateSharedDatabaseID())
+                        .putAllDBMSConnectionProperties(context.getDBMSSynchronizer().getConnectionProperties());
+                sharedDBs.add(context.getDatabase().getSharedDatabaseID().orElse(""));
+
                 context.convertToLocalDatabase();
                 context.getDBMSSynchronizer().closeSharedDatabase();
                 context.clearDBMSSynchronizer();
@@ -498,7 +511,7 @@ public class JabRefFrame extends BorderPane {
         waitForSaveFinishedDialog.showAndWait(getLibraryTabs());
 
         // Good bye!
-        tearDownJabRef(filenames);
+        tearDownJabRef(filenames, sharedDBs);
         Platform.exit();
         return true;
     }

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1087,8 +1087,12 @@ public class JabRefFrame extends BorderPane {
             // Add the entries to the open tab.
             LibraryTab libraryTab = getCurrentLibraryTab();
             if (libraryTab == null) {
+                if (parserResult.getContext().getLocation() == DatabaseLocation.SHARED) {
+                    addTab(parserResult.getContext(), focusPanel);
+                } else {
                 // There is no open tab to add to, so we create a new tab:
                 addTab(parserResult.getDatabaseContext(), focusPanel);
+                }
             } else {
                 addImportedEntries(libraryTab, parserResult);
             }

--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javafx.application.Platform;
-import javafx.collections.ObservableList;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Screen;
@@ -22,11 +21,9 @@ import org.jabref.gui.shared.SharedDatabaseUIManager;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.ProxyRegisterer;
-import org.jabref.logic.shared.DBMSConnectionProperties;
 import org.jabref.logic.shared.DatabaseNotSupportedException;
 import org.jabref.logic.shared.exception.InvalidDBMSConnectionPropertiesException;
 import org.jabref.logic.shared.exception.NotASharedDatabaseException;
-import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.util.WebViewStore;
 import org.jabref.preferences.GuiPreferences;
 import org.jabref.preferences.PreferencesService;
@@ -143,33 +140,10 @@ public class JabRefGUI {
         }
     }
 
-    private void connectToSharedDatabases() {
-        ObservableList<String> lastConnectedSharedDBs = preferencesService.getExternalApplicationsPreferences().getLastConnectedSharedDatabases();
-
-        if (lastConnectedSharedDBs.isEmpty()) {
-            return;
-        }
-        SharedDatabaseUIManager sharedDatabaseUIManager = new SharedDatabaseUIManager(mainFrame, preferencesService);
-        for (String sharedDBId : lastConnectedSharedDBs) {
-            SharedDatabasePreferences preferences = new SharedDatabasePreferences(sharedDBId);
-            DBMSConnectionProperties connectionProperties = new DBMSConnectionProperties(preferences);
-
-            try {
-                sharedDatabaseUIManager.openNewSharedDatabaseTab(connectionProperties);
-            } catch (SQLException | InvalidDBMSConnectionPropertiesException | DatabaseNotSupportedException e) {
-                getMainFrame().getDialogService().showErrorDialogAndWait(Localization.lang("Connection error"), e);
-            }
-        }
-    }
-
     private void openDatabases() {
         // If the option is enabled, open the last edited libraries, if any.
         if (!isBlank && preferencesService.getImportExportPreferences().shouldOpenLastEdited()) {
             openLastEditedDatabases();
-        }
-
-        if (!isBlank && preferencesService.getExternalApplicationsPreferences().shouldAutoConnectToLastSharedDatabases()) {
-            connectToSharedDatabases();
         }
 
         // From here on, the libraries provided by command line arguments are treated

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -212,7 +212,8 @@ public class LibraryTab extends Tab {
     }
 
     public void onDatabaseLoadingSucceed(ParserResult result) {
-        BibDatabaseContext context = result.getDatabaseContext();
+//      BibDatabaseContext context = result.getDatabaseContext();
+        BibDatabaseContext context = result.getContext();
         OpenDatabaseAction.performPostOpenActions(this, result);
 
         feedData(context);

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
@@ -33,6 +33,7 @@ import org.jabref.gui.preferences.nameformatter.NameFormatterTab;
 import org.jabref.gui.preferences.network.NetworkTab;
 import org.jabref.gui.preferences.preview.PreviewTab;
 import org.jabref.gui.preferences.protectedterms.ProtectedTermsTab;
+import org.jabref.gui.preferences.shareddatabase.SharedDatabaseTab;
 import org.jabref.gui.preferences.table.TableTab;
 import org.jabref.gui.preferences.xmp.XmpPrivacyTab;
 import org.jabref.gui.util.FileDialogConfiguration;
@@ -82,7 +83,8 @@ public class PreferencesDialogViewModel extends AbstractViewModel {
                 new CustomEntryTypesTab(),
                 new XmpPrivacyTab(),
                 new NetworkTab(),
-                new AppearanceTab()
+                new AppearanceTab(),
+                new SharedDatabaseTab()
         );
     }
 

--- a/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTab.fxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<fx:root maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.preferences.shareddatabase.SharedDatabaseTab">
+    <Label styleClass="titleHeader" text="%Shared Database" />
+    <HBox alignment="CENTER_LEFT" spacing="10.0" />
+
+    <Label styleClass="sectionHeader" text="%Loading" />
+
+    <CheckBox fx:id="connectLastStartup" text="%Open last shared database connections at startup" />
+
+    <HBox alignment="CENTER_LEFT" spacing="10.0" />
+
+    <HBox alignment="CENTER_LEFT" spacing="10.0" />
+</fx:root>

--- a/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTab.java
+++ b/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTab.java
@@ -1,0 +1,31 @@
+package org.jabref.gui.preferences.shareddatabase;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
+
+import org.jabref.gui.preferences.AbstractPreferenceTabView;
+import org.jabref.gui.preferences.PreferencesTab;
+import org.jabref.logic.l10n.Localization;
+
+import com.airhacks.afterburner.views.ViewLoader;
+
+public class SharedDatabaseTab extends AbstractPreferenceTabView<SharedDatabaseTabViewModel> implements PreferencesTab {
+
+    @FXML private CheckBox connectLastStartup;
+
+    public SharedDatabaseTab() {
+        ViewLoader.view(this)
+                .root(this)
+                .load();
+    }
+
+    public void initialize() {
+        this.viewModel = new SharedDatabaseTabViewModel(preferencesService.getExternalApplicationsPreferences());
+        this.connectLastStartup.selectedProperty().bindBidirectional(viewModel.connectLastStartupProperty());
+    }
+
+    @Override
+    public String getTabName() {
+        return Localization.lang("Shared Database");
+    }
+}

--- a/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
@@ -17,12 +17,12 @@ public class SharedDatabaseTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public void setValues() {
-        connectLastStartupProperty.setValue(externalApplicationsPreferences.shouldAutoConnectToLastSharedDatabase());
+        connectLastStartupProperty.setValue(externalApplicationsPreferences.shouldAutoConnectToLastSharedDatabases());
     }
 
     @Override
     public void storeSettings() {
-        externalApplicationsPreferences.setAutoConnectToLastSharedDatabase(connectLastStartupProperty.getValue());
+        externalApplicationsPreferences.setAutoConnectToLastSharedDatabases(connectLastStartupProperty.getValue());
     }
 
     public BooleanProperty connectLastStartupProperty() {

--- a/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
@@ -1,0 +1,31 @@
+package org.jabref.gui.preferences.shareddatabase;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import org.jabref.gui.preferences.PreferenceTabViewModel;
+import org.jabref.preferences.ExternalApplicationsPreferences;
+
+public class SharedDatabaseTabViewModel implements PreferenceTabViewModel {
+
+    private final BooleanProperty connectLastStartupProperty = new SimpleBooleanProperty();
+    private final ExternalApplicationsPreferences externalApplicationsPreferences;
+
+    public SharedDatabaseTabViewModel(ExternalApplicationsPreferences externalApplicationsPreferences) {
+        this.externalApplicationsPreferences = externalApplicationsPreferences;
+    }
+
+    @Override
+    public void setValues() {
+        connectLastStartupProperty.setValue(externalApplicationsPreferences.shouldAutoConnectToLastSharedDatabase());
+    }
+
+    @Override
+    public void storeSettings() {
+        externalApplicationsPreferences.setAutoConnectToLastSharedDatabase(connectLastStartupProperty.getValue());
+    }
+
+    public BooleanProperty connectLastStartupProperty() {
+        return connectLastStartupProperty;
+    }
+}

--- a/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/shareddatabase/SharedDatabaseTabViewModel.java
@@ -17,12 +17,12 @@ public class SharedDatabaseTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public void setValues() {
-        connectLastStartupProperty.setValue(externalApplicationsPreferences.shouldAutoConnectToLastSharedDatabases());
+        connectLastStartupProperty.setValue(externalApplicationsPreferences.shouldAutoConnectToLastSharedDatabase());
     }
 
     @Override
     public void storeSettings() {
-        externalApplicationsPreferences.setAutoConnectToLastSharedDatabases(connectLastStartupProperty.getValue());
+        externalApplicationsPreferences.setAutoConnectToLastSharedDatabase(connectLastStartupProperty.getValue());
     }
 
     public BooleanProperty connectLastStartupProperty() {

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
@@ -179,7 +179,8 @@ public class SharedDatabaseUIManager {
         dbmsSynchronizer = bibDatabaseContext.getDBMSSynchronizer();
         dbmsSynchronizer.openSharedDatabase(new DBMSConnection(dbmsConnectionProperties));
         dbmsSynchronizer.registerListener(this);
-        parserResult.setDatabaseContext(bibDatabaseContext);
+//      parserResult.setDatabaseContext(bibDatabaseContext);
+        parserResult.setContext(bibDatabaseContext);
         jabRefFrame.getDialogService().notify(Localization.lang("Connection to %0 server established.", dbmsConnectionProperties.getType().toString()));
     }
 }

--- a/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -26,6 +26,7 @@ public class ParserResult {
     private boolean invalid;
     private boolean toOpenTab;
     private boolean changedOnMigration = false;
+    private BibDatabaseContext context;
 
     public ParserResult() {
         this(Collections.emptyList());
@@ -144,6 +145,14 @@ public class ParserResult {
         database = bibDatabaseContext.getDatabase();
         metaData = bibDatabaseContext.getMetaData();
         file = bibDatabaseContext.getDatabasePath().orElse(null);
+    }
+
+    public BibDatabaseContext getContext() {
+        return this.context;
+    }
+
+    public void setContext(BibDatabaseContext context) {
+        this.context = context;
     }
 
     public boolean isEmpty() {

--- a/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
+++ b/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
@@ -1,13 +1,9 @@
 package org.jabref.preferences;
 
-import java.util.List;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 
 public class ExternalApplicationsPreferences {
 
@@ -18,8 +14,7 @@ public class ExternalApplicationsPreferences {
     private final StringProperty customTerminalCommand;
     private final BooleanProperty useCustomFileBrowser;
     private final StringProperty customFileBrowserCommand;
-    private final BooleanProperty shouldConnectLastSharedDatabases;
-    private final ObservableList<String> lastConnectedSharedDatabases;
+    private final BooleanProperty shouldConnectLastSharedDatabase;
 
     public ExternalApplicationsPreferences(String eMailSubject,
                                            boolean shouldAutoOpenEmailAttachmentsFolder,
@@ -28,7 +23,7 @@ public class ExternalApplicationsPreferences {
                                            String customTerminalCommand,
                                            boolean useCustomFileBrowser,
                                            String customFileBrowserCommand,
-                                           boolean shouldConnectLastSharedDatabases, List<String> lastConnectedSharedDatabases) {
+                                           boolean shouldConnectLastSharedDatabase) {
 
         this.eMailSubject = new SimpleStringProperty(eMailSubject);
         this.shouldAutoOpenEmailAttachmentsFolder = new SimpleBooleanProperty(shouldAutoOpenEmailAttachmentsFolder);
@@ -37,8 +32,7 @@ public class ExternalApplicationsPreferences {
         this.customTerminalCommand = new SimpleStringProperty(customTerminalCommand);
         this.useCustomFileBrowser = new SimpleBooleanProperty(useCustomFileBrowser);
         this.customFileBrowserCommand = new SimpleStringProperty(customFileBrowserCommand);
-        this.shouldConnectLastSharedDatabases = new SimpleBooleanProperty(shouldConnectLastSharedDatabases);
-        this.lastConnectedSharedDatabases = FXCollections.observableArrayList(lastConnectedSharedDatabases);
+        this.shouldConnectLastSharedDatabase = new SimpleBooleanProperty(shouldConnectLastSharedDatabase);
     }
 
     public String getEmailSubject() {
@@ -125,23 +119,15 @@ public class ExternalApplicationsPreferences {
         this.customFileBrowserCommand.set(customFileBrowserCommand);
     }
 
-    public boolean shouldAutoConnectToLastSharedDatabases() {
-        return shouldConnectLastSharedDatabases.get();
+    public boolean shouldAutoConnectToLastSharedDatabase() {
+        return shouldConnectLastSharedDatabase.get();
     }
 
-    public BooleanProperty autoConnectToLastSharedDatabases() {
-        return shouldConnectLastSharedDatabases;
+    public BooleanProperty autoConnectToLastSharedDatabase() {
+        return shouldConnectLastSharedDatabase;
     }
 
-    public void setAutoConnectToLastSharedDatabases(boolean shouldAutoConnectToLastSharedDatabase) {
-        this.shouldConnectLastSharedDatabases.set(shouldAutoConnectToLastSharedDatabase);
-    }
-
-    public ObservableList<String> getLastConnectedSharedDatabases() {
-        return lastConnectedSharedDatabases;
-    }
-
-    public void setLastConnectedSharedDatabases(List<String> sharedDBs) {
-        this.lastConnectedSharedDatabases.setAll(sharedDBs);
+    public void setAutoConnectToLastSharedDatabase(boolean shouldAutoConnectToLastSharedDatabase) {
+        this.shouldConnectLastSharedDatabase.set(shouldAutoConnectToLastSharedDatabase);
     }
 }

--- a/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
+++ b/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
@@ -1,9 +1,13 @@
 package org.jabref.preferences;
 
+import java.util.List;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 public class ExternalApplicationsPreferences {
 
@@ -14,7 +18,8 @@ public class ExternalApplicationsPreferences {
     private final StringProperty customTerminalCommand;
     private final BooleanProperty useCustomFileBrowser;
     private final StringProperty customFileBrowserCommand;
-    private final BooleanProperty shouldConnectLastSharedDatabase;
+    private final BooleanProperty shouldConnectLastSharedDatabases;
+    private final ObservableList<String> lastConnectedSharedDatabases;
 
     public ExternalApplicationsPreferences(String eMailSubject,
                                            boolean shouldAutoOpenEmailAttachmentsFolder,
@@ -23,7 +28,7 @@ public class ExternalApplicationsPreferences {
                                            String customTerminalCommand,
                                            boolean useCustomFileBrowser,
                                            String customFileBrowserCommand,
-                                           boolean shouldConnectLastSharedDatabase) {
+                                           boolean shouldConnectLastSharedDatabases, List<String> lastConnectedSharedDatabases) {
 
         this.eMailSubject = new SimpleStringProperty(eMailSubject);
         this.shouldAutoOpenEmailAttachmentsFolder = new SimpleBooleanProperty(shouldAutoOpenEmailAttachmentsFolder);
@@ -32,7 +37,8 @@ public class ExternalApplicationsPreferences {
         this.customTerminalCommand = new SimpleStringProperty(customTerminalCommand);
         this.useCustomFileBrowser = new SimpleBooleanProperty(useCustomFileBrowser);
         this.customFileBrowserCommand = new SimpleStringProperty(customFileBrowserCommand);
-        this.shouldConnectLastSharedDatabase = new SimpleBooleanProperty(shouldConnectLastSharedDatabase);
+        this.shouldConnectLastSharedDatabases = new SimpleBooleanProperty(shouldConnectLastSharedDatabases);
+        this.lastConnectedSharedDatabases = FXCollections.observableArrayList(lastConnectedSharedDatabases);
     }
 
     public String getEmailSubject() {
@@ -119,15 +125,23 @@ public class ExternalApplicationsPreferences {
         this.customFileBrowserCommand.set(customFileBrowserCommand);
     }
 
-    public boolean shouldAutoConnectToLastSharedDatabase() {
-        return shouldConnectLastSharedDatabase.get();
+    public boolean shouldAutoConnectToLastSharedDatabases() {
+        return shouldConnectLastSharedDatabases.get();
     }
 
-    public BooleanProperty autoConnectToLastSharedDatabase() {
-        return shouldConnectLastSharedDatabase;
+    public BooleanProperty autoConnectToLastSharedDatabases() {
+        return shouldConnectLastSharedDatabases;
     }
 
-    public void setAutoConnectToLastSharedDatabase(boolean shouldAutoConnectToLastSharedDatabase) {
-        this.shouldConnectLastSharedDatabase.set(shouldAutoConnectToLastSharedDatabase);
+    public void setAutoConnectToLastSharedDatabases(boolean shouldAutoConnectToLastSharedDatabase) {
+        this.shouldConnectLastSharedDatabases.set(shouldAutoConnectToLastSharedDatabase);
+    }
+
+    public ObservableList<String> getLastConnectedSharedDatabases() {
+        return lastConnectedSharedDatabases;
+    }
+
+    public void setLastConnectedSharedDatabases(List<String> sharedDBs) {
+        this.lastConnectedSharedDatabases.setAll(sharedDBs);
     }
 }

--- a/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
+++ b/src/main/java/org/jabref/preferences/ExternalApplicationsPreferences.java
@@ -14,6 +14,7 @@ public class ExternalApplicationsPreferences {
     private final StringProperty customTerminalCommand;
     private final BooleanProperty useCustomFileBrowser;
     private final StringProperty customFileBrowserCommand;
+    private final BooleanProperty shouldConnectLastSharedDatabase;
 
     public ExternalApplicationsPreferences(String eMailSubject,
                                            boolean shouldAutoOpenEmailAttachmentsFolder,
@@ -21,7 +22,8 @@ public class ExternalApplicationsPreferences {
                                            boolean useCustomTerminal,
                                            String customTerminalCommand,
                                            boolean useCustomFileBrowser,
-                                           String customFileBrowserCommand) {
+                                           String customFileBrowserCommand,
+                                           boolean shouldConnectLastSharedDatabase) {
 
         this.eMailSubject = new SimpleStringProperty(eMailSubject);
         this.shouldAutoOpenEmailAttachmentsFolder = new SimpleBooleanProperty(shouldAutoOpenEmailAttachmentsFolder);
@@ -30,6 +32,7 @@ public class ExternalApplicationsPreferences {
         this.customTerminalCommand = new SimpleStringProperty(customTerminalCommand);
         this.useCustomFileBrowser = new SimpleBooleanProperty(useCustomFileBrowser);
         this.customFileBrowserCommand = new SimpleStringProperty(customFileBrowserCommand);
+        this.shouldConnectLastSharedDatabase = new SimpleBooleanProperty(shouldConnectLastSharedDatabase);
     }
 
     public String getEmailSubject() {
@@ -114,5 +117,17 @@ public class ExternalApplicationsPreferences {
 
     public void setCustomFileBrowserCommand(String customFileBrowserCommand) {
         this.customFileBrowserCommand.set(customFileBrowserCommand);
+    }
+
+    public boolean shouldAutoConnectToLastSharedDatabase() {
+        return shouldConnectLastSharedDatabase.get();
+    }
+
+    public BooleanProperty autoConnectToLastSharedDatabase() {
+        return shouldConnectLastSharedDatabase;
+    }
+
+    public void setAutoConnectToLastSharedDatabase(boolean shouldAutoConnectToLastSharedDatabase) {
+        this.shouldConnectLastSharedDatabase.set(shouldAutoConnectToLastSharedDatabase);
     }
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -256,6 +256,7 @@ public class JabRefPreferences implements PreferencesService {
     public static final String USE_DEFAULT_FILE_BROWSER_APPLICATION = "userDefaultFileBrowserApplication";
     public static final String FILE_BROWSER_COMMAND = "fileBrowserCommand";
     public static final String MAIN_FILE_DIRECTORY = "fileDirectory";
+    public static final String CONNECT_LAST_SHARED_DB = "connectLastSharedDB";
 
     public static final String SEARCH_DISPLAY_MODE = "searchDisplayMode";
     public static final String SEARCH_CASE_SENSITIVE = "caseSensitiveSearch";
@@ -481,6 +482,8 @@ public class JabRefPreferences implements PreferencesService {
         // Otherwise that language framework will be instantiated and more importantly, statically initialized preferences
         // like the SearchDisplayMode will never be translated.
         Localization.setLanguage(getLanguage());
+
+        defaults.put(CONNECT_LAST_SHARED_DB, Boolean.FALSE);
 
         defaults.put(SEARCH_DISPLAY_MODE, SearchDisplayMode.FILTER.toString());
         defaults.put(SEARCH_CASE_SENSITIVE, Boolean.FALSE);
@@ -1776,7 +1779,9 @@ public class JabRefPreferences implements PreferencesService {
                 !getBoolean(USE_DEFAULT_CONSOLE_APPLICATION), // mind the !
                 get(CONSOLE_COMMAND),
                 !getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION), // mind the !
-                get(FILE_BROWSER_COMMAND));
+                get(FILE_BROWSER_COMMAND),
+                getBoolean(CONNECT_LAST_SHARED_DB)
+        );
 
         EasyBind.listen(externalApplicationsPreferences.eMailSubjectProperty(),
                 (obs, oldValue, newValue) -> put(EMAIL_SUBJECT, newValue));
@@ -1792,6 +1797,8 @@ public class JabRefPreferences implements PreferencesService {
                 (obs, oldValue, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue)); // mind the !
         EasyBind.listen(externalApplicationsPreferences.customFileBrowserCommandProperty(),
                 (obs, oldValue, newValue) -> put(FILE_BROWSER_COMMAND, newValue));
+        EasyBind.listen(externalApplicationsPreferences.autoConnectToLastSharedDatabase(),
+                (obs, oldValue, newValue) -> putBoolean(CONNECT_LAST_SHARED_DB, newValue));
 
         return externalApplicationsPreferences;
     }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -256,7 +256,8 @@ public class JabRefPreferences implements PreferencesService {
     public static final String USE_DEFAULT_FILE_BROWSER_APPLICATION = "userDefaultFileBrowserApplication";
     public static final String FILE_BROWSER_COMMAND = "fileBrowserCommand";
     public static final String MAIN_FILE_DIRECTORY = "fileDirectory";
-    public static final String CONNECT_LAST_SHARED_DB = "connectLastSharedDB";
+    public static final String CONNECT_LAST_SHARED_DATABASES = "connectLastSharedDatabases";
+    public static final String LAST_CONNECTED = "lastConnected";
 
     public static final String SEARCH_DISPLAY_MODE = "searchDisplayMode";
     public static final String SEARCH_CASE_SENSITIVE = "caseSensitiveSearch";
@@ -483,7 +484,8 @@ public class JabRefPreferences implements PreferencesService {
         // like the SearchDisplayMode will never be translated.
         Localization.setLanguage(getLanguage());
 
-        defaults.put(CONNECT_LAST_SHARED_DB, Boolean.FALSE);
+        defaults.put(CONNECT_LAST_SHARED_DATABASES, Boolean.FALSE);
+        defaults.put(LAST_CONNECTED, "");
 
         defaults.put(SEARCH_DISPLAY_MODE, SearchDisplayMode.FILTER.toString());
         defaults.put(SEARCH_CASE_SENSITIVE, Boolean.FALSE);
@@ -1780,8 +1782,8 @@ public class JabRefPreferences implements PreferencesService {
                 get(CONSOLE_COMMAND),
                 !getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION), // mind the !
                 get(FILE_BROWSER_COMMAND),
-                getBoolean(CONNECT_LAST_SHARED_DB)
-        );
+                getBoolean(CONNECT_LAST_SHARED_DATABASES),
+                getStringList(LAST_CONNECTED));
 
         EasyBind.listen(externalApplicationsPreferences.eMailSubjectProperty(),
                 (obs, oldValue, newValue) -> put(EMAIL_SUBJECT, newValue));
@@ -1797,8 +1799,15 @@ public class JabRefPreferences implements PreferencesService {
                 (obs, oldValue, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue)); // mind the !
         EasyBind.listen(externalApplicationsPreferences.customFileBrowserCommandProperty(),
                 (obs, oldValue, newValue) -> put(FILE_BROWSER_COMMAND, newValue));
-        EasyBind.listen(externalApplicationsPreferences.autoConnectToLastSharedDatabase(),
-                (obs, oldValue, newValue) -> putBoolean(CONNECT_LAST_SHARED_DB, newValue));
+        EasyBind.listen(externalApplicationsPreferences.autoConnectToLastSharedDatabases(),
+                (obs, oldValue, newValue) -> putBoolean(CONNECT_LAST_SHARED_DATABASES, newValue));
+        externalApplicationsPreferences.getLastConnectedSharedDatabases().addListener((ListChangeListener<String>) change -> {
+            if (change.getList().isEmpty()) {
+                prefs.remove(LAST_CONNECTED);
+            } else {
+                putStringList(LAST_CONNECTED, externalApplicationsPreferences.getLastConnectedSharedDatabases());
+            }
+        });
 
         return externalApplicationsPreferences;
     }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -256,8 +256,7 @@ public class JabRefPreferences implements PreferencesService {
     public static final String USE_DEFAULT_FILE_BROWSER_APPLICATION = "userDefaultFileBrowserApplication";
     public static final String FILE_BROWSER_COMMAND = "fileBrowserCommand";
     public static final String MAIN_FILE_DIRECTORY = "fileDirectory";
-    public static final String CONNECT_LAST_SHARED_DATABASES = "connectLastSharedDatabases";
-    public static final String LAST_CONNECTED = "lastConnected";
+    public static final String CONNECT_LAST_SHARED_DB = "connectLastSharedDB";
 
     public static final String SEARCH_DISPLAY_MODE = "searchDisplayMode";
     public static final String SEARCH_CASE_SENSITIVE = "caseSensitiveSearch";
@@ -484,8 +483,7 @@ public class JabRefPreferences implements PreferencesService {
         // like the SearchDisplayMode will never be translated.
         Localization.setLanguage(getLanguage());
 
-        defaults.put(CONNECT_LAST_SHARED_DATABASES, Boolean.FALSE);
-        defaults.put(LAST_CONNECTED, "");
+        defaults.put(CONNECT_LAST_SHARED_DB, Boolean.FALSE);
 
         defaults.put(SEARCH_DISPLAY_MODE, SearchDisplayMode.FILTER.toString());
         defaults.put(SEARCH_CASE_SENSITIVE, Boolean.FALSE);
@@ -1782,8 +1780,8 @@ public class JabRefPreferences implements PreferencesService {
                 get(CONSOLE_COMMAND),
                 !getBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION), // mind the !
                 get(FILE_BROWSER_COMMAND),
-                getBoolean(CONNECT_LAST_SHARED_DATABASES),
-                getStringList(LAST_CONNECTED));
+                getBoolean(CONNECT_LAST_SHARED_DB)
+        );
 
         EasyBind.listen(externalApplicationsPreferences.eMailSubjectProperty(),
                 (obs, oldValue, newValue) -> put(EMAIL_SUBJECT, newValue));
@@ -1799,15 +1797,8 @@ public class JabRefPreferences implements PreferencesService {
                 (obs, oldValue, newValue) -> putBoolean(USE_DEFAULT_FILE_BROWSER_APPLICATION, !newValue)); // mind the !
         EasyBind.listen(externalApplicationsPreferences.customFileBrowserCommandProperty(),
                 (obs, oldValue, newValue) -> put(FILE_BROWSER_COMMAND, newValue));
-        EasyBind.listen(externalApplicationsPreferences.autoConnectToLastSharedDatabases(),
-                (obs, oldValue, newValue) -> putBoolean(CONNECT_LAST_SHARED_DATABASES, newValue));
-        externalApplicationsPreferences.getLastConnectedSharedDatabases().addListener((ListChangeListener<String>) change -> {
-            if (change.getList().isEmpty()) {
-                prefs.remove(LAST_CONNECTED);
-            } else {
-                putStringList(LAST_CONNECTED, externalApplicationsPreferences.getLastConnectedSharedDatabases());
-            }
-        });
+        EasyBind.listen(externalApplicationsPreferences.autoConnectToLastSharedDatabase(),
+                (obs, oldValue, newValue) -> putBoolean(CONNECT_LAST_SHARED_DB, newValue));
 
         return externalApplicationsPreferences;
     }

--- a/src/main/resources/l10n/JabRef_ar.properties
+++ b/src/main/resources/l10n/JabRef_ar.properties
@@ -710,6 +710,8 @@ Copy\ content=نسخ المحتوى
 Move\ content=نقل المحتوى
 Swap\ content=مبادلة المحتوى
 Copy\ or\ move\ the\ content\ of\ one\ field\ to\ another=نسخ أو نقل محتوى حقل إلى آخر
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ar.properties
+++ b/src/main/resources/l10n/JabRef_ar.properties
@@ -710,8 +710,6 @@ Copy\ content=نسخ المحتوى
 Move\ content=نقل المحتوى
 Swap\ content=مبادلة المحتوى
 Copy\ or\ move\ the\ content\ of\ one\ field\ to\ another=نسخ أو نقل محتوى حقل إلى آخر
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -996,8 +996,6 @@ Find\ and\ replace=Søg og erstat
 
 Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Tilføj altid bogstav (a, b, ...) til genererede nøgler
 Default\ pattern=Standardmønster
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -996,6 +996,8 @@ Find\ and\ replace=Søg og erstat
 
 Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Tilføj altid bogstav (a, b, ...) til genererede nøgler
 Default\ pattern=Standardmønster
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2527,5 +2527,3 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Bibliothek für Import
 
 Multiline=Mehrzeilig
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2527,3 +2527,5 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Bibliothek für Import
 
 Multiline=Mehrzeilig
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -1652,8 +1652,6 @@ plain\ text=απλό κείμενο
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Θέλετε να επαναφέρετε τη βιβλιοθήκη από το αντίγραφο ασφαλείας;
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Αυτό ίσως υποδεικνύει πως το JabRef δεν τερματίστηκε σωστά την τελευταία φορά που χρησιμοποιήθηκε το αρχείο.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -1652,6 +1652,8 @@ plain\ text=απλό κείμενο
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Θέλετε να επαναφέρετε τη βιβλιοθήκη από το αντίγραφο ασφαλείας;
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Αυτό ίσως υποδεικνύει πως το JabRef δεν τερματίστηκε σωστά την τελευταία φορά που χρησιμοποιήθηκε το αρχείο.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2542,3 +2542,5 @@ Delete\ %0\ files=Delete %0 files
 Delete\ %0\ files\ permanently\ from\ disk,\ or\ just\ remove\ the\ files\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ files\ permanently\ from\ disk.=Delete %0 files permanently from disk, or just remove the files from the entry? Pressing Delete will delete the files permanently from disk.
 Error\ accessing\ file\ '%0'.=Error accessing file '%0'.
 This\ operation\ requires\ selected\ linked\ files.=This operation requires selected linked files.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2447,6 +2447,8 @@ Review\ backup=Revisar respaldo
 A\ backup\ file\ for\ '%0'\ was\ found\ at\ [%1]=Se encontró un archivo de respaldo para «%0» en [%1]
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=¿Quiere recuperar la biblioteca desde la copia de seguridad?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Esto puede indicar que JabRef no se cerró correctamente la última vez que se usó ese archivo.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2447,8 +2447,6 @@ Review\ backup=Revisar respaldo
 A\ backup\ file\ for\ '%0'\ was\ found\ at\ [%1]=Se encontró un archivo de respaldo para «%0» en [%1]
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=¿Quiere recuperar la biblioteca desde la copia de seguridad?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Esto puede indicar que JabRef no se cerró correctamente la última vez que se usó ese archivo.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -606,6 +606,8 @@ String\ constants=ثابت های رشته
 
 Auto\ complete\ disabled.=تکمیل خودکار غیرفعال شد.
 Auto\ complete\ enabled.=تکمیل خودکار غیرفعال شد.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -606,8 +606,6 @@ String\ constants=ثابت های رشته
 
 Auto\ complete\ disabled.=تکمیل خودکار غیرفعال شد.
 Auto\ complete\ enabled.=تکمیل خودکار غیرفعال شد.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2525,3 +2525,5 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Fichier à importer dans
 
 Multiline=Multiligne
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1059,7 +1059,7 @@ exportFormat=Format d'exportation
 Output\ file\ missing=Fichier de sortie manquant
 The\ output\ option\ depends\ on\ a\ valid\ input\ option.=L'option de sortie dépend d'une option d'entrée valide.
 Linked\ file\ name\ conventions=Conventions pour les noms de fichiers liés
-Filename\ format\ pattern=Modèle de format de nom de fichier 
+Filename\ format\ pattern=Modèle de format de nom de fichier
 Additional\ parameters=Paramètres additionnels
 Cite\ selected\ entries\ between\ parenthesis=Citer les entrées sélectionnées entre parenthèses
 Cite\ selected\ entries\ with\ in-text\ citation=Citer les entrées sélectionnées comme incluse dans le texte
@@ -2525,3 +2525,5 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Fichier à importer dans
 
 Multiline=Multiligne
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2525,5 +2525,3 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Fichier à importer dans
 
 Multiline=Multiligne
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_id.properties
+++ b/src/main/resources/l10n/JabRef_id.properties
@@ -1596,8 +1596,6 @@ plain\ text=teks biasa
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Apakah Anda ingin memulihkan perpustakaan dari file cadangan?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Ini bisa menunjukkan bahwa JabRef tidak dimatikan secara bersih terakhir kali file tersebut digunakan.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_id.properties
+++ b/src/main/resources/l10n/JabRef_id.properties
@@ -1596,6 +1596,8 @@ plain\ text=teks biasa
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Apakah Anda ingin memulihkan perpustakaan dari file cadangan?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Ini bisa menunjukkan bahwa JabRef tidak dimatikan secara bersih terakhir kali file tersebut digunakan.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2525,5 +2525,3 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Libreria in cui importare
 
 Multiline=Multilinea
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2525,3 +2525,5 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Libreria in cui importare
 
 Multiline=Multilinea
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2442,6 +2442,8 @@ plain\ text=平文
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=ライブラリをバックアップファイルから復活させますか？
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=これは，このファイルが最後に使用された際にJabRefが正常に終了しなかったことを意味している可能性があります．
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2442,8 +2442,6 @@ plain\ text=平文
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=ライブラリをバックアップファイルから復活させますか？
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=これは，このファイルが最後に使用された際にJabRefが正常に終了しなかったことを意味している可能性があります．
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ko.properties
+++ b/src/main/resources/l10n/JabRef_ko.properties
@@ -2321,8 +2321,6 @@ plain\ text=일반 텍스트
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=백업 파일에서 라이브러리를 복구하시겠습니까?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=이것은 JabRef가 파일이 마지막으로 사용되었을 때 완전히 종료되지 않았음을 나타낼 수 있습니다.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ko.properties
+++ b/src/main/resources/l10n/JabRef_ko.properties
@@ -2321,6 +2321,8 @@ plain\ text=일반 텍스트
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=백업 파일에서 라이브러리를 복구하시겠습니까?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=이것은 JabRef가 파일이 마지막으로 사용되었을 때 완전히 종료되지 않았음을 나타낼 수 있습니다.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ko.properties
+++ b/src/main/resources/l10n/JabRef_ko.properties
@@ -1852,7 +1852,7 @@ Add\ new\ String=문자열 추가
 Must\ not\ be\ empty\!=비워둘 수 없습니다\!
 Open\ Help\ page=도움말 열기
 Add\ new\ field\ name=새 필드 이름 추가
-Field\ name\:=필드 이름\: 
+Field\ name\:=필드 이름\:
 Field\ name\ "%0"\ already\ exists=필드 이름 "%0"이 이미 존재합니다
 No\ field\ name\ selected\!=필드 이름을 선택하지 않았습니다
 Remove\ field\ name=필드 이름 제거
@@ -2321,6 +2321,8 @@ plain\ text=일반 텍스트
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=백업 파일에서 라이브러리를 복구하시겠습니까?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=이것은 JabRef가 파일이 마지막으로 사용되었을 때 완전히 종료되지 않았음을 나타낼 수 있습니다.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -1710,6 +1710,8 @@ plain\ text=onopgemaakte tekst
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Wilt u de bibliotheek herstellen van het backup bestand?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Dit kan erop duiden dat JabRef niet netjes werd afgesloten toen het bestand voor het laatst werd gebruikt.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -1710,8 +1710,6 @@ plain\ text=onopgemaakte tekst
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Wilt u de bibliotheek herstellen van het backup bestand?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Dit kan erop duiden dat JabRef niet netjes werd afgesloten toen het bestand voor het laatst werd gebruikt.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -1110,8 +1110,6 @@ Import\ BibTeX=Importer BibTeX
 
 Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Legg alltid til en bokstav (a, b, ...) til genererte nøkler
 Default\ pattern=Standardmønster
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -1110,6 +1110,8 @@ Import\ BibTeX=Importer BibTeX
 
 Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Legg alltid til en bokstav (a, b, ...) til genererte nøkler
 Default\ pattern=Standardmønster
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_pl.properties
+++ b/src/main/resources/l10n/JabRef_pl.properties
@@ -1054,6 +1054,8 @@ Reset=Reset
 
 
 plain\ text=czysty tekst
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_pl.properties
+++ b/src/main/resources/l10n/JabRef_pl.properties
@@ -1054,8 +1054,6 @@ Reset=Reset
 
 
 plain\ text=czysty tekst
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_pt.properties
+++ b/src/main/resources/l10n/JabRef_pt.properties
@@ -1315,8 +1315,6 @@ Default\ pattern=Ppadrão predefinido
 
 
 plain\ text=texto sem formatação
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_pt.properties
+++ b/src/main/resources/l10n/JabRef_pt.properties
@@ -1315,6 +1315,8 @@ Default\ pattern=Ppadrão predefinido
 
 
 plain\ text=texto sem formatação
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2525,3 +2525,5 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Biblioteca para onde importar
 
 Multiline=Multilinha
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2525,5 +2525,3 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 Library\ to\ import\ into=Biblioteca para onde importar
 
 Multiline=Multilinha
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2230,7 +2230,7 @@ This\ entry\ type\ is\ intended\ for\ sources\ such\ as\ web\ sites\ which\ are\
 A\ single-volume\ work\ of\ reference\ such\ as\ an\ encyclopedia\ or\ a\ dictionary.=Неделимая работа или ссылка, как энциклопедия или словарь.
 A\ technical\ report,\ research\ report,\ or\ white\ paper\ published\ by\ a\ university\ or\ some\ other\ institution.=Технический отчет, исследовательский отчет, или белая книга, выпущенная институтом или другим учреждением.
 An\ entry\ set\ is\ a\ group\ of\ entries\ which\ are\ cited\ as\ a\ single\ reference\ and\ listed\ as\ a\ single\ item\ in\ the\ bibliography.=Набор записей представляет собой группу записей, которые приводятся в виде единой ссылки и перечислены в виде одного элемента в библиографии.
-Supplemental\ material\ in\ a\ "Book".\ This\ type\ is\ provided\ for\ elements\ such\ as\ prefaces,\ introductions,\ forewords,\ afterwords,\ etc.\ which\ often\ have\ a\ generic\ title\ only.=Дополнительный материал в "Книге" предназначен для таких элементов, как предисловия, введения, послесловия и т.д. 
+Supplemental\ material\ in\ a\ "Book".\ This\ type\ is\ provided\ for\ elements\ such\ as\ prefaces,\ introductions,\ forewords,\ afterwords,\ etc.\ which\ often\ have\ a\ generic\ title\ only.=Дополнительный материал в "Книге" предназначен для таких элементов, как предисловия, введения, послесловия и т.д.
 Supplemental\ material\ in\ a\ "Collection".=Дополнительные материалы в "Коллекции".
 Supplemental\ material\ in\ a\ "Periodical".\ This\ type\ may\ be\ useful\ when\ referring\ to\ items\ such\ as\ regular\ columns,\ obituaries,\ letters\ to\ the\ editor,\ etc.\ which\ only\ have\ a\ generic\ title.=Дополнительные материалы в "Периодическом издании". Этот тип может быть полезен при обращении к таким элементам, как обычные колонки, некрологи, письма к редактору и т.д., которые имеют только общее название.
 A\ thesis\ written\ for\ an\ educational\ institution\ to\ satisfy\ the\ requirements\ for\ a\ degree.=Тезис, написанный для учебного заведения с целью удовлетворения требований к степени.
@@ -2429,6 +2429,8 @@ plain\ text=обычный текст
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Вы хотите восстановить библиотеку из файла резервной копии?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Это может означать что JabRef не закрылся правильно при последнем использовании файла.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2429,8 +2429,6 @@ plain\ text=обычный текст
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Вы хотите восстановить библиотеку из файла резервной копии?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Это может означать что JabRef не закрылся правильно при последнем использовании файла.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2429,6 +2429,8 @@ plain\ text=обычный текст
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Вы хотите восстановить библиотеку из файла резервной копии?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Это может означать что JabRef не закрылся правильно при последнем использовании файла.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1525,8 +1525,6 @@ Previous\ preview\ style=Föregående förhandsgranskningsstil
 
 
 plain\ text=klartext
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1525,6 +1525,8 @@ Previous\ preview\ style=Föregående förhandsgranskningsstil
 
 
 plain\ text=klartext
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_tl.properties
+++ b/src/main/resources/l10n/JabRef_tl.properties
@@ -1319,6 +1319,8 @@ Default\ pattern=Default na pattern
 
 
 plain\ text=plain na teksto
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_tl.properties
+++ b/src/main/resources/l10n/JabRef_tl.properties
@@ -1319,8 +1319,6 @@ Default\ pattern=Default na pattern
 
 
 plain\ text=plain na teksto
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2517,5 +2517,7 @@ Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Veritabanın�
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Bu, dosya son kullanıldığında JabRef'in temiz kapatılmadığını belirtiyor olabilir.
 
 Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbreviations\ in\ the\ entry=Dergi adını girdideki kısaltmalar için tamamıyla kaydetmek üzere FJournal alanını kullanın
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2517,7 +2517,5 @@ Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Veritabanın�
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Bu, dosya son kullanıldığında JabRef'in temiz kapatılmadığını belirtiyor olabilir.
 
 Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbreviations\ in\ the\ entry=Dergi adını girdideki kısaltmalar için tamamıyla kaydetmek üzere FJournal alanını kullanın
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 

--- a/src/main/resources/l10n/JabRef_uk.properties
+++ b/src/main/resources/l10n/JabRef_uk.properties
@@ -599,3 +599,5 @@
 
 
 
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_uk.properties
+++ b/src/main/resources/l10n/JabRef_uk.properties
@@ -599,5 +599,3 @@
 
 
 
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -1105,8 +1105,6 @@ Default\ pattern=Kiểu mặc định
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Bạn có muốn phục hồi cơ sở dữ liệu từ tập tin lưu dự phòng không?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Điều này cho thấy là JabRef không được kết thúc hoàn chỉnh khi sử dụng tập tin lần cuối.
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -1105,6 +1105,8 @@ Default\ pattern=Kiểu mặc định
 
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Bạn có muốn phục hồi cơ sở dữ liệu từ tập tin lưu dự phòng không?
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Điều này cho thấy là JabRef không được kết thúc hoàn chỉnh khi sử dụng tập tin lần cuối.
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_zh_CN.properties
+++ b/src/main/resources/l10n/JabRef_zh_CN.properties
@@ -2518,7 +2518,5 @@ Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=是否要从�
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=这可能表明, 上次使用该文件时, JabRef 没有完全关闭。
 
 Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbreviations\ in\ the\ entry=使用FJournal字段记录Journal全称
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 

--- a/src/main/resources/l10n/JabRef_zh_CN.properties
+++ b/src/main/resources/l10n/JabRef_zh_CN.properties
@@ -2518,5 +2518,7 @@ Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=是否要从�
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=这可能表明, 上次使用该文件时, JabRef 没有完全关闭。
 
 Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbreviations\ in\ the\ entry=使用FJournal字段记录Journal全称
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 

--- a/src/main/resources/l10n/JabRef_zh_TW.properties
+++ b/src/main/resources/l10n/JabRef_zh_TW.properties
@@ -1070,6 +1070,8 @@ Use\ custom\ DOI\ base\ URI\ for\ article\ access=使用自訂的 DOI 基礎網�
 
 Question=問題
 Select\ directory=選擇資料夾
+Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
+Shared\ Database=Shared Database
 
 
 

--- a/src/main/resources/l10n/JabRef_zh_TW.properties
+++ b/src/main/resources/l10n/JabRef_zh_TW.properties
@@ -1070,8 +1070,6 @@ Use\ custom\ DOI\ base\ URI\ for\ article\ access=使用自訂的 DOI 基礎網�
 
 Question=問題
 Select\ directory=選擇資料夾
-Open\ last\ shared\ database\ connections\ at\ startup=Open last shared database connections at startup
-Shared\ Database=Shared Database
 
 
 


### PR DESCRIPTION
Fixes #9714 
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

Created a new preference tab called Shared Database 
![new tab on preferences](https://user-images.githubusercontent.com/82181439/236536062-b87277e2-9d01-4350-b84c-920b9276a160.png)

Added two new preferences to the JabRefPreferences class. One boolean for the checkbox and one list containing the last shared database IDs. 



<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
