### PR TITLE
Hotfix: Always create a PR for updating journal lists

### DIFF
--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -58,17 +58,8 @@ jobs:
           cd $GITHUB_WORKSPACE
           ./gradlew generateJournalAbbreviationList
       - uses: peter-evans/create-pull-request@v5
-        if: github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-journallist
           title: "[Bot] Update journal abbreviation lists"
           commit-message: Update journal abbreviation lists
-      - name: Commit and push changes
-        uses: EndBug/add-and-commit@v9
-        if: github.ref != 'refs/heads/main'
-        with:
-          message: 'Update journal abbreviation lists'
-          committer_email: actions@github.com
-          fetch: false
-          push: true


### PR DESCRIPTION
Our .mv file gets updated too often. I don't see, why.

Thus adapting the workflow not to commit and push, but always to create a PR.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
