### PR TITLE
Change lucene index path to have sub directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where entering a date in the format "YYYY/MM" in the entry editor date field caused an exception. [#9492](https://github.com/JabRef/jabref/issues/9492)
 - For portable versions, the `.deb` file now works on plain debian again. [#9472](https://github.com/JabRef/jabref/issues/9472)
 - We fixed an issue where the download of linked online files failed after an import of entries for certain urls. [#9518](https://github.com/JabRef/jabref/issues/9518)
-- We fixed an issue where an exception occured when manually downloading a file from an URL in the entry editor. [#9521](https://github.com/JabRef/jabref/issues/9521)
+- We fixed an issue where an exception occurred when manually downloading a file from an URL in the entry editor. [#9521](https://github.com/JabRef/jabref/issues/9521)
 - We fixed an issue with open office csv file formatting where commas in the abstract field where not escaped. [#9087][https://github.com/JabRef/jabref/issues/9087]
 - We fixed an issue with deleting groups where subgroups different from the selected group were deleted. [#9281][https://github.com/JabRef/jabref/issues/9281]
 
@@ -412,7 +412,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 ### Fixed
 
 - We fixed an issue where an exception occurred when pasting an entry with a publication date-range of the form 1910/1917 [#7864](https://github.com/JabRef/jabref/issues/7864)
-- We fixed an issue where an exception occured when a preview style was edited and afterwards another preview style selected. [#8280](https://github.com/JabRef/jabref/issues/8280)
+- We fixed an issue where an exception occurred when a preview style was edited and afterwards another preview style selected. [#8280](https://github.com/JabRef/jabref/issues/8280)
 - We fixed an issue where the actions to move a file to a directory were incorrectly disabled. [#7908](https://github.com/JabRef/jabref/issues/7908)
 - We fixed an issue where an exception occurred when a linked online file was edited in the entry editor [#8008](https://github.com/JabRef/jabref/issues/8008)
 - We fixed an issue when checking for a new version when JabRef is used behind a corporate proxy. [#7884](https://github.com/JabRef/jabref/issues/7884)
@@ -496,11 +496,11 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
-- We fixed an isuse where some texts (e.g. descriptionss) in dialogs could not be translated [#7854](https://github.com/JabRef/jabref/issues/7854)
+- We fixed an issue where some texts (e.g. descriptions) in dialogs could not be translated [#7854](https://github.com/JabRef/jabref/issues/7854)
 - We fixed an issue where import hangs for ris files with "ER - " [#7737](https://github.com/JabRef/jabref/issues/7737)
 - We fixed an issue where getting bibliograhpic data from DOI or another identifer did not respect the library mode (BibTeX/biblatex)[#1018](https://github.com/JabRef/jabref/issues/6267)
 - We fixed an issue where importing entries would not respect the library mode (BibTeX/biblatex)[#1018](https://github.com/JabRef/jabref/issues/1018)
-- We fixed an issue where an exception occured when importing entries from a web search [#7606](https://github.com/JabRef/jabref/issues/7606)
+- We fixed an issue where an exception occurred when importing entries from a web search [#7606](https://github.com/JabRef/jabref/issues/7606)
 - We fixed an issue where the table column sort order was not properly stored and resulted in unsorted eports [#7524](https://github.com/JabRef/jabref/issues/7524)
 - We fixed an issue where the value of the field `school` or `institution` would be printed twice in the HTML Export [forum#2634](https://discourse.jabref.org/t/problem-with-exporting-techreport-phdthesis-mastersthesis-to-html/2634)
 - We fixed an issue preventing to connect to a shared database. [#7570](https://github.com/JabRef/jabref/pull/7570)
@@ -725,11 +725,11 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where long directory names created from patterns could create an exception. [#3915](https://github.com/JabRef/jabref/issues/3915)
 - We fixed an issue where sort on numeric cases was broken. [#6349](https://github.com/JabRef/jabref/issues/6349)
 - We fixed an issue where year and month fields were not cleared when converting to biblatex [#6224](https://github.com/JabRef/jabref/issues/6224)
-- We fixed an issue where an "Not on FX thread" exception occured when saving on linux [#6453](https://github.com/JabRef/jabref/issues/6453)
+- We fixed an issue where an "Not on FX thread" exception occurred when saving on linux [#6453](https://github.com/JabRef/jabref/issues/6453)
 - We fixed an issue where the library sort order was lost. [#6091](https://github.com/JabRef/jabref/issues/6091)
 - We fixed an issue where brackets in regular expressions were not working. [6469](https://github.com/JabRef/jabref/pull/6469)
 - We fixed an issue where multiple background task popups stacked over each other.. [#6472](https://github.com/JabRef/jabref/issues/6472)
-- We fixed an issue where LaTeX citations for specific commands (\autocites) of biblatex-mla were not recognized. [#6476](https://github.com/JabRef/jabref/issues/6476)
+- We fixed an issue where LaTeX citations for specific commands (`\autocite`s) of biblatex-mla were not recognized. [#6476](https://github.com/JabRef/jabref/issues/6476)
 - We fixed an issue where drag and drop was not working on empty database. [#6487](https://github.com/JabRef/jabref/issues/6487)
 - We fixed an issue where the name fields were not updated after the preferences changed. [#6515](https://github.com/JabRef/jabref/issues/6515)
 - We fixed an issue where "null" appeared in generated BibTeX keys. [#6459](https://github.com/JabRef/jabref/issues/6459)

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.jabref.gui.Globals;
 import org.jabref.gui.MainApplication;
+import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.ProxyAuthenticator;
@@ -21,14 +22,10 @@ import org.jabref.logic.net.ssl.TrustStoreManager;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
-import org.jabref.logic.util.BuildInfo;
-import org.jabref.logic.util.OS;
 import org.jabref.migrations.PreferencesMigrations;
-import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.preferences.JabRefPreferences;
 import org.jabref.preferences.PreferencesService;
 
-import net.harawata.appdirs.AppDirsFactory;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,12 +87,7 @@ public class Launcher {
      * the log configuration programmatically anymore.
      */
     private static void addLogToDisk() {
-        Path directory = Path.of(AppDirsFactory.getInstance()
-                                               .getUserDataDir(
-                OS.APP_DIR_APP_NAME,
-                "logs",
-                OS.APP_DIR_APP_AUTHOR))
-                .resolve(new BuildInfo().version.toString());
+        Path directory = JabRefDesktop.getNativeDesktop().getLogDirectory();
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {
@@ -168,7 +160,7 @@ public class Launcher {
     }
 
     private static void clearOldSearchIndices() {
-        Path currentIndexPath = BibDatabaseContext.getFulltextIndexBasePath();
+        Path currentIndexPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path appData = currentIndexPath.getParent();
 
         try {

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import org.jabref.gui.Globals;
 import org.jabref.gui.MainApplication;
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.ProxyAuthenticator;
@@ -22,6 +21,7 @@ import org.jabref.logic.net.ssl.TrustStoreManager;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
+import org.jabref.logic.util.OS;
 import org.jabref.migrations.PreferencesMigrations;
 import org.jabref.preferences.JabRefPreferences;
 import org.jabref.preferences.PreferencesService;
@@ -87,7 +87,7 @@ public class Launcher {
      * the log configuration programmatically anymore.
      */
     private static void addLogToDisk() {
-        Path directory = JabRefDesktop.getNativeDesktop().getLogDirectory();
+        Path directory = OS.getNativeDesktop().getLogDirectory();
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {
@@ -160,7 +160,7 @@ public class Launcher {
     }
 
     private static void clearOldSearchIndices() {
-        Path currentIndexPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory();
+        Path currentIndexPath = OS.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path appData = currentIndexPath.getParent();
 
         try {

--- a/src/main/java/org/jabref/gui/OpenConsoleAction.java
+++ b/src/main/java/org/jabref/gui/OpenConsoleAction.java
@@ -47,7 +47,7 @@ public class OpenConsoleAction extends SimpleCommand {
     public void execute() {
         Optional.ofNullable(databaseContext.get()).or(stateManager::getActiveDatabase).flatMap(BibDatabaseContext::getDatabasePath).ifPresent(path -> {
             try {
-                JabRefDesktop.openConsole(path.toFile(), preferencesService, dialogService);
+                JabRefDesktop.openConsole(path, preferencesService, dialogService);
             } catch (IOException e) {
                 LOGGER.info("Could not open console", e);
             }

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -13,11 +13,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
-import org.jabref.gui.desktop.os.DefaultDesktop;
-import org.jabref.gui.desktop.os.Linux;
 import org.jabref.gui.desktop.os.NativeDesktop;
-import org.jabref.gui.desktop.os.OSX;
-import org.jabref.gui.desktop.os.Windows;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.logic.importer.util.IdentifierParser;
@@ -43,7 +39,7 @@ public class JabRefDesktop {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JabRefDesktop.class);
 
-    private static final NativeDesktop NATIVE_DESKTOP = getNativeDesktop();
+    private static final NativeDesktop NATIVE_DESKTOP = OS.getNativeDesktop();
     private static final Pattern REMOTE_LINK_PATTERN = Pattern.compile("[a-z]+://.*");
 
     private JabRefDesktop() {
@@ -294,17 +290,5 @@ public class JabRefDesktop {
             dialogService.notify(couldNotOpenBrowser);
             dialogService.showErrorDialogAndWait(couldNotOpenBrowser, couldNotOpenBrowser + "\n" + openManually + "\n" + copiedToClipboard);
         }
-    }
-
-    // TODO: Move to OS.java
-    public static NativeDesktop getNativeDesktop() {
-        if (OS.WINDOWS) {
-            return new Windows();
-        } else if (OS.OS_X) {
-            return new OSX();
-        } else if (OS.LINUX) {
-            return new Linux();
-        }
-        return new DefaultDesktop();
     }
 }

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.desktop;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -57,7 +56,7 @@ public class JabRefDesktop {
             throws IOException {
         String link = initialLink;
         Field field = initialField;
-        if (StandardField.PS == field || StandardField.PDF == field) {
+        if ((StandardField.PS == field) || (StandardField.PDF == field)) {
             // Find the default directory for this field type:
             List<Path> directories = databaseContext.getFileDirectories(preferencesService.getFilePreferences());
 
@@ -218,12 +217,12 @@ public class JabRefDesktop {
      * @param file Location the console should be opened at.
      *
      */
-    public static void openConsole(File file, PreferencesService preferencesService, DialogService dialogService) throws IOException {
+    public static void openConsole(Path file, PreferencesService preferencesService, DialogService dialogService) throws IOException {
         if (file == null) {
             return;
         }
 
-        String absolutePath = file.toPath().toAbsolutePath().getParent().toString();
+        String absolutePath = file.toAbsolutePath().getParent().toString();
 
         boolean useCustomTerminal = preferencesService.getExternalApplicationsPreferences().useCustomTerminal();
         if (!useCustomTerminal) {

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -218,7 +218,7 @@ public class JabRefDesktop {
                     new ProcessBuilder(subcommands).start();
                 } catch (IOException exception) {
                     LOGGER.error("Open File Browser", exception);
-                    dialogService.notify(Localization.lang("Error occured while executing the command \"%0\".", command));
+                    dialogService.notify(Localization.lang("Error occurred while executing the command \"%0\".", command));
                 }
             }
         }

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -36,8 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * TODO: Replace by http://docs.oracle.com/javase/7/docs/api/java/awt/Desktop.html
- * http://stackoverflow.com/questions/18004150/desktop-api-is-not-supported-on-the-current-platform
+ * See http://stackoverflow.com/questions/18004150/desktop-api-is-not-supported-on-the-current-platform for more implementation hints.
+ * http://docs.oracle.com/javase/7/docs/api/java/awt/Desktop.html cannot be used as we don't want to rely on AWT
  */
 public class JabRefDesktop {
 

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -1,9 +1,15 @@
 package org.jabref.gui.desktop.os;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
 import org.jabref.gui.DialogService;
+import org.jabref.logic.util.BuildInfo;
+import org.jabref.logic.util.OS;
+import org.jabref.model.pdf.search.SearchFieldConstants;
+
+import net.harawata.appdirs.AppDirsFactory;
 
 public interface NativeDesktop {
 
@@ -44,5 +50,36 @@ public interface NativeDesktop {
      */
     default Path getUserDirectory() {
         return Path.of(System.getProperty("user.home"));
+    }
+
+    default Path getLogDirectory() {
+        return Path.of(AppDirsFactory.getInstance()
+                                     .getUserDataDir(
+                                             OS.APP_DIR_APP_NAME,
+                                             "logs",
+                                             OS.APP_DIR_APP_AUTHOR))
+                   .resolve(new BuildInfo().version.toString());
+    }
+
+    default Path getBackupDirectory() {
+        return Path.of(AppDirsFactory.getInstance()
+                                               .getUserDataDir(
+                                                       OS.APP_DIR_APP_NAME,
+                                                       "backups",
+                                                       OS.APP_DIR_APP_AUTHOR);
+    }
+
+    default Path getFulltextIndexBaseDirectory() {
+        return Path.of(AppDirsFactory.getInstance()
+                                     .getUserDataDir(OS.APP_DIR_APP_NAME,
+                                             "lucene" + File.separator + SearchFieldConstants.VERSION,
+                                             OS.APP_DIR_APP_AUTHOR));
+    }
+
+    default Path getSslDirectory() {
+        return Path.of(AppDirsFactory.getInstance()
+                                     .getUserDataDir(OS.APP_DIR_APP_NAME,
+                                             "ssl",
+                                             OS.APP_DIR_APP_AUTHOR));
     }
 }

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -63,10 +63,10 @@ public interface NativeDesktop {
 
     default Path getBackupDirectory() {
         return Path.of(AppDirsFactory.getInstance()
-                                               .getUserDataDir(
-                                                       OS.APP_DIR_APP_NAME,
-                                                       "backups",
-                                                       OS.APP_DIR_APP_AUTHOR);
+                                     .getUserDataDir(
+                                             OS.APP_DIR_APP_NAME,
+                                             "backups",
+                                             OS.APP_DIR_APP_AUTHOR));
     }
 
     default Path getFulltextIndexBaseDirectory() {

--- a/src/main/java/org/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Windows.java
@@ -15,11 +15,9 @@ import com.sun.jna.platform.win32.KnownFolders;
 import com.sun.jna.platform.win32.Shell32Util;
 import com.sun.jna.platform.win32.ShlObj;
 import com.sun.jna.platform.win32.Win32Exception;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Windows implements NativeDesktop {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Windows.class);
 
     private static final String DEFAULT_EXECUTABLE_EXTENSION = ".exe";
 
@@ -89,7 +87,8 @@ public class Windows implements NativeDesktop {
                 return Path.of(Shell32Util.getFolderPath(ShlObj.CSIDL_MYDOCUMENTS));
             }
         } catch (Win32Exception e) {
-            LOGGER.error("Error accessing folder", e);
+            // needs to be non-static because of org.jabref.cli.Launcher.addLogToDisk
+            LoggerFactory.getLogger(Windows.class).error("Error accessing folder", e);
             return Path.of(System.getProperty("user.home"));
         }
     }

--- a/src/main/java/org/jabref/gui/fieldeditors/identifier/BaseIdentifierEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/identifier/BaseIdentifierEditorViewModel.java
@@ -75,9 +75,9 @@ public abstract class BaseIdentifierEditorViewModel<T extends Identifier> extend
         } else if (exception instanceof FetcherServerException) {
             dialogService.showInformationDialogAndWait(Localization.lang("Look up %0", fetcher.getName()), Localization.lang("Server not available"));
         } else if (exception.getCause() != null) {
-            dialogService.showWarningDialogAndWait(Localization.lang("Look up %0", fetcher.getName()), Localization.lang("Error occured %0", exception.getCause().getMessage()));
+            dialogService.showWarningDialogAndWait(Localization.lang("Look up %0", fetcher.getName()), Localization.lang("Error occurred %0", exception.getCause().getMessage()));
         } else {
-            dialogService.showWarningDialogAndWait(Localization.lang("Look up %0", fetcher.getName()), Localization.lang("Error occured %0", exception.getCause().getMessage()));
+            dialogService.showWarningDialogAndWait(Localization.lang("Look up %0", fetcher.getName()), Localization.lang("Error occurred %0", exception.getCause().getMessage()));
         }
     }
 

--- a/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
+++ b/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
@@ -89,7 +89,7 @@ public class FetchAndMergeEntry {
                                       } else if (exception instanceof FetcherServerException) {
                                           dialogService.showInformationDialogAndWait(Localization.lang("Fetching information using %0", fetcher.get().getName()), Localization.lang("Server not available"));
                                       } else {
-                                          dialogService.showInformationDialogAndWait(Localization.lang("Fetching information using %0", fetcher.get().getName()), Localization.lang("Error occured %0", exception.getMessage()));
+                                          dialogService.showInformationDialogAndWait(Localization.lang("Fetching information using %0", fetcher.get().getName()), Localization.lang("Error occurred %0", exception.getMessage()));
                                       }
                                   })
                                   .executeWith(taskExecutor);

--- a/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
+++ b/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.desktop.os.NativeDesktop;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.logic.l10n.Localization;
@@ -33,7 +32,7 @@ public class DetectOpenOfficeInstallation {
     }
 
     public Optional<Path> selectInstallationPath() {
-        final NativeDesktop nativeDesktop = JabRefDesktop.getNativeDesktop();
+        final NativeDesktop nativeDesktop = OS.getNativeDesktop();
 
         dialogService.showInformationDialogAndWait(Localization.lang("Could not find OpenOffice/LibreOffice installation"),
                 Localization.lang("Unable to autodetect OpenOffice/LibreOffice installation. Please choose the installation directory manually."));

--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/EditExternalFileTypeEntryDialog.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/EditExternalFileTypeEntryDialog.java
@@ -10,10 +10,10 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleGroup;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.desktop.os.NativeDesktop;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.logic.util.OS;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import jakarta.inject.Inject;
@@ -31,7 +31,7 @@ public class EditExternalFileTypeEntryDialog extends BaseDialog<Void> {
     @FXML private Label icon;
     @Inject private DialogService dialogService;
 
-    private final NativeDesktop nativeDesktop = JabRefDesktop.getNativeDesktop();
+    private final NativeDesktop nativeDesktop = OS.getNativeDesktop();
     private final FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder().withInitialDirectory(nativeDesktop.getApplicationDirectory()).build();
 
     private final ExternalFileTypeItemViewModel item;

--- a/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/INSPIREFetcher.java
@@ -108,7 +108,7 @@ public class INSPIREFetcher implements SearchBasedParserFetcher, EntryBasedFetch
             results.forEach(this::doPostCleanup);
             return results;
         } catch (IOException | ParseException e) {
-            throw new FetcherException("Error occured during fetching", e);
+            throw new FetcherException("Error occurred during fetching", e);
         }
     }
 }

--- a/src/main/java/org/jabref/logic/util/OS.java
+++ b/src/main/java/org/jabref/logic/util/OS.java
@@ -11,9 +11,6 @@ public class OS {
     public static final String APP_DIR_APP_NAME = "jabref";
     public static final String APP_DIR_APP_AUTHOR = "org.jabref";
 
-    // File separator obtained from system
-    private static final String FILE_SEPARATOR = System.getProperty("file.separator");
-
     // https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/SystemUtils.html
     private static final String OS_NAME = System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT);
     public static final boolean LINUX = OS_NAME.startsWith("linux");

--- a/src/main/java/org/jabref/logic/util/OS.java
+++ b/src/main/java/org/jabref/logic/util/OS.java
@@ -2,12 +2,21 @@ package org.jabref.logic.util;
 
 import java.util.Locale;
 
+import org.jabref.gui.desktop.os.DefaultDesktop;
+import org.jabref.gui.desktop.os.Linux;
+import org.jabref.gui.desktop.os.NativeDesktop;
+import org.jabref.gui.desktop.os.OSX;
+import org.jabref.gui.desktop.os.Windows;
+
 /**
  * Operating system (OS) detection
  *
  * For OS-specific actions see {@link org.jabref.gui.desktop.JabRefDesktop} and {@link org.jabref.gui.desktop.os.NativeDesktop}.
  */
 public class OS {
+    // No LOGGER may be initialized directly
+    // Otherwise, org.jabref.cli.Launcher.addLogToDisk will fail, because tinylog's properties are frozen
+
     public static final String NEWLINE = System.lineSeparator();
 
     public static final String APP_DIR_APP_NAME = "jabref";
@@ -21,5 +30,16 @@ public class OS {
     public static final boolean OS_X = OS_NAME.startsWith("mac");
 
     private OS() {
+    }
+
+    public static NativeDesktop getNativeDesktop() {
+        if (WINDOWS) {
+            return new Windows();
+        } else if (OS_X) {
+            return new OSX();
+        } else if (LINUX) {
+            return new Linux();
+        }
+        return new DefaultDesktop();
     }
 }

--- a/src/main/java/org/jabref/logic/util/OS.java
+++ b/src/main/java/org/jabref/logic/util/OS.java
@@ -2,8 +2,10 @@ package org.jabref.logic.util;
 
 import java.util.Locale;
 
-/***
+/**
  * Operating system (OS) detection
+ *
+ * For OS-specific actions see {@link org.jabref.gui.desktop.JabRefDesktop} and {@link org.jabref.gui.desktop.os.NativeDesktop}.
  */
 public class OS {
     public static final String NEWLINE = System.lineSeparator();

--- a/src/main/java/org/jabref/logic/util/io/BackupFileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/BackupFileUtil.java
@@ -10,9 +10,7 @@ import java.util.HexFormat;
 import java.util.Optional;
 
 import org.jabref.logic.util.BackupFileType;
-import org.jabref.logic.util.OS;
 
-import net.harawata.appdirs.AppDirsFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,15 +19,6 @@ public class BackupFileUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(BackupFileUtil.class);
 
     private BackupFileUtil() {
-    }
-
-    public static Path getAppDataBackupDir() {
-        Path directory = Path.of(AppDirsFactory.getInstance()
-                                               .getUserDataDir(
-                                                       OS.APP_DIR_APP_NAME,
-                                                       "backups",
-                                                       OS.APP_DIR_APP_AUTHOR));
-        return directory;
     }
 
     /**

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -1,6 +1,5 @@
 package org.jabref.model.database;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -11,19 +10,17 @@ import java.util.stream.Collectors;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.gui.LibraryTab;
+import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.crawler.Crawler;
 import org.jabref.logic.crawler.StudyRepository;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.shared.DatabaseSynchronizer;
 import org.jabref.logic.util.CoarseChangeFilter;
-import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.metadata.MetaData;
-import org.jabref.model.pdf.search.SearchFieldConstants;
 import org.jabref.model.study.Study;
 import org.jabref.preferences.FilePreferences;
 
-import net.harawata.appdirs.AppDirsFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,15 +246,9 @@ public class BibDatabaseContext {
         return this.getEntries().stream().anyMatch(entry -> entry.getFields().isEmpty());
     }
 
-    public static Path getFulltextIndexBasePath() {
-        return Path.of(AppDirsFactory.getInstance()
-                                     .getUserDataDir(OS.APP_DIR_APP_NAME,
-                                             "lucene" + File.separator + SearchFieldConstants.VERSION,
-                                             OS.APP_DIR_APP_AUTHOR));
-    }
 
     public Path getFulltextIndexPath() {
-        Path appData = getFulltextIndexBasePath();
+        Path appData = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path indexPath;
 
         if (getDatabasePath().isPresent()) {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -10,12 +10,12 @@ import java.util.stream.Collectors;
 
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.gui.LibraryTab;
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.crawler.Crawler;
 import org.jabref.logic.crawler.StudyRepository;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.shared.DatabaseSynchronizer;
 import org.jabref.logic.util.CoarseChangeFilter;
+import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.study.Study;
@@ -248,7 +248,7 @@ public class BibDatabaseContext {
 
 
     public Path getFulltextIndexPath() {
-        Path appData = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory();
+        Path appData = OS.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path indexPath;
 
         if (getDatabasePath().isPresent()) {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -246,7 +246,6 @@ public class BibDatabaseContext {
         return this.getEntries().stream().anyMatch(entry -> entry.getFields().isEmpty());
     }
 
-
     public Path getFulltextIndexPath() {
         Path appData = OS.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path indexPath;

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -1,5 +1,6 @@
 package org.jabref.model.database;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -249,7 +250,10 @@ public class BibDatabaseContext {
     }
 
     public static Path getFulltextIndexBasePath() {
-        return Path.of(AppDirsFactory.getInstance().getUserDataDir(OS.APP_DIR_APP_NAME, SearchFieldConstants.VERSION, OS.APP_DIR_APP_AUTHOR));
+        return Path.of(AppDirsFactory.getInstance()
+                                     .getUserDataDir(OS.APP_DIR_APP_NAME,
+                                             "lucene" + File.separator + SearchFieldConstants.VERSION,
+                                             OS.APP_DIR_APP_AUTHOR));
     }
 
     public Path getFulltextIndexPath() {

--- a/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
+++ b/src/main/java/org/jabref/model/pdf/search/SearchFieldConstants.java
@@ -10,5 +10,5 @@ public class SearchFieldConstants {
 
     public static final String[] PDF_FIELDS = new String[]{PATH, CONTENT, PAGE_NUMBER, MODIFIED, ANNOTATIONS};
 
-    public static final String VERSION = "lucene95";
+    public static final String VERSION = "95";
 }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -100,7 +100,6 @@ import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.util.OS;
 import org.jabref.logic.util.Version;
 import org.jabref.logic.util.io.AutoLinkPreferences;
-import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.logic.util.io.FileHistory;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseMode;
@@ -543,12 +542,9 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(PROXY_PASSWORD, "");
 
         // SSL
-        defaults.put(TRUSTSTORE_PATH, Path.of(AppDirsFactory.getInstance()
-                                                            .getUserDataDir(
-                                                                    OS.APP_DIR_APP_NAME,
-                                                                    "ssl",
-                                                                    OS.APP_DIR_APP_AUTHOR))
-                                          .resolve("truststore.jks").toString());
+        defaults.put(TRUSTSTORE_PATH, JabRefDesktop.getNativeDesktop()
+                                                   .getSslDirectory()
+                                                   .resolve("truststore.jks").toString());
 
         defaults.put(POS_X, 0);
         defaults.put(POS_Y, 0);
@@ -2123,7 +2119,7 @@ public class JabRefPreferences implements PreferencesService {
                 ExternalFileTypes.fromString(get(EXTERNAL_FILE_TYPES)),
                 getBoolean(CREATE_BACKUP),
                 // We choose the data directory, because a ".bak" file should survive cache cleanups
-                getPath(BACKUP_DIRECTORY, BackupFileUtil.getAppDataBackupDir()));
+                getPath(BACKUP_DIRECTORY, JabRefDesktop.getNativeDesktop().getBackupDirectory()));
 
         EasyBind.listen(filePreferences.mainFileDirectoryProperty(), (obs, oldValue, newValue) -> put(MAIN_FILE_DIRECTORY, newValue));
         EasyBind.listen(filePreferences.storeFilesRelativeToBibFileProperty(), (obs, oldValue, newValue) -> putBoolean(STORE_RELATIVE_TO_BIB, newValue));

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -117,7 +117,6 @@ import org.jabref.model.search.rules.SearchRules;
 import org.jabref.model.strings.StringUtil;
 
 import com.tobiasdiez.easybind.EasyBind;
-import net.harawata.appdirs.AppDirsFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -41,7 +41,6 @@ import javafx.scene.control.TableColumn.SortType;
 import org.jabref.gui.Globals;
 import org.jabref.gui.autocompleter.AutoCompleteFirstNameMode;
 import org.jabref.gui.autocompleter.AutoCompletePreferences;
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.entryeditor.EntryEditorPreferences;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
@@ -498,9 +497,9 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(GROBID_OPT_OUT, Boolean.FALSE);
         defaults.put(GROBID_URL, "http://grobid.jabref.org:8070");
 
-        defaults.put(PUSH_TEXMAKER_PATH, JabRefDesktop.getNativeDesktop().detectProgramPath("texmaker", "Texmaker"));
-        defaults.put(PUSH_WINEDT_PATH, JabRefDesktop.getNativeDesktop().detectProgramPath("WinEdt", "WinEdt Team\\WinEdt"));
-        defaults.put(PUSH_TEXSTUDIO_PATH, JabRefDesktop.getNativeDesktop().detectProgramPath("texstudio", "TeXstudio"));
+        defaults.put(PUSH_TEXMAKER_PATH, OS.getNativeDesktop().detectProgramPath("texmaker", "Texmaker"));
+        defaults.put(PUSH_WINEDT_PATH, OS.getNativeDesktop().detectProgramPath("WinEdt", "WinEdt Team\\WinEdt"));
+        defaults.put(PUSH_TEXSTUDIO_PATH, OS.getNativeDesktop().detectProgramPath("texstudio", "TeXstudio"));
         defaults.put(PUSH_LYXPIPE, USER_HOME + File.separator + ".lyx/lyxpipe");
         defaults.put(PUSH_VIM, "vim");
         defaults.put(PUSH_VIM_SERVER, "vim");
@@ -541,9 +540,9 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(PROXY_PASSWORD, "");
 
         // SSL
-        defaults.put(TRUSTSTORE_PATH, JabRefDesktop.getNativeDesktop()
-                                                   .getSslDirectory()
-                                                   .resolve("truststore.jks").toString());
+        defaults.put(TRUSTSTORE_PATH, OS.getNativeDesktop()
+                                        .getSslDirectory()
+                                        .resolve("truststore.jks").toString());
 
         defaults.put(POS_X, 0);
         defaults.put(POS_Y, 0);
@@ -2010,7 +2009,7 @@ public class JabRefPreferences implements PreferencesService {
 
         internalPreferences = new InternalPreferences(
                 Version.parse(get(VERSION_IGNORED_UPDATE)),
-                getPath(PREFS_EXPORT_PATH, JabRefDesktop.getNativeDesktop().getDefaultFileChooserDirectory()),
+                getPath(PREFS_EXPORT_PATH, OS.getNativeDesktop().getDefaultFileChooserDirectory()),
                 getUser()
         );
 
@@ -2108,7 +2107,7 @@ public class JabRefPreferences implements PreferencesService {
 
         filePreferences = new FilePreferences(
                 getInternalPreferences().getUser(),
-                getPath(MAIN_FILE_DIRECTORY, JabRefDesktop.getNativeDesktop().getDefaultFileChooserDirectory()).toString(),
+                getPath(MAIN_FILE_DIRECTORY, OS.getNativeDesktop().getDefaultFileChooserDirectory()).toString(),
                 getBoolean(STORE_RELATIVE_TO_BIB),
                 get(IMPORT_FILENAMEPATTERN),
                 get(IMPORT_FILEDIRPATTERN),
@@ -2118,7 +2117,7 @@ public class JabRefPreferences implements PreferencesService {
                 ExternalFileTypes.fromString(get(EXTERNAL_FILE_TYPES)),
                 getBoolean(CREATE_BACKUP),
                 // We choose the data directory, because a ".bak" file should survive cache cleanups
-                getPath(BACKUP_DIRECTORY, JabRefDesktop.getNativeDesktop().getBackupDirectory()));
+                getPath(BACKUP_DIRECTORY, OS.getNativeDesktop().getBackupDirectory()));
 
         EasyBind.listen(filePreferences.mainFileDirectoryProperty(), (obs, oldValue, newValue) -> put(MAIN_FILE_DIRECTORY, newValue));
         EasyBind.listen(filePreferences.storeFilesRelativeToBibFileProperty(), (obs, oldValue, newValue) -> putBoolean(STORE_RELATIVE_TO_BIB, newValue));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1631,7 +1631,7 @@ Found\ overlapping\ ranges=Found overlapping ranges
 Found\ touching\ ranges=Found touching ranges
 
 Note\:\ Use\ the\ placeholder\ %DIR%\ for\ the\ location\ of\ the\ opened\ library\ file.=Note: Use the placeholder %DIR% for the location of the opened library file.
-Error\ occured\ while\ executing\ the\ command\ \"%0\".=Error occured while executing the command \"%0\".
+Error\ occurred\ while\ executing\ the\ command\ \"%0\".=Error occurred while executing the command \"%0\".
 Reformat\ ISSN=Reformat ISSN
 
 Countries\ and\ territories\ in\ English=Countries and territories in English
@@ -2504,7 +2504,7 @@ Edit\ file\ link=Edit file link
 Assign=Assign
 Do\ not\ assign=Do not assign
 
-Error\ occured\ %0=Error occured %0
+Error\ occurred\ %0=Error occurred %0
 Left\ Entry=Left Entry
 Merge\ %0=Merge %0
 Right\ Entry=Right Entry

--- a/src/test/java/org/jabref/logic/autosaveandbackup/BackupManagerTest.java
+++ b/src/test/java/org/jabref/logic/autosaveandbackup/BackupManagerTest.java
@@ -8,8 +8,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.util.BackupFileType;
+import org.jabref.logic.util.OS;
 import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -44,7 +44,7 @@ public class BackupManagerTest {
     @Test
     public void backupFileNameIsCorrectlyGeneratedInAppDataDirectory() {
         Path bibPath = Path.of("tmp", "test.bib");
-        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
+        backupDir = OS.getNativeDesktop().getBackupDirectory();
         Path bakPath = BackupManager.getBackupPathForNewBackup(bibPath, backupDir);
 
         // Pattern is "27182d3c--test.bib--", but the hashing is implemented differently on Linux than on Windows

--- a/src/test/java/org/jabref/logic/autosaveandbackup/BackupManagerTest.java
+++ b/src/test/java/org/jabref/logic/autosaveandbackup/BackupManagerTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.util.BackupFileType;
 import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.model.database.BibDatabase;
@@ -43,7 +44,7 @@ public class BackupManagerTest {
     @Test
     public void backupFileNameIsCorrectlyGeneratedInAppDataDirectory() {
         Path bibPath = Path.of("tmp", "test.bib");
-        backupDir = BackupFileUtil.getAppDataBackupDir();
+        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
         Path bakPath = BackupManager.getBackupPathForNewBackup(bibPath, backupDir);
 
         // Pattern is "27182d3c--test.bib--", but the hashing is implemented differently on Linux than on Windows

--- a/src/test/java/org/jabref/logic/util/io/BackupFileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/BackupFileUtilTest.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.util.BackupFileType;
+import org.jabref.logic.util.OS;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,8 +34,8 @@ public class BackupFileUtilTest {
 
     @Test
     void getPathOfBackupFileAndCreateDirectoryReturnsAppDirectoryInCaseOfNoError() {
-        String start = JabRefDesktop.getNativeDesktop().getBackupDirectory().toString();
-        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
+        String start = OS.getNativeDesktop().getBackupDirectory().toString();
+        backupDir = OS.getNativeDesktop().getBackupDirectory();
         String result = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(Path.of("test.bib"), BackupFileType.BACKUP, backupDir).toString();
         // We just check the prefix
         assertEquals(start, result.substring(0, start.length()));
@@ -43,9 +43,9 @@ public class BackupFileUtilTest {
 
     @Test
     void getPathOfBackupFileAndCreateDirectoryReturnsSameDirectoryInCaseOfException() {
-        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
+        backupDir = OS.getNativeDesktop().getBackupDirectory();
         try (MockedStatic<Files> files = Mockito.mockStatic(Files.class, Answers.RETURNS_DEEP_STUBS)) {
-            files.when(() -> Files.createDirectories(JabRefDesktop.getNativeDesktop().getBackupDirectory()))
+            files.when(() -> Files.createDirectories(OS.getNativeDesktop().getBackupDirectory()))
                  .thenThrow(new IOException());
             Path testPath = Path.of("tmp", "test.bib");
             Path result = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(testPath, BackupFileType.BACKUP, backupDir);

--- a/src/test/java/org/jabref/logic/util/io/BackupFileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/BackupFileUtilTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.logic.util.BackupFileType;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,8 +34,8 @@ public class BackupFileUtilTest {
 
     @Test
     void getPathOfBackupFileAndCreateDirectoryReturnsAppDirectoryInCaseOfNoError() {
-        String start = BackupFileUtil.getAppDataBackupDir().toString();
-        backupDir = BackupFileUtil.getAppDataBackupDir();
+        String start = JabRefDesktop.getNativeDesktop().getBackupDirectory().toString();
+        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
         String result = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(Path.of("test.bib"), BackupFileType.BACKUP, backupDir).toString();
         // We just check the prefix
         assertEquals(start, result.substring(0, start.length()));
@@ -42,9 +43,9 @@ public class BackupFileUtilTest {
 
     @Test
     void getPathOfBackupFileAndCreateDirectoryReturnsSameDirectoryInCaseOfException() {
-        backupDir = BackupFileUtil.getAppDataBackupDir();
+        backupDir = JabRefDesktop.getNativeDesktop().getBackupDirectory();
         try (MockedStatic<Files> files = Mockito.mockStatic(Files.class, Answers.RETURNS_DEEP_STUBS)) {
-            files.when(() -> Files.createDirectories(BackupFileUtil.getAppDataBackupDir()))
+            files.when(() -> Files.createDirectories(JabRefDesktop.getNativeDesktop().getBackupDirectory()))
                  .thenThrow(new IOException());
             Path testPath = Path.of("tmp", "test.bib");
             Path result = BackupFileUtil.getPathForNewBackupFileAndCreateDirectory(testPath, BackupFileType.BACKUP, backupDir);

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.gui.desktop.JabRefDesktop;
+import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.IEEETranEntryType;
 import org.jabref.model.metadata.MetaData;
@@ -94,7 +94,7 @@ class BibDatabaseContextTest {
     @Test
     void getUserFileDirectoryIfAllAreEmpty() {
         when(fileDirPrefs.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
-        Path userDirJabRef = JabRefDesktop.getNativeDesktop().getDefaultFileChooserDirectory();
+        Path userDirJabRef = OS.getNativeDesktop().getDefaultFileChooserDirectory();
 
         when(fileDirPrefs.getMainFileDirectory()).thenReturn(Optional.of(userDirJabRef));
         BibDatabaseContext database = new BibDatabaseContext();
@@ -135,7 +135,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
         bibDatabaseContext.setDatabasePath(null);
 
-        Path expectedPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory().resolve("unsaved");
+        Path expectedPath = OS.getNativeDesktop().getFulltextIndexBaseDirectory().resolve("unsaved");
         Path actualPath = bibDatabaseContext.getFulltextIndexPath();
 
         assertEquals(expectedPath, actualPath);
@@ -148,7 +148,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
         bibDatabaseContext.setDatabasePath(existingPath);
 
-        Path expectedPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory().resolve(existingPath.hashCode() + "");
+        Path expectedPath = OS.getNativeDesktop().getFulltextIndexBaseDirectory().resolve(existingPath.hashCode() + "");
         Path actualPath = bibDatabaseContext.getFulltextIndexPath();
 
         assertEquals(expectedPath, actualPath);

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -135,7 +135,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
         bibDatabaseContext.setDatabasePath(null);
 
-        Path expectedPath = BibDatabaseContext.getFulltextIndexBasePath().resolve("unsaved");
+        Path expectedPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory().resolve("unsaved");
         Path actualPath = bibDatabaseContext.getFulltextIndexPath();
 
         assertEquals(expectedPath, actualPath);
@@ -148,7 +148,7 @@ class BibDatabaseContextTest {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
         bibDatabaseContext.setDatabasePath(existingPath);
 
-        Path expectedPath = BibDatabaseContext.getFulltextIndexBasePath().resolve(existingPath.hashCode() + "");
+        Path expectedPath = JabRefDesktop.getNativeDesktop().getFulltextIndexBaseDirectory().resolve(existingPath.hashCode() + "");
         Path actualPath = bibDatabaseContext.getFulltextIndexPath();
 
         assertEquals(expectedPath, actualPath);


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/9584. Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/93.

Lucene-Index is now stored in `lucence/<version>`.

```text
├───backups
├───logs
│   ├───100.0.0
│   ├───5.10--2023-04-06--0111d59
│   └───5.9--2023-01-04--bc3b9892f
├───lucene
│   └───95
│       ├───-369469544
│       └───40622060
└───ssl
```

Thus, `%APPDATA%\..\Local\org.jabref` looks more clean to the user

Discussion was done at https://github.com/JabRef/jabref/pull/9676.

Upgrade from lucene94 to 95 was done after release of JabRef v5.9 and thus this change does not affect users basing on the release version. They will encounter a re-index in all cases.


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
