### PR TITLE
Update Java Keyring dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ dependencies {
 
     implementation 'io.github.java-diff-utils:java-diff-utils:4.12'
     implementation 'info.debatty:java-string-similarity:2.0.0'
-    implementation 'com.github.javakeyring:java-keyring:1.0.3'
+    implementation 'com.github.javakeyring:java-keyring:1.0.4'
 
     antlr4 'org.antlr:antlr4:4.13.0'
     implementation 'org.antlr:antlr4-runtime:4.13.0'


### PR DESCRIPTION
Java Keyring released a new version, which integrated our fix https://github.com/javakeyring/java-keyring/pull/90.

Follow-up to https://github.com/JabRef/jabref/pull/10224, refs https://github.com/JabRef/jabref/issues/8055.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
