### PR TITLE
Add fill in of selectedApplicationProperty when opening the editDialog of external application preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where passing a URL containing a DOI led to a "No entry found" notification. [#9821](https://github.com/JabRef/jabref/issues/9821)
 - We fixed some minor visual inconsistencies and issues in the preferences dialog. [#9866](https://github.com/JabRef/jabref/pull/9866)
 - The order of save actions is now retained. [#9890](https://github.com/JabRef/jabref/pull/9890)
+- In the 'External file types' tab, under 'Preferences', if you have an application selected in an entry and decide to edit said entry, the application-path now properly shows in the edit dialog [#9895](https://github.com/JabRef/jabref/issues/9895)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/EditExternalFileTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/EditExternalFileTypeViewModel.java
@@ -27,6 +27,7 @@ public class EditExternalFileTypeViewModel {
             defaultApplicationSelectedProperty.setValue(true);
         } else {
             customApplicationSelectedProperty.setValue(true);
+            selectedApplicationProperty.setValue(fileTypeViewModel.applicationProperty().getValue());
         }
     }
 


### PR DESCRIPTION
Fixes #9895

In **Preferences**, in the **External file types** tab, if an application is set for an entry and you try to edit said entry, the application path doesn't fill in into the selected-application field of the dialog window. This change fixes that by setting that value from the 'external file types' viewmodel.


```[tasklist]
### Compulsory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
