### PR TITLE
Remove "Field name:" from localization - we already have "Field name"

### DIFF
--- a/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
@@ -102,7 +102,7 @@ public class ContentSelectorViewModel implements PropertiesTabViewModel {
     }
 
     void showInputFieldNameDialog() {
-        dialogService.showInputDialogAndWait(Localization.lang("Add new field name"), Localization.lang("Field name:"))
+        dialogService.showInputDialogAndWait(Localization.lang("Add new field name"), Localization.lang("Field name") + ":")
                      .map(FieldFactory::parseField)
                      .ifPresent(this::addFieldIfUnique);
     }

--- a/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
@@ -102,7 +102,7 @@ public class ContentSelectorViewModel implements PropertiesTabViewModel {
     }
 
     void showInputFieldNameDialog() {
-        dialogService.showInputDialogAndWait(Localization.lang("Add new field name"), Localization.lang("Field name") + ":")
+        dialogService.showInputDialogAndWait(Localization.lang("Add new field name"), Localization.lang("Field name"))
                      .map(FieldFactory::parseField)
                      .ifPresent(this::addFieldIfUnique);
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -335,12 +335,18 @@ External\ programs=External programs
 Failed\ to\ import\ by\ ID=Failed to import by ID
 
 Field=Field
-
 field=field
 
 Field\ name=Field name
-
+Field\ names=Field names
 Field\ names\ are\ not\ allowed\ to\ contain\ white\ spaces\ or\ certain\ characters\ (%0).=Field names are not allowed to contain white spaces or certain characters (%0).
+New\ field\ name=New field name
+Add\ new\ field\ name=Add new field name
+Field\ name\ \"%0\"\ already\ exists=Field name "%0" already exists
+No\ field\ name\ selected\!=No field name selected!
+Remove\ field\ name=Remove field name
+Are\ you\ sure\ you\ want\ to\ remove\ field\ name\:\ \"%0\"?=Are you sure you want to remove field name: "%0"?
+Manage\ field\ names\ &\ content=Manage field names & content
 
 Field\ to\ group\ by=Field to group by
 
@@ -1955,12 +1961,6 @@ Select\ the\ entries\ to\ be\ imported\:=Select the entries to be imported\:
 Add\ new\ String=Add new String
 Must\ not\ be\ empty\!=Must not be empty\!
 Open\ Help\ page=Open Help page
-Add\ new\ field\ name=Add new field name
-Field\ name\:=Field name:
-Field\ name\ \"%0\"\ already\ exists=Field name "%0" already exists
-No\ field\ name\ selected\!=No field name selected!
-Remove\ field\ name=Remove field name
-Are\ you\ sure\ you\ want\ to\ remove\ field\ name\:\ \"%0\"?=Are you sure you want to remove field name: "%0"?
 Add\ new\ keyword=Add new keyword
 Keyword\:=Keyword:
 Keyword\ \"%0\"\ already\ exists=Keyword "%0" already exists
@@ -1971,7 +1971,6 @@ Reset\ to\ default=Reset to default
 String\ constants=String constants
 Export\ all\ entries=Export all entries
 Generate\ citation\ keys=Generate citation keys
-Manage\ field\ names\ &\ content=Manage field names & content
 New\ library=New library
 OpenOffice/LibreOffice=OpenOffice/LibreOffice
 Open\ document\ viewer=Open document viewer
@@ -2380,7 +2379,6 @@ File\ '%1'\ is\ a\ duplicate\ of\ '%0'.\ Keeping\ both\ due\ to\ deletion\ error
 Enable\ field\ formatters=Enable field formatters
 Entry\ Type=Entry Type
 Entry\ types=Entry types
-Field\ names=Field names
 Others=Others
 Recommended=Recommended
 
@@ -2469,7 +2467,6 @@ Clear\ field\ content=Clear field content
 Set\ or\ append\ content=Set or append content
 Edit\ field\ content\ for\ selected\ entries=Edit field content for selected entries
 Rename=Rename
-New\ field\ name=New field name
 Copy\ content=Copy content
 Move\ content=Move content
 Swap\ content=Swap content

--- a/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
@@ -147,7 +147,7 @@ public class ContentSelectorViewModelTest {
 
     private void addField(Field field) {
         when(dialogService.showInputDialogAndWait(
-                Localization.lang("Add new field name"), Localization.lang("Field name") + ":"))
+                Localization.lang("Add new field name"), Localization.lang("Field name")))
                 .thenReturn(Optional.of(field.getDisplayName()));
 
         viewModel.showInputFieldNameDialog();

--- a/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
@@ -147,7 +147,7 @@ public class ContentSelectorViewModelTest {
 
     private void addField(Field field) {
         when(dialogService.showInputDialogAndWait(
-                Localization.lang("Add new field name"), Localization.lang("Field name:")))
+                Localization.lang("Add new field name"), Localization.lang("Field name") + ":"))
                 .thenReturn(Optional.of(field.getDisplayName()));
 
         viewModel.showInputFieldNameDialog();


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/9989/files#diff-f1bccc4fe4e0595584a0e84d950cb03c36f9246fa7f5799a526b1d34d1c434be

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
