### PR TITLE
Enable single backslashes at fileDirectory

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/BibWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibWriter.java
@@ -26,7 +26,7 @@ public class BibWriter {
     }
 
     /**
-     * Writes the given string. The newlines of the given string are converted to the newline set for this clas
+     * Writes the given string. The newlines of the given string are converted to the newline set for this class
      */
     public void write(String string) throws IOException {
         if (precedingNewLineRequired) {

--- a/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
@@ -22,6 +22,9 @@ import org.jabref.model.metadata.ContentSelector;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.model.strings.StringUtil;
 
+/**
+ * Reading is done at {@link org.jabref.logic.importer.util.MetaDataParser}
+ */
 public class MetaDataSerializer {
 
     private MetaDataSerializer() {

--- a/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
@@ -75,7 +75,8 @@ public class MetaDataSerializer {
         // finally add all unknown meta data items to the serialization map
         Map<String, List<String>> unknownMetaData = metaData.getUnknownMetaData();
         for (Map.Entry<String, List<String>> entry : unknownMetaData.entrySet()) {
-            StringJoiner value = new StringJoiner(MetaData.SEPARATOR_STRING + OS.NEWLINE, OS.NEWLINE, OS.NEWLINE);
+            // The last "MetaData.SEPARATOR_STRING" adds compatibility to JabRef v5.9 and earlier
+            StringJoiner value = new StringJoiner(MetaData.SEPARATOR_STRING + OS.NEWLINE, OS.NEWLINE, MetaData.SEPARATOR_STRING + OS.NEWLINE);
             for (String line : entry.getValue()) {
                 value.add(line.replace(MetaData.SEPARATOR_STRING, "\\" + MetaData.SEPARATOR_STRING));
             }
@@ -88,25 +89,33 @@ public class MetaDataSerializer {
     private static Map<String, String> serializeMetaData(Map<String, List<String>> stringyMetaData) {
         Map<String, String> serializedMetaData = new TreeMap<>();
         for (Map.Entry<String, List<String>> metaItem : stringyMetaData.entrySet()) {
-            StringBuilder stringBuilder = new StringBuilder();
-            for (String dataItem : metaItem.getValue()) {
-                if (!metaItem.getKey().equals(MetaData.VERSION_DB_STRUCT)) {
-                    stringBuilder.append(StringUtil.quote(dataItem, MetaData.SEPARATOR_STRING, MetaData.ESCAPE_CHARACTER)).append(MetaData.SEPARATOR_STRING);
-                } else {
-                    stringBuilder.append(StringUtil.quote(dataItem, MetaData.SEPARATOR_STRING, MetaData.ESCAPE_CHARACTER));
-                }
-
-                // in case of save actions, add an additional newline after the enabled flag
-                if (metaItem.getKey().equals(MetaData.SAVE_ACTIONS)
-                        && (FieldFormatterCleanups.ENABLED.equals(dataItem)
-                        || FieldFormatterCleanups.DISABLED.equals(dataItem))) {
-                    stringBuilder.append(OS.NEWLINE);
-                }
+            List<String> itemList = metaItem.getValue();
+            if (itemList.isEmpty()) {
+                // Only add non-empty values
+                continue;
             }
 
-            String serializedItem = stringBuilder.toString();
-            // Only add non-empty values
-            if (!serializedItem.isEmpty() && !MetaData.SEPARATOR_STRING.equals(serializedItem)) {
+            boolean isSaveActions = metaItem.getKey().equals(MetaData.SAVE_ACTIONS);
+            // The last "MetaData.SEPARATOR_STRING" adds compatibility to JabRef v5.9 and earlier
+            StringJoiner joiner = new StringJoiner(MetaData.SEPARATOR_STRING, "", MetaData.SEPARATOR_STRING);
+            boolean lastWasSaveActionsEnablement = false;
+            for (String dataItem : itemList) {
+                String string;
+                if (lastWasSaveActionsEnablement) {
+                    string = OS.NEWLINE;
+                } else {
+                    string = "";
+                }
+                string += StringUtil.quote(dataItem, MetaData.SEPARATOR_STRING, MetaData.ESCAPE_CHARACTER);
+                // in case of save actions, add an additional newline after the enabled flag
+                lastWasSaveActionsEnablement = isSaveActions
+                        && (FieldFormatterCleanups.ENABLED.equals(dataItem)
+                        || FieldFormatterCleanups.DISABLED.equals(dataItem));
+                joiner.add(string);
+            }
+            String serializedItem = joiner.toString();
+            if (!serializedItem.isEmpty()) {
+                // Only add non-empty values
                 serializedMetaData.put(metaItem.getKey(), serializedItem);
             }
         }

--- a/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -32,8 +33,12 @@ public class MetaDataSerializer {
     public static Map<String, String> getSerializedStringMap(MetaData metaData,
                                                              GlobalCitationKeyPattern globalCiteKeyPattern) {
 
-        // First write all meta data except groups
+        // metadata-key, list of contents
+        //  - contents to be separated by OS.NEWLINE
+        //  - each meta data item is written as separate @Comment entry - see org.jabref.logic.exporter.BibtexDatabaseWriter.writeMetaDataItem
         Map<String, List<String>> stringyMetaData = new HashMap<>();
+
+        // First write all meta data except groups
         metaData.getSaveOrderConfig().ifPresent(
                 saveOrderConfig -> stringyMetaData.put(MetaData.SAVE_ORDER_CONFIG, saveOrderConfig.getAsStringList()));
         metaData.getSaveActions().ifPresent(
@@ -51,7 +56,7 @@ public class MetaDataSerializer {
         metaData.getLatexFileDirectories().forEach((user, path) -> stringyMetaData
                 .put(MetaData.FILE_DIRECTORY + "Latex-" + user, Collections.singletonList(path.toString().trim())));
         metaData.getVersionDBStructure().ifPresent(
-                VersionDBStructure -> stringyMetaData.put(MetaData.VERSION_DB_STRUCT, Collections.singletonList(VersionDBStructure.trim())));
+                versionDBStructure -> stringyMetaData.put(MetaData.VERSION_DB_STRUCT, Collections.singletonList(versionDBStructure.trim())));
 
         for (ContentSelector selector : metaData.getContentSelectorList()) {
             stringyMetaData.put(MetaData.SELECTOR_META_PREFIX + selector.getField().getName(), selector.getValues());
@@ -67,10 +72,9 @@ public class MetaDataSerializer {
         // finally add all unknown meta data items to the serialization map
         Map<String, List<String>> unknownMetaData = metaData.getUnknownMetaData();
         for (Map.Entry<String, List<String>> entry : unknownMetaData.entrySet()) {
-            StringBuilder value = new StringBuilder();
-            value.append(OS.NEWLINE);
+            StringJoiner value = new StringJoiner(MetaData.SEPARATOR_STRING + OS.NEWLINE, OS.NEWLINE, OS.NEWLINE);
             for (String line : entry.getValue()) {
-                value.append(line.replaceAll(";", "\\\\;") + MetaData.SEPARATOR_STRING + OS.NEWLINE);
+                value.add(line.replace(MetaData.SEPARATOR_STRING, "\\" + MetaData.SEPARATOR_STRING));
             }
             serializedMetaData.put(entry.getKey(), value.toString());
         }

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -92,7 +92,6 @@ public class BibtexParser implements Parser {
      * It is undetermined which entry is returned, so use this in case you know there is only one entry in the string.
      *
      * @return An Optional&lt;BibEntry>. Optional.empty() if non was found or an error occurred.
-     * @throws ParseException
      */
     public static Optional<BibEntry> singleFromString(String bibtexString, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) throws ParseException {
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences, fileMonitor).parseEntries(bibtexString);

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -177,7 +177,14 @@ public class MetaDataParser {
         StringBuilder res = new StringBuilder();
         while ((c = reader.read()) != -1) {
             if (escape) {
-                res.append((char) c);
+                // at org.jabref.logic.exporter.MetaDataSerializer.serializeMetaData, only MetaData.SEPARATOR_CHARACTER, MetaData.ESCAPE_CHARACTER are quoted
+                // That means ; and \\
+                char character = (char) c;
+                if (character != MetaData.SEPARATOR_CHARACTER && character != MetaData.ESCAPE_CHARACTER) {
+                    // Keep the escape character
+                    res.append("\\");
+                }
+                res.append(character);
                 escape = false;
             } else if (c == MetaData.ESCAPE_CHARACTER) {
                 escape = true;

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -29,6 +29,9 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Writing is done at {@link org.jabref.logic.exporter.MetaDataSerializer}.
+ */
 public class MetaDataParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataParser.class);

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.jabref.logic.cleanup.FieldFormatterCleanups;
 import org.jabref.logic.importer.ParseException;
@@ -84,46 +85,46 @@ public class MetaDataParser {
         entryList.sort(groupsLast());
 
         for (Map.Entry<String, String> entry : entryList) {
-            List<String> value = getAsList(entry.getValue());
+            List<String> values = getAsList(entry.getValue());
 
             if (entry.getKey().startsWith(MetaData.PREFIX_KEYPATTERN)) {
                 EntryType entryType = EntryTypeFactory.parse(entry.getKey().substring(MetaData.PREFIX_KEYPATTERN.length()));
-                nonDefaultCiteKeyPatterns.put(entryType, Collections.singletonList(getSingleItem(value)));
+                nonDefaultCiteKeyPatterns.put(entryType, Collections.singletonList(getSingleItem(values)));
             } else if (entry.getKey().startsWith(MetaData.SELECTOR_META_PREFIX)) {
                 // edge case, it might be one special field e.g. article from biblatex-apa, but we can't distinguish this from any other field and rather prefer to handle it as UnknownField
                 metaData.addContentSelector(ContentSelectors.parse(FieldFactory.parseField(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length())), StringUtil.unquote(entry.getValue(), MetaData.ESCAPE_CHARACTER)));
+            } else if (entry.getKey().equals(MetaData.FILE_DIRECTORY)) {
+                metaData.setDefaultFileDirectory(parseDirectory(entry.getValue()));
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY + '-')) {
                 // The user name starts directly after FILE_DIRECTORY + '-'
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY.length() + 1);
-                metaData.setUserFileDirectory(user, getSingleItem(value));
+                metaData.setUserFileDirectory(user, parseDirectory(entry.getValue()));
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY_LATEX)) {
                 // The user name starts directly after FILE_DIRECTORY_LATEX" + '-'
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY_LATEX.length() + 1);
-                Path path = Path.of(getSingleItem(value)).normalize();
+                Path path = Path.of(parseDirectory(entry.getValue())).normalize();
                 metaData.setLatexFileDirectory(user, path);
-            } else if (entry.getKey().equals(MetaData.FILE_DIRECTORY)) {
-                metaData.setDefaultFileDirectory(getSingleItem(value));
             } else if (entry.getKey().equals(MetaData.SAVE_ACTIONS)) {
-                metaData.setSaveActions(FieldFormatterCleanups.parse(value));
+                metaData.setSaveActions(FieldFormatterCleanups.parse(values));
             } else if (entry.getKey().equals(MetaData.DATABASE_TYPE)) {
-                metaData.setMode(BibDatabaseMode.parse(getSingleItem(value)));
+                metaData.setMode(BibDatabaseMode.parse(getSingleItem(values)));
             } else if (entry.getKey().equals(MetaData.KEYPATTERNDEFAULT)) {
-                defaultCiteKeyPattern = Collections.singletonList(getSingleItem(value));
+                defaultCiteKeyPattern = Collections.singletonList(getSingleItem(values));
             } else if (entry.getKey().equals(MetaData.PROTECTED_FLAG_META)) {
-                if (Boolean.parseBoolean(getSingleItem(value))) {
+                if (Boolean.parseBoolean(getSingleItem(values))) {
                     metaData.markAsProtected();
                 } else {
                     metaData.markAsNotProtected();
                 }
             } else if (entry.getKey().equals(MetaData.SAVE_ORDER_CONFIG)) {
-                metaData.setSaveOrderConfig(SaveOrder.parse(value));
+                metaData.setSaveOrderConfig(SaveOrder.parse(values));
             } else if (entry.getKey().equals(MetaData.GROUPSTREE) || entry.getKey().equals(MetaData.GROUPSTREE_LEGACY)) {
-                metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator, fileMonitor, metaData));
+                metaData.setGroups(GroupsParser.importGroups(values, keywordSeparator, fileMonitor, metaData));
             } else if (entry.getKey().equals(MetaData.VERSION_DB_STRUCT)) {
-                metaData.setVersionDBStructure(getSingleItem(value));
+                metaData.setVersionDBStructure(getSingleItem(values));
             } else {
                 // Keep meta data items that we do not know in the file
-                metaData.putUnknownMetaDataItem(entry.getKey(), value);
+                metaData.putUnknownMetaDataItem(entry.getKey(), values);
             }
         }
 
@@ -132,6 +133,31 @@ public class MetaDataParser {
         }
 
         return metaData;
+    }
+
+    /**
+     * Parse the content of the value as provided by "raw" content.
+     *
+     * We do not use unescaped value (created by @link{#getAsList(java.lang.String)}),
+     * because this leads to difficulties with UNC names.
+     *
+     * No normalization is done - the general file directory could be passed as Mac OS X path, but the user could sit on Windows.
+     *
+     * @param value the raw value (as stored in the .bib file)
+     */
+    static String parseDirectory(String value) {
+        value = StringUtil.removeStringAtTheEnd(value, MetaData.SEPARATOR_STRING);
+        Pattern SINGLE_BACKSLASH = Pattern.compile("[^\\\\]\\\\[^\\\\]");
+        if (value.contains("\\\\\\\\")) {
+            // This is an escaped Windows UNC path
+            return value.replace("\\\\", "\\");
+        } else if (value.contains("\\\\") && !SINGLE_BACKSLASH.matcher(value).find()) {
+            // All backslashes escaped
+            return value.replace("\\\\", "\\");
+        } else {
+            // No backslash escaping
+            return value;
+        }
     }
 
     private static Comparator<? super Map.Entry<String, String>> groupsLast() {

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -89,18 +89,20 @@ public class MetaDataParser {
             if (entry.getKey().startsWith(MetaData.PREFIX_KEYPATTERN)) {
                 EntryType entryType = EntryTypeFactory.parse(entry.getKey().substring(MetaData.PREFIX_KEYPATTERN.length()));
                 nonDefaultCiteKeyPatterns.put(entryType, Collections.singletonList(getSingleItem(value)));
+            } else if (entry.getKey().startsWith(MetaData.SELECTOR_META_PREFIX)) {
+                // edge case, it might be one special field e.g. article from biblatex-apa, but we can't distinguish this from any other field and rather prefer to handle it as UnknownField
+                metaData.addContentSelector(ContentSelectors.parse(FieldFactory.parseField(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length())), StringUtil.unquote(entry.getValue(), MetaData.ESCAPE_CHARACTER)));
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY + '-')) {
                 // The user name starts directly after FILE_DIRECTORY + '-'
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY.length() + 1);
                 metaData.setUserFileDirectory(user, getSingleItem(value));
-            } else if (entry.getKey().startsWith(MetaData.SELECTOR_META_PREFIX)) {
-                // edge case, it might be one special field e.g. article from biblatex-apa, but we can't distinguish this from any other field and rather prefer to handle it as UnknownField
-                metaData.addContentSelector(ContentSelectors.parse(FieldFactory.parseField(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length())), StringUtil.unquote(entry.getValue(), MetaData.ESCAPE_CHARACTER)));
             } else if (entry.getKey().startsWith(MetaData.FILE_DIRECTORY_LATEX)) {
                 // The user name starts directly after FILE_DIRECTORY_LATEX" + '-'
                 String user = entry.getKey().substring(MetaData.FILE_DIRECTORY_LATEX.length() + 1);
                 Path path = Path.of(getSingleItem(value)).normalize();
                 metaData.setLatexFileDirectory(user, path);
+            } else if (entry.getKey().equals(MetaData.FILE_DIRECTORY)) {
+                metaData.setDefaultFileDirectory(getSingleItem(value));
             } else if (entry.getKey().equals(MetaData.SAVE_ACTIONS)) {
                 metaData.setSaveActions(FieldFormatterCleanups.parse(value));
             } else if (entry.getKey().equals(MetaData.DATABASE_TYPE)) {
@@ -113,8 +115,6 @@ public class MetaDataParser {
                 } else {
                     metaData.markAsNotProtected();
                 }
-            } else if (entry.getKey().equals(MetaData.FILE_DIRECTORY)) {
-                metaData.setDefaultFileDirectory(getSingleItem(value));
             } else if (entry.getKey().equals(MetaData.SAVE_ORDER_CONFIG)) {
                 metaData.setSaveOrderConfig(SaveOrder.parse(value));
             } else if (entry.getKey().equals(MetaData.GROUPSTREE) || entry.getKey().equals(MetaData.GROUPSTREE_LEGACY)) {

--- a/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -72,7 +72,7 @@ public class MetaData {
     private final Map<String, List<String>> unknownMetaData = new HashMap<>();
     private boolean isEventPropagationEnabled = true;
     private boolean encodingExplicitlySupplied;
-    private String VersionDBStructure;
+    private String versionDBStructure;
 
     /**
      * Constructs an empty metadata.
@@ -214,11 +214,11 @@ public class MetaData {
     }
 
     public Optional<String> getVersionDBStructure() {
-        return Optional.ofNullable(VersionDBStructure);
+        return Optional.ofNullable(versionDBStructure);
     }
 
     public void setVersionDBStructure(String version) {
-        VersionDBStructure = Objects.requireNonNull(version).trim();
+        versionDBStructure = Objects.requireNonNull(version).trim();
         postChange();
     }
 
@@ -384,17 +384,17 @@ public class MetaData {
                 && (mode == metaData.mode)
                 && Objects.equals(defaultFileDirectory, metaData.defaultFileDirectory)
                 && Objects.equals(contentSelectors, metaData.contentSelectors)
-                && Objects.equals(VersionDBStructure, metaData.VersionDBStructure);
+                && Objects.equals(versionDBStructure, metaData.versionDBStructure);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(isProtected, groupsRoot.getValue(), encoding, encodingExplicitlySupplied, saveOrder, citeKeyPatterns, userFileDirectory,
-                laTexFileDirectory, defaultCiteKeyPattern, saveActions, mode, defaultFileDirectory, contentSelectors, VersionDBStructure);
+                laTexFileDirectory, defaultCiteKeyPattern, saveActions, mode, defaultFileDirectory, contentSelectors, versionDBStructure);
     }
 
     @Override
     public String toString() {
-        return "MetaData [citeKeyPatterns=" + citeKeyPatterns + ", userFileDirectory=" + userFileDirectory + ", laTexFileDirectory=" + laTexFileDirectory + ", groupsRoot=" + groupsRoot + ", encoding=" + encoding + ", saveOrderConfig=" + saveOrder + ", defaultCiteKeyPattern=" + defaultCiteKeyPattern + ", saveActions=" + saveActions + ", mode=" + mode + ", isProtected=" + isProtected + ", defaultFileDirectory=" + defaultFileDirectory + ", contentSelectors=" + contentSelectors + ", encodingExplicitlySupplied=" + encodingExplicitlySupplied + ", VersionDBStructure=" + VersionDBStructure + "]";
+        return "MetaData [citeKeyPatterns=" + citeKeyPatterns + ", userFileDirectory=" + userFileDirectory + ", laTexFileDirectory=" + laTexFileDirectory + ", groupsRoot=" + groupsRoot + ", encoding=" + encoding + ", saveOrderConfig=" + saveOrder + ", defaultCiteKeyPattern=" + defaultCiteKeyPattern + ", saveActions=" + saveActions + ", mode=" + mode + ", isProtected=" + isProtected + ", defaultFileDirectory=" + defaultFileDirectory + ", contentSelectors=" + contentSelectors + ", encodingExplicitlySupplied=" + encodingExplicitlySupplied + ", VersionDBStructure=" + versionDBStructure + "]";
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -60,6 +60,8 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -129,11 +131,10 @@ class BibtexParserTest {
                         """,
                 importFormatPreferences, fileMonitor);
 
-        BibEntry expected = new BibEntry();
-        expected.setType(StandardEntryType.Article);
-        expected.setCitationKey("canh05");
-        expected.setField(StandardField.AUTHOR, "Crowston, K. and Annabi, H.");
-        expected.setField(StandardField.TITLE, "Title A");
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("canh05")
+                .withField(StandardField.AUTHOR, "Crowston, K. and Annabi, H.")
+                .withField(StandardField.TITLE, "Title A");
 
         assertEquals(Optional.of(expected), parsed);
     }
@@ -1653,6 +1654,24 @@ class BibtexParserTest {
         assertEquals("\\Literature\\", result.getMetaData().getDefaultFileDirectory().get());
         assertEquals("D:\\Documents", result.getMetaData().getUserFileDirectory("defaultOwner-user").get());
         assertEquals("D:\\Latex", result.getMetaData().getLatexFileDirectory("defaultOwner-user").get().toString());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // single backsslash kept
+            "C:\\temp\\test",
+            "."})
+    void fileDirectoriesUnmodified(String directory) throws IOException {
+        ParserResult result = parser.parse(
+                new StringReader("@comment{jabref-meta: fileDirectory:" + directory + "}"));
+        assertEquals(directory, result.getMetaData().getDefaultFileDirectory().get());
+    }
+
+    @Test
+    void fileDirectoryWithDoubleEscapeIsRead() throws IOException {
+        ParserResult result = parser.parse(
+                new StringReader("@comment{jabref-meta: fileDirectory: C:\\\\temp\\\\test}"));
+        assertEquals("C:\\temp\\test", result.getMetaData().getDefaultFileDirectory().get());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1658,8 +1658,10 @@ class BibtexParserTest {
 
     @ParameterizedTest
     @CsvSource({
-            // single backsslash kept
+            // single backslash kept
             "C:\\temp\\test",
+            "\\\\servername\\path\\to\\file",
+            "//servername/path/to/file",
             "."})
     void fileDirectoriesUnmodified(String directory) throws IOException {
         ParserResult result = parser.parse(
@@ -1667,11 +1669,14 @@ class BibtexParserTest {
         assertEquals(directory, result.getMetaData().getDefaultFileDirectory().get());
     }
 
-    @Test
-    void fileDirectoryWithDoubleEscapeIsRead() throws IOException {
+    @ParameterizedTest
+    @CsvSource({
+            "C:\\temp\\test, C:\\\\temp\\\\test",
+            "\\\\servername\\path\\to\\file, \\\\\\\\servername\\\\path\\\\to\\\\file"})
+    void fileDirectoryWithDoubleEscapeIsRead(String expected, String provided) throws IOException {
         ParserResult result = parser.parse(
-                new StringReader("@comment{jabref-meta: fileDirectory: C:\\\\temp\\\\test}"));
-        assertEquals("C:\\temp\\test", result.getMetaData().getDefaultFileDirectory().get());
+                new StringReader("@comment{jabref-meta: fileDirectory: " + provided + "}"));
+        assertEquals(expected, result.getMetaData().getDefaultFileDirectory().get());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/util/MetaDataParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/MetaDataParserTest.java
@@ -1,0 +1,23 @@
+package org.jabref.logic.importer.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MetaDataParserTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "C:\\temp\\test,                 C:\\temp\\test",
+            "\\\\servername\\path\\to\\file, \\\\\\\\servername\\\\path\\\\to\\\\file",
+            "\\\\servername\\path\\to\\file, \\\\servername\\path\\to\\file",
+            "//servername/path/to/file,      //servername/path/to/file",
+            ".\\pdfs,                        .\\pdfs,",
+            ".\\pdfs,                        .\\\\pdfs,",
+            ".,                              .",
+    })
+    void parseDirectory(String expected, String input) {
+        assertEquals(expected, MetaDataParser.parseDirectory(input));
+    }
+}

--- a/src/test/java/org/jabref/logic/importer/util/MetaDataParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/MetaDataParserTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.importer.util;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MetaDataParserTest {
 

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -146,17 +146,16 @@ class IntegrityCheckTest {
     }
 
     private BibDatabaseContext createContext(Field field, String value, EntryType type) {
-        BibEntry entry = new BibEntry();
-        entry.setField(field, value);
-        entry.setType(type);
+        BibEntry entry = new BibEntry(type)
+                .withField(field, value);
         BibDatabase bibDatabase = new BibDatabase();
         bibDatabase.insertEntry(entry);
         return new BibDatabaseContext(bibDatabase);
     }
 
     private BibDatabaseContext createContext(Field field, String value, MetaData metaData) {
-        BibEntry entry = new BibEntry();
-        entry.setField(field, value);
+        BibEntry entry = new BibEntry()
+                .withField(field, value);
         BibDatabase bibDatabase = new BibDatabase();
         bibDatabase.insertEntry(entry);
         return new BibDatabaseContext(bibDatabase, metaData);


### PR DESCRIPTION
My JabRef showed `C:git-repositoriesjabrefsrctestresourcespdfs` as path. Don't know why. I checked the source and modified the parsing logic that JabRef also accepts paths with single \ in the field.

    @Comment{jabref-meta: fileDirectory:C:\git-repositories\jabref\src\test\resources\pdfs;}

When JabRef writes, there will be double backslashes.

This PR also modifes the meta data writing code in a way that the trailing ; of each entry could be removed. I think, this should be done for JabRef 6.0. -- Maybe, also a complete rewrite of the metadata serialization could be done (refs https://github.com/koppor/jabref/issues/232)

Minor fixes include

- Rename variable to lower case start
- Use `.withField` in test


```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
