### PR TITLE
Update download comment at PR if PR closed

### DIFF
--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -29,3 +29,9 @@ jobs:
           port: 9922
           username: jrrsync
           key: ${{ secrets.buildJabRefPrivateKey }}
+      - name: Remove PR comment
+        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: download-link
+          mode: delete

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -34,5 +34,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: download-link
-          message: The PR is integrated in the main branch. Head to <https://builds.jabref.org/main/> for the latest build.
+          message: A build of this PR is not available. Head to <https://builds.jabref.org/main/> for the latest build.
           mode: upsert

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           comment_tag: download-link
           message: The PR is integrated in the main branch. Head to <https://builds.jabref.org/main/> for the latest build.
-          mode: replace
+          mode: upsert

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -34,5 +34,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: download-link
-          message: to-be-deleted
-          mode: delete
+          message: The PR is integrated in the main branch. Head to <https://builds.jabref.org/main/> for the latest build.
+          mode: replace

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -29,7 +29,7 @@ jobs:
           port: 9922
           username: jrrsync
           key: ${{ secrets.buildJabRefPrivateKey }}
-      - name: Remove PR comment
+      - name: Update PR comment
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: thollander/actions-comment-pull-request@v2
         with:

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -34,4 +34,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: download-link
+          message: to-be-deleted
           mode: delete


### PR DESCRIPTION
We also have an action adding a link to the build at the PR (https://github.com/JabRef/jabref/blob/9e14b0ec5c544c62d41b1c8af7cecdacdf23df7e/.github/workflows/deployment.yml#L371). We have an action removing the branch on builds.jabref.org (https://github.com/JabRef/jabref/blob/main/.github/workflows/cleanup_pr.yml). Then, the link is 404. Thus, the comment should be deleted. This PR tries that.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
