### PR TITLE
fix group parser if group has no name

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -191,11 +191,11 @@ public class GroupsParser {
                 .length()), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
 
         String name = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
-        GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
+        GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(convertTokenToNumber(tok.nextToken()));
         Field field = FieldFactory.parseField(StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
         String expression = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
-        boolean caseSensitive = Integer.parseInt(tok.nextToken()) == 1;
-        boolean regExp = Integer.parseInt(tok.nextToken()) == 1;
+        boolean caseSensitive = convertTokenToNumber(tok.nextToken()) == 1;
+        boolean regExp = convertTokenToNumber(tok.nextToken()) == 1;
         KeywordGroup newGroup;
         if (regExp) {
             newGroup = new RegexKeywordGroup(name, context, field, expression, caseSensitive);
@@ -204,6 +204,14 @@ public class GroupsParser {
         }
         addGroupDetails(tok, newGroup);
         return newGroup;
+    }
+
+    private static int convertTokenToNumber(String token) {
+        try {
+            return Integer.parseInt(token);
+    	} catch (Exception e) {
+    		return -1;
+    	}
     }
 
     private static ExplicitGroup explicitGroupFromString(String input, Character keywordSeparator) throws ParseException {

--- a/src/main/java/org/jabref/logic/util/strings/QuotedStringTokenizer.java
+++ b/src/main/java/org/jabref/logic/util/strings/QuotedStringTokenizer.java
@@ -23,9 +23,9 @@ public class QuotedStringTokenizer {
         quoteChar = quoteCharacter;
         contentLength = this.content.length();
         // skip leading delimiters
-        while (isDelimiter(this.content.charAt(index)) && index < contentLength) {
-            ++index;
-        }
+//        while (isDelimiter(this.content.charAt(index)) && index < contentLength) {
+//            ++index;
+//        }
     }
 
     /**

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -28,8 +28,7 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GroupsParserTest {
     private FileUpdateMonitor fileMonitor;
@@ -62,6 +61,11 @@ class GroupsParserTest {
         AutomaticGroup expected = new AutomaticKeywordGroup("group1", GroupHierarchyType.INDEPENDENT, StandardField.KEYWORDS, ',', ';');
         AbstractGroup parsed = GroupsParser.fromString("AutomaticKeywordGroup:group1;0;keywords;,;\\;;1;;;;;", ';', fileMonitor, metaData);
         assertEquals(expected, parsed);
+    }
+
+    @Test
+    public void testKeywordGroupFromString() {
+        assertDoesNotThrow(()-> GroupsParser.fromString("KeywordGroup:;0;priority;prio1;1;0;1;0x8a8a8aff;\\;\\;;", '\\', null, null));
     }
 
     @Test


### PR DESCRIPTION
Fix #9776 

  fix file: GroupsParser.java
  fix file: QuotedStringTokenizer.java
  add new test: GroupsParserTest.java

<!-- 
Describe the changes you have made here: what:GroupsParser.java
What: Write a function convertTokenToNumber() with the function of Integer.parseInt(), and replace the part with Integer.parseInt() in the keywordGroupFromString() function with this function.
why:Catch exceptions for Integer.parseInt() so that invalid fields don't abort the program even if they occur.
What:QuotedStringTokenizer.java, The annotation constructor skips any leading delimiters in the input string. This means that if the input string starts with one or more delimiters, the tokenizer will consider them as part of the tokenization process.
why:This has two advantages:
1. The tokenizer would generate tokens based on the exact input string, including any leading delimiters
2. It could be useful in cases where leading delimiters are considered significant and should be included in the tokenization process
what:GroupsParserTest.java,KeywordGroup:;0;priority;prio1\;1\;0\;1\;0x8a8a8aff\;\;\;; why,The name is empty, the QuotedStringTokenizer class removes the first empty field when it is initialized, skips the first 0 as the first field, and the priority as the second field. Originally, the second field is 0 and must be Integer, the result priority cannot be converted to an integer. 
Link issues that are fixed, e.g. "Fixes #9776 ".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/JabRef/jabref/issues/9776".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
