### PR TITLE
OpenRewrite: Enable RemoveJavaDocAuthorTag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
     id 'idea'
 
-    id("org.openrewrite.rewrite") version("5.40.4")
+    id("org.openrewrite.rewrite") version("5.40.6")
 }
 
 // Enable following for debugging
@@ -221,8 +221,7 @@ dependencies {
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-xjc', version: '3.0.2'
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.2'
 
-    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:1.19.3"))
-    rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
+    rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:1.19.4"))
 }
 
 clean {
@@ -486,10 +485,7 @@ checkstyle {
 
 rewrite {
     activeRecipe(
-        'org.jabref.config.rewrite.cleanup',
-        'org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass',
-        'org.openrewrite.java.logging.slf4j.ParameterizedLogging',
-        'org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant'
+        'org.jabref.config.rewrite.cleanup'
     )
     exclusion (
         "build.gradle",

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -146,7 +146,7 @@ recipeList:
   - org.openrewrite.java.cleanup.RemoveCallsToObjectFinalize
   - org.openrewrite.java.cleanup.RemoveEmptyJavaDocParameters
   - org.openrewrite.java.cleanup.RemoveExtraSemicolons
-#  - org.openrewrite.java.cleanup.RemoveJavaDocAuthorTag
+  - org.openrewrite.java.cleanup.RemoveJavaDocAuthorTag
   - org.openrewrite.java.cleanup.RemoveRedundantTypeCast
   - org.openrewrite.java.cleanup.RemoveUnneededAssertion
   - org.openrewrite.java.cleanup.RemoveUnneededBlock

--- a/src/main/java/org/jabref/gui/groups/UndoableMoveGroup.java
+++ b/src/main/java/org/jabref/gui/groups/UndoableMoveGroup.java
@@ -7,9 +7,6 @@ import org.jabref.gui.undo.AbstractUndoableJabRefEdit;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.groups.GroupTreeNode;
 
-/**
- * @author jzieren
- */
 class UndoableMoveGroup extends AbstractUndoableJabRefEdit {
 
     private final GroupTreeNodeViewModel root;


### PR DESCRIPTION
This enables [RemoveJavaDocAuthorTag](https://docs.openrewrite.org/recipes/java/cleanup/removejavadocauthortag)

Also updates `org.openrewrite.rewrite` gradle plugin to 5.40.6. Update to 6.0.0 is not possible. I filed an issue at https://github.com/openrewrite/rewrite-gradle-plugin/issues/203.

I also removed all logging recipes, because they were not triggered at all - and 6.0.0 showed some exceptions when they were loaded.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
