### PR TITLE
Fix paste of BibTeX data

### DIFF
--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -87,10 +87,6 @@ public class ClipBoardManager {
         return result;
     }
 
-    public Optional<String> getBibTeXEntriesFromClipboard() {
-        return Optional.ofNullable(clipboard.getContent(DragAndDropDataFormats.ENTRIES)).map(String.class::cast);
-    }
-
     /**
      * Get the String residing on the primary clipboard (if it exists).
      *
@@ -150,7 +146,9 @@ public class ClipBoardManager {
         final ClipboardContent content = new ClipboardContent();
         BibEntryWriter writer = new BibEntryWriter(new FieldWriter(preferencesService.getFieldPreferences()), Globals.entryTypesManager);
         String serializedEntries = writer.serializeAll(entries, BibDatabaseMode.BIBTEX);
-        content.put(DragAndDropDataFormats.ENTRIES, serializedEntries);
+        // BibEntry is not Java serializable. Thus, we need to do the serialization manually
+        // At reading of the clipboard in JabRef, we parse the plain string in all cases, so we don't need to flag we put BibEntries here
+        // Furthermore, storing a string also enables other applications to work with the data
         content.putString(serializedEntries);
         clipboard.setContent(content);
         setPrimaryClipboardContent(content);

--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -7,7 +7,6 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import javafx.application.Platform;
 import javafx.scene.control.TextInputControl;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -253,9 +253,9 @@ public class JabRefFrame extends BorderPane {
 
                         Dragboard dragboard = tabDragEvent.getDragboard();
 
-                        if (DragAndDropHelper.hasBibFiles(tabDragEvent.getDragboard())) {
+                        if (DragAndDropHelper.hasBibFiles(dragboard)) {
                             tabbedPane.getTabs().remove(dndIndicator);
-                            List<Path> bibFiles = DragAndDropHelper.getBibFiles(tabDragEvent.getDragboard());
+                            List<Path> bibFiles = DragAndDropHelper.getBibFiles(dragboard);
                             OpenDatabaseAction openDatabaseAction = this.getOpenDatabaseAction();
                             openDatabaseAction.openFiles(bibFiles);
                             tabDragEvent.setDropCompleted(true);
@@ -265,8 +265,8 @@ public class JabRefFrame extends BorderPane {
                                 if (libraryTab.getId().equals(destinationTabNode.getId()) &&
                                         !tabbedPane.getSelectionModel().getSelectedItem().equals(libraryTab)) {
                                     LibraryTab destinationLibraryTab = (LibraryTab) libraryTab;
-                                    if (DragAndDropHelper.hasGroups(tabDragEvent.getDragboard())) {
-                                        List<String> groupPathToSources = DragAndDropHelper.getGroups(tabDragEvent.getDragboard());
+                                    if (DragAndDropHelper.hasGroups(dragboard)) {
+                                        List<String> groupPathToSources = DragAndDropHelper.getGroups(dragboard);
 
                                         copyRootNode(destinationLibraryTab);
 

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -3,7 +3,6 @@ package org.jabref.gui.maintable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -267,6 +267,11 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
     }
 
     private void setupKeyBindings(KeyBindingRepository keyBindings) {
+        EditAction pasteAction = new EditAction(StandardActions.PASTE, libraryTab.frame(), stateManager);
+        EditAction copyAction = new EditAction(StandardActions.COPY, libraryTab.frame(), stateManager);
+        EditAction cutAction = new EditAction(StandardActions.CUT, libraryTab.frame(), stateManager);
+        EditAction deleteAction = new EditAction(StandardActions.DELETE_ENTRY, libraryTab.frame(), stateManager);
+
         this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
             if (event.getCode() == KeyCode.ENTER) {
                 getSelectedEntries().stream()
@@ -288,19 +293,19 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         event.consume();
                         break;
                     case PASTE:
-                        new EditAction(StandardActions.PASTE, libraryTab.frame(), stateManager).execute();
+                        pasteAction.execute();
                         event.consume();
                         break;
                     case COPY:
-                        new EditAction(StandardActions.COPY, libraryTab.frame(), stateManager).execute();
+                        copyAction.execute();
                         event.consume();
                         break;
                     case CUT:
-                        new EditAction(StandardActions.CUT, libraryTab.frame(), stateManager).execute();
+                        cutAction.execute();
                         event.consume();
                         break;
                     case DELETE_ENTRY:
-                        new EditAction(StandardActions.DELETE_ENTRY, libraryTab.frame(), stateManager).execute();
+                        deleteAction.execute();
                         event.consume();
                         break;
                     default:
@@ -393,8 +398,8 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
 
         List<BibEntry> entries = getSelectionModel().getSelectedItems().stream().map(BibEntryTableViewModel::getEntry).collect(Collectors.toList());
 
-        // The following is necesary to initiate the drag and drop in javafx, although we don't need the contents
-        // It doesn't work without
+        // The following is necessary to initiate the drag and drop in JavaFX,
+        // although we don't need the contents, it does not work without
         // Drag'n'drop to other tabs use COPY TransferMode, drop to group sidepane use MOVE
         ClipboardContent content = new ClipboardContent();
         Dragboard dragboard = startDragAndDrop(TransferMode.COPY_OR_MOVE);


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/187.

No CHANGELOG.md entry, because it worked in 5.9

In the first commit, I did some code improvements:

- JabRefFrame: Use unusaed variable
- EditAction: Keep order of actions consistent
- MainTable: Prevent unnecessary object construction

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
