### PR TITLE
Remove JSpecify salt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,9 +214,6 @@ dependencies {
 
     implementation group: 'org.jooq', name: 'jool', version: '0.9.15'
 
-    compileOnly 'org.jspecify:jspecify:0.3.0'
-    testCompileOnly 'org.jspecify:jspecify:0.3.0'
-
     testImplementation 'io.github.classgraph:classgraph:4.8.162'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.junit.platform:junit-platform-launcher:1.10.0'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -123,6 +123,4 @@ open module org.jabref {
     requires org.eclipse.jgit;
     uses org.eclipse.jgit.transport.SshSessionFactory;
     uses org.eclipse.jgit.lib.GpgSigner;
-
-    requires static org.jspecify;
 }

--- a/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
@@ -42,7 +42,6 @@ import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.strings.StringUtil;
 
 import org.jooq.lambda.Unchecked;
-import org.jspecify.annotations.NullMarked;
 
 /**
  * A generic writer for our database. This is independent of the concrete serialization format.
@@ -52,7 +51,6 @@ import org.jspecify.annotations.NullMarked;
  * <p>
  * The opposite class is {@link org.jabref.logic.importer.fileformat.BibtexParser}
  */
-@NullMarked
 public abstract class BibDatabaseWriter {
 
     public enum SaveType { WITH_JABREF_META_DATA, PLAIN_BIBTEX }

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -30,8 +30,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.metadata.SaveOrder;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,11 +101,11 @@ public class TemplateExporter extends Exporter {
      * @param directory         Directory in which to find the layout file.
      * @param extension         Should contain the . (for instance .txt).
      */
-    public TemplateExporter(@NonNull String displayName,
-                            @NonNull String consoleName,
-                            @NonNull String lfFileName,
-                            @Nullable String directory,
-                            @NonNull FileType extension,
+    public TemplateExporter(String displayName,
+                            String consoleName,
+                            String lfFileName,
+                            String directory,
+                            FileType extension,
                             LayoutFormatterPreferences layoutPreferences,
                             SaveOrder saveOrder) {
         this(displayName, consoleName, lfFileName, directory, extension, layoutPreferences, saveOrder, null);


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/10227

Remove [JSpecify](https://jspecify.dev/).

Although JSpecify is cool and annotations can be made, the concrete usage should be more "useful". A follow-up PR can add a real example, code howto, and an ADR.

Link to the stackoverflow question for null annotations: https://stackoverflow.com/q/4963300/873282

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
