### PR TITLE
Add git merge conflict finder

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,3 +201,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
+  # This ensures that no git merge conflict markers (<<<, ...) are contained
+  merge_conflict_job:
+    name: Find merge conflicts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Merge Conflict finder
+        uses: olivernybroe/action-conflict-finder@v4.0


### PR DESCRIPTION
This adds https://github.com/marketplace/actions/merge-conflict-finder.

We sometimes have git merge conflict markers when merging CSL updates. This action ensures that we notice it early.

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
