### PR TITLE
Enable ISBN search with GVK

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -159,7 +159,7 @@ public class EntryTypeViewModel {
                 dialogService.showInformationDialogAndWait(Localization.lang("Failed to import by ID"), Localization.lang("Error message %0", fetcherExceptionMessage));
             }
 
-            LOGGER.error(String.format("Exception during fetching when using fetcher '%s' with entry id '%s'.", searchId, fetcher), exception);
+            LOGGER.error(String.format("Exception during fetching when using fetcher '%s' with entry id '%s'.", fetcher, searchId), exception);
 
             searchingProperty.set(false);
             fetcherWorker = new FetcherWorker();

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -99,7 +99,7 @@ public class WebFetchers {
         SortedSet<SearchBasedFetcher> set = new TreeSet<>(Comparator.comparing(WebFetcher::getName));
         set.add(new ArXivFetcher(importFormatPreferences));
         set.add(new INSPIREFetcher(importFormatPreferences));
-        set.add(new GvkFetcher());
+        set.add(new GvkFetcher(importFormatPreferences));
         set.add(new BvbFetcher());
         set.add(new MedlineFetcher());
         set.add(new AstrophysicsDataSystem(importFormatPreferences, importerPreferences));

--- a/src/main/java/org/jabref/logic/importer/fetcher/GvkFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/GvkFetcher.java
@@ -7,25 +7,35 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
+import org.jabref.logic.cleanup.FieldFormatterCleanup;
+import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
+import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.GVKQueryTransformer;
 import org.jabref.logic.importer.fileformat.PicaXmlParser;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
-public class GvkFetcher implements SearchBasedParserFetcher {
+public class GvkFetcher extends AbstractIsbnFetcher implements SearchBasedParserFetcher {
 
-    private static final String URL_PATTERN = "https://sru.k10plus.de/gvk?";
+    private static final String URL_PATTERN = "https://sru.k10plus.de/opac-de-627?";
 
     /**
      * Searchkeys are used to specify a search request. For example "tit" stands for "title".
      * If no searchkey is used, the default searchkey "all" is used.
      */
     private final Collection<String> searchKeys = Arrays.asList("all", "tit", "per", "thm", "slw", "txt", "num", "kon", "ppn", "bkl", "erj");
+
+    public GvkFetcher(ImportFormatPreferences importFormatPreferences) {
+        super(importFormatPreferences);
+    }
 
     @Override
     public String getName() {
@@ -50,7 +60,31 @@ public class GvkFetcher implements SearchBasedParserFetcher {
     }
 
     @Override
+    public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException, FetcherException {
+        this.ensureThatIsbnIsValid(identifier);
+        URIBuilder uriBuilder = new URIBuilder(URL_PATTERN);
+        uriBuilder.addParameter("version", "1.1");
+        uriBuilder.addParameter("operation", "searchRetrieve");
+        uriBuilder.addParameter("query", "pica.isb=" + identifier);
+        uriBuilder.addParameter("maximumRecords", "50");
+        uriBuilder.addParameter("recordSchema", "picaxml");
+        uriBuilder.addParameter("sortKeys", "Year,,1");
+        return uriBuilder.build().toURL();
+    }
+
+    @Override
     public Parser getParser() {
         return new PicaXmlParser();
+    }
+
+    @Override
+    public void doPostCleanup(BibEntry entry) {
+        super.doPostCleanup(entry);
+
+        // Fetcher returns page numbers as "30 Seiten" -> remove every non-digit character in the PAGETOTAL field
+        entry.getField(StandardField.PAGETOTAL).ifPresent(pages ->
+                entry.setField(StandardField.PAGETOTAL, pages.replaceAll("[\\D]", "")));
+        new FieldFormatterCleanup(StandardField.PAGETOTAL, new NormalizePagesFormatter()).cleanup(entry);
+        new FieldFormatterCleanup(StandardField.AUTHOR, new NormalizeNamesFormatter()).cleanup(entry);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/isbntobibtex/IsbnFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/isbntobibtex/IsbnFetcher.java
@@ -13,13 +13,11 @@ import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ImportFormatPreferences;
-import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.fetcher.AbstractIsbnFetcher;
 import org.jabref.logic.importer.fetcher.GvkFetcher;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.ISBN;
-import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.OptionalUtil;
 
 import org.slf4j.Logger;
@@ -65,7 +63,7 @@ public class IsbnFetcher implements EntryBasedFetcher, IdBasedFetcher {
         try {
             identifier = removeNewlinesAndSpacesFromIdentifier(identifier);
             Optional<ISBN> isbn = ISBN.parse(identifier);
-            if(isbn.isPresent()) {
+            if (isbn.isPresent()) {
                 bibEntry = gvkIbsnFetcher.performSearchById(isbn.get().getNormalized());
             }
         } catch (FetcherException ex) {

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.jabref.logic.importer.fetcher.AbstractIsbnFetcher;
 import org.jabref.logic.importer.fetcher.GoogleScholar;
 import org.jabref.logic.importer.fetcher.GrobidCitationFetcher;
+import org.jabref.logic.importer.fetcher.GvkFetcher;
 import org.jabref.logic.importer.fetcher.JstorFetcher;
 import org.jabref.logic.importer.fetcher.MrDLibFetcher;
 import org.jabref.logic.importer.fetcher.isbntobibtex.DoiToBibtexConverterComIsbnFetcher;
@@ -74,6 +75,7 @@ class WebFetchersTest {
             // Remove special ISBN fetcher since we don't want to expose them to the user
             expected.remove(OpenLibraryIsbnFetcher.class);
             expected.remove(EbookDeIsbnFetcher.class);
+            expected.remove(GvkFetcher.class);
             expected.remove(DoiToBibtexConverterComIsbnFetcher.class);
 
             // Remove the following, because they don't work at the moment

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeIdFetcherTest.java
@@ -79,12 +79,16 @@ class CompositeIdFetcherTest {
                 Arguments.arguments(
                         "performSearchByIdReturnsCorrectEntryForIsbnId",
                         new BibEntry(StandardEntryType.Book)
-                                .withField(StandardField.TITLE, "Effective Java")
-                                .withField(StandardField.PUBLISHER, "Addison-Wesley Professional")
-                                .withField(StandardField.YEAR, "2017")
                                 .withField(StandardField.AUTHOR, "Bloch, Joshua")
-                                .withField(StandardField.PAGES, "416")
-                                .withField(StandardField.ISBN, "9780134685991"),
+                                .withField(StandardField.TITLE, "Effective Java")
+                                .withField(StandardField.PUBLISHER, "Addison-Wesley")
+                                .withField(StandardField.YEAR, "2018")
+                                .withField(StandardField.ISBN, "9780134685991")
+                                .withField(StandardField.NOTE, "Titelzusätze auf dem Umschlag: \"Updated for Java 9. Best practices for ... the Java platform\"")
+                                .withField(StandardField.PAGETOTAL, "392")
+                                .withField(new UnknownField("ppn_gvk"), "100121840X")
+                                .withField(StandardField.EDITION, "Third edition")
+                                .withField(StandardField.ADDRESS, "Boston"),
                         "9780134685991"
                 ),
                 Arguments.arguments(

--- a/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
@@ -100,7 +100,7 @@ public class CompositeSearchBasedFetcherTest {
         List<SearchBasedFetcher> list = List.of(
                 new ArXivFetcher(importFormatPreferences),
                 new INSPIREFetcher(importFormatPreferences),
-                new GvkFetcher(),
+                new GvkFetcher(importFormatPreferences),
                 new AstrophysicsDataSystem(importFormatPreferences, importerPreferences),
                 new MathSciNet(importFormatPreferences),
                 new ZbMATH(importFormatPreferences),

--- a/src/test/java/org/jabref/logic/importer/fetcher/DiVATest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DiVATest.java
@@ -38,7 +38,7 @@ public class DiVATest {
         entry.setType(StandardEntryType.Article);
         entry.setCitationKey("Gustafsson260746");
         entry.setField(StandardField.AUTHOR, "Gustafsson, Oscar");
-        entry.setField(StandardField.INSTITUTION, "Linköping University, The Institute of Technology");
+        entry.setField(StandardField.INSTITUTION, "The Institute of Technology");
         entry.setField(StandardField.JOURNAL,
                 "IEEE transactions on circuits and systems. 2, Analog and digital signal processing (Print)");
         entry.setField(StandardField.NUMBER, "11");

--- a/src/test/java/org/jabref/logic/importer/fetcher/GvkFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GvkFetcherTest.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fetcher.transformers.AbstractQueryTransformer;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -16,9 +17,11 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.standard.parser.StandardSyntaxParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @FetcherTest
 public class GvkFetcherTest {
@@ -29,19 +32,19 @@ public class GvkFetcherTest {
 
     @BeforeEach
     public void setUp() {
-        fetcher = new GvkFetcher();
+        fetcher = new GvkFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
 
         bibEntryPPN591166003 = new BibEntry(StandardEntryType.Book)
                 .withField(StandardField.TITLE, "Effective Java")
                 .withField(StandardField.PUBLISHER, "Addison-Wesley")
                 .withField(StandardField.YEAR, "2008")
-                .withField(StandardField.AUTHOR, "Joshua Bloch")
+                .withField(StandardField.AUTHOR, "Bloch, Joshua")
                 .withField(StandardField.SERIES, "The Java series ... from the source")
                 .withField(StandardField.ADDRESS, "Upper Saddle River, NJ")
                 .withField(StandardField.EDITION, "2. ed., 5. print.")
                 .withField(StandardField.NOTE, "Includes bibliographical references and index. - Previous ed.: 2001. - Hier auch später erschienene, unveränderte Nachdrucke")
                 .withField(StandardField.ISBN, "9780321356680")
-                .withField(StandardField.PAGETOTAL, "XXI, 346")
+                .withField(StandardField.PAGETOTAL, "346")
                 .withField(new UnknownField("ppn_gvk"), "591166003")
                 .withField(StandardField.SUBTITLE, "[revised and updated for JAVA SE 6]");
 
@@ -49,10 +52,10 @@ public class GvkFetcherTest {
                 .withField(StandardField.TITLE, "Effective unit testing")
                 .withField(StandardField.PUBLISHER, "Manning")
                 .withField(StandardField.YEAR, "2013")
-                .withField(StandardField.AUTHOR, "Lasse Koskela")
+                .withField(StandardField.AUTHOR, "Koskela, Lasse")
                 .withField(StandardField.ADDRESS, "Shelter Island, NY")
                 .withField(StandardField.ISBN, "9781935182573")
-                .withField(StandardField.PAGETOTAL, "XXIV, 223")
+                .withField(StandardField.PAGETOTAL, "223")
                 .withField(new UnknownField("ppn_gvk"), "66391437X")
                 .withField(StandardField.SUBTITLE, "A guide for Java developers");
     }
@@ -67,7 +70,7 @@ public class GvkFetcherTest {
         String query = "java jdk";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(query, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         URL url = fetcher.getURLForQuery(luceneQuery);
-        assertEquals("https://sru.k10plus.de/gvk?version=1.1&operation=searchRetrieve&query=pica.all%3Djava+and+pica.all%3Djdk&maximumRecords=50&recordSchema=picaxml&sortKeys=Year%2C%2C1", url.toString());
+        assertEquals("https://sru.k10plus.de/opac-de-627?version=1.1&operation=searchRetrieve&query=pica.all%3Djava+and+pica.all%3Djdk&maximumRecords=50&recordSchema=picaxml&sortKeys=Year%2C%2C1", url.toString());
     }
 
     @Test
@@ -75,7 +78,7 @@ public class GvkFetcherTest {
         String query = "kon:java tit:jdk";
         QueryNode luceneQuery = new StandardSyntaxParser().parse(query, AbstractQueryTransformer.NO_EXPLICIT_FIELD);
         URL url = fetcher.getURLForQuery(luceneQuery);
-        assertEquals("https://sru.k10plus.de/gvk?version=1.1&operation=searchRetrieve&query=pica.kon%3Djava+and+pica.tit%3Djdk&maximumRecords=50&recordSchema=picaxml&sortKeys=Year%2C%2C1", url.toString());
+        assertEquals("https://sru.k10plus.de/opac-de-627?version=1.1&operation=searchRetrieve&query=pica.kon%3Djava+and+pica.tit%3Djdk&maximumRecords=50&recordSchema=picaxml&sortKeys=Year%2C%2C1", url.toString());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/GVKIsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/GVKIsbnFetcherTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher.isbntobibtex;
 
 import java.util.Optional;
 
-import org.jabref.logic.importer.FetcherClientException;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fetcher.AbstractIsbnFetcherTest;
@@ -46,7 +45,6 @@ public class GVKIsbnFetcherTest extends AbstractIsbnFetcherTest {
                 .withField(StandardField.PAGETOTAL, "346")
                 .withField(new UnknownField("ppn_gvk"), "67954951X")
                 .withField(StandardField.SUBTITLE, "[revised and updated for Java SE 6]");
-
 
         fetcher = new GvkFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/GVKIsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/GVKIsbnFetcherTest.java
@@ -1,0 +1,105 @@
+package org.jabref.logic.importer.fetcher.isbntobibtex;
+
+import java.util.Optional;
+
+import org.jabref.logic.importer.FetcherClientException;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.fetcher.AbstractIsbnFetcherTest;
+import org.jabref.logic.importer.fetcher.GvkFetcher;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class GVKIsbnFetcherTest extends AbstractIsbnFetcherTest {
+
+    private BibEntry bibEntryEffectiveJavaLongISBN;
+
+    @BeforeEach
+    public void setUp() {
+        bibEntryEffectiveJava = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "Effective Java(TM) Programming Language Guide (2nd Edition) (The Java Series)")
+                .withField(StandardField.PUBLISHER, "Prentice Hall PTR")
+                .withField(StandardField.YEAR, "2007")
+                .withField(StandardField.AUTHOR, "Bloch, Joshua")
+                .withField(StandardField.ISBN, "9780321356680")
+                .withField(StandardField.PAGES, "256");
+
+        bibEntryEffectiveJavaLongISBN = new BibEntry(StandardEntryType.Book)
+                .withField(StandardField.TITLE, "Effective Java")
+                .withField(StandardField.PUBLISHER, "Addison-Wesley")
+                .withField(StandardField.YEAR, "2011")
+                .withField(StandardField.AUTHOR, "Bloch, Joshua")
+                .withField(StandardField.SERIES, "The @Java series")
+                .withField(StandardField.ADDRESS, "Upper Saddle River, NJ [u.a.]")
+                .withField(StandardField.EDITION, "2. ed., rev. and updated for Java SE 6")
+                .withField(StandardField.NOTE, "*Hier auch später erschienene, unveränderte Nachdrucke*")
+                .withField(StandardField.ISBN, "9780321356680")
+                .withField(StandardField.PAGETOTAL, "346")
+                .withField(new UnknownField("ppn_gvk"), "67954951X")
+                .withField(StandardField.SUBTITLE, "[revised and updated for Java SE 6]");
+
+
+        fetcher = new GvkFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
+    }
+
+    @Test
+    @Override
+    public void testName() {
+        assertEquals("GVK", fetcher.getName());
+    }
+
+    @Test
+    @Override
+    public void searchByIdSuccessfulWithShortISBN() throws FetcherException {
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("0321356683");
+        assertEquals(Optional.of(bibEntryEffectiveJavaLongISBN), fetchedEntry);
+    }
+
+    @Test
+    @Override
+    public void searchByIdSuccessfulWithLongISBN() throws FetcherException {
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("9780321356680");
+        assertEquals(Optional.of(bibEntryEffectiveJavaLongISBN), fetchedEntry);
+    }
+
+    @Test
+    @Override
+    public void authorsAreCorrectlyFormatted() throws Exception {
+        BibEntry bibEntry = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.TITLE, "Repository")
+                .withField(StandardField.SUBTITLE, "Eine Einführung")
+                .withField(StandardField.PUBLISHER, "De Gruyter Oldenbourg")
+                .withField(StandardField.AUTHOR, "Habermann, Hans-Joachim")
+                .withField(StandardField.ISBN, "9783110702125")
+                .withField(StandardField.YEAR, "2020")
+                .withField(StandardField.ADDRESS, "München")
+                .withField(StandardField.EDITION, "Reprint 2020")
+                .withField(StandardField.EDITOR, "Frank Leymann")
+                .withField(StandardField.NUMBER, "8.1")
+                .withField(StandardField.PAGETOTAL, "1294")
+                .withField(StandardField.SERIES, "Handbuch der Informatik")
+                .withField(new UnknownField("ppn_gvk"), "1738076555");
+
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("9783110702125");
+        assertEquals(Optional.of(bibEntry), fetchedEntry);
+    }
+
+    /**
+     * Checks whether the given ISBN is <emph>NOT</emph> available at any ISBN fetcher
+     */
+    @Test
+    public void testIsbnNeitherAvailableOnEbookDeNorOrViaOpenLibrary() throws Exception {
+        // In this test, the ISBN needs to be a valid (syntax+checksum) ISBN number
+        // However, the ISBN number must not be assigned to a real book
+       assertEquals(Optional.empty(), fetcher.performSearchById("9785646216541"));
+    }
+}

--- a/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/IsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/isbntobibtex/IsbnFetcherTest.java
@@ -8,6 +8,7 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
 
@@ -33,10 +34,14 @@ class IsbnFetcherTest {
         bibEntry = new BibEntry(StandardEntryType.Book)
                 .withField(StandardField.AUTHOR, "Bloch, Joshua")
                 .withField(StandardField.TITLE, "Effective Java")
-                .withField(StandardField.PUBLISHER, "Addison-Wesley Professional")
-                .withField(StandardField.YEAR, "2017")
-                .withField(StandardField.PAGES, "416")
-                .withField(StandardField.ISBN, "9780134685991");
+                .withField(StandardField.PUBLISHER, "Addison-Wesley")
+                .withField(StandardField.YEAR, "2018")
+                .withField(StandardField.ISBN, "9780134685991")
+                .withField(StandardField.NOTE, "Titelzusätze auf dem Umschlag: \"Updated for Java 9. Best practices for ... the Java platform\"")
+                .withField(StandardField.PAGETOTAL, "392")
+                .withField(new UnknownField("ppn_gvk"), "100121840X")
+                .withField(StandardField.EDITION, "Third edition")
+                .withField(StandardField.ADDRESS, "Boston");
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ParseException;
@@ -74,7 +75,7 @@ public class ACMPortalParserTest {
         for (BibEntry bibEntry : bibEntries) {
             bibEntry.clearField(StandardField.ABSTRACT);
         }
-        assertEquals(searchEntryList.get(0), bibEntries.get(0));
+        assertEquals(Optional.of(searchEntryList.get(0)), bibEntries.stream().findFirst());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GrobidServiceTest.java
@@ -47,16 +47,13 @@ public class GrobidServiceTest {
     @Test
     public void processValidCitationTest() throws IOException, ParseException {
         BibEntry exampleBibEntry = new BibEntry(StandardEntryType.Article).withCitationKey("-1")
-                                                                                    .withField(StandardField.AUTHOR, "Derwing, Tracey and Rossiter, Marian and Munro, Murray")
-                                                                                    .withField(StandardField.TITLE, "Teaching Native Speakers to Listen to Foreign-accented Speech")
+                                                                                    .withField(StandardField.AUTHOR, "Derwing, T and Rossiter, M and Munro, M")
+                                                                                    .withField(StandardField.TITLE, "Teaching native speakers to listen to foreign-accented speech")
                                                                                     .withField(StandardField.JOURNAL, "Journal of Multilingual and Multicultural Development")
-                                                                                    .withField(StandardField.DOI, "10.1080/01434630208666468")
-                                                                                    .withField(StandardField.DATE, "2002-09")
+                                                                                    .withField(StandardField.DATE, "2002")
                                                                                     .withField(StandardField.YEAR, "2002")
-                                                                                    .withField(StandardField.MONTH, "9")
-                                                                                    .withField(StandardField.PAGES, "245-259")
+                                                                                    .withField(StandardField.PAGES, "245--259")
                                                                                     .withField(StandardField.VOLUME, "23")
-                                                                                    .withField(StandardField.PUBLISHER, "Informa UK Limited")
                                                                                     .withField(StandardField.NUMBER, "4");
         Optional<BibEntry> response = grobidService.processCitation("Derwing, T. M., Rossiter, M. J., & Munro, " +
                 "M. J. (2002). Teaching native speakers to listen to foreign-accented speech. " +


### PR DESCRIPTION
Fixes #10123
Fixes #9979

Refs #10125

Tested with the ISBNs
Only the first ISBN seems odd,  alternative isbn is working now
https://opac.k10plus.de/DB=2.299/SET=2/PRS=HOL/SHW?FRST=1&ACT=SRCHA

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
