### PR TITLE
Fix save actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the preferences option to open the last edited files on startup to the 'General' tab. [#9808](https://github.com/JabRef/jabref/pull/9808)
 - We split the 'Import and Export' tab into 'Web Search' and 'Export'. [#9839](https://github.com/JabRef/jabref/pull/9839)
 - We improved the recognition of DOIs when pasting a link containing a DOI on the maintable [#9864](https://github.com/JabRef/jabref/issues/9864s)
+- The formatter `remove_unicode_ligatures` is now called `replace_unicode_ligatures`.
 
 ### Fixed
 
@@ -74,6 +75,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
 - We fixed an issue regarding recording redundant prefixes in search history. [#9685](https://github.com/JabRef/jabref/issues/9685)
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
+- The order of save actions is now retained.
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
+++ b/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
@@ -3,12 +3,11 @@ package org.jabref.logic.cleanup;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +30,12 @@ import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.strings.StringUtil;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class FieldFormatterCleanups {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FieldFormatterCleanups.class);
 
     public static final List<FieldFormatterCleanup> DEFAULT_SAVE_ACTIONS;
     public static final List<FieldFormatterCleanup> RECOMMEND_BIBTEX_ACTIONS;
@@ -42,23 +46,23 @@ public class FieldFormatterCleanups {
 
     /**
      * This parses the key/list map of fields and clean up actions for the field.
-     *
+     * <p>
      * General format for one key/list map: <code>...[...]</code> - <code>field[formatter1,formatter2,...]</code>
      * Multiple are written as <code>...[...]...[...]...[...]</code>
-     *   <code>field1[formatter1,formatter2,...]field2[formatter3,formatter4,...]</code>
-     *
+     * <code>field1[formatter1,formatter2,...]field2[formatter3,formatter4,...]</code>
+     * <p>
      * The idea is that characters are field names until <code>[</code> is reached and that formatter lists are terminated by <code>]</code>
-     *
+     * <p>
      * Example: <code>pages[normalize_page_numbers]title[escapeAmpersands,escapeDollarSign,escapeUnderscores,latex_cleanup]</code>
      */
     private static final Pattern FIELD_FORMATTER_CLEANUP_PATTERN = Pattern.compile("([^\\[]+)\\[([^]]+)]");
 
     static {
         DEFAULT_SAVE_ACTIONS = List.of(
-            new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()),
-            new FieldFormatterCleanup(StandardField.DATE, new NormalizeDateFormatter()),
-            new FieldFormatterCleanup(StandardField.MONTH, new NormalizeMonthFormatter()),
-            new FieldFormatterCleanup(InternalField.INTERNAL_ALL_TEXT_FIELDS_FIELD, new ReplaceUnicodeLigaturesFormatter()));
+                new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()),
+                new FieldFormatterCleanup(StandardField.DATE, new NormalizeDateFormatter()),
+                new FieldFormatterCleanup(StandardField.MONTH, new NormalizeMonthFormatter()),
+                new FieldFormatterCleanup(InternalField.INTERNAL_ALL_TEXT_FIELDS_FIELD, new ReplaceUnicodeLigaturesFormatter()));
 
         List<FieldFormatterCleanup> recommendedBibtexFormatters = new ArrayList<>(DEFAULT_SAVE_ACTIONS);
         recommendedBibtexFormatters.addAll(List.of(
@@ -87,8 +91,9 @@ public class FieldFormatterCleanups {
      * Note: String parsing is done at {@link FieldFormatterCleanups#parse(String)}
      */
     public static String getMetaDataString(List<FieldFormatterCleanup> actionList, String newLineSeparator) {
-        // first, group all formatters by the field for which they apply
-        Map<Field, List<String>> groupedByField = new TreeMap<>(Comparator.comparing(Field::getName));
+        // First, group all formatters by the field for which they apply
+        // Order of the list should be kept
+        Map<Field, List<String>> groupedByField = new LinkedHashMap<>();
         for (FieldFormatterCleanup cleanup : actionList) {
             Field key = cleanup.getField();
 
@@ -198,12 +203,13 @@ public class FieldFormatterCleanups {
         }
     }
 
-    private static Formatter getFormatterFromString(String formatterName) {
+    static Formatter getFormatterFromString(String formatterName) {
         for (Formatter formatter : Formatters.getAll()) {
             if (formatterName.equals(formatter.getKey())) {
                 return formatter;
             }
         }
+        LOGGER.info("Formatter {} not found.", formatterName);
         return new IdentityFormatter();
     }
 

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -35,6 +35,7 @@ import org.jabref.logic.formatter.casechanger.UpperCaseFormatter;
 import org.jabref.logic.formatter.minifier.MinifyNameListFormatter;
 import org.jabref.logic.formatter.minifier.TruncateFormatter;
 import org.jabref.logic.layout.format.LatexToUnicodeFormatter;
+import org.jabref.logic.layout.format.ReplaceUnicodeLigaturesFormatter;
 
 public class Formatters {
     private static final Pattern TRUNCATE_PATTERN = Pattern.compile("\\Atruncate\\d+\\z");
@@ -78,6 +79,7 @@ public class Formatters {
                 new EscapeAmpersandsFormatter(),
                 new EscapeDollarSignFormatter(),
                 new ShortenDOIFormatter(),
+                new ReplaceUnicodeLigaturesFormatter(),
                 new UnprotectTermsFormatter()
         );
     }

--- a/src/main/java/org/jabref/logic/layout/format/ReplaceUnicodeLigaturesFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/ReplaceUnicodeLigaturesFormatter.java
@@ -28,13 +28,12 @@ public class ReplaceUnicodeLigaturesFormatter extends Formatter implements Layou
 
     @Override
     public String getKey() {
-        return "remove_unicode_ligatures";
+        return "replace_unicode_ligatures";
     }
 
     @Override
     public String format(String fieldText) {
         String result = fieldText;
-
         for (Pattern key : ligaturesMap.keySet()) {
             result = key.matcher(result).replaceAll(ligaturesMap.get(key));
         }

--- a/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupsTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupsTest.java
@@ -1,4 +1,4 @@
-package org.jabref.logic.exporter;
+package org.jabref.logic.cleanup;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -6,8 +6,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.cleanup.FieldFormatterCleanup;
-import org.jabref.logic.cleanup.FieldFormatterCleanups;
 import org.jabref.logic.formatter.IdentityFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeAmpersandsFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeDollarSignFormatter;
@@ -17,6 +15,7 @@ import org.jabref.logic.formatter.bibtexfields.NormalizeDateFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import org.jabref.logic.formatter.casechanger.LowerCaseFormatter;
+import org.jabref.logic.layout.format.ReplaceUnicodeLigaturesFormatter;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
@@ -308,5 +307,30 @@ public class FieldFormatterCleanupsTest {
                         new FieldFormatterCleanup(StandardField.BOOKTITLE, new LatexCleanupFormatter())
                 ),
                 fieldFormatterCleanups);
+    }
+
+    @Test
+    void getMetaDataStringWorks() {
+        assertEquals("""
+                pages[normalize_page_numbers]
+                date[normalize_date]
+                month[normalize_month]
+                all-text-fields[replace_unicode_ligatures]
+                """, FieldFormatterCleanups.getMetaDataString(FieldFormatterCleanups.DEFAULT_SAVE_ACTIONS, "\n"));
+    }
+
+    @Test
+    void parsingOfDefaultSaveActions() {
+        assertEquals(FieldFormatterCleanups.DEFAULT_SAVE_ACTIONS, FieldFormatterCleanups.parse("""
+                pages[normalize_page_numbers]
+                date[normalize_date]
+                month[normalize_month]
+                all-text-fields[replace_unicode_ligatures]
+                """));
+    }
+
+    @Test
+    void formatterFromString() {
+        assertEquals(new ReplaceUnicodeLigaturesFormatter(), FieldFormatterCleanups.getFormatterFromString("replace_unicode_ligatures"));
     }
 }


### PR DESCRIPTION
This fixes https://github.com/JabRef/jabref/issues/9881.

While playing around, we had two major issues:

1. The order of the save actions was not retained. They were sorted alphabetically by field. I think, as user, I want to have some logical order of the fields (and not JabRef reordering my things)
2. The `remove_unicode_formatter` was not parsed. Never. Therefore, I took the liberty and adapted the name to the name of the class - and enabled its parsing.

As a result, no save actions are written if they are the default.

More info: The list of save actions was compared as list for checking if they are the default. Since that list was not ordered by field name (in #9126), it was always different.

```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
