### PR TITLE
Fix JavaDocs (and enable PlantUML)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,6 +70,18 @@ jobs:
         with:
           args: CHANGELOG.md CONTRIBUTING.md README.md
           config: '.markdownlint.yml'
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 20
+          distribution: 'temurin'
+          cache: 'gradle'
+      - run: ./gradlew generateDocs
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -377,8 +377,8 @@ run {
 javadoc {
     options {
         encoding = 'UTF-8'
-        version = true
-        author = true
+        version = false
+        author = false
          addMultilineStringsOption("-add-exports").setValue([
             'javafx.controls/com.sun.javafx.scene.control=org.jabref',
             'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref'

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ configurations {
         extendsFrom implementation
         exclude group: "javax.activation"
     }
+    javadocTaglets
 }
 
 dependencyLocking {
@@ -235,6 +236,8 @@ dependencies {
     rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:2.2.1"))
     rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
     rewrite("org.openrewrite.recipe:rewrite-static-analysis")
+
+    javadocTaglets "org.jdrupes.taglets:plantuml-taglet:2.1.0"
 }
 
 clean {
@@ -379,11 +382,19 @@ javadoc {
         encoding = 'UTF-8'
         version = false
         author = false
-         addMultilineStringsOption("-add-exports").setValue([
+        addMultilineStringsOption("-add-exports").setValue([
             'javafx.controls/com.sun.javafx.scene.control=org.jabref',
             'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref'
         ])
     }
+}
+
+task generateDocs(type: Javadoc) {
+    group = 'documentation'
+    source = sourceSets.main.allJava
+    destinationDir = reporting.file("jabref-docs")
+    options.docletpath = configurations.javadocTaglets.files.asType(List)
+    options.doclet = ["org.jdrupes.taglets.plantUml.PlantUml"]
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,8 @@ javadoc {
             'javafx.controls/com.sun.javafx.scene.control=org.jabref',
             'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref'
         ])
+        docletpath = configurations.javadocTaglets.files.asType(List)
+        doclet = ["org.jdrupes.taglets.plantUml.PlantUml"]
     }
 }
 
@@ -393,8 +395,6 @@ task generateDocs(type: Javadoc) {
     group = 'documentation'
     source = sourceSets.main.allJava
     destinationDir = reporting.file("jabref-docs")
-    options.docletpath = configurations.javadocTaglets.files.asType(List)
-    options.doclet = ["org.jdrupes.taglets.plantUml.PlantUml"]
 }
 
 test {


### PR DESCRIPTION
First attempt to check for JavaDoc validity.

Adds [PlantUML-taglet](https://mnlipp.github.io/jdrupes-taglets/plantuml-taglet/javadoc/) to enable PlantUML in JavaDoc. There is MermaidJS support for JavaDoc, thus I opted for PlantUML.

IntelliJ will eventualle get support for PlantUML as well: https://youtrack.jetbrains.com/issue/IDEA-315387 - **please vote up**

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
