### PR TITLE
Add workaround for IDEA-317606

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
@@ -25,7 +25,7 @@ In the following, we will use `c:\git-repositories` as base folder:
 cd \
 mkdir git-repositories
 cd git-repositories
-git clone --depth=10 https://github.com/JabRef/jabref.git
+git clone --depth=10 https://github.com/JabRef/jabref.git JabRef
 cd jabref
 git remote rename origin upstream
 git remote add origin https://github.com/YOUR_USERNAME/jabref.git
@@ -36,6 +36,8 @@ git branch --set-upstream-to=origin/main main
 > Note that putting the repo JabRef directly on `C:\` or any other drive letter on Windows causes compile errors (**negative example**: `C:\jabref`).
 >
 > Further, if you are building on Windows, make sure that the absolute path to the location of the clone does not contain folders starting with '`u`' (**negative example**: `C:\university\jabref`) as this may currently also cause [compile errors](https://github.com/JabRef/jabref/issues/9783).
+>
+> Please really ensure that you pass `JabRef` as parameter. Otherwise, you will get `java.lang.IllegalStateException: Module entity with name: jabref.main should be available`. See [IDEA-317606](https://youtrack.jetbrains.com/issue/IDEA-317606/Changing-only-the-case-of-the-Gradle-root-project-name-causes-exception-while-importing-project-java.lang.IllegalStateException) for details.
 
 {: .note-title }
 > Background


### PR DESCRIPTION
When starting from scratch in IntelliJ, one might see `java.lang.IllegalStateException: Module entity with name: jabref.main should be available`. See [IDEA-317606](https://youtrack.jetbrains.com/issue/IDEA-317606/Changing-only-the-case-of-the-Gradle-root-project-name-causes-exception-while-importing-project-java.lang.IllegalStateException) for details.

This PR adds a work around.

The underlying issue is that in `settings.gradle`, we have `JabRef` as project name. However, our source repository is called `jabref`, which is not the same casing. This started to confuse IntelliJ.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
