### PR TITLE
Try to fix branch deletion

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -20,16 +20,11 @@ jobs:
           fi
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
-      - name: Extract branch name
-        id: extract_branch
-        if: ${{ steps.checksecrets.outputs.secretspresent }}
-        run: |
-          echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
       - name: Delete folder on builds.jabref.org
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: appleboy/ssh-action@v0.1.10
         with:
-          script: rm -rf /var/www/builds.jabref.org/www/${{ steps.extract_branch.outputs.branch }} || true
+          script: rm -rf /var/www/builds.jabref.org/www/pull/${{ github.event.pull_request.number }} || true
           host: build-upload.jabref.org
           port: 9922
           username: jrrsync


### PR DESCRIPTION
Our directory on the build server grows. See https://builds.jabref.org/pull/.

We had a script for deletion. We, however, changed the directory scheme - without adapting this action.

This PR should fix it.

However, I can only try when a branch is deleted.

Thus, I merge ^^.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
