### PR TITLE
Modernize tests at BibtexParserTest

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -91,7 +91,7 @@ public class BibtexParser implements Parser {
      * <p>
      * It is undetermined which entry is returned, so use this in case you know there is only one entry in the string.
      *
-     * @return An Optional&lt;BibEntry>. Optional.empty() if non was found or an error occurred.
+     * @return An <code>Optional<BibEntry></code>. <code>Optional.empty()</code> if non was found or an error occurred.
      */
     public static Optional<BibEntry> singleFromString(String bibtexString, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) throws ParseException {
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences, fileMonitor).parseEntries(bibtexString);

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -91,7 +91,7 @@ public class BibtexParser implements Parser {
      * <p>
      * It is undetermined which entry is returned, so use this in case you know there is only one entry in the string.
      *
-     * @return An <code>Optional<BibEntry></code>. <code>Optional.empty()</code> if non was found or an error occurred.
+     * @return An {code Optional<BibEntry>. Optional.empty()} if non was found or an error occurred.
      */
     public static Optional<BibEntry> singleFromString(String bibtexString, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) throws ParseException {
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences, fileMonitor).parseEntries(bibtexString);

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -91,7 +91,7 @@ public class BibtexParser implements Parser {
      * <p>
      * It is undetermined which entry is returned, so use this in case you know there is only one entry in the string.
      *
-     * @return An {code Optional<BibEntry>. Optional.empty()} if non was found or an error occurred.
+     * @return An {@code Optional<BibEntry>. Optional.empty()} if non was found or an error occurred.
      */
     public static Optional<BibEntry> singleFromString(String bibtexString, ImportFormatPreferences importFormatPreferences, FileUpdateMonitor fileMonitor) throws ParseException {
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences, fileMonitor).parseEntries(bibtexString);

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexImporterTest.java
@@ -36,7 +36,8 @@ import static org.mockito.Mockito.mock;
 /**
  * This class tests the BibtexImporter.
  * <p>
- * The tests for writing can be found at {@link org.jabref.logic.exporter.BibtexDatabaseWriterTest}
+ * Tests for writing can be found at {@link org.jabref.logic.exporter.BibtexDatabaseWriterTest}.
+ * Tests for parsing single entry BibTeX can be found at {@link BibtexParserTest}
  */
 public class BibtexImporterTest {
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -66,12 +66,16 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests for reading whole bib files can be found at {@link org.jabref.logic.importer.fileformat.BibtexImporterTest}
+ * <p>
+ * Tests cannot be executed concurrently, because Localization is used at {@link BibtexParser#parseAndAddEntry(String)}
+ */
 class BibtexParserTest {
 
     private ImportFormatPreferences importFormatPreferences;
@@ -88,28 +92,22 @@ class BibtexParserTest {
     @Test
     void parseWithNullThrowsNullPointerException() throws Exception {
         Executable toBeTested = () -> parser.parse(null);
-
         assertThrows(NullPointerException.class, toBeTested);
     }
 
     @Test
     void fromStringRecognizesEntry() throws ParseException {
-        List<BibEntry> parsed = parser
+        List<BibEntry> result = parser
                 .parseEntries("@article{test,author={Ed von Test}}");
-
-        BibEntry expected = new BibEntry();
-        expected.setType(StandardEntryType.Article);
-        expected.setCitationKey("test");
-        expected.setField(StandardField.AUTHOR, "Ed von Test");
-
-        assertEquals(List.of(expected), parsed);
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result);
     }
 
     @Test
     void fromStringReturnsEmptyListFromEmptyString() throws ParseException {
         Collection<BibEntry> parsed = parser.parseEntries("");
-
-        assertNotNull(parsed);
         assertEquals(Collections.emptyList(), parsed);
     }
 
@@ -117,8 +115,6 @@ class BibtexParserTest {
     void fromStringReturnsEmptyListIfNoEntryRecognized() throws ParseException {
         Collection<BibEntry> parsed = parser
                 .parseEntries("@@article@@{{{{{{}");
-
-        assertNotNull(parsed);
         assertEquals(Collections.emptyList(), parsed);
     }
 
@@ -130,12 +126,10 @@ class BibtexParserTest {
                           title = {Title A}}
                         """,
                 importFormatPreferences, fileMonitor);
-
         BibEntry expected = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("canh05")
                 .withField(StandardField.AUTHOR, "Crowston, K. and Annabi, H.")
                 .withField(StandardField.TITLE, "Title A");
-
         assertEquals(Optional.of(expected), parsed);
     }
 
@@ -146,7 +140,6 @@ class BibtexParserTest {
                             title = {Title A}}
                         @inProceedings{foo,  author={Norton Bar}}""",
                 importFormatPreferences, fileMonitor);
-
         assertTrue(parsed.get().getCitationKey().equals(Optional.of("canh05"))
                 || parsed.get().getCitationKey().equals(Optional.of("foo")));
     }
@@ -154,14 +147,12 @@ class BibtexParserTest {
     @Test
     void singleFromStringReturnsEmptyFromEmptyString() throws ParseException {
         Optional<BibEntry> parsed = BibtexParser.singleFromString("", importFormatPreferences, fileMonitor);
-
         assertEquals(Optional.empty(), parsed);
     }
 
     @Test
     void singleFromStringReturnsEmptyIfNoEntryRecognized() throws ParseException {
         Optional<BibEntry> parsed = BibtexParser.singleFromString("@@article@@{{{{{{}", importFormatPreferences, fileMonitor);
-
         assertEquals(Optional.empty(), parsed);
     }
 
@@ -169,132 +160,89 @@ class BibtexParserTest {
     void parseRecognizesEntry() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,author={Ed von Test}}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
-    void parseQuotedEntries() throws IOException {
+    void parseRecognizesFieldValuesInQuotationMarks() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,author=\"Ed von Test\"}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryOnlyWithKey() throws IOException {
         ParserResult result = parser.parse(new StringReader("@article{test}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
-    void parseRecognizesEntryWithWhitespaceAtBegining() throws IOException {
+    void parseRecognizesEntryWithWhitespaceAtBeginning() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader(" @article{test,author={Ed von Test}}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withUserComments(" ")
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWithWhitespace() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article { test,author={Ed von Test}}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWithNewlines() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article\n{\ntest,author={Ed von Test}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWithUnknownType() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@unknown{test,author={Ed von Test}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(new UnknownEntryType("unknown"), entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(new UnknownEntryType("unknown"))
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWithVeryLongType() throws IOException {
         ParserResult result = parser.parse(
                 new StringReader("@thisIsALongStringToTestMaybeItIsToLongWhoKnowsNOTme{test,author={Ed von Test}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(new UnknownEntryType("thisisalongstringtotestmaybeitistolongwhoknowsnotme"), entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(new UnknownEntryType("thisisalongstringtotestmaybeitistolongwhoknowsnotme"))
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryInParenthesis() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article(test,author={Ed von Test})"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
@@ -304,57 +252,42 @@ class BibtexParserTest {
                 isbn2 = {1234567890123456789},
                 small = 1234,
                 }"""));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("canh05"), entry.getCitationKey());
-        assertEquals(Optional.of("1234567890123456789"), entry.getField(StandardField.ISBN));
-        assertEquals(Optional.of("1234567890123456789"), entry.getField(new UnknownField("isbn2")));
-        assertEquals(Optional.of("1234"), entry.getField(new UnknownField("small")));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("canh05")
+                .withField(StandardField.ISBN, "1234567890123456789")
+                .withField(new UnknownField("isbn2"), "1234567890123456789")
+                .withField(new UnknownField("small"), "1234");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesCitationKeyWithSpecialCharacters() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{te_st:with-special(characters),author={Ed von Test}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("te_st:with-special(characters)"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("te_st:with-special(characters)")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWhereLastFieldIsFinishedWithComma() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,author={Ed von Test},}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesEntryWithAtInField() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,author={Ed von T@st}}"));
-
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-
-        BibEntry expected = new BibEntry(StandardEntryType.Article).withField(InternalField.KEY_FIELD, "test")
-                                                                   .withField(StandardField.AUTHOR, "Ed von T@st");
-
-        assertEquals(List.of(expected), parsed);
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withField(InternalField.KEY_FIELD, "test")
+                .withField(StandardField.AUTHOR, "Ed von T@st");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
@@ -376,28 +309,20 @@ class BibtexParserTest {
 
     @Test
     void parseRecognizesMultipleEntries() throws IOException {
-        List<BibEntry> expected = new ArrayList<>();
-        BibEntry firstEntry = new BibEntry();
-        firstEntry.setType(StandardEntryType.Article);
-        firstEntry.setCitationKey("canh05");
-        firstEntry.setField(StandardField.AUTHOR, "Crowston, K. and Annabi, H.");
-        firstEntry.setField(StandardField.TITLE, "Title A");
-        expected.add(firstEntry);
-
-        BibEntry secondEntry = new BibEntry();
-        secondEntry.setType(StandardEntryType.InProceedings);
-        secondEntry.setCitationKey("foo");
-        secondEntry.setField(StandardField.AUTHOR, "Norton Bar");
-        expected.add(secondEntry);
-
         ParserResult result = parser.parse(
                 new StringReader("""
                         @article{canh05,  author = {Crowston, K. and Annabi, H.},
                           title = {Title A}}
                         @inProceedings{foo,  author={Norton Bar}}"""));
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-
-        assertEquals(expected, parsed);
+        List<BibEntry> expected = List.of(
+                new BibEntry(StandardEntryType.Article)
+                        .withCitationKey("canh05")
+                        .withField(StandardField.AUTHOR, "Crowston, K. and Annabi, H.")
+                        .withField(StandardField.TITLE, "Title A"),
+                new BibEntry(StandardEntryType.InProceedings)
+                        .withCitationKey("foo")
+                        .withField(StandardField.AUTHOR, "Norton Bar"));
+        assertEquals(expected, result.getDatabase().getEntries());
     }
 
     @Test
@@ -405,82 +330,52 @@ class BibtexParserTest {
         String firstEntry = "@article{canh05," + "  author = {Crowston, K. and Annabi, H.}," + OS.NEWLINE
                 + "  title = {Title A}}" + OS.NEWLINE;
         String secondEntry = "@inProceedings{foo," + "  author={Norton Bar}}";
-
-        ParserResult result = parser
-                .parse(new StringReader(firstEntry + secondEntry));
-
-        for (BibEntry entry : result.getDatabase().getEntries()) {
-            if (entry.getCitationKey().equals(Optional.of("canh05"))) {
-                assertEquals(firstEntry, entry.getParsedSerialization());
-            } else {
-                assertEquals(secondEntry, entry.getParsedSerialization());
-            }
-        }
+        List<BibEntry> parsedEntries = parser.parse(new StringReader(firstEntry + secondEntry))
+                                             .getDatabase().getEntries();
+        assertEquals(firstEntry, parsedEntries.get(0).getParsedSerialization());
+        assertEquals(secondEntry, parsedEntries.get(1).getParsedSerialization());
     }
 
     @Test
     void parseRecognizesMultipleEntriesOnSameLine() throws IOException {
-        List<BibEntry> expected = new ArrayList<>();
-        BibEntry firstEntry = new BibEntry();
-        firstEntry.setType(StandardEntryType.Article);
-        firstEntry.setCitationKey("canh05");
-        expected.add(firstEntry);
-
-        BibEntry secondEntry = new BibEntry();
-        secondEntry.setType(StandardEntryType.InProceedings);
-        secondEntry.setCitationKey("foo");
-        expected.add(secondEntry);
-
         ParserResult result = parser
                 .parse(new StringReader("@article{canh05}" + "@inProceedings{foo}"));
-        List<BibEntry> parsed = result.getDatabase().getEntries();
-
-        assertEquals(expected, parsed);
+        List<BibEntry> expected = List.of(
+                new BibEntry(StandardEntryType.Article)
+                        .withCitationKey("canh05"),
+                new BibEntry(StandardEntryType.InProceedings)
+                        .withCitationKey("foo"));
+        assertEquals(expected, result.getDatabase().getEntries());
     }
 
     @Test
     void parseCombinesMultipleAuthorFields() throws IOException {
         ParserResult result = parser.parse(
                 new StringReader("@article{test,author={Ed von Test},author={Second Author},author={Third Author}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test and Second Author and Third Author"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test and Second Author and Third Author");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseCombinesMultipleEditorFields() throws IOException {
         ParserResult result = parser.parse(
                 new StringReader("@article{test,editor={Ed von Test},editor={Second Author},editor={Third Author}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test and Second Author and Third Author"), entry.getField(StandardField.EDITOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.EDITOR, "Ed von Test and Second Author and Third Author");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseCombinesMultipleKeywordsFields() throws IOException {
         ParserResult result = parser.parse(
                 new StringReader("@article{test,Keywords={Test},Keywords={Second Keyword},Keywords={Third Keyword}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Test, Second Keyword, Third Keyword"), entry.getField(StandardField.KEYWORDS));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.KEYWORDS, "Test, Second Keyword, Third Keyword");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
@@ -551,77 +446,46 @@ class BibtexParserTest {
     }
 
     @Test
-    void parseRecognizesFieldValuesInQuotationMarks() throws IOException {
-        ParserResult result = parser
-                .parse(new StringReader("@article{test,author=\"Ed von Test\"}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
-    }
-
-    @Test
     void parseRecognizesNumbersWithoutBracketsOrQuotationMarks() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,year = 2005}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("2005"), entry.getField(StandardField.YEAR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.YEAR, "2005");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesUppercaseFields() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,AUTHOR={Ed von Test}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("Ed von Test"), entry.getField(StandardField.AUTHOR));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesAbsoluteFile() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,file = {D:\\Documents\\literature\\Tansel-PRL2006.pdf}}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("D:\\Documents\\literature\\Tansel-PRL2006.pdf"), entry.getField(StandardField.FILE));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.FILE, "D:\\Documents\\literature\\Tansel-PRL2006.pdf");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseRecognizesFinalSlashAsSlash() throws Exception {
         ParserResult result = parser
                 .parse(new StringReader("""
-        @misc{,
-          test = {wired\\},
-        }
-        """));
-
+                        @misc{,
+                          test = {wired\\},
+                        }
+                        """));
         assertEquals(
                 List.of(new BibEntry()
-                .withField(new UnknownField("test"), "wired\\")),
+                        .withField(new UnknownField("test"), "wired\\")),
                 result.getDatabase().getEntries()
         );
     }
@@ -640,15 +504,10 @@ class BibtexParserTest {
     void parseRecognizesDateFieldWithConcatenation() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,date = {1-4~} # nov}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-        BibEntry entry = parsed.iterator().next();
-
-        assertEquals(1, parsed.size());
-        assertEquals(StandardEntryType.Article, entry.getType());
-        assertEquals(Optional.of("test"), entry.getCitationKey());
-        assertEquals(2, entry.getFields().size());
-        assertEquals(Optional.of("1-4~#nov#"), entry.getField(StandardField.DATE));
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.DATE, "1-4~#nov#");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
@@ -676,35 +535,25 @@ class BibtexParserTest {
                         This was created with JabRef 2.1 beta 2.
                         Encoding: Cp1252
                         """));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-
-        assertEquals(0, parsed.size());
+        assertEquals(List.of(), result.getDatabase().getEntries());
     }
 
     @Test
     void parseNotWarnsAboutEntryWithoutCitationKey() throws IOException {
-        BibEntry expected = new BibEntry();
-        expected.setField(StandardField.AUTHOR, "Ed von Test");
-        expected.setType(StandardEntryType.Article);
-
         ParserResult result = parser
                 .parse(new StringReader("@article{,author={Ed von Test}}"));
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-
         assertFalse(result.hasWarnings());
-        assertEquals(List.of(expected), parsed);
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Ed von Test");
+        assertEquals(List.of(expected), result.getDatabase().getEntries());
     }
 
     @Test
     void parseIgnoresAndWarnsAboutEntryWithUnmatchedOpenBracket() throws IOException {
         ParserResult result = parser
                 .parse(new StringReader("@article{test,author={author missing bracket}"));
-
-        Collection<BibEntry> parsed = result.getDatabase().getEntries();
-
-        assertEquals(0, parsed.size());
         assertTrue(result.hasWarnings());
+        assertEquals(List.of(), result.getDatabase().getEntries());
     }
 
     @Test
@@ -1479,9 +1328,9 @@ class BibtexParserTest {
         Optional<SaveOrder> saveOrderConfig = result.getMetaData().getSaveOrderConfig();
 
         assertEquals(new SaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(
-                new SaveOrder.SortCriterion(StandardField.AUTHOR, false),
-                new SaveOrder.SortCriterion(StandardField.YEAR, true),
-                new SaveOrder.SortCriterion(StandardField.ABSTRACT, false))),
+                        new SaveOrder.SortCriterion(StandardField.AUTHOR, false),
+                        new SaveOrder.SortCriterion(StandardField.YEAR, true),
+                        new SaveOrder.SortCriterion(StandardField.ABSTRACT, false))),
                 saveOrderConfig.get());
     }
 
@@ -1540,20 +1389,20 @@ class BibtexParserTest {
     @Test
     void integrationTestTexGroup() throws Exception {
         ParserResult result = parser.parse(new StringReader(
-             "@comment{jabref-meta: grouping:" + OS.NEWLINE
-                     + "0 AllEntriesGroup:;" + OS.NEWLINE
-                     + "1 TexGroup:cited entries\\;0\\;paper.aux\\;1\\;0x8a8a8aff\\;\\;\\;;"
-                     + "}" + OS.NEWLINE
-           + "@Comment{jabref-meta: databaseType:biblatex;}" + OS.NEWLINE
-           + "@Comment{jabref-meta: fileDirectory:src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
-           + "@Comment{jabref-meta: fileDirectory-"
-                     + System.getProperty("user.name") + "-"
-                     + InetAddress.getLocalHost().getHostName()
-                     + ":src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
-           + "@Comment{jabref-meta: fileDirectoryLatex-"
-                     + System.getProperty("user.name") + "-"
-                     + InetAddress.getLocalHost().getHostName()
-                     + ":src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
+                "@comment{jabref-meta: grouping:" + OS.NEWLINE
+                        + "0 AllEntriesGroup:;" + OS.NEWLINE
+                        + "1 TexGroup:cited entries\\;0\\;paper.aux\\;1\\;0x8a8a8aff\\;\\;\\;;"
+                        + "}" + OS.NEWLINE
+                        + "@Comment{jabref-meta: databaseType:biblatex;}" + OS.NEWLINE
+                        + "@Comment{jabref-meta: fileDirectory:src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
+                        + "@Comment{jabref-meta: fileDirectory-"
+                        + System.getProperty("user.name") + "-"
+                        + InetAddress.getLocalHost().getHostName()
+                        + ":src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
+                        + "@Comment{jabref-meta: fileDirectoryLatex-"
+                        + System.getProperty("user.name") + "-"
+                        + InetAddress.getLocalHost().getHostName()
+                        + ":src/test/resources/org/jabref/model/groups;}" + OS.NEWLINE
         ));
 
         GroupTreeNode root = result.getMetaData().getGroups().get();
@@ -1649,7 +1498,7 @@ class BibtexParserTest {
         ParserResult result = parser.parse(
                 new StringReader("@comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}"
                         + "@comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
-                         + "@comment{jabref-meta: fileDirectoryLatex-defaultOwner-user:D:\\\\Latex;}"));
+                        + "@comment{jabref-meta: fileDirectoryLatex-defaultOwner-user:D:\\\\Latex;}"));
 
         assertEquals("\\Literature\\", result.getMetaData().getDefaultFileDirectory().get());
         assertEquals("D:\\Documents", result.getMetaData().getUserFileDirectory("defaultOwner-user").get());
@@ -1878,6 +1727,13 @@ class BibtexParserTest {
 
     @Test
     void parseYearWithMonthString() throws Exception {
+        Optional<BibEntry> result = parser.parseSingleEntry("@ARTICLE{HipKro03, year = {2003}, month = feb }");
+
+        assertEquals(new Date(2003, 2), result.get().getPublicationDate().get());
+    }
+
+    @Test
+    void parseYearWithIllFormattedMonthString() throws Exception {
         Optional<BibEntry> result = parser.parseSingleEntry("@ARTICLE{HipKro03, year = {2003}, month = #FEB# }");
 
         assertEquals(new Date(2003, 2), result.get().getPublicationDate().get());
@@ -1979,12 +1835,12 @@ class BibtexParserTest {
     @Test
     void parseDuplicateKeywordsWithOnlyOneEntry() throws ParseException {
         Optional<BibEntry> result = parser.parseSingleEntry("@Article{,\n"
-            + "Keywords={asdf,asdf,asdf},\n"
-            + "}\n"
-            + "");
+                + "Keywords={asdf,asdf,asdf},\n"
+                + "}\n"
+                + "");
 
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
-            .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
+                .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
 
         assertEquals(Optional.of(expectedEntry), result);
     }
@@ -1992,21 +1848,21 @@ class BibtexParserTest {
     @Test
     void parseDuplicateKeywordsWithTwoEntries() throws Exception {
         BibEntry expectedEntryFirst = new BibEntry(StandardEntryType.Article)
-            .withField(StandardField.KEYWORDS, "bbb")
-            .withCitationKey("Test2017");
+                .withField(StandardField.KEYWORDS, "bbb")
+                .withCitationKey("Test2017");
 
         BibEntry expectedEntrySecond = new BibEntry(StandardEntryType.Article)
-            .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
+                .withField(StandardField.KEYWORDS, "asdf,asdf,asdf");
 
         String entries = """
-            @Article{Test2017,
-              keywords = {bbb},
-            }
+                @Article{Test2017,
+                  keywords = {bbb},
+                }
 
-            @Article{,
-              keywords = {asdf,asdf,asdf},
-            },
-            """;
+                @Article{,
+                  keywords = {asdf,asdf,asdf},
+                },
+                """;
         ParserResult result = parser.parse(new StringReader(entries));
         assertEquals(List.of(expectedEntryFirst, expectedEntrySecond), result.getDatabase().getEntries());
     }


### PR DESCRIPTION
This streamlines tests in BibtexParserTest.

I did not touch all, but I think, even this is an improvement.

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
