### PR TITLE
Fix respecting overWriteOwner preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was thrown for the user after <kbd>Ctrl</kbd>+<kbd>Z</kbd> command [#9737](https://github.com/JabRef/jabref/issues/9737)
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
-- We fixed an issue when overwriting the owner was disabled. [#9894](https://github.com/JabRef/jabref/issues/9894)
+- We fixed an issue when overwriting the owner was disabled. [#9896](https://github.com/JabRef/jabref/pull/9896)
 - We fixed an issue regarding recording redundant prefixes in search history. [#9685](https://github.com/JabRef/jabref/issues/9685)
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where an exception was thrown for the user after <kbd>Ctrl</kbd>+<kbd>Z</kbd> command [#9737](https://github.com/JabRef/jabref/issues/9737)
 - We fixed the citation key generation for (`[authors]`, `[authshort]`, `[authorsAlpha]`, `authIniN`, `authEtAl`, `auth.etal`)[https://docs.jabref.org/setup/citationkeypatterns#special-field-markers] to handle `and others` properly. [koppor#626](https://github.com/koppor/jabref/issues/626)
 - We fixed the Save/save as file type shows BIBTEX_DB instead of "Bibtex library" [#9372](https://github.com/JabRef/jabref/issues/9372)
+- We fixed an issue when overwriting the owner was disabled. [#9894](https://github.com/JabRef/jabref/issues/9894)
 - We fixed an issue regarding recording redundant prefixes in search history. [#9685](https://github.com/JabRef/jabref/issues/9685)
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -469,13 +469,9 @@ public class LibraryTab extends Tab {
             bibDatabaseContext.getDatabase().insertEntries(entries);
 
             // Set owner and timestamp
-            for (BibEntry entry : entries) {
-                UpdateField.setAutomaticFields(entry,
-                        true,
-                        true,
-                        preferencesService.getOwnerPreferences(),
-                        preferencesService.getTimestampPreferences());
-            }
+            UpdateField.setAutomaticFields(entries,
+                    preferencesService.getOwnerPreferences(),
+                    preferencesService.getTimestampPreferences());
             // Create an UndoableInsertEntries object.
             getUndoManager().addEdit(new UndoableInsertEntries(bibDatabaseContext.getDatabase(), entries));
 

--- a/src/main/java/org/jabref/logic/util/UpdateField.java
+++ b/src/main/java/org/jabref/logic/util/UpdateField.java
@@ -17,10 +17,6 @@ public class UpdateField {
 
     /**
      * Updating a field will result in the entry being reformatted on save
-     *
-     * @param be       BibEntry
-     * @param field    Field name
-     * @param newValue New field value
      */
     public static Optional<FieldChange> updateField(BibEntry be, Field field, String newValue) {
         return updateField(be, field, newValue, false);
@@ -28,10 +24,6 @@ public class UpdateField {
 
     /**
      * Updating a non-displayable field does not result in the entry being reformatted on save
-     *
-     * @param be       BibEntry
-     * @param field    Field name
-     * @param newValue New field value
      */
     public static Optional<FieldChange> updateNonDisplayableField(BibEntry be, Field field, String newValue) {
         boolean changed = be.hasChanged();
@@ -43,9 +35,6 @@ public class UpdateField {
     /**
      * Undoable change of field value
      *
-     * @param be                        BibEntry
-     * @param field                     Field name
-     * @param newValue                  New field value
      * @param nullFieldIfValueIsTheSame If true the field value is removed when the current value is equals to newValue
      */
     public static Optional<FieldChange> updateField(BibEntry be, Field field, String newValue,
@@ -80,24 +69,6 @@ public class UpdateField {
         return Optional.of(new FieldChange(be, field, oldValue, writtenValue));
     }
 
-    /**
-     * Sets empty or non-existing owner fields of a bibtex entry to a specified default value. Timestamp field is also
-     * set. Preferences are checked to see if these options are enabled.
-     *
-     * @param entry              The entry to set fields for.
-     * @param overwriteOwner     Indicates whether owner should be set if it is already set.
-     * @param overwriteTimestamp Indicates whether timestamp should be set if it is already set.
-     */
-    public static void setAutomaticFields(BibEntry entry, boolean overwriteOwner, boolean overwriteTimestamp,
-                                          OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences) {
-        String defaultOwner = ownerPreferences.getDefaultOwner();
-        String timestamp = timestampPreferences.now();
-        boolean setOwner = ownerPreferences.isUseOwner() && (overwriteOwner || (!entry.hasField(StandardField.OWNER)));
-        boolean setTimeStamp = timestampPreferences.shouldAddCreationDate();
-
-        setAutomaticFields(entry, setOwner, defaultOwner, setTimeStamp, timestamp);
-    }
-
     private static void setAutomaticFields(BibEntry entry, boolean setOwner, String owner, boolean setTimeStamp, String timeStamp) {
         // Set owner field if this option is enabled:
         if (setOwner) {
@@ -113,12 +84,8 @@ public class UpdateField {
     /**
      * Sets empty or non-existing owner fields of bibtex entries inside a List to a specified default value. Timestamp
      * field is also set. Preferences are checked to see if these options are enabled.
-     *
-     * @param bibs List of bibtex entries
      */
-    public static void setAutomaticFields(Collection<BibEntry> bibs, boolean overwriteOwner,
-                                          OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences) {
-
+    public static void setAutomaticFields(Collection<BibEntry> entries, OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences) {
         boolean globalSetOwner = ownerPreferences.isUseOwner();
         boolean setTimeStamp = timestampPreferences.shouldAddCreationDate();
 
@@ -129,19 +96,11 @@ public class UpdateField {
 
         String defaultOwner = ownerPreferences.getDefaultOwner();
         String timestamp = timestampPreferences.now();
+        boolean overwriteOwner = ownerPreferences.isOverwriteOwner();
 
-        // Iterate through all entries
-        for (BibEntry curEntry : bibs) {
+        for (BibEntry curEntry : entries) {
             boolean setOwner = globalSetOwner && (overwriteOwner || (!curEntry.hasField(StandardField.OWNER)));
             setAutomaticFields(curEntry, setOwner, defaultOwner, setTimeStamp, timestamp);
         }
-    }
-
-    public static void setAutomaticFields(Collection<BibEntry> bibs,
-                                          OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences) {
-        UpdateField.setAutomaticFields(bibs,
-                ownerPreferences.isOverwriteOwner(),
-                ownerPreferences,
-                timestampPreferences);
     }
 }

--- a/src/main/java/org/jabref/logic/util/UpdateField.java
+++ b/src/main/java/org/jabref/logic/util/UpdateField.java
@@ -95,8 +95,8 @@ public class UpdateField {
         }
 
         String defaultOwner = ownerPreferences.getDefaultOwner();
-        String timestamp = timestampPreferences.now();
         boolean overwriteOwner = ownerPreferences.isOverwriteOwner();
+        String timestamp = timestampPreferences.now();
 
         for (BibEntry curEntry : entries) {
             boolean setOwner = globalSetOwner && (overwriteOwner || (!curEntry.hasField(StandardField.OWNER)));

--- a/src/test/java/org/jabref/logic/util/UpdateFieldTest.java
+++ b/src/test/java/org/jabref/logic/util/UpdateFieldTest.java
@@ -2,6 +2,7 @@ package org.jabref.logic.util;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.jabref.logic.preferences.OwnerPreferences;
@@ -179,7 +180,7 @@ public class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(entry, false, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
 
         assertEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER), "No owner exists");
     }
@@ -188,7 +189,7 @@ public class UpdateFieldTest {
     public void ownerAssignedCorrectlyAfterAutomaticSet() {
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(entry, false, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
 
         assertEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER));
     }
@@ -202,19 +203,19 @@ public class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, false);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(entry, false, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
 
         assertNotEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER), "Owner has changed");
         assertEquals(Optional.of(alreadySetOwner), entry.getField(StandardField.OWNER), "Owner has not changed");
     }
 
     @Test
-    public void emptyCreationdateFieldNowPresentAfterAutomaticSet() {
+    public void emptyCreationDateFieldNowPresentAfterAutomaticSet() {
         assertEquals(Optional.empty(), entry.getField(StandardField.CREATIONDATE), "CreationDate is present");
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(entry, false, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
 
         String creationDate = timestampPreferences.now();
 
@@ -222,10 +223,10 @@ public class UpdateFieldTest {
     }
 
     @Test
-    public void creationdateAssignedCorrectlyAfterAutomaticSet() {
+    public void creationDateAssignedCorrectlyAfterAutomaticSet() {
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(entry, false, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
 
         String creationDate = timestampPreferences.now();
 
@@ -245,7 +246,7 @@ public class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(bibs, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences);
 
         String defaultOwner = "testDefaultOwner";
 
@@ -269,7 +270,7 @@ public class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, false);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(bibs, false, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences);
 
         assertEquals(Optional.of(initialOwner), entry.getField(StandardField.OWNER), "entry has new value for owner field");
         assertEquals(Optional.of(initialOwner), entry2.getField(StandardField.OWNER), "entry2 has new value for owner field");


### PR DESCRIPTION
I removed some Booleans from the code. I think, the "overWriteOwner" preference is now working. Before, it was always overwritten.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
