### PR TITLE
CLI: Make help output consistent: import and export formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue in the preferences 'External file types' tab ignoring a custom application path in the edit dialog. [#9895](https://github.com/JabRef/jabref/issues/9895)
 - We fixed an issue in the preferences where custom columns could be added to the entry table with no qualifier. [#9913](https://github.com/JabRef/jabref/issues/9913)
 - We fixed an issue where the encoding header in a bib file was not respected when the file contained a BOM (Byte Order Mark). [#9926](https://github.com/JabRef/jabref/issues/9926)
+- We fixed the issue where cli output import and export format inconsistent. [koppor#429](https://github.com/koppor/jabref/issues/429)
 
 ### Removed
 

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -7,8 +7,8 @@ import org.jabref.logic.exporter.Exporter;
 import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.importer.ImportFormatReader;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.model.strings.StringUtil;
+import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
 import org.apache.commons.cli.CommandLine;
@@ -305,11 +305,7 @@ public class JabRefCLI {
                 Globals.entryTypesManager,
                 Globals.journalAbbreviationRepository);
         String outFormatsIntro = Localization.lang("Available export formats");
-
-        // issue 429: change the output format into "display name : id" pairs and start from new line
         String outFormats = getExportFormatList(exporterFactory.getExporters());
-
-//        String outFormatsList = String.format("%s: %s%n", outFormatsIntro, outFormats);
         String outFormatsList = String.format("%s:%n%s%n", outFormatsIntro, outFormats);
 
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -8,6 +8,7 @@ import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.importer.ImportFormatReader;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.util.DummyFileUpdateMonitor;
+import org.jabref.model.strings.StringUtil;
 import org.jabref.preferences.PreferencesService;
 
 import org.apache.commons.cli.CommandLine;
@@ -304,8 +305,12 @@ public class JabRefCLI {
                 Globals.entryTypesManager,
                 Globals.journalAbbreviationRepository);
         String outFormatsIntro = Localization.lang("Available export formats");
-        String outFormats = wrapStringList(exporterFactory.getExporters().stream().map(Exporter::getId).toList(), outFormatsIntro.length());
-        String outFormatsList = String.format("%s: %s%n", outFormatsIntro, outFormats);
+
+        // issue 429: change the output format into "display name : id" pairs and start from new line
+        String outFormats = getExportFormatList(exporterFactory.getExporters());
+
+//        String outFormatsList = String.format("%s: %s%n", outFormatsIntro, outFormats);
+        String outFormatsList = String.format("%s:%n%s%n", outFormatsIntro, outFormats);
 
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";
 
@@ -319,6 +324,24 @@ public class JabRefCLI {
 
     public List<String> getLeftOver() {
         return leftOver;
+    }
+
+    protected static String getExportFormatList(List<Exporter> exporters){
+        StringBuilder sb = new StringBuilder();
+
+        for (Exporter exporter : exporters) {
+            int pad = Math.max(0, 14 - exporter.getName().length());
+            sb.append("  ");
+            sb.append(exporter.getName());
+
+            sb.append(StringUtil.repeatSpaces(pad));
+
+            sb.append(" : ");
+            sb.append(exporter.getId());
+            sb.append('\n');
+        }
+
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -162,7 +162,7 @@ public class JabRefCLI {
     public String getWriteMetadatatoPdf() {
         return cl.hasOption("writeMetadatatoPdf") ? cl.getOptionValue("writeMetadatatoPdf") :
                 cl.hasOption("writeXMPtoPdf") ? cl.getOptionValue("writeXMPtoPdf") :
-                cl.hasOption("embeddBibfileInPdf") ? cl.getOptionValue("embeddBibfileInPdf") : null;
+                        cl.hasOption("embeddBibfileInPdf") ? cl.getOptionValue("embeddBibfileInPdf") : null;
     }
 
     private static Options getOptions() {
@@ -326,7 +326,7 @@ public class JabRefCLI {
         return leftOver;
     }
 
-    protected static String getExportFormatList(List<Exporter> exporters){
+    protected static String getExportFormatList(List<Exporter> exporters) {
         StringBuilder sb = new StringBuilder();
 
         for (Exporter exporter : exporters) {

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.preferences.JabRefPreferences;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -3,6 +3,7 @@ package org.jabref.cli;
 import java.util.Collections;
 import java.util.List;
 
+import org.jabref.preferences.JabRefPreferences;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -142,5 +143,11 @@ class JabRefCLITest {
                 oocalc, ods, MSBib, mods, xmp, pdf, bib""";
 
         assertEquals(expected, "Available export formats: " + JabRefCLI.wrapStringList(given, 26));
+    }
+
+    @Test
+    void uniformImportExportFormat(){
+        JabRefPreferences preferences = JabRefPreferences.getInstance();
+        JabRefCLI.printUsage(preferences);
     }
 }

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -146,7 +146,7 @@ class JabRefCLITest {
     }
 
     @Test
-    void uniformImportExportFormat(){
+    void uniformImportExportFormat() {
         JabRefPreferences preferences = JabRefPreferences.getInstance();
         JabRefCLI.printUsage(preferences);
     }

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -3,8 +3,6 @@ package org.jabref.cli;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.preferences.JabRefPreferences;
-
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -146,9 +144,4 @@ class JabRefCLITest {
         assertEquals(expected, "Available export formats: " + JabRefCLI.wrapStringList(given, 26));
     }
 
-    @Test
-    void uniformImportExportFormat() {
-        JabRefPreferences preferences = JabRefPreferences.getInstance();
-        JabRefCLI.printUsage(preferences);
-    }
 }

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -143,5 +143,4 @@ class JabRefCLITest {
 
         assertEquals(expected, "Available export formats: " + JabRefCLI.wrapStringList(given, 26));
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/429

Modify the method printUage() in file: src/main/java/org/jabref/cli/JabRefCLI.java

Make the import and export format of cli output consistent.



<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

```[tasklist]
### Compulsory checks
- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
```
![image](https://github.com/SPI-2023/SPI_2023_jabref/assets/37678524/2ac81864-6f16-4484-b143-8382ffb67c23)
