### PR TITLE
Make SINGLE-BACKSLASH private static final

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -38,6 +38,8 @@ public class MetaDataParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataParser.class);
     private static FileUpdateMonitor fileMonitor;
 
+    private static final Pattern SINGLE_BACKSLASH = Pattern.compile("[^\\\\]\\\\[^\\\\]");
+
     public MetaDataParser(FileUpdateMonitor fileMonitor) {
         MetaDataParser.fileMonitor = fileMonitor;
     }
@@ -148,7 +150,6 @@ public class MetaDataParser {
      */
     static String parseDirectory(String value) {
         value = StringUtil.removeStringAtTheEnd(value, MetaData.SEPARATOR_STRING);
-        Pattern SINGLE_BACKSLASH = Pattern.compile("[^\\\\]\\\\[^\\\\]");
         if (value.contains("\\\\\\\\")) {
             // This is an escaped Windows UNC path
             return value.replace("\\\\", "\\");


### PR DESCRIPTION
I am looking into the diff of https://github.com/JabRef/jabref/pull/10009 and am thinking, where we did "wrong". While submitting a feature request to open rewrite (https://github.com/openrewrite/rewrite-static-analysis/issues/123), I think we can also work on the position of variables.

Creating new Objects takes time in Java. Therefore, constants are put as class variables. I did this for `SINGLE_BACKSLASH`. OK? Or should we keep the constant local, because a) we think, keeping constants as class members is not always appropriate, b) the variables is used only there and c) we don't really care about that micro optimization.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
