### PR TITLE
Migrate jabref-authors.bib to new format

### DIFF
--- a/src/test/resources/testbib/jabref-authors.bib
+++ b/src/test/resources/testbib/jabref-authors.bib
@@ -39,7 +39,7 @@
   bibsource  = {dblp computer science bibliography, http://dblp.org},
   biburl     = {http://dblp.uni-trier.de/rec/bib/conf/icdsp/JohanssonG15a},
   groups     = {By rating},
-  keywords   = {rank4},
+  ranking    = {rank4},
   readstatus = {read},
   timestamp  = {Tue, 22 Sep 2015 18:08:19 +0200},
   year       = {2015},
@@ -1174,8 +1174,8 @@
   pages     = {120--128},
   address   = {Oxford, UK},
   file      = {:geiger2016evolution.pdf:PDF},
-  keywords  = {rank4},
   month     = mar,
+  ranking   = {rank4},
   year      = {2016},
 }
 
@@ -1222,8 +1222,8 @@
   address      = {San Francisco Bay, CA, USA},
   file         = {:Harrer2015ImprovingStaticAnalysis.pdf:PDF},
   groups       = {By rating},
-  keywords     = {rank5},
   month        = mar,
+  ranking      = {rank5},
   year         = {2015},
 }
 
@@ -1237,8 +1237,8 @@
   address   = {Cleveland, Ohio, USA},
   file      = {:Harrer2014AutomatedandIsolated.pdf:PDF},
   groups    = {By rating},
-  keywords  = {rank2},
   month     = apr,
+  ranking   = {rank2},
   year      = {2014},
 }
 
@@ -1591,7 +1591,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/fgcs/WettingerBKL16},
   journal   = {Future Generation Comp. Syst.},
-  keywords  = {rank4},
+  ranking   = {rank4},
   timestamp = {Thu, 31 Mar 2016 01:00:00 +0200},
   year      = {2016},
 }
@@ -1624,7 +1624,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/conf/closer/BreitenbucherBK15},
   groups    = {My papers},
-  keywords  = {rank3},
+  ranking   = {rank3},
   timestamp = {Tue, 04 Aug 2015 09:17:34 +0200},
   year      = {2015},
 }
@@ -1706,7 +1706,7 @@
   bibsource = {dblp computer science bibliography, http://dblp.org},
   biburl    = {http://dblp.uni-trier.de/rec/bib/journals/tsc/EshuisNKP15},
   journal   = {{IEEE} Trans. Services Computing},
-  keywords  = {rank2},
+  ranking   = {rank2},
   timestamp = {Wed, 09 Mar 2016 00:00:00 +0100},
   year      = {2015},
 }


### PR DESCRIPTION
`jabref-authors.bib` contained the old special field format. We migrated special fields away from keywords. JabRef silently changes the format without any warning and thus triggers "file changed on disk" errors. This PR fixes that for the concrete file.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
