### PR TITLE
Changed database to catalog in org.jabref.gui.slr and org.jabref.logic.crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - In case the library contains empty entries, they are not written to disk. [#8645](https://github.com/JabRef/jabref/issues/8645)
 - The formatter `remove_unicode_ligatures` is now called `replace_unicode_ligatures`. [#9890](https://github.com/JabRef/jabref/pull/9890)
 - We improved the error message when no terminal was found [#9607](https://github.com/JabRef/jabref/issues/9607)
+- We changed database to catalog in `org.jabref.gui.slr` and `org.jabref.logic.crawler` [#9951](https://github.com/JabRef/jabref/pull/9951)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - In case the library contains empty entries, they are not written to disk. [#8645](https://github.com/JabRef/jabref/issues/8645)
 - The formatter `remove_unicode_ligatures` is now called `replace_unicode_ligatures`. [#9890](https://github.com/JabRef/jabref/pull/9890)
 - We improved the error message when no terminal was found [#9607](https://github.com/JabRef/jabref/issues/9607)
-- We changed database to catalog in `org.jabref.gui.slr` and `org.jabref.logic.crawler` [#9951](https://github.com/JabRef/jabref/pull/9951)
+- In the context of the "systematic literature functionality", we changed the name "database" to "catalog" to use a separate term for online catalogs in comparison to SQL databases. [#9951](https://github.com/JabRef/jabref/pull/9951)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/slr/ManageStudyDefinition.fxml
+++ b/src/main/java/org/jabref/gui/slr/ManageStudyDefinition.fxml
@@ -217,12 +217,12 @@
                                 <Label text="%Select Databases:"/>
                                 <HBox alignment="CENTER_LEFT">
                                     <TableView
-                                            fx:id="databaseTable"
+                                            fx:id="catalogTable"
                                             HBox.hgrow="ALWAYS"
                                             editable="true">
                                         <columns>
                                             <TableColumn
-                                                    fx:id="databaseEnabledColumn"
+                                                    fx:id="catalogEnabledColumn"
                                                     text="%Enabled"
                                                     maxWidth="80.0"
                                                     prefWidth="80.0"
@@ -230,7 +230,7 @@
                                                     reorderable="false"
                                                     resizable="false"/>
                                             <TableColumn
-                                                    fx:id="databaseColumn"
+                                                    fx:id="catalogColumn"
                                                     text="%Database"/>
                                         </columns>
                                         <columnResizePolicy>

--- a/src/main/java/org/jabref/gui/slr/ManageStudyDefinition.fxml
+++ b/src/main/java/org/jabref/gui/slr/ManageStudyDefinition.fxml
@@ -208,13 +208,13 @@
                             </VBox>
                         </ScrollPane>
                     </Tab>
-                    <Tab text="%Databases">
+                    <Tab text="%Catalogs">
                         <ScrollPane
                                 fitToWidth="true"
                                 fitToHeight="true"
                                 styleClass="slr-tab">
                             <VBox spacing="20.0">
-                                <Label text="%Select Databases:"/>
+                                <Label text="%Select Catalogs:"/>
                                 <HBox alignment="CENTER_LEFT">
                                     <TableView
                                             fx:id="catalogTable"
@@ -231,7 +231,7 @@
                                                     resizable="false"/>
                                             <TableColumn
                                                     fx:id="catalogColumn"
-                                                    text="%Database"/>
+                                                    text="%Catalog"/>
                                         </columns>
                                         <columnResizePolicy>
                                             <TableView

--- a/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionView.java
+++ b/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionView.java
@@ -66,9 +66,9 @@ public class ManageStudyDefinitionView extends BaseDialog<SlrStudyAndDirectory> 
     @FXML private TableColumn<String, String> queriesColumn;
     @FXML private TableColumn<String, String> queriesActionColumn;
 
-    @FXML private TableView<StudyDatabaseItem> databaseTable;
-    @FXML private TableColumn<StudyDatabaseItem, Boolean> databaseEnabledColumn;
-    @FXML private TableColumn<StudyDatabaseItem, String> databaseColumn;
+    @FXML private TableView<StudyCatalogItem> catalogTable;
+    @FXML private TableColumn<StudyCatalogItem, Boolean> catalogEnabledColumn;
+    @FXML private TableColumn<StudyCatalogItem, String> catalogColumn;
 
     @Inject private DialogService dialogService;
     @Inject private PreferencesService prefs;
@@ -132,7 +132,7 @@ public class ManageStudyDefinitionView extends BaseDialog<SlrStudyAndDirectory> 
 
         saveSurveyButton.disableProperty().bind(Bindings.or(Bindings.or(Bindings.or(Bindings.or(
                                 Bindings.isEmpty(viewModel.getQueries()),
-                                Bindings.isEmpty(viewModel.getDatabases())),
+                                Bindings.isEmpty(viewModel.getCatalogs())),
                                 Bindings.isEmpty(viewModel.getAuthors())),
                                 viewModel.getTitle().isEmpty()),
                                 viewModel.getDirectory().isEmpty()));
@@ -166,14 +166,14 @@ public class ManageStudyDefinitionView extends BaseDialog<SlrStudyAndDirectory> 
             selectStudyDirectory.setDisable(true);
         }
 
-        // Listen whether any databases are removed from selection -> Add back to the database selector
+        // Listen whether any catalogs are removed from selection -> Add back to the catalog selector
         studyTitle.textProperty().bindBidirectional(viewModel.titleProperty());
         studyDirectory.textProperty().bindBidirectional(viewModel.getDirectory());
 
         initAuthorTab();
         initQuestionsTab();
         initQueriesTab();
-        initDatabasesTab();
+        initCatalogsTab();
     }
 
     private void initAuthorTab() {
@@ -202,27 +202,27 @@ public class ManageStudyDefinitionView extends BaseDialog<SlrStudyAndDirectory> 
                 .toString()));
     }
 
-    private void initDatabasesTab() {
-        new ViewModelTableRowFactory<StudyDatabaseItem>()
+    private void initCatalogsTab() {
+        new ViewModelTableRowFactory<StudyCatalogItem>()
                 .withOnMouseClickedEvent((entry, event) -> {
                     if (event.getButton() == MouseButton.PRIMARY) {
                         entry.setEnabled(!entry.isEnabled());
                     }
                 })
-                .install(databaseTable);
+                .install(catalogTable);
 
-        databaseColumn.setReorderable(false);
-        databaseColumn.setCellFactory(TextFieldTableCell.forTableColumn());
+        catalogColumn.setReorderable(false);
+        catalogColumn.setCellFactory(TextFieldTableCell.forTableColumn());
 
-        databaseEnabledColumn.setResizable(false);
-        databaseEnabledColumn.setReorderable(false);
-        databaseEnabledColumn.setCellFactory(CheckBoxTableCell.forTableColumn(databaseEnabledColumn));
-        databaseEnabledColumn.setCellValueFactory(param -> param.getValue().enabledProperty());
+        catalogEnabledColumn.setResizable(false);
+        catalogEnabledColumn.setReorderable(false);
+        catalogEnabledColumn.setCellFactory(CheckBoxTableCell.forTableColumn(catalogEnabledColumn));
+        catalogEnabledColumn.setCellValueFactory(param -> param.getValue().enabledProperty());
 
-        databaseColumn.setEditable(false);
-        databaseColumn.setCellValueFactory(param -> param.getValue().nameProperty());
+        catalogColumn.setEditable(false);
+        catalogColumn.setCellValueFactory(param -> param.getValue().nameProperty());
 
-        databaseTable.setItems(viewModel.getDatabases());
+        catalogTable.setItems(viewModel.getCatalogs());
     }
 
     private void setupCommonPropertiesForTables(Node addControl,

--- a/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
+++ b/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
@@ -53,7 +53,7 @@ public class ManageStudyDefinitionViewModel {
     private final ObservableList<String> authors = FXCollections.observableArrayList();
     private final ObservableList<String> researchQuestions = FXCollections.observableArrayList();
     private final ObservableList<String> queries = FXCollections.observableArrayList();
-    private final ObservableList<StudyDatabaseItem> databases = FXCollections.observableArrayList();
+    private final ObservableList<StudyCatalogItem> databases = FXCollections.observableArrayList();
 
     // Hold the complement of databases for the selector
     private final SimpleStringProperty directory = new SimpleStringProperty();
@@ -74,7 +74,7 @@ public class ManageStudyDefinitionViewModel {
                                     .filter(name -> !name.equals(CompositeSearchBasedFetcher.FETCHER_NAME))
                                     .map(name -> {
                                         boolean enabled = DEFAULT_SELECTION.contains(name);
-                                        return new StudyDatabaseItem(name, enabled);
+                                        return new StudyCatalogItem(name, enabled);
                                     })
                                     .toList());
         this.dialogService = Objects.requireNonNull(dialogService);
@@ -105,7 +105,7 @@ public class ManageStudyDefinitionViewModel {
                                     .filter(name -> !name.equals(CompositeSearchBasedFetcher.FETCHER_NAME))
                                     .map(name -> {
                                         boolean enabled = studyDatabases.contains(new StudyDatabase(name, true));
-                                        return new StudyDatabaseItem(name, enabled);
+                                        return new StudyCatalogItem(name, enabled);
                                     })
                                     .toList());
 
@@ -133,7 +133,7 @@ public class ManageStudyDefinitionViewModel {
         return queries;
     }
 
-    public ObservableList<StudyDatabaseItem> getDatabases() {
+    public ObservableList<StudyCatalogItem> getCatalogs() {
         return databases;
     }
 

--- a/src/main/java/org/jabref/gui/slr/StudyCatalogItem.java
+++ b/src/main/java/org/jabref/gui/slr/StudyCatalogItem.java
@@ -12,11 +12,11 @@ import org.jabref.model.study.StudyDatabase;
 /**
  * View representation of {@link StudyDatabase}
  */
-public class StudyDatabaseItem {
+public class StudyCatalogItem {
     private final StringProperty name;
     private final BooleanProperty enabled;
 
-    public StudyDatabaseItem(String name, boolean enabled) {
+    public StudyCatalogItem(String name, boolean enabled) {
         this.name = new SimpleStringProperty(Objects.requireNonNull(name));
         this.enabled = new SimpleBooleanProperty(enabled);
     }
@@ -47,7 +47,7 @@ public class StudyDatabaseItem {
 
     @Override
     public String toString() {
-        return "StudyDatabaseItem{" +
+        return "StudyCatalogItem{" +
                 "name=" + name.get() +
                 ", enabled=" + enabled.get() +
                 '}';
@@ -61,7 +61,7 @@ public class StudyDatabaseItem {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        StudyDatabaseItem that = (StudyDatabaseItem) o;
+        StudyCatalogItem that = (StudyCatalogItem) o;
         return Objects.equals(getName(), that.getName()) && Objects.equals(isEnabled(), that.isEnabled());
     }
 

--- a/src/main/java/org/jabref/logic/crawler/Crawler.java
+++ b/src/main/java/org/jabref/logic/crawler/Crawler.java
@@ -43,12 +43,12 @@ public class Crawler {
                 preferencesService,
                 fileUpdateMonitor,
                 bibEntryTypesManager);
-        StudyDatabaseToFetcherConverter studyDatabaseToFetcherConverter = new StudyDatabaseToFetcherConverter(
+        StudyCatalogToFetcherConverter studyCatalogToFetcherConverter = new StudyCatalogToFetcherConverter(
                 studyRepository.getActiveLibraryEntries(),
                 preferencesService.getImportFormatPreferences(),
                 preferencesService.getImporterPreferences());
         this.studyFetcher = new StudyFetcher(
-                studyDatabaseToFetcherConverter.getActiveFetchers(),
+                studyCatalogToFetcherConverter.getActiveFetchers(),
                 studyRepository.getSearchQueryStrings());
     }
 

--- a/src/main/java/org/jabref/logic/crawler/StudyCatalogToFetcherConverter.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyCatalogToFetcherConverter.java
@@ -14,14 +14,14 @@ import org.jabref.model.study.StudyDatabase;
 /**
  * Converts library entries from the given study into their corresponding fetchers.
  */
-class StudyDatabaseToFetcherConverter {
+class StudyCatalogToFetcherConverter {
     private final List<StudyDatabase> libraryEntries;
     private final ImportFormatPreferences importFormatPreferences;
     private final ImporterPreferences importerPreferences;
 
-    public StudyDatabaseToFetcherConverter(List<StudyDatabase> libraryEntries,
-                                           ImportFormatPreferences importFormatPreferences,
-                                           ImporterPreferences importerPreferences) {
+    public StudyCatalogToFetcherConverter(List<StudyDatabase> libraryEntries,
+                                          ImportFormatPreferences importFormatPreferences,
+                                          ImporterPreferences importerPreferences) {
         this.libraryEntries = libraryEntries;
         this.importFormatPreferences = importFormatPreferences;
         this.importerPreferences = importerPreferences;

--- a/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -48,7 +48,7 @@ class StudyFetcher {
     }
 
     /**
-     * Queries all Catalogs on the given searchQuery.
+     * Queries all catalogs on the given searchQuery.
      *
      * @param searchQuery The query the search is performed for.
      * @return Mapping of each fetcher by name and all their retrieved publications as a BibDatabase

--- a/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyFetcher.java
@@ -48,7 +48,7 @@ class StudyFetcher {
     }
 
     /**
-     * Queries all Databases on the given searchQuery.
+     * Queries all Catalogs on the given searchQuery.
      *
      * @param searchQuery The query the search is performed for.
      * @return Mapping of each fetcher by name and all their retrieved publications as a BibDatabase

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -279,7 +279,7 @@ public class StudyRepository {
      */
     private void setUpRepositoryStructureForQueriesAndFetchers() throws IOException {
         // Cannot use stream here since IOException has to be thrown
-        StudyDatabaseToFetcherConverter converter = new StudyDatabaseToFetcherConverter(
+        StudyCatalogToFetcherConverter converter = new StudyCatalogToFetcherConverter(
                 this.getActiveLibraryEntries(),
                 preferencesService.getImportFormatPreferences(),
                 preferencesService.getImporterPreferences());

--- a/src/main/java/org/jabref/model/study/StudyDatabase.java
+++ b/src/main/java/org/jabref/model/study/StudyDatabase.java
@@ -1,9 +1,7 @@
 package org.jabref.model.study;
 
-import org.jabref.gui.slr.StudyCatalogItem;
-
 /**
- * data model for the view {@link StudyCatalogItem}
+ * data model for the view {@link org.jabref.gui.slr.StudyCatalogItem}
  */
 public class StudyDatabase {
     private String name;

--- a/src/main/java/org/jabref/model/study/StudyDatabase.java
+++ b/src/main/java/org/jabref/model/study/StudyDatabase.java
@@ -1,7 +1,9 @@
 package org.jabref.model.study;
 
+import org.jabref.gui.slr.StudyCatalogItem;
+
 /**
- * data model for the view {@link org.jabref.gui.slr.StudyDatabaseItem}
+ * data model for the view {@link StudyCatalogItem}
  */
 public class StudyDatabase {
     private String name;

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -6,3 +6,4 @@ springerNatureAPIKey=${springerNatureAPIKey}
 astrophysicsDataSystemAPIKey=${astrophysicsDataSystemAPIKey}
 ieeeAPIKey=${ieeeAPIKey}
 biodiversityHeritageApiKey=${biodiversityHeritageApiKey}
+Catalogs=Create property

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -6,4 +6,3 @@ springerNatureAPIKey=${springerNatureAPIKey}
 astrophysicsDataSystemAPIKey=${astrophysicsDataSystemAPIKey}
 ieeeAPIKey=${ieeeAPIKey}
 biodiversityHeritageApiKey=${biodiversityHeritageApiKey}
-Catalogs=Create property

--- a/src/main/resources/l10n/JabRef_ar.properties
+++ b/src/main/resources/l10n/JabRef_ar.properties
@@ -735,4 +735,3 @@ Copy\ or\ move\ the\ content\ of\ one\ field\ to\ another=نسخ أو نقل م�
 
 
 
-

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1063,4 +1063,3 @@ Default\ pattern=Standardmønster
 
 
 
-

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2394,7 +2394,7 @@ Recommended=Empfohlen
 
 Authors\ and\ Title=Autoren und Titel
 Database=Datenbank
-Databases=Datenbanken
+
 Add\ Author\:=Autor hinzufügen\:
 Add\ Query\:=Abfrage hinzufügen\:
 Add\ Research\ Question\:=Forschungsfrage hinzufügen\:
@@ -2405,7 +2405,6 @@ Start\ new\ systematic\ literature\ review=Neue systematische Literaturübersich
 Manage\ study\ definition=Studiendefinition verwalten
 Update\ study\ search\ results=Studiensuchergebnisse aktualisieren
 Study\ repository\ could\ not\ be\ created=Studienrepository konnte nicht angelegt werden
-Select\ Databases\:=Datenbanken auswählen\:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=Alle Suchbegriffe werden mit den logischen Operatoren AND und OR verknüpft
 Finalize=Fertigstellen

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2385,8 +2385,9 @@ Others=Others
 Recommended=Recommended
 
 Authors\ and\ Title=Authors and Title
-Database=Database
-Databases=Databases
+Catalog=Catalog
+Catalogs=Catalogs
+Select\ Catalogs\:=Select Catalogs:
 Add\ Author\:=Add Author\:
 Add\ Query\:=Add Query\:
 Add\ Research\ Question\:=Add Research Question\:
@@ -2397,7 +2398,6 @@ Start\ new\ systematic\ literature\ review=Start new systematic literature revie
 Manage\ study\ definition=Manage study definition
 Update\ study\ search\ results=Update study search results
 Study\ repository\ could\ not\ be\ created=Study repository could not be created
-Select\ Databases\:=Select Databases:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=All query terms are joined using the logical AND, and OR operators
 Finalize=Finalize

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2354,7 +2354,6 @@ Recommended=Recomendado
 
 Authors\ and\ Title=Autoría y título
 Database=Base de datos
-Databases=Bases de datos
 Add\ Author\:=Añadir autor\:
 Add\ Query\:=Añadir consulta\:
 Add\ Research\ Question\:=Añadir pregunta de investigación\:

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1055,7 +1055,7 @@ exportFormat=Format d'exportation
 Output\ file\ missing=Fichier de sortie manquant
 The\ output\ option\ depends\ on\ a\ valid\ input\ option.=L'option de sortie dépend d'une option d'entrée valide.
 Linked\ file\ name\ conventions=Conventions pour les noms de fichiers liés
-Filename\ format\ pattern=Modèle de format de nom de fichier 
+Filename\ format\ pattern=Modèle de format de nom de fichier
 Additional\ parameters=Paramètres additionnels
 Cite\ selected\ entries\ between\ parenthesis=Citer les entrées sélectionnées entre parenthèses
 Cite\ selected\ entries\ with\ in-text\ citation=Citer les entrées sélectionnées comme incluse dans le texte
@@ -2394,7 +2394,6 @@ Recommended=Usuels
 
 Authors\ and\ Title=Auteurs et titre
 Database=Base de données
-Databases=Bases de données
 Add\ Author\:=Ajouter un auteur \:
 Add\ Query\:=Ajouter une requête \:
 Add\ Research\ Question\:=Ajouter une question de recherche \:
@@ -2405,7 +2404,6 @@ Start\ new\ systematic\ literature\ review=Lancer une nouvelle revue systématiq
 Manage\ study\ definition=Gérer la définition de la revue
 Update\ study\ search\ results=Mettre à jour les résultats de recherche de la revue
 Study\ repository\ could\ not\ be\ created=Le dépôt de la revue n'a pas pu être créé
-Select\ Databases\:=Sélectionnez les bases de données \:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=Tous les termes de la requête sont joints en utilisant les opérateurs logiques AND et OR
 Finalize=Finaliser

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2394,7 +2394,6 @@ Recommended=Consigliato
 
 Authors\ and\ Title=Autori e Titolo
 Database=Database
-Databases=Banche dati
 Add\ Author\:=Aggiungi Autore\:
 Add\ Query\:=Aggiungi Query\:
 Add\ Research\ Question\:=Aggiungi Domanda Di Ricerca\:
@@ -2405,7 +2404,6 @@ Start\ new\ systematic\ literature\ review=Inizia una nuova revisione sistematic
 Manage\ study\ definition=Gestisci definizione di studio
 Update\ study\ search\ results=Aggiorna i risultati della ricerca
 Study\ repository\ could\ not\ be\ created=Impossibile creare il repository dello studio
-Select\ Databases\:=Seleziona i Database\:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=Tutti i termini di query sono uniti utilizzando gli operatori logici AND e OR
 Finalize=Concludere

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2350,7 +2350,6 @@ Recommended=推奨
 
 Authors\ and\ Title=著者とタイトル
 Database=データベース
-Databases=データベース
 Add\ Author\:=著者を追加\:
 Add\ Query\:=クエリを追加：
 Add\ Research\ Question\:=研究課題を追加

--- a/src/main/resources/l10n/JabRef_ko.properties
+++ b/src/main/resources/l10n/JabRef_ko.properties
@@ -1849,7 +1849,7 @@ Add\ new\ String=문자열 추가
 Must\ not\ be\ empty\!=비워둘 수 없습니다\!
 Open\ Help\ page=도움말 열기
 Add\ new\ field\ name=새 필드 이름 추가
-Field\ name\:=필드 이름\: 
+Field\ name\:=필드 이름\:
 Field\ name\ "%0"\ already\ exists=필드 이름 "%0"이 이미 존재합니다
 No\ field\ name\ selected\!=필드 이름을 선택하지 않았습니다
 Remove\ field\ name=필드 이름 제거
@@ -2257,7 +2257,6 @@ Recommended=권장
 
 Authors\ and\ Title=작가와 제목
 Database=데이터베이스
-Databases=데이터베이스
 Add\ Author\:=작가 추가\:
 Add\ Query\:=쿼리 추가하기
 Add\ Research\ Question\:=연구 질문 추가\:

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -1177,4 +1177,3 @@ Default\ pattern=Standardmønster
 
 
 
-

--- a/src/main/resources/l10n/JabRef_pl.properties
+++ b/src/main/resources/l10n/JabRef_pl.properties
@@ -1062,4 +1062,3 @@ plain\ text=czysty tekst
 
 
 
-

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2394,7 +2394,6 @@ Recommended=Recomendado
 
 Authors\ and\ Title=Autores e Título
 Database=Banco de dados
-Databases=Bancos de dados
 Add\ Author\:=Adicionar Autor\:
 Add\ Query\:=Adicionar Consulta\:
 Add\ Research\ Question\:=Adicionar Questões de Pesquisa\:
@@ -2405,7 +2404,6 @@ Start\ new\ systematic\ literature\ review=Iniciar nova revisão sistemática da
 Manage\ study\ definition=Gerenciar definição de estudo
 Update\ study\ search\ results=Atualizar resultados da busca de estudo
 Study\ repository\ could\ not\ be\ created=Não foi possível criar o repositório de estudo
-Select\ Databases\:=Selecionar Banco de Dados\:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=Todos os termos de consulta são unidos usando os operadores lógicos AND e OR
 Finalize=Finalizar

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2225,7 +2225,7 @@ This\ entry\ type\ is\ intended\ for\ sources\ such\ as\ web\ sites\ which\ are\
 A\ single-volume\ work\ of\ reference\ such\ as\ an\ encyclopedia\ or\ a\ dictionary.=Неделимая работа или ссылка, как энциклопедия или словарь.
 A\ technical\ report,\ research\ report,\ or\ white\ paper\ published\ by\ a\ university\ or\ some\ other\ institution.=Технический отчет, исследовательский отчет, или белая книга, выпущенная институтом или другим учреждением.
 An\ entry\ set\ is\ a\ group\ of\ entries\ which\ are\ cited\ as\ a\ single\ reference\ and\ listed\ as\ a\ single\ item\ in\ the\ bibliography.=Набор записей представляет собой группу записей, которые приводятся в виде единой ссылки и перечислены в виде одного элемента в библиографии.
-Supplemental\ material\ in\ a\ "Book".\ This\ type\ is\ provided\ for\ elements\ such\ as\ prefaces,\ introductions,\ forewords,\ afterwords,\ etc.\ which\ often\ have\ a\ generic\ title\ only.=Дополнительный материал в "Книге" предназначен для таких элементов, как предисловия, введения, послесловия и т.д. 
+Supplemental\ material\ in\ a\ "Book".\ This\ type\ is\ provided\ for\ elements\ such\ as\ prefaces,\ introductions,\ forewords,\ afterwords,\ etc.\ which\ often\ have\ a\ generic\ title\ only.=Дополнительный материал в "Книге" предназначен для таких элементов, как предисловия, введения, послесловия и т.д.
 Supplemental\ material\ in\ a\ "Collection".=Дополнительные материалы в "Коллекции".
 Supplemental\ material\ in\ a\ "Periodical".\ This\ type\ may\ be\ useful\ when\ referring\ to\ items\ such\ as\ regular\ columns,\ obituaries,\ letters\ to\ the\ editor,\ etc.\ which\ only\ have\ a\ generic\ title.=Дополнительные материалы в "Периодическом издании". Этот тип может быть полезен при обращении к таким элементам, как обычные колонки, некрологи, письма к редактору и т.д., которые имеют только общее название.
 A\ thesis\ written\ for\ an\ educational\ institution\ to\ satisfy\ the\ requirements\ for\ a\ degree.=Тезис, написанный для учебного заведения с целью удовлетворения требований к степени.
@@ -2342,7 +2342,6 @@ Recommended=Рекомендованный
 
 Authors\ and\ Title=Авторы и Заголовок
 Database=База данных
-Databases=Базы данных
 Add\ Author\:=Добавить автора\:
 Add\ Query\:=Добавить запрос\:
 Add\ Research\ Question\:=Добавить вопрос исследования\:

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2386,7 +2386,6 @@ Recommended=Önerilen
 
 Authors\ and\ Title=Yazarlar ve Başlık
 Database=Veri tabanı
-Databases=Veri tabanları
 Add\ Author\:=Yazar Ekle\:
 Add\ Query\:=Sorgu Ekle\:
 Add\ Research\ Question\:=Araştırma Sorusu Ekle\:
@@ -2397,7 +2396,6 @@ Start\ new\ systematic\ literature\ review=Yeni sistematik literatür derlemesin
 Manage\ study\ definition=Çalışma tanımını yönet
 Update\ study\ search\ results=Çalışma arama sonuçlarını güncelle
 Study\ repository\ could\ not\ be\ created=Çalışma veri havuzu oluşturulamadı
-Select\ Databases\:=Veri Tabanlarını Seçin\:
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=Tüm sorgu terimleri mantıksal VE ve VEYA işlemcileriyle birleştirildi
 Finalize=Tamamla

--- a/src/main/resources/l10n/JabRef_zh_CN.properties
+++ b/src/main/resources/l10n/JabRef_zh_CN.properties
@@ -2394,7 +2394,6 @@ Recommended=推荐
 
 Authors\ and\ Title=作者和标题
 Database=数据库
-Databases=数据库
 Add\ Author\:=添加作者：
 Add\ Query\:=添加查询：
 Add\ Research\ Question\:=添加研究问题：
@@ -2405,7 +2404,6 @@ Start\ new\ systematic\ literature\ review=Start new systematic literature revie
 Manage\ study\ definition=Manage study definition
 Update\ study\ search\ results=Update study search results
 Study\ repository\ could\ not\ be\ created=无法创建研究仓库
-Select\ Databases\:=选择数据库：
 
 All\ query\ terms\ are\ joined\ using\ the\ logical\ AND,\ and\ OR\ operators=所有查询条目都使用AND和OR运算符连接
 Finalize=完成

--- a/src/main/resources/l10n/JabRef_zh_TW.properties
+++ b/src/main/resources/l10n/JabRef_zh_TW.properties
@@ -896,8 +896,6 @@ Used\ libraries=使用的函式庫
 
 
 
-
-
 Previous\ page=上一頁
 Next\ page=下一頁
 

--- a/src/test/java/org/jabref/gui/slr/ManageStudyDefinitionViewModelTest.java
+++ b/src/test/java/org/jabref/gui/slr/ManageStudyDefinitionViewModelTest.java
@@ -34,26 +34,26 @@ class ManageStudyDefinitionViewModelTest {
     public void emptyStudyConstructorFillsDatabasesCorrectly() {
         ManageStudyDefinitionViewModel manageStudyDefinitionViewModel = new ManageStudyDefinitionViewModel(importFormatPreferences, importerPreferences, dialogService);
         assertEquals(List.of(
-                new StudyDatabaseItem("ACM Portal", true),
-                new StudyDatabaseItem("ArXiv", false),
-                new StudyDatabaseItem("Bibliotheksverbund Bayern (Experimental)", false),
-                new StudyDatabaseItem("Biodiversity Heritage", false),
-                new StudyDatabaseItem("Collection of Computer Science Bibliographies", false),
-                new StudyDatabaseItem("Crossref", false),
-                new StudyDatabaseItem("DBLP", true),
-                new StudyDatabaseItem("DOAB", false),
-                new StudyDatabaseItem("DOAJ", false),
-                new StudyDatabaseItem("GVK", false),
-                new StudyDatabaseItem("IEEEXplore", true),
-                new StudyDatabaseItem("INSPIRE", false),
-                new StudyDatabaseItem("MathSciNet", false),
-                new StudyDatabaseItem("Medline/PubMed", false),
-                new StudyDatabaseItem("ResearchGate", false),
-                new StudyDatabaseItem("SAO/NASA ADS", false),
-                new StudyDatabaseItem("SemanticScholar", false),
-                new StudyDatabaseItem("Springer", true),
-                new StudyDatabaseItem("zbMATH", false)
-        ), manageStudyDefinitionViewModel.getDatabases());
+                new StudyCatalogItem("ACM Portal", true),
+                new StudyCatalogItem("ArXiv", false),
+                new StudyCatalogItem("Bibliotheksverbund Bayern (Experimental)", false),
+                new StudyCatalogItem("Biodiversity Heritage", false),
+                new StudyCatalogItem("Collection of Computer Science Bibliographies", false),
+                new StudyCatalogItem("Crossref", false),
+                new StudyCatalogItem("DBLP", true),
+                new StudyCatalogItem("DOAB", false),
+                new StudyCatalogItem("DOAJ", false),
+                new StudyCatalogItem("GVK", false),
+                new StudyCatalogItem("IEEEXplore", true),
+                new StudyCatalogItem("INSPIRE", false),
+                new StudyCatalogItem("MathSciNet", false),
+                new StudyCatalogItem("Medline/PubMed", false),
+                new StudyCatalogItem("ResearchGate", false),
+                new StudyCatalogItem("SAO/NASA ADS", false),
+                new StudyCatalogItem("SemanticScholar", false),
+                new StudyCatalogItem("Springer", true),
+                new StudyCatalogItem("zbMATH", false)
+        ), manageStudyDefinitionViewModel.getCatalogs());
     }
 
     @Test
@@ -74,25 +74,25 @@ class ManageStudyDefinitionViewModelTest {
                 importerPreferences,
                 dialogService);
         assertEquals(List.of(
-                new StudyDatabaseItem("ACM Portal", true),
-                new StudyDatabaseItem("ArXiv", false),
-                new StudyDatabaseItem("Bibliotheksverbund Bayern (Experimental)", false),
-                new StudyDatabaseItem("Biodiversity Heritage", false),
-                new StudyDatabaseItem("Collection of Computer Science Bibliographies", false),
-                new StudyDatabaseItem("Crossref", false),
-                new StudyDatabaseItem("DBLP", false),
-                new StudyDatabaseItem("DOAB", false),
-                new StudyDatabaseItem("DOAJ", false),
-                new StudyDatabaseItem("GVK", false),
-                new StudyDatabaseItem("IEEEXplore", false),
-                new StudyDatabaseItem("INSPIRE", false),
-                new StudyDatabaseItem("MathSciNet", false),
-                new StudyDatabaseItem("Medline/PubMed", false),
-                new StudyDatabaseItem("ResearchGate", false),
-                new StudyDatabaseItem("SAO/NASA ADS", false),
-                new StudyDatabaseItem("SemanticScholar", false),
-                new StudyDatabaseItem("Springer", false),
-                new StudyDatabaseItem("zbMATH", false)
-        ), manageStudyDefinitionViewModel.getDatabases());
+                new StudyCatalogItem("ACM Portal", true),
+                new StudyCatalogItem("ArXiv", false),
+                new StudyCatalogItem("Bibliotheksverbund Bayern (Experimental)", false),
+                new StudyCatalogItem("Biodiversity Heritage", false),
+                new StudyCatalogItem("Collection of Computer Science Bibliographies", false),
+                new StudyCatalogItem("Crossref", false),
+                new StudyCatalogItem("DBLP", false),
+                new StudyCatalogItem("DOAB", false),
+                new StudyCatalogItem("DOAJ", false),
+                new StudyCatalogItem("GVK", false),
+                new StudyCatalogItem("IEEEXplore", false),
+                new StudyCatalogItem("INSPIRE", false),
+                new StudyCatalogItem("MathSciNet", false),
+                new StudyCatalogItem("Medline/PubMed", false),
+                new StudyCatalogItem("ResearchGate", false),
+                new StudyCatalogItem("SAO/NASA ADS", false),
+                new StudyCatalogItem("SemanticScholar", false),
+                new StudyCatalogItem("Springer", false),
+                new StudyCatalogItem("zbMATH", false)
+        ), manageStudyDefinitionViewModel.getCatalogs());
     }
 }

--- a/src/test/java/org/jabref/logic/crawler/StudyCatalogToFetcherConverterTest.java
+++ b/src/test/java/org/jabref/logic/crawler/StudyCatalogToFetcherConverterTest.java
@@ -27,7 +27,7 @@ import org.mockito.Answers;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class StudyDatabaseToFetcherConverterTest {
+class StudyCatalogToFetcherConverterTest {
     SaveConfiguration saveConfiguration;
     PreferencesService preferencesService;
     BibEntryTypesManager entryTypesManager;
@@ -59,7 +59,7 @@ class StudyDatabaseToFetcherConverterTest {
                 preferencesService,
                 new DummyFileUpdateMonitor(),
                 entryTypesManager);
-        StudyDatabaseToFetcherConverter converter = new StudyDatabaseToFetcherConverter(
+        StudyCatalogToFetcherConverter converter = new StudyCatalogToFetcherConverter(
                 studyRepository.getActiveLibraryEntries(),
                 mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(ImporterPreferences.class));


### PR DESCRIPTION
In Issue #9951, it was instructed to replace the term "database" with "catalog" in the code files `org.jabref.gui.slr` and `org.jabref.logic.crawler`.

Fixes https://github.com/koppor/jabref/issues/615

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
