### PR TITLE
Fix order of string in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where empty grey containers would remain in the groups panel, if displaying of group item count is turned off. [#9972](https://github.com/JabRef/jabref/issues/9972)
 - We fixed an issue where fetching an ISBN could lead to application freezing when the fetcher did not return any results. [#9979](https://github.com/JabRef/jabref/issues/9979)
 - We fixed an issue where closing a library containing groups and entries caused an exception [#9997](https://github.com/JabRef/jabref/issues/9997)
+- We fixed a bug where the editor for strings in a bibliography file did not sort the entries by their keys [#10083](https://github.com/JabRef/jabref/pull/10083)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
@@ -77,7 +77,14 @@ public class ConstantsPropertiesView extends AbstractPropertiesTabView<Constants
                 cellItem.setLabel(cellEvent.getNewValue());
             }
 
-            cellEvent.getTableView().refresh();
+            // Resort the entries based on the keys and set the focus to the newly-created entry
+            viewModel.resortStrings();
+            var selectionModel = cellEvent.getTableView().getSelectionModel();
+            var tableView = cellEvent.getTableView();
+            selectionModel.select(cellItem);
+            selectionModel.focus(selectionModel.getSelectedIndex());
+            tableView.refresh();
+            tableView.scrollTo(cellItem);
         });
 
         contentColumn.setSortable(true);

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
@@ -62,8 +62,8 @@ public class ConstantsPropertiesView extends AbstractPropertiesTabView<Constants
                 .install(labelColumn, new DefaultStringConverter());
         labelColumn.setOnEditCommit((TableColumn.CellEditEvent<ConstantsItemModel, String> cellEvent) -> {
 
-            ConstantsItemModel cellItem = cellEvent.getTableView()
-                                                   .getItems()
+            var tableView = cellEvent.getTableView();
+            ConstantsItemModel cellItem = tableView.getItems()
                                                    .get(cellEvent.getTablePosition().getRow());
 
             Optional<ConstantsItemModel> existingItem = viewModel.labelAlreadyExists(cellEvent.getNewValue());
@@ -79,7 +79,6 @@ public class ConstantsPropertiesView extends AbstractPropertiesTabView<Constants
 
             // Resort the entries based on the keys and set the focus to the newly-created entry
             viewModel.resortStrings();
-            var tableView = cellEvent.getTableView();
             var selectionModel = tableView.getSelectionModel();
             selectionModel.select(cellItem);
             selectionModel.focus(selectionModel.getSelectedIndex());

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesView.java
@@ -79,8 +79,8 @@ public class ConstantsPropertiesView extends AbstractPropertiesTabView<Constants
 
             // Resort the entries based on the keys and set the focus to the newly-created entry
             viewModel.resortStrings();
-            var selectionModel = cellEvent.getTableView().getSelectionModel();
             var tableView = cellEvent.getTableView();
+            var selectionModel = tableView.getSelectionModel();
             selectionModel.select(cellItem);
             selectionModel.focus(selectionModel.getSelectedIndex());
             tableView.refresh();

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
@@ -48,7 +48,7 @@ public class ConstantsPropertiesViewModel implements PropertiesTabViewModel {
         stringsListProperty.addAll(databaseContext.getDatabase().getStringValues().stream()
                                                   .sorted(new BibtexStringComparator(false))
                                                   .map(this::convertFromBibTexString)
-                                                  .collect(Collectors.toSet()));
+                                                  .toList());
     }
 
     public void addNewString() {

--- a/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModel.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.libraryproperties.constants;
 
+import java.util.Comparator;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -68,6 +70,11 @@ public class ConstantsPropertiesViewModel implements PropertiesTabViewModel {
 
     public void removeString(ConstantsItemModel item) {
         stringsListProperty.remove(item);
+    }
+
+    public void resortStrings() {
+        // Resort the strings list in the same order as setValues() does
+        stringsListProperty.sort(Comparator.comparing(c -> c.labelProperty().get().toLowerCase(Locale.ROOT)));
     }
 
     private ConstantsItemModel convertFromBibTexString(BibtexString bibtexString) {

--- a/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
@@ -1,0 +1,43 @@
+package org.jabref.gui.libraryproperties.constants;
+
+import java.util.Collection;
+import java.util.List;
+
+import javafx.beans.property.ListProperty;
+
+import org.jabref.gui.DialogService;
+import org.jabref.model.database.BibDatabase;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibtexString;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConstantsPropertiesViewModelTest {
+
+    @DisplayName("Check that the list of strings is sorted according to their keys")
+    @Test
+    void testStringsListPropertySorting() {
+        DialogService service = mock(DialogService.class);
+        BibDatabaseContext context = mock(BibDatabaseContext.class);
+        BibDatabase db = mock(BibDatabase.class);
+        BibtexString string1 = new BibtexString("TSE", "Transactions on Software Engineering");
+        BibtexString string2 = new BibtexString("ICSE", "International Conference on Software Engineering");
+        Collection<BibtexString> stringValues = List.of(string1, string2);
+        when(db.getStringValues()).thenReturn(stringValues);
+        when(context.getDatabase()).thenReturn(db);
+
+        ConstantsPropertiesViewModel model = new ConstantsPropertiesViewModel(context, service);
+        model.setValues();
+
+        ListProperty<ConstantsItemModel> strings = model.stringsListProperty();
+        assertAll(
+                () -> assertEquals("ICSE", strings.get(0).labelProperty().getValue()),
+                () -> assertEquals("TSE", strings.get(1).labelProperty().getValue()));
+    }
+}

--- a/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
@@ -38,4 +38,27 @@ class ConstantsPropertiesViewModelTest {
 
         assertEquals(expected, actual);
     }
+
+    @DisplayName("Check that the list of strings is sorted after resorting it")
+    @Test
+    void testStringsListPropertyResorting() {
+        BibDatabase db = new BibDatabase();
+        BibDatabaseContext context = new BibDatabaseContext(db);
+        DialogService service = mock(DialogService.class);
+        List<String> expected = List.of("ICSE", "TSE");
+
+        ConstantsPropertiesViewModel model = new ConstantsPropertiesViewModel(context, service);
+        var stringsList = model.stringsListProperty();
+        stringsList.add(new ConstantsItemModel("TSE", "Transactions on Software Engineering"));
+        stringsList.add(new ConstantsItemModel("ICSE", "International Conference on Software Engineering"));
+
+        model.resortStrings();
+
+        List<String> actual = model.stringsListProperty().stream()
+                .map(ConstantsItemModel::labelProperty)
+                .map(StringProperty::getValue)
+                .toList();
+
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/constants/ConstantsPropertiesViewModelTest.java
@@ -1,9 +1,8 @@
 package org.jabref.gui.libraryproperties.constants;
 
-import java.util.Collection;
 import java.util.List;
 
-import javafx.beans.property.ListProperty;
+import javafx.beans.property.StringProperty;
 
 import org.jabref.gui.DialogService;
 import org.jabref.model.database.BibDatabase;
@@ -13,31 +12,30 @@ import org.jabref.model.entry.BibtexString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class ConstantsPropertiesViewModelTest {
 
     @DisplayName("Check that the list of strings is sorted according to their keys")
     @Test
     void testStringsListPropertySorting() {
-        DialogService service = mock(DialogService.class);
-        BibDatabaseContext context = mock(BibDatabaseContext.class);
-        BibDatabase db = mock(BibDatabase.class);
         BibtexString string1 = new BibtexString("TSE", "Transactions on Software Engineering");
         BibtexString string2 = new BibtexString("ICSE", "International Conference on Software Engineering");
-        Collection<BibtexString> stringValues = List.of(string1, string2);
-        when(db.getStringValues()).thenReturn(stringValues);
-        when(context.getDatabase()).thenReturn(db);
+        BibDatabase db = new BibDatabase();
+        db.setStrings(List.of(string1, string2));
+        BibDatabaseContext context = new BibDatabaseContext(db);
+        DialogService service = mock(DialogService.class);
+        List<String> expected = List.of(string2.getName(), string1.getName()); // ICSE before TSE
 
         ConstantsPropertiesViewModel model = new ConstantsPropertiesViewModel(context, service);
         model.setValues();
 
-        ListProperty<ConstantsItemModel> strings = model.stringsListProperty();
-        assertAll(
-                () -> assertEquals("ICSE", strings.get(0).labelProperty().getValue()),
-                () -> assertEquals("TSE", strings.get(1).labelProperty().getValue()));
+        List<String> actual = model.stringsListProperty().stream()
+                .map(ConstantsItemModel::labelProperty)
+                .map(StringProperty::getValue)
+                .toList();
+
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
The string defined in a BibTeX file were shown in random order in the respective GUI editor. While the code already sorts them, by storing the items into a set, it destroys the order again. Fix this behaviour by storing them as a list, which retains the order.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
