### PR TITLE
Replaced abandoned JFoenix controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We moved the custom entry types dialog into the preferences dialog. [#9760](https://github.com/JabRef/jabref/pull/9760)
 - We moved the manage content selectors dialog to the library properties. [#9768](https://github.com/JabRef/jabref/pull/9768)
 - We moved the preferences menu command from the options menu to the file menu. [#9768](https://github.com/JabRef/jabref/pull/9768)
+- We reworked the cross ref labels in the entry editor and added a right click menu. [#10046](https://github.com/JabRef/jabref/pull/10046)
 - We reorganized the order of tabs and settings in the library properties. [#9836](https://github.com/JabRef/jabref/pull/9836)
 - We changed the handling of an "overflow" of authors at `[authIniN]`: JabRef uses `+` to indicate an overflow. Example: `[authIni2]` produces `A+` (instead of `AB`) for `Aachen and Berlin and Chemnitz`. [#9703](https://github.com/JabRef/jabref/pull/9703)
 - We moved the preferences option to open the last edited files on startup to the 'General' tab. [#9808](https://github.com/JabRef/jabref/pull/9808)

--- a/build.gradle
+++ b/build.gradle
@@ -588,7 +588,8 @@ jlink {
                 'org.mariadb.jdbc.credential.env.EnvCredentialPlugin',
                 'org.mariadb.jdbc.credential.system.PropertiesCredentialPlugin'
         provides 'java.security.Provider' with 'org.bouncycastle.jce.provider.BouncyCastleProvider',
-                'org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider'    }
+                'org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider'
+    }
 
     jpackage {
         outputDir = "distribution"

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/groups/public' }
     maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
     maven { url 'https://jitpack.io' }
+    maven { url 'https://sandec.jfrog.io/artifactory/repo' }
 }
 
 configurations {
@@ -176,7 +177,11 @@ dependencies {
     implementation 'com.tobiasdiez:easybind:2.2.1-SNAPSHOT'
     implementation 'org.fxmisc.flowless:flowless:0.7.0'
     implementation 'org.fxmisc.richtext:richtextfx:0.11.0'
-    implementation 'com.jfoenix:jfoenix:9.0.10'
+    implementation (group: 'com.dlsc.gemsfx', name: 'gemsfx', version: '1.74.0') {
+        exclude module: 'javax.inject' // Split package, use only jakarta.inject
+        exclude group: 'org.apache.logging.log4j'
+    }
+
     implementation 'org.controlsfx:controlsfx:11.1.2'
 
     implementation 'org.jsoup:jsoup:1.16.1'
@@ -343,8 +348,6 @@ run {
                 'javafx.controls/com.sun.javafx.scene.control' : 'org.jabref',
                 'org.controlsfx.controls/impl.org.controlsfx.skin' : 'org.jabref',
 
-                'javafx.controls/com.sun.javafx.scene.control.behavior' : 'com.jfoenix',
-
                 // Not sure why we need to restate the controlfx exports
                 // Taken from here: https://github.com/controlsfx/controlsfx/blob/9.0.0/build.gradle#L1
                 'javafx.graphics/com.sun.javafx.scene' : 'org.controlsfx.controls',
@@ -365,12 +368,7 @@ run {
                 'javafx.controls/com.sun.javafx.scene.control' : 'org.jabref',
 
                 'javafx.controls/javafx.scene.control.skin' : 'org.controlsfx.controls',
-                'javafx.graphics/javafx.scene' : 'org.controlsfx.controls',
-
-                'javafx.controls/com.sun.javafx.scene.control.behavior' : 'com.jfoenix',
-                'javafx.base/com.sun.javafx.binding' : 'com.jfoenix',
-                'javafx.graphics/com.sun.javafx.stage' : 'com.jfoenix',
-                'javafx.base/com.sun.javafx.event' : 'com.jfoenix'
+                'javafx.graphics/javafx.scene' : 'org.controlsfx.controls'
         ]
     }
 }

--- a/docs/code-howtos/javafx.md
+++ b/docs/code-howtos/javafx.md
@@ -201,7 +201,6 @@ JabRef makes heavy use of Properties and Bindings. These are wrappers around Obs
 * [Validation framework](https://github.com/sialcasa/mvvmFX/wiki/Validation)
 * [mvvm framework](https://github.com/sialcasa/mvvmFX/wiki)
 * [CSS Reference](http://docs.oracle.com/javafx/2/api/javafx/scene/doc-files/cssref.html)
-* [JFoenix](https://github.com/jfoenixadmin/JFoenix) Material Designs look & feel
 * [JavaFX Documentation project](https://fxdocs.github.io/docs/html5/index.html): Collected information on JavaFX in a central place
 * [FXExperience](http://fxexperience.com) JavaFX Links of the week
 * [Foojay](https://foojay.io) Java and JavaFX tutorials

--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -25,12 +25,11 @@ eclipse {
                 }
 
                 def javafxcontrols = entries.find { isJavafxControls(it) };
-                javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=com.jfoenix';
+                javafxcontrols.entryAttributes['add-exports'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref';
                 javafxcontrols.entryAttributes['add-opens'] = 'javafx.controls/com.sun.javafx.scene.control=org.jabref:javafx.controls/com.sun.javafx.scene.control.behavior=org.jabref:javafx.controls/javafx.scene.control=org.jabref:javafx.controls/javafx.scene.control.skin=org.controlsfx.controls';
 
                 def javafxgraphics = entries.find { isJavafxGraphics(it) };
                 javafxgraphics.entryAttributes['add-opens'] = 'javafx.graphics/javafx.scene=org.controlsfx.controls';
-                javafxgraphics.entryAttributes['add-exports'] = 'javafx.graphics/com.sun.javafx.stage=com.jfoenix';
 
                 def javafxbase = entries.find { isJavafxBase(it) };
                 javafxbase.entryAttributes['add-exports'] = 'javafx.base/com.sun.javafx.event=org.controlsfx.controls:';

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -100,13 +100,6 @@ License: Apache-2.0
 ```
 
 ```yaml
-Id:      com.jfoenix:jfoenix
-Project: JavaFX MAterial Design Library
-URL:     https://github.com/jfoenixadmin/JFoenix
-License: Apache-2.0
-```
-
-```yaml
 Id:      com.konghq.unirest
 Project: Unirest for Java
 URL:     https://github.com/Kong/unirest-java
@@ -539,7 +532,6 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 com.googlecode.javaewah:JavaEWAH:1.1.13
 com.h2database:h2-mvstore:2.1.214
-com.jfoenix:jfoenix:9.0.10
 com.konghq:unirest-java:3.14.1
 com.microsoft.azure:applicationinsights-core:2.4.1
 com.microsoft.azure:applicationinsights-logging-log4j2:2.4.1

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -9,7 +9,6 @@ open module org.jabref {
     // JavaFX
     requires javafx.base;
     requires javafx.graphics;
-    requires javafx.swing;
     requires javafx.controls;
     requires javafx.web;
     requires javafx.fxml;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -13,7 +13,8 @@ open module org.jabref {
     requires javafx.web;
     requires javafx.fxml;
     requires afterburner.fx;
-    requires com.jfoenix;
+    requires com.dlsc.gemsfx;
+    uses com.dlsc.gemsfx.TagsField;
     requires de.saxsys.mvvmfx;
 
     requires org.kordamp.ikonli.core;

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -1244,10 +1244,10 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: -jr-accent;
 }
 
-.jfx-color-picker:armed,
-.jfx-color-picker:hover,
-.jfx-color-picker:focused,
-.jfx-color-picker {
+.color-picker:armed,
+.color-picker:hover,
+.color-picker:focused,
+.color-picker {
     -fx-background-color: transparent, transparent, transparent, transparent;
     -fx-background-radius: 0px;
     -fx-background-insets: 0px;
@@ -1387,6 +1387,27 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-pref-height: 30px;
     -fx-padding: 0px 0px 0px -8px;
     -fx-margin: 0em;
+    -fx-border-style: none;
+}
+
+.tags-field {
+    -fx-pref-height: 30px;
+    -fx-margin: 0em;
+    -fx-border-style: none;
+}
+
+.tags-field > .flow-pane > .tag-view {
+    -fx-background-color: -fx-default-button;
+    -fx-text-fill: -fx-focused-text-base-color;
+}
+
+.tags-field > .flow-pane > .tag-view:selected {
+    -fx-background-color: derive(-fx-default-button, -20%);
+    -fx-text-fill: -fx-focused-text-base-color;
+}
+
+.tags-field-editor {
+    -fx-border-width: 0;
 }
 
 .searchBar:invalid {

--- a/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/PdfDocumentPageViewModel.java
@@ -5,8 +5,9 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Objects;
 
-import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.image.Image;
+import javafx.scene.image.PixelWriter;
+import javafx.scene.image.WritableImage;
 
 import org.jabref.architecture.AllowedToUseAwt;
 
@@ -51,7 +52,7 @@ public class PdfDocumentPageViewModel extends DocumentPageViewModel {
         try {
             int resolution = 96;
             BufferedImage image = renderer.renderImageWithDPI(pageNumber, 2 * resolution, ImageType.RGB);
-            return SwingFXUtils.toFXImage(resize(image, width, height), null);
+            return convertToFxImage(resize(image, width, height));
         } catch (IOException e) {
             // TODO: LOG
             return null;
@@ -67,5 +68,20 @@ public class PdfDocumentPageViewModel extends DocumentPageViewModel {
     public double getAspectRatio() {
         PDRectangle mediaBox = page.getMediaBox();
         return mediaBox.getWidth() / mediaBox.getHeight();
+    }
+
+    // See https://stackoverflow.com/a/57552025/3450689
+    private static Image convertToFxImage(BufferedImage image) {
+        WritableImage wr = null;
+        if (image != null) {
+            wr = new WritableImage(image.getWidth(), image.getHeight());
+            PixelWriter pw = wr.getPixelWriter();
+            for (int x = 0; x < image.getWidth(); x++) {
+                for (int y = 0; y < image.getHeight(); y++) {
+                    pw.setArgb(x, y, image.getRGB(x, y));
+                }
+            }
+        }
+        return wr;
     }
 }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.fxml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.layout.HBox?>
-<?import com.jfoenix.controls.JFXChipView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.LinkedEntriesEditor">
-    <JFXChipView fx:id="chipView" HBox.hgrow="ALWAYS" maxWidth="Infinity"/>
+
 </fx:root>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.fxml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.layout.HBox?>
+<?import com.dlsc.gemsfx.TagsField?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.LinkedEntriesEditor">
-
+    <TagsField fx:id="entryLinkField" HBox.hgrow="ALWAYS"/>
 </fx:root>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -1,13 +1,19 @@
 package org.jabref.gui.fieldeditors;
 
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 import javafx.beans.binding.Bindings;
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 
 import org.jabref.gui.autocompleter.SuggestionProvider;
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.database.BibDatabaseContext;
@@ -16,38 +22,27 @@ import org.jabref.model.entry.ParsedEntryLink;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import com.jfoenix.controls.JFXChip;
-import com.jfoenix.controls.JFXChipView;
-import com.jfoenix.controls.JFXDefaultChip;
+import com.dlsc.gemsfx.TagsField;
 
 public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
 
-    @FXML
-    private final LinkedEntriesEditorViewModel viewModel;
-    @FXML
-    private JFXChipView<ParsedEntryLink> chipView;
+    @FXML private final LinkedEntriesEditorViewModel viewModel;
+
+    private final SuggestionProvider<BibEntry> suggestionProvider;
 
     public LinkedEntriesEditor(Field field, BibDatabaseContext databaseContext, SuggestionProvider<BibEntry> suggestionProvider, FieldCheckers fieldCheckers) {
-        this.viewModel = new LinkedEntriesEditorViewModel(field, suggestionProvider, databaseContext, fieldCheckers);
-
         ViewLoader.view(this)
                   .root(this)
                   .load();
 
-        chipView.setConverter(viewModel.getStringConverter());
-        var autoCompletionItemFactory = new ViewModelListCellFactory<ParsedEntryLink>()
-                .withText(ParsedEntryLink::getKey);
-        chipView.getAutoCompletePopup().setSuggestionsCellFactory(autoCompletionItemFactory);
-        chipView.getAutoCompletePopup().setCellLimit(5);
-        chipView.getSuggestions().addAll(suggestionProvider.getPossibleSuggestions().stream().map(ParsedEntryLink::new).collect(Collectors.toList()));
+        this.viewModel = new LinkedEntriesEditorViewModel(field, suggestionProvider, databaseContext, fieldCheckers);
+        this.suggestionProvider = suggestionProvider;
 
-        chipView.setChipFactory((view, item) -> {
-            JFXChip<ParsedEntryLink> chip = new JFXDefaultChip<>(view, item);
-            chip.setOnMouseClicked(event -> viewModel.jumpToEntry(item));
-            return chip;
-        });
+        ParsedEntryLinkField entryLinkField = new ParsedEntryLinkField();
+        HBox.setHgrow(entryLinkField, Priority.ALWAYS);
+        Bindings.bindContentBidirectional(entryLinkField.getTags(), viewModel.linkedEntriesProperty());
 
-        Bindings.bindContentBidirectional(chipView.getChips(), viewModel.linkedEntriesProperty());
+        getChildren().add(entryLinkField);
     }
 
     public LinkedEntriesEditorViewModel getViewModel() {
@@ -62,5 +57,41 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
     @Override
     public Parent getNode() {
         return this;
+    }
+
+    public class ParsedEntryLinkField extends TagsField<ParsedEntryLink> {
+        public ParsedEntryLinkField() {
+            super();
+
+            setCellFactory(new ViewModelListCellFactory<ParsedEntryLink>().withText(ParsedEntryLink::getKey));
+            // Mind the .collect(Collectors.toList()) as the list needs to be mutable
+            setSuggestionProvider(request ->
+                    suggestionProvider.getPossibleSuggestions().stream()
+                                      .filter(suggestion -> suggestion.getCitationKey().orElse("").toLowerCase()
+                                                                      .contains(request.getUserText().toLowerCase()))
+                                      .map(ParsedEntryLink::new).collect(Collectors.toList()));
+            setTagViewFactory(this::createTag);
+            setConverter(viewModel.getStringConverter());
+            setNewItemProducer(searchText -> viewModel.getStringConverter().fromString(searchText));
+            setMatcher((entryLink, searchText) -> entryLink.getKey().toLowerCase().startsWith(searchText.toLowerCase()));
+            setComparator(Comparator.comparing(ParsedEntryLink::getKey));
+            setShowSearchIcon(false);
+            getEditor().getStyleClass().clear();
+            getEditor().getStyleClass().add("tags-field-editor");
+        }
+
+        private Node createTag(ParsedEntryLink entryLink) {
+            Label tagLabel = new Label();
+            tagLabel.setText(getConverter().toString(entryLink));
+            tagLabel.setGraphic(IconTheme.JabRefIcons.REMOVE_TAGS.getGraphicNode());
+            tagLabel.getGraphic().setOnMouseClicked(event -> removeTags(entryLink));
+            tagLabel.setContentDisplay(ContentDisplay.RIGHT);
+            tagLabel.setOnMouseClicked(event -> {
+                if (event.getClickCount() == 2) {
+                    viewModel.jumpToEntry(entryLink);
+                }
+            });
+            return tagLabel;
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -345,11 +345,9 @@ public class IconTheme {
         KEEP_ON_TOP(MaterialDesignP.PIN),
         KEEP_ON_TOP_OFF(MaterialDesignP.PIN_OFF_OUTLINE),
         OPEN_GLOBAL_SEARCH(MaterialDesignO.OPEN_IN_NEW),
-
+        REMOVE_TAGS(MaterialDesignC.CLOSE),
         ACCEPT_LEFT(MaterialDesignS.SUBDIRECTORY_ARROW_LEFT),
-
         ACCEPT_RIGHT(MaterialDesignS.SUBDIRECTORY_ARROW_RIGHT),
-
         MERGE_GROUPS(MaterialDesignS.SOURCE_MERGE);
 
         private final JabRefIcon icon;

--- a/src/test/java/org/jabref/testutils/interactive/styletester/StyleTester.fxml
+++ b/src/test/java/org/jabref/testutils/interactive/styletester/StyleTester.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.ColorPicker?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
@@ -35,7 +36,6 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
-<?import com.jfoenix.controls.JFXColorPicker?>
 <AnchorPane prefHeight="600.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/8.0.121"
             xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.testutils.interactive.styletester.StyleTesterView">
     <TabPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
@@ -383,7 +383,7 @@
                                     <Hyperlink maxWidth="1.7976931348623157E308" text="Hyperlink (Visited)"
                                                visited="true"/>
                                     <Separator prefWidth="200.0"/>
-                                    <JFXColorPicker/>
+                                    <ColorPicker/>
                                 </children>
                             </VBox>
                             <Separator orientation="VERTICAL" prefHeight="200.0"/>


### PR DESCRIPTION
Sadly JFoenix is not developed anymore. Using JFoenix with JPMS was very clumsy.

- Replaced call to SwingFxUtils with some native code
- Removed JFoenix Colorpicker with vanilla
- Replaced JFoenix Chipview with GemsFX TagView

Turn autocompletion on and restart JabRef to test this.

![grafik](https://github.com/JabRef/jabref/assets/50491877/b85386e3-64c3-4317-bd08-20c539e6673b)

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
