### PR TITLE
Add cleanup operation in reference to the Urldate field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added drag and drop events for field 'Groups' in entry editor panel. [#569](https://github.com/koppor/jabref/issues/569)
 - We added support for parsing MathML in the Medline importer. [#4273](https://github.com/JabRef/jabref/issues/4273)
 - We added the ability to search for a DOI directly from 'Web Search'. [#9674](https://github.com/JabRef/jabref/issues/9674)
-- We added a cleanup activity that identifies a URL in the `note` field and moves it to the `url` field. [koppor#216](https://github.com/koppor/jabref/issues/216)
+- We added a cleanup activity that identifies a URL and/or a URL-DATE in the `note` field and moves it/them to the `url` and `urldate` field correspondingly. [koppor#216](https://github.com/koppor/jabref/issues/216)
 - We enabled the user to change the name of a field in a custom entry type by double-clicking on it. [#9840](https://github.com/JabRef/jabref/issues/9840)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added drag and drop events for field 'Groups' in entry editor panel. [#569](https://github.com/koppor/jabref/issues/569)
 - We added support for parsing MathML in the Medline importer. [#4273](https://github.com/JabRef/jabref/issues/4273)
 - We added the ability to search for a DOI directly from 'Web Search'. [#9674](https://github.com/JabRef/jabref/issues/9674)
-- We added a cleanup activity that identifies a URL and/or a URL-DATE in the `note` field and moves it/them to the `url` and `urldate` field correspondingly. [koppor#216](https://github.com/koppor/jabref/issues/216)
+- We added a cleanup activity that identifies a URL or a last-visited-date in the `note` field and moves it to the `url` and `urldate` field respectively. [koppor#216](https://github.com/koppor/jabref/issues/216)
 - We enabled the user to change the name of a field in a custom entry type by double-clicking on it. [#9840](https://github.com/JabRef/jabref/issues/9840)
 
 

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -17,9 +17,26 @@ import org.jabref.model.entry.field.StandardField;
  */
 public class URLCleanup implements CleanupJob {
 
+    /*
+     * The urlRegex was originally fetched from a suggested solution in
+     * https://stackoverflow.com/questions/28185064/python-infinite-loop-in-regex-to-match-url.
+     * In order to be functional, we made the necessary adjustments regarding Java
+     * features (mainly doubled backslashes).
+     */
+    public static final String URL_REGEX = "(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.]"
+            + "[a-z]{2,4}/)(?:[^\\s()<>\\\\]+|\\(([^\\s()<>\\\\]+|(\\([^\\s()"
+            + "<>\\\\]+\\)))*\\))+(?:\\(([^\\s()<>\\\\]+|(\\([^\\s()<>\\\\]+\\"
+            + ")))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))";
+
+    public static final String DATE_TERMS_REGEX = "accessed on|visited on|retrieved on|viewed on";
+
     private static final Field NOTE_FIELD = StandardField.NOTE;
     private static final Field URL_FIELD = StandardField.URL;
     private static final Field URLDATE_FIELD = StandardField.URLDATE;
+
+    final Pattern urlPattern = Pattern.compile(URL_REGEX, Pattern.CASE_INSENSITIVE);
+    final Pattern dateTermsPattern = Pattern.compile(DATE_TERMS_REGEX, Pattern.CASE_INSENSITIVE);
+    final Pattern datePattern = Pattern.compile(Date.DATE_REGEX, Pattern.CASE_INSENSITIVE);
 
     private NormalizeDateFormatter formatter = new NormalizeDateFormatter();
 
@@ -28,23 +45,6 @@ public class URLCleanup implements CleanupJob {
         List<FieldChange> changes = new ArrayList<>();
 
         String noteFieldValue = entry.getField(NOTE_FIELD).orElse(null);
-
-        /*
-         * The urlRegex was originally fetched from a suggested solution in
-         * https://stackoverflow.com/questions/28185064/python-infinite-loop-in-regex-to-match-url.
-         * In order to be functional, we made the necessary adjustments regarding Java
-         * features (mainly doubled backslashes).
-         */
-        String urlRegex = "(?i)\\b((?:https?://|www\\d{0,3}[.]|[a-z0-9.\\-]+[.]"
-                + "[a-z]{2,4}/)(?:[^\\s()<>\\\\]+|\\(([^\\s()<>\\\\]+|(\\([^\\s()"
-                + "<>\\\\]+\\)))*\\))+(?:\\(([^\\s()<>\\\\]+|(\\([^\\s()<>\\\\]+\\"
-                + ")))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))";
-
-        String dateTermsRegex = "accessed on|visited on|retrieved on|viewed on";
-
-        final Pattern urlPattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
-        final Pattern dateTermsPattern = Pattern.compile(dateTermsRegex, Pattern.CASE_INSENSITIVE);
-        final Pattern datePattern = Pattern.compile(Date.DATE_REGEX, Pattern.CASE_INSENSITIVE);
 
         final Matcher urlMatcher = urlPattern.matcher(noteFieldValue);
         final Matcher dateTermsMatcher = dateTermsPattern.matcher(noteFieldValue);

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -107,9 +107,9 @@ public class URLCleanup implements CleanupJob {
                     String formattedDate = formatter.format(date);
                     newNoteFieldValue = newNoteFieldValue
                             .replace(date, "").trim()
-                            .replaceAll("^,|,$", "").trim(); // either starts or ends with comma
+                            .replaceAll("^,|,$", "").trim(); // either starts or ends with a comma
 
-                    // same behaviour with URL cleanup
+                    // Same approach with the URL cleanup.
                     if (entry.hasField(URLDATE_FIELD)) {
                         String urlDateFieldValue = entry.getField(URLDATE_FIELD).orElse(null);
                         if (urlDateFieldValue.equals(formattedDate)) {

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 import org.jabref.logic.formatter.bibtexfields.NormalizeDateFormatter;
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.Date;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 
@@ -41,37 +42,9 @@ public class URLCleanup implements CleanupJob {
 
         String dateTermsRegex = "accessed on|visited on|retrieved on|viewed on";
 
-        /*
-         * Several date patterns are available at:
-         * jabref/src/main/java/org/jabref/model/entry/Date.java class
-         *
-         * However, these cannot be used for the needs of the operation
-         * as Date.parse static method requires the newNoteFieldValue String to
-         * hold only a date to match correctly. Besides that, it is not possible to
-         * extract a certain regex introduced in the parse method and call it in
-         * the current class. Reasoning:
-         * Defining a public static final attribute (containing desired regex)
-         * within the parse static method, it is not allowed, as public static
-         * constants must be declared at class-level and not inside the method.
-         *
-         * dateRegex matches several date formats. Explanation:
-         * <ul>
-         *     <li>"\d{4}": Matches exactly four digits (YYYY)</li>
-         *     <li>"\d{1,2}": Matches one or two digits (M or MM)</li>
-         *     <li>"\d{1,2}": Matches one or two digits (D or DD)</li>
-         * </ul>
-         * Indicative formats identified:
-         * YYYY-MM-DD, YYYY-M-DD, YYYY-MM-D, YYYY-M-D
-         * YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
-         * Month DD, YYYY & Month D, YYYY
-         */
-        String dateRegex = "\\d{4}-\\d{1,2}-\\d{1,2}|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" +
-                "(January|February|March|April|May|June|July|August|September|" +
-                "October|November|December) \\d{1,2}, \\d{4}";
-
         final Pattern urlPattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
         final Pattern dateTermsPattern = Pattern.compile(dateTermsRegex, Pattern.CASE_INSENSITIVE);
-        final Pattern datePattern = Pattern.compile(dateRegex, Pattern.CASE_INSENSITIVE);
+        final Pattern datePattern = Pattern.compile(Date.DATE_REGEX, Pattern.CASE_INSENSITIVE);
 
         final Matcher urlMatcher = urlPattern.matcher(noteFieldValue);
         final Matcher dateTermsMatcher = dateTermsPattern.matcher(noteFieldValue);

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -39,9 +39,21 @@ public class URLCleanup implements CleanupJob {
                 + "<>\\\\]+\\)))*\\))+(?:\\(([^\\s()<>\\\\]+|(\\([^\\s()<>\\\\]+\\"
                 + ")))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?«»“”‘’]))";
 
-        String dateTermsRegex = "Accessed on|Visited on|Retrieved on|Viewed on";
+        String dateTermsRegex = "accessed on|visited on|retrieved on|viewed on";
 
         /*
+         * Several date patterns are available in:
+         * jabref/src/main/java/org/jabref/model/entry/Date.java class
+         *
+         * However, these cannot be used for the needs of the operation
+         * as Date.parse method requires the whole String (i.e. newNoteFieldValue)
+         * to be a date, in order to be matched. Besides that, it is not possible to
+         * extract a certain regex introduced in the parse method and call it in
+         * the current class. Reasoning:
+         * Defining a public static final variable (containing desired regex)
+         * within the parse static method, it is not allowed, as public static constants
+         * must be declared at class-level and not inside the method.
+         *
          * dateRegex matches several date formats. Explanation:
          * <ul>
          *     <li>"\d{4}": Matches exactly four digits (YYYY)</li>
@@ -58,11 +70,11 @@ public class URLCleanup implements CleanupJob {
                 "October|November|December) \\d{1,2}, \\d{4}";
 
         final Pattern urlPattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
-        final Pattern termsPattern = Pattern.compile(dateTermsRegex, Pattern.CASE_INSENSITIVE);
+        final Pattern dateTermsPattern = Pattern.compile(dateTermsRegex, Pattern.CASE_INSENSITIVE);
         final Pattern datePattern = Pattern.compile(dateRegex, Pattern.CASE_INSENSITIVE);
 
         final Matcher urlMatcher = urlPattern.matcher(noteFieldValue);
-        final Matcher termsMatcher = termsPattern.matcher(noteFieldValue);
+        final Matcher dateTermsMatcher = dateTermsPattern.matcher(noteFieldValue);
         final Matcher dateMatcher = datePattern.matcher(noteFieldValue);
 
         if (urlMatcher.find()) {
@@ -98,8 +110,8 @@ public class URLCleanup implements CleanupJob {
                 entry.setField(URL_FIELD, url).ifPresent(changes::add);
             }
 
-            if (termsMatcher.find()) {
-                String term = termsMatcher.group();
+            if (dateTermsMatcher.find()) {
+                String term = dateTermsMatcher.group();
                 newNoteFieldValue = newNoteFieldValue
                         .replace(term, "");
                 if (dateMatcher.find()) {

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -49,8 +49,8 @@ public class URLCleanup implements CleanupJob {
          *     <li>"\d{1,2}": Matches one or two digits (D or DD)</li>
          * </ul>
          * Indicative formats identified:
-         * YYYY-MM-DD, YYYY-MM-DD, YYYY-M-DD, YYYY-MM-D, YYYY-M-D
-         * YYYY.MM.DD, YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
+         * YYYY-MM-DD, YYYY-M-DD, YYYY-MM-D, YYYY-M-D
+         * YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
          * Month DD, YYYY & Month D, YYYY
          */
         String dateRegex = ("\\d{4}-\\d{1,2}-\\d{1,2}|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" +

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -53,9 +53,9 @@ public class URLCleanup implements CleanupJob {
          * YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
          * Month DD, YYYY & Month D, YYYY
          */
-        String dateRegex = ("\\d{4}-\\d{1,2}-\\d{1,2}|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" +
+        String dateRegex = "\\d{4}-\\d{1,2}-\\d{1,2}|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" +
                 "(January|February|March|April|May|June|July|August|September|" +
-                "October|November|December) \\d{1,2}, \\d{4}");
+                "October|November|December) \\d{1,2}, \\d{4}";
 
         final Pattern urlPattern = Pattern.compile(urlRegex, Pattern.CASE_INSENSITIVE);
         final Pattern termsPattern = Pattern.compile(dateTermsRegex, Pattern.CASE_INSENSITIVE);

--- a/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/URLCleanup.java
@@ -42,17 +42,17 @@ public class URLCleanup implements CleanupJob {
         String dateTermsRegex = "accessed on|visited on|retrieved on|viewed on";
 
         /*
-         * Several date patterns are available in:
+         * Several date patterns are available at:
          * jabref/src/main/java/org/jabref/model/entry/Date.java class
          *
          * However, these cannot be used for the needs of the operation
-         * as Date.parse method requires the whole String (i.e. newNoteFieldValue)
-         * to be a date, in order to be matched. Besides that, it is not possible to
+         * as Date.parse static method requires the newNoteFieldValue String to
+         * hold only a date to match correctly. Besides that, it is not possible to
          * extract a certain regex introduced in the parse method and call it in
          * the current class. Reasoning:
-         * Defining a public static final variable (containing desired regex)
-         * within the parse static method, it is not allowed, as public static constants
-         * must be declared at class-level and not inside the method.
+         * Defining a public static final attribute (containing desired regex)
+         * within the parse static method, it is not allowed, as public static
+         * constants must be declared at class-level and not inside the method.
          *
          * dateRegex matches several date formats. Explanation:
          * <ul>

--- a/src/main/java/org/jabref/model/entry/Date.java
+++ b/src/main/java/org/jabref/model/entry/Date.java
@@ -67,6 +67,13 @@ public class Date {
                                                    (builder, formatterBuilder) -> builder.append(formatterBuilder.toFormatter()))
                                            .toFormatter(Locale.US);
 
+        /*
+         * There is also {@link org.jabref.model.entry.Date#parse(java.lang.String)}.
+         * The regex of that method cannot be used as we parse single dates here and that method parses:
+         * i) date ranges
+         * ii) two dates separated by '/'
+         * Additionally, parse method requires the reviewed String to hold only a date.
+         */
         DATE_REGEX = "\\d{4}-\\d{1,2}-\\d{1,2}" + // covers YYYY-MM-DD, YYYY-M-DD, YYYY-MM-D, YYYY-M-D
                 "|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" + // covers YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
                 "(January|February|March|April|May|June|July|August|September|" +

--- a/src/main/java/org/jabref/model/entry/Date.java
+++ b/src/main/java/org/jabref/model/entry/Date.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class Date {
 
+    public static final String DATE_REGEX;
     private static final DateTimeFormatter NORMALIZED_DATE_FORMATTER = DateTimeFormatter.ofPattern("uuuu[-MM][-dd]");
     private static final DateTimeFormatter SIMPLE_DATE_FORMATS;
     private static final Logger LOGGER = LoggerFactory.getLogger(Date.class);
@@ -65,6 +66,11 @@ public class Date {
                                                    DateTimeFormatterBuilder::appendOptional,
                                                    (builder, formatterBuilder) -> builder.append(formatterBuilder.toFormatter()))
                                            .toFormatter(Locale.US);
+
+        DATE_REGEX = "\\d{4}-\\d{1,2}-\\d{1,2}" + // covers YYYY-MM-DD, YYYY-M-DD, YYYY-MM-D, YYYY-M-D
+                "|\\d{4}\\.\\d{1,2}\\.\\d{1,2}|" + // covers YYYY.MM.DD, YYYY.M.DD, YYYY.MM.D, YYYY.M.D
+                "(January|February|March|April|May|June|July|August|September|" +
+                "October|November|December) \\d{1,2}, \\d{4}"; // covers Month DD, YYYY & Month D, YYYY
     }
 
     private final TemporalAccessor date;

--- a/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
@@ -123,7 +123,7 @@ public class URLCleanupTest {
                 new BibEntry().withField(StandardField.NOTE,
                                     "https://www.example.com/foo/?bar=baz&inga=42&quux")),
 
-            // Expected entry returns formatted the url-date in Urldate field.
+            // Expected entry returns formatted the url-date in the Urldate field.
             Arguments.of(
                 new BibEntry().withField(StandardField.URL,
                                     "http://142.42.1.1:8080")
@@ -132,14 +132,14 @@ public class URLCleanupTest {
                 new BibEntry().withField(StandardField.NOTE,
                                     "\\url{http://142.42.1.1:8080}, Accessed on January 15, 2021")),
 
-            // Input entry doesn't hold any URL both in Note field.
+            // Input entry doesn't hold any URL in the Note field.
             Arguments.of(
                 new BibEntry().withField(StandardField.NOTE,
                                     "Accessed on 2015-01-15"),
                 new BibEntry().withField(StandardField.NOTE,
                                     "Accessed on 2015-01-15")),
 
-            // Input entry has multiple url-dates stored in Note field.
+            // Input entry has multiple url-dates stored in the Note field.
             Arguments.of(
                 new BibEntry().withField(StandardField.URL,
                                     "http://142.42.1.1:8080")

--- a/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
@@ -130,7 +130,7 @@ public class URLCleanupTest {
                               .withField(StandardField.URLDATE,
                                     "2021-01-15"),
                 new BibEntry().withField(StandardField.NOTE,
-                                    "\\url{http://142.42.1.1:8080}, Accessed on January 15, 2021")),
+                                    "\\url{http://142.42.1.1:8080}, accessed on January 15, 2021")),
 
             // Input entry doesn't hold any URL in the Note field.
             Arguments.of(
@@ -146,9 +146,9 @@ public class URLCleanupTest {
                               .withField(StandardField.URLDATE,
                                     "2021-01-15")
                               .withField(StandardField.NOTE,
-                                    "Visited on February 12, 2017"),
+                                    "visited on February 12, 2017"),
                 new BibEntry().withField(StandardField.NOTE,
-                                    "\\url{http://142.42.1.1:8080}, Accessed on January 15, 2021, Visited on February 12, 2017")),
+                                    "\\url{http://142.42.1.1:8080}, accessed on January 15, 2021, visited on February 12, 2017")),
 
             // Input entry holds the same url-date in both Note and Urldate field.
             Arguments.of(
@@ -157,7 +157,7 @@ public class URLCleanupTest {
                               .withField(StandardField.URLDATE,
                                     "2015-01-15"),
                 new BibEntry().withField(StandardField.NOTE,
-                                    "\\url{http://142.42.1.1:8080}, Visited on 2015.01.15")
+                                    "\\url{http://142.42.1.1:8080}, visited on 2015.01.15")
                               .withField(StandardField.URLDATE,
                                     "2015-01-15")),
 
@@ -170,7 +170,7 @@ public class URLCleanupTest {
                               .withField(StandardField.NOTE,
                                     "cited by Kramer"),
                 new BibEntry().withField(StandardField.NOTE,
-                                    "\\url{https://example.org}, cited by Kramer, Accessed on 2023-04-11"))
+                                    "\\url{https://example.org}, cited by Kramer, accessed on 2023-04-11"))
         );
     }
 }

--- a/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/URLCleanupTest.java
@@ -53,6 +53,15 @@ public class URLCleanupTest {
                                     "\\url{https://hdl.handle.net/10442/hedi/6089}, "
                                         + "\\url{http://142.42.1.1:8080}")),
 
+            // Input entry holds the same URL both in Note and Url field.
+            Arguments.of(
+                new BibEntry().withField(StandardField.URL,
+                                     "https://hdl.handle.net/10442/hedi/6089"),
+                new BibEntry().withField(StandardField.NOTE,
+                                     "\\url{https://hdl.handle.net/10442/hedi/6089}")
+                              .withField(StandardField.URL,
+                                     "https://hdl.handle.net/10442/hedi/6089")),
+
             // Input Note field has several values stored.
             Arguments.of(
                 new BibEntry().withField(StandardField.URL,
@@ -112,7 +121,56 @@ public class URLCleanupTest {
                 new BibEntry().withField(StandardField.URL,
                                     "https://www.example.com/foo/?bar=baz&inga=42&quux"),
                 new BibEntry().withField(StandardField.NOTE,
-                                    "https://www.example.com/foo/?bar=baz&inga=42&quux"))
+                                    "https://www.example.com/foo/?bar=baz&inga=42&quux")),
+
+            // Expected entry returns formatted the url-date in Urldate field.
+            Arguments.of(
+                new BibEntry().withField(StandardField.URL,
+                                    "http://142.42.1.1:8080")
+                              .withField(StandardField.URLDATE,
+                                    "2021-01-15"),
+                new BibEntry().withField(StandardField.NOTE,
+                                    "\\url{http://142.42.1.1:8080}, Accessed on January 15, 2021")),
+
+            // Input entry doesn't hold any URL both in Note field.
+            Arguments.of(
+                new BibEntry().withField(StandardField.NOTE,
+                                    "Accessed on 2015-01-15"),
+                new BibEntry().withField(StandardField.NOTE,
+                                    "Accessed on 2015-01-15")),
+
+            // Input entry has multiple url-dates stored in Note field.
+            Arguments.of(
+                new BibEntry().withField(StandardField.URL,
+                                    "http://142.42.1.1:8080")
+                              .withField(StandardField.URLDATE,
+                                    "2021-01-15")
+                              .withField(StandardField.NOTE,
+                                    "Visited on February 12, 2017"),
+                new BibEntry().withField(StandardField.NOTE,
+                                    "\\url{http://142.42.1.1:8080}, Accessed on January 15, 2021, Visited on February 12, 2017")),
+
+            // Input entry holds the same url-date in both Note and Urldate field.
+            Arguments.of(
+                new BibEntry().withField(StandardField.URL,
+                                    "http://142.42.1.1:8080")
+                              .withField(StandardField.URLDATE,
+                                    "2015-01-15"),
+                new BibEntry().withField(StandardField.NOTE,
+                                    "\\url{http://142.42.1.1:8080}, Visited on 2015.01.15")
+                              .withField(StandardField.URLDATE,
+                                    "2015-01-15")),
+
+            // Input Note field has several values stored.
+            Arguments.of(
+                new BibEntry().withField(StandardField.URL,
+                                    "https://example.org")
+                              .withField(StandardField.URLDATE,
+                                    "2023-04-11")
+                              .withField(StandardField.NOTE,
+                                    "cited by Kramer"),
+                new BibEntry().withField(StandardField.NOTE,
+                                    "\\url{https://example.org}, cited by Kramer, Accessed on 2023-04-11"))
         );
     }
 }


### PR DESCRIPTION
Follow-up to #9970
Fixes [#koppor216](https://github.com/koppor/jabref/issues/216)

## Overview on the cleanup operation

Following up to the recently added cleanup operation for the `Url` field, the current proposal serves as a cleanup operation for the `Urldate` field of a BibTex entry.  Essentially, when a date referring to the access date of a URL address is identified in the `Note` field then we move it to the `Urldate` field. Including the aforementioned operation, we achieve more **precise** and **effective** handling of user's mistaken entries' recording.

### Step by Step

1. User stores a URL and a corresponding URL-DATE in the `Note` field
2. User clicks on `Quality` section
            a. Selects `Cleanup entries` option
            b. Enables `Move URL in note field to url field` action
            c. Clicks on `OK`
3. Afterwards, the cleanup operation will have been successfully completed and the URL-DATE is replaced under the `Urldate` field.

### Some noteworthy comments

- We take it as a prerequisite that the user has also placed a URL address, besides URL-DATE, in the `Note` field.
- In case multiple URL-DATES are recorded in the `Note` field, then we only move the first found.
- On the assumption that there is an existing URL-DATE in the `Urldate`, no action should be performed, unless the URL-DATES in both `Note` and `Urldate` fields are equal. In that case we just remove the url-date from the `Note` field.
- User is expected to be familiar with a BibTex-based terminology, when storing this type of data.

## About the implementation

- Enhanced `URLCleanup` class with the url-date cleanup operation and made the necessary adjustments (minor refactoring).
- Added parameterized tests to validate the expected behavior of the operation.

https://github.com/JabRef/jabref/assets/93869307/aa83d7a8-c021-4546-88a3-daa4c475e37c


### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
