### PR TITLE
Java Keyring / secret service: Downgrade de.swiesend:secret-service to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,11 @@ dependencies {
 
     implementation 'io.github.java-diff-utils:java-diff-utils:4.12'
     implementation 'info.debatty:java-string-similarity:2.0.0'
-    implementation 'com.github.javakeyring:java-keyring:1.0.4'
+
+    implementation('com.github.javakeyring:java-keyring:1.0.4') {
+        exclude group: 'de.swiesend', module: 'secret-service'
+    }
+    implementation 'de.swiesend:secret-service:1.7.0'
 
     antlr4 'org.antlr:antlr4:4.13.0'
     implementation 'org.antlr:antlr4-runtime:4.13.0'


### PR DESCRIPTION
Alternative solution to https://github.com/JabRef/jabref/pull/10329 to fix' https://github.com/JabRef/jabref/issues/10274.

Version 1.7.0 of secret-service runs fine (see https://github.com/javakeyring/java-keyring/pull/91).

Thus, we could just use that version?

The build should be checked by a GNOME user. @credmond?

I tend to hope that the other solution works, too.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
