### PR TITLE
Fix exception when opening preferences

### DIFF
--- a/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
@@ -13,7 +13,6 @@ import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import org.jabref.logic.importer.ParserResult;

--- a/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/org/jabref/benchmarks/Benchmarks.java
@@ -14,6 +14,7 @@ import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.fileformat.BibtexParser;
@@ -82,7 +83,7 @@ public class Benchmarks {
         BibWriter bibWriter = new BibWriter(outputWriter, OS.NEWLINE);
         BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(
                 bibWriter,
-                mock(SaveConfiguration.class),
+                mock(SelfContainedSaveConfiguration.class),
                 mock(FieldPreferences.class),
                 mock(CitationKeyPatternPreferences.class),
                 new BibEntryTypesManager());

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -26,6 +26,7 @@ import org.jabref.logic.exporter.EmbeddedBibFilePdfExporter;
 import org.jabref.logic.exporter.Exporter;
 import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.exporter.XmpPdfExporter;
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImportException;
@@ -598,7 +599,7 @@ public class ArgumentProcessor {
             System.out.println(Localization.lang("Saving") + ": " + subName);
             try (AtomicFileWriter fileWriter = new AtomicFileWriter(Path.of(subName), StandardCharsets.UTF_8)) {
                 BibWriter bibWriter = new BibWriter(fileWriter, OS.NEWLINE);
-                SaveConfiguration saveConfiguration = new SaveConfiguration()
+                SelfContainedSaveConfiguration saveConfiguration = (SelfContainedSaveConfiguration) new SelfContainedSaveConfiguration()
                         .withReformatOnSave(preferencesService.getLibraryPreferences().shouldAlwaysReformatOnSave());
                 BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(
                         bibWriter,

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -25,7 +25,6 @@ import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.EmbeddedBibFilePdfExporter;
 import org.jabref.logic.exporter.Exporter;
 import org.jabref.logic.exporter.ExporterFactory;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.exporter.XmpPdfExporter;
 import org.jabref.logic.importer.FetcherException;

--- a/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
@@ -28,7 +28,7 @@ import org.jabref.logic.bibtex.InvalidFieldValueException;
 import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
-import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.util.BackupFileType;
 import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.logic.util.io.BackupFileUtil;
@@ -250,7 +250,7 @@ public class BackupManager {
                     }
                 })
                 .orElse(SaveOrder.getDefaultSaveOrder());
-        SaveConfiguration saveConfiguration = new SaveConfiguration()
+        SelfContainedSaveConfiguration saveConfiguration = (SelfContainedSaveConfiguration) new SelfContainedSaveConfiguration()
                 .withMakeBackup(false)
                 .withSaveOrder(saveOrder)
                 .withReformatOnSave(preferences.getLibraryPreferences().shouldAlwaysReformatOnSave());

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
@@ -67,7 +67,7 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
                 layoutFile.get(),
                 extension.get(),
                 preferences.getLayoutFormatterPreferences(),
-                preferences.getExportConfiguration().getSaveOrder());
+                preferences.getSelfContainedExportConfiguration().getSelfContainedSaveOrder());
         format.setCustomExport(true);
         return new ExporterViewModel(format);
     }

--- a/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/exporter/SaveDatabaseAction.java
@@ -31,8 +31,8 @@ import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SaveException;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.l10n.Encodings;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.shared.DatabaseLocation;
@@ -256,11 +256,8 @@ public class SaveDatabaseAction {
 
     private boolean saveDatabase(Path file, boolean selectedOnly, Charset encoding, BibDatabaseWriter.SaveType saveType, SelfContainedSaveOrder saveOrder) throws SaveException {
         // if this code is adapted, please also adapt org.jabref.logic.autosaveandbackup.BackupManager.performBackup
-
-        SaveConfiguration saveConfiguration = new SaveConfiguration()
-                .withSaveType(saveType)
-                .withSaveOrder(saveOrder)
-                .withReformatOnSave(preferences.getLibraryPreferences().shouldAlwaysReformatOnSave());
+        SelfContainedSaveConfiguration saveConfiguration
+                = new SelfContainedSaveConfiguration(saveOrder, false, saveType, preferences.getLibraryPreferences().shouldAlwaysReformatOnSave());
         BibDatabaseContext bibDatabaseContext = libraryTab.getBibDatabaseContext();
         synchronized (bibDatabaseContext) {
             try (AtomicFileWriter fileWriter = new AtomicFileWriter(file, encoding, saveConfiguration.shouldMakeBackup())) {

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -16,7 +16,6 @@ import org.jabref.logic.database.DatabaseMerger;
 import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SaveException;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.git.SlrGitHandler;

--- a/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -18,6 +18,7 @@ import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SaveException;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.git.SlrGitHandler;
 import org.jabref.logic.importer.OpenDatabase;
 import org.jabref.logic.importer.SearchBasedFetcher;
@@ -427,7 +428,7 @@ public class StudyRepository {
 
     private void writeResultToFile(Path pathToFile, BibDatabaseContext context) throws SaveException {
         try (AtomicFileWriter fileWriter = new AtomicFileWriter(pathToFile, StandardCharsets.UTF_8)) {
-            SaveConfiguration saveConfiguration = new SaveConfiguration()
+            SelfContainedSaveConfiguration saveConfiguration = (SelfContainedSaveConfiguration) new SelfContainedSaveConfiguration()
                     .withSaveOrder(context.getMetaData().getSaveOrder().map(so -> SelfContainedSaveOrder.of(so)).orElse(SaveOrder.getDefaultSaveOrder()))
                     .withReformatOnSave(preferencesService.getLibraryPreferences().shouldAlwaysReformatOnSave());
             BibWriter bibWriter = new BibWriter(fileWriter, OS.NEWLINE);

--- a/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibDatabaseWriter.java
@@ -58,13 +58,13 @@ public abstract class BibDatabaseWriter {
 
     private static final Pattern REFERENCE_PATTERN = Pattern.compile("(#[A-Za-z]+#)"); // Used to detect string references in strings
     protected final BibWriter bibWriter;
-    protected final SaveConfiguration saveConfiguration;
+    protected final SelfContainedSaveConfiguration saveConfiguration;
     protected final CitationKeyPatternPreferences keyPatternPreferences;
     protected final List<FieldChange> saveActionsFieldChanges = new ArrayList<>();
     protected final BibEntryTypesManager entryTypesManager;
 
     public BibDatabaseWriter(BibWriter bibWriter,
-                             SaveConfiguration saveConfiguration,
+                             SelfContainedSaveConfiguration saveConfiguration,
                              CitationKeyPatternPreferences keyPatternPreferences,
                              BibEntryTypesManager entryTypesManager) {
         this.bibWriter = Objects.requireNonNull(bibWriter);
@@ -181,7 +181,7 @@ public abstract class BibDatabaseWriter {
         writeStrings(bibDatabaseContext.getDatabase());
 
         // Write database entries.
-        List<BibEntry> sortedEntries = getSortedEntries(entries, saveConfiguration.getSaveOrder());
+        List<BibEntry> sortedEntries = getSortedEntries(entries, saveConfiguration.getSelfContainedSaveOrder());
         List<FieldChange> saveActionChanges = applySaveActions(sortedEntries, bibDatabaseContext.getMetaData());
         saveActionsFieldChanges.addAll(saveActionChanges);
         if (keyPatternPreferences.shouldGenerateCiteKeysBeforeSaving()) {

--- a/src/main/java/org/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/org/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -35,7 +35,7 @@ public class BibtexDatabaseWriter extends BibDatabaseWriter {
     private final FieldPreferences fieldPreferences;
 
     public BibtexDatabaseWriter(BibWriter bibWriter,
-                                SaveConfiguration saveConfiguration,
+                                SelfContainedSaveConfiguration saveConfiguration,
                                 FieldPreferences fieldPreferences,
                                 CitationKeyPatternPreferences citationKeyPatternPreferences,
                                 BibEntryTypesManager entryTypesManager) {
@@ -49,7 +49,7 @@ public class BibtexDatabaseWriter extends BibDatabaseWriter {
 
     public BibtexDatabaseWriter(Writer writer,
                                 String newline,
-                                SaveConfiguration saveConfiguration,
+                                SelfContainedSaveConfiguration saveConfiguration,
                                 FieldPreferences fieldPreferences,
                                 CitationKeyPatternPreferences citationKeyPatternPreferences,
                                 BibEntryTypesManager entryTypesManager) {

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -29,7 +29,7 @@ public class ExporterFactory {
 
         List<TemplateExporter> customFormats = preferencesService.getExportPreferences().getCustomExporters();
         LayoutFormatterPreferences layoutPreferences = preferencesService.getLayoutFormatterPreferences();
-        SelfContainedSaveOrder saveOrder = SelfContainedSaveOrder.of(preferencesService.getExportConfiguration().getSaveOrder());
+        SelfContainedSaveOrder saveOrder = SelfContainedSaveOrder.of(preferencesService.getSelfContainedExportConfiguration().getSaveOrder());
         XmpPreferences xmpPreferences = preferencesService.getXmpPreferences();
         FieldPreferences fieldPreferences = preferencesService.getFieldPreferences();
         BibDatabaseMode bibDatabaseMode = preferencesService.getLibraryPreferences().getDefaultBibDatabaseMode();

--- a/src/main/java/org/jabref/logic/exporter/SaveConfiguration.java
+++ b/src/main/java/org/jabref/logic/exporter/SaveConfiguration.java
@@ -2,7 +2,6 @@ package org.jabref.logic.exporter;
 
 import org.jabref.gui.autosaveandbackup.BackupManager;
 import org.jabref.model.metadata.SaveOrder;
-import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 public class SaveConfiguration {
 
@@ -10,11 +9,11 @@ public class SaveConfiguration {
     public static final String ENCODING_PREFIX = "Encoding: ";
 
     private boolean reformatFile;
-    private SelfContainedSaveOrder saveOrder;
+    private SaveOrder saveOrder;
     private boolean makeBackup;
     private BibDatabaseWriter.SaveType saveType;
 
-    public SaveConfiguration(SelfContainedSaveOrder saveOrder,
+    public SaveConfiguration(SaveOrder saveOrder,
                              Boolean makeBackup,
                              BibDatabaseWriter.SaveType saveType,
                              Boolean reformatFile) {
@@ -31,11 +30,11 @@ public class SaveConfiguration {
                 false);
     }
 
-    public SelfContainedSaveOrder getSaveOrder() {
+    public SaveOrder getSaveOrder() {
         return saveOrder;
     }
 
-    public SaveConfiguration withSaveOrder(SelfContainedSaveOrder newSaveOrder) {
+    public SaveConfiguration withSaveOrder(SaveOrder newSaveOrder) {
         this.saveOrder = newSaveOrder;
         return this;
     }

--- a/src/main/java/org/jabref/logic/exporter/SelfContainedSaveConfiguration.java
+++ b/src/main/java/org/jabref/logic/exporter/SelfContainedSaveConfiguration.java
@@ -1,0 +1,25 @@
+package org.jabref.logic.exporter;
+
+import org.jabref.model.metadata.SaveOrder;
+import org.jabref.model.metadata.SelfContainedSaveOrder;
+
+/**
+ * This is a {@link SaveOrder} where the contained saveConfiguration is a {@link org.jabref.model.metadata.SelfContainedSaveOrder}
+ */
+public class SelfContainedSaveConfiguration extends SaveConfiguration {
+    public SelfContainedSaveConfiguration() {
+        super();
+    }
+
+    public SelfContainedSaveConfiguration(
+            SelfContainedSaveOrder saveOrder,
+            Boolean makeBackup,
+            BibDatabaseWriter.SaveType saveType,
+            Boolean reformatFile) {
+        super(saveOrder, makeBackup, saveType, reformatFile);
+    }
+
+    public SelfContainedSaveOrder getSelfContainedSaveOrder() {
+        return (SelfContainedSaveOrder) getSaveOrder();
+    }
+}

--- a/src/main/java/org/jabref/model/metadata/SelfContainedSaveOrder.java
+++ b/src/main/java/org/jabref/model/metadata/SelfContainedSaveOrder.java
@@ -2,14 +2,23 @@ package org.jabref.model.metadata;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * With this class, the user of an instance can directly sort things. Without looking up anything in the preferences or in the UI.
+ *
+ * To avoid confusion at the caller, we offer ORIGINAL and SPECIFIED only. Not TABLE.
  */
 public class SelfContainedSaveOrder extends SaveOrder {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(SelfContainedSaveOrder.class);
+
     public SelfContainedSaveOrder(OrderType orderType, List<SortCriterion> sortCriteria) {
         super(orderType, sortCriteria);
         if (orderType == OrderType.TABLE) {
-            throw new IllegalArgumentException("TABLE requires external lookup.");
+            LOGGER.debug("TABLE with sort criteria {}", sortCriteria);
+            throw new IllegalArgumentException("TABLE might require external lookup.");
         }
     }
 
@@ -21,6 +30,11 @@ public class SelfContainedSaveOrder extends SaveOrder {
     public static SelfContainedSaveOrder of(SaveOrder saveOrder) {
         if (saveOrder instanceof SelfContainedSaveOrder order) {
             return order;
+        }
+        if ((saveOrder.getOrderType() == OrderType.TABLE) && (!saveOrder.getSortCriteria().isEmpty())) {
+            // We map from TABLE to SPECIFIED to have the users of this class just to `switch` between
+            //   ORIGINAL and SPECIFIED
+            return new SelfContainedSaveOrder(OrderType.SPECIFIED, saveOrder.getSortCriteria());
         }
         return new SelfContainedSaveOrder(saveOrder.getOrderType(), saveOrder.getSortCriteria());
     }

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -65,8 +65,9 @@ import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStylePreviewLayout;
 import org.jabref.logic.cleanup.FieldFormatterCleanups;
+import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.MetaDataSerializer;
-import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
@@ -2256,29 +2257,33 @@ public class JabRefPreferences implements PreferencesService {
         putBoolean(EXPORT_TERTIARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(2).descending);
     }
 
-    public SaveOrder getTableSaveOrder() {
+    /**
+     * For the export configuration, generates the SelfContainedSaveOrder having the reference to TABLE resolved.
+     */
+    public SelfContainedSaveOrder getSelfContainedTableSaveOrder() {
         List<MainTableColumnModel> sortOrder = mainTableColumnPreferences.getColumnSortOrder();
-        return new SaveOrder(
-                SaveOrder.OrderType.TABLE,
+        return new SelfContainedSaveOrder(
+                SaveOrder.OrderType.SPECIFIED,
                 sortOrder.stream().flatMap(model -> model.getSortCriteria().stream()).toList());
     }
 
     @Override
-    public SaveConfiguration getExportConfiguration() {
-        SaveOrder saveOrder = switch (getExportSaveOrder().getOrderType()) {
-            case TABLE -> this.getTableSaveOrder();
-            case SPECIFIED -> this.getExportSaveOrder();
+    public SelfContainedSaveConfiguration getSelfContainedExportConfiguration() {
+        SaveOrder exportSaveOrder = getExportSaveOrder();
+        SelfContainedSaveOrder saveOrder = switch (exportSaveOrder.getOrderType()) {
+            case TABLE -> this.getSelfContainedTableSaveOrder();
+            case SPECIFIED -> SelfContainedSaveOrder.of(exportSaveOrder);
             case ORIGINAL -> SaveOrder.getDefaultSaveOrder();
         };
 
-        return new SaveConfiguration()
-                .withSaveOrder(SelfContainedSaveOrder.of(saveOrder))
-                .withReformatOnSave(getLibraryPreferences().shouldAlwaysReformatOnSave());
+        return new SelfContainedSaveConfiguration(
+                saveOrder, false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, getLibraryPreferences()
+                .shouldAlwaysReformatOnSave());
     }
 
     private List<TemplateExporter> getCustomExportFormats() {
         LayoutFormatterPreferences layoutPreferences = getLayoutFormatterPreferences();
-        SaveConfiguration saveConfiguration = getExportConfiguration();
+        SelfContainedSaveConfiguration saveConfiguration = getSelfContainedExportConfiguration();
         List<TemplateExporter> formats = new ArrayList<>();
 
         for (String toImport : getSeries(CUSTOM_EXPORT_FORMAT)) {
@@ -2288,7 +2293,7 @@ public class JabRefPreferences implements PreferencesService {
                     formatData.get(EXPORTER_FILENAME_INDEX),
                     formatData.get(EXPORTER_EXTENSION_INDEX),
                     layoutPreferences,
-                    saveConfiguration.getSaveOrder());
+                    saveConfiguration.getSelfContainedSaveOrder());
             format.setCustomExport(true);
             formats.add(format);
         }

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -15,7 +15,6 @@ import org.jabref.gui.specialfields.SpecialFieldsPreferences;
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;

--- a/src/main/java/org/jabref/preferences/PreferencesService.java
+++ b/src/main/java/org/jabref/preferences/PreferencesService.java
@@ -16,6 +16,7 @@ import org.jabref.logic.JabRefException;
 import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.fetcher.GrobidPreferences;
@@ -73,7 +74,7 @@ public interface PreferencesService {
     /**
      * Returns the export configuration. The contained SaveConfiguration is a {@link org.jabref.model.metadata.SelfContainedSaveOrder}
      */
-    SaveConfiguration getExportConfiguration();
+    SelfContainedSaveConfiguration getSelfContainedExportConfiguration();
 
     BibEntryTypesManager getCustomEntryTypesRepository();
 

--- a/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
+++ b/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
@@ -11,6 +11,7 @@ import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -38,7 +39,7 @@ class BackupManagerDiscardedTest {
     private BibDatabaseContext bibDatabaseContext;
     private BackupManager backupManager;
     private Path testBib;
-    private SaveConfiguration saveConfiguration;
+    private SelfContainedSaveConfiguration saveConfiguration;
     private PreferencesService preferencesService;
     private BibEntryTypesManager bibEntryTypesManager;
     private Path backupDir;
@@ -55,7 +56,7 @@ class BackupManagerDiscardedTest {
 
         bibEntryTypesManager = new BibEntryTypesManager();
 
-        saveConfiguration = mock(SaveConfiguration.class);
+        saveConfiguration = mock(SelfContainedSaveConfiguration.class);
         when(saveConfiguration.shouldMakeBackup()).thenReturn(false);
         when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
         when(saveConfiguration.withMakeBackup(anyBoolean())).thenReturn(saveConfiguration);

--- a/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
+++ b/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 
 import org.jabref.gui.LibraryTab;
 import org.jabref.logic.exporter.AtomicFileWriter;
+import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
@@ -26,9 +27,7 @@ import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Test for "discarded" flag
@@ -54,17 +53,13 @@ class BackupManagerDiscardedTest {
         bibDatabaseContext.setDatabasePath(testBib);
 
         bibEntryTypesManager = new BibEntryTypesManager();
-
-        saveConfiguration = mock(SelfContainedSaveConfiguration.class);
-        when(saveConfiguration.shouldMakeBackup()).thenReturn(false);
-        when(saveConfiguration.getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
-        when(saveConfiguration.withMakeBackup(anyBoolean())).thenReturn(saveConfiguration);
-
+        saveConfiguration = new SelfContainedSaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, false);
         preferencesService = mock(PreferencesService.class, Answers.RETURNS_DEEP_STUBS);
 
         saveDatabase();
 
         backupManager = new BackupManager(mock(LibraryTab.class), bibDatabaseContext, bibEntryTypesManager, preferencesService);
+
         makeBackup();
     }
 

--- a/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
+++ b/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
@@ -10,7 +10,6 @@ import org.jabref.gui.LibraryTab;
 import org.jabref.logic.exporter.AtomicFileWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.BibtexDatabaseWriter;
-import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;

--- a/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
+++ b/src/test/java/org/jabref/gui/exporter/ExportToClipboardActionTest.java
@@ -14,7 +14,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.exporter.Exporter;
-import org.jabref.logic.exporter.SaveConfiguration;
+import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.xmp.XmpPreferences;
@@ -67,7 +67,7 @@ public class ExportToClipboardActionTest {
 
         taskExecutor = new CurrentThreadTaskExecutor();
         when(preferences.getExportPreferences().getCustomExporters()).thenReturn(FXCollections.observableList(List.of()));
-        when(preferences.getExportConfiguration()).thenReturn(mock(SaveConfiguration.class));
+        when(preferences.getSelfContainedExportConfiguration()).thenReturn(mock(SelfContainedSaveConfiguration.class));
         when(preferences.getXmpPreferences()).thenReturn(mock(XmpPreferences.class));
         exportToClipboardAction = new ExportToClipboardAction(dialogService, stateManager, clipBoardManager, taskExecutor, preferences);
     }
@@ -93,7 +93,7 @@ public class ExportToClipboardActionTest {
         when(preferences.getFilePreferences()).thenReturn(filePreferences);
         when(preferences.getLibraryPreferences()).thenReturn(libraryPreferences);
         when(preferences.getExportPreferences().getLastExportExtension()).thenReturn("HTML");
-        when(preferences.getExportConfiguration().getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
+        when(preferences.getSelfContainedExportConfiguration().getSaveOrder()).thenReturn(SaveOrder.getDefaultSaveOrder());
         when(stateManager.getSelectedEntries()).thenReturn(selectedEntries);
         when(stateManager.getActiveDatabase()).thenReturn(Optional.ofNullable(databaseContext));
         // noinspection ConstantConditions since databaseContext is mocked

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -72,7 +72,7 @@ public class BibtexDatabaseWriterTest {
     private MetaData metaData;
     private BibDatabaseContext bibtexContext;
     private ImportFormatPreferences importFormatPreferences;
-    private SaveConfiguration saveConfiguration;
+    private SelfContainedSaveConfiguration saveConfiguration;
     private FieldPreferences fieldPreferences;
     private CitationKeyPatternPreferences citationKeyPatternPreferences;
     private BibEntryTypesManager entryTypesManager;
@@ -82,7 +82,7 @@ public class BibtexDatabaseWriterTest {
     @BeforeEach
     void setUp() {
         fieldPreferences = new FieldPreferences(true, Collections.emptyList(), Collections.emptyList());
-        saveConfiguration = new SaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, false);
+        saveConfiguration = new SelfContainedSaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, false);
         citationKeyPatternPreferences = mock(CitationKeyPatternPreferences.class, Answers.RETURNS_DEEP_STUBS);
         entryTypesManager = new BibEntryTypesManager();
         stringWriter = new StringWriter();
@@ -680,7 +680,7 @@ public class BibtexDatabaseWriterTest {
         entry.setChanged(false);
         database.insertEntry(entry);
 
-        saveConfiguration = new SaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, true);
+        saveConfiguration = new SelfContainedSaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, true);
         initializeDatabaseWriter();
         databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry));
 
@@ -706,7 +706,7 @@ public class BibtexDatabaseWriterTest {
         string.setParsedSerialization("wrong serialization");
         database.addString(string);
 
-        saveConfiguration = new SaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, true);
+        saveConfiguration = new SelfContainedSaveConfiguration(SaveOrder.getDefaultSaveOrder(), false, BibDatabaseWriter.SaveType.WITH_JABREF_META_DATA, true);
         initializeDatabaseWriter();
         databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList());
 


### PR DESCRIPTION
I "forgot" to properly handly self-containedness at the exporters. This caused

```
Caused by: java.lang.IllegalArgumentException: TABLE requires external lookup.
	at org.jabref@100.0.0/org.jabref.model.metadata.selfcontainedsaveorder.<init>(selfcontainedsaveorder.java:12)
	at org.jabref@100.0.0/org.jabref.model.metadata.selfcontainedsaveorder.of(selfcontainedsaveorder.java:25)
	at org.jabref@100.0.0/org.jabref.preferences.jabrefpreferences.getexportconfiguration(jabrefpreferences.java:2275)
	at org.jabref@100.0.0/org.jabref.preferences.jabrefpreferences.getcustomexportformats(jabrefpreferences.java:2281)
```

The underlying issue is that concrete exporters are generated in the preferences. In future work, this should be solved. This PR "only" fixes that setting the preferences works again.

There is `SelfContainedSaveConfiguration` introduced analogous to `SelfContainedSaveOrder`.

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
