### PR TITLE
Fix empty fields being added to the entry table preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 - We fixed some minor visual inconsistencies and issues in the preferences dialog. [#9866](https://github.com/JabRef/jabref/pull/9866)
 - The order of save actions is now retained. [#9890](https://github.com/JabRef/jabref/pull/9890)
+- We fixed custom columns being added to entry table prefs, while field text is empty [#9913](https://github.com/JabRef/jabref/issues/9913)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 - We fixed some minor visual inconsistencies and issues in the preferences dialog. [#9866](https://github.com/JabRef/jabref/pull/9866)
 - The order of save actions is now retained. [#9890](https://github.com/JabRef/jabref/pull/9890)
-- We fixed custom columns being added to entry table prefs, while field text is empty [#9913](https://github.com/JabRef/jabref/issues/9913)
+- We fixed an issue in the preferences where custom columns could be added to the entry table with no qualifier. [#9913](https://github.com/JabRef/jabref/issues/9913)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/table/TableTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/table/TableTabViewModel.java
@@ -193,7 +193,8 @@ public class TableTabViewModel implements PreferenceTabViewModel {
     }
 
     public void insertColumnInList() {
-        if (addColumnProperty.getValue() == null) {
+        if (addColumnProperty.getValue() == null ||
+            addColumnProperty.getValue().getQualifier().isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Fixes #9913 

In the `Entry Table` - tab in **Preferences**, you can add custom columns by specifying a name in the combobox below the grid. If you type in something into the textfield and delete it, you can still add a custom column entry into the list, despite the textfield being empty.
We add one more check for the actual textual content to avoid this bug.


```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
