### PR TITLE
Preferences cleanup C (ExporterFactory & setPreviewStyle)

### DIFF
--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -167,8 +167,8 @@ public class ArgumentProcessor {
                 ImportFormatReader.UnknownFormatImport importResult =
                         importFormatReader.importUnknownFormat(file, new DummyFileUpdateMonitor());
 
-                System.out.println(Localization.lang("Format used") + ": " + importResult.format);
-                return Optional.of(importResult.parserResult);
+                System.out.println(Localization.lang("Format used") + ": " + importResult.format());
+                return Optional.of(importResult.parserResult());
             }
         } catch (ImportException ex) {
             System.err

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -478,8 +478,7 @@ public class ArgumentProcessor {
                 // export new database
                 ExporterFactory exporterFactory = ExporterFactory.create(
                         preferencesService,
-                        Globals.entryTypesManager,
-                        Globals.journalAbbreviationRepository);
+                        Globals.entryTypesManager);
                 Optional<Exporter> exporter = exporterFactory.getExporterByName(formatName);
                 if (exporter.isEmpty()) {
                     System.err.println(Localization.lang("Unknown export format") + ": " + formatName);
@@ -653,8 +652,7 @@ public class ArgumentProcessor {
             System.out.println(Localization.lang("Exporting") + ": " + data[0]);
             ExporterFactory exporterFactory = ExporterFactory.create(
                     preferencesService,
-                    Globals.entryTypesManager,
-                    Globals.journalAbbreviationRepository);
+                    Globals.entryTypesManager);
             Optional<Exporter> exporter = exporterFactory.getExporterByName(data[1]);
             if (exporter.isEmpty()) {
                 System.err.println(Localization.lang("Unknown export format") + ": " + data[1]);

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -38,6 +38,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.SearchBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fileformat.BibtexParser;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.search.DatabaseSearcher;
@@ -241,13 +242,14 @@ public class ArgumentProcessor {
 
         if (cli.isWriteMetadatatoPdf() || cli.isWriteXMPtoPdf() || cli.isEmbeddBibfileInPdf()) {
             if (!loaded.isEmpty()) {
-                writeMetadatatoPdf(loaded,
+                writeMetadataToPdf(loaded,
                         cli.getWriteMetadatatoPdf(),
                         preferencesService.getXmpPreferences(),
                         preferencesService.getFilePreferences(),
                         preferencesService.getLibraryPreferences().getDefaultBibDatabaseMode(),
                         Globals.entryTypesManager,
                         preferencesService.getFieldPreferences(),
+                        Globals.journalAbbreviationRepository,
                         cli.isWriteXMPtoPdf() || cli.isWriteMetadatatoPdf(),
                         cli.isEmbeddBibfileInPdf() || cli.isWriteMetadatatoPdf());
             }
@@ -277,7 +279,16 @@ public class ArgumentProcessor {
         return loaded;
     }
 
-    private void writeMetadatatoPdf(List<ParserResult> loaded, String filesAndCitekeys, XmpPreferences xmpPreferences, FilePreferences filePreferences, BibDatabaseMode databaseMode, BibEntryTypesManager entryTypesManager, FieldPreferences fieldPreferences, boolean writeXMP, boolean embeddBibfile) {
+    private void writeMetadataToPdf(List<ParserResult> loaded,
+                                    String filesAndCitekeys,
+                                    XmpPreferences xmpPreferences,
+                                    FilePreferences filePreferences,
+                                    BibDatabaseMode databaseMode,
+                                    BibEntryTypesManager entryTypesManager,
+                                    FieldPreferences fieldPreferences,
+                                    JournalAbbreviationRepository abbreviationRepository,
+                                    boolean writeXMP,
+                                    boolean embeddBibfile) {
         if (loaded.isEmpty()) {
             LOGGER.error("The write xmp option depends on a valid import option.");
             return;
@@ -291,7 +302,16 @@ public class ArgumentProcessor {
 
         if ("all".equals(filesAndCitekeys)) {
             for (BibEntry entry : dataBase.getEntries()) {
-                writeMetadatatoPDFsOfEntry(databaseContext, entry.getCitationKey().orElse("<no cite key defined>"), entry, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
+                writeMetadataToPDFsOfEntry(
+                        databaseContext,
+                        entry.getCitationKey().orElse("<no cite key defined>"),
+                        entry,
+                        filePreferences,
+                        xmpPdfExporter,
+                        embeddedBibFilePdfExporter,
+                        abbreviationRepository,
+                        writeXMP,
+                        embeddBibfile);
             }
             return;
         }
@@ -306,21 +326,47 @@ public class ArgumentProcessor {
             }
         }
 
-        writeMetadatatoPdfByCitekey(databaseContext, dataBase, citeKeys, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
-        writeMetadatatoPdfByFileNames(databaseContext, dataBase, pdfs, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
+        writeMetadataToPdfByCitekey(
+                databaseContext,
+                dataBase,
+                citeKeys,
+                filePreferences,
+                xmpPdfExporter,
+                embeddedBibFilePdfExporter,
+                abbreviationRepository,
+                writeXMP,
+                embeddBibfile);
+        writeMetadataToPdfByFileNames(
+                databaseContext,
+                dataBase,
+                pdfs,
+                filePreferences,
+                xmpPdfExporter,
+                embeddedBibFilePdfExporter,
+                abbreviationRepository,
+                writeXMP,
+                embeddBibfile);
     }
 
-    private void writeMetadatatoPDFsOfEntry(BibDatabaseContext databaseContext, String citeKey, BibEntry entry, FilePreferences filePreferences, XmpPdfExporter xmpPdfExporter, EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter, boolean writeXMP, boolean embeddBibfile) {
+    private void writeMetadataToPDFsOfEntry(BibDatabaseContext databaseContext,
+                                            String citeKey,
+                                            BibEntry entry,
+                                            FilePreferences filePreferences,
+                                            XmpPdfExporter xmpPdfExporter,
+                                            EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter,
+                                            JournalAbbreviationRepository abbreviationRepository,
+                                            boolean writeXMP,
+                                            boolean embeddBibfile) {
         try {
             if (writeXMP) {
-                if (xmpPdfExporter.exportToAllFilesOfEntry(databaseContext, filePreferences, entry, List.of(entry))) {
+                if (xmpPdfExporter.exportToAllFilesOfEntry(databaseContext, filePreferences, entry, List.of(entry), abbreviationRepository)) {
                     System.out.printf("Successfully written XMP metadata on at least one linked file of %s%n", citeKey);
                 } else {
                     System.err.printf("Cannot write XMP metadata on any linked files of %s. Make sure there is at least one linked file and the path is correct.%n", citeKey);
                 }
             }
             if (embeddBibfile) {
-                if (embeddedBibFilePdfExporter.exportToAllFilesOfEntry(databaseContext, filePreferences, entry, List.of(entry))) {
+                if (embeddedBibFilePdfExporter.exportToAllFilesOfEntry(databaseContext, filePreferences, entry, List.of(entry), abbreviationRepository)) {
                     System.out.printf("Successfully embedded metadata on at least one linked file of %s%n", citeKey);
                 } else {
                     System.out.printf("Cannot embedd metadata on any linked files of %s. Make sure there is at least one linked file and the path is correct.%n", citeKey);
@@ -331,7 +377,15 @@ public class ArgumentProcessor {
         }
     }
 
-    private void writeMetadatatoPdfByCitekey(BibDatabaseContext databaseContext, BibDatabase dataBase, List<String> citeKeys, FilePreferences filePreferences, XmpPdfExporter xmpPdfExporter, EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter, boolean writeXMP, boolean embeddBibfile) {
+    private void writeMetadataToPdfByCitekey(BibDatabaseContext databaseContext,
+                                             BibDatabase dataBase,
+                                             List<String> citeKeys,
+                                             FilePreferences filePreferences,
+                                             XmpPdfExporter xmpPdfExporter,
+                                             EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter,
+                                             JournalAbbreviationRepository abbreviationRepository,
+                                             boolean writeXMP,
+                                             boolean embeddBibfile) {
         for (String citeKey : citeKeys) {
             List<BibEntry> bibEntryList = dataBase.getEntriesByCitationKey(citeKey);
             if (bibEntryList.isEmpty()) {
@@ -339,12 +393,20 @@ public class ArgumentProcessor {
                 continue;
             }
             for (BibEntry entry : bibEntryList) {
-                writeMetadatatoPDFsOfEntry(databaseContext, citeKey, entry, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, writeXMP, embeddBibfile);
+                writeMetadataToPDFsOfEntry(databaseContext, citeKey, entry, filePreferences, xmpPdfExporter, embeddedBibFilePdfExporter, abbreviationRepository, writeXMP, embeddBibfile);
             }
         }
     }
 
-    private void writeMetadatatoPdfByFileNames(BibDatabaseContext databaseContext, BibDatabase dataBase, List<String> pdfs, FilePreferences filePreferences, XmpPdfExporter xmpPdfExporter, EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter, boolean writeXMP, boolean embeddBibfile) {
+    private void writeMetadataToPdfByFileNames(BibDatabaseContext databaseContext,
+                                               BibDatabase dataBase,
+                                               List<String> pdfs,
+                                               FilePreferences filePreferences,
+                                               XmpPdfExporter xmpPdfExporter,
+                                               EmbeddedBibFilePdfExporter embeddedBibFilePdfExporter,
+                                               JournalAbbreviationRepository abbreviationRepository,
+                                               boolean writeXMP,
+                                               boolean embeddBibfile) {
         for (String fileName : pdfs) {
             Path filePath = Path.of(fileName);
             if (!filePath.isAbsolute()) {
@@ -353,14 +415,14 @@ public class ArgumentProcessor {
             if (Files.exists(filePath)) {
                 try {
                     if (writeXMP) {
-                        if (xmpPdfExporter.exportToFileByPath(databaseContext, dataBase, filePreferences, filePath)) {
+                        if (xmpPdfExporter.exportToFileByPath(databaseContext, dataBase, filePreferences, filePath, abbreviationRepository)) {
                             System.out.printf("Successfully written XMP metadata of at least one entry to %s%n", fileName);
                         } else {
                             System.out.printf("File %s is not linked to any entry in database.%n", fileName);
                         }
                     }
                     if (embeddBibfile) {
-                        if (embeddedBibFilePdfExporter.exportToFileByPath(databaseContext, dataBase, filePreferences, filePath)) {
+                        if (embeddedBibFilePdfExporter.exportToFileByPath(databaseContext, dataBase, filePreferences, filePath, abbreviationRepository)) {
                             System.out.printf("Successfully embedded XMP metadata of at least one entry to %s%n", fileName);
                         } else {
                             System.out.printf("File %s is not linked to any entry in database.%n", fileName);
@@ -425,7 +487,7 @@ public class ArgumentProcessor {
                     // We have an TemplateExporter instance:
                     try {
                         System.out.println(Localization.lang("Exporting") + ": " + data[1]);
-                        exporter.get().export(databaseContext, Path.of(data[1]), matches, Collections.emptyList());
+                        exporter.get().export(databaseContext, Path.of(data[1]), matches, Collections.emptyList(), Globals.journalAbbreviationRepository);
                     } catch (Exception ex) {
                         System.err.println(Localization.lang("Could not export file") + " '" + data[1] + "': "
                                 + Throwables.getStackTraceAsString(ex));
@@ -603,7 +665,8 @@ public class ArgumentProcessor {
                             pr.getDatabaseContext(),
                             Path.of(data[0]),
                             pr.getDatabaseContext().getDatabase().getEntries(),
-                            fileDirForDatabase);
+                            fileDirForDatabase,
+                            Globals.journalAbbreviationRepository);
                 } catch (Exception ex) {
                     System.err.println(Localization.lang("Could not export file") + " '" + data[0] + "': "
                             + Throwables.getStackTraceAsString(ex));

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -311,8 +311,7 @@ public class JabRefCLI {
 
         ExporterFactory exporterFactory = ExporterFactory.create(
                 preferencesService,
-                Globals.entryTypesManager,
-                Globals.journalAbbreviationRepository);
+                Globals.entryTypesManager);
         List<Pair<String, String>> exportFormats = exporterFactory
                 .getExporters().stream()
                 .map(format -> new Pair<>(format.getName(), format.getId()))

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -643,7 +643,7 @@ public class JabRefFrame extends BorderPane {
     }
 
     public void init() {
-        sidePane = new SidePane(prefs, taskExecutor, dialogService, stateManager, undoManager);
+        sidePane = new SidePane(prefs, Globals.journalAbbreviationRepository, taskExecutor, dialogService, stateManager, undoManager);
         tabbedPane = new TabPane();
         tabbedPane.setTabDragPolicy(TabPane.TabDragPolicy.REORDER);
 
@@ -808,12 +808,12 @@ public class JabRefFrame extends BorderPane {
 
                 factory.createMenuItem(StandardActions.COPY, new EditAction(StandardActions.COPY, this, stateManager)),
                 factory.createSubMenu(StandardActions.COPY_MORE,
-                        factory.createMenuItem(StandardActions.COPY_TITLE, new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
-                        factory.createMenuItem(StandardActions.COPY_KEY, new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
-                        factory.createMenuItem(StandardActions.COPY_CITE_KEY, new CopyMoreAction(StandardActions.COPY_CITE_KEY, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
-                        factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
-                        factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, Globals.getClipboardManager(), prefs)),
-                        factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, Globals.getClipboardManager(), Globals.TASK_EXECUTOR, prefs.getPreviewPreferences())),
+                        factory.createMenuItem(StandardActions.COPY_TITLE, new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs, Globals.journalAbbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_KEY, new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, Globals.getClipboardManager(), prefs, Globals.journalAbbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_CITE_KEY, new CopyMoreAction(StandardActions.COPY_CITE_KEY, dialogService, stateManager, Globals.getClipboardManager(), prefs, Globals.journalAbbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, Globals.getClipboardManager(), prefs, Globals.journalAbbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, Globals.getClipboardManager(), prefs, Globals.journalAbbreviationRepository)),
+                        factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, Globals.getClipboardManager(), Globals.TASK_EXECUTOR, prefs, Globals.journalAbbreviationRepository)),
                         factory.createMenuItem(StandardActions.EXPORT_SELECTED_TO_CLIPBOARD, new ExportToClipboardAction(dialogService, stateManager, Globals.getClipboardManager(), Globals.TASK_EXECUTOR, prefs))),
 
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, this, stateManager)),

--- a/src/main/java/org/jabref/gui/edit/CopyMoreAction.java
+++ b/src/main/java/org/jabref/gui/edit/CopyMoreAction.java
@@ -8,12 +8,12 @@ import java.util.stream.Collectors;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefDialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionHelper;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutHelper;
@@ -33,17 +33,20 @@ public class CopyMoreAction extends SimpleCommand {
     private final StateManager stateManager;
     private final ClipBoardManager clipBoardManager;
     private final PreferencesService preferencesService;
+    private final JournalAbbreviationRepository abbreviationRepository;
 
     public CopyMoreAction(StandardActions action,
                           DialogService dialogService,
                           StateManager stateManager,
                           ClipBoardManager clipBoardManager,
-                          PreferencesService preferencesService) {
+                          PreferencesService preferencesService,
+                          JournalAbbreviationRepository abbreviationRepository) {
         this.action = action;
         this.dialogService = dialogService;
         this.stateManager = stateManager;
         this.clipBoardManager = clipBoardManager;
         this.preferencesService = preferencesService;
+        this.abbreviationRepository = abbreviationRepository;
 
         this.executable.bind(ActionHelper.needsEntriesSelected(stateManager));
     }
@@ -192,7 +195,7 @@ public class CopyMoreAction extends SimpleCommand {
         StringReader layoutString = new StringReader("\\citationkey - \\begin{title}\\format[RemoveBrackets]{\\title}\\end{title}\n");
         Layout layout;
         try {
-            layout = new LayoutHelper(layoutString, preferencesService.getLayoutFormatterPreferences(Globals.journalAbbreviationRepository)).getLayoutFromText();
+            layout = new LayoutHelper(layoutString, preferencesService.getLayoutFormatterPreferences(), abbreviationRepository).getLayoutFromText();
         } catch (IOException e) {
             LOGGER.info("Could not get layout.", e);
             return;

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogView.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogView.java
@@ -7,7 +7,6 @@ import javafx.scene.control.TextField;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.BaseDialog;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.PreferencesService;
 
@@ -16,7 +15,6 @@ import jakarta.inject.Inject;
 
 public class CreateModifyExporterDialogView extends BaseDialog<ExporterViewModel> {
 
-    @Inject private JournalAbbreviationRepository repository;
     private final ExporterViewModel exporter;
     @FXML private TextField name;
     @FXML private TextField fileName;
@@ -45,7 +43,7 @@ public class CreateModifyExporterDialogView extends BaseDialog<ExporterViewModel
 
     @FXML
     private void initialize() {
-        viewModel = new CreateModifyExporterDialogViewModel(exporter, dialogService, preferences, repository);
+        viewModel = new CreateModifyExporterDialogViewModel(exporter, dialogService, preferences);
         name.textProperty().bindBidirectional(viewModel.getName());
         fileName.textProperty().bindBidirectional(viewModel.getLayoutFileName());
         extension.textProperty().bindBidirectional(viewModel.getExtension());

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
@@ -8,11 +8,9 @@ import javafx.beans.property.StringProperty;
 import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.FileDialogConfiguration;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.preferences.PreferencesService;
 
@@ -37,15 +35,15 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
     private final StringProperty layoutFile = new SimpleStringProperty("");
     private final StringProperty extension = new SimpleStringProperty("");
 
-    private final JournalAbbreviationRepository repository;
+    private final JournalAbbreviationRepository abbreviationRepository;
 
     public CreateModifyExporterDialogViewModel(ExporterViewModel exporter,
                                                DialogService dialogService,
                                                PreferencesService preferences,
-                                               JournalAbbreviationRepository repository) {
+                                               JournalAbbreviationRepository abbreviationRepository) {
         this.dialogService = dialogService;
         this.preferences = preferences;
-        this.repository = repository;
+        this.abbreviationRepository = abbreviationRepository;
 
         // Set text of each of the boxes
         if (exporter != null) {
@@ -69,14 +67,13 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
         }
 
         // Create a new exporter to be returned to ExportCustomizationDialogViewModel, which requested it
-        LayoutFormatterPreferences layoutPreferences = preferences.getLayoutFormatterPreferences(repository);
-        SaveConfiguration saveConfiguration = preferences.getExportConfiguration();
         TemplateExporter format = new TemplateExporter(
                 name.get(),
                 layoutFile.get(),
                 extension.get(),
-                layoutPreferences,
-                saveConfiguration);
+                preferences.getLayoutFormatterPreferences(),
+                abbreviationRepository,
+                preferences.getExportConfiguration());
         format.setCustomExport(true);
         return new ExporterViewModel(format);
     }

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
@@ -9,7 +9,6 @@ import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.logic.exporter.TemplateExporter;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.preferences.PreferencesService;
@@ -35,15 +34,11 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
     private final StringProperty layoutFile = new SimpleStringProperty("");
     private final StringProperty extension = new SimpleStringProperty("");
 
-    private final JournalAbbreviationRepository abbreviationRepository;
-
     public CreateModifyExporterDialogViewModel(ExporterViewModel exporter,
                                                DialogService dialogService,
-                                               PreferencesService preferences,
-                                               JournalAbbreviationRepository abbreviationRepository) {
+                                               PreferencesService preferences) {
         this.dialogService = dialogService;
         this.preferences = preferences;
-        this.abbreviationRepository = abbreviationRepository;
 
         // Set text of each of the boxes
         if (exporter != null) {
@@ -72,7 +67,6 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
                 layoutFile.get(),
                 extension.get(),
                 preferences.getLayoutFormatterPreferences(),
-                abbreviationRepository,
                 preferences.getExportConfiguration());
         format.setCustomExport(true);
         return new ExporterViewModel(format);

--- a/src/main/java/org/jabref/gui/exporter/ExportCommand.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCommand.java
@@ -70,8 +70,7 @@ public class ExportCommand extends SimpleCommand {
         // Get list of exporters and sort before adding to file dialog
         ExporterFactory exporterFactory = ExporterFactory.create(
                 preferences,
-                Globals.entryTypesManager,
-                Globals.journalAbbreviationRepository);
+                Globals.entryTypesManager);
         List<Exporter> exporters = exporterFactory.getExporters().stream()
                                                   .sorted(Comparator.comparing(Exporter::getName))
                                                   .collect(Collectors.toList());

--- a/src/main/java/org/jabref/gui/exporter/ExportCommand.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCommand.java
@@ -120,7 +120,8 @@ public class ExportCommand extends SimpleCommand {
                     format.export(stateManager.getActiveDatabase().get(),
                             file,
                             finEntries,
-                            fileDirForDatabase);
+                            fileDirForDatabase,
+                            Globals.journalAbbreviationRepository);
                     return null; // can not use BackgroundTask.wrap(Runnable) because Runnable.run() can't throw Exceptions
                 })
                 .onSuccess(save -> {

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -118,7 +118,7 @@ public class ExportToClipboardAction extends SimpleCommand {
             entries.addAll(stateManager.getSelectedEntries());
 
             // Write to file:
-            exporter.export(stateManager.getActiveDatabase().get(), tmp, entries, fileDirForDatabase);
+            exporter.export(stateManager.getActiveDatabase().get(), tmp, entries, fileDirForDatabase, Globals.journalAbbreviationRepository);
             // Read the file and put the contents on the clipboard:
 
             return new ExportResult(Files.readString(tmp), exporter.getFileType());

--- a/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportToClipboardAction.java
@@ -75,8 +75,7 @@ public class ExportToClipboardAction extends SimpleCommand {
 
         ExporterFactory exporterFactory = ExporterFactory.create(
                 preferences,
-                Globals.entryTypesManager,
-                Globals.journalAbbreviationRepository);
+                Globals.entryTypesManager);
         List<Exporter> exporters = exporterFactory.getExporters().stream()
                                                   .sorted(Comparator.comparing(Exporter::getName))
                                                   .filter(exporter -> SUPPORTED_FILETYPES.contains(exporter.getFileType()))

--- a/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteMetadataToPdfAction.java
@@ -21,6 +21,7 @@ import javafx.stage.Stage;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.FXDialog;
+import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.BackgroundTask;
@@ -196,7 +197,7 @@ public class WriteMetadataToPdfAction extends SimpleCommand {
         new XmpUtilWriter(xmpPreferences).writeXmp(file, entry, database);
 
         EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), entryTypesManager, fieldPreferences);
-        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, file);
+        embeddedBibExporter.exportToFileByPath(databaseContext, database, filePreferences, file, Globals.journalAbbreviationRepository);
     }
 
     class OptionsDialog extends FXDialog {

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -313,7 +313,7 @@ public class ImportHandler {
                     preferencesService.getImportFormatPreferences(),
                     fileUpdateMonitor);
             UnknownFormatImport unknownFormatImport = importFormatReader.importUnknownFormat(data);
-            return unknownFormatImport.parserResult.getDatabase().getEntries();
+            return unknownFormatImport.parserResult().getDatabase().getEntries();
         } catch (ImportException ex) { // ex is already localized
             dialogService.showErrorDialogAndWait(Localization.lang("Import error"), ex);
             return Collections.emptyList();

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -70,7 +70,7 @@ public class FieldEditors {
         } else if (field == StandardField.GROUPS) {
             return new GroupEditor(field, suggestionProvider, fieldCheckers, preferences, isMultiLine);
         } else if (fieldProperties.contains(FieldProperty.FILE_EDITOR)) {
-            return new LinkedFilesEditor(field, dialogService, databaseContext, taskExecutor, suggestionProvider, fieldCheckers, preferences);
+            return new LinkedFilesEditor(field, databaseContext, suggestionProvider, fieldCheckers);
         } else if (fieldProperties.contains(FieldProperty.YES_NO)) {
             return new OptionEditor<>(new YesNoEditorViewModel(field, suggestionProvider, fieldCheckers));
         } else if (fieldProperties.contains(FieldProperty.MONTH)) {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -23,8 +23,7 @@
         <Button onAction="#fetchFulltext" styleClass="icon-button">
             <graphic>
                 <StackPane>
-                    <JabRefIconView glyph="FETCH_FULLTEXT"
-                                    visible="${controller.viewModel.fulltextLookupInProgress == false}"/>
+                    <JabRefIconView fx:id="fulltextFetcher" glyph="FETCH_FULLTEXT" visible="false"/>
                     <ProgressIndicator maxHeight="12.0" maxWidth="12.0"
                                        visible="${controller.viewModel.fulltextLookupInProgress}"/>
                 </StackPane>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
@@ -107,10 +108,6 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
                 taskExecutor,
                 dialogService,
                 preferences);
-    }
-
-    public boolean isFulltextLookupInProgress() {
-        return fulltextLookupInProgress.get();
     }
 
     private List<LinkedFileViewModel> parseToFileViewModel(String stringValue) {
@@ -264,5 +261,9 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
 
     public void removeFileLink(LinkedFileViewModel file) {
         files.remove(file);
+    }
+
+    public ReadOnlyBooleanProperty fulltextLookupInProgressProperty() {
+        return fulltextLookupInProgress;
     }
 }

--- a/src/main/java/org/jabref/gui/fieldeditors/WriteMetadataToPdfCommand.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/WriteMetadataToPdfCommand.java
@@ -53,7 +53,7 @@ public class WriteMetadataToPdfCommand extends SimpleCommand {
                         new XmpUtilWriter(preferences.getXmpPreferences()).writeXmp(file.get(), entry, databaseContext.getDatabase());
 
                         EmbeddedBibFilePdfExporter embeddedBibExporter = new EmbeddedBibFilePdfExporter(databaseContext.getMode(), Globals.entryTypesManager, preferences.getFieldPreferences());
-                        embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get());
+                        embeddedBibExporter.exportToFileByPath(databaseContext, databaseContext.getDatabase(), preferences.getFilePreferences(), file.get(), Globals.journalAbbreviationRepository);
 
                         dialogService.notify(Localization.lang("Success! Finished writing metadata."));
                     } catch (IOException | TransformerException ex) {

--- a/src/main/java/org/jabref/gui/importer/ImportAction.java
+++ b/src/main/java/org/jabref/gui/importer/ImportAction.java
@@ -173,15 +173,15 @@ public class ImportAction {
             if (importResult == null) {
                 continue;
             }
-            ParserResult parserResult = importResult.parserResult;
+            ParserResult parserResult = importResult.parserResult();
             resultDatabase.insertEntries(parserResult.getDatabase().getEntries());
 
-            if (ImportFormatReader.BIBTEX_FORMAT.equals(importResult.format)) {
+            if (ImportFormatReader.BIBTEX_FORMAT.equals(importResult.format())) {
                 // additional treatment of BibTeX
                 new DatabaseMerger(preferencesService.getBibEntryPreferences().getKeywordSeparator()).mergeMetaData(
                         result.getMetaData(),
                         parserResult.getMetaData(),
-                        importResult.parserResult.getPath().map(path -> path.getFileName().toString()).orElse("unknown"),
+                        importResult.parserResult().getPath().map(path -> path.getFileName().toString()).orElse("unknown"),
                         parserResult.getDatabase().getEntries());
             }
             // TODO: collect errors into ParserResult, because they are currently ignored (see caller of this method)

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -133,6 +133,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         undoManager,
                         clipBoardManager,
                         Globals.TASK_EXECUTOR,
+                        Globals.journalAbbreviationRepository,
                         Globals.entryTypesManager))
                 .setOnDragDetected(this::handleOnDragDetected)
                 .setOnDragDropped(this::handleOnDragDropped)

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -27,6 +27,7 @@ import org.jabref.gui.specialfields.SpecialFieldMenuItemFactory;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
 import org.jabref.logic.citationstyle.CitationStylePreviewLayout;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.preferences.PreferencesService;
@@ -43,13 +44,14 @@ public class RightClickMenu {
                                      UndoManager undoManager,
                                      ClipBoardManager clipBoardManager,
                                      TaskExecutor taskExecutor,
+                                     JournalAbbreviationRepository abbreviationRepository,
                                      BibEntryTypesManager entryTypesManager) {
         ActionFactory factory = new ActionFactory(keyBindingRepository);
         ContextMenu contextMenu = new ContextMenu();
 
         contextMenu.getItems().addAll(
                 factory.createMenuItem(StandardActions.COPY, new EditAction(StandardActions.COPY, libraryTab.frame(), stateManager)),
-                createCopySubMenu(factory, dialogService, stateManager, preferencesService, clipBoardManager, taskExecutor),
+                createCopySubMenu(factory, dialogService, stateManager, preferencesService, clipBoardManager, abbreviationRepository, taskExecutor),
                 factory.createMenuItem(StandardActions.PASTE, new EditAction(StandardActions.PASTE, libraryTab.frame(), stateManager)),
                 factory.createMenuItem(StandardActions.CUT, new EditAction(StandardActions.CUT, libraryTab.frame(), stateManager)),
                 factory.createMenuItem(StandardActions.MERGE_ENTRIES, new MergeEntriesAction(dialogService, stateManager, preferencesService.getBibEntryPreferences())),
@@ -92,17 +94,18 @@ public class RightClickMenu {
                                           StateManager stateManager,
                                           PreferencesService preferencesService,
                                           ClipBoardManager clipBoardManager,
+                                          JournalAbbreviationRepository abbreviationRepository,
                                           TaskExecutor taskExecutor) {
         Menu copySpecialMenu = factory.createMenu(StandardActions.COPY_MORE);
 
         copySpecialMenu.getItems().addAll(
-                factory.createMenuItem(StandardActions.COPY_TITLE, new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_KEY, new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_CITE_KEY, new CopyMoreAction(StandardActions.COPY_CITE_KEY, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_DOI, new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService)),
-                factory.createMenuItem(StandardActions.COPY_DOI_URL, new CopyMoreAction(StandardActions.COPY_DOI_URL, dialogService, stateManager, clipBoardManager, preferencesService)),
+                factory.createMenuItem(StandardActions.COPY_TITLE, new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_KEY, new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_CITE_KEY, new CopyMoreAction(StandardActions.COPY_CITE_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_KEY_AND_TITLE, new CopyMoreAction(StandardActions.COPY_KEY_AND_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_KEY_AND_LINK, new CopyMoreAction(StandardActions.COPY_KEY_AND_LINK, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_DOI, new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
+                factory.createMenuItem(StandardActions.COPY_DOI_URL, new CopyMoreAction(StandardActions.COPY_DOI_URL, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository)),
                 new SeparatorMenuItem()
         );
 
@@ -110,10 +113,10 @@ public class RightClickMenu {
         PreviewPreferences previewPreferences = preferencesService.getPreviewPreferences();
         if (previewPreferences.getSelectedPreviewLayout() instanceof CitationStylePreviewLayout) {
             copySpecialMenu.getItems().addAll(
-                    factory.createMenuItem(StandardActions.COPY_CITATION_HTML, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, taskExecutor, previewPreferences)),
-                    factory.createMenuItem(StandardActions.COPY_CITATION_TEXT, new CopyCitationAction(CitationStyleOutputFormat.TEXT, dialogService, stateManager, clipBoardManager, taskExecutor, previewPreferences)));
+                    factory.createMenuItem(StandardActions.COPY_CITATION_HTML, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, taskExecutor, preferencesService, abbreviationRepository)),
+                    factory.createMenuItem(StandardActions.COPY_CITATION_TEXT, new CopyCitationAction(CitationStyleOutputFormat.TEXT, dialogService, stateManager, clipBoardManager, taskExecutor, preferencesService, abbreviationRepository)));
         } else {
-            copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, taskExecutor, previewPreferences)));
+            copySpecialMenu.getItems().add(factory.createMenuItem(StandardActions.COPY_CITATION_PREVIEW, new CopyCitationAction(CitationStyleOutputFormat.HTML, dialogService, stateManager, clipBoardManager, taskExecutor, preferencesService, abbreviationRepository)));
         }
 
         copySpecialMenu.getItems().addAll(

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -27,7 +27,6 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.Globals;
 import org.jabref.gui.JabRefGUI;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionFactory;
@@ -43,6 +42,7 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.help.HelpFile;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.openoffice.OpenOfficeFileSearch;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
@@ -94,8 +94,8 @@ public class OpenOfficePanel {
     private OOBibStyle style;
 
     public OpenOfficePanel(PreferencesService preferencesService,
-                           OpenOfficePreferences openOfficePreferences,
                            KeyBindingRepository keyBindingRepository,
+                           JournalAbbreviationRepository abbreviationRepository,
                            TaskExecutor taskExecutor,
                            DialogService dialogService,
                            StateManager stateManager,
@@ -130,8 +130,10 @@ public class OpenOfficePanel {
         update.setTooltip(new Tooltip(Localization.lang("Sync OpenOffice/LibreOffice bibliography")));
         update.setMaxWidth(Double.MAX_VALUE);
 
-        loader = new StyleLoader(openOfficePreferences,
-                preferencesService.getLayoutFormatterPreferences(Globals.journalAbbreviationRepository));
+        loader = new StyleLoader(
+                preferencesService.getOpenOfficePreferences(),
+                preferencesService.getLayoutFormatterPreferences(),
+                abbreviationRepository);
 
         initPanel();
     }

--- a/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTab.java
+++ b/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTab.java
@@ -8,12 +8,10 @@ import javafx.scene.control.TableView;
 import org.jabref.gui.exporter.ExporterViewModel;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import com.tobiasdiez.easybind.EasyBind;
-import jakarta.inject.Inject;
 
 public class CustomExporterTab extends AbstractPreferenceTabView<CustomExporterTabViewModel> implements PreferencesTab {
 
@@ -21,8 +19,6 @@ public class CustomExporterTab extends AbstractPreferenceTabView<CustomExporterT
     @FXML private TableColumn<ExporterViewModel, String> nameColumn;
     @FXML private TableColumn<ExporterViewModel, String> layoutColumn;
     @FXML private TableColumn<ExporterViewModel, String> extensionColumn;
-
-    @Inject private JournalAbbreviationRepository repository;
 
     public CustomExporterTab() {
         ViewLoader.view(this)
@@ -37,7 +33,7 @@ public class CustomExporterTab extends AbstractPreferenceTabView<CustomExporterT
 
     @FXML
     private void initialize() {
-        viewModel = new CustomExporterTabViewModel(preferencesService, dialogService, repository);
+        viewModel = new CustomExporterTabViewModel(preferencesService, dialogService);
 
         exporterTable.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
         exporterTable.itemsProperty().bind(viewModel.exportersProperty());

--- a/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTabViewModel.java
@@ -13,7 +13,6 @@ import org.jabref.gui.exporter.CreateModifyExporterDialogView;
 import org.jabref.gui.exporter.ExporterViewModel;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.logic.exporter.TemplateExporter;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.preferences.PreferencesService;
 
 public class CustomExporterTabViewModel implements PreferenceTabViewModel {
@@ -23,17 +22,15 @@ public class CustomExporterTabViewModel implements PreferenceTabViewModel {
 
     private final PreferencesService preferences;
     private final DialogService dialogService;
-    private final JournalAbbreviationRepository repository;
 
-    public CustomExporterTabViewModel(PreferencesService preferences, DialogService dialogService, JournalAbbreviationRepository repository) {
+    public CustomExporterTabViewModel(PreferencesService preferences, DialogService dialogService) {
         this.preferences = preferences;
         this.dialogService = dialogService;
-        this.repository = repository;
     }
 
     @Override
     public void setValues() {
-        List<TemplateExporter> exportersLogic = preferences.getCustomExportFormats(repository);
+        List<TemplateExporter> exportersLogic = preferences.getCustomExportFormats();
         for (TemplateExporter exporter : exportersLogic) {
             exporters.add(new ExporterViewModel(exporter));
         }

--- a/src/main/java/org/jabref/gui/preferences/customimporter/CustomImporterTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/customimporter/CustomImporterTabViewModel.java
@@ -15,6 +15,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.importer.ImporterViewModel;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.StandardFileType;
@@ -103,7 +104,7 @@ public class CustomImporterTabViewModel implements PreferenceTabViewModel {
                             Localization.lang("Could not open %0", selectedFile.get().toString()) + "\n"
                                     + Localization.lang("Have you chosen the correct package path?"),
                             exc);
-                } catch (ClassNotFoundException exc) {
+                } catch (ImportException exc) {
                     LOGGER.error("Could not instantiate importer", exc);
                     dialogService.showErrorDialogAndWait(
                             Localization.lang("Could not instantiate %0 %1", "importer"),

--- a/src/main/java/org/jabref/gui/preview/CopyCitationAction.java
+++ b/src/main/java/org/jabref/gui/preview/CopyCitationAction.java
@@ -19,15 +19,15 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.citationstyle.CitationStyleGenerator;
 import org.jabref.logic.citationstyle.CitationStyleOutputFormat;
 import org.jabref.logic.citationstyle.CitationStylePreviewLayout;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.Layout;
-import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.layout.LayoutHelper;
 import org.jabref.logic.layout.TextBasedPreviewLayout;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.logic.util.OS;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.preferences.PreviewPreferences;
+import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,29 +40,30 @@ public class CopyCitationAction extends SimpleCommand {
     private static final Logger LOGGER = LoggerFactory.getLogger(CopyCitationAction.class);
 
     private final List<BibEntry> selectedEntries;
-    private final PreviewLayout previewLayout;
-    private final TextBasedPreviewLayout customPreviewLayout;
     private final CitationStyleOutputFormat outputFormat;
 
     private final StateManager stateManager;
     private final DialogService dialogService;
     private final ClipBoardManager clipBoardManager;
     private final TaskExecutor taskExecutor;
+    private final PreferencesService preferencesService;
+    private final JournalAbbreviationRepository abbreviationRepository;
 
     public CopyCitationAction(CitationStyleOutputFormat outputFormat,
                               DialogService dialogService,
                               StateManager stateManager,
                               ClipBoardManager clipBoardManager,
                               TaskExecutor taskExecutor,
-                              PreviewPreferences previewPreferences) {
+                              PreferencesService preferencesService,
+                              JournalAbbreviationRepository abbreviationRepository) {
         this.outputFormat = outputFormat;
         this.dialogService = dialogService;
         this.stateManager = stateManager;
         this.selectedEntries = stateManager.getSelectedEntries();
         this.clipBoardManager = clipBoardManager;
         this.taskExecutor = taskExecutor;
-        this.previewLayout = previewPreferences.getSelectedPreviewLayout();
-        this.customPreviewLayout = previewPreferences.getCustomPreviewLayout();
+        this.preferencesService = preferencesService;
+        this.abbreviationRepository = abbreviationRepository;
 
         this.executable.bind(ActionHelper.needsEntriesSelected(stateManager));
     }
@@ -79,6 +80,7 @@ public class CopyCitationAction extends SimpleCommand {
         // This worker stored the style as filename. The CSLAdapter and the CitationStyleCache store the source of the
         // style. Therefore, we extract the style source from the file.
         String styleSource = null;
+        PreviewLayout previewLayout = preferencesService.getPreviewPreferences().getSelectedPreviewLayout();
 
         if (previewLayout instanceof CitationStylePreviewLayout citationStyleLayout) {
             styleSource = citationStyleLayout.getSource();
@@ -96,9 +98,10 @@ public class CopyCitationAction extends SimpleCommand {
             return Collections.emptyList();
         }
 
+        TextBasedPreviewLayout customPreviewLayout = preferencesService.getPreviewPreferences().getCustomPreviewLayout();
         StringReader customLayoutReader = new StringReader(customPreviewLayout.getText().replace("__NEWLINE__", "\n"));
-        LayoutFormatterPreferences layoutFormatterPreferences = Globals.prefs.getLayoutFormatterPreferences(Globals.journalAbbreviationRepository);
-        Layout layout = new LayoutHelper(customLayoutReader, layoutFormatterPreferences).getLayoutFromText();
+        Layout layout = new LayoutHelper(customLayoutReader, preferencesService.getLayoutFormatterPreferences(), abbreviationRepository)
+                .getLayoutFromText();
 
         List<String> citations = new ArrayList<>(selectedEntries.size());
         for (BibEntry entry : selectedEntries) {
@@ -149,6 +152,8 @@ public class CopyCitationAction extends SimpleCommand {
     }
 
     private void setClipBoardContent(List<String> citations) {
+        PreviewLayout previewLayout = preferencesService.getPreviewPreferences().getSelectedPreviewLayout();
+
         // if it's not a citation style take care of the preview
         if (!(previewLayout instanceof CitationStylePreviewLayout)) {
             clipBoardManager.setContent(processPreview(citations));

--- a/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -23,8 +23,8 @@ import org.jabref.gui.desktop.JabRefDesktop;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
-import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.format.Number;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.logic.util.WebViewStore;
@@ -249,7 +249,7 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
             return;
         }
 
-        ExporterFactory.entryNumber = 1; // Set entry number in case that is included in the preview layout.
+        Number.serialExportNumber = 1; // Set entry number in case that is included in the preview layout.
 
         BackgroundTask
                 .wrap(() -> layout.generatePreview(entry.get(), database))

--- a/src/main/java/org/jabref/gui/sidepane/SidePane.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePane.java
@@ -14,6 +14,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.preferences.PreferencesService;
 
 public class SidePane extends VBox {
@@ -26,13 +27,14 @@ public class SidePane extends VBox {
     private final Map<SidePaneType, BooleanBinding> visibleBindings = new HashMap<>();
 
     public SidePane(PreferencesService preferencesService,
+                    JournalAbbreviationRepository abbreviationRepository,
                     TaskExecutor taskExecutor,
                     DialogService dialogService,
                     StateManager stateManager,
                     UndoManager undoManager) {
         this.stateManager = stateManager;
         this.preferencesService = preferencesService;
-        this.viewModel = new SidePaneViewModel(preferencesService, stateManager, taskExecutor, dialogService, undoManager);
+        this.viewModel = new SidePaneViewModel(preferencesService, abbreviationRepository, stateManager, taskExecutor, dialogService, undoManager);
 
         stateManager.getVisibleSidePaneComponents().addListener((ListChangeListener<SidePaneType>) c -> updateView());
         updateView();

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneContentFactory.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneContentFactory.java
@@ -10,21 +10,25 @@ import org.jabref.gui.groups.GroupTreeView;
 import org.jabref.gui.importer.fetcher.WebSearchPaneView;
 import org.jabref.gui.openoffice.OpenOfficePanel;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.preferences.PreferencesService;
 
 public class SidePaneContentFactory {
     private final PreferencesService preferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
     private final TaskExecutor taskExecutor;
     private final DialogService dialogService;
     private final StateManager stateManager;
     private final UndoManager undoManager;
 
     public SidePaneContentFactory(PreferencesService preferences,
+                                  JournalAbbreviationRepository abbreviationRepository,
                                   TaskExecutor taskExecutor,
                                   DialogService dialogService,
                                   StateManager stateManager,
                                   UndoManager undoManager) {
         this.preferences = preferences;
+        this.abbreviationRepository = abbreviationRepository;
         this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;
         this.stateManager = stateManager;
@@ -40,8 +44,8 @@ public class SidePaneContentFactory {
                     dialogService);
             case OPEN_OFFICE -> new OpenOfficePanel(
                     preferences,
-                    preferences.getOpenOfficePreferences(),
                     preferences.getKeyBindingRepository(),
+                    abbreviationRepository,
                     taskExecutor,
                     dialogService,
                     stateManager,

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
@@ -18,6 +18,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.preferences.PreferencesService;
 import org.jabref.preferences.SidePanePreferences;
 
@@ -35,6 +36,7 @@ public class SidePaneViewModel extends AbstractViewModel {
     private final DialogService dialogService;
 
     public SidePaneViewModel(PreferencesService preferencesService,
+                             JournalAbbreviationRepository abbreviationRepository,
                              StateManager stateManager,
                              TaskExecutor taskExecutor,
                              DialogService dialogService,
@@ -44,6 +46,7 @@ public class SidePaneViewModel extends AbstractViewModel {
         this.dialogService = dialogService;
         this.sidePaneContentFactory = new SidePaneContentFactory(
                 preferencesService,
+                abbreviationRepository,
                 taskExecutor,
                 dialogService,
                 stateManager,

--- a/src/main/java/org/jabref/logic/exporter/Exporter.java
+++ b/src/main/java/org/jabref/logic/exporter/Exporter.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.util.FileType;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -60,28 +61,33 @@ public abstract class Exporter {
      */
     public abstract void export(BibDatabaseContext databaseContext, Path file, List<BibEntry> entries) throws Exception;
 
-    public void export(BibDatabaseContext databaseContext, Path file, List<BibEntry> entries, List<Path> fileDirForDatabase) throws Exception {
+    public void export(BibDatabaseContext databaseContext, Path file, List<BibEntry> entries, List<Path> fileDirForDatabase, JournalAbbreviationRepository abbreviationRepository) throws Exception {
         export(databaseContext, file, entries);
     }
 
     /**
      * Exports to all files linked to a given entry
      *
-     * @param databaseContext   the database to export from
-     * @param filePreferences   the filePreferences to use for resolving paths
-     * @param entryToWriteOn    the entry for which we want to write on all linked pdfs
-     * @param entriesToWrite    the content that we want to export to the pdfs
+     * @param databaseContext        the database to export from
+     * @param filePreferences        the filePreferences to use for resolving paths
+     * @param entryToWriteOn         the entry for which we want to write on all linked pdfs
+     * @param entriesToWrite         the content that we want to export to the pdfs
+     * @param abbreviationRepository the opened repository of journal abbreviations
      * @return whether any file was written on
      * @throws Exception if the writing fails
      */
-    public boolean exportToAllFilesOfEntry(BibDatabaseContext databaseContext, FilePreferences filePreferences, BibEntry entryToWriteOn, List<BibEntry> entriesToWrite) throws Exception {
+    public boolean exportToAllFilesOfEntry(BibDatabaseContext databaseContext,
+                                           FilePreferences filePreferences,
+                                           BibEntry entryToWriteOn,
+                                           List<BibEntry> entriesToWrite,
+                                           JournalAbbreviationRepository abbreviationRepository) throws Exception {
         boolean writtenToAFile = false;
 
         for (LinkedFile file : entryToWriteOn.getFiles()) {
             if (file.getFileType().equals(fileType.getName())) {
                 Optional<Path> filePath = file.findIn(databaseContext, filePreferences);
                 if (filePath.isPresent()) {
-                    export(databaseContext, filePath.get(), entriesToWrite, Collections.emptyList());
+                    export(databaseContext, filePath.get(), entriesToWrite, Collections.emptyList(), abbreviationRepository);
                     writtenToAFile = true;
                 }
             }
@@ -96,14 +102,19 @@ public abstract class Exporter {
      * If it overwrites any existing information, only the last found bib-entry will be exported (as the previous exports are overwritten).
      * If it extends existing information, all found bib-entries will be exported.
      *
-     * @param databaseContext   the database-context to export from
-     * @param dataBase          the database to export from
-     * @param filePreferences   the filePreferences to use for resolving paths
-     * @param filePath          the path to the file we want to write on
+     * @param databaseContext        the database-context to export from
+     * @param dataBase               the database to export from
+     * @param filePreferences        the filePreferences to use for resolving paths
+     * @param filePath               the path to the file we want to write on
+     * @param abbreviationRepository the opened repository of journal abbreviations
      * @return whether the file was written on at least once
      * @throws Exception if the writing fails
      */
-    public boolean exportToFileByPath(BibDatabaseContext databaseContext, BibDatabase dataBase, FilePreferences filePreferences, Path filePath) throws Exception {
+    public boolean exportToFileByPath(BibDatabaseContext databaseContext,
+                                      BibDatabase dataBase,
+                                      FilePreferences filePreferences,
+                                      Path filePath,
+                                      JournalAbbreviationRepository abbreviationRepository) throws Exception {
         if (!Files.exists(filePath)) {
             return false;
         }
@@ -113,7 +124,7 @@ public abstract class Exporter {
                 if (linkedFile.getFileType().equals(fileType.getName())) {
                     Optional<Path> linkedFilePath = linkedFile.findIn(databaseContext.getFileDirectories(filePreferences));
                     if (linkedFilePath.isPresent() && Files.exists(linkedFilePath.get()) && Files.isSameFile(linkedFilePath.get(), filePath)) {
-                        export(databaseContext, filePath, List.of(entry), Collections.emptyList());
+                        export(databaseContext, filePath, List.of(entry), Collections.emptyList(), abbreviationRepository);
                         writtenABibEntry = true;
                     }
                 }

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.jabref.logic.bibtex.FieldPreferences;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
@@ -25,10 +24,9 @@ public class ExporterFactory {
     }
 
     public static ExporterFactory create(PreferencesService preferencesService,
-                                         BibEntryTypesManager entryTypesManager,
-                                         JournalAbbreviationRepository abbreviationRepository) {
+                                         BibEntryTypesManager entryTypesManager) {
 
-        List<TemplateExporter> customFormats = preferencesService.getCustomExportFormats(abbreviationRepository);
+        List<TemplateExporter> customFormats = preferencesService.getCustomExportFormats();
         LayoutFormatterPreferences layoutPreferences = preferencesService.getLayoutFormatterPreferences();
         SaveConfiguration saveConfiguration = preferencesService.getExportConfiguration();
         XmpPreferences xmpPreferences = preferencesService.getXmpPreferences();
@@ -38,23 +36,23 @@ public class ExporterFactory {
         List<Exporter> exporters = new ArrayList<>();
 
         // Initialize build-in exporters
-        exporters.add(new TemplateExporter("HTML", "html", "html", null, StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("Simple HTML"), "simplehtml", "simplehtml", null, StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("DocBook 5.1", "docbook5", "docbook5", null, StandardFileType.XML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("DocBook 4", "docbook4", "docbook4", null, StandardFileType.XML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("DIN 1505", "din1505", "din1505winword", "din1505", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("BibO RDF", "bibordf", "bibordf", null, StandardFileType.RDF, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("Endnote", "endnote", "EndNote", "endnote", StandardFileType.TXT, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("OpenOffice/LibreOffice CSV", "oocsv", "openoffice-csv", "openoffice", StandardFileType.CSV, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("RIS", "ris", "ris", "ris", StandardFileType.RIS, layoutPreferences, abbreviationRepository, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
-        exporters.add(new TemplateExporter("MIS Quarterly", "misq", "misq", "misq", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
-        exporters.add(new TemplateExporter("CSL YAML", "yaml", "yaml", null, StandardFileType.YAML, layoutPreferences, abbreviationRepository, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
+        exporters.add(new TemplateExporter("HTML", "html", "html", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("Simple HTML"), "simplehtml", "simplehtml", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("DocBook 5.1", "docbook5", "docbook5", null, StandardFileType.XML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("DocBook 4", "docbook4", "docbook4", null, StandardFileType.XML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("DIN 1505", "din1505", "din1505winword", "din1505", StandardFileType.RTF, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("BibO RDF", "bibordf", "bibordf", null, StandardFileType.RDF, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("Endnote", "endnote", "EndNote", "endnote", StandardFileType.TXT, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("OpenOffice/LibreOffice CSV", "oocsv", "openoffice-csv", "openoffice", StandardFileType.CSV, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("RIS", "ris", "ris", "ris", StandardFileType.RIS, layoutPreferences, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
+        exporters.add(new TemplateExporter("MIS Quarterly", "misq", "misq", "misq", StandardFileType.RTF, layoutPreferences, saveConfiguration));
+        exporters.add(new TemplateExporter("CSL YAML", "yaml", "yaml", null, StandardFileType.YAML, layoutPreferences, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
         exporters.add(new OpenOfficeDocumentCreator());
         exporters.add(new OpenDocumentSpreadsheetCreator());
         exporters.add(new MSBibExporter());

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -29,7 +29,8 @@ public class ExporterFactory {
                                          JournalAbbreviationRepository abbreviationRepository) {
         return ExporterFactory.create(
                 preferencesService.getCustomExportFormats(abbreviationRepository),
-                preferencesService.getLayoutFormatterPreferences(abbreviationRepository),
+                preferencesService.getLayoutFormatterPreferences(),
+                abbreviationRepository,
                 preferencesService.getExportConfiguration(),
                 preferencesService.getXmpPreferences(),
                 preferencesService.getFieldPreferences(),
@@ -39,6 +40,7 @@ public class ExporterFactory {
 
     public static ExporterFactory create(List<TemplateExporter> customFormats,
                                          LayoutFormatterPreferences layoutPreferences,
+                                         JournalAbbreviationRepository abbreviationRepository,
                                          SaveConfiguration saveConfiguration,
                                          XmpPreferences xmpPreferences,
                                          FieldPreferences fieldPreferences,
@@ -48,23 +50,23 @@ public class ExporterFactory {
         List<Exporter> exporters = new ArrayList<>();
 
         // Initialize build-in exporters
-        exporters.add(new TemplateExporter("HTML", "html", "html", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("Simple HTML"), "simplehtml", "simplehtml", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("DocBook 5.1", "docbook5", "docbook5", null, StandardFileType.XML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("DocBook 4", "docbook4", "docbook4", null, StandardFileType.XML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("DIN 1505", "din1505", "din1505winword", "din1505", StandardFileType.RTF, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("BibO RDF", "bibordf", "bibordf", null, StandardFileType.RDF, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("Endnote", "endnote", "EndNote", "endnote", StandardFileType.TXT, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("OpenOffice/LibreOffice CSV", "oocsv", "openoffice-csv", "openoffice", StandardFileType.CSV, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("RIS", "ris", "ris", "ris", StandardFileType.RIS, layoutPreferences, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
-        exporters.add(new TemplateExporter("MIS Quarterly", "misq", "misq", "misq", StandardFileType.RTF, layoutPreferences, saveConfiguration));
-        exporters.add(new TemplateExporter("CSL YAML", "yaml", "yaml", null, StandardFileType.YAML, layoutPreferences, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
+        exporters.add(new TemplateExporter("HTML", "html", "html", null, StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("Simple HTML"), "simplehtml", "simplehtml", null, StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("DocBook 5.1", "docbook5", "docbook5", null, StandardFileType.XML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("DocBook 4", "docbook4", "docbook4", null, StandardFileType.XML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("DIN 1505", "din1505", "din1505winword", "din1505", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("BibO RDF", "bibordf", "bibordf", null, StandardFileType.RDF, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("Endnote", "endnote", "EndNote", "endnote", StandardFileType.TXT, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("OpenOffice/LibreOffice CSV", "oocsv", "openoffice-csv", "openoffice", StandardFileType.CSV, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("RIS", "ris", "ris", "ris", StandardFileType.RIS, layoutPreferences, abbreviationRepository, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
+        exporters.add(new TemplateExporter("MIS Quarterly", "misq", "misq", "misq", StandardFileType.RTF, layoutPreferences, abbreviationRepository, saveConfiguration));
+        exporters.add(new TemplateExporter("CSL YAML", "yaml", "yaml", null, StandardFileType.YAML, layoutPreferences, abbreviationRepository, saveConfiguration, BlankLineBehaviour.DELETE_BLANKS));
         exporters.add(new OpenOfficeDocumentCreator());
         exporters.add(new OpenDocumentSpreadsheetCreator());
         exporters.add(new MSBibExporter());

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -55,8 +55,6 @@ public class ExporterFactory {
         List<Exporter> exporters = new ArrayList<>();
 
         // Initialize build-in exporters
-
-        // Initialize build-in exporters
         exporters.add(new TemplateExporter("HTML", "html", "html", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
         exporters.add(new TemplateExporter(Localization.lang("Simple HTML"), "simplehtml", "simplehtml", null, StandardFileType.HTML, layoutPreferences, saveConfiguration));
         exporters.add(new TemplateExporter("DocBook 5.1", "docbook5", "docbook5", null, StandardFileType.XML, layoutPreferences, saveConfiguration));

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -18,13 +18,6 @@ import org.jabref.preferences.PreferencesService;
 
 public class ExporterFactory {
 
-    /**
-     * Global variable that is used for counting output entries when exporting:
-     *
-     * @deprecated find a better way to do this
-     */
-    @Deprecated public static int entryNumber;
-
     private final List<Exporter> exporters;
 
     private ExporterFactory(List<Exporter> exporters) {

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -27,25 +27,13 @@ public class ExporterFactory {
     public static ExporterFactory create(PreferencesService preferencesService,
                                          BibEntryTypesManager entryTypesManager,
                                          JournalAbbreviationRepository abbreviationRepository) {
-        return ExporterFactory.create(
-                preferencesService.getCustomExportFormats(abbreviationRepository),
-                preferencesService.getLayoutFormatterPreferences(),
-                abbreviationRepository,
-                preferencesService.getExportConfiguration(),
-                preferencesService.getXmpPreferences(),
-                preferencesService.getFieldPreferences(),
-                preferencesService.getLibraryPreferences().getDefaultBibDatabaseMode(),
-                entryTypesManager);
-    }
 
-    public static ExporterFactory create(List<TemplateExporter> customFormats,
-                                         LayoutFormatterPreferences layoutPreferences,
-                                         JournalAbbreviationRepository abbreviationRepository,
-                                         SaveConfiguration saveConfiguration,
-                                         XmpPreferences xmpPreferences,
-                                         FieldPreferences fieldPreferences,
-                                         BibDatabaseMode bibDatabaseMode,
-                                         BibEntryTypesManager entryTypesManager) {
+        List<TemplateExporter> customFormats = preferencesService.getCustomExportFormats(abbreviationRepository);
+        LayoutFormatterPreferences layoutPreferences = preferencesService.getLayoutFormatterPreferences();
+        SaveConfiguration saveConfiguration = preferencesService.getExportConfiguration();
+        XmpPreferences xmpPreferences = preferencesService.getXmpPreferences();
+        FieldPreferences fieldPreferences = preferencesService.getFieldPreferences();
+        BibDatabaseMode bibDatabaseMode = preferencesService.getLibraryPreferences().getDefaultBibDatabaseMode();
 
         List<Exporter> exporters = new ArrayList<>();
 

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.layout.LayoutHelper;
+import org.jabref.logic.layout.format.Number;
 import org.jabref.logic.util.FileType;
 import org.jabref.logic.util.OS;
 import org.jabref.logic.util.StandardFileType;
@@ -260,9 +261,9 @@ public class TemplateExporter extends Exporter {
             Map<EntryType, Layout> layouts = new HashMap<>();
             Layout layout;
 
-            ExporterFactory.entryNumber = 0;
+            Number.serialExportNumber = 0;
             for (BibEntry entry : sorted) {
-                ExporterFactory.entryNumber++; // Increment entry counter.
+                Number.serialExportNumber++; // Increment entry counter.
                 // Get the layout
                 EntryType type = entry.getType();
                 if (layouts.containsKey(type)) {

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
@@ -210,14 +211,15 @@ public class TemplateExporter extends Exporter {
 
     @Override
     public void export(BibDatabaseContext databaseContext, Path file, List<BibEntry> entries) throws Exception {
-        export(databaseContext, file, entries, Collections.emptyList());
+        export(databaseContext, file, entries, Collections.emptyList(), JournalAbbreviationLoader.loadBuiltInRepository());
     }
 
     @Override
     public void export(final BibDatabaseContext databaseContext,
                        final Path file,
                        List<BibEntry> entries,
-                       List<Path> fileDirForDatabase) throws Exception {
+                       List<Path> fileDirForDatabase,
+                       JournalAbbreviationRepository journalAbbreviationRepository) throws Exception {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
 

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -59,7 +59,11 @@ public class TemplateExporter extends Exporter {
      * @param directory   Directory in which to find the layout file.
      * @param extension   Should contain the . (for instance .txt).
      */
-    public TemplateExporter(String displayName, String consoleName, String lfFileName, String directory, FileType extension) {
+    public TemplateExporter(String displayName,
+                            String consoleName,
+                            String lfFileName,
+                            String directory,
+                            FileType extension) {
         this(displayName, consoleName, lfFileName, directory, extension, null, null);
     }
 
@@ -72,7 +76,10 @@ public class TemplateExporter extends Exporter {
      * @param layoutPreferences Preferences for the layout
      * @param saveConfiguration   Preferences for saving
      */
-    public TemplateExporter(String name, String lfFileName, String extension, LayoutFormatterPreferences layoutPreferences,
+    public TemplateExporter(String name,
+                            String lfFileName,
+                            String extension,
+                            LayoutFormatterPreferences layoutPreferences,
                             SaveConfiguration saveConfiguration) {
         this(name, name, lfFileName, null, StandardFileType.fromExtensions(extension), layoutPreferences, saveConfiguration);
     }
@@ -88,8 +95,13 @@ public class TemplateExporter extends Exporter {
      * @param layoutPreferences Preferences for layout
      * @param saveConfiguration   Preferences for saving
      */
-    public TemplateExporter(String displayName, String consoleName, String lfFileName, String directory, FileType extension,
-                            LayoutFormatterPreferences layoutPreferences, SaveConfiguration saveConfiguration) {
+    public TemplateExporter(String displayName,
+                            String consoleName,
+                            String lfFileName,
+                            String directory,
+                            FileType extension,
+                            LayoutFormatterPreferences layoutPreferences,
+                            SaveConfiguration saveConfiguration) {
         super(consoleName, displayName, extension);
         if (Objects.requireNonNull(lfFileName).endsWith(LAYOUT_EXTENSION)) {
             this.lfFileName = lfFileName.substring(0, lfFileName.length() - LAYOUT_EXTENSION.length());
@@ -113,8 +125,13 @@ public class TemplateExporter extends Exporter {
      * @param saveConfiguration   Preferences for saving
      * @param blankLineBehaviour how to behave regarding blank lines.
      */
-    public TemplateExporter(String displayName, String consoleName, String lfFileName, String directory, FileType extension,
-                            LayoutFormatterPreferences layoutPreferences, SaveConfiguration saveConfiguration,
+    public TemplateExporter(String displayName,
+                            String consoleName,
+                            String lfFileName,
+                            String directory,
+                            FileType extension,
+                            LayoutFormatterPreferences layoutPreferences,
+                            SaveConfiguration saveConfiguration,
                             BlankLineBehaviour blankLineBehaviour) {
         super(consoleName, displayName, extension);
         if (Objects.requireNonNull(lfFileName).endsWith(LAYOUT_EXTENSION)) {

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.layout.LayoutHelper;
@@ -47,6 +48,7 @@ public class TemplateExporter extends Exporter {
     private final String lfFileName;
     private final String directory;
     private final LayoutFormatterPreferences layoutPreferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
     private final SaveConfiguration saveConfiguration;
     private boolean customExport;
     private BlankLineBehaviour blankLineBehaviour;
@@ -65,7 +67,7 @@ public class TemplateExporter extends Exporter {
                             String lfFileName,
                             String directory,
                             FileType extension) {
-        this(displayName, consoleName, lfFileName, directory, extension, null, null);
+        this(displayName, consoleName, lfFileName, directory, extension, null, null, null);
     }
 
     /**
@@ -81,8 +83,16 @@ public class TemplateExporter extends Exporter {
                             String lfFileName,
                             String extension,
                             LayoutFormatterPreferences layoutPreferences,
+                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration) {
-        this(name, name, lfFileName, null, StandardFileType.fromExtensions(extension), layoutPreferences, saveConfiguration);
+        this(name,
+                name,
+                lfFileName,
+                null,
+                StandardFileType.fromExtensions(extension),
+                layoutPreferences,
+                abbreviationRepository,
+                saveConfiguration);
     }
 
     /**
@@ -102,6 +112,7 @@ public class TemplateExporter extends Exporter {
                             String directory,
                             FileType extension,
                             LayoutFormatterPreferences layoutPreferences,
+                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration) {
         super(consoleName, displayName, extension);
         if (Objects.requireNonNull(lfFileName).endsWith(LAYOUT_EXTENSION)) {
@@ -111,6 +122,7 @@ public class TemplateExporter extends Exporter {
         }
         this.directory = directory;
         this.layoutPreferences = layoutPreferences;
+        this.abbreviationRepository = abbreviationRepository;
         this.saveConfiguration = saveConfiguration;
     }
 
@@ -132,6 +144,7 @@ public class TemplateExporter extends Exporter {
                             String directory,
                             FileType extension,
                             LayoutFormatterPreferences layoutPreferences,
+                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration,
                             BlankLineBehaviour blankLineBehaviour) {
         super(consoleName, displayName, extension);
@@ -142,6 +155,7 @@ public class TemplateExporter extends Exporter {
         }
         this.directory = directory;
         this.layoutPreferences = layoutPreferences;
+        this.abbreviationRepository = abbreviationRepository;
         this.saveConfiguration = saveConfiguration;
         this.blankLineBehaviour = blankLineBehaviour;
     }
@@ -224,7 +238,7 @@ public class TemplateExporter extends Exporter {
 
             // Print header
             try (Reader reader = getReader(lfFileName + BEGIN_INFIX + LAYOUT_EXTENSION)) {
-                LayoutHelper layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences);
+                LayoutHelper layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences, abbreviationRepository);
                 beginLayout = layoutHelper.getLayoutFromText();
             } catch (IOException ex) {
                 // If an exception was cast, export filter doesn't have a begin
@@ -249,7 +263,7 @@ public class TemplateExporter extends Exporter {
             Layout defLayout;
             LayoutHelper layoutHelper;
             try (Reader reader = getReader(lfFileName + LAYOUT_EXTENSION)) {
-                layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences);
+                layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences, abbreviationRepository);
                 defLayout = layoutHelper.getLayoutFromText();
             }
             if (defLayout != null) {
@@ -271,7 +285,7 @@ public class TemplateExporter extends Exporter {
                 } else {
                     try (Reader reader = getReader(lfFileName + '.' + type.getName() + LAYOUT_EXTENSION)) {
                         // We try to get a type-specific layout for this entry.
-                        layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences);
+                        layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences, abbreviationRepository);
                         layout = layoutHelper.getLayoutFromText();
                         layouts.put(type, layout);
                         if (layout != null) {
@@ -303,7 +317,7 @@ public class TemplateExporter extends Exporter {
             // Print footer
             Layout endLayout = null;
             try (Reader reader = getReader(lfFileName + END_INFIX + LAYOUT_EXTENSION)) {
-                layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences);
+                layoutHelper = new LayoutHelper(reader, fileDirForDatabase, layoutPreferences, abbreviationRepository);
                 endLayout = layoutHelper.getLayoutFromText();
             } catch (IOException ex) {
                 // If an exception was thrown, export filter doesn't have an end

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -49,7 +49,6 @@ public class TemplateExporter extends Exporter {
     private final String lfFileName;
     private final String directory;
     private final LayoutFormatterPreferences layoutPreferences;
-    private final JournalAbbreviationRepository abbreviationRepository;
     private final SaveConfiguration saveConfiguration;
     private boolean customExport;
     private BlankLineBehaviour blankLineBehaviour;
@@ -84,7 +83,6 @@ public class TemplateExporter extends Exporter {
                             String lfFileName,
                             String extension,
                             LayoutFormatterPreferences layoutPreferences,
-                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration) {
         this(name,
                 name,
@@ -92,7 +90,6 @@ public class TemplateExporter extends Exporter {
                 null,
                 StandardFileType.fromExtensions(extension),
                 layoutPreferences,
-                abbreviationRepository,
                 saveConfiguration);
     }
 
@@ -113,7 +110,6 @@ public class TemplateExporter extends Exporter {
                             String directory,
                             FileType extension,
                             LayoutFormatterPreferences layoutPreferences,
-                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration) {
         super(consoleName, displayName, extension);
         if (Objects.requireNonNull(lfFileName).endsWith(LAYOUT_EXTENSION)) {
@@ -123,7 +119,6 @@ public class TemplateExporter extends Exporter {
         }
         this.directory = directory;
         this.layoutPreferences = layoutPreferences;
-        this.abbreviationRepository = abbreviationRepository;
         this.saveConfiguration = saveConfiguration;
     }
 
@@ -145,7 +140,6 @@ public class TemplateExporter extends Exporter {
                             String directory,
                             FileType extension,
                             LayoutFormatterPreferences layoutPreferences,
-                            JournalAbbreviationRepository abbreviationRepository,
                             SaveConfiguration saveConfiguration,
                             BlankLineBehaviour blankLineBehaviour) {
         super(consoleName, displayName, extension);
@@ -156,7 +150,6 @@ public class TemplateExporter extends Exporter {
         }
         this.directory = directory;
         this.layoutPreferences = layoutPreferences;
-        this.abbreviationRepository = abbreviationRepository;
         this.saveConfiguration = saveConfiguration;
         this.blankLineBehaviour = blankLineBehaviour;
     }
@@ -219,7 +212,7 @@ public class TemplateExporter extends Exporter {
                        final Path file,
                        List<BibEntry> entries,
                        List<Path> fileDirForDatabase,
-                       JournalAbbreviationRepository journalAbbreviationRepository) throws Exception {
+                       JournalAbbreviationRepository abbreviationRepository) throws Exception {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
 

--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -125,8 +125,7 @@ public class ImportFormatReader {
 
     /**
      * All importers.
-     * <p>
-     * <p>
+     *
      * Elements are sorted by name.
      * </p>
      *
@@ -136,15 +135,7 @@ public class ImportFormatReader {
         return new TreeSet<>(this.formats);
     }
 
-    public static class UnknownFormatImport {
-
-        public final String format;
-        public final ParserResult parserResult;
-
-        public UnknownFormatImport(String format, ParserResult parserResult) {
-            this.format = format;
-            this.parserResult = parserResult;
-        }
+    public record UnknownFormatImport(String format, ParserResult parserResult) {
     }
 
     /**

--- a/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CustomImporter.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.Importer;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.util.FileType;
@@ -25,21 +26,21 @@ public class CustomImporter extends Importer {
 
     private final Importer importer;
 
-    public CustomImporter(String basePath, String className) throws ClassNotFoundException {
+    public CustomImporter(String basePath, String className) throws ImportException {
         this.basePath = Path.of(basePath);
         this.className = className;
         try {
             importer = load(this.basePath.toUri().toURL(), this.className);
-        } catch (IOException | InstantiationException | IllegalAccessException exception) {
-            throw new ClassNotFoundException("", exception);
+        } catch (IOException | ReflectiveOperationException exception) {
+            throw new ImportException(exception);
         }
     }
 
     private static Importer load(URL basePathURL, String className)
-            throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+            throws IOException, ReflectiveOperationException {
         try (URLClassLoader cl = new URLClassLoader(new URL[]{basePathURL})) {
             Class<?> clazz = Class.forName(className, true, cl);
-            return (Importer) clazz.newInstance();
+            return (Importer) clazz.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/src/main/java/org/jabref/logic/layout/Layout.java
+++ b/src/main/java/org/jabref/logic/layout/Layout.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -21,7 +22,10 @@ public class Layout {
 
     private final List<String> missingFormatters = new ArrayList<>();
 
-    public Layout(List<StringInt> parsedEntries, List<Path> fileDirForDatabase, LayoutFormatterPreferences prefs) {
+    public Layout(List<StringInt> parsedEntries,
+                  List<Path> fileDirForDatabase,
+                  LayoutFormatterPreferences layoutPreferences,
+                  JournalAbbreviationRepository abbreviationRepository) {
         List<LayoutEntry> tmpEntries = new ArrayList<>(parsedEntries.size());
 
         List<StringInt> blockEntries = null;
@@ -48,7 +52,8 @@ public class Layout {
                             le = new LayoutEntry(blockEntries,
                                     parsedEntry.i == LayoutHelper.IS_FIELD_END ? LayoutHelper.IS_FIELD_START : LayoutHelper.IS_GROUP_START,
                                     fileDirForDatabase,
-                                    prefs);
+                                    layoutPreferences,
+                                    abbreviationRepository);
                             tmpEntries.add(le);
                             blockEntries = null;
                         } else {
@@ -63,7 +68,7 @@ public class Layout {
             }
 
             if (blockEntries == null) {
-                tmpEntries.add(new LayoutEntry(parsedEntry, fileDirForDatabase, prefs));
+                tmpEntries.add(new LayoutEntry(parsedEntry, fileDirForDatabase, layoutPreferences, abbreviationRepository));
             } else {
                 blockEntries.add(parsedEntry);
             }

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.format.AuthorAbbreviator;
 import org.jabref.logic.layout.format.AuthorAndToSemicolonReplacer;
 import org.jabref.logic.layout.format.AuthorAndsCommaReplacer;
@@ -108,31 +109,37 @@ class LayoutEntry {
 
     private final List<Path> fileDirForDatabase;
     private final LayoutFormatterPreferences preferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
 
-    public LayoutEntry(StringInt si, List<Path> fileDirForDatabase, LayoutFormatterPreferences preferences) {
+    public LayoutEntry(StringInt si,
+                       List<Path> fileDirForDatabase,
+                       LayoutFormatterPreferences preferences,
+                       JournalAbbreviationRepository abbreviationRepository) {
         this.preferences = preferences;
+        this.abbreviationRepository = abbreviationRepository;
         this.fileDirForDatabase = Objects.requireNonNullElse(fileDirForDatabase, Collections.emptyList());
 
         type = si.i;
         switch (type) {
-            case LayoutHelper.IS_LAYOUT_TEXT:
-                text = si.s;
-                break;
-            case LayoutHelper.IS_SIMPLE_COMMAND:
-                text = si.s.trim();
-                break;
-            case LayoutHelper.IS_OPTION_FIELD:
-                doOptionField(si.s);
-                break;
-            case LayoutHelper.IS_FIELD_START:
-            case LayoutHelper.IS_FIELD_END:
-            default:
-                break;
+            case LayoutHelper.IS_LAYOUT_TEXT ->
+                    text = si.s;
+            case LayoutHelper.IS_SIMPLE_COMMAND ->
+                    text = si.s.trim();
+            case LayoutHelper.IS_OPTION_FIELD ->
+                    doOptionField(si.s);
+            default -> {
+                // IS_FIELD_START and IS_FIELD_END
+            }
         }
     }
 
-    public LayoutEntry(List<StringInt> parsedEntries, int layoutType, List<Path> fileDirForDatabase, LayoutFormatterPreferences preferences) {
+    public LayoutEntry(List<StringInt> parsedEntries,
+                       int layoutType,
+                       List<Path> fileDirForDatabase,
+                       LayoutFormatterPreferences preferences,
+                       JournalAbbreviationRepository abbreviationRepository) {
         this.preferences = preferences;
+        this.abbreviationRepository = abbreviationRepository;
         this.fileDirForDatabase = Objects.requireNonNullElse(fileDirForDatabase, Collections.emptyList());
 
         List<LayoutEntry> tmpEntries = new ArrayList<>();
@@ -159,7 +166,7 @@ class LayoutEntry {
                         blockEntries.add(parsedEntry);
                         int groupType = parsedEntry.i == LayoutHelper.IS_GROUP_END ? LayoutHelper.IS_GROUP_START :
                                 LayoutHelper.IS_FIELD_START;
-                        LayoutEntry le = new LayoutEntry(blockEntries, groupType, fileDirForDatabase, preferences);
+                        LayoutEntry le = new LayoutEntry(blockEntries, groupType, fileDirForDatabase, preferences, abbreviationRepository);
                         tmpEntries.add(le);
                         blockEntries = null;
                     } else {
@@ -175,7 +182,7 @@ class LayoutEntry {
             }
 
             if (blockEntries == null) {
-                tmpEntries.add(new LayoutEntry(parsedEntry, fileDirForDatabase, preferences));
+                tmpEntries.add(new LayoutEntry(parsedEntry, fileDirForDatabase, preferences, abbreviationRepository));
             } else {
                 blockEntries.add(parsedEntry);
             }
@@ -446,7 +453,7 @@ class LayoutEntry {
             case "HTMLParagraphs" -> new HTMLParagraphs();
             case "Iso690FormatDate" -> new Iso690FormatDate();
             case "Iso690NamesAuthors" -> new Iso690NamesAuthors();
-            case "JournalAbbreviator" -> new JournalAbbreviator(preferences.getJournalAbbreviationRepository());
+            case "JournalAbbreviator" -> new JournalAbbreviator(abbreviationRepository);
             case "LastPage" -> new LastPage();
 // For backward compatibility
             case "FormatChars", "LatexToUnicode" -> new LatexToUnicodeFormatter();

--- a/src/main/java/org/jabref/logic/layout/LayoutFormatterPreferences.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutFormatterPreferences.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import javafx.beans.property.StringProperty;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.format.NameFormatterPreferences;
 
 public class LayoutFormatterPreferences {
@@ -14,14 +13,11 @@ public class LayoutFormatterPreferences {
     private final NameFormatterPreferences nameFormatterPreferences;
     private final StringProperty mainFileDirectoryProperty;
     private final Map<String, String> customExportNameFormatters = new HashMap<>();
-    private final JournalAbbreviationRepository journalAbbreviationRepository;
 
     public LayoutFormatterPreferences(NameFormatterPreferences nameFormatterPreferences,
-                                      StringProperty mainFileDirectoryProperty,
-                                      JournalAbbreviationRepository journalAbbreviationRepository) {
+                                      StringProperty mainFileDirectoryProperty) {
         this.nameFormatterPreferences = nameFormatterPreferences;
         this.mainFileDirectoryProperty = mainFileDirectoryProperty;
-        this.journalAbbreviationRepository = journalAbbreviationRepository;
     }
 
     public NameFormatterPreferences getNameFormatterPreferences() {
@@ -32,8 +28,8 @@ public class LayoutFormatterPreferences {
         return mainFileDirectoryProperty.get();
     }
 
-    public JournalAbbreviationRepository getJournalAbbreviationRepository() {
-        return journalAbbreviationRepository;
+    public Optional<String> getCustomExportNameFormatter(String formatterName) {
+        return Optional.ofNullable(customExportNameFormatters.get(formatterName));
     }
 
     public void clearCustomExportNameFormatters() {
@@ -42,9 +38,5 @@ public class LayoutFormatterPreferences {
 
     public void putCustomExportNameFormatter(String formatterName, String contents) {
         customExportNameFormatters.put(formatterName, contents);
-    }
-
-    public Optional<String> getCustomExportNameFormatter(String formatterName) {
-        return Optional.ofNullable(customExportNameFormatters.get(formatterName));
     }
 }

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+
 /**
  * Helper class to get a Layout object.
  *
@@ -39,16 +41,23 @@ public class LayoutHelper {
     private final List<StringInt> parsedEntries = new ArrayList<>();
     private final List<Path> fileDirForDatabase;
     private final LayoutFormatterPreferences preferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
     private boolean endOfFile;
 
-    public LayoutHelper(Reader in, List<Path> fileDirForDatabase, LayoutFormatterPreferences preferences) {
+    public LayoutHelper(Reader in,
+                        List<Path> fileDirForDatabase,
+                        LayoutFormatterPreferences preferences,
+                        JournalAbbreviationRepository abbreviationRepository) {
         this.in = new PushbackReader(Objects.requireNonNull(in));
         this.preferences = Objects.requireNonNull(preferences);
+        this.abbreviationRepository = abbreviationRepository;
         this.fileDirForDatabase = fileDirForDatabase;
     }
 
-    public LayoutHelper(Reader in, LayoutFormatterPreferences preferences) {
-        this(in, Collections.emptyList(), preferences);
+    public LayoutHelper(Reader in,
+                        LayoutFormatterPreferences preferences,
+                        JournalAbbreviationRepository abbreviationRepository) {
+        this(in, Collections.emptyList(), preferences, abbreviationRepository);
     }
 
     public Layout getLayoutFromText() throws IOException {
@@ -62,7 +71,7 @@ public class LayoutHelper {
             }
         }
 
-        return new Layout(parsedEntries, fileDirForDatabase, preferences);
+        return new Layout(parsedEntries, fileDirForDatabase, preferences, abbreviationRepository);
     }
 
     public static String getCurrentGroup() {

--- a/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
+++ b/src/main/java/org/jabref/logic/layout/TextBasedPreviewLayout.java
@@ -3,6 +3,7 @@ package org.jabref.logic.layout;
 import java.io.IOException;
 import java.io.StringReader;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.model.database.BibDatabaseContext;
@@ -12,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements the preview based JabRef's <a href="https://docs.jabref.org/import-export/export/customexports">Custom export fitlters</a>.
+ * Implements the preview based JabRef's <a href="https://docs.jabref.org/import-export/export/customexports">Custom export filters</a>.
  */
 public class TextBasedPreviewLayout implements PreviewLayout {
     public static final String NAME = "PREVIEW";
@@ -21,9 +22,11 @@ public class TextBasedPreviewLayout implements PreviewLayout {
     private Layout layout;
     private String text;
     private LayoutFormatterPreferences layoutFormatterPreferences;
+    private JournalAbbreviationRepository abbreviationRepository;
 
-    public TextBasedPreviewLayout(String text, LayoutFormatterPreferences layoutFormatterPreferences) {
+    public TextBasedPreviewLayout(String text, LayoutFormatterPreferences layoutFormatterPreferences, JournalAbbreviationRepository abbreviationRepository) {
         this.layoutFormatterPreferences = layoutFormatterPreferences;
+        this.abbreviationRepository = abbreviationRepository;
         setText(text);
     }
 
@@ -36,7 +39,7 @@ public class TextBasedPreviewLayout implements PreviewLayout {
         this.text = text;
         StringReader sr = new StringReader(text.replace("__NEWLINE__", "\n"));
         try {
-            layout = new LayoutHelper(sr, layoutFormatterPreferences).getLayoutFromText();
+            layout = new LayoutHelper(sr, layoutFormatterPreferences, abbreviationRepository).getLayoutFromText();
         } catch (IOException e) {
             LOGGER.error("Could not generate layout", e);
         }

--- a/src/main/java/org/jabref/logic/layout/format/Number.java
+++ b/src/main/java/org/jabref/logic/layout/format/Number.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.layout.format;
 
-import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.layout.ParamLayoutFormatter;
 
 /**
@@ -9,6 +8,8 @@ import org.jabref.logic.layout.ParamLayoutFormatter;
  */
 public class Number implements ParamLayoutFormatter {
 
+    public static int serialExportNumber;
+
     @Override
     public void setArgument(String arg) {
         // No effect currently.
@@ -16,6 +17,6 @@ public class Number implements ParamLayoutFormatter {
 
     @Override
     public String format(String fieldText) {
-        return String.valueOf(ExporterFactory.entryNumber);
+        return String.valueOf(serialExportNumber);
     }
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
@@ -19,6 +19,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
@@ -130,7 +131,8 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private final Map<String, Object> citProperties = new HashMap<>();
     private final boolean fromResource;
     private final String path;
-    private final LayoutFormatterPreferences prefs;
+    private final LayoutFormatterPreferences layoutPreferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
     private String name = "";
     private Layout defaultBibLayout;
     private boolean valid;
@@ -139,8 +141,9 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private String localCopy;
     private boolean isDefaultLayoutPresent;
 
-    public OOBibStyle(Path styleFile, LayoutFormatterPreferences prefs) throws IOException {
-        this.prefs = Objects.requireNonNull(prefs);
+    public OOBibStyle(Path styleFile, LayoutFormatterPreferences layoutPreferences, JournalAbbreviationRepository abbreviationRepository) throws IOException {
+        this.layoutPreferences = Objects.requireNonNull(layoutPreferences);
+        this.abbreviationRepository = abbreviationRepository;
         this.styleFile = Objects.requireNonNull(styleFile);
         setDefaultProperties();
         reload();
@@ -148,8 +151,10 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         path = styleFile.toAbsolutePath().toString();
     }
 
-    public OOBibStyle(String resourcePath, LayoutFormatterPreferences prefs) throws IOException {
-        this.prefs = Objects.requireNonNull(prefs);
+    public OOBibStyle(String resourcePath, LayoutFormatterPreferences layoutPreferences, JournalAbbreviationRepository abbreviationRepository) throws IOException {
+        this.layoutPreferences = Objects.requireNonNull(layoutPreferences);
+        this.abbreviationRepository = abbreviationRepository;
+
         Objects.requireNonNull(resourcePath);
         setDefaultProperties();
         initialize(OOBibStyle.class.getResourceAsStream(resourcePath));
@@ -379,7 +384,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
             try {
                 final String typeName = line.substring(0, index);
                 final String formatString = line.substring(index + 1);
-                Layout layout = new LayoutHelper(new StringReader(formatString), this.prefs).getLayoutFromText();
+                Layout layout = new LayoutHelper(new StringReader(formatString), layoutPreferences, abbreviationRepository).getLayoutFromText();
                 EntryType type = EntryTypeFactory.parse(typeName);
 
                 if (!isDefaultLayoutPresent && OOBibStyle.DEFAULT_MARK.equals(typeName)) {
@@ -654,8 +659,8 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         valid = isValid;
     }
 
-    protected LayoutFormatterPreferences getPrefs() {
-        return prefs;
+    protected LayoutFormatterPreferences getLayoutPreferences() {
+        return layoutPreferences;
     }
 
     protected void setDefaultBibLayout(Layout layout) {

--- a/src/main/java/org/jabref/logic/openoffice/style/StyleLoader.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/StyleLoader.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.openoffice.OpenOfficePreferences;
 
@@ -27,15 +28,19 @@ public class StyleLoader {
 
     private final OpenOfficePreferences openOfficePreferences;
     private final LayoutFormatterPreferences layoutFormatterPreferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
 
     // Lists of the internal
     // and external styles
     private final List<OOBibStyle> internalStyles = new ArrayList<>();
     private final List<OOBibStyle> externalStyles = new ArrayList<>();
 
-    public StyleLoader(OpenOfficePreferences openOfficePreferences, LayoutFormatterPreferences formatterPreferences) {
+    public StyleLoader(OpenOfficePreferences openOfficePreferences,
+                       LayoutFormatterPreferences formatterPreferences,
+                       JournalAbbreviationRepository abbreviationRepository) {
         this.openOfficePreferences = Objects.requireNonNull(openOfficePreferences);
         this.layoutFormatterPreferences = Objects.requireNonNull(formatterPreferences);
+        this.abbreviationRepository = Objects.requireNonNull(abbreviationRepository);
         loadInternalStyles();
         loadExternalStyles();
     }
@@ -55,7 +60,7 @@ public class StyleLoader {
     public boolean addStyleIfValid(String filename) {
         Objects.requireNonNull(filename);
         try {
-            OOBibStyle newStyle = new OOBibStyle(Path.of(filename), layoutFormatterPreferences);
+            OOBibStyle newStyle = new OOBibStyle(Path.of(filename), layoutFormatterPreferences, abbreviationRepository);
             if (externalStyles.contains(newStyle)) {
                 LOGGER.info("External style file {} already existing.", filename);
             } else if (newStyle.isValid()) {
@@ -80,7 +85,7 @@ public class StyleLoader {
         List<String> lists = openOfficePreferences.getExternalStyles();
         for (String filename : lists) {
             try {
-                OOBibStyle style = new OOBibStyle(Path.of(filename), layoutFormatterPreferences);
+                OOBibStyle style = new OOBibStyle(Path.of(filename), layoutFormatterPreferences, abbreviationRepository);
                 if (style.isValid()) { // Problem!
                     externalStyles.add(style);
                 } else {
@@ -99,7 +104,7 @@ public class StyleLoader {
         internalStyles.clear();
         for (String filename : internalStyleFiles) {
             try {
-                internalStyles.add(new OOBibStyle(filename, layoutFormatterPreferences));
+                internalStyles.add(new OOBibStyle(filename, layoutFormatterPreferences, abbreviationRepository));
             } catch (IOException e) {
                 LOGGER.info("Problem reading internal style file {}", filename, e);
             }

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -52,14 +52,13 @@ public class PreferencesMigrations {
         upgradeStoredBibEntryTypes(preferences, mainPrefsNode);
         upgradeKeyBindingsToJavaFX(preferences);
         addCrossRefRelatedFieldsForAutoComplete(preferences);
-        upgradePreviewStyleFromReviewToComment(preferences);
+        upgradePreviewStyle(preferences);
         // changeColumnVariableNamesFor51 needs to be run before upgradeColumnPre50Preferences to ensure
         // backwardcompatibility, as it copies the old values to new variable names and keeps th old sored with the old
         // variable names. However, the variables from 5.0 need to be copied to the new variable name too.
         changeColumnVariableNamesFor51(preferences);
         upgradeColumnPreferences(preferences);
         restoreVariablesForBackwardCompatibility(preferences);
-        upgradePreviewStyleAllowMarkdown(preferences);
         upgradeCleanups(preferences);
     }
 
@@ -310,21 +309,21 @@ public class PreferencesMigrations {
         prefs.storeGlobalCitationKeyPattern(keyPattern);
     }
 
-    static void upgradePreviewStyleFromReviewToComment(JabRefPreferences prefs) {
-        String currentPreviewStyle = prefs.getPreviewStyle();
+    /**
+     * Customizable preview style migrations
+     * <ul>
+     *     <li> Since v5.0-alpha the custom preview layout shows the 'comment' field instead of the 'review' field (<a href="https://github.com/JabRef/jabref/pull/4100">#4100</a>).</li>
+     *     <li> Since v5.1 a marker enables markdown in comments (<a href="https://github.com/JabRef/jabref/pull/6232">#6232</a>).</li>
+     *     <li> Since v5.2 'bibtexkey' is rebranded as citationkey (<a href="https://github.com/JabRef/jabref/pull/6875">#6875</a>).</li>
+     * </ul>
+     */
+    protected static void upgradePreviewStyle(JabRefPreferences prefs) {
+        String currentPreviewStyle = prefs.get(JabRefPreferences.PREVIEW_STYLE);
         String migratedStyle = currentPreviewStyle.replace("\\begin{review}<BR><BR><b>Review: </b> \\format[HTMLChars]{\\review} \\end{review}", "\\begin{comment}<BR><BR><b>Comment: </b> \\format[HTMLChars]{\\comment} \\end{comment}")
+                                                  .replace("\\format[HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars]{\\comment}")
                                                   .replace("<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>", "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>")
                                                   .replace("\\end{bibtexkey}</b><br>__NEWLINE__", "\\end{citationkey}</b><br>__NEWLINE__");
-        prefs.setPreviewStyle(migratedStyle);
-    }
-
-    static void upgradePreviewStyleAllowMarkdown(JabRefPreferences prefs) {
-        String currentPreviewStyle = prefs.getPreviewStyle();
-        String migratedStyle = currentPreviewStyle.replace("\\format[HTMLChars]{\\comment}", "\\format[Markdown,HTMLChars]{\\comment}")
-                                                  .replace("<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>", "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>")
-                                                  .replace("\\end{bibtexkey}</b><br>__NEWLINE__", "\\end{citationkey}</b><br>__NEWLINE__");
-
-        prefs.setPreviewStyle(migratedStyle);
+        prefs.put(JabRefPreferences.PREVIEW_STYLE, migratedStyle);
     }
 
     /**

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -2784,7 +2784,7 @@ public class JabRefPreferences implements PreferencesService {
         return importers;
     }
 
-    public void storeCustomImportFormats(Set<CustomImporter> importers) {
+    private void storeCustomImportFormats(Set<CustomImporter> importers) {
         purgeSeries(CUSTOM_IMPORT_FORMAT, 0);
         CustomImporter[] importersArray = importers.toArray(new CustomImporter[0]);
         for (int i = 0; i < importersArray.length; i++) {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -343,14 +343,14 @@ public class JabRefPreferences implements PreferencesService {
     // String delimiter
     public static final Character STRINGLIST_DELIMITER = ';';
 
+    // Preview - public for pref migrations
+    public static final String PREVIEW_STYLE = "previewStyle";
+    public static final String CYCLE_PREVIEW_POS = "cyclePreviewPos";
+    public static final String CYCLE_PREVIEW = "cyclePreview";
+    public static final String PREVIEW_AS_TAB = "previewAsTab";
+
     // UI
     private static final String FONT_FAMILY = "fontFamily";
-
-    // Preview
-    private static final String PREVIEW_STYLE = "previewStyle";
-    private static final String CYCLE_PREVIEW_POS = "cyclePreviewPos";
-    private static final String CYCLE_PREVIEW = "cyclePreview";
-    private static final String PREVIEW_AS_TAB = "previewAsTab";
 
     // Proxy
     private static final String PROXY_PORT = "proxyPort";
@@ -1147,14 +1147,6 @@ public class JabRefPreferences implements PreferencesService {
     public void storeKeyBindingRepository(KeyBindingRepository keyBindingRepository) {
         putStringList(BIND_NAMES, keyBindingRepository.getBindNames());
         putStringList(BINDINGS, keyBindingRepository.getBindings());
-    }
-
-    public String getPreviewStyle() {
-        return get(PREVIEW_STYLE);
-    }
-
-    public void setPreviewStyle(String previewStyle) {
-        put(PREVIEW_STYLE, previewStyle);
     }
 
     @Override

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1131,11 +1131,10 @@ public class JabRefPreferences implements PreferencesService {
     //*************************************************************************************************************
 
     @Override
-    public LayoutFormatterPreferences getLayoutFormatterPreferences(JournalAbbreviationRepository repository) {
+    public LayoutFormatterPreferences getLayoutFormatterPreferences() {
         return new LayoutFormatterPreferences(
                 getNameFormatterPreferences(),
-                getFilePreferences().mainFileDirectoryProperty(),
-                repository);
+                getFilePreferences().mainFileDirectoryProperty());
     }
 
     @Override
@@ -2250,7 +2249,7 @@ public class JabRefPreferences implements PreferencesService {
 
     @Override
     public List<TemplateExporter> getCustomExportFormats(JournalAbbreviationRepository abbreviationRepository) {
-        LayoutFormatterPreferences layoutPreferences = getLayoutFormatterPreferences(abbreviationRepository);
+        LayoutFormatterPreferences layoutPreferences = getLayoutFormatterPreferences();
         SaveConfiguration saveConfiguration = getExportConfiguration();
         List<TemplateExporter> formats = new ArrayList<>();
 
@@ -2261,6 +2260,7 @@ public class JabRefPreferences implements PreferencesService {
                     formatData.get(EXPORTER_FILENAME_INDEX),
                     formatData.get(EXPORTER_EXTENSION_INDEX),
                     layoutPreferences,
+                    abbreviationRepository,
                     saveConfiguration);
             format.setCustomExport(true);
             formats.add(format);
@@ -2301,7 +2301,7 @@ public class JabRefPreferences implements PreferencesService {
         this.previewPreferences = new PreviewPreferences(
                 layouts,
                 getPreviewCyclePosition(layouts),
-                new TextBasedPreviewLayout(style, getLayoutFormatterPreferences(Globals.journalAbbreviationRepository)),
+                new TextBasedPreviewLayout(style, getLayoutFormatterPreferences(), Globals.journalAbbreviationRepository),
                 (String) defaults.get(PREVIEW_STYLE),
                 getBoolean(PREVIEW_AS_TAB));
 
@@ -2328,7 +2328,7 @@ public class JabRefPreferences implements PreferencesService {
                                                 .map(file -> (PreviewLayout) new CitationStylePreviewLayout(file, Globals.entryTypesManager))
                                                 .orElse(null);
                         } else {
-                            return new TextBasedPreviewLayout(style, getLayoutFormatterPreferences(Globals.journalAbbreviationRepository));
+                            return new TextBasedPreviewLayout(style, getLayoutFormatterPreferences(), Globals.journalAbbreviationRepository);
                         }
                     })
                     .filter(Objects::nonNull)

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -75,7 +75,6 @@ import org.jabref.logic.importer.fetcher.GrobidPreferences;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.util.MetaDataParser;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
@@ -2248,7 +2247,7 @@ public class JabRefPreferences implements PreferencesService {
     }
 
     @Override
-    public List<TemplateExporter> getCustomExportFormats(JournalAbbreviationRepository abbreviationRepository) {
+    public List<TemplateExporter> getCustomExportFormats() {
         LayoutFormatterPreferences layoutPreferences = getLayoutFormatterPreferences();
         SaveConfiguration saveConfiguration = getExportConfiguration();
         List<TemplateExporter> formats = new ArrayList<>();
@@ -2260,7 +2259,6 @@ public class JabRefPreferences implements PreferencesService {
                     formatData.get(EXPORTER_FILENAME_INDEX),
                     formatData.get(EXPORTER_EXTENSION_INDEX),
                     layoutPreferences,
-                    abbreviationRepository,
                     saveConfiguration);
             format.setCustomExport(true);
             formats.add(format);

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -23,7 +23,6 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.fetcher.GrobidPreferences;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.layout.format.NameFormatterPreferences;
 import org.jabref.logic.net.ProxyPreferences;
@@ -129,7 +128,7 @@ public interface PreferencesService {
 
     ExportPreferences getExportPreferences();
 
-    List<TemplateExporter> getCustomExportFormats(JournalAbbreviationRepository repository);
+    List<TemplateExporter> getCustomExportFormats();
 
     void storeCustomExportFormats(List<TemplateExporter> exporters);
 

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -71,7 +71,7 @@ public interface PreferencesService {
 
     Map<String, Object> getDefaults();
 
-    LayoutFormatterPreferences getLayoutFormatterPreferences(JournalAbbreviationRepository repository);
+    LayoutFormatterPreferences getLayoutFormatterPreferences();
 
     ImportFormatPreferences getImportFormatPreferences();
 

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -41,6 +41,16 @@ import org.jabref.model.entry.field.Field;
 
 public interface PreferencesService {
 
+    void clear() throws BackingStoreException;
+
+    void deleteKey(String key) throws IllegalArgumentException;
+
+    void flush();
+
+    void exportPreferences(Path file) throws JabRefException;
+
+    void importPreferences(Path file) throws JabRefException;
+
     InternalPreferences getInternalPreferences();
 
     BibEntryPreferences getBibEntryPreferences();
@@ -61,21 +71,11 @@ public interface PreferencesService {
 
     Map<String, Object> getDefaults();
 
-    void exportPreferences(Path file) throws JabRefException;
-
-    void importPreferences(Path file) throws JabRefException;
-
     LayoutFormatterPreferences getLayoutFormatterPreferences(JournalAbbreviationRepository repository);
 
     ImportFormatPreferences getImportFormatPreferences();
 
     SaveConfiguration getExportConfiguration();
-
-    void clear() throws BackingStoreException;
-
-    void deleteKey(String key) throws IllegalArgumentException;
-
-    void flush();
 
     BibEntryTypesManager getCustomEntryTypesRepository();
 
@@ -95,15 +95,7 @@ public interface PreferencesService {
 
     TimestampPreferences getTimestampPreferences();
 
-    //*************************************************************************************************************
-    // GroupsPreferences
-    //*************************************************************************************************************
-
     GroupsPreferences getGroupsPreferences();
-
-    //*************************************************************************************************************
-    // EntryEditorPreferences
-    //*************************************************************************************************************
 
     Map<String, Set<Field>> getDefaultTabNamesAndFields();
 
@@ -111,33 +103,17 @@ public interface PreferencesService {
 
     EntryEditorPreferences getEntryEditorPreferences();
 
-    //*************************************************************************************************************
-    // Network preferences
-    //*************************************************************************************************************
-
     RemotePreferences getRemotePreferences();
 
     ProxyPreferences getProxyPreferences();
 
     SSLPreferences getSSLPreferences();
 
-    //*************************************************************************************************************
-    // CitationKeyPatternPreferences
-    //*************************************************************************************************************
-
     CitationKeyPatternPreferences getCitationKeyPatternPreferences();
-
-    //*************************************************************************************************************
-    // ExternalApplicationsPreferences
-    //*************************************************************************************************************
 
     PushToApplicationPreferences getPushToApplicationPreferences();
 
     ExternalApplicationsPreferences getExternalApplicationsPreferences();
-
-    //*************************************************************************************************************
-    // MainTablePreferences
-    //*************************************************************************************************************
 
     ColumnPreferences getMainTableColumnPreferences();
 
@@ -145,27 +121,11 @@ public interface PreferencesService {
 
     NameDisplayPreferences getNameDisplayPreferences();
 
-    //*************************************************************************************************************
-    // SearchDialogColumnPreferences
-    //*************************************************************************************************************
-
     ColumnPreferences getSearchDialogColumnPreferences();
-
-    //*************************************************************************************************************
-    // AppearancePreferences
-    //*************************************************************************************************************
 
     WorkspacePreferences getWorkspacePreferences();
 
-    //*************************************************************************************************************
-    // File preferences
-    //*************************************************************************************************************
-
     AutoLinkPreferences getAutoLinkPreferences();
-
-    //*************************************************************************************************************
-    // Import/Export preferences
-    //*************************************************************************************************************
 
     ExportPreferences getExportPreferences();
 
@@ -177,27 +137,11 @@ public interface PreferencesService {
 
     GrobidPreferences getGrobidPreferences();
 
-    //*************************************************************************************************************
-    // Preview preferences
-    //*************************************************************************************************************
-
     PreviewPreferences getPreviewPreferences();
-
-    //*************************************************************************************************************
-    // SidePanePreferences
-    //*************************************************************************************************************
 
     SidePanePreferences getSidePanePreferences();
 
-    //*************************************************************************************************************
-    // GuiPreferences
-    //*************************************************************************************************************
-
     GuiPreferences getGuiPreferences();
-
-    //*************************************************************************************************************
-    // Misc preferences
-    //*************************************************************************************************************
 
     XmpPreferences getXmpPreferences();
 

--- a/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyMoreActionTest.java
@@ -12,6 +12,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.JabRefDialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -32,15 +33,17 @@ import static org.mockito.Mockito.when;
 
 public class CopyMoreActionTest {
 
+    private final DialogService dialogService = spy(DialogService.class);
+    private final ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
+    private final PreferencesService preferencesService = mock(PreferencesService.class);
+    private final JournalAbbreviationRepository abbreviationRepository = mock(JournalAbbreviationRepository.class);
+    private final StateManager stateManager = mock(StateManager.class);
+    private final List<String> titles = new ArrayList<>();
+    private final List<String> keys = new ArrayList<>();
+    private final List<String> dois = new ArrayList<>();
+
     private CopyMoreAction copyMoreAction;
-    private DialogService dialogService = spy(DialogService.class);
-    private ClipBoardManager clipBoardManager = mock(ClipBoardManager.class);
-    private PreferencesService preferencesService = mock(PreferencesService.class);
-    private StateManager stateManager = mock(StateManager.class);
     private BibEntry entry;
-    private List<String> titles = new ArrayList<>();
-    private List<String> keys = new ArrayList<>();
-    private List<String> dois = new ArrayList<>();
 
     @BeforeEach
     public void setUp() {
@@ -61,7 +64,7 @@ public class CopyMoreActionTest {
     public void testExecuteOnFail() {
         when(stateManager.getActiveDatabase()).thenReturn(Optional.empty());
         when(stateManager.getSelectedEntries()).thenReturn(FXCollections.emptyObservableList());
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         verify(clipBoardManager, times(0)).setContent(any(String.class));
@@ -77,7 +80,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoTitles);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         verify(clipBoardManager, times(0)).setContent(any(String.class));
@@ -93,7 +96,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedTitles = String.join("\n", titles);
@@ -109,7 +112,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithTitles);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_TITLE, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedTitles = String.join("\n", titles);
@@ -127,7 +130,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoKeys);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         verify(clipBoardManager, times(0)).setContent(any(String.class));
@@ -143,7 +146,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedKeys = String.join("\n", keys);
@@ -159,7 +162,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithKeys);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_KEY, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedKeys = String.join("\n", keys);
@@ -177,7 +180,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithNoDois);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         verify(clipBoardManager, times(0)).setContent(any(String.class));
@@ -193,7 +196,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(mixedEntries);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedDois = String.join("\n", dois);
@@ -209,7 +212,7 @@ public class CopyMoreActionTest {
 
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         when(stateManager.getSelectedEntries()).thenReturn(entriesWithDois);
-        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService);
+        copyMoreAction = new CopyMoreAction(StandardActions.COPY_DOI, dialogService, stateManager, clipBoardManager, preferencesService, abbreviationRepository);
         copyMoreAction.execute();
 
         String copiedDois = String.join("\n", dois);

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -14,7 +14,6 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.exporter.Exporter;
-import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.StandardFileType;
@@ -52,7 +51,6 @@ public class ExportToClipboardActionTest {
     private final ExportPreferences importExportPrefs = mock(ExportPreferences.class);
     private final StateManager stateManager = mock(StateManager.class);
 
-    private ExporterFactory exporterFactory;
     private TaskExecutor taskExecutor;
     private ObservableList<BibEntry> selectedEntries;
 
@@ -69,7 +67,7 @@ public class ExportToClipboardActionTest {
         when(stateManager.getSelectedEntries()).thenReturn(selectedEntries);
 
         taskExecutor = new CurrentThreadTaskExecutor();
-        when(preferences.getCustomExportFormats(any())).thenReturn(List.of());
+        when(preferences.getCustomExportFormats()).thenReturn(List.of());
         when(preferences.getExportConfiguration()).thenReturn(mock(SaveConfiguration.class));
         when(preferences.getXmpPreferences()).thenReturn(mock(XmpPreferences.class));
         exportToClipboardAction = new ExportToClipboardAction(dialogService, stateManager, clipBoardManager, taskExecutor, preferences);

--- a/src/test/java/org/jabref/gui/sidepane/SidePaneViewModelTest.java
+++ b/src/test/java/org/jabref/gui/sidepane/SidePaneViewModelTest.java
@@ -14,6 +14,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.util.CustomLocalDragboard;
 import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.preferences.PreferencesService;
 import org.jabref.preferences.SidePanePreferences;
 
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.when;
 class SidePaneViewModelTest {
 
     PreferencesService preferencesService = mock(PreferencesService.class);
+    JournalAbbreviationRepository abbreviationRepository = mock(JournalAbbreviationRepository.class);
     StateManager stateManager = mock(StateManager.class);
     TaskExecutor taskExecutor = mock(TaskExecutor.class);
     DialogService dialogService = mock(DialogService.class);
@@ -52,7 +54,7 @@ class SidePaneViewModelTest {
         sidePanePreferences.getPreferredPositions().put(SidePaneType.WEB_SEARCH, 1);
         sidePanePreferences.getPreferredPositions().put(SidePaneType.OPEN_OFFICE, 2);
 
-        sidePaneViewModel = new SidePaneViewModel(preferencesService, stateManager, taskExecutor, dialogService, undoManager);
+        sidePaneViewModel = new SidePaneViewModel(preferencesService, abbreviationRepository, stateManager, taskExecutor, dialogService, undoManager);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -40,6 +40,7 @@ public class CsvExportFormatTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),
@@ -60,9 +61,8 @@ public class CsvExportFormatTest {
     public void testPerformExportForSingleAuthor(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AUTHOR, "Someone, Van Something");
-        List<BibEntry> entries = Arrays.asList(entry);
+        BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Someone, Van Something");
+        List<BibEntry> entries = List.of(entry);
 
         exportFormat.export(databaseContext, path, entries);
 
@@ -77,9 +77,8 @@ public class CsvExportFormatTest {
     public void testPerformExportForMultipleAuthors(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
 
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.AUTHOR, "von Neumann, John and Smith, John and Black Brown, Peter");
-        List<BibEntry> entries = Arrays.asList(entry);
+        BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "von Neumann, John and Smith, John and Black Brown, Peter");
+        List<BibEntry> entries = List.of(entry);
 
         exportFormat.export(databaseContext, path, entries);
 
@@ -94,9 +93,8 @@ public class CsvExportFormatTest {
     public void testPerformExportForSingleEditor(@TempDir Path testFolder) throws Exception {
         Path path = testFolder.resolve("ThisIsARandomlyNamedFile");
         File tmpFile = path.toFile();
-        BibEntry entry = new BibEntry();
-        entry.setField(StandardField.EDITOR, "Someone, Van Something");
-        List<BibEntry> entries = Arrays.asList(entry);
+        BibEntry entry = new BibEntry().withField(StandardField.EDITOR, "Someone, Van Something");
+        List<BibEntry> entries = List.of(entry);
 
         exportFormat.export(databaseContext, tmpFile.toPath(), entries);
 
@@ -113,7 +111,7 @@ public class CsvExportFormatTest {
         File tmpFile = path.toFile();
         BibEntry entry = new BibEntry();
         entry.setField(StandardField.EDITOR, "von Neumann, John and Smith, John and Black Brown, Peter");
-        List<BibEntry> entries = Arrays.asList(entry);
+        List<BibEntry> entries = List.of(entry);
 
         exportFormat.export(databaseContext, tmpFile.toPath(), entries);
 

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -40,7 +39,6 @@ public class CsvExportFormatTest {
                 "openoffice",
                 StandardFileType.CSV,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
                 saveConfiguration);
 
         databaseContext = new BibDatabaseContext();

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -3,17 +3,13 @@ package org.jabref.logic.exporter;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
@@ -37,17 +33,15 @@ public class CsvExportFormatTest {
         SaveConfiguration saveConfiguration = mock(SaveConfiguration.class);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
+        exportFormat = new TemplateExporter(
+                "OpenOffice/LibreOffice CSV",
+                "oocsv",
+                "openoffice-csv",
+                "openoffice",
+                StandardFileType.CSV,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(JournalAbbreviationRepository.class),
-                saveConfiguration,
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
-
-        exportFormat = exporterFactory.getExporterByName("oocsv").get();
+                saveConfiguration);
 
         databaseContext = new BibDatabaseContext();
     }

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -6,18 +6,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.SaveOrder;
@@ -47,24 +43,22 @@ public class DocBook5ExporterTest {
 
     @BeforeEach
     void setUp() throws URISyntaxException {
-        xmlFile = Path.of(DocBook5ExporterTest.class.getResource("Docbook5ExportFormat.xml").toURI());
         SaveConfiguration saveConfiguration = mock(SaveConfiguration.class);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
+        exporter = new TemplateExporter(
+                "DocBook 5.1",
+                "docbook5",
+                "docbook5",
+                null,
+                StandardFileType.XML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(JournalAbbreviationRepository.class),
-                saveConfiguration,
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
-
-        exporter = exporterFactory.getExporterByName("docbook5").get();
+                saveConfiguration);
 
         LocalDate myDate = LocalDate.of(2018, 1, 1);
 
+        xmlFile = Path.of(DocBook5ExporterTest.class.getResource("Docbook5ExportFormat.xml").toURI());
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
         BibEntry entry = new BibEntry(StandardEntryType.Book);

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -53,6 +54,7 @@ public class DocBook5ExporterTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),

--- a/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocBook5ExporterTest.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -53,7 +52,6 @@ public class DocBook5ExporterTest {
                 null,
                 StandardFileType.XML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
                 saveConfiguration);
 
         LocalDate myDate = LocalDate.of(2018, 1, 1);

--- a/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -43,7 +42,6 @@ public class DocbookExporterTest {
                 null,
                 StandardFileType.XML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
                 saveConfiguration);
     }
 

--- a/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -42,6 +43,7 @@ public class DocbookExporterTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),

--- a/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/DocbookExporterTest.java
@@ -4,18 +4,14 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
@@ -40,16 +36,15 @@ public class DocbookExporterTest {
         SaveConfiguration saveConfiguration = mock(SaveConfiguration.class);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
+        exportFormat = new TemplateExporter(
+                "DocBook 4",
+                "docbook4",
+                "docbook4",
+                null,
+                StandardFileType.XML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(JournalAbbreviationRepository.class),
-                saveConfiguration,
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
-        exportFormat = exporterFactory.getExporterByName("docbook4").get();
+                saveConfiguration);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -43,6 +44,7 @@ class EmbeddedBibFilePdfExporterTest {
 
     private BibDatabaseContext databaseContext;
     private BibDatabase dataBase;
+    private JournalAbbreviationRepository abbreviationRepository;
     private FilePreferences filePreferences;
 
     private static void initBibEntries() throws IOException {
@@ -93,6 +95,8 @@ class EmbeddedBibFilePdfExporterTest {
      */
     @BeforeEach
     void setUp() throws IOException {
+        abbreviationRepository = mock(JournalAbbreviationRepository.class);
+
         filePreferences = mock(FilePreferences.class);
         when(filePreferences.getUserAndHost()).thenReturn(tempDir.toAbsolutePath().toString());
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
@@ -118,13 +122,13 @@ class EmbeddedBibFilePdfExporterTest {
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithValidPdfFileLinks")
     void successfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
+        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018), abbreviationRepository));
     }
 
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithInvalidPdfFileLinks")
     void unsuccessfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
+        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018), abbreviationRepository));
     }
 
     public static Stream<Arguments> provideBibEntriesWithValidPdfFileLinks() {
@@ -138,13 +142,13 @@ class EmbeddedBibFilePdfExporterTest {
     @ParameterizedTest
     @MethodSource("providePathsToValidPDFs")
     void successfulExportToFileByPath(Path path) throws Exception {
-        assertTrue(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path));
+        assertTrue(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path, abbreviationRepository));
     }
 
     @ParameterizedTest
     @MethodSource("providePathsToInvalidPDFs")
     void unsuccessfulExportToFileByPath(Path path) throws Exception {
-        assertFalse(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path));
+        assertFalse(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path, abbreviationRepository));
     }
 
     public static Stream<Arguments> providePathsToValidPDFs() {

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -10,14 +10,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.metadata.SaveOrder;
+import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,7 +25,9 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ExporterTest {
 
@@ -43,18 +43,16 @@ public class ExporterTest {
     }
 
     private static Stream<Object[]> exportFormats() {
-        Collection<Object[]> result = new ArrayList<>();
+        PreferencesService preferencesService = mock(PreferencesService.class, Answers.RETURNS_DEEP_STUBS);
+        when(preferencesService.getExportPreferences().getExportSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
+        when(preferencesService.getCustomExportFormats(any())).thenReturn(new ArrayList<>());
 
         ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
-                mock(LayoutFormatterPreferences.class),
-                mock(JournalAbbreviationRepository.class),
-                mock(SaveConfiguration.class),
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
+                preferencesService,
+                mock(BibEntryTypesManager.class),
+                mock(JournalAbbreviationRepository.class));
 
+        Collection<Object[]> result = new ArrayList<>();
         for (Exporter format : exporterFactory.getExporters()) {
             result.add(new Object[]{format, format.getName()});
         }

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -47,6 +48,7 @@ public class ExporterTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class),
+                mock(JournalAbbreviationRepository.class),
                 mock(SaveConfiguration.class),
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class, Answers.RETURNS_DEEP_STUBS),

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -1,7 +1,5 @@
 package org.jabref.logic.exporter;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -10,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
@@ -25,32 +22,28 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ExporterTest {
 
     public BibDatabaseContext databaseContext;
-    public Charset charset;
     public List<BibEntry> entries;
 
     @BeforeEach
     public void setUp() {
         databaseContext = new BibDatabaseContext();
-        charset = StandardCharsets.UTF_8;
         entries = Collections.emptyList();
     }
 
     private static Stream<Object[]> exportFormats() {
         PreferencesService preferencesService = mock(PreferencesService.class, Answers.RETURNS_DEEP_STUBS);
         when(preferencesService.getExportPreferences().getExportSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
-        when(preferencesService.getCustomExportFormats(any())).thenReturn(new ArrayList<>());
+        when(preferencesService.getCustomExportFormats()).thenReturn(new ArrayList<>());
 
         ExporterFactory exporterFactory = ExporterFactory.create(
                 preferencesService,
-                mock(BibEntryTypesManager.class),
-                mock(JournalAbbreviationRepository.class));
+                mock(BibEntryTypesManager.class));
 
         Collection<Object[]> result = new ArrayList<>();
         for (Exporter format : exporterFactory.getExporters()) {

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -41,7 +40,6 @@ public class HtmlExportFormatTest {
                 null,
                 StandardFileType.HTML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
                 saveConfiguration);
 
         databaseContext = new BibDatabaseContext();

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -4,18 +4,13 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
@@ -40,17 +35,14 @@ public class HtmlExportFormatTest {
         SaveConfiguration saveConfiguration = mock(SaveConfiguration.class);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
+        exportFormat = new TemplateExporter("HTML",
+                "html",
+                "html",
+                null,
+                StandardFileType.HTML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(JournalAbbreviationRepository.class),
-                saveConfiguration,
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
-
-        exportFormat = exporterFactory.getExporterByName("html").get();
+                saveConfiguration);
 
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;
@@ -58,7 +50,7 @@ public class HtmlExportFormatTest {
         entry.setField(StandardField.TITLE, "my paper title");
         entry.setField(StandardField.AUTHOR, "Stefan Kolb");
         entry.setCitationKey("mykey");
-        entries = Arrays.asList(entry);
+        entries = List.of(entry);
     }
 
     @AfterEach

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -42,6 +43,7 @@ public class HtmlExportFormatTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),

--- a/src/test/java/org/jabref/logic/exporter/OpenOfficeDocumentCreatorTest.java
+++ b/src/test/java/org/jabref/logic/exporter/OpenOfficeDocumentCreatorTest.java
@@ -15,6 +15,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -53,6 +54,7 @@ public class OpenOfficeDocumentCreatorTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 mock(SaveConfiguration.class),
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),

--- a/src/test/java/org/jabref/logic/exporter/OpenOfficeDocumentCreatorTest.java
+++ b/src/test/java/org/jabref/logic/exporter/OpenOfficeDocumentCreatorTest.java
@@ -8,38 +8,27 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.jabref.logic.bibtex.FieldPreferences;
-import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Answers;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.DefaultNodeMatcher;
 import org.xmlunit.diff.ElementSelectors;
 import org.xmlunit.matchers.CompareMatcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 
 public class OpenOfficeDocumentCreatorTest {
-    private static final String OPEN_OFFICE_EXPORTER_ID = "oocalc";
-
     public BibDatabaseContext databaseContext;
     public Charset charset;
     public List<BibEntry> entries;
@@ -51,17 +40,7 @@ public class OpenOfficeDocumentCreatorTest {
     void setUp() throws URISyntaxException {
         xmlFile = Path.of(OpenOfficeDocumentCreatorTest.class.getResource("OldOpenOfficeCalcExportFormatContentSingleEntry.xml").toURI());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
-                mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
-                mock(SaveConfiguration.class),
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
-
-        exporter = exporterFactory.getExporterByName(OPEN_OFFICE_EXPORTER_ID).get();
+        exporter = new OpenOfficeDocumentCreator();
 
         databaseContext = new BibDatabaseContext();
         charset = StandardCharsets.UTF_8;

--- a/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 import javafx.beans.property.SimpleObjectProperty;
 
 import org.jabref.logic.importer.fileformat.PdfXmpImporter;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -48,6 +49,7 @@ class XmpPdfExporterTest {
 
     private BibDatabaseContext databaseContext;
     private BibDatabase dataBase;
+    private JournalAbbreviationRepository abbreviationRepository;
     private FilePreferences filePreferences;
 
     private static void initBibEntries() throws IOException {
@@ -98,6 +100,8 @@ class XmpPdfExporterTest {
      */
     @BeforeEach
     void setUp() throws IOException {
+        abbreviationRepository = mock(JournalAbbreviationRepository.class);
+
         xmpPreferences = new XmpPreferences(false, Collections.emptySet(), new SimpleObjectProperty<>(','));
 
         encoding = Charset.defaultCharset();
@@ -121,13 +125,13 @@ class XmpPdfExporterTest {
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithValidPdfFileLinks")
     void successfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
+        assertTrue(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018), abbreviationRepository));
     }
 
     @ParameterizedTest
     @MethodSource("provideBibEntriesWithInvalidPdfFileLinks")
     void unsuccessfulExportToAllFilesOfEntry(BibEntry bibEntryWithValidPdfFileLink) throws Exception {
-        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018)));
+        assertFalse(exporter.exportToAllFilesOfEntry(databaseContext, filePreferences, bibEntryWithValidPdfFileLink, List.of(olly2018), abbreviationRepository));
     }
 
     public static Stream<Arguments> provideBibEntriesWithValidPdfFileLinks() {
@@ -141,13 +145,13 @@ class XmpPdfExporterTest {
     @ParameterizedTest
     @MethodSource("providePathsToValidPDFs")
     void successfulExportToFileByPath(Path path) throws Exception {
-        assertTrue(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path));
+        assertTrue(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path, abbreviationRepository));
     }
 
     @ParameterizedTest
     @MethodSource("providePathsToInvalidPDFs")
     void unsuccessfulExportToFileByPath(Path path) throws Exception {
-        assertFalse(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path));
+        assertFalse(exporter.exportToFileByPath(databaseContext, dataBase, filePreferences, path, abbreviationRepository));
     }
 
     public static Stream<Arguments> providePathsToValidPDFs() {

--- a/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
@@ -1,21 +1,15 @@
 package org.jabref.logic.exporter;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
-import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.SaveOrder;
@@ -31,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 public class YamlExporterTest {
 
-    private static Charset charset;
     private static Exporter yamlExporter;
     private static BibDatabaseContext databaseContext;
 
@@ -40,19 +33,18 @@ public class YamlExporterTest {
         SaveConfiguration saveConfiguration = mock(SaveConfiguration.class);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
 
-        ExporterFactory exporterFactory = ExporterFactory.create(
-                new ArrayList<>(),
+        yamlExporter = new TemplateExporter(
+                "CSL YAML",
+                "yaml",
+                "yaml",
+                null,
+                StandardFileType.YAML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
                 mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
-                mock(XmpPreferences.class),
-                mock(FieldPreferences.class),
-                BibDatabaseMode.BIBTEX,
-                mock(BibEntryTypesManager.class));
+                BlankLineBehaviour.DELETE_BLANKS);
 
         databaseContext = new BibDatabaseContext();
-        charset = StandardCharsets.UTF_8;
-        yamlExporter = exporterFactory.getExporterByName("yaml").get();
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -42,6 +43,7 @@ public class YamlExporterTest {
         ExporterFactory exporterFactory = ExporterFactory.create(
                 new ArrayList<>(),
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 mock(XmpPreferences.class),
                 mock(FieldPreferences.class),

--- a/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/YamlExporterTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -40,7 +39,6 @@ public class YamlExporterTest {
                 null,
                 StandardFileType.YAML,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                mock(JournalAbbreviationRepository.class),
                 saveConfiguration,
                 BlankLineBehaviour.DELETE_BLANKS);
 

--- a/src/test/java/org/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
@@ -38,7 +38,7 @@ class ImportFormatReaderIntegrationTest {
     void testImportUnknownFormat(String resource, String format, int count) throws Exception {
         Path file = Path.of(ImportFormatReaderIntegrationTest.class.getResource(resource).toURI());
         ImportFormatReader.UnknownFormatImport unknownFormat = reader.importUnknownFormat(file, new DummyFileUpdateMonitor());
-        assertEquals(count, unknownFormat.parserResult.getDatabase().getEntryCount());
+        assertEquals(count, unknownFormat.parserResult().getDatabase().getEntryCount());
     }
 
     @ParameterizedTest
@@ -53,7 +53,7 @@ class ImportFormatReaderIntegrationTest {
     void testImportUnknownFormatFromString(String resource, String format, int count) throws Exception {
         Path file = Path.of(ImportFormatReaderIntegrationTest.class.getResource(resource).toURI());
         String data = Files.readString(file);
-        assertEquals(count, reader.importUnknownFormat(data).parserResult.getDatabase().getEntries().size());
+        assertEquals(count, reader.importUnknownFormat(data).parserResult().getDatabase().getEntries().size());
     }
 
     private static Stream<Object[]> importFormats() {

--- a/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -3,6 +3,7 @@ package org.jabref.logic.layout;
 import java.io.IOException;
 import java.io.StringReader;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.entry.field.StandardField;
@@ -62,7 +63,7 @@ public class LayoutEntryTest {
 
     public String layout(String layoutFile, BibEntry entry) throws IOException {
         StringReader sr = new StringReader(layoutFile.replace("__NEWLINE__", "\n"));
-        Layout layout = new LayoutHelper(sr, mock(LayoutFormatterPreferences.class)).getLayoutFromText();
+        Layout layout = new LayoutHelper(sr, mock(LayoutFormatterPreferences.class), mock(JournalAbbreviationRepository.class)).getLayoutFromText();
 
         return layout.doLayout(entry, null);
     }

--- a/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutHelperTest.java
@@ -3,6 +3,8 @@ package org.jabref.logic.layout;
 import java.io.IOException;
 import java.io.StringReader;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,19 +13,20 @@ import static org.mockito.Mockito.mock;
 
 class LayoutHelperTest {
 
+    private final LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
+    private final JournalAbbreviationRepository abbreviationRepository = mock(JournalAbbreviationRepository.class);
+
     @Test
     public void backslashDoesNotTriggerException() {
         StringReader stringReader = new StringReader("\\");
-        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
-        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);
         assertThrows(IOException.class, layoutHelper::getLayoutFromText);
     }
 
     @Test
     public void unbalancedBeginEndIsParsed() throws Exception {
         StringReader stringReader = new StringReader("\\begin{doi}, DOI: \\doi");
-        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
-        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);
         Layout layout = layoutHelper.getLayoutFromText();
         assertNotNull(layout);
     }
@@ -31,8 +34,7 @@ class LayoutHelperTest {
     @Test
     public void minimalExampleWithDoiGetsParsed() throws Exception {
         StringReader stringReader = new StringReader("\\begin{doi}, DOI: \\doi\\end{doi}");
-        LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class);
-        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences);
+        LayoutHelper layoutHelper = new LayoutHelper(stringReader, layoutFormatterPreferences, abbreviationRepository);
         Layout layout = layoutHelper.getLayoutFromText();
         assertNotNull(layout);
     }

--- a/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.format.NameFormatterPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
@@ -25,16 +26,19 @@ import static org.mockito.Mockito.when;
 class LayoutTest {
 
     private LayoutFormatterPreferences layoutFormatterPreferences;
+    private JournalAbbreviationRepository abbreviationRepository;
 
     @BeforeEach
     void setUp() {
         layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        abbreviationRepository = mock(JournalAbbreviationRepository.class);
+
     }
 
     private String layout(String layout, List<Path> fileDirForDatabase, BibEntry entry) throws IOException {
         StringReader layoutStringReader = new StringReader(layout.replace("__NEWLINE__", "\n"));
 
-        return new LayoutHelper(layoutStringReader, fileDirForDatabase, layoutFormatterPreferences)
+        return new LayoutHelper(layoutStringReader, fileDirForDatabase, layoutFormatterPreferences, abbreviationRepository)
                 .getLayoutFromText()
                 .doLayout(entry, null);
     }

--- a/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -32,7 +32,6 @@ class LayoutTest {
     void setUp() {
         layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
         abbreviationRepository = mock(JournalAbbreviationRepository.class);
-
     }
 
     private String layout(String layout, List<Path> fileDirForDatabase, BibEntry entry) throws IOException {

--- a/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.model.database.BibDatabase;
@@ -26,7 +27,6 @@ import org.jabref.model.openoffice.style.CitationMarkerNumericBibEntry;
 import org.jabref.model.openoffice.style.CitationMarkerNumericEntry;
 import org.jabref.model.openoffice.style.NonUniqueCitationMarker;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
@@ -37,16 +37,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class OOBibStyleTest {
-    private LayoutFormatterPreferences layoutFormatterPreferences;
-
-    @BeforeEach
-    void setUp() {
-        layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
-    }
+    private final LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);;
+    private final JournalAbbreviationRepository abbreviationRepository = mock(JournalAbbreviationRepository.class);
 
     @Test
     void testAuthorYear() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, layoutFormatterPreferences, abbreviationRepository);
         assertTrue(style.isValid());
         assertTrue(style.isInternalStyle());
         assertFalse(style.isCitationKeyCiteMarkers());
@@ -61,7 +57,7 @@ class OOBibStyleTest {
     void testAuthorYearAsFile() throws URISyntaxException, IOException {
         Path defFile = Path.of(OOBibStyleTest.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI());
 
-        OOBibStyle style = new OOBibStyle(defFile, layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(defFile, layoutFormatterPreferences, abbreviationRepository);
         assertTrue(style.isValid());
         assertFalse(style.isInternalStyle());
         assertFalse(style.isCitationKeyCiteMarkers());
@@ -74,8 +70,10 @@ class OOBibStyleTest {
 
     @Test
     void testNumerical() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertTrue(style.isValid());
         assertFalse(style.isCitationKeyCiteMarkers());
         assertFalse(style.isBoldCitations());
@@ -163,8 +161,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetNumCitationMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertEquals("[1] ", runGetNumCitationMarker2a(style, List.of(1), -1, true));
 
         assertEquals("[1]", runGetNumCitationMarker2a(style, List.of(1), -1, false));
@@ -181,8 +181,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetNumCitationMarkerUndefined() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         // unresolved citations look like [??key]
         assertEquals("[" + OOBibStyle.UNDEFINED_CITATION_MARKER + "key" + "]",
@@ -229,8 +231,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitProperty() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertEquals(", ", style.getStringCitProperty("AuthorSeparator"));
 
         // old
@@ -248,7 +252,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitationMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         BibEntry entry = new BibEntry()
                 .withField(StandardField.AUTHOR, "Gustav Bostr\\\"{o}m and Jaana W\\\"{a}yrynen and Marine Bod\\'{e}n and Konstantin Beznosov and Philippe Kruchten")
                 .withField(StandardField.YEAR, "2006")
@@ -287,7 +294,10 @@ class OOBibStyleTest {
 
     @Test
     void testLayout() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         BibEntry entry = new BibEntry()
                 .withField(StandardField.AUTHOR, "Gustav Bostr\\\"{o}m and Jaana W\\\"{a}yrynen and Marine Bod\\'{e}n and Konstantin Beznosov and Philippe Kruchten")
@@ -314,7 +324,10 @@ class OOBibStyleTest {
 
     @Test
     void testInstitutionAuthor() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat(StandardEntryType.Article);
@@ -332,8 +345,10 @@ class OOBibStyleTest {
 
     @Test
     void testVonAuthor() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat(StandardEntryType.Article);
@@ -351,8 +366,10 @@ class OOBibStyleTest {
 
     @Test
     void testInstitutionAuthorMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -375,8 +392,10 @@ class OOBibStyleTest {
 
     @Test
     void testVonAuthorMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -396,8 +415,10 @@ class OOBibStyleTest {
 
     @Test
     void testNullAuthorMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle
+                (StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                        layoutFormatterPreferences,
+                        abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -415,8 +436,10 @@ class OOBibStyleTest {
 
     @Test
     void testNullYearMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -434,8 +457,10 @@ class OOBibStyleTest {
 
     @Test
     void testEmptyEntryMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -452,8 +477,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitationMarkerInParenthesisUniquefiers() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -494,8 +521,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitationMarkerInTextUniquefiers() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -536,8 +565,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitationMarkerInParenthesisUniquefiersThreeSameAuthor() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -577,8 +608,10 @@ class OOBibStyleTest {
 
     @Test
     void testGetCitationMarkerInTextUniquefiersThreeSameAuthor() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -619,45 +652,61 @@ class OOBibStyleTest {
     @Test
         // TODO: equals only work when initialized from file, not from reader
     void testEquals() throws IOException {
-        OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
-        OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style1 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
+        OOBibStyle style2 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertEquals(style1, style2);
     }
 
     @Test
         // TODO: equals only work when initialized from file, not from reader
     void testNotEquals() throws IOException {
-        OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
-        OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style1 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
+        OOBibStyle style2 = new OOBibStyle(
+                StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertNotEquals(style1, style2);
     }
 
     @Test
     void testCompareToEqual() throws IOException {
-        OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
-        OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style1 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
+        OOBibStyle style2 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertEquals(0, style1.compareTo(style2));
     }
 
     @Test
     void testCompareToNotEqual() throws IOException {
-        OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
-        OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style1 = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
+        OOBibStyle style2 = new OOBibStyle(
+                StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
         assertTrue(style1.compareTo(style2) > 0);
         assertFalse(style2.compareTo(style1) > 0);
     }
 
     @Test
     void testEmptyStringPropertyAndOxfordComma() throws Exception {
-        OOBibStyle style = new OOBibStyle("test.jstyle", layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle("test.jstyle", layoutFormatterPreferences, abbreviationRepository);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
         BibDatabase database = new BibDatabase();
@@ -677,14 +726,16 @@ class OOBibStyleTest {
 
     @Test
     void testIsValidWithDefaultSectionAtTheStart() throws Exception {
-        OOBibStyle style = new OOBibStyle("testWithDefaultAtFirstLIne.jstyle", layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle("testWithDefaultAtFirstLIne.jstyle", layoutFormatterPreferences, abbreviationRepository);
         assertTrue(style.isValid());
     }
 
     @Test
     void testGetCitationMarkerJoinFirst() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                layoutFormatterPreferences);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         // Question: What should happen if some sources are
         // marked as isFirstAppearanceOfSource?

--- a/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 class OOBibStyleTest {
-    private final LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);;
+    private final LayoutFormatterPreferences layoutFormatterPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
     private final JournalAbbreviationRepository abbreviationRepository = mock(JournalAbbreviationRepository.class);
 
     @Test
@@ -415,10 +415,10 @@ class OOBibStyleTest {
 
     @Test
     void testNullAuthorMarker() throws IOException {
-        OOBibStyle style = new OOBibStyle
-                (StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                        layoutFormatterPreferences,
-                        abbreviationRepository);
+        OOBibStyle style = new OOBibStyle(
+                StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
+                layoutFormatterPreferences,
+                abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();

--- a/src/test/java/org/jabref/migrations/PreferencesMigrationsTest.java
+++ b/src/test/java/org/jabref/migrations/PreferencesMigrationsTest.java
@@ -69,123 +69,24 @@ class PreferencesMigrationsTest {
     }
 
     @Test
-    void testPreviewStyle() {
-        String oldPreviewStyle = "<font face=\"sans-serif\">"
-                + "<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>"
-                + "\\end{bibtexkey}</b><br>__NEWLINE__"
-                + "\\begin{author} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\author}<BR>\\end{author}__NEWLINE__"
-                + "\\begin{editor} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\editor} "
-                + "<i>(\\format[IfPlural(Eds.,Ed.)]{\\editor})</i><BR>\\end{editor}__NEWLINE__"
-                + "\\begin{title} \\format[HTMLChars]{\\title} \\end{title}<BR>__NEWLINE__"
-                + "\\begin{chapter} \\format[HTMLChars]{\\chapter}<BR>\\end{chapter}__NEWLINE__"
-                + "\\begin{journal} <em>\\format[HTMLChars]{\\journal}, </em>\\end{journal}__NEWLINE__"
-                // Include the booktitle field for @inproceedings, @proceedings, etc.
-                + "\\begin{booktitle} <em>\\format[HTMLChars]{\\booktitle}, </em>\\end{booktitle}__NEWLINE__"
-                + "\\begin{school} <em>\\format[HTMLChars]{\\school}, </em>\\end{school}__NEWLINE__"
-                + "\\begin{institution} <em>\\format[HTMLChars]{\\institution}, </em>\\end{institution}__NEWLINE__"
-                + "\\begin{publisher} <em>\\format[HTMLChars]{\\publisher}, </em>\\end{publisher}__NEWLINE__"
-                + "\\begin{year}<b>\\year</b>\\end{year}\\begin{volume}<i>, \\volume</i>\\end{volume}"
-                + "\\begin{pages}, \\format[FormatPagesForHTML]{\\pages} \\end{pages}__NEWLINE__"
-                + "\\begin{abstract}<BR><BR><b>Abstract: </b> \\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__"
-                + "\\begin{review}<BR><BR><b>Review: </b> \\format[HTMLChars]{\\review} \\end{review}"
-                + "</dd>__NEWLINE__<p></p></font>";
+    void testPreviewStyleReviewToComment() {
+        String oldPreviewStyle = "<font face=\"sans-serif\">__NEWLINE__"
+                + "Customized preview style using reviews and comments:__NEWLINE__"
+                + "\\begin{review}<BR><BR><b>Review: </b> \\format[HTMLChars]{\\review} \\end{review}__NEWLINE__"
+                + "\\begin{comment} Something: \\format[HTMLChars]{\\comment} special \\end{comment}__NEWLINE__"
+                + "</font>__NEWLINE__";
 
-        String newPreviewStyle = "<font face=\"sans-serif\">"
-                + "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>"
-                + "\\end{citationkey}</b><br>__NEWLINE__"
-                + "\\begin{author} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\author}<BR>\\end{author}__NEWLINE__"
-                + "\\begin{editor} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\editor} "
-                + "<i>(\\format[IfPlural(Eds.,Ed.)]{\\editor})</i><BR>\\end{editor}__NEWLINE__"
-                + "\\begin{title} \\format[HTMLChars]{\\title} \\end{title}<BR>__NEWLINE__"
-                + "\\begin{chapter} \\format[HTMLChars]{\\chapter}<BR>\\end{chapter}__NEWLINE__"
-                + "\\begin{journal} <em>\\format[HTMLChars]{\\journal}, </em>\\end{journal}__NEWLINE__"
-                // Include the booktitle field for @inproceedings, @proceedings, etc.
-                + "\\begin{booktitle} <em>\\format[HTMLChars]{\\booktitle}, </em>\\end{booktitle}__NEWLINE__"
-                + "\\begin{school} <em>\\format[HTMLChars]{\\school}, </em>\\end{school}__NEWLINE__"
-                + "\\begin{institution} <em>\\format[HTMLChars]{\\institution}, </em>\\end{institution}__NEWLINE__"
-                + "\\begin{publisher} <em>\\format[HTMLChars]{\\publisher}, </em>\\end{publisher}__NEWLINE__"
-                + "\\begin{year}<b>\\year</b>\\end{year}\\begin{volume}<i>, \\volume</i>\\end{volume}"
-                + "\\begin{pages}, \\format[FormatPagesForHTML]{\\pages} \\end{pages}__NEWLINE__"
-                + "\\begin{abstract}<BR><BR><b>Abstract: </b> \\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__"
-                + "\\begin{comment}<BR><BR><b>Comment: </b> \\format[HTMLChars]{\\comment} \\end{comment}"
-                + "</dd>__NEWLINE__<p></p></font>";
+        String newPreviewStyle = "<font face=\"sans-serif\">__NEWLINE__"
+                + "Customized preview style using reviews and comments:__NEWLINE__"
+                + "\\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars]{\\comment} \\end{comment}__NEWLINE__"
+                + "\\begin{comment} Something: \\format[Markdown,HTMLChars]{\\comment} special \\end{comment}__NEWLINE__"
+                + "</font>__NEWLINE__";
 
-        prefs.setPreviewStyle(oldPreviewStyle);
-        when(prefs.getPreviewStyle()).thenReturn(oldPreviewStyle);
+        when(prefs.get(JabRefPreferences.PREVIEW_STYLE)).thenReturn(oldPreviewStyle);
 
-        PreferencesMigrations.upgradePreviewStyleFromReviewToComment(prefs);
+        PreferencesMigrations.upgradePreviewStyle(prefs);
 
-        verify(prefs).setPreviewStyle(newPreviewStyle);
-    }
-
-    @Test
-    void upgradePreviewStyleAllowMarkupDefault() {
-        String oldPreviewStyle = "<font face=\"sans-serif\">"
-                + "<b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>"
-                + "\\end{bibtexkey}</b><br>__NEWLINE__"
-                + "\\begin{author} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\author}<BR>\\end{author}__NEWLINE__"
-                + "\\begin{editor} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\editor} "
-                + "<i>(\\format[IfPlural(Eds.,Ed.)]{\\editor})</i><BR>\\end{editor}__NEWLINE__"
-                + "\\begin{title} \\format[HTMLChars]{\\title} \\end{title}<BR>__NEWLINE__"
-                + "\\begin{chapter} \\format[HTMLChars]{\\chapter}<BR>\\end{chapter}__NEWLINE__"
-                + "\\begin{journal} <em>\\format[HTMLChars]{\\journal}, </em>\\end{journal}__NEWLINE__"
-                // Include the booktitle field for @inproceedings, @proceedings, etc.
-                + "\\begin{booktitle} <em>\\format[HTMLChars]{\\booktitle}, </em>\\end{booktitle}__NEWLINE__"
-                + "\\begin{school} <em>\\format[HTMLChars]{\\school}, </em>\\end{school}__NEWLINE__"
-                + "\\begin{institution} <em>\\format[HTMLChars]{\\institution}, </em>\\end{institution}__NEWLINE__"
-                + "\\begin{publisher} <em>\\format[HTMLChars]{\\publisher}, </em>\\end{publisher}__NEWLINE__"
-                + "\\begin{year}<b>\\year</b>\\end{year}\\begin{volume}<i>, \\volume</i>\\end{volume}"
-                + "\\begin{pages}, \\format[FormatPagesForHTML]{\\pages} \\end{pages}__NEWLINE__"
-                + "\\begin{abstract}<BR><BR><b>Abstract: </b> \\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__"
-                + "\\begin{comment}<BR><BR><b>Comment: </b> \\format[HTMLChars]{\\comment} \\end{comment}"
-                + "</dd>__NEWLINE__<p></p></font>";
-
-        String newPreviewStyle = "<font face=\"sans-serif\">"
-                + "<b><i>\\bibtextype</i><a name=\"\\citationkey\">\\begin{citationkey} (\\citationkey)</a>"
-                + "\\end{citationkey}</b><br>__NEWLINE__"
-                + "\\begin{author} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\author}<BR>\\end{author}__NEWLINE__"
-                + "\\begin{editor} \\format[Authors(LastFirst,Initials,Semicolon,Amp),HTMLChars]{\\editor} "
-                + "<i>(\\format[IfPlural(Eds.,Ed.)]{\\editor})</i><BR>\\end{editor}__NEWLINE__"
-                + "\\begin{title} \\format[HTMLChars]{\\title} \\end{title}<BR>__NEWLINE__"
-                + "\\begin{chapter} \\format[HTMLChars]{\\chapter}<BR>\\end{chapter}__NEWLINE__"
-                + "\\begin{journal} <em>\\format[HTMLChars]{\\journal}, </em>\\end{journal}__NEWLINE__"
-                // Include the booktitle field for @inproceedings, @proceedings, etc.
-                + "\\begin{booktitle} <em>\\format[HTMLChars]{\\booktitle}, </em>\\end{booktitle}__NEWLINE__"
-                + "\\begin{school} <em>\\format[HTMLChars]{\\school}, </em>\\end{school}__NEWLINE__"
-                + "\\begin{institution} <em>\\format[HTMLChars]{\\institution}, </em>\\end{institution}__NEWLINE__"
-                + "\\begin{publisher} <em>\\format[HTMLChars]{\\publisher}, </em>\\end{publisher}__NEWLINE__"
-                + "\\begin{year}<b>\\year</b>\\end{year}\\begin{volume}<i>, \\volume</i>\\end{volume}"
-                + "\\begin{pages}, \\format[FormatPagesForHTML]{\\pages} \\end{pages}__NEWLINE__"
-                + "\\begin{abstract}<BR><BR><b>Abstract: </b> \\format[HTMLChars]{\\abstract} \\end{abstract}__NEWLINE__"
-                + "\\begin{comment}<BR><BR><b>Comment: </b> \\format[Markdown,HTMLChars]{\\comment} \\end{comment}"
-                + "</dd>__NEWLINE__<p></p></font>";
-
-        prefs.setPreviewStyle(oldPreviewStyle);
-        when(prefs.getPreviewStyle()).thenReturn(oldPreviewStyle);
-
-        PreferencesMigrations.upgradePreviewStyleAllowMarkdown(prefs);
-
-        verify(prefs).setPreviewStyle(newPreviewStyle);
-    }
-
-    @Test
-    void upgradePreviewStyleAllowMarkupCustomized() {
-        String oldPreviewStyle = "<font face=\"sans-serif\">"
-                + "My highly customized format only using comments:<br>"
-                + "\\begin{comment} Something: \\format[HTMLChars]{\\comment} special \\end{comment}"
-                + "</dd>__NEWLINE__<p></p></font>";
-
-        String newPreviewStyle = "<font face=\"sans-serif\">"
-                + "My highly customized format only using comments:<br>"
-                + "\\begin{comment} Something: \\format[Markdown,HTMLChars]{\\comment} special \\end{comment}"
-                + "</dd>__NEWLINE__<p></p></font>";
-
-        prefs.setPreviewStyle(oldPreviewStyle);
-        when(prefs.getPreviewStyle()).thenReturn(oldPreviewStyle);
-
-        PreferencesMigrations.upgradePreviewStyleAllowMarkdown(prefs);
-
-        verify(prefs).setPreviewStyle(newPreviewStyle);
+        verify(prefs).put(JabRefPreferences.PREVIEW_STYLE, newPreviewStyle);
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #9866

In preparation for refactoring the getCustomExporters to the new preferences pattern, I had to move the JournalAbbreviationRepository argument in the constructor to the actual export method. As the journalAbbreviationRepository variable in Globals is overwritten when the preferences are imported or reset, this might have also fixed some hidden bugs. As for now I leave the call to Globals in some places, as fixing that call too would explode this PR.

Commits are mostly self explaining.
Refactoring was made in several iterations, so I had to introduce the JournalAbbreviationRepository in some steps, just to remove it in the next one.

Also made some very small fixes on the fly.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
