### PR TITLE
Speedup "deployment" (to builds.jabref.org)

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -117,7 +117,6 @@ jobs:
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services
       - name: Build pkg (macos)
-        if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
         run: |
           ${{env.JDK21}}/Contents/Home/bin/jpackage \
@@ -161,13 +160,7 @@ jobs:
       - name: Package application image
         shell: bash
         run: ${{ matrix.archivePortable }}
-      - name: Upload to GitHub workflow artifacts store
-        uses: actions/upload-artifact@v3
-        with:
-          name: JabRef-${{ matrix.displayName }}
-          path: build/distribution
-      - name: Deploy to builds.jabref.org
-        id: deploy
+      - name: Upload to builds.jabref.org
         uses: Pendect/action-rsyncer@v2.0.0
         env:
           DEPLOY_KEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -178,3 +171,8 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
+      - name: Upload to GitHub workflow artifacts store
+        uses: actions/upload-artifact@v3
+        with:
+          name: JabRef-${{ matrix.displayName }}
+          path: build/distribution

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -160,7 +160,12 @@ jobs:
       - name: Package application image
         shell: bash
         run: ${{ matrix.archivePortable }}
-      - name: Upload to builds.jabref.org
+      - name: Upload to GitHub workflow artifacts store
+        uses: actions/upload-artifact@v3
+        with:
+          name: JabRef-${{ matrix.displayName }}
+          path: build/distribution
+      - name: Upload to builds.jabref.org (TODO - won't run on Mac, because Dockerized action)
         uses: Pendect/action-rsyncer@v2.0.0
         env:
           DEPLOY_KEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -171,8 +176,3 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
-      - name: Upload to GitHub workflow artifacts store
-        uses: actions/upload-artifact@v3
-        with:
-          name: JabRef-${{ matrix.displayName }}
-          path: build/distribution

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -222,12 +222,18 @@ jobs:
           ar -m -c -a sdsd jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64_repackaged.deb debian-binary control.tar.xz data.tar.xz
           rm debian-binary control.tar.* data.tar.*
           mv -f jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64_repackaged.deb  jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64.deb
-      - name: Upload to GitHub workflow artifacts store (non-macos)
-        if: (matrix.os != 'macos-latest')
-        uses: actions/upload-artifact@v3
+      - name: Upload to builds.jabref.org
+        if: (matrix.os != 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
+        uses: Pendect/action-rsyncer@v2.0.0
+        env:
+          DEPLOY_KEY: ${{ secrets.buildJabRefPrivateKey }}
+          BRANCH: ${{ steps.gitversion.outputs.branchName }}
         with:
-          name: JabRef-${{ matrix.displayName }}
-          path: build/distribution
+          flags: -vaz --itemize-changes --stats --partial-dir=/tmp/partial --rsync-path="mkdir -p /var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }} && rsync"
+          options: ''
+          ssh_options: '-p 9922'
+          src: 'build/distribution/'
+          dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
       - name: Upload to GitHub workflow artifacts store (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: actions/upload-artifact@v3
@@ -293,65 +299,7 @@ jobs:
         with:
           name: JabRef-macOS
           path: build/distribution
-  deploy:
-    strategy:
-      fail-fast: false
-    name: Deploy binaries on builds.jabref.org
-    runs-on: ubuntu-latest
-    needs: [build, notarize]
-    steps:
-      - name: Check secrets presence
-        id: checksecrets
-        shell: bash
-        run: |
-          if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            echo "secretspresent=NO" >> $GITHUB_OUTPUT
-          else
-            echo "secretspresent=YES" >> $GITHUB_OUTPUT
-          fi
-        env:
-          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - name: Checkout source
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        uses: actions/checkout@v3
-      - name: Fetch all history for all tags and branches
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        run: git fetch --prune --unshallow
-      - name: Install GitVersion
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        uses: gittools/actions/gitversion/setup@v0.10.2
-        with:
-          versionSpec: '5.x'
-      - name: Run GitVersion
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Get linux binaries
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        uses: actions/download-artifact@master
-        with:
-          name: JabRef-linux
-          path: build/distribution
-      - name: Get windows binaries
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
-        uses: actions/download-artifact@master
-        with:
-          name: JabRef-windows
-          path: build/distribution
-      - name: Get macOS binaries unsigned
-        if: steps.checksecrets.outputs.secretspresent == 'YES' && ! (${{ inputs.notarization }})) && ! (startsWith(github.ref, 'refs/tags/') 
-        uses: actions/download-artifact@master
-        with:
-          name: JabRef-macOS-tbn
-          path: build/distribution/
-      - name: Get macOS binaries notarized
-        if: (startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }})) && (steps.checksecrets.outputs.secretspresent == 'YES')
-        uses: actions/download-artifact@master
-        with:
-          name: JabRef-macOS
-          path: build/distribution/
-      - name: Deploy to builds.jabref.org
-        id: deploy
+      - name: Upload to builds.jabref.org
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: Pendect/action-rsyncer@v2.0.0
         env:
@@ -363,6 +311,22 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
+  notify:
+    name: notify
+    runs-on: ubuntu-latest
+    needs: [build, notarize]
+    steps:
+      - name: Check secrets presence
+        id: checksecrets
+        shell: bash
+        run: |
+          if [[ -z "$BUILDJABREFPRIVATEKEY" && "${{ github.event_name }}" != "pull_request" ]]; then
+              echo "secretspresent=NO" >> $GITHUB_ENV
+          else
+              echo "secretspresent=YES" >> $GITHUB_ENV
+          fi
+        env:
+          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
       - name: Comment PR
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -87,7 +87,7 @@ jobs:
           java-version: 20
           distribution: 'temurin'
           cache: 'gradle'
-      - name: setup jdk JabRef-fix windows
+      - name: setup jdk JabRef-fix (windows)
         if: (matrix.os == 'windows-latest')
         shell: bash
         run: |
@@ -101,7 +101,7 @@ jobs:
          cat gradle.properties
 
          sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk JabRef-fix ubuntu
+      - name: setup jdk JabRef-fix (ubuntu)
         if: (matrix.os == 'ubuntu-latest')
         shell: bash
         run: |
@@ -115,7 +115,7 @@ jobs:
           cat gradle.properties
 
           sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk JabRef-fix mac
+      - name: setup jdk JabRef-fix (macos)
         if: (matrix.os == 'macos-latest')
         shell: bash
         run: |
@@ -130,14 +130,14 @@ jobs:
           cat gradle.properties
 
           sed -i'.bak' -e "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: Setup OSX key chain on OSX
+      - name: Setup OSX key chain (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.OSX_SIGNING_CERT }}
           p12-password: ${{ secrets.OSX_CERT_PWD }}
           keychain-password: jabref
-      - name: Setup OSX key chain on OSX for app id cert
+      - name: Setup OSX key chain on OSX for app id cert (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: apple-actions/import-codesign-certs@v2
         with:
@@ -222,8 +222,8 @@ jobs:
           ar -m -c -a sdsd jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64_repackaged.deb debian-binary control.tar.xz data.tar.xz
           rm debian-binary control.tar.* data.tar.*
           mv -f jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64_repackaged.deb  jabref_${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}_amd64.deb
-      - name: Upload to builds.jabref.org
-        if: (matrix.os != 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
+      - name: Upload to builds.jabref.org (ubuntu)
+        if: (matrix.os == 'ubuntu-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: Pendect/action-rsyncer@v2.0.0
         env:
           DEPLOY_KEY: ${{ secrets.buildJabRefPrivateKey }}
@@ -234,6 +234,12 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
+      - name: Upload to GitHub workflow artifacts store (windows)
+        if: (matrix.os == 'windows-latest')
+        uses: actions/upload-artifact@v3
+        with:
+          name: JabRef-${{ matrix.displayName }}
+          path: build/distribution
       - name: Upload to GitHub workflow artifacts store (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: actions/upload-artifact@v3
@@ -299,6 +305,59 @@ jobs:
         with:
           name: JabRef-macOS
           path: build/distribution
+  upload:
+    strategy:
+      fail-fast: false
+    name: Upload binaries on builds.jabref.org
+    runs-on: ubuntu-latest
+    needs: [build, notarize]
+    steps:
+      - name: Check secrets presence
+        id: checksecrets
+        shell: bash
+        run: |
+          if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
+            echo "secretspresent=NO" >> $GITHUB_OUTPUT
+          else
+            echo "secretspresent=YES" >> $GITHUB_OUTPUT
+          fi
+        env:
+          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
+      - name: Checkout source
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        uses: actions/checkout@v3
+      - name: Fetch all history for all tags and branches
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        run: git fetch --prune --unshallow
+      - name: Install GitVersion
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.x'
+      - name: Run GitVersion
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+      - name: Get windows binaries
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        uses: actions/download-artifact@master
+        with:
+          name: JabRef-windows
+          path: build/distribution
+      - name: Get macOS binaries unsigned
+        if: (steps.checksecrets.outputs.secretspresent == 'YES') && ! (${{ inputs.notarization }})) && ! (startsWith(github.ref, 'refs/tags/')
+        uses: actions/download-artifact@master
+        with:
+          name: JabRef-macOS-tbn
+          path: build/distribution/
+      - name: Get macOS binaries notarized
+        if: (steps.checksecrets.outputs.secretspresent == 'YES') && ((${{ inputs.notarization }})) || (startsWith(github.ref, 'refs/tags/'))
+        uses: actions/download-artifact@master
+        with:
+          name: JabRef-macOS
+          path: build/distribution/
+      # Upload to build server using rsync
+      # The action runs on linux only (because it is a Dockerized action), therefore it is embedded in a separate workflow
       - name: Upload to builds.jabref.org
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: Pendect/action-rsyncer@v2.0.0
@@ -311,22 +370,6 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
-  notify:
-    name: notify
-    runs-on: ubuntu-latest
-    needs: [build, notarize]
-    steps:
-      - name: Check secrets presence
-        id: checksecrets
-        shell: bash
-        run: |
-          if [[ -z "$BUILDJABREFPRIVATEKEY" && "${{ github.event_name }}" != "pull_request" ]]; then
-              echo "secretspresent=NO" >> $GITHUB_ENV
-          else
-              echo "secretspresent=YES" >> $GITHUB_ENV
-          fi
-        env:
-          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
       - name: Comment PR
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: thollander/actions-comment-pull-request@v2


### PR DESCRIPTION
This removes upload to GitHub artifact store (to speed up build)

Also:

- Rename (internal) "Deploy" to "Upload"
- Minor fix in deployment-arm64 (follow-up to https://github.com/JabRef/jabref/pull/10041)

This keeps https://github.com/JabRef/jabref/pull/10049 functional.

Old measures:

![image](https://github.com/JabRef/jabref/assets/1366654/f242d3d7-199d-4cdc-a072-44ca964a9755)

(From https://github.com/JabRef/jabref/actions/runs/5432766102 / https://github.com/JabRef/jabref/pull/10049)

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
