### PR TITLE
Enable CompareEnumsWithEqualityOperator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ dependencies {
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '3.0.2'
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.2'
 
-    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:1.18.0"))
+    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:1.19.3"))
     rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
 }
 
@@ -522,6 +522,7 @@ rewrite {
         "**/*.xml",
         "**/*.yml"
     )
+    plainTextMask("**/*.md")
 }
 
 modernizer {

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -100,7 +100,8 @@ recipeList:
   - org.openrewrite.java.cleanup.CaseInsensitiveComparisonsDoNotChangeCase
   - org.openrewrite.java.cleanup.CatchClauseOnlyRethrows
   - org.openrewrite.java.cleanup.ChainStringBuilderAppendCalls
-#  - org.openrewrite.java.cleanup.CompareEnumsWithEqualityOperator
+  # Might need manual intervention, because negations are not treated properly
+  - org.openrewrite.java.cleanup.CompareEnumsWithEqualityOperator
 #  - org.openrewrite.java.cleanup.ControlFlowIndentation
 #  - org.openrewrite.java.cleanup.CovariantEquals
 #  - org.openrewrite.java.cleanup.DeclarationSiteTypeVariance

--- a/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
+++ b/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
@@ -36,7 +36,7 @@ public class SuggestionProviders {
             return new PersonNameSuggestionProvider(field, database);
         } else if (fieldProperties.contains(FieldProperty.SINGLE_ENTRY_LINK) || fieldProperties.contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
             return new BibEntrySuggestionProvider(database);
-        } else if (fieldProperties.contains(FieldProperty.JOURNAL_NAME) || StandardField.PUBLISHER.equals(field)) {
+        } else if (fieldProperties.contains(FieldProperty.JOURNAL_NAME) || StandardField.PUBLISHER == field) {
             return new JournalsSuggestionProvider(field, database, abbreviationRepository);
         } else {
             return new WordSuggestionProvider(field, database);

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -61,7 +61,7 @@ public class JabRefDesktop {
             throws IOException {
         String link = initialLink;
         Field field = initialField;
-        if (StandardField.PS.equals(field) || StandardField.PDF.equals(field)) {
+        if (StandardField.PS == field || StandardField.PDF == field) {
             // Find the default directory for this field type:
             List<Path> directories = databaseContext.getFileDirectories(preferencesService.getFilePreferences());
 
@@ -83,10 +83,10 @@ public class JabRefDesktop {
                     field = StandardField.PS;
                 }
             }
-        } else if (StandardField.DOI.equals(field)) {
+        } else if (StandardField.DOI == field) {
             openDoi(link);
             return;
-        } else if (StandardField.EPRINT.equals(field)) {
+        } else if (StandardField.EPRINT == field) {
             IdentifierParser identifierParser = new IdentifierParser(entry);
             link = identifierParser.parse(StandardField.EPRINT)
                     .flatMap(Identifier::getExternalURI)
@@ -105,15 +105,15 @@ public class JabRefDesktop {
             field = StandardField.URL;
         }
 
-        if (StandardField.URL.equals(field)) {
+        if (StandardField.URL == field) {
             openBrowser(link);
-        } else if (StandardField.PS.equals(field)) {
+        } else if (StandardField.PS == field) {
             try {
                 NATIVE_DESKTOP.openFile(link, StandardField.PS.getName());
             } catch (IOException e) {
                 LOGGER.error("An error occurred on the command: " + link, e);
             }
-        } else if (StandardField.PDF.equals(field)) {
+        } else if (StandardField.PDF == field) {
             try {
                 NATIVE_DESKTOP.openFile(link, StandardField.PDF.getName());
             } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
@@ -88,19 +88,19 @@ public class FileAnnotationViewModel {
     @Override
     public String toString() {
         if (annotation.hasLinkedAnnotation() && this.getContent().isEmpty()) {
-            if (FileAnnotationType.UNDERLINE.equals(annotation.getAnnotationType())) {
+            if (FileAnnotationType.UNDERLINE == annotation.getAnnotationType()) {
                 return Localization.lang("Empty Underline");
             }
-            if (FileAnnotationType.HIGHLIGHT.equals(annotation.getAnnotationType())) {
+            if (FileAnnotationType.HIGHLIGHT == annotation.getAnnotationType()) {
                 return Localization.lang("Empty Highlight");
             }
             return Localization.lang("Empty Marking");
         }
 
-        if (FileAnnotationType.UNDERLINE.equals(annotation.getAnnotationType())) {
+        if (FileAnnotationType.UNDERLINE == annotation.getAnnotationType()) {
             return Localization.lang("Underline") + ": " + this.getContent();
         }
-        if (FileAnnotationType.HIGHLIGHT.equals(annotation.getAnnotationType())) {
+        if (FileAnnotationType.HIGHLIGHT == annotation.getAnnotationType()) {
             return Localization.lang("Highlight") + ": " + this.getContent();
         }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -91,7 +91,7 @@ public class FieldEditors {
             return new LinkedEntriesEditor(field, databaseContext, (SuggestionProvider<BibEntry>) suggestionProvider, fieldCheckers);
         } else if (fieldProperties.contains(FieldProperty.PERSON_NAMES)) {
             return new PersonsEditor(field, suggestionProvider, preferences, fieldCheckers, isMultiLine);
-        } else if (StandardField.KEYWORDS.equals(field)) {
+        } else if (StandardField.KEYWORDS == field) {
             return new KeywordsEditor(field, suggestionProvider, fieldCheckers, preferences);
         } else if (field == InternalField.KEY_FIELD) {
             return new CitationKeyEditor(field, preferences, suggestionProvider, fieldCheckers, databaseContext, undoManager, dialogService);

--- a/src/main/java/org/jabref/gui/fieldeditors/identifier/EprintIdentifierEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/identifier/EprintIdentifierEditorViewModel.java
@@ -24,7 +24,7 @@ public class EprintIdentifierEditorViewModel extends BaseIdentifierEditorViewMod
     // https://en.wikipedia.org/wiki/Lapsed_listener_problem
     private MapChangeListener<Field, String> eprintTypeFieldListener = change -> {
         Field changedField = change.getKey();
-        if (StandardField.EPRINTTYPE.equals(changedField)) {
+        if (StandardField.EPRINTTYPE == changedField) {
             updateIdentifier();
         }
     };

--- a/src/main/java/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.java
@@ -39,11 +39,11 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
                             SuggestionProvider<?> suggestionProvider,
                             FieldCheckers fieldCheckers,
                             PreferencesService preferences) {
-        if (StandardField.DOI.equals(field)) {
+        if (StandardField.DOI == field) {
             this.viewModel = new DoiIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences);
-        } else if (StandardField.ISBN.equals(field)) {
+        } else if (StandardField.ISBN == field) {
             this.viewModel = new ISBNIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences);
-        } else if (StandardField.EPRINT.equals(field)) {
+        } else if (StandardField.EPRINT == field) {
             this.viewModel = new EprintIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences);
         } else {
             throw new IllegalStateException(String.format("Unable to instantiate a view model for identifier field editor '%s'", field.getDisplayName()));

--- a/src/main/java/org/jabref/gui/journals/UndoableAbbreviator.java
+++ b/src/main/java/org/jabref/gui/journals/UndoableAbbreviator.java
@@ -55,7 +55,7 @@ public class UndoableAbbreviator {
         }
 
         // Store full name into fjournal but only if it exists
-        if (useFJournalField && (StandardField.JOURNAL.equals(fieldName) || StandardField.JOURNALTITLE.equals(fieldName))) {
+        if (useFJournalField && (StandardField.JOURNAL == fieldName || StandardField.JOURNALTITLE == fieldName)) {
             entry.setField(AMSField.FJOURNAL, abbreviation.getName());
             ce.addEdit(new UndoableFieldChange(entry, AMSField.FJOURNAL, null, abbreviation.getName()));
         }

--- a/src/main/java/org/jabref/gui/journals/UndoableUnabbreviator.java
+++ b/src/main/java/org/jabref/gui/journals/UndoableUnabbreviator.java
@@ -58,7 +58,7 @@ public class UndoableUnabbreviator {
     }
 
     public boolean restoreFromFJournal(BibEntry entry, Field field, CompoundEdit ce) {
-        if ((!StandardField.JOURNAL.equals(field) && !StandardField.JOURNALTITLE.equals(field)) || !entry.hasField(AMSField.FJOURNAL)) {
+        if ((StandardField.JOURNAL != field && StandardField.JOURNALTITLE != field) || !entry.hasField(AMSField.FJOURNAL)) {
             return false;
         }
 

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -130,7 +130,7 @@ public class GlobalSearchBar extends HBox {
         searchField.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             Optional<KeyBinding> keyBinding = keyBindingRepository.mapToKeyBinding(event);
             if (keyBinding.isPresent()) {
-                if (keyBinding.get().equals(KeyBinding.CLOSE)) {
+                if (keyBinding.get() == KeyBinding.CLOSE) {
                     // Clear search and select first entry, if available
                     searchField.setText("");
                     frame.getCurrentLibraryTab().getMainTable().getSelectionModel().selectFirst();

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -173,7 +173,7 @@ public class BibEntryWriter {
     }
 
     static int getLengthOfLongestFieldName(BibEntry entry) {
-        Predicate<Field> isNotCitationKey = field -> !InternalField.KEY_FIELD.equals(field);
+        Predicate<Field> isNotCitationKey = field -> InternalField.KEY_FIELD != field;
         return entry.getFields()
                     .stream()
                     .filter(isNotCitationKey)

--- a/src/main/java/org/jabref/logic/bibtex/comparator/FieldComparator.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/FieldComparator.java
@@ -59,13 +59,13 @@ public class FieldComparator implements Comparator<BibEntry> {
     }
 
     private FieldType determineFieldType() {
-        if (InternalField.TYPE_HEADER.equals(this.fields.getPrimary())) {
+        if (InternalField.TYPE_HEADER == this.fields.getPrimary()) {
             return FieldType.TYPE;
         } else if (this.fields.getPrimary().getProperties().contains(FieldProperty.PERSON_NAMES)) {
             return FieldType.NAME;
-        } else if (StandardField.YEAR.equals(this.fields.getPrimary())) {
+        } else if (StandardField.YEAR == this.fields.getPrimary()) {
             return FieldType.YEAR;
-        } else if (StandardField.MONTH.equals(this.fields.getPrimary())) {
+        } else if (StandardField.MONTH == this.fields.getPrimary()) {
             return FieldType.MONTH;
         } else {
             return FieldType.OTHER;

--- a/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
+++ b/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
@@ -155,7 +155,7 @@ public class JabRefItemDataProvider implements ItemDataProvider {
                     .map(removeNewlinesFormatter::format)
                     .map(LatexToUnicodeAdapter::format)
                     .ifPresent(value -> {
-                        if (StandardField.MONTH.equals(key)) {
+                        if (StandardField.MONTH == key) {
                             // Change month from #mon# to mon because CSL does not support the former format
                             value = bibEntry.getMonth().map(Month::getShortName).orElse(value);
                         }

--- a/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanup.java
@@ -29,9 +29,9 @@ public class FieldFormatterCleanup implements CleanupJob {
 
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
-        if (InternalField.INTERNAL_ALL_FIELD.equals(field)) {
+        if (InternalField.INTERNAL_ALL_FIELD == field) {
             return cleanupAllFields(entry);
-        } else if (InternalField.INTERNAL_ALL_TEXT_FIELDS_FIELD.equals(field)) {
+        } else if (InternalField.INTERNAL_ALL_TEXT_FIELDS_FIELD == field) {
             return cleanupAllTextFields(entry);
         } else {
             return cleanupSingleField(field, entry);

--- a/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -171,11 +171,11 @@ public class DuplicateCheck {
 
         if (field.getProperties().contains(FieldProperty.PERSON_NAMES)) {
             return compareAuthorField(stringOne, stringTwo);
-        } else if (StandardField.PAGES.equals(field)) {
+        } else if (StandardField.PAGES == field) {
             return comparePagesField(stringOne, stringTwo);
-        } else if (StandardField.JOURNAL.equals(field)) {
+        } else if (StandardField.JOURNAL == field) {
             return compareJournalField(stringOne, stringTwo);
-        } else if (StandardField.CHAPTER.equals(field)) {
+        } else if (StandardField.CHAPTER == field) {
             return compareChapterField(stringOne, stringTwo);
         }
 

--- a/src/main/java/org/jabref/logic/exporter/ModsExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/ModsExporter.java
@@ -93,41 +93,41 @@ class ModsExporter extends Exporter {
                     Field field = entry.getKey();
                     String value = entry.getValue();
 
-                    if (StandardField.AUTHOR.equals(field)) {
+                    if (StandardField.AUTHOR == field) {
                         handleAuthors(mods, value);
                     } else if (new UnknownField("affiliation").equals(field)) {
                         addAffiliation(mods, value);
-                    } else if (StandardField.ABSTRACT.equals(field)) {
+                    } else if (StandardField.ABSTRACT == field) {
                         addAbstract(mods, value);
-                    } else if (StandardField.TITLE.equals(field)) {
+                    } else if (StandardField.TITLE == field) {
                         addTitle(mods, value);
-                    } else if (StandardField.LANGUAGE.equals(field)) {
+                    } else if (StandardField.LANGUAGE == field) {
                         addLanguage(mods, value);
-                    } else if (StandardField.LOCATION.equals(field)) {
+                    } else if (StandardField.LOCATION == field) {
                         addLocation(mods, value);
-                    } else if (StandardField.URL.equals(field)) {
+                    } else if (StandardField.URL == field) {
                         addUrl(mods, value);
-                    } else if (StandardField.NOTE.equals(field)) {
+                    } else if (StandardField.NOTE == field) {
                         addNote(mods, value);
-                    } else if (StandardField.KEYWORDS.equals(field)) {
+                    } else if (StandardField.KEYWORDS == field) {
                         addKeyWords(mods, value);
-                    } else if (StandardField.VOLUME.equals(field)) {
+                    } else if (StandardField.VOLUME == field) {
                         addDetail(StandardField.VOLUME, value, partDefinition);
-                    } else if (StandardField.ISSUE.equals(field)) {
+                    } else if (StandardField.ISSUE == field) {
                         addDetail(StandardField.ISSUE, value, partDefinition);
-                    } else if (StandardField.PAGES.equals(field)) {
+                    } else if (StandardField.PAGES == field) {
                         addPages(partDefinition, value);
-                    } else if (StandardField.URI.equals(field)) {
+                    } else if (StandardField.URI == field) {
                         addIdentifier(StandardField.URI, value, mods);
-                    } else if (StandardField.ISBN.equals(field)) {
+                    } else if (StandardField.ISBN == field) {
                         addIdentifier(StandardField.ISBN, value, mods);
-                    } else if (StandardField.ISSN.equals(field)) {
+                    } else if (StandardField.ISSN == field) {
                         addIdentifier(StandardField.ISSN, value, mods);
-                    } else if (StandardField.DOI.equals(field)) {
+                    } else if (StandardField.DOI == field) {
                         addIdentifier(StandardField.DOI, value, mods);
-                    } else if (StandardField.PMID.equals(field)) {
+                    } else if (StandardField.PMID == field) {
                         addIdentifier(StandardField.PMID, value, mods);
-                    } else if (StandardField.JOURNAL.equals(field)) {
+                    } else if (StandardField.JOURNAL == field) {
                         addJournal(value, relatedItem);
                     }
 
@@ -377,7 +377,7 @@ class ModsExporter extends Exporter {
             addDate("dateModified", value, originInfo);
         } else if (field.equals(StandardField.CREATIONDATE)) {
             addDate("dateCaptured", value, originInfo);
-        } else if (StandardField.PUBLISHER.equals(field)) {
+        } else if (StandardField.PUBLISHER == field) {
             StringPlusLanguagePlusSupplied publisher = new StringPlusLanguagePlusSupplied();
             publisher.setValue(value);
             JAXBElement<StringPlusLanguagePlusSupplied> element = new JAXBElement<>(

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -617,7 +617,7 @@ public class BibtexParser implements Parser {
                 // for users if JabRef did not accept it.
                 if (field.getProperties().contains(FieldProperty.PERSON_NAMES)) {
                     entry.setField(field, entry.getField(field).get() + " and " + content);
-                } else if (StandardField.KEYWORDS.equals(field)) {
+                } else if (StandardField.KEYWORDS == field) {
                     // multiple keywords fields should be combined to one
                     entry.addKeyword(content, importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
                 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -115,7 +115,7 @@ public class PdfMergeMetadataImporter extends Importer {
             for (Map.Entry<Field, String> fieldEntry : candidate.getFieldMap().entrySet()) {
                 // Don't merge FILE fields that point to a stored file as we set that to filePath anyway.
                 // Nevertheless, retain online links.
-                if (StandardField.FILE.equals(fieldEntry.getKey()) &&
+                if (StandardField.FILE == fieldEntry.getKey() &&
                         FileFieldParser.parse(fieldEntry.getValue()).stream().noneMatch(LinkedFile::isOnlineLink)) {
                     continue;
                 }

--- a/src/main/java/org/jabref/logic/importer/util/IdentifierParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/IdentifierParser.java
@@ -29,13 +29,13 @@ public class IdentifierParser {
             return Optional.empty();
         }
 
-        if (StandardField.DOI.equals(field)) {
+        if (StandardField.DOI == field) {
             return DOI.parse(fieldValue);
-        } else if (StandardField.ISBN.equals(field)) {
+        } else if (StandardField.ISBN == field) {
             return ISBN.parse(fieldValue);
-        } else if (StandardField.EPRINT.equals(field)) {
+        } else if (StandardField.EPRINT == field) {
             return parseEprint(fieldValue);
-        } else if (StandardField.MR_NUMBER.equals(field)) {
+        } else if (StandardField.MR_NUMBER == field) {
             return MathSciNetId.parse(fieldValue);
         }
 

--- a/src/main/java/org/jabref/logic/integrity/TypeChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/TypeChecker.java
@@ -18,7 +18,7 @@ public class TypeChecker implements EntryChecker {
             return Collections.emptyList();
         }
 
-        if (StandardEntryType.Proceedings.equals(entry.getType())) {
+        if (StandardEntryType.Proceedings == entry.getType()) {
             return Collections.singletonList(new IntegrityMessage(
                     Localization.lang("wrong entry type as proceedings has page numbers"), entry, StandardField.PAGES));
         }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -724,7 +724,7 @@ class OOBibStyleGetCitationMarker {
                                                                && !uniqueLettersDiffer);
 
                 if (uniqueLetterDoesNotMakeUnique &&
-                    nonUniqueCitationMarkerHandling.equals(NonUniqueCitationMarker.THROWS)) {
+                        nonUniqueCitationMarkerHandling == NonUniqueCitationMarker.THROWS) {
                     throw new IllegalArgumentException("different citation keys,"
                                                        + " but same normalizedMarker and uniqueLetter");
                 }

--- a/src/main/java/org/jabref/logic/xmp/DocumentInformationExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DocumentInformationExtractor.java
@@ -63,7 +63,7 @@ public class DocumentInformationExtractor {
                 String value = dict.getString(key);
                 key = key.substring("bibtex/".length());
                 Field field = FieldFactory.parseField(key);
-                if (InternalField.TYPE_HEADER.equals(field)) {
+                if (InternalField.TYPE_HEADER == field) {
                     bibEntry.setType(EntryTypeFactory.parse(value));
                 } else {
                     bibEntry.setField(field, value);

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -152,7 +152,7 @@ public class DublinCoreExtractor {
                 // only for month field - override value
                 // workaround, because the date value of the xmp component of pdf box is corrupted
                 // see also DublinCoreExtractor#extractYearAndMonth
-                if (StandardField.MONTH.equals(key)) {
+                if (StandardField.MONTH == key) {
                     Optional<Month> parsedMonth = Month.parse(value);
                     parsedMonth.ifPresent(bibEntry::setMonth);
                 }

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -237,13 +237,13 @@ public class XmpUtilWriter {
         for (Field field : resolvedEntry.getFields()) {
             if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {
                 // erase field instead of adding it
-                if (StandardField.AUTHOR.equals(field)) {
+                if (StandardField.AUTHOR == field) {
                     di.setAuthor(null);
-                } else if (StandardField.TITLE.equals(field)) {
+                } else if (StandardField.TITLE == field) {
                     di.setTitle(null);
-                } else if (StandardField.KEYWORDS.equals(field)) {
+                } else if (StandardField.KEYWORDS == field) {
                     di.setKeywords(null);
-                } else if (StandardField.ABSTRACT.equals(field)) {
+                } else if (StandardField.ABSTRACT == field) {
                     di.setSubject(null);
                 } else {
                     di.setCustomMetadataValue("bibtex/" + field, null);
@@ -254,13 +254,13 @@ public class XmpUtilWriter {
             // LaTeX content is removed from the string for "standard" fields in the PDF
             String value = unprotectTermsFormatter.format(resolvedEntry.getField(field).get());
 
-            if (StandardField.AUTHOR.equals(field)) {
+            if (StandardField.AUTHOR == field) {
                 di.setAuthor(value);
-            } else if (StandardField.TITLE.equals(field)) {
+            } else if (StandardField.TITLE == field) {
                 di.setTitle(value);
-            } else if (StandardField.KEYWORDS.equals(field)) {
+            } else if (StandardField.KEYWORDS == field) {
                 di.setKeywords(value);
-            } else if (StandardField.ABSTRACT.equals(field)) {
+            } else if (StandardField.ABSTRACT == field) {
                 di.setSubject(value);
             } else {
                 // We hit the case of an PDF-unsupported field --> write it directly

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -313,11 +313,11 @@ public class BibEntry implements Cloneable {
     }
 
     private Optional<String> genericGetResolvedFieldOrAlias(Field field, BibDatabase database, BiFunction<BibEntry, Field, Optional<String>> getFieldOrAlias) {
-        if (InternalField.TYPE_HEADER.equals(field) || InternalField.OBSOLETE_TYPE_HEADER.equals(field)) {
+        if (InternalField.TYPE_HEADER == field || InternalField.OBSOLETE_TYPE_HEADER == field) {
             return Optional.of(type.get().getDisplayName());
         }
 
-        if (InternalField.KEY_FIELD.equals(field)) {
+        if (InternalField.KEY_FIELD == field) {
             return getCitationKey();
         }
 
@@ -480,7 +480,7 @@ public class BibEntry implements Cloneable {
         }
 
         // Finally, handle dates
-        if (StandardField.DATE.equals(field)) {
+        if (StandardField.DATE == field) {
             Optional<Date> date = Date.parse(
                     getFieldValue.apply(this, StandardField.YEAR),
                     getFieldValue.apply(this, StandardField.MONTH),
@@ -489,7 +489,7 @@ public class BibEntry implements Cloneable {
             return date.map(Date::getNormalized);
         }
 
-        if (StandardField.YEAR.equals(field) || StandardField.MONTH.equals(field) || StandardField.DAY.equals(field)) {
+        if (StandardField.YEAR == field || StandardField.MONTH == field || StandardField.DAY == field) {
             Optional<String> date = getFieldValue.apply(this, StandardField.DATE);
             if (date.isEmpty()) {
                 return Optional.empty();
@@ -497,13 +497,13 @@ public class BibEntry implements Cloneable {
 
             Optional<Date> parsedDate = Date.parse(date.get());
             if (parsedDate.isPresent()) {
-                if (StandardField.YEAR.equals(field)) {
+                if (StandardField.YEAR == field) {
                     return parsedDate.get().getYear().map(Object::toString);
                 }
-                if (StandardField.MONTH.equals(field)) {
+                if (StandardField.MONTH == field) {
                     return parsedDate.get().getMonth().map(Month::getJabRefFormat);
                 }
-                if (StandardField.DAY.equals(field)) {
+                if (StandardField.DAY == field) {
                     return parsedDate.get().getDay().map(Object::toString);
                 }
             } else {
@@ -999,10 +999,10 @@ public class BibEntry implements Cloneable {
     }
 
     public Optional<String> getLatexFreeField(Field field) {
-        if (InternalField.KEY_FIELD.equals(field)) {
+        if (InternalField.KEY_FIELD == field) {
             // the key field should not be converted
             return getCitationKey();
-        } else if (InternalField.TYPE_HEADER.equals(field)) {
+        } else if (InternalField.TYPE_HEADER == field) {
             return Optional.of(type.get().getDisplayName());
         } else if (latexFreeFields.containsKey(field)) {
             return Optional.ofNullable(latexFreeFields.get(field));

--- a/src/main/java/org/jabref/model/groups/WordKeywordGroup.java
+++ b/src/main/java/org/jabref/model/groups/WordKeywordGroup.java
@@ -36,7 +36,7 @@ public class WordKeywordGroup extends KeywordGroup implements GroupEntryChanger 
         this.onlySplitWordsAtSeparator = onlySplitWordsAtSeparator;
 
         if (onlySplitWordsAtSeparator) {
-            if (InternalField.TYPE_HEADER.equals(searchField)) {
+            if (InternalField.TYPE_HEADER == searchField) {
                 searchStrategy = new TypeSearchStrategy();
             } else {
                 searchStrategy = new KeywordListSearchStrategy();


### PR DESCRIPTION
Updates openrewrite to most recent version (refs https://github.com/openrewrite/rewrite-gradle-plugin/issues/199)

Enables [CompareEnumsWithEqualityOperator](https://docs.openrewrite.org/recipes/java/cleanup/compareenumswithequalityoperator)

Code looks uncommon, because `==` is used instead of `equals`. Is that OK for us?

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
