### PR TITLE
Change delimiter of csv from `;` to `,`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We now encrypt and store the custom API keys in the OS native credential store. [#10044](https://github.com/JabRef/jabref/issues/10044)
 - We changed the behavior of group addition/edit, so that sorting by alphabetical order is not performed by default after the modification [#10017](https://github.com/JabRef/jabref/issues/10017)
 - We fixed an issue with spacing in the cleanup dialogue. [#10081](https://github.com/JabRef/jabref/issues/10081)
+- We changed the delimiter of the CSV file that stored the journal abbreviations from semicolon to comma. [#10190](https://github.com/JabRef/jabref/pull/10190)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/journals/AbbreviationFormat.java
+++ b/src/main/java/org/jabref/logic/journals/AbbreviationFormat.java
@@ -4,7 +4,7 @@ import org.apache.commons.csv.CSVFormat;
 
 public final class AbbreviationFormat {
 
-    public static final char DELIMITER = ';';
+    public static final char DELIMITER = ',';
     public static final char ESCAPE = '\\';
     public static final char QUOTE = '"';
 

--- a/src/test/java/org/jabref/gui/preferences/journals/JournalAbbreviationsViewModelTabTest.java
+++ b/src/test/java/org/jabref/gui/preferences/journals/JournalAbbreviationsViewModelTabTest.java
@@ -85,9 +85,9 @@ class JournalAbbreviationsViewModelTabTest {
         @Override
         public String toString() {
             if (showShortestUniqueAbbreviation) {
-                return this.getName() + ";" + this.getAbbreviation() + ";" + this.getShortestUniqueAbbreviation();
+                return this.getName() + "," + this.getAbbreviation() + "," + this.getShortestUniqueAbbreviation();
             }
-            return this.getName() + ";" + this.getAbbreviation();
+            return this.getName() + "," + this.getAbbreviation();
         }
     }
 

--- a/src/test/java/org/jabref/logic/journals/AbbreviationWriterTest.java
+++ b/src/test/java/org/jabref/logic/journals/AbbreviationWriterTest.java
@@ -21,7 +21,7 @@ class AbbreviationWriterTest {
         AbbreviationWriter.writeOrCreate(
                 csvFile,
                 List.of(abbreviation));
-        assertEquals(List.of("Full;Abbr;A"), Files.readAllLines(csvFile));
+        assertEquals(List.of("Full,Abbr,A"), Files.readAllLines(csvFile));
     }
 
     @Test
@@ -31,6 +31,6 @@ class AbbreviationWriterTest {
         AbbreviationWriter.writeOrCreate(
                 csvFile,
                 List.of(abbreviation));
-        assertEquals(List.of("Full;Abbr"), Files.readAllLines(csvFile));
+        assertEquals(List.of("Full,Abbr"), Files.readAllLines(csvFile));
     }
 }


### PR DESCRIPTION
Change delimiter of csv from `;` to `,`

Fixes JabRef/abbrv.jabref.org#130
Refs JabRef/abbrv.jabref.org#139

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
