### PR TITLE
Java keyring / secret-service: Switch from native-unixsocket to jnr-unixsocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,15 @@ dependencies {
 
     implementation 'io.github.java-diff-utils:java-diff-utils:4.12'
     implementation 'info.debatty:java-string-similarity:2.0.0'
-    implementation 'com.github.javakeyring:java-keyring:1.0.4'
+
+    implementation('com.github.javakeyring:java-keyring:1.0.4') {
+        // We need to replace native-unixsocket by jnr-unixsocket,
+        //   because GNOME dbus creates an "abstract" socket, which is not supported by native-unixsocket
+        exclude group: 'com.github.hypfvieh', module: 'dbus-java-transport-native-unixsocket'
+        exclude group: 'com.github.hypfvieh', module: 'dbus-java-core'
+    }
+    implementation 'com.github.hypfvieh:dbus-java-transport-jnr-unixsocket:4.3.0'
+    implementation 'com.github.hypfvieh:dbus-java-core:4.3.0'
 
     antlr4 'org.antlr:antlr4:4.13.0'
     implementation 'org.antlr:antlr4-runtime:4.13.0'


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/issues/10274

Long journey. See for a harbour I visited: https://github.com/javakeyring/java-keyring/pull/92. (More details at https://github.com/swiesend/secret-service/pull/43#issue-1882746789)

This build should be checked by a GNOME user. @credmond?


### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
