### PR TITLE
OpenRewrite ReplaceLambdaWithMethodReference

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -658,7 +658,7 @@ public class JabRefFrame extends BorderPane {
 
         // Bind global state
         FilteredList<Tab> filteredTabs = new FilteredList<>(tabbedPane.getTabs());
-        filteredTabs.setPredicate(tab -> tab instanceof LibraryTab);
+        filteredTabs.setPredicate(LibraryTab.class::isInstance);
 
         // This variable cannot be inlined, since otherwise the list created by EasyBind is being garbage collected
         openDatabaseList = EasyBind.map(filteredTabs, tab -> ((LibraryTab) tab).getBibDatabaseContext());

--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -279,7 +279,7 @@ public class JabRefGUI {
             return;
         }
 
-        List<Path> filesToOpen = lastFiles.stream().map(file -> Path.of(file)).collect(Collectors.toList());
+        List<Path> filesToOpen = lastFiles.stream().map(Path::of).collect(Collectors.toList());
         getMainFrame().getOpenDatabaseAction().openFiles(filesToOpen);
     }
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
@@ -51,7 +51,7 @@ public class DocumentViewerView extends BaseDialog<Void> {
 
         // Remove button bar at bottom, but add close button to keep the dialog closable by clicking the "x" window symbol
         getDialogPane().getButtonTypes().add(ButtonType.CLOSE);
-        getDialogPane().getChildren().removeIf(node -> node instanceof ButtonBar);
+        getDialogPane().getChildren().removeIf(ButtonBar.class::isInstance);
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/externalfiles/GitIgnoreFileFilter.java
+++ b/src/main/java/org/jabref/gui/externalfiles/GitIgnoreFileFilter.java
@@ -37,7 +37,7 @@ public class GitIgnoreFileFilter implements DirectoryStream.Filter<Path> {
             Path gitIgnore = currentPath.resolve(".gitignore");
             try {
                 Set<PathMatcher> plainGitIgnorePatternsFromGitIgnoreFile = Files.readAllLines(gitIgnore).stream()
-                                                                                .map(line -> line.trim())
+                                                                                .map(String::trim)
                                                                                 .filter(not(String::isEmpty))
                                                                                 .filter(line -> !line.startsWith("#"))
                                                                                 // convert to Java syntax for Glob patterns

--- a/src/main/java/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/identifier/IdentifierEditor.java
@@ -86,12 +86,12 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
 
     @FXML
     private void fetchInformationByIdentifier() {
-        entry.ifPresent(bibEntry -> viewModel.fetchBibliographyInformation(bibEntry));
+        entry.ifPresent(viewModel::fetchBibliographyInformation);
     }
 
     @FXML
     private void lookupIdentifier() {
-        entry.ifPresent(bibEntry -> viewModel.lookupIdentifier(bibEntry));
+        entry.ifPresent(viewModel::lookupIdentifier);
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -371,9 +371,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
                 //    undoAddPreviousEntries = UndoableChangeEntriesOfGroup.getUndoableEdit(null, addChange);
                 // }
 
-                oldGroup.getParent().ifPresent(parent -> {
-                    sortAlphabeticallyRecursive(parent);
-                });
+                oldGroup.getParent().ifPresent(this::sortAlphabeticallyRecursive);
 
                 dialogService.notify(Localization.lang("Modified group \"%0\".", group.getName()));
                 writeGroupChangesToMetaData();

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -118,7 +118,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         dialogService,
                         stateManager).createColumns());
 
-        this.getColumns().removeIf(col -> col instanceof LibraryColumn);
+        this.getColumns().removeIf(LibraryColumn.class::isInstance);
 
         new ViewModelTableRowFactory<BibEntryTableViewModel>()
                 .withOnMouseClickedEvent((entry, event) -> {

--- a/src/main/java/org/jabref/gui/mergeentries/MultiMergeEntriesView.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MultiMergeEntriesView.java
@@ -233,9 +233,9 @@ public class MultiMergeEntriesView extends BaseDialog<BibEntry> {
             if (newValue) {
                 optionsGrid.getChildrenUnmodifiable().stream()
                            .filter(node -> GridPane.getColumnIndex(node) == column)
-                           .filter(node -> node instanceof HBox)
+                           .filter(HBox.class::isInstance)
                            .forEach(hbox -> ((HBox) hbox).getChildrenUnmodifiable().stream()
-                                                         .filter(node -> node instanceof ToggleButton)
+                                                         .filter(ToggleButton.class::isInstance)
                                                          .forEach(toggleButton -> ((ToggleButton) toggleButton).setSelected(true)));
                 sourceButton.setSelected(true);
             }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -54,7 +54,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
                         .mapObservable(SelectionModel::selectedItemProperty)
                         .mapObservable(TreeItem::valueProperty)
         );
-        keyBindingsTable.setOnKeyPressed(evt -> viewModel.setNewBindingForCurrent(evt));
+        keyBindingsTable.setOnKeyPressed(viewModel::setNewBindingForCurrent);
         keyBindingsTable.rootProperty().bind(
                 EasyBind.map(viewModel.rootKeyBindingProperty(),
                         keybinding -> new RecursiveTreeItem<>(keybinding, KeyBindingViewModel::getChildren))

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -117,7 +117,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         chosenListProperty.getValue().addAll(previewPreferences.getLayoutCycle());
 
         availableListProperty.clear();
-        if (chosenListProperty.stream().noneMatch(layout -> layout instanceof TextBasedPreviewLayout)) {
+        if (chosenListProperty.stream().noneMatch(TextBasedPreviewLayout.class::isInstance)) {
             availableListProperty.getValue().add(previewPreferences.getCustomPreviewLayout());
         }
 

--- a/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
@@ -57,7 +57,7 @@ public class GlobalSearchResultDialog extends BaseDialog<Void> {
         SearchResultsTableDataModel model = new SearchResultsTableDataModel(viewModel.getSearchDatabaseContext(), preferencesService, stateManager);
         SearchResultsTable resultsTable = new SearchResultsTable(model, viewModel.getSearchDatabaseContext(), preferencesService, undoManager, dialogService, stateManager);
 
-        resultsTable.getColumns().removeIf(col -> col instanceof SpecialFieldColumn);
+        resultsTable.getColumns().removeIf(SpecialFieldColumn.class::isInstance);
         resultsTable.getSelectionModel().selectFirst();
 
         if (resultsTable.getSelectionModel().getSelectedItem() != null) {

--- a/src/main/java/org/jabref/gui/search/SearchResultsTable.java
+++ b/src/main/java/org/jabref/gui/search/SearchResultsTable.java
@@ -41,7 +41,7 @@ public class SearchResultsTable extends TableView<BibEntryTableViewModel> {
                                    dialogService,
                                    stateManager).createColumns();
 
-        if (allCols.stream().noneMatch(col -> col instanceof LibraryColumn)) {
+        if (allCols.stream().noneMatch(LibraryColumn.class::isInstance)) {
             allCols.add(0, new LibraryColumn());
         }
         this.getColumns().addAll(allCols);

--- a/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
+++ b/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
@@ -191,7 +191,7 @@ public class JabRefItemDataProvider implements ItemDataProvider {
         return entries.stream()
                 .map(entry -> bibEntryToCSLItemData(entry, bibDatabaseContext, entryTypesManager))
                 .map(item -> item.toJson(stringJsonBuilderFactory.createJsonBuilder()))
-                .map(item -> (String) item)
+                .map(String.class::cast)
                 .collect(Collectors.joining(",", "[", "]"));
     }
 

--- a/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
+++ b/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
 import org.jabref.logic.integrity.PagesChecker;

--- a/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
+++ b/src/main/java/org/jabref/logic/citationstyle/JabRefItemDataProvider.java
@@ -185,16 +185,6 @@ public class JabRefItemDataProvider implements ItemDataProvider {
         this.pagesChecker = new PagesChecker(ctx);
     }
 
-    public String toJson() {
-        List<BibEntry> entries = bibDatabaseContext.getEntries();
-        this.setData(entries, bibDatabaseContext, entryTypesManager);
-        return entries.stream()
-                .map(entry -> bibEntryToCSLItemData(entry, bibDatabaseContext, entryTypesManager))
-                .map(item -> item.toJson(stringJsonBuilderFactory.createJsonBuilder()))
-                .map(String.class::cast)
-                .collect(Collectors.joining(",", "[", "]"));
-    }
-
     @Override
     public CSLItemData retrieveItem(String id) {
         return data.stream()

--- a/src/main/java/org/jabref/logic/l10n/Localization.java
+++ b/src/main/java/org/jabref/logic/l10n/Localization.java
@@ -130,7 +130,7 @@ public class Localization {
                 Collectors.toMap(
                         // not required to unescape content, because that is already done by the ResourceBundle itself
                         key -> key,
-                        key -> baseBundle.getString(key))
+                        baseBundle::getString)
         ));
     }
 

--- a/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/indexing/IndexingTaskManager.java
@@ -86,7 +86,7 @@ public class IndexingTaskManager extends BackgroundTask<Void> {
     }
 
     public void createIndex(PdfIndexer indexer) {
-        enqueueTask(() -> indexer.createIndex());
+        enqueueTask(indexer::createIndex);
     }
 
     public void updateIndex(PdfIndexer indexer, BibDatabaseContext databaseContext) {

--- a/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsParser.java
+++ b/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsParser.java
@@ -50,7 +50,7 @@ public class ProtectedTermsParser {
             return;
         }
         try (Stream<String> lines = Files.lines(path, StandardCharsets.UTF_8)) {
-            this.terms.addAll(lines.map(this::setDescription).filter(line -> line != null).collect(Collectors.toList()));
+            this.terms.addAll(lines.map(this::setDescription).filter(Objects::nonNull).collect(Collectors.toList()));
         } catch (IOException e) {
             LOGGER.warn("Could not read terms from file {}", path, e);
         }

--- a/src/main/java/org/jabref/logic/util/StandardFileType.java
+++ b/src/main/java/org/jabref/logic/util/StandardFileType.java
@@ -72,7 +72,7 @@ public enum StandardFileType implements FileType {
         var exts = Arrays.asList(extensions);
 
         return OptionalUtil.orElse(Arrays.stream(StandardFileType.values())
-                                         .filter(field -> field.getExtensions().stream().anyMatch(elem -> exts.contains(elem)))
+                                         .filter(field -> field.getExtensions().stream().anyMatch(exts::contains))
                                          .findAny(),
                                    new UnknownFileType(extensions));
     }

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -423,7 +423,7 @@ public class DublinCoreExtractor {
         // Query privacy filter settings
         boolean useXmpPrivacyFilter = xmpPreferences.shouldUseXmpPrivacyFilter();
 
-        SortedSet<Field> fields = new TreeSet<>(Comparator.comparing(field -> field.getName()));
+        SortedSet<Field> fields = new TreeSet<>(Comparator.comparing(Field::getName));
         fields.addAll(bibEntry.getFields());
         for (Field field : fields) {
             if (useXmpPrivacyFilter && xmpPreferences.getXmpPrivacyFilter().contains(field)) {

--- a/src/main/java/org/jabref/model/ChainNode.java
+++ b/src/main/java/org/jabref/model/ChainNode.java
@@ -115,7 +115,7 @@ public abstract class ChainNode<T extends ChainNode<T>> {
         }
 
         // Remove from previous parent
-        getParent().ifPresent(oldParent -> oldParent.removeChild());
+        getParent().ifPresent(ChainNode::removeChild);
 
         // Add as child
         target.setChild((T) this);

--- a/src/main/java/org/jabref/model/entry/EntryLinkList.java
+++ b/src/main/java/org/jabref/model/entry/EntryLinkList.java
@@ -26,6 +26,6 @@ public class EntryLinkList {
     }
 
     public static String serialize(List<ParsedEntryLink> list) {
-        return String.join(SEPARATOR, list.stream().map(link -> link.getKey()).collect(Collectors.toList()));
+        return String.join(SEPARATOR, list.stream().map(ParsedEntryLink::getKey).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2339,7 +2339,7 @@ public class JabRefPreferences implements PreferencesService {
                     .map(layout -> {
                         if (CitationStyle.isCitationStyleFile(layout)) {
                             return CitationStyle.createCitationStyleFromFile(layout)
-                                                .map(file -> (PreviewLayout) new CitationStylePreviewLayout(file, Globals.entryTypesManager))
+                                                .map(PreviewLayout.class::cast)
                                                 .orElse(null);
                         } else {
                             return new TextBasedPreviewLayout(style, getLayoutFormatterPreferences(Globals.journalAbbreviationRepository));

--- a/src/test/java/org/jabref/gui/search/GlobalSearchBarTest.java
+++ b/src/test/java/org/jabref/gui/search/GlobalSearchBarTest.java
@@ -86,7 +86,7 @@ public class GlobalSearchBarTest {
         }
 
         // Set the focus to another node to trigger the listener and finally record the query.
-        DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> hBox.requestFocus());
+        DefaultTaskExecutor.runAndWaitInJavaFXThread(hBox::requestFocus);
         List<String> lastSearchHistory = stateManager.getWholeSearchHistory().stream().toList();
 
         assertEquals(List.of("Smith"), lastSearchHistory);
@@ -101,7 +101,7 @@ public class GlobalSearchBarTest {
         var searchFieldRoboto = robot.clickOn(searchField);
         searchFieldRoboto.write(searchQuery);
 
-        DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> hBox.requestFocus());
+        DefaultTaskExecutor.runAndWaitInJavaFXThread(hBox::requestFocus);
         List<String> lastSearchHistory = stateManager.getWholeSearchHistory().stream().toList();
 
         assertEquals(List.of(), lastSearchHistory);

--- a/src/test/java/org/jabref/logic/database/DatabaseMergerTest.java
+++ b/src/test/java/org/jabref/logic/database/DatabaseMergerTest.java
@@ -136,7 +136,7 @@ class DatabaseMergerTest {
         new DatabaseMerger(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).mergeStrings(target, source);
         List<BibtexString> resultStringsSorted = target.getStringValues()
                 .stream()
-                .sorted((s1, s2) -> new BibtexStringComparator(false).compare(s1, s2))
+                .sorted(new BibtexStringComparator(false)::compare)
                 .collect(Collectors.toList());
 
         assertEquals(List.of(targetString1, targetString2), resultStringsSorted);

--- a/src/test/java/org/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/FormatterTest.java
@@ -42,7 +42,7 @@ class FormatterTest {
         // idea for uniqueness checking by https://stackoverflow.com/a/44032568/873282
         assertEquals(Collections.emptyList(),
                 getFormatters().collect(Collectors.groupingBy(
-                        formatter -> formatter.getKey(),
+                                       Formatter::getKey,
                         Collectors.counting()))
                                .entrySet().stream()
                                .filter(e -> e.getValue() > 1)

--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -16,7 +16,7 @@ class LayoutHelperTest {
         StringReader stringReader = new StringReader("\\");
         LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
         LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
-        assertThrows(IOException.class, () -> layoutHelper.getLayoutFromText());
+        assertThrows(IOException.class, layoutHelper::getLayoutFromText);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -130,7 +130,7 @@ public class URLDownloadTest {
     public void test503ErrorThrowsNestedIOExceptionWithFetcherServerException() throws Exception {
         URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/503"));
 
-        Exception exception = assertThrows(IOException.class, () -> urlDownload.asString());
+        Exception exception = assertThrows(IOException.class, urlDownload::asString);
         assertTrue(exception.getCause() instanceof FetcherServerException);
     }
 
@@ -138,7 +138,7 @@ public class URLDownloadTest {
     public void test429ErrorThrowsNestedIOExceptionWithFetcherServerException() throws Exception {
         URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/429"));
 
-        Exception exception = assertThrows(IOException.class, () -> urlDownload.asString());
+        Exception exception = assertThrows(IOException.class, urlDownload::asString);
         assertTrue(exception.getCause() instanceof FetcherClientException);
     }
 }

--- a/src/test/java/org/jabref/logic/shared/DBMSConnectionTest.java
+++ b/src/test/java/org/jabref/logic/shared/DBMSConnectionTest.java
@@ -16,6 +16,17 @@ public class DBMSConnectionTest {
     @EnumSource(DBMSType.class)
     public void getConnectionFailsWhenconnectingToInvalidHost(DBMSType dbmsType) {
         assertThrows(SQLException.class,
-                () -> new DBMSConnection(new DBMSConnectionPropertiesBuilder().setType(dbmsType).setHost("XXXX").setPort(33778).setDatabase("XXXX").setUser("XXXX").setPassword("XXXX").setUseSSL(false).setServerTimezone("XXXX").createDBMSConnectionProperties()).getConnection());
+                () -> new DBMSConnection(
+                        new DBMSConnectionPropertiesBuilder()
+                                .setType(dbmsType)
+                                .setHost("XXXX")
+                                .setPort(33778)
+                                .setDatabase("XXXX")
+                                .setUser("XXXX")
+                                .setPassword("XXXX")
+                                .setUseSSL(false)
+                                .setServerTimezone("XXXX")
+                                .createDBMSConnectionProperties())
+                        .getConnection());
     }
 }

--- a/src/test/java/org/jabref/model/TreeNodeTest.java
+++ b/src/test/java/org/jabref/model/TreeNodeTest.java
@@ -28,7 +28,7 @@ public class TreeNodeTest {
 
     @Test
     public void constructorChecksThatClassImplementsCorrectInterface() {
-        assertThrows(UnsupportedOperationException.class, () -> new WrongTreeNodeImplementation());
+        assertThrows(UnsupportedOperationException.class, WrongTreeNodeImplementation::new);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class TreeNodeTest {
     @Test
     public void getPositionInParentForRootThrowsException() {
         TreeNodeTestData.TreeNodeMock root = new TreeNodeTestData.TreeNodeMock();
-        assertThrows(UnsupportedOperationException.class, () -> root.getPositionInParent());
+        assertThrows(UnsupportedOperationException.class, root::getPositionInParent);
     }
 
     @Test


### PR DESCRIPTION
Manually applies the rule https://docs.openrewrite.org/recipes/java/cleanup/replacelambdawithmethodreference.

Not automatic possible, because of

- https://github.com/openrewrite/rewrite-static-analysis/issues/94
- https://github.com/openrewrite/rewrite-static-analysis/issues/95
- https://github.com/openrewrite/rewrite-static-analysis/issues/86#issuecomment-1537855430

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
