### PR TITLE
Add test cases in testCheckLegalKey 

### DIFF
--- a/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
+++ b/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
@@ -208,6 +208,10 @@ public class UnicodeToReadableCharMap extends HashMap<String, String> {
         put("\u01EB", "o");
         put("\u1E0C", "D");
         put("\u1E0D", "d");
+        put("\u1E1A", "E"); // "~" subscript
+        put("\u1E1B", "e");
+        put("\u1E2C", "I");
+        put("\u1E2D", "i");
         put("\u1E24", "H");
         put("\u1E25", "h");
         put("\u1E36", "L");
@@ -226,6 +230,8 @@ public class UnicodeToReadableCharMap extends HashMap<String, String> {
         put("\u1E63", "s");
         put("\u1E6C", "T");
         put("\u1E6D", "t");
+        put("\u1E74", "U");
+        put("\u1E75", "u");
         put("\u1EA2", "A"); // hook
         put("\u1EA3", "a");
         put("\u1EBA", "E");

--- a/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
+++ b/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
@@ -245,7 +245,6 @@ public class UnicodeToReadableCharMap extends HashMap<String, String> {
         put("\u1EF6", "Y");
         put("\u1EF7", "y");
 
-
         put("\u00CF", "I");
 
         put("\u008C", "AE"); // doesn't work?

--- a/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
+++ b/src/main/java/org/jabref/model/strings/UnicodeToReadableCharMap.java
@@ -226,6 +226,20 @@ public class UnicodeToReadableCharMap extends HashMap<String, String> {
         put("\u1E63", "s");
         put("\u1E6C", "T");
         put("\u1E6D", "t");
+        put("\u1EA2", "A"); // hook
+        put("\u1EA3", "a");
+        put("\u1EBA", "E");
+        put("\u1EBB", "e");
+        put("\u1EC8", "I");
+        put("\u1EC9", "i");
+        put("\u1ECE", "O");
+        put("\u1ECF", "o");
+        put("\u1EE6", "U");
+        put("\u1EE7", "u");
+        put("\u1EF6", "Y");
+        put("\u1EF7", "y");
+
+
         put("\u00CF", "I");
 
         put("\u008C", "AE"); // doesn't work?

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -257,6 +257,7 @@ class CitationKeyGeneratorTest {
             " Ǎ ǎ Č č Ď ď Ě ě Ǐ ǐ Ľ ľ Ň ň Ǒ ǒ Ř ř Š š Ť ť Ǔ ǔ Ž ž   ", "AaCcDdEeIiLlNnOoRrSsTtUuZz",
             "Ā ā Ē ē Ī ī Ō ō Ū ū Ȳ ȳ", "AaEeIiOoUuYy",
             "Ă ă Ĕ ĕ Ğ ğ Ĭ ĭ Ŏ ŏ Ŭ ŭ   ", "AaEeGgIiOoUu",
+            "Ả ả Ẻ ẻ Ỉ ỉ Ỏ ỏ Ủ ủ Ỷ ỷ", "AaEeIiOoUuYy"
             "Ċ ċ Ė ė Ġ ġ İ ı Ż ż   Ą ą Ę ę Į į Ǫ ǫ Ų ų   ", "CcEeGgIiZzAaEeIiOoUu",
             "Ḍ ḍ Ḥ ḥ Ḷ ḷ Ḹ ḹ Ṃ ṃ Ṇ ṇ Ṛ ṛ Ṝ ṝ Ṣ ṣ Ṭ ṭ   ", "DdHhLlLlMmNnRrRrSsTt"
             """

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -244,7 +244,7 @@ class CitationKeyGeneratorTest {
     @CsvSource(quoteCharacter = '"', textBlock = """
             "ÀàÈèÌìÒòÙù Â â Ĉ ĉ Ê ê Ĝ ĝ Ĥ ĥ Î î Ĵ ĵ Ô ô Ŝ ŝ Û û Ŵ ŵ Ŷ ŷ", "AaEeIiOoUuAaCcEeGgHhIiJjOoSsUuWwYy",
             "ÄäËëÏïÖöÜüŸÿ", "AeaeEeIiOeoeUeueYy",
-            "ÅåŮů", "AaaaUu"
+            "ÅåŮů", "AaaaUu",
             "Ç ç Ģ ģ Ķ ķ Ļ ļ Ņ ņ Ŗ ŗ Ş ş Ţ ţ", "CcGgKkLlNnRrSsTt",
             "Ă ă Ĕ ĕ Ğ ğ Ĭ ĭ Ŏ ŏ Ŭ ŭ", "AaEeGgIiOoUu",
             "Ċ ċ Ė ė Ġ ġ İ ı Ż ż", "CcEeGgIiZz",

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -257,7 +257,8 @@ class CitationKeyGeneratorTest {
             " Ǎ ǎ Č č Ď ď Ě ě Ǐ ǐ Ľ ľ Ň ň Ǒ ǒ Ř ř Š š Ť ť Ǔ ǔ Ž ž   ", "AaCcDdEeIiLlNnOoRrSsTtUuZz",
             "Ā ā Ē ē Ī ī Ō ō Ū ū Ȳ ȳ", "AaEeIiOoUuYy",
             "Ă ă Ĕ ĕ Ğ ğ Ĭ ĭ Ŏ ŏ Ŭ ŭ   ", "AaEeGgIiOoUu",
-            "Ả ả Ẻ ẻ Ỉ ỉ Ỏ ỏ Ủ ủ Ỷ ỷ", "AaEeIiOoUuYy"
+            "Ả ả Ẻ ẻ Ỉ ỉ Ỏ ỏ Ủ ủ Ỷ ỷ", "AaEeIiOoUuYy",
+            "Ḛ ḛ Ḭ ḭ Ṵ ṵ", "EeIiUu",
             "Ċ ċ Ė ė Ġ ġ İ ı Ż ż   Ą ą Ę ę Į į Ǫ ǫ Ų ų   ", "CcEeGgIiZzAaEeIiOoUu",
             "Ḍ ḍ Ḥ ḥ Ḷ ḷ Ḹ ḹ Ṃ ṃ Ṇ ṇ Ṛ ṛ Ṝ ṝ Ṣ ṣ Ṭ ṭ   ", "DdHhLlLlMmNnRrRrSsTt"
             """

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -244,6 +244,7 @@ class CitationKeyGeneratorTest {
     @CsvSource(quoteCharacter = '"', textBlock = """
             "ÀàÈèÌìÒòÙù Â â Ĉ ĉ Ê ê Ĝ ĝ Ĥ ĥ Î î Ĵ ĵ Ô ô Ŝ ŝ Û û Ŵ ŵ Ŷ ŷ", "AaEeIiOoUuAaCcEeGgHhIiJjOoSsUuWwYy",
             "ÄäËëÏïÖöÜüŸÿ", "AeaeEeIiOeoeUeueYy",
+            "ÅåŮů", "AaaaUu"
             "Ç ç Ģ ģ Ķ ķ Ļ ļ Ņ ņ Ŗ ŗ Ş ş Ţ ţ", "CcGgKkLlNnRrSsTt",
             "Ă ă Ĕ ĕ Ğ ğ Ĭ ĭ Ŏ ŏ Ŭ ŭ", "AaEeGgIiOoUu",
             "Ċ ċ Ė ė Ġ ġ İ ı Ż ż", "CcEeGgIiZz",


### PR DESCRIPTION
Add three test cases for method testCheckLegalKey in org.jabref.logic.citationkeypattern.CitationKeyGeneratorTest.java
Related to the edge cases in #9799 disscussion
Two of the tests fail because they are edge cases. 
<img width="329" alt="Screen Shot 2023-05-21 at 6 59 04 PM" src="https://github.com/JabRef/jabref/assets/91009762/504ce56e-94c2-4639-bed8-da0fd5214897">
<img width="410" alt="Screen Shot 2023-05-21 at 6 58 47 PM" src="https://github.com/JabRef/jabref/assets/91009762/2189097b-807a-46ed-8a0e-50c9aef8c3cc">


To solve this, we need to put more characters in UnicodeToReadableCharMap 



<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
