### PR TITLE
Observable Preferences X (EntryEditorPreferences revisited)

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -260,7 +260,7 @@ public class EntryEditor extends BorderPane {
 
         // General fields from preferences
         // First, remove all tabs that are already handled above or below; except for the source tab (which has different titles for BibTeX and BibLaTeX mode)
-        Map<String, Set<Field>> entryEditorTabList = new HashMap<>(entryEditorPreferences.getEntryEditorTabList());
+        Map<String, Set<Field>> entryEditorTabList = new HashMap<>(entryEditorPreferences.getEntryEditorTabs());
         entryEditorTabList.remove(PreviewTab.NAME);
         entryEditorTabList.remove(RequiredFieldsTab.NAME);
         entryEditorTabList.remove(OptionalFieldsTab.NAME);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorPreferences.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorPreferences.java
@@ -17,6 +17,7 @@ import org.jabref.model.entry.field.Field;
 public class EntryEditorPreferences {
 
     private final MapProperty<String, Set<Field>> entryEditorTabList;
+    private final MapProperty<String, Set<Field>> defaultEntryEditorTabList;
     private final BooleanProperty shouldOpenOnNewEntry;
     private final BooleanProperty shouldShowRecommendationsTab;
     private final BooleanProperty isMrdlibAccepted;
@@ -28,6 +29,7 @@ public class EntryEditorPreferences {
     private final BooleanProperty autoLinkFiles;
 
     public EntryEditorPreferences(Map<String, Set<Field>> entryEditorTabList,
+                                  Map<String, Set<Field>> defaultEntryEditorTabList,
                                   boolean shouldOpenOnNewEntry,
                                   boolean shouldShowRecommendationsTab,
                                   boolean isMrdlibAccepted,
@@ -39,6 +41,7 @@ public class EntryEditorPreferences {
                                   boolean autolinkFilesEnabled) {
 
         this.entryEditorTabList = new SimpleMapProperty<>(FXCollections.observableMap(entryEditorTabList));
+        this.defaultEntryEditorTabList = new SimpleMapProperty<>(FXCollections.observableMap(defaultEntryEditorTabList));
         this.shouldOpenOnNewEntry = new SimpleBooleanProperty(shouldOpenOnNewEntry);
         this.shouldShowRecommendationsTab = new SimpleBooleanProperty(shouldShowRecommendationsTab);
         this.isMrdlibAccepted = new SimpleBooleanProperty(isMrdlibAccepted);
@@ -50,16 +53,20 @@ public class EntryEditorPreferences {
         this.autoLinkFiles = new SimpleBooleanProperty(autolinkFilesEnabled);
     }
 
-    public ObservableMap<String, Set<Field>> getEntryEditorTabList() {
+    public ObservableMap<String, Set<Field>> getEntryEditorTabs() {
         return entryEditorTabList.get();
     }
 
-    public MapProperty<String, Set<Field>> entryEditorTabListProperty() {
+    public MapProperty<String, Set<Field>> entryEditorTabs() {
         return entryEditorTabList;
     }
 
     public void setEntryEditorTabList(Map<String, Set<Field>> entryEditorTabList) {
         this.entryEditorTabList.set(FXCollections.observableMap(entryEditorTabList));
+    }
+
+    public ObservableMap<String, Set<Field>> getDefaultEntryEditorTabs() {
+        return defaultEntryEditorTabList.get();
     }
 
     public boolean shouldOpenOnNewEntry() {

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -1,8 +1,9 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,7 +36,7 @@ import org.jabref.preferences.PreferencesService;
 public class OtherFieldsTab extends FieldsEditorTab {
 
     public static final String NAME = "Other fields";
-    private final Set<Field> customTabFieldNames;
+    private final List<Field> customTabFieldNames;
     private final BibEntryTypesManager entryTypesManager;
 
     public OtherFieldsTab(BibDatabaseContext databaseContext,
@@ -62,7 +63,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
                 indexingTaskManager);
 
         this.entryTypesManager = entryTypesManager;
-        this.customTabFieldNames = new HashSet<>();
+        this.customTabFieldNames = new ArrayList<>();
         preferences.getEntryEditorPreferences().getDefaultEntryEditorTabs().values().forEach(customTabFieldNames::addAll);
 
         setText(Localization.lang("Other fields"));

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -1,8 +1,8 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,7 +35,7 @@ import org.jabref.preferences.PreferencesService;
 public class OtherFieldsTab extends FieldsEditorTab {
 
     public static final String NAME = "Other fields";
-    private final List<Field> customTabFieldNames;
+    private final Set<Field> customTabFieldNames;
     private final BibEntryTypesManager entryTypesManager;
 
     public OtherFieldsTab(BibDatabaseContext databaseContext,
@@ -62,7 +62,8 @@ public class OtherFieldsTab extends FieldsEditorTab {
                 indexingTaskManager);
 
         this.entryTypesManager = entryTypesManager;
-        this.customTabFieldNames = preferences.getAllDefaultTabFieldNames();
+        this.customTabFieldNames = new HashSet<>();
+        preferences.getDefaultTabNamesAndFields().values().forEach(customTabFieldNames::addAll);
 
         setText(Localization.lang("Other fields"));
         setTooltip(new Tooltip(Localization.lang("Show remaining fields")));
@@ -82,7 +83,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
             otherFields.removeAll(entryType.get().getDeprecatedFields(mode));
             otherFields.removeAll(entryType.get().getOptionalFields().stream().map(BibField::field).collect(Collectors.toSet()));
             otherFields.remove(InternalField.KEY_FIELD);
-            otherFields.removeAll(customTabFieldNames);
+            customTabFieldNames.forEach(otherFields::remove);
             return otherFields;
         } else {
             // Entry type unknown -> treat all fields as required

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -63,7 +63,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
 
         this.entryTypesManager = entryTypesManager;
         this.customTabFieldNames = new HashSet<>();
-        preferences.getDefaultTabNamesAndFields().values().forEach(customTabFieldNames::addAll);
+        preferences.getEntryEditorPreferences().getDefaultEntryEditorTabs().values().forEach(customTabFieldNames::addAll);
 
         setText(Localization.lang("Other fields"));
         setTooltip(new Tooltip(Localization.lang("Show remaining fields")));

--- a/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
@@ -55,11 +55,11 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         allowIntegerEditionProperty.setValue(entryEditorPreferences.shouldAllowIntegerEditionBibtex());
         autoLinkEnabledProperty.setValue(entryEditorPreferences.autoLinkFilesEnabled());
 
-        setFields(entryEditorPreferences.getEntryEditorTabList());
+        setFields(entryEditorPreferences.getEntryEditorTabs());
     }
 
     public void resetToDefaults() {
-        setFields(preferencesService.getDefaultTabNamesAndFields());
+        setFields(preferencesService.getEntryEditorPreferences().getDefaultEntryEditorTabs());
     }
 
     private void setFields(Map<String, Set<Field>> tabNamesAndFields) {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -420,7 +420,6 @@ public class JabRefPreferences implements PreferencesService {
     /**
      * Cache variables
      */
-    private Map<String, Set<Field>> entryEditorTabList;
     private String userAndHost;
 
     private LibraryPreferences libraryPreferences;
@@ -1394,22 +1393,46 @@ public class JabRefPreferences implements PreferencesService {
     // EntryEditorPreferences
     //*************************************************************************************************************
 
-    /**
-     * Creates a list of defined tabs in the entry editor from cache
-     *
-     * @return a map of defined tabs and associated fields
-     */
-    private Map<String, Set<Field>> getEntryEditorTabList() {
-        if (entryEditorTabList == null) {
-            updateEntryEditorTabList();
+    @Override
+    public EntryEditorPreferences getEntryEditorPreferences() {
+        if (Objects.nonNull(entryEditorPreferences)) {
+            return entryEditorPreferences;
         }
-        return entryEditorTabList;
+
+        entryEditorPreferences = new EntryEditorPreferences(
+                getEntryEditorTabs(),
+                getDefaultEntryEditorTabs(),
+                getBoolean(AUTO_OPEN_FORM),
+                getBoolean(SHOW_RECOMMENDATIONS),
+                getBoolean(ACCEPT_RECOMMENDATIONS),
+                getBoolean(SHOW_LATEX_CITATIONS),
+                getBoolean(DEFAULT_SHOW_SOURCE),
+                getBoolean(VALIDATE_IN_ENTRY_EDITOR),
+                getBoolean(ALLOW_INTEGER_EDITION_BIBTEX),
+                getDouble(ENTRY_EDITOR_HEIGHT),
+                getBoolean(AUTOLINK_FILES_ENABLED));
+
+        EasyBind.listen(entryEditorPreferences.entryEditorTabs(), (obs, oldValue, newValue) -> storeEntryEditorTabs(newValue));
+        // defaultEntryEditorTabs are read-only
+        EasyBind.listen(entryEditorPreferences.shouldOpenOnNewEntryProperty(), (obs, oldValue, newValue) -> putBoolean(AUTO_OPEN_FORM, newValue));
+        EasyBind.listen(entryEditorPreferences.shouldShowRecommendationsTabProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_RECOMMENDATIONS, newValue));
+        EasyBind.listen(entryEditorPreferences.isMrdlibAcceptedProperty(), (obs, oldValue, newValue) -> putBoolean(ACCEPT_RECOMMENDATIONS, newValue));
+        EasyBind.listen(entryEditorPreferences.shouldShowLatexCitationsTabProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_LATEX_CITATIONS, newValue));
+        EasyBind.listen(entryEditorPreferences.showSourceTabByDefaultProperty(), (obs, oldValue, newValue) -> putBoolean(DEFAULT_SHOW_SOURCE, newValue));
+        EasyBind.listen(entryEditorPreferences.enableValidationProperty(), (obs, oldValue, newValue) -> putBoolean(VALIDATE_IN_ENTRY_EDITOR, newValue));
+        EasyBind.listen(entryEditorPreferences.allowIntegerEditionBibtexProperty(), (obs, oldValue, newValue) -> putBoolean(ALLOW_INTEGER_EDITION_BIBTEX, newValue));
+        EasyBind.listen(entryEditorPreferences.dividerPositionProperty(), (obs, oldValue, newValue) -> putDouble(ENTRY_EDITOR_HEIGHT, newValue.doubleValue()));
+        EasyBind.listen(entryEditorPreferences.autoLinkEnabledProperty(), (obs, oldValue, newValue) -> putBoolean(AUTOLINK_FILES_ENABLED, newValue));
+
+        return entryEditorPreferences;
     }
 
     /**
-     * Reloads the list of the currently defined tabs  in the entry editor from scratch to cache
+     * Get a Map of defined tab names to default tab fields.
+     *
+     * @return A map of the currently defined tabs in the entry editor from scratch to cache
      */
-    private void updateEntryEditorTabList() {
+    private Map<String, Set<Field>> getEntryEditorTabs() {
         Map<String, Set<Field>> tabs = new LinkedHashMap<>();
         List<String> tabNames = getSeries(CUSTOM_TAB_NAME);
         List<String> tabFields = getSeries(CUSTOM_TAB_FIELDS);
@@ -1423,7 +1446,7 @@ public class JabRefPreferences implements PreferencesService {
         for (int i = 0; i < tabNames.size(); i++) {
             tabs.put(tabNames.get(i), FieldFactory.parseFieldList(tabFields.get(i)));
         }
-        entryEditorTabList = tabs;
+        return tabs;
     }
 
     /**
@@ -1431,7 +1454,7 @@ public class JabRefPreferences implements PreferencesService {
      *
      * @param customTabs a map of tab names and the corresponding set of fields to be displayed in
      */
-    private void storeEntryEditorTabList(Map<String, Set<Field>> customTabs) {
+    private void storeEntryEditorTabs(Map<String, Set<Field>> customTabs) {
         String[] names = customTabs.keySet().toArray(String[]::new);
         String[] fields = customTabs.values().stream()
                                     .map(set -> set.stream()
@@ -1447,16 +1470,10 @@ public class JabRefPreferences implements PreferencesService {
         purgeSeries(CUSTOM_TAB_NAME, customTabs.size());
         purgeSeries(CUSTOM_TAB_FIELDS, customTabs.size());
 
-        updateEntryEditorTabList();
+        getEntryEditorTabs();
     }
 
-    /**
-     * Get a Map of default tab names to default tab fields.
-     *
-     * @return A map of keys with tab names and a set of corresponding fields
-     */
-    @Override
-    public Map<String, Set<Field>> getDefaultTabNamesAndFields() {
+    private Map<String, Set<Field>> getDefaultEntryEditorTabs() {
         Map<String, Set<Field>> customTabsMap = new LinkedHashMap<>();
 
         int defNumber = 0;
@@ -1473,37 +1490,6 @@ public class JabRefPreferences implements PreferencesService {
             defNumber++;
         }
         return customTabsMap;
-    }
-
-    @Override
-    public EntryEditorPreferences getEntryEditorPreferences() {
-        if (Objects.nonNull(entryEditorPreferences)) {
-            return entryEditorPreferences;
-        }
-
-        entryEditorPreferences = new EntryEditorPreferences(getEntryEditorTabList(),
-                getBoolean(AUTO_OPEN_FORM),
-                getBoolean(SHOW_RECOMMENDATIONS),
-                getBoolean(ACCEPT_RECOMMENDATIONS),
-                getBoolean(SHOW_LATEX_CITATIONS),
-                getBoolean(DEFAULT_SHOW_SOURCE),
-                getBoolean(VALIDATE_IN_ENTRY_EDITOR),
-                getBoolean(ALLOW_INTEGER_EDITION_BIBTEX),
-                getDouble(ENTRY_EDITOR_HEIGHT),
-                getBoolean(AUTOLINK_FILES_ENABLED));
-
-        EasyBind.listen(entryEditorPreferences.entryEditorTabListProperty(), (obs, oldValue, newValue) -> storeEntryEditorTabList(newValue));
-        EasyBind.listen(entryEditorPreferences.shouldOpenOnNewEntryProperty(), (obs, oldValue, newValue) -> putBoolean(AUTO_OPEN_FORM, newValue));
-        EasyBind.listen(entryEditorPreferences.shouldShowRecommendationsTabProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_RECOMMENDATIONS, newValue));
-        EasyBind.listen(entryEditorPreferences.isMrdlibAcceptedProperty(), (obs, oldValue, newValue) -> putBoolean(ACCEPT_RECOMMENDATIONS, newValue));
-        EasyBind.listen(entryEditorPreferences.shouldShowLatexCitationsTabProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_LATEX_CITATIONS, newValue));
-        EasyBind.listen(entryEditorPreferences.showSourceTabByDefaultProperty(), (obs, oldValue, newValue) -> putBoolean(DEFAULT_SHOW_SOURCE, newValue));
-        EasyBind.listen(entryEditorPreferences.enableValidationProperty(), (obs, oldValue, newValue) -> putBoolean(VALIDATE_IN_ENTRY_EDITOR, newValue));
-        EasyBind.listen(entryEditorPreferences.allowIntegerEditionBibtexProperty(), (obs, oldValue, newValue) -> putBoolean(ALLOW_INTEGER_EDITION_BIBTEX, newValue));
-        EasyBind.listen(entryEditorPreferences.dividerPositionProperty(), (obs, oldValue, newValue) -> putDouble(ENTRY_EDITOR_HEIGHT, newValue.doubleValue()));
-        EasyBind.listen(entryEditorPreferences.autoLinkEnabledProperty(), (obs, oldValue, newValue) -> putBoolean(AUTOLINK_FILES_ENABLED, newValue));
-
-        return entryEditorPreferences;
     }
 
     //*************************************************************************************************************

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1475,30 +1475,6 @@ public class JabRefPreferences implements PreferencesService {
         return customTabsMap;
     }
 
-    /**
-     * Get a Map of default tab names to default tab fields.
-     *
-     * @return A map of keys with tab names and a set of corresponding fields
-     */
-    @Override
-    public List<Field> getAllDefaultTabFieldNames() {
-        List<Field> customFields = new ArrayList<>();
-
-        int defNumber = 0;
-        while (true) {
-            // saved as CUSTOMTABNAME_def{number} and ; separated
-            String fields = (String) defaults.get(CUSTOM_TAB_FIELDS + "_def" + defNumber);
-
-            if (StringUtil.isNullOrEmpty(fields)) {
-                break;
-            }
-
-            customFields.addAll(Arrays.stream(fields.split(STRINGLIST_DELIMITER.toString())).map(FieldFactory::parseField).toList());
-            defNumber++;
-        }
-        return customFields;
-    }
-
     @Override
     public EntryEditorPreferences getEntryEditorPreferences() {
         if (Objects.nonNull(entryEditorPreferences)) {

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -1,7 +1,6 @@
 package org.jabref.preferences;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Map;
 import java.util.prefs.BackingStoreException;
 

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -98,8 +98,6 @@ public interface PreferencesService {
 
     Map<String, Set<Field>> getDefaultTabNamesAndFields();
 
-    List<Field> getAllDefaultTabFieldNames();
-
     EntryEditorPreferences getEntryEditorPreferences();
 
     RemotePreferences getRemotePreferences();

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -3,7 +3,6 @@ package org.jabref.preferences;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.prefs.BackingStoreException;
 
 import org.jabref.gui.autocompleter.AutoCompletePreferences;
@@ -36,7 +35,6 @@ import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.util.io.AutoLinkPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.Field;
 
 public interface PreferencesService {
 
@@ -95,8 +93,6 @@ public interface PreferencesService {
     TimestampPreferences getTimestampPreferences();
 
     GroupsPreferences getGroupsPreferences();
-
-    Map<String, Set<Field>> getDefaultTabNamesAndFields();
 
     EntryEditorPreferences getEntryEditorPreferences();
 


### PR DESCRIPTION
Follow-up to #10001

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
