### PR TITLE
Enable MethodParamPad

### DIFF
--- a/rewrite.yml
+++ b/rewrite.yml
@@ -122,7 +122,7 @@ recipeList:
 #  - org.openrewrite.java.cleanup.IndexOfShouldNotCompareGreaterThanZero
 #  - org.openrewrite.java.cleanup.InstanceOfPatternMatch
 #  - org.openrewrite.java.cleanup.IsEmptyCallOnCollections
-#  - org.openrewrite.java.cleanup.MethodParamPad
+  - org.openrewrite.java.cleanup.MethodParamPad
 #  - org.openrewrite.java.cleanup.MissingOverrideAnnotation
 #  - org.openrewrite.java.cleanup.ModifierOrder
   - org.openrewrite.java.cleanup.MultipleVariableDeclarations

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -364,7 +364,7 @@ public class JabRefDialogService implements DialogService {
                                               .text(
                                                     "(" + Localization.lang("Check the event log to see all notifications") + ")"
                                                      + "\n\n" + message)
-                                              .onAction(e-> {
+                                              .onAction(e -> {
                                                      ErrorConsoleAction ec = new ErrorConsoleAction();
                                                      ec.execute();
                                                  }))

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -62,7 +62,7 @@ public class StateManager {
     private final OptionalObjectProperty<SearchQuery> activeSearchQuery = OptionalObjectProperty.empty();
     private final ObservableMap<BibDatabaseContext, IntegerProperty> searchResultMap = FXCollections.observableHashMap();
     private final OptionalObjectProperty<Node> focusOwner = OptionalObjectProperty.empty();
-    private final ObservableList<Pair<BackgroundTask<?>, Task<?>>> backgroundTasks = FXCollections.observableArrayList(task -> new Observable[] {task.getValue().progressProperty(), task.getValue().runningProperty()});
+    private final ObservableList<Pair<BackgroundTask<?>, Task<?>>> backgroundTasks = FXCollections.observableArrayList(task -> new Observable[]{task.getValue().progressProperty(), task.getValue().runningProperty()});
     private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.map(Pair::getValue).anyMatch(Task::isRunning));
     private final EasyBinding<Boolean> anyTasksThatWillNotBeRecoveredRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.anyMatch(task -> !task.getKey().willBeRecoveredAutomatically() && task.getValue().isRunning()));
     private final EasyBinding<Double> tasksProgress = EasyBind.reduce(backgroundTasks, tasks -> tasks.map(Pair::getValue).filter(Task::isRunning).mapToDouble(Task::getProgress).average().orElse(1));

--- a/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
+++ b/src/main/java/org/jabref/gui/duplicationFinder/DuplicateResolverDialog.java
@@ -106,7 +106,7 @@ public class DuplicateResolverDialog extends BaseDialog<DuplicateResolverResult>
             // Read more: https://stackoverflow.com/questions/45866249/javafx-8-alert-different-button-sizes
             getDialogPane().getButtonTypes().stream()
                            .map(getDialogPane()::lookupButton)
-                           .forEach(btn-> ButtonBar.setButtonUniformSize(btn, false));
+                           .forEach(btn -> ButtonBar.setButtonUniformSize(btn, false));
         }
 
         // Retrieves the previous window state and sets the new dialog window size and position to match it

--- a/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
+++ b/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
@@ -66,7 +66,7 @@ public class AutomaticFieldEditorDialog extends BaseDialog<String> {
         // Read more: https://stackoverflow.com/questions/45866249/javafx-8-alert-different-button-sizes
         getDialogPane().getButtonTypes().stream()
             .map(getDialogPane()::lookupButton)
-            .forEach(btn-> ButtonBar.setButtonUniformSize(btn, false));
+            .forEach(btn -> ButtonBar.setButtonUniformSize(btn, false));
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/importer/ImportAction.java
+++ b/src/main/java/org/jabref/gui/importer/ImportAction.java
@@ -94,7 +94,7 @@ public class ImportAction {
                 frame.addTab(parserResult.getDatabaseContext(), true);
                 dialogService.notify(Localization.lang("Imported entries") + ": " + parserResult.getDatabase().getEntries().size());
             })
-           .onFailure(ex-> {
+           .onFailure(ex -> {
                LOGGER.error("Error importing", ex);
                dialogService.notify(Localization.lang("Error importing. See the error log for details."));
            })

--- a/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTabViewModel.java
@@ -45,7 +45,7 @@ public class CustomEntryTypesTabViewModel implements PreferenceTabViewModel {
     private final ObjectProperty<EntryTypeViewModel> selectedEntryType = new SimpleObjectProperty<>();
     private final StringProperty entryTypeToAdd = new SimpleStringProperty("");
     private final ObjectProperty<Field> newFieldToAdd = new SimpleObjectProperty<>();
-    private final ObservableList<EntryTypeViewModel> entryTypesWithFields = FXCollections.observableArrayList(extractor -> new Observable[] {extractor.entryType(), extractor.fields()});
+    private final ObservableList<EntryTypeViewModel> entryTypesWithFields = FXCollections.observableArrayList(extractor -> new Observable[]{extractor.entryType(), extractor.fields()});
     private final List<BibEntryType> entryTypesToDelete = new ArrayList<>();
 
     private final PreferencesService preferencesService;

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -123,7 +123,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
 
         BackgroundTask.wrap(CitationStyle::discoverCitationStyles)
                       .onSuccess(styles -> styles.stream()
-                                                 .map(style-> new CitationStylePreviewLayout(style, Globals.entryTypesManager))
+                                                 .map(style -> new CitationStylePreviewLayout(style, Globals.entryTypesManager))
                                                  .filter(style -> chosenListProperty.getValue().filtered(item ->
                                                          item.getName().equals(style.getName())).isEmpty())
                                                  .sorted(Comparator.comparing(PreviewLayout::getName))

--- a/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
@@ -37,7 +37,7 @@ public class CustomImporter extends Importer {
 
     private static Importer load(URL basePathURL, String className)
             throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
-        try (URLClassLoader cl = new URLClassLoader(new URL[] {basePathURL})) {
+        try (URLClassLoader cl = new URLClassLoader(new URL[]{basePathURL})) {
             Class<?> clazz = Class.forName(className, true, cl);
             return (Importer) clazz.newInstance();
         }

--- a/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSProcessor.java
@@ -191,7 +191,7 @@ public abstract class DBMSProcessor {
         }
 
         try (PreparedStatement preparedEntryStatement = connection.prepareStatement(insertIntoEntryQuery.toString(),
-                new String[] {"SHARED_ID"})) {
+                new String[]{"SHARED_ID"})) {
             for (int i = 0; i < bibEntries.size(); i++) {
                 preparedEntryStatement.setString(i + 1, bibEntries.get(i).getType().getName());
             }

--- a/src/main/java/org/jabref/logic/shared/OracleProcessor.java
+++ b/src/main/java/org/jabref/logic/shared/OracleProcessor.java
@@ -144,7 +144,7 @@ public class OracleProcessor extends DBMSProcessor {
                                 ") VALUES(?)";
 
                 try (PreparedStatement preparedEntryStatement = connection.prepareStatement(insertIntoEntryQuery,
-                        new String[] {"SHARED_ID"})) {
+                        new String[]{"SHARED_ID"})) {
 
                     preparedEntryStatement.setString(1, entry.getType().getName());
                     preparedEntryStatement.executeUpdate();

--- a/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -37,10 +37,10 @@ public class FileFieldWriterTest {
 
     private static Stream<Arguments> getEncodingTestData() {
         return Stream.of(
-                Arguments.of("a:b;c:d", new String[][] {{"a", "b"}, {"c", "d"}}),
-                Arguments.of("a:;c:d", new String[][] {{"a", ""}, {"c", "d"}}),
-                Arguments.of("a:" + null + ";c:d", new String[][] {{"a", null}, {"c", "d"}}),
-                Arguments.of("a:\\:b;c\\;:d", new String[][] {{"a", ":b"}, {"c;", "d"}})
+                Arguments.of("a:b;c:d", new String[][]{{"a", "b"}, {"c", "d"}}),
+                Arguments.of("a:;c:d", new String[][]{{"a", ""}, {"c", "d"}}),
+                Arguments.of("a:" + null + ";c:d", new String[][]{{"a", null}, {"c", "d"}}),
+                Arguments.of("a:\\:b;c\\;:d", new String[][]{{"a", ":b"}, {"c;", "d"}})
         );
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/EbookDeIsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/EbookDeIsbnFetcherTest.java
@@ -84,6 +84,6 @@ public class EbookDeIsbnFetcherTest extends AbstractIsbnFetcherTest {
      */
     @Test
     public void searchForValidButNotFoundISBN() throws Exception {
-        assertThrows(FetcherClientException.class, ()-> fetcher.performSearchById("3728128155"));
+        assertThrows(FetcherClientException.class, () -> fetcher.performSearchById("3728128155"));
     }
 }

--- a/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
@@ -274,14 +274,14 @@ class OOBibStyleTest {
         assertEquals("Boström et al. [2006]",
                 getCitationMarker2(style,
                         Collections.singletonList(entry), entryDBMap,
-                        false, null, new Boolean[] {false}, null));
+                        false, null, new Boolean[]{false}, null));
 
         assertEquals("[Boström, Wäyrynen, Bodén, Beznosov & Kruchten, 2006]",
                 getCitationMarker2(style,
                         Collections.singletonList(entry), entryDBMap,
                         true,
                         null,
-                        new Boolean[] {true},
+                        new Boolean[]{true},
                         null));
     }
 
@@ -487,8 +487,8 @@ class OOBibStyleTest {
                 getCitationMarker2b(style, entries, entryDBMap, true, null, null, null));
         assertEquals("[Beta, 2000a,b; Epsilon, 2001]",
                 getCitationMarker2(style, entries, entryDBMap, true,
-                        new String[] {"a", "b", ""},
-                        new Boolean[] {false, false, false},
+                        new String[]{"a", "b", ""},
+                        new Boolean[]{false, false, false},
                         null));
     }
 
@@ -529,8 +529,8 @@ class OOBibStyleTest {
                 getCitationMarker2b(style, entries, entryDBMap, false, null, null, null));
         assertEquals("Beta [2000a,b]; Epsilon [2001]",
                 getCitationMarker2(style, entries, entryDBMap, false,
-                        new String[] {"a", "b", ""},
-                        new Boolean[] {false, false, false},
+                        new String[]{"a", "b", ""},
+                        new Boolean[]{false, false, false},
                         null));
     }
 
@@ -570,8 +570,8 @@ class OOBibStyleTest {
 
         assertEquals("[Beta, 2000a,b,c]",
                 getCitationMarker2(style, entries, entryDBMap, true,
-                        new String[] {"a", "b", "c"},
-                        new Boolean[] {false, false, false},
+                        new String[]{"a", "b", "c"},
+                        new Boolean[]{false, false, false},
                         null));
     }
 
@@ -611,8 +611,8 @@ class OOBibStyleTest {
 
         assertEquals("Beta [2000a,b,c]",
                 getCitationMarker2(style, entries, entryDBMap, false,
-                        new String[] {"a", "b", "c"},
-                        new Boolean[] {false, false, false},
+                        new String[]{"a", "b", "c"},
+                        new Boolean[]{false, false, false},
                         null));
     }
 


### PR DESCRIPTION
This enables https://docs.openrewrite.org/recipes/java/cleanup/methodparampad.

- Good: ` -> ` always there
- Bad: `new Array[]` is also treated as function, thus no space between `[]` and `{`

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
