### PR TITLE
Try to fix .mv

### DIFF
--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'src/main/java/org/jabref/logic/journals/**'
+      - 'buildSrc/build.gradle'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -3,8 +3,9 @@ name: Refresh Journal Lists
 on:
   push:
     paths:
-      - 'src/main/java/org/jabref/logic/journals/**'
+      - '.github/workflows/refresh-journal-lists.yml'
       - 'buildSrc/build.gradle'
+      - 'src/main/java/org/jabref/logic/journals/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -1,7 +1,9 @@
 name: Refresh Journal Lists
 
 on:
-  # Allow to run manually
+  push:
+    paths:
+      - 'src/main/java/org/jabref/logic/journals/**'
   workflow_dispatch:
 
 permissions:
@@ -58,13 +60,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-journallist
-          title: "[Bot] Update Journal abbrev list"
-          commit-message: Update journal abbrev list
+          title: "[Bot] Update journal abbreviation lists"
+          commit-message: Update journal abbreviation lists
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v9
         if: github.ref != 'refs/heads/main'
         with:
-          message: 'Update journal abbrev list'
+          message: 'Update journal abbreviation lists'
           committer_email: actions@github.com
           fetch: false
           push: true

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'java'
+plugins {
+    id 'java'
+    id 'org.openjfx.javafxplugin' version '0.0.14'
+}
 
 repositories {
     mavenLocal()
@@ -9,6 +12,11 @@ dependencies {
     implementation 'com.h2database:h2-mvstore:2.2.220'
     implementation 'org.apache.commons:commons-csv:1.10.0'
     implementation 'org.slf4j:slf4j-api:2.0.7'
+}
+
+javafx {
+    version = "20"
+    modules = [ 'javafx.base' ]
 }
 
 sourceSets{

--- a/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.journals;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -62,6 +61,6 @@ public class JournalAbbreviationLoader {
     }
 
     public static JournalAbbreviationRepository loadBuiltInRepository() {
-        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), StandardCharsets.UTF_8, true));
+        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), true));
     }
 }

--- a/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -1,37 +1,41 @@
 package org.jabref.logic.journals;
 
-import java.nio.charset.Charset;
 import java.util.List;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 public class JournalAbbreviationPreferences {
 
-    private final Charset defaultEncoding;
-    private List<String> externalJournalLists;
-    private boolean useFJournalField;
+    private final ObservableList<String> externalJournalLists;
+    private final BooleanProperty useFJournalField;
 
-    public JournalAbbreviationPreferences(List<String> externalJournalLists, Charset defaultEncoding, boolean useFJournalField) {
-        this.externalJournalLists = externalJournalLists;
-        this.defaultEncoding = defaultEncoding;
-        this.useFJournalField = useFJournalField;
+    public JournalAbbreviationPreferences(List<String> externalJournalLists,
+                                          boolean useFJournalField) {
+        this.externalJournalLists = FXCollections.observableArrayList(externalJournalLists);
+        this.useFJournalField = new SimpleBooleanProperty(useFJournalField);
     }
 
-    public List<String> getExternalJournalLists() {
+    public ObservableList<String> getExternalJournalLists() {
         return externalJournalLists;
     }
 
-    public void setExternalJournalLists(List<String> externalJournalLists) {
-        this.externalJournalLists = externalJournalLists;
+    public void setExternalJournalLists(List<String> list) {
+        externalJournalLists.clear();
+        externalJournalLists.addAll(list);
     }
 
-    public Charset getDefaultEncoding() {
-        return defaultEncoding;
+    public boolean shouldUseFJournalField() {
+        return useFJournalField.get();
     }
 
-    public boolean useAMSFJournalFieldForAbbrevAndUnabbrev() {
+    public BooleanProperty useFJournalFieldProperty() {
         return useFJournalField;
     }
 
-    public void setUseAMSFJournalFieldForAbbrevAndUnabbrev(boolean useFJournalField) {
-        this.useFJournalField = useFJournalField;
+    public void setUseFJournalField(boolean useFJournalField) {
+        this.useFJournalField.set(useFJournalField);
     }
 }


### PR DESCRIPTION
Working on fixing following:

```
f$ ./gradlew run

> Configure project :
Project : => 'org.jabref' Java module

> Task :run
2023-07-11 20:37:35 [main] org.jabref.cli.Launcher.main()
ERROR: Unexpected exception: org.h2.mvstore.MVStoreException: The read format 2 is smaller than the supported format 3 [2.2.220/5]
        at com.h2database.mvstore@2.2.220/org.h2.mvstore.datautils.newmvstoreexception(datautils.java:996)
```

There are also build errors when the update workflow is triggered manually:

https://github.com/JabRef/jabref/actions/runs/5527607325/jobs/10083532466

```
Starting a Gradle Daemon (subsequent builds will be faster)
/home/runner/work/jabref/jabref/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java:5: error: package javafx.beans.property does not exist
import javafx.beans.property.BooleanProperty;
                            ^
/home/runner/work/jabref/jabref/buildSrc/src/copied/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java:6: error: package javafx.beans.property does not exist
import javafx.beans.property.SimpleBooleanProperty;
                            ^
```

Caused by Observable Preferences S (#9619).

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
