### PR TITLE
Fix condition for notarization

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -283,14 +283,14 @@ jobs:
           name: JabRef-macOS-tbn
           path: build/distribution/
       - name: Notarize dmg
-        if: (startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }})) && (steps.checksecrets.outputs.secretspresent == 'YES')
+        if: (steps.checksecrets.outputs.secretspresent == 'YES') && ((startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }}))
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"
           xcrun notarytool submit build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg --keychain-profile "notarytool-profile" --wait
           xcrun stapler staple build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg
       - name: Notarize pkg
-        if: (startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }})) && (steps.checksecrets.outputs.secretspresent == 'YES')
+        if: (steps.checksecrets.outputs.secretspresent == 'YES') && ((startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }}))
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"


### PR DESCRIPTION
The notarization was executed for PRs. I think, a brace was missing. I reordered the condition so that it is more consistent to the previous one - and I added the missing brace.

Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/231

Example: https://github.com/JabRef/jabref/pull/10066

https://github.com/JabRef/jabref/actions/runs/5459748285/jobs/9936231235?pr=10066

![image](https://github.com/JabRef/jabref-issue-melting-pot/assets/1366654/084874f5-68ea-4900-aabf-b8dc86f3374b)

Workflow file:

https://github.com/JabRef/jabref/blob/ffedea2d79f66eff0cabe2a18e3d747a4bed90a3/.github/workflows/deployment.yml#L286

- `steps.checksecrets.outputs.secretspresent == 'YES'` is `false`
- `(startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }})) && (steps.checksecrets.outputs.secretspresent == 'YES')` is `true`


### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
