### PR TITLE
Support for $\backslash$ in file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We enabled scrolling in the groups list when dragging a group on another group. [#2869](https://github.com/JabRef/jabref/pull/2869)
 - We added the option to automatically download online files when a new entry is created from an existing ID (e.g. DOI). The option can be disabled in the preferences under "Import and Export" [#9756](https://github.com/JabRef/jabref/issues/9756)
 - We added a new Integrity check for unscaped ampersands. [koppor#585](https://github.com/koppor/jabref/issues/585)
+- We added support for parsing `$\backslash$` in file paths (as exported by Mendeley). [forum#3470](https://discourse.jabref.org/t/mendeley-bib-import-with-linked-files/3470)
 - We added the possibility to automatically fetch entries when an IBSN is pasted on the main table [#9864](https://github.com/JabRef/jabref/issues/9864)
 
 ### Changed

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -18,10 +18,15 @@ public class FileFieldParser {
     private final String value;
 
     private StringBuilder charactersOfCurrentElement;
+
     private boolean windowsPath;
 
     public FileFieldParser(String value) {
-        this.value = value;
+        if (value == null) {
+            this.value = null;
+        } else {
+            this.value = value.replace("$\\backslash$", "\\");
+        }
     }
 
     /**

--- a/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
@@ -57,6 +57,12 @@ class FileFieldParserTest {
                         "Desc:File.PDF:PDF"
                 ),
 
+                // Mendeley input
+                Arguments.of(
+                        Collections.singletonList(new LinkedFile("", Path.of("C:/Users/XXXXXX/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Brown - 2017 - Physical test methods for elastomers.pdf"), "pdf")),
+                        ":C$\\backslash$:/Users/XXXXXX/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Brown - 2017 - Physical test methods for elastomers.pdf:pdf"
+                ),
+
                 // parseCorrectOnlineInput
                 Arguments.of(
                         Collections.singletonList(new LinkedFile(new URL("http://arxiv.org/pdf/2010.08497v1"), "PDF")),


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/mendeley-bib-import-with-linked-files/3470. Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/178.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
