### PR TITLE
Fix triggers for deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,12 +1,6 @@
 name: Deployment
 
 on:
-  workflow_dispatch:
-    inputs:
-      notarization:
-        type: boolean
-        required: false
-        default: false
   push:
     branches:
       - main
@@ -18,11 +12,13 @@ on:
     tags:
        - '*'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'src/test/**'
-      - 'README.md'
   merge_group:
+  workflow_dispatch:
+    inputs:
+      notarization:
+        type: boolean
+        required: false
+        default: false
 
 env:
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
       - main
       - main-release
   pull_request:
-    # always run on pull requests
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
We had the issue that the deployment workflow as not triggered for some PRs. See https://github.com/JabRef/jabref/pull/9769#issuecomment-1705542648.

The reason was a wrong trigger. We had the idea that binaries should only be created if there actually was changed something leading to changes in the binaries. Only changing tests does not lead to a change in the binary. For instance, test-only PRs do not change the binary. -- GitHub's branch protection rules demand that the workflows run. Regardless if the trigger ignores the changes. Thus, either make the workflows success optional - or trigger the workflow always.

Since test-only PRs are very seldom and we do want to have the deplyoment required, I remove the "filter" at the trigger.

Kind of hotfix.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
