### PR TITLE
Fix concurrency groups

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -22,7 +22,7 @@ env:
   JAVA_OPTS: -Xmx4g
 
 concurrency:
-  group: ${{ github.ref }}-arm64mac
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -35,7 +35,7 @@ env:
   JDK21: ""
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -29,7 +29,7 @@ env:
   BiodiversityHeritageApiKey: ${{ secrets.BiodiversityHeritageApiKey_FOR_TESTS}}
 
 concurrency:
-  group: fetcher-tests-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Each of our workflows should be in a separate concurrency group. This was not quite the case before. This PR fixes that.

Hotfix.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
