### PR TITLE
Add ability to use ISBN & ArXiv ID in websearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added the option to unprotect a text selection, which strips all pairs of curly braces away. [#9950](https://github.com/JabRef/jabref/issues/9950)
 - We added drag and drop events for field 'Groups' in entry editor panel. [#569](https://github.com/koppor/jabref/issues/569)
 - We added support for parsing MathML in the Medline importer. [#4273](https://github.com/JabRef/jabref/issues/4273)
-- We added the ability to search for a DOI directly from 'Web Search'. [#9674](https://github.com/JabRef/jabref/issues/9674)
+- We added the ability to search for an identifier (DOI, ISBN, ArXiv ID) directly from 'Web Search'. [#7575](https://github.com/JabRef/jabref/issues/7575) [#9674](https://github.com/JabRef/jabref/issues/9674)
 - We added a cleanup activity that identifies a URL or a last-visited-date in the `note` field and moves it to the `url` and `urldate` field respectively. [koppor#216](https://github.com/koppor/jabref/issues/216)
 - We enabled the user to change the name of a field in a custom entry type by double-clicking on it. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We integrated two mail actions ("As Email" and "To Kindle") under a new "Send" option in the right-click & Tools menus. The Kindle option creates an email targeted to the user's Kindle email, which can be set in preferences under "External programs" [#6186](https://github.com/JabRef/jabref/issues/6186)

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.jabref.logic.importer.fetcher.ArXivFetcher;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
@@ -46,5 +47,13 @@ public class CompositeIdFetcher {
 
     public String getName() {
         return "CompositeIdFetcher";
+    }
+
+    public static boolean containsValidId(String identifier) {
+        Optional<DOI> doi = DOI.findInText(identifier);
+        Optional<ArXivIdentifier> arXivIdentifier = ArXivIdentifier.parse(identifier);
+        Optional<ISBN> isbn = ISBN.parse(identifier);
+
+        return Stream.of(doi, arXivIdentifier, isbn).anyMatch(Optional::isPresent);
     }
 }

--- a/src/test/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModelTest.java
+++ b/src/test/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModelTest.java
@@ -75,4 +75,28 @@ class WebSearchPaneViewModelTest {
         viewModel.queryProperty().setValue("101.1007/JHEP02(2023)082");
         assertFalse(viewModel.queryValidationStatus().validProperty().getValue());
     }
+
+    @Test
+    void queryConsistingOfISBNIsValid() {
+        viewModel.queryProperty().setValue("9780134685991");
+        assertTrue(viewModel.queryValidationStatus().validProperty().getValue());
+    }
+
+    @Test
+    void canExtractISBNFromQueryText() {
+        viewModel.queryProperty().setValue(";:isbn (9780134685991), text2");
+        assertTrue(viewModel.queryValidationStatus().validProperty().getValue());
+    }
+
+    @Test
+    void queryConsistingOfArXivIdIsValid() {
+        viewModel.queryProperty().setValue("arXiv:2110.02957");
+        assertTrue(viewModel.queryValidationStatus().validProperty().getValue());
+    }
+
+    @Test
+    void canExtractArXivIdFromQueryText() {
+        viewModel.queryProperty().setValue("this query contains an ArXiv identifier 2110.02957");
+        assertTrue(viewModel.queryValidationStatus().validProperty().getValue());
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->

This fixes #7575 by adding a pre-processing step to the web search, using `org.jabref.logic.importer.CompositeIdFetcher`.
This is a followup to PR #9969, and extends the logic to cover ISBN and ArXiv ID cases as well.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
