### PR TITLE
Fixing "working directory" argument of two of the three Linux "open terminal" commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where the encoding header in a bib file was not respected when the file contained a BOM (Byte Order Mark). [#9926](https://github.com/JabRef/jabref/issues/9926)
 - We fixed an issue where cli help output for import and export format was inconsistent. [koppor#429](https://github.com/koppor/jabref/issues/429)
 - We fixed an issue where no preview could be generated for some entry types and led to an exception [#9947](https://github.com/JabRef/jabref/issues/9947)
+- We fixed an issue where the Linux terminal working directory argument was malformed and therefore ignored upon opening a terminal [#9953](https://github.com/JabRef/jabref/issues/9953)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/org/jabref/gui/desktop/os/Linux.java
@@ -142,11 +142,12 @@ public class Linux implements NativeDesktop {
 
                 String[] cmd;
                 if (emulatorName.contains("gnome")) {
-                    cmd = new String[] {"gnome-terminal", "--working-directory=", absolutePath};
+                    cmd = new String[] {"gnome-terminal", "--working-directory", absolutePath};
                 } else if (emulatorName.contains("xfce4")) {
-                    cmd = new String[] {"xfce4-terminal", "--working-directory=", absolutePath};
+                    // xfce4-terminal requires "--working-directory=<directory>" format (one arg)
+                    cmd = new String[] {"xfce4-terminal", "--working-directory=" + absolutePath};
                 } else if (emulatorName.contains("konsole")) {
-                    cmd = new String[] {"konsole", "--workdir=", absolutePath};
+                    cmd = new String[] {"konsole", "--workdir", absolutePath};
                 } else {
                     cmd = new String[] {emulatorName, absolutePath};
                 }


### PR DESCRIPTION
Fixes #9953 

The "working directory" arguments to "gnome-terminal" and "konsole" were incorrect due to slight mis-use of ProcessBuilder, which meant they were badly formed and the terminal loaded in a default directory (most likely the user's home dir).

There are currently no tests at all for any of this functionality at a low-level (i.e., what operating system commands are called and with what args), nor any OS-specific test filtering, etc... probably because it is significant and complex to assert a running terminal's directory, especially from a unit test. Therefore, I have intentionally not attempted to add a test because doing so would require considerable refactoring of existing tests (OpenConsoleActionTest), with not much benefit -- and it still might not be possible to truly prove a terminal opens in a particular directory anyway.

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
