### PR TITLE
Enable LoggersNamedForEnclosingClass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -494,6 +494,7 @@ checkstyle {
 rewrite {
     activeRecipe(
         'org.jabref.config.rewrite.cleanup',
+        'org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass',
         'org.openrewrite.java.logging.slf4j.ParameterizedLogging',
         'org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant'
     )


### PR DESCRIPTION
Enables https://docs.openrewrite.org/recipes/java/logging/slf4j/loggersnamedforenclosingclass

Seems not to work here, see  https://github.com/openrewrite/rewrite-logging-frameworks/issues/105

I would nevertheless merge it.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
