### PR TITLE
Fixing unwanted tree group node expansion selection bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
+- We fixed an issue where click the group expansion pane/arrow caused the node to be selected, when it should just expand/detract the node - We fixed an issue when overwriting the owner was disabled. [#10111](https://github.com/JabRef/jabref/pull/10111)
 - We fixed an issue where the browser import would add ' characters before the BibTeX entry on Linux. [#9588](https://github.com/JabRef/jabref/issues/9588)
 - We fixed an issue where searching for a specific term with the DOAB fetcher lead to an exception. [#9571](https://github.com/JabRef/jabref/issues/9571)
 - We fixed an issue where the "Import" -> "Library to import to" did not show the correct library name if two opened libraries had the same suffix. [#9567](https://github.com/JabRef/jabref/issues/9567)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 
 ### Fixed
 
-- We fixed an issue where click the group expansion pane/arrow caused the node to be selected, when it should just expand/detract the node - We fixed an issue when overwriting the owner was disabled. [#10111](https://github.com/JabRef/jabref/pull/10111)
+- We fixed an issue where clicking the group expansion pane/arrow caused the node to be selected, when it should just expand/detract the node - [#10111](https://github.com/JabRef/jabref/pull/10111)
 - We fixed an issue where the browser import would add ' characters before the BibTeX entry on Linux. [#9588](https://github.com/JabRef/jabref/issues/9588)
 - We fixed an issue where searching for a specific term with the DOAB fetcher lead to an exception. [#9571](https://github.com/JabRef/jabref/issues/9571)
 - We fixed an issue where the "Import" -> "Library to import to" did not show the correct library name if two opened libraries had the same suffix. [#9567](https://github.com/JabRef/jabref/issues/9567)

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -230,7 +230,7 @@ public class GroupTreeView extends BorderPane {
                             event.consume();
                         }
                     }
-                })
+                }, true)
                 .withCustomInitializer(row -> {
                     // Remove disclosure node since we display custom version in separate column
                     // Simply setting to null is not enough since it would be replaced by the default node on every change

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -224,13 +224,13 @@ public class GroupTreeView extends BorderPane {
 
         new ViewModelTreeTableRowFactory<GroupNodeViewModel>()
                 .withContextMenu(this::createContextMenuForGroup)
-                .withOnMousePressedEvent((row, event) -> {
+                .withEventFilter(MouseEvent.MOUSE_PRESSED, (row, event) -> {
                     if (event.getTarget() instanceof StackPane pane) {
                         if (pane.getStyleClass().contains("arrow") || pane.getStyleClass().contains("tree-disclosure-node")) {
                             event.consume();
                         }
                     }
-                }, true)
+                })
                 .withCustomInitializer(row -> {
                     // Remove disclosure node since we display custom version in separate column
                     // Simply setting to null is not enough since it would be replaced by the default node on every change

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
@@ -27,6 +27,10 @@ import org.reactfx.util.TriConsumer;
 
 public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S>, TreeTableRow<S>> {
     private BiConsumer<S, ? super MouseEvent> onMouseClickedEvent;
+
+    // True if listener should be at filter stage, otherwise use default Node method
+    private boolean onMousePressedEventCapturePhase;
+
     private BiConsumer<S, ? super MouseEvent> onMousePressedEvent;
     private Consumer<TreeTableRow<S>> toCustomInitializer;
     private Function<S, ContextMenu> contextMenuFactory;
@@ -44,7 +48,12 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
     }
 
     public ViewModelTreeTableRowFactory<S> withOnMousePressedEvent(BiConsumer<S, ? super MouseEvent> event) {
+        return withOnMousePressedEvent(event, false);
+    }
+
+    public ViewModelTreeTableRowFactory<S> withOnMousePressedEvent(BiConsumer<S, ? super MouseEvent> event, boolean capturePhase) {
         this.onMousePressedEvent = event;
+        this.onMousePressedEventCapturePhase = capturePhase;
         return this;
     }
 
@@ -165,7 +174,11 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
                     }
 
                     if (onMousePressedEvent != null) {
-                        setOnMousePressed(event -> onMousePressedEvent.accept(getItem(), event));
+                        if (onMousePressedEventCapturePhase) {
+                            addEventFilter(MouseEvent.MOUSE_PRESSED, event -> onMousePressedEvent.accept(getItem(), event));
+                        } else {
+                            setOnMousePressed(event -> onMousePressedEvent.accept(getItem(), event));
+                        }
                     }
 
                     if (toCustomInitializer != null) {

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
@@ -10,6 +10,8 @@ import java.util.function.Function;
 
 import javafx.beans.value.ObservableValue;
 import javafx.css.PseudoClass;
+import javafx.event.Event;
+import javafx.event.EventType;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.control.ContextMenu;
@@ -27,11 +29,6 @@ import org.reactfx.util.TriConsumer;
 
 public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S>, TreeTableRow<S>> {
     private BiConsumer<S, ? super MouseEvent> onMouseClickedEvent;
-
-    // True if event capture should be at capture phase via an event filter, otherwise use default Node method to setup
-    // event handler (bubbling phase)
-    private boolean onMousePressedEventCapturePhase;
-
     private BiConsumer<S, ? super MouseEvent> onMousePressedEvent;
     private Consumer<TreeTableRow<S>> toCustomInitializer;
     private Function<S, ContextMenu> contextMenuFactory;
@@ -41,6 +38,7 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
     private TriConsumer<TreeTableRow<S>, S, ? super DragEvent> toOnDragExited;
     private TriConsumer<TreeTableRow<S>, S, ? super DragEvent> toOnDragOver;
     private TriConsumer<TreeTableRow<S>, S, ? super MouseDragEvent> toOnMouseDragEntered;
+    private final Map<EventType<?>, BiConsumer<S, ? super Event>> eventFilters = new HashMap<>();
     private final Map<PseudoClass, Callback<TreeTableRow<S>, ObservableValue<Boolean>>> pseudoClasses = new HashMap<>();
 
     public ViewModelTreeTableRowFactory<S> withOnMouseClickedEvent(BiConsumer<S, ? super MouseEvent> event) {
@@ -49,12 +47,7 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
     }
 
     public ViewModelTreeTableRowFactory<S> withOnMousePressedEvent(BiConsumer<S, ? super MouseEvent> event) {
-        return withOnMousePressedEvent(event, false);
-    }
-
-    public ViewModelTreeTableRowFactory<S> withOnMousePressedEvent(BiConsumer<S, ? super MouseEvent> event, boolean capturePhase) {
         this.onMousePressedEvent = event;
-        this.onMousePressedEventCapturePhase = capturePhase;
         return this;
     }
 
@@ -124,6 +117,11 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
         return this;
     }
 
+    public ViewModelTreeTableRowFactory<S> withEventFilter(EventType<?> event, BiConsumer<S, ? super Event> toCondition) {
+        this.eventFilters.putIfAbsent(event, toCondition);
+        return this;
+    }
+
     public void install(TreeTableView<S> table) {
         table.setRowFactory(this);
     }
@@ -175,11 +173,7 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
                     }
 
                     if (onMousePressedEvent != null) {
-                        if (onMousePressedEventCapturePhase) {
-                            addEventFilter(MouseEvent.MOUSE_PRESSED, event -> onMousePressedEvent.accept(getItem(), event));
-                        } else {
-                            setOnMousePressed(event -> onMousePressedEvent.accept(getItem(), event));
-                        }
+                        setOnMousePressed(event -> onMousePressedEvent.accept(getItem(), event));
                     }
 
                     if (toCustomInitializer != null) {
@@ -204,6 +198,10 @@ public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S
 
                     if (toOnMouseDragEntered != null) {
                         setOnMouseDragEntered(event -> toOnMouseDragEntered.accept(this, getItem(), event));
+                    }
+
+                    for (Map.Entry<EventType<?>, BiConsumer<S, ? super Event>> eventFilter : eventFilters.entrySet()) {
+                        addEventFilter(eventFilter.getKey(), event -> eventFilter.getValue().accept(getItem(), event));
                     }
 
                     for (Map.Entry<PseudoClass, Callback<TreeTableRow<S>, ObservableValue<Boolean>>> pseudoClassWithCondition : pseudoClasses.entrySet()) {

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeTableRowFactory.java
@@ -28,7 +28,8 @@ import org.reactfx.util.TriConsumer;
 public class ViewModelTreeTableRowFactory<S> implements Callback<TreeTableView<S>, TreeTableRow<S>> {
     private BiConsumer<S, ? super MouseEvent> onMouseClickedEvent;
 
-    // True if listener should be at filter stage, otherwise use default Node method
+    // True if event capture should be at capture phase via an event filter, otherwise use default Node method to setup
+    // event handler (bubbling phase)
     private boolean onMousePressedEventCapturePhase;
 
     private BiConsumer<S, ? super MouseEvent> onMousePressedEvent;


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Fixing bug introduced in https://github.com/JabRef/jabref/pull/9728 which undid/broke this improvement: https://github.com/JabRef/jabref/pull/8785, which prevented the group node from being selected when the user is just attempting to expand or shrink the tree node. Now, once again, the mouse click is handled and consumed at the capture stage if the expansion pane is clicked, therefore preventing the node from being selected.


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
