### PR TITLE
Fix container for group item count still visible if display count is off 

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -266,7 +266,6 @@ public class GroupTreeView extends BorderPane {
 
     private StackPane createNumberCell(GroupNodeViewModel group) {
         final StackPane node = new StackPane();
-        node.getStyleClass().setAll("hits");
         if (!group.isRoot()) {
             BindingsHelper.includePseudoClassWhen(node, PSEUDOCLASS_ANYSELECTED,
                     group.anySelectedEntriesMatchedProperty());
@@ -281,7 +280,10 @@ public class GroupTreeView extends BorderPane {
                         text.setText("");
                     }
 
+                    node.getStyleClass().clear();
+
                     if (newValue) {
+                        node.getStyleClass().setAll("hits");
                         text.textProperty().bind(group.getHits().map(Number::intValue).map(this::getFormattedNumber));
                     }
                 });

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -274,7 +274,7 @@ public class GroupTreeView extends BorderPane {
         }
         Text text = new Text();
         EasyBind.subscribe(preferencesService.getGroupsPreferences().displayGroupCountProperty(),
-                newValue -> {
+                shouldDisplayGroupCount -> {
                     if (text.textProperty().isBound()) {
                         text.textProperty().unbind();
                         text.setText("");
@@ -282,8 +282,8 @@ public class GroupTreeView extends BorderPane {
 
                     node.getStyleClass().clear();
 
-                    if (newValue) {
-                        node.getStyleClass().setAll("hits");
+                    if (shouldDisplayGroupCount) {
+                        node.getStyleClass().add("hits");
                         text.textProperty().bind(group.getHits().map(Number::intValue).map(this::getFormattedNumber));
                     }
                 });


### PR DESCRIPTION
Fixes #9972

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
I moved the setting of the `'hits'` style (which contains the styling of the grey container) into the update-callback of the `displayGroupCountProperty`. That way, whenever said property is updated, it clears all styling of it (mimicking the clearing of the `setAll()` method, that was used before my change) and adds the `'hits'` style if the setting corresponding to the property was switched to true.


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request. (too small of a feature, not documented)
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository. (too small of a feature, not documented)
