### PR TITLE
Make consequences of "Keep original order" more clear

### DIFF
--- a/src/main/java/org/jabref/gui/commonfxcontrols/SaveOrderConfigPanel.fxml
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/SaveOrderConfigPanel.fxml
@@ -16,7 +16,7 @@
         <ToggleGroup fx:id="saveOrderToggleGroup"/>
     </fx:define>
 
-    <RadioButton fx:id="exportInOriginalOrder" text="%Keep original order"
+    <RadioButton fx:id="exportInOriginalOrder" text="%Keep original order and add new entries at the end"
                  toggleGroup="$saveOrderToggleGroup"/>
     <RadioButton fx:id="exportInTableOrder" text="%Use current table sort order"
                  toggleGroup="$saveOrderToggleGroup"/>

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1268,7 +1268,7 @@ Open\ folder=Open folder
 Export\ sort\ order=Export sort order
 Save\ sort\ order=Save sort order
 
-Keep\ original\ order=Keep original order
+Keep\ original\ order\ and\ add\ new\ entries\ at\ the\ end=Keep original order and add new entries at the end
 Use\ current\ table\ sort\ order=Use current table sort order
 Use\ specified\ order=Use specified order
 Show\ extra\ columns=Show extra columns


### PR DESCRIPTION
"Keep original order" in save preferences is not that clear for the user. Here a proposal with more clarity:

![image](https://github.com/JabRef/jabref/assets/1366654/da7d4e61-4afa-408a-9582-4766297a3ea3)

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
