### PR TITLE
Update automerge.yml

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,34 +1,22 @@
-name: Automerge Pull Requests
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  automerge:
-    name: Automerge Dependency Updates
+  dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' || contains(github.event.pull_request.labels.*.name, 'dependencies')
+    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: 'Wait for status checks'
-        id: waitforstatuschecks
-        uses: "WyriHaximus/github-action-wait-for-status@v1.8.0"
-        with:
-          ignoreActions: Automerge Dependabot,Code coverage,Create snapcraft image,Deploy binaries on builds.jabref.org,codecov/project,markdown-link-check
-          checkInterval: 13
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Auto approve
-        uses: hmarr/auto-approve-action@v3.2.1
-        if: steps.waitforstatuschecks.outputs.status == 'success'
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Merge pull requests
-        uses: pascalgn/automerge-action@v0.15.6
-        if: steps.waitforstatuschecks.outputs.status == 'success'
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Merge PR
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
-          MERGE_METHOD: "merge"
-          MERGE_LABELS: ""
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,7 +16,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Merge PR
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The [GitHub Command Line](https://cli.github.com/) `gh` directly supports handling of PRs. No need for separate actions.

This PR makes use of the public documentation of https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request. The proposed worklfow automatically merges updates only of a selected dependency (`my-dependency`) if there is a patch update.

In this PR, all dependabot updates are merged. The guard is as follows

    if: ${{ github.actor == 'dependabot[bot]' }}

The workflow also auto-approves, thus, this is 100% automatic now.

According tohttps://stackoverflow.com/a/75679050/873282, no wait for status checks (https://github.com/WyriHaximus/github-action-wait-for-status) or other things required, because the merge queue config covers that.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
