### PR TITLE
Fix high CPU usage because of author name autocomplete

### DIFF
--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
@@ -64,7 +64,7 @@ public class PersonNameSuggestionProvider extends SuggestionProvider<Author> {
     @Override
     public Stream<Author> getSource() {
         return database.getEntries()
-                       .stream()
+                       .parallelStream()
                        .flatMap(this::getAuthors);
     }
 }

--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
@@ -64,7 +64,7 @@ public class PersonNameSuggestionProvider extends SuggestionProvider<Author> {
     @Override
     public Stream<Author> getSource() {
         return database.getEntries()
-                       .parallelStream()
+                       .stream()
                        .flatMap(this::getAuthors);
     }
 }

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -1,6 +1,8 @@
 package org.jabref.model.entry;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.function.Function;
@@ -115,7 +117,7 @@ import org.jabref.logic.importer.AuthorListParser;
 @AllowedToUseLogic("because it needs access to AuthorList parser")
 public class AuthorList {
 
-    private static final WeakHashMap<String, AuthorList> AUTHOR_CACHE = new WeakHashMap<>();
+    private static final Map<String, AuthorList> AUTHOR_CACHE = Collections.synchronizedMap(new WeakHashMap<>());
     private final List<Author> authors;
     private AuthorList latexFreeAuthors;
 


### PR DESCRIPTION
Fix https://github.com/JabRef/jabref/issues/9952
Fix https://github.com/JabRef/jabref/issues/6967 


~~Probably because of a deadlock while accessing AthorList#AUTHOR_CACHE but can't confirm...~~

Actually, this can't be a deadlock because there were no use of locks. It's a well known problem that cause non thread-safe Map implementations to get into an infinite loop if accessed concurrently.
https://dzone.com/articles/java-7-hashmap-vs


### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
