### PR TITLE
Detect and remove ?doi= tag before passing to DOI.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
 - We fixed an issue regarding recording redundant prefixes in search history. [#9685](https://github.com/JabRef/jabref/issues/9685)
+- We fixed an issue where passing a valid URL containing a "?doi=" tag to DOI.parse yielded a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
 - We fixed an issue regarding recording redundant prefixes in search history. [#9685](https://github.com/JabRef/jabref/issues/9685)
-- We fixed an issue where passing a valid URL containing a "?doi=" tag to DOI.parse yielded a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
+- We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -43,7 +43,7 @@ public class CompositeIdFetcher {
 
         return Optional.empty();
     }
-    // Package private
+
     public String filterForDOITag(String candidate) {
         return candidate.contains("?doi=") ? DOI.findInText(candidate).get().getDOI() : candidate;
     }

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -20,7 +20,7 @@ public class CompositeIdFetcher {
     }
 
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        Optional<DOI> doi = DOI.parse(filterForDOITag(identifier));
+        Optional<DOI> doi = DOI.findInText(identifier);
         if (doi.isPresent()) {
             return new DoiFetcher(importFormatPreferences).performSearchById(doi.get().getNormalized());
         }
@@ -42,10 +42,6 @@ public class CompositeIdFetcher {
         }*/
 
         return Optional.empty();
-    }
-
-    public String filterForDOITag(String candidate) {
-        return candidate.contains("?doi=") ? DOI.findInText(candidate).get().getDOI() : candidate;
     }
 
     public String getName() {

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -20,7 +20,7 @@ public class CompositeIdFetcher {
     }
 
     public Optional<BibEntry> performSearchById(String identifier) throws FetcherException {
-        Optional<DOI> doi = DOI.parse(identifier);
+        Optional<DOI> doi = DOI.parse(filterForDOITag(identifier));
         if (doi.isPresent()) {
             return new DoiFetcher(importFormatPreferences).performSearchById(doi.get().getNormalized());
         }
@@ -42,6 +42,10 @@ public class CompositeIdFetcher {
         }*/
 
         return Optional.empty();
+    }
+    // Package private
+    public String filterForDOITag(String candidate) {
+        return candidate.contains("?doi=") ? DOI.findInText(candidate).get().getDOI() : candidate;
     }
 
     public String getName() {

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -37,7 +37,7 @@ public class DOI implements Identifier {
             + "("                               // begin group \1
             + "10"                              // directory indicator
             + "(?:\\.[0-9]+)+"                  // registrant codes
-            + "[/:%]" // divider
+            + "[/:%]"                           // divider
             + "(?:.+)"                          // suffix alphanumeric string
             + ")";                              // end group \1
     private static final String FIND_DOI_EXP = ""

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -121,4 +121,16 @@ class CompositeIdFetcherTest {
     void performSearchByIdReturnsCorrectEntryForIdentifier(String name, BibEntry bibEntry, String identifier) throws FetcherException {
         assertEquals(Optional.of(bibEntry), compositeIdFetcher.performSearchById(identifier));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = "https://www.scitepress.org/Link.aspx?doi=10.5220/0010404301780189")
+    void filterForDOITagReturnsDOI(String DOIString) throws FetcherException {
+        assertEquals("10.5220/0010404301780189", compositeIdFetcher.filterForDOITag(DOIString));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "10.5220/0010404301780189")
+    void filterForDOITagReturnsOriginalString(String nonDOIString) {
+        assertEquals("10.5220/0010404301780189", compositeIdFetcher.filterForDOITag(nonDOIString));
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -121,16 +121,4 @@ class CompositeIdFetcherTest {
     void performSearchByIdReturnsCorrectEntryForIdentifier(String name, BibEntry bibEntry, String identifier) throws FetcherException {
         assertEquals(Optional.of(bibEntry), compositeIdFetcher.performSearchById(identifier));
     }
-
-    @ParameterizedTest
-    @ValueSource(strings = "https://www.scitepress.org/Link.aspx?doi=10.5220/0010404301780189")
-    void filterForDOITagReturnsDOI(String DOIString) throws FetcherException {
-        assertEquals("10.5220/0010404301780189", compositeIdFetcher.filterForDOITag(DOIString));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = "10.5220/0010404301780189")
-    void filterForDOITagReturnsOriginalString(String nonDOIString) {
-        assertEquals("10.5220/0010404301780189", compositeIdFetcher.filterForDOITag(nonDOIString));
-    }
 }

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -200,7 +200,9 @@ public class DOITest {
                 Arguments.of("10/ab123", DOI.findInText("other stuff doi.org/ab123 end").get().getDOI()),
                 Arguments.of("10/76543", DOI.findInText("other stuff www.doi.org/76543 end").get().getDOI()),
                 Arguments.of("10/abcde", DOI.findInText("other stuff https://www.doi.org/abcde end").get().getDOI()),
-                Arguments.of("10/abcde", DOI.findInText("other stuff https://doi.org/abcde end").get().getDOI())
+                Arguments.of("10/abcde", DOI.findInText("other stuff https://doi.org/abcde end").get().getDOI()),
+                Arguments.of("10.5220/0010404301780189", DOI.findInText("https://www.scitepress.org/Link.aspx?doi=10.5220/0010404301780189").get().getDOI()),
+                Arguments.of("10.5220/0010404301780189", DOI.findInText("10.5220/0010404301780189").get().getDOI())
         );
     }
 


### PR DESCRIPTION
Fixes #9821

Modify org/jabref/logic/importer/CompositeIdFetcher.java to detect and remove ?doi= tag before passing to DOI.parse

Add unit tests to org/jabref/model/entry/identifier/DOITest.java

Update CHANGELOG.md
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
