### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -91,7 +91,7 @@ jobs:
          echo "JDK21=${{runner.temp}}\jdk\jdk-21" >> "$GITHUB_ENV"
          ls "$(cygpath -u "$RUNNER_TEMP\jdk\jdk-21")"
 
-         echo "org.gradle.java.installations.paths=${{runner.temp}}\jdk\jdk-21" >> gradle.properties
+         echo "org.gradle.java.installations.paths=${{runner.temp}}\jdk\jdk-21" | sed "s/\\\\/\\\\\\\\/" >> gradle.properties
          echo "org.gradle.java.installations.auto-detect=false" >> gradle.properties
          cat gradle.properties
 
@@ -143,10 +143,10 @@ jobs:
       - name: Build runtime image
         if: (matrix.os != 'macos-latest') || (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
-        run: ./gradlew -Porg.gradle.java.installations.paths="${{env.JDK21}}" -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
+        run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
       - name: Build installer
         if: (matrix.os != 'macos-latest') || (steps.checksecrets.outputs.secretspresent == 'YES')
-        run: ./gradlew -Porg.gradle.java.installations.paths="${{env.JDK21}}" -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
+        run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
         shell: bash
       - name: Resign app image for OSX and build dmg
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -91,7 +91,7 @@ jobs:
          echo "JDK21=${{runner.temp}}\jdk\jdk-21" >> "$GITHUB_ENV"
          ls "$(cygpath -u "$RUNNER_TEMP\jdk\jdk-21")"
 
-         echo "org.gradle.java.installations.paths=${{runner.temp}}\jdk\jdk-21" | sed "s/\\\\/\\\\\\\\/" >> gradle.properties
+         echo "org.gradle.java.installations.paths=${{runner.temp}}\jdk\jdk-21" | sed "s/\\\\/\\\\\\\\/g" >> gradle.properties
          echo "org.gradle.java.installations.auto-detect=false" >> gradle.properties
          cat gradle.properties
 


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/10004

It used to work, but suddenly gradle starts to complain:

    Cannot locate tasks that match '.gradle.java.installations.paths=D:\a\_temp\jdk\jdk-21' as project '.gradle.java.installations.paths=D' not found in root project 'JabRef'.

Example: https://github.com/JabRef/jabref/actions/runs/5416997856/jobs/9847443571

This PR tries to fix that.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
