### PR TITLE
Add link to build binary

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -334,3 +334,5 @@ jobs:
         with:
           message: |
             The build of this PR is available at <https://builds.jabref.org/pull/${{ github.event.pull_request.number }}/merge>
+          comment_tag: download-link
+          mode: recreate

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -328,3 +328,9 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
+      - name: Comment PR
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            The build of this PR is available at <https://builds.jabref.org/pull/${{ github.event.pull_request.number }}/merge>

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -333,6 +333,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            The build of this PR is available at <https://builds.jabref.org/pull/${{ github.event.pull_request.number }}/merge>
+            The build of this PR is available at <https://builds.jabref.org/pull/${{ github.event.pull_request.number }}/merge>.
           comment_tag: download-link
           mode: recreate


### PR DESCRIPTION
We often write messages like: "The builds should be available in 30mins at builds.jabref.org". With this PR, there will be an automatic message as soon as the binaries got uploaded. In case of another push, there will be a new comment be created (and the old one deleted). This way, the logical order of commits and comments is kept.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
