### PR TITLE
Fix RfcFetcher (and ACMPortalParserTest)

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/RfcFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/RfcFetcher.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.jabref.logic.help.HelpFile;
@@ -47,16 +48,13 @@ public class RfcFetcher implements IdBasedParserFetcher {
      */
     @Override
     public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
-
-        String prefixedIdentifier = identifier;
+        String prefixedIdentifier = identifier.toLowerCase(Locale.ENGLISH);
         // if not a "draft" version
-        if (!identifier.toLowerCase().startsWith(DRAFT_PREFIX)) {
+        if ((!prefixedIdentifier.startsWith(DRAFT_PREFIX)) && (!prefixedIdentifier.startsWith("rfc"))) {
             // Add "rfc" prefix if user's search entry was numerical
-            prefixedIdentifier = (!identifier.toLowerCase().startsWith("rfc")) ? "rfc" + prefixedIdentifier : prefixedIdentifier;
+            prefixedIdentifier = "rfc" + prefixedIdentifier;
         }
-
         URIBuilder uriBuilder = new URIBuilder("https://datatracker.ietf.org/doc/" + prefixedIdentifier + "/bibtex/");
-
         return uriBuilder.build().toURL();
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/RfcFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/RfcFetcherTest.java
@@ -10,8 +10,9 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,29 +22,21 @@ import static org.mockito.Mockito.mock;
 @FetcherTest
 public class RfcFetcherTest {
 
-    private RfcFetcher fetcher;
-    private BibEntry bibEntry;
-
-    @BeforeEach
-    public void setUp() {
-        fetcher = new RfcFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
-
-        bibEntry = new BibEntry();
-        bibEntry.setType(StandardEntryType.Misc);
-        bibEntry.setField(StandardField.SERIES, "Request for Comments");
-        bibEntry.setField(StandardField.NUMBER, "1945");
-        bibEntry.setField(StandardField.HOWPUBLISHED, "RFC 1945");
-        bibEntry.setField(StandardField.PUBLISHER, "RFC Editor");
-        bibEntry.setField(StandardField.DOI, "10.17487/RFC1945");
-        bibEntry.setField(StandardField.URL, "https://www.rfc-editor.org/info/rfc1945");
-        bibEntry.setField(StandardField.AUTHOR, "Henrik Nielsen and Roy T. Fielding and Tim Berners-Lee");
-        bibEntry.setField(StandardField.TITLE, "{Hypertext Transfer Protocol -- HTTP/1.0}");
-        bibEntry.setField(StandardField.PAGETOTAL, "60");
-        bibEntry.setField(StandardField.YEAR, "1996");
-        bibEntry.setField(StandardField.MONTH, "#may#");
-        bibEntry.setField(StandardField.ABSTRACT, "The Hypertext Transfer Protocol (HTTP) is an application-level protocol with the lightness and speed necessary for distributed, collaborative, hypermedia information systems. This memo provides information for the Internet community. This memo does not specify an Internet standard of any kind.");
-        bibEntry.setCitationKey("rfc1945");
-    }
+    private RfcFetcher fetcher = new RfcFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
+    private BibEntry bibEntry = new BibEntry(StandardEntryType.Misc)
+            .withCitationKey("rfc1945")
+            .withField(StandardField.SERIES, "Request for Comments")
+            .withField(StandardField.NUMBER, "1945")
+            .withField(StandardField.HOWPUBLISHED, "RFC 1945")
+            .withField(StandardField.PUBLISHER, "RFC Editor")
+            .withField(StandardField.DOI, "10.17487/RFC1945")
+            .withField(StandardField.URL, "https://www.rfc-editor.org/info/rfc1945")
+            .withField(StandardField.AUTHOR, "Henrik Nielsen and Roy T. Fielding and Tim Berners-Lee")
+            .withField(StandardField.TITLE, "{Hypertext Transfer Protocol -- HTTP/1.0}")
+            .withField(StandardField.PAGETOTAL, "60")
+            .withField(StandardField.YEAR, "1996")
+            .withField(StandardField.MONTH, "#may#")
+            .withField(StandardField.ABSTRACT, "The Hypertext Transfer Protocol (HTTP) is an application-level protocol with the lightness and speed necessary for distributed, collaborative, hypermedia information systems. This memo provides information for the Internet community. This memo does not specify an Internet standard of any kind.");
 
     @Test
     public void getNameReturnsEqualIdName() {
@@ -52,35 +45,30 @@ public class RfcFetcherTest {
 
     @Test
     public void performSearchByIdFindsEntryWithDraftIdentifier() throws Exception {
-        BibEntry bibDraftEntry = new BibEntry();
-        bibDraftEntry.setType(StandardEntryType.TechReport);
-        bibDraftEntry.setField(InternalField.KEY_FIELD, "fielding-http-spec-01");
-        bibDraftEntry.setField(StandardField.AUTHOR, "Henrik Nielsen and Roy T. Fielding and Tim Berners-Lee");
-        bibDraftEntry.setField(StandardField.DAY, "20");
-        bibDraftEntry.setField(StandardField.INSTITUTION, "Internet Engineering Task Force");
-        bibDraftEntry.setField(StandardField.MONTH, "#dec#");
-        bibDraftEntry.setField(StandardField.NOTE, "Work in Progress");
-        bibDraftEntry.setField(StandardField.NUMBER, "draft-fielding-http-spec-01");
-        bibDraftEntry.setField(StandardField.PAGETOTAL, "41");
-        bibDraftEntry.setField(StandardField.PUBLISHER, "Internet Engineering Task Force");
-        bibDraftEntry.setField(StandardField.TITLE, "{Hypertext Transfer Protocol -- HTTP/1.0}");
-        bibDraftEntry.setField(StandardField.TYPE, "Internet-Draft");
-        bibDraftEntry.setField(StandardField.URL, "https://datatracker.ietf.org/doc/draft-fielding-http-spec/01/");
-        bibDraftEntry.setField(StandardField.YEAR, "1994");
-        bibDraftEntry.setField(StandardField.ABSTRACT, "The Hypertext Transfer Protocol (HTTP) is an application-level protocol with the lightness and speed necessary for distributed, collaborative, hypermedia information systems. It is a generic, stateless, object-oriented protocol which can be used for many tasks, such as name servers and distributed object management systems, through extension of its request methods (commands). A feature of HTTP is the typing and negotiation of data representation, allowing systems to be built independently of the data being transferred. HTTP has been in use by the World-Wide Web global information initiative since 1990. This specification reflects preferred usage of the protocol referred to as 'HTTP/1.0', and is compatible with the most commonly used HTTP server and client programs implemented prior to November 1994.");
+        BibEntry bibDraftEntry = new BibEntry(StandardEntryType.TechReport)
+                .withField(InternalField.KEY_FIELD, "fielding-http-spec-01")
+                .withField(StandardField.AUTHOR, "Henrik Nielsen and Roy T. Fielding and Tim Berners-Lee")
+                .withField(StandardField.DAY, "20")
+                .withField(StandardField.INSTITUTION, "Internet Engineering Task Force")
+                .withField(StandardField.MONTH, "#dec#")
+                .withField(StandardField.NOTE, "Work in Progress")
+                .withField(StandardField.NUMBER, "draft-fielding-http-spec-01")
+                .withField(StandardField.PAGETOTAL, "41")
+                .withField(StandardField.PUBLISHER, "Internet Engineering Task Force")
+                .withField(StandardField.TITLE, "{Hypertext Transfer Protocol -- HTTP/1.0}")
+                .withField(StandardField.TYPE, "Internet-Draft")
+                .withField(StandardField.URL, "https://datatracker.ietf.org/doc/draft-fielding-http-spec/01/")
+                .withField(StandardField.YEAR, "1994")
+                .withField(StandardField.ABSTRACT, "The Hypertext Transfer Protocol (HTTP) is an application-level protocol with the lightness and speed necessary for distributed, collaborative, hypermedia information systems. It is a generic, stateless, object-oriented protocol which can be used for many tasks, such as name servers and distributed object management systems, through extension of its request methods (commands). A feature of HTTP is the typing and negotiation of data representation, allowing systems to be built independently of the data being transferred. HTTP has been in use by the World-Wide Web global information initiative since 1990. This specification reflects preferred usage of the protocol referred to as 'HTTP/1.0', and is compatible with the most commonly used HTTP server and client programs implemented prior to November 1994.");
         bibDraftEntry.setCommentsBeforeEntry("%% You should probably cite draft-ietf-http-v10-spec instead of this I-D.\n");
 
         assertEquals(Optional.of(bibDraftEntry), fetcher.performSearchById("draft-fielding-http-spec"));
     }
 
-    @Test
-    public void performSearchByIdFindsEntryWithRfcPrefix() throws Exception {
-        assertEquals(Optional.of(bibEntry), fetcher.performSearchById("RFC1945"));
-    }
-
-    @Test
-    public void performSearchByIdFindsEntryWithoutRfcPrefix() throws Exception {
-        assertEquals(Optional.of(bibEntry), fetcher.performSearchById("1945"));
+    @ParameterizedTest
+    @CsvSource({"rfc1945", "RFC1945", "1945"})
+    public void performSearchByIdFindsEntry(String identifier) throws Exception {
+        assertEquals(Optional.of(bibEntry), fetcher.performSearchById(identifier));
     }
 
     @Test
@@ -88,18 +76,14 @@ public class RfcFetcherTest {
         assertEquals(Optional.empty(), fetcher.performSearchById(""));
     }
 
-    @Test
-    public void performSearchByIdFindsNothingWithValidDraftIdentifier() throws Exception {
-        assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("draft-test-draft-spec"));
-    }
-
-    @Test
-    public void performSearchByIdFindsNothingWithValidIdentifier() throws Exception {
-        assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("RFC9999"));
-    }
-
-    @Test
-    public void performSearchByIdFindsNothingWithInvalidIdentifier() throws Exception {
-        assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("banana"));
+    @ParameterizedTest
+    @CsvSource({
+            // syntactically valid identifier
+            "draft-test-draft-spec",
+            "RFC9999",
+            // invalid identifier
+            "banana"})
+    public void performSearchByIdFindsNothingWithValidDraftIdentifier(String identifier) throws Exception {
+        assertThrows(FetcherClientException.class, () -> fetcher.performSearchById(identifier));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
@@ -58,6 +58,7 @@ public class ACMPortalParserTest {
                         .withField(StandardField.PAGES, "152–158"),
                 new BibEntry(StandardEntryType.Book)
                         .withField(StandardField.YEAR, "2016")
+                        .withField(StandardField.MONTH, "10")
                         .withField(StandardField.TITLE, "Proceedings of the 2016 24th ACM SIGSOFT International Symposium on Foundations of Software Engineering")
                         .withField(StandardField.LOCATION, "Seattle, WA, USA")
                         .withField(StandardField.ISBN, "9781450342186")


### PR DESCRIPTION
The RFC portal does no longer accept upper case letters when querying for BibTeX: https://datatracker.ietf.org/doc/RFC1945/bibtex/ is 404.

This PR converts the letters to lowercase.

In addition, tests are converted to parameterized tests and ACMPortalParserTest is also fixed.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
