### PR TITLE
Fix adding files with illegal characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We added an option to encrypt and remember the proxy password. [#8055](https://github.com/JabRef/jabref/issues/8055)[#10044](https://github.com/JabRef/jabref/issues/10044)
 - We added support for showing journal information, via info buttons next to the `Journal` and `ISSN` fields in the entry editor. [#6189](https://github.com/JabRef/jabref/issues/6189)
 - We added support for pushing citations to Sublime Text 3 [#10098](https://github.com/JabRef/jabref/issues/10098)
+- We added support for the Finnish language. [#10183](https://github.com/JabRef/jabref/pull/10183)
+- We added the option to automatically repleaces  illegal characters in the filename when adding a file to JabRef. [#10182](https://github.com/JabRef/jabref/issues/10182)
 
 ### Changed
 
@@ -129,7 +131,7 @@ Note that this project **does not** adhere to [Semantic Versioning](http://semve
 - We fixed an issue where JabRef would not remember if the window was in fullscreen or not [#4939](https://github.com/JabRef/jabref/issues/4939)
 - We fixed an issue where the ACM Portal search sometimes would not return entries for some search queries when the article author had no given name [#10107](https://github.com/JabRef/jabref/issues/10107)
 - We fixed an issue that caused high CPU usage and a zombie process after quitting JabRef because of author names autocompletion [#10159](https://github.com/JabRef/jabref/pull/10159)
-- We added support for the Finnish language. [#10183](https://github.com/JabRef/jabref/pull/10183)
+- We fixed an issue where files with illegal characters in the filename could be added to JabRef. [#10182](https://github.com/JabRef/jabref/issues/10182)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -1,8 +1,6 @@
 package org.jabref.gui.entryeditor;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,9 +50,6 @@ import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fileformat.PdfMergeMetadataImporter;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
-import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.util.io.FileNameCleaner;
-import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;

--- a/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -116,12 +116,13 @@ public class ExternalFilesEntryLinker {
 
         for (Path fileToAdd : filesToAdd) {
             if (FileUtil.detectBadFileName(fileToAdd.toString())) {
+                String newFilename = FileNameCleaner.cleanFileName(fileToAdd.getFileName().toString());
+
                 boolean correctButtonPressed = dialogService.showConfirmationDialogAndWait(Localization.lang("File \"%0\" cannot be added!", fileToAdd.getFileName()),
-                        Localization.lang("Detected illegal characters in the file name.\nSelect \"Correct filename\" to automatically correct the filename and add it to JabRef.\nSelect cancel to not add the file"),
-                        Localization.lang("Correct filename"));
+                        Localization.lang("Illegal characters in the file name detected.\nFile will be renamed to \"%0\" and added.", newFilename),
+                        Localization.lang("Rename and add"));
 
                 if (correctButtonPressed) {
-                    String newFilename = FileNameCleaner.cleanFileName(fileToAdd.getFileName().toString());
                     Path correctPath = fileToAdd.resolveSibling(newFilename);
                     try {
                         Files.move(fileToAdd, correctPath);

--- a/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -111,7 +111,6 @@ public class ExternalFilesEntryLinker {
         }
     }
 
-
     private List<Path> getValidFileNames(List<Path> filesToAdd) {
         List<Path> validFileNames = new ArrayList<>();
 

--- a/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -1,18 +1,23 @@
 package org.jabref.gui.externalfiles;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.jabref.gui.DialogService;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.externalfiletype.UnknownExternalFileType;
 import org.jabref.logic.cleanup.MoveFilesCleanup;
 import org.jabref.logic.cleanup.RenamePdfCleanup;
+import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.pdf.search.indexing.IndexingTaskManager;
 import org.jabref.logic.pdf.search.indexing.PdfIndexer;
+import org.jabref.logic.util.io.FileNameCleaner;
 import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -30,12 +35,14 @@ public class ExternalFilesEntryLinker {
     private final BibDatabaseContext bibDatabaseContext;
     private final MoveFilesCleanup moveFilesCleanup;
     private final RenamePdfCleanup renameFilesCleanup;
+    private final DialogService dialogService;
 
-    public ExternalFilesEntryLinker(FilePreferences filePreferences, BibDatabaseContext bibDatabaseContext) {
+    public ExternalFilesEntryLinker(FilePreferences filePreferences, BibDatabaseContext bibDatabaseContext, DialogService dialogService) {
         this.filePreferences = filePreferences;
         this.bibDatabaseContext = bibDatabaseContext;
         this.moveFilesCleanup = new MoveFilesCleanup(bibDatabaseContext, filePreferences);
         this.renameFilesCleanup = new RenamePdfCleanup(false, bibDatabaseContext, filePreferences);
+        this.dialogService = dialogService;
     }
 
     public Optional<Path> copyFileToFileDir(Path file) {
@@ -58,7 +65,8 @@ public class ExternalFilesEntryLinker {
     }
 
     public void addFilesToEntry(BibEntry entry, List<Path> files) {
-        for (Path file : files) {
+        List<Path> validFiles = getValidFileNames(files);
+        for (Path file : validFiles) {
             FileUtil.getFileExtension(file).ifPresent(ext -> {
                 ExternalFileType type = ExternalFileTypes.getExternalFileTypeByExt(ext, filePreferences)
                                                          .orElse(new UnknownExternalFileType(ext));
@@ -69,7 +77,7 @@ public class ExternalFilesEntryLinker {
         }
     }
 
-    public void moveFilesToFileDirAndAddToEntry(BibEntry entry, List<Path> files, IndexingTaskManager indexingTaskManager) {
+    public void moveFilesToFileDirRenameAndAddToEntry(BibEntry entry, List<Path> files, IndexingTaskManager indexingTaskManager) {
         try (AutoCloseable blocker = indexingTaskManager.blockNewTasks()) {
             addFilesToEntry(entry, files);
             moveLinkedFilesToFileDir(entry);
@@ -101,5 +109,33 @@ public class ExternalFilesEntryLinker {
         } catch (IOException e) {
             LOGGER.error("Could not access Fulltext-Index", e);
         }
+    }
+
+
+    private List<Path> getValidFileNames(List<Path> filesToAdd) {
+        List<Path> validFileNames = new ArrayList<>();
+
+        for (Path fileToAdd : filesToAdd) {
+            if (FileUtil.detectBadFileName(fileToAdd.toString())) {
+                boolean correctButtonPressed = dialogService.showConfirmationDialogAndWait(Localization.lang("File \"%0\" cannot be added!", fileToAdd.getFileName()),
+                        Localization.lang("Detected illegal characters in the file name.\nSelect \"Correct filename\" to automatically correct the filename and add it to JabRef.\nSelect cancel to not add the file"),
+                        Localization.lang("Correct filename"));
+
+                if (correctButtonPressed) {
+                    String newFilename = FileNameCleaner.cleanFileName(fileToAdd.getFileName().toString());
+                    Path correctPath = fileToAdd.resolveSibling(newFilename);
+                    try {
+                        Files.move(fileToAdd, correctPath);
+                        validFileNames.add(correctPath);
+                    } catch (IOException ex) {
+                        LOGGER.error("Error moving file", ex);
+                        dialogService.showErrorDialogAndWait(ex);
+                    }
+                }
+            } else {
+                validFileNames.add(fileToAdd);
+            }
+        }
+        return validFileNames;
     }
 }

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -83,7 +83,7 @@ public class ImportHandler {
         this.dialogService = dialogService;
         this.taskExecutor = taskExecutor;
 
-        this.linker = new ExternalFilesEntryLinker(preferencesService.getFilePreferences(), database);
+        this.linker = new ExternalFilesEntryLinker(preferencesService.getFilePreferences(), database, dialogService);
         this.contentImporter = new ExternalFilesContentImporter(preferencesService.getImportFormatPreferences());
         this.undoManager = undoManager;
     }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -149,12 +149,13 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
 
         for (Path fileToAdd : selectedFiles) {
             if (FileUtil.detectBadFileName(fileToAdd.toString())) {
+                String newFilename = FileNameCleaner.cleanFileName(fileToAdd.getFileName().toString());
+
                 boolean correctButtonPressed = dialogService.showConfirmationDialogAndWait(Localization.lang("File \"%0\" cannot be added!", fileToAdd.getFileName()),
-                        Localization.lang("Detected illegal characters in the file name.\nSelect \"Correct filename\" to automatically correct the filename and add it to JabRef.\nSelect cancel to not add the file"),
-                        Localization.lang("Correct filename"));
+                        Localization.lang("Illegal characters in the file name detected.\nFile will be renamed to \"%0\" and added.", newFilename),
+                        Localization.lang("Rename and add"));
 
                 if (correctButtonPressed) {
-                    String newFilename = FileNameCleaner.cleanFileName(fileToAdd.getFileName().toString());
                     Path correctPath = fileToAdd.resolveSibling(newFilename);
                     try {
                         Files.move(fileToAdd, correctPath);

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -169,6 +169,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
             }
         }
     }
+
     private void addNewLinkedFile(Path correctPath, List<Path> fileDirectories) {
         LinkedFile newLinkedFile = fromFile(correctPath, fileDirectories, preferences.getFilePreferences());
         files.add(new LinkedFileViewModel(

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -44,9 +44,12 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.preferences.FilePreferences;
 import org.jabref.preferences.PreferencesService;
-import org.tinylog.Logger;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
 
 public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFilesEditorViewModel.class);
 
     private final ListProperty<LinkedFileViewModel> files = new SimpleListProperty<>(FXCollections.observableArrayList(LinkedFileViewModel::getObservables));
     private final BooleanProperty fulltextLookupInProgress = new SimpleBooleanProperty(false);
@@ -157,16 +160,14 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
                         Files.move(fileToAdd, correctPath);
                         addNewLinkedFile(correctPath, fileDirectories);
                     } catch (IOException ex) {
-                        Logger.error("Error moving file", ex);
+                        LOGGER.error("Error moving file", ex);
                         dialogService.showErrorDialogAndWait(ex);
                     }
                 }
-            }
-            else {
+            } else {
                 addNewLinkedFile(fileToAdd, fileDirectories);
             }
         }
-
     }
     private void addNewLinkedFile(Path correctPath, List<Path> fileDirectories) {
         LinkedFile newLinkedFile = fromFile(correctPath, fileDirectories, preferences.getFilePreferences());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -45,8 +45,8 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.preferences.FilePreferences;
 import org.jabref.preferences.PreferencesService;
 
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFilesEditorViewModel.class);

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -433,7 +433,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                         }
                         case MOVE -> {
                             LOGGER.debug("Mode MOVE"); // alt on win
-                            importHandler.getLinker().moveFilesToFileDirAndAddToEntry(entry, files, libraryTab.getIndexingTaskManager());
+                            importHandler.getLinker().moveFilesToFileDirRenameAndAddToEntry(entry, files, libraryTab.getIndexingTaskManager());
                         }
                         case COPY -> {
                             LOGGER.debug("Mode Copy"); // ctrl on win

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -59,7 +59,7 @@ public class PreviewPanel extends VBox {
         this.stateManager = stateManager;
         this.previewPreferences = preferences.getPreviewPreferences();
         this.indexingTaskManager = indexingTaskManager;
-        this.fileLinker = new ExternalFilesEntryLinker(preferences.getFilePreferences(), database);
+        this.fileLinker = new ExternalFilesEntryLinker(preferences.getFilePreferences(), database, dialogService);
 
         PreviewPreferences previewPreferences = preferences.getPreviewPreferences();
         previewView = new PreviewViewer(database, dialogService, stateManager, themeManager);
@@ -90,7 +90,7 @@ public class PreviewPanel extends VBox {
 
                 if (event.getTransferMode() == TransferMode.MOVE) {
                     LOGGER.debug("Mode MOVE"); // shift on win or no modifier
-                    fileLinker.moveFilesToFileDirAndAddToEntry(entry, files, indexingTaskManager);
+                    fileLinker.moveFilesToFileDirRenameAndAddToEntry(entry, files, indexingTaskManager);
                 }
                 if (event.getTransferMode() == TransferMode.LINK) {
                     LOGGER.debug("Node LINK"); // alt on win

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2562,5 +2562,5 @@ Create\ backup=Create backup
 Automatically\ search\ and\ show\ unlinked\ files\ in\ the\ entry\ editor=Automatically search and show unlinked files in the entry editor
 
 File\ "%0"\ cannot\ be\ added\!=File "%0" cannot be added!
-Detected\ illegal\ characters\ in\ the\ file\ name.\nSelect\ "Correct\ filename"\ to\ automatically\ correct\ the\ filename\ and\ add\ it\ to\ JabRef.\nSelect\ cancel\ to\ not\ add\ the\ file=Detected illegal characters in the file name.\nSelect "Correct filename" to automatically correct the filename and add it to JabRef.\nSelect cancel to not add the file
-Correct\ filename=Correct filename
+Illegal\ characters\ in\ the\ file\ name\ detected.\nFile\ will\ be\ renamed\ to\ "%0"\ and\ added.=Illegal characters in the file name detected.\nFile will be renamed to "%0" and added.
+Rename\ and\ add=Rename and add

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2560,3 +2560,7 @@ This\ operation\ requires\ selected\ linked\ files.=This operation requires sele
 
 Create\ backup=Create backup
 Automatically\ search\ and\ show\ unlinked\ files\ in\ the\ entry\ editor=Automatically search and show unlinked files in the entry editor
+
+File\ "%0"\ cannot\ be\ added\!=File "%0" cannot be added!
+Detected\ illegal\ characters\ in\ the\ file\ name.\nSelect\ "Correct\ filename"\ to\ automatically\ correct\ the\ filename\ and\ add\ it\ to\ JabRef.\nSelect\ cancel\ to\ not\ add\ the\ file=Detected illegal characters in the file name.\nSelect "Correct filename" to automatically correct the filename and add it to JabRef.\nSelect cancel to not add the file
+Correct\ filename=Correct filename

--- a/src/test/java/org/jabref/logic/util/FileNameCleanerTest.java
+++ b/src/test/java/org/jabref/logic/util/FileNameCleanerTest.java
@@ -12,6 +12,7 @@ public class FileNameCleanerTest {
     public void testCleanFileName() {
         assertEquals("legalFilename.txt", FileNameCleaner.cleanFileName("legalFilename.txt"));
         assertEquals("illegalFilename______.txt", FileNameCleaner.cleanFileName("illegalFilename/?*<>|.txt"));
+        assertEquals("illegalFileName_.txt", FileNameCleaner.cleanFileName("illegalFileName{.txt"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #10182

Also supported for drag and drop


(The FilenameCleanerTest can be converted to parameterized test, bu this can be an easy student task)


<img width="459" alt="grafik" src="https://github.com/JabRef/jabref/assets/320228/3cf01d19-f4f7-4e2a-a197-4e87db4c7595">


Display a dialog with auto-renaming option

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
