### PR TITLE
Add missing do-not-notarize guard when in merge queue

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -254,6 +254,7 @@ jobs:
     name: Notarize and package Mac OS binaries
     runs-on: macos-latest
     needs: [build]
+    if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
     steps:
       - name: Check secrets presence
         id: checksecrets


### PR DESCRIPTION
Failing run at merge queue: https://github.com/JabRef/jabref/actions/runs/6076277004/job/16484394051

I do not know why some others went through...

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
