### PR TITLE
Allow enabling debug logs

### DIFF
--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -187,10 +187,6 @@ public class ArgumentProcessor {
     }
 
     private List<ParserResult> processArguments() {
-        if (!cli.isBlank() && cli.isDebugLogging()) {
-            System.err.println("use java property -Dtinylog.level=debug");
-        }
-
         if ((startupMode == Mode.INITIAL_START) && cli.isShowVersion()) {
             cli.displayVersion();
         }

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -6,7 +6,6 @@ import java.net.Authenticator;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -6,6 +6,7 @@ import java.net.Authenticator;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 
@@ -43,8 +44,14 @@ public class Launcher {
     private static Logger LOGGER;
     private static String[] ARGUMENTS;
 
+    private static boolean isDebugEnabled = false;
+
     public static void main(String[] args) {
         ARGUMENTS = args;
+
+        if (Arrays.stream(ARGUMENTS).anyMatch("--debug"::equalsIgnoreCase)) {
+            isDebugEnabled = true;
+        }
 
         addLogToDisk();
         try {
@@ -105,7 +112,8 @@ public class Launcher {
         // https://tinylog.org/v2/configuration/#shared-file-writer
         Map<String, String> configuration = Map.of(
                 "writerFile", "shared file",
-                "writerFile.level", "debug",
+                "writerFile.level", isDebugEnabled ? "debug" : "info",
+                "level", isDebugEnabled ? "debug" : "info",
                 "writerFile.file", directory.resolve("log.txt").toString(),
                 "writerFile.charset", "UTF-8");
 

--- a/src/main/java/org/jabref/cli/Launcher.java
+++ b/src/main/java/org/jabref/cli/Launcher.java
@@ -43,14 +43,19 @@ import org.tinylog.configuration.Configuration;
 public class Launcher {
     private static Logger LOGGER;
     private static String[] ARGUMENTS;
-
-    private static boolean isDebugEnabled = false;
+    private static boolean isDebugEnabled;
 
     public static void main(String[] args) {
         ARGUMENTS = args;
 
-        if (Arrays.stream(ARGUMENTS).anyMatch("--debug"::equalsIgnoreCase)) {
-            isDebugEnabled = true;
+        // We must configure logging as soon as possible, which is why we cannot wait for the usual
+        // argument parsing workflow to parse logging options .e.g. --debug
+        JabRefCLI jabRefCLI;
+        try {
+            jabRefCLI = new JabRefCLI(ARGUMENTS);
+            isDebugEnabled = jabRefCLI.isDebugLogging();
+        } catch (ParseException e) {
+            isDebugEnabled = false;
         }
 
         addLogToDisk();


### PR DESCRIPTION
Just pass `--debug` to the command line.

![image](https://github.com/JabRef/jabref/assets/21198231/7e7dfb93-4240-4089-a90d-3b28c9e4d38c)

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
