### PR TITLE
No version and author in JavaDoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,9 +377,9 @@ run {
 javadoc {
     options {
         encoding = 'UTF-8'
-        version = true
-        author = true
-         addMultilineStringsOption("-add-exports").setValue([
+        version = false
+        author = false
+        addMultilineStringsOption("-add-exports").setValue([
             'javafx.controls/com.sun.javafx.scene.control=org.jabref',
             'org.controlsfx.controls/impl.org.controlsfx.skin=org.jabref'
         ])


### PR DESCRIPTION
We do not use `@version` and `@author`. Thus, it should not be shown in any JavaDoc.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
