### PR TITLE
Modernize GitHub workflow for refresh CSL

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -13,19 +13,22 @@ jobs:
   publish:
     name: Refresh Citation Style Language Files
     runs-on: ubuntu-latest
-    if: github.repository == 'JabRef/jabref'
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    if: (github.repository == 'JabRef/jabref' || github.repository == 'koppor/jabref')
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
+          persist-credentials: true
           ref: main
           fetch-depth: 0
       - name: Initialize git
         run: |
           git checkout main
           git config --local core.editor /usr/bin/cat
-          git config user.name "github actions"
-          git config user.email "jabrefmail+webfeedback@gmail.com"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Add csl-styles remote
         run: git remote add -f csl-styles https://github.com/citation-style-language/styles.git
       - name: Update csl-styles
@@ -48,8 +51,8 @@ jobs:
           git commit -m"Refresh example styles" || true
       - uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: refresh-csl
-          commit-message: Update CSL styles
           title: "[Bot] Update CSL styles"
+          commit-message: Update CSL styles
           labels: dependencies


### PR DESCRIPTION
This makes the action more consistent with the refresh journal list action (https://github.com/JabRef/jabref/blob/main/.github/workflows/refresh-journal-lists.yml)

I tried out the update at - and it worked in general. No PR created, but I assume that this will work.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
