### PR TITLE
Fix devcontainer prebuilds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Java",
-    "image": "mcr.microsoft.com/vscode/devcontainers/base:bullseye",
+    "image": "mcr.microsoft.com/devcontainers/base:debian",
     "customizations": {
         "vscode": {
             "extensions": [
@@ -14,7 +14,7 @@
 
     // Source code generation needs to be done before hand-over to VS Code.
     // Otherwise, the Java extension will go mad.
-    "onCreateCommand": "./gradlew testClasses --no-daemon",
+    "onCreateCommand": "./gradlew testClasses --console=plain --no-daemon",
 
     // Forward the vncPort and noVNC port.
     // They are provided by desktop-lite:
@@ -31,7 +31,7 @@
         // Install java.
         // See https://github.com/devcontainers/features/tree/main/src/java#options for details.
         "ghcr.io/devcontainers/features/java:1": {
-            "version": "19.0.2-tem",
+            "version": "20.0.2-tem",
             "installGradle": false,
             "jdkDistro": "tem"
         }

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ java {
     modularity.inferModulePath.set(false)
 
     toolchain {
+        // If this is updated, also update .devcontainer/devcontainer.json#L34
         languageVersion = JavaLanguageVersion.of(20)
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,8 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 rootProject.name = "JabRef"


### PR DESCRIPTION
The pre-builds of our devcontainers failed. (They are configured at https://github.com/JabRef/jabref/settings/codespaces). 

This PR fixes it with two ways:

1. Introduces [Foojay Toolchains Plugin](https://github.com/gradle/foojay-toolchains#foojay-toolchains-plugin) to allow gradle download the JDK by itself (already it - see https://github.com/JabRef/jabref/actions/runs/6094889864)
2. Install JDK20 in the container

Other improvements:

- Always take latest debian release
- Gradle should have a nicer output

Side note: I udpated the pre-build configuration to build once a week only. Should be enough (as currently no one seems to use that feature - we should nevertheless keep it as maintaining is less effort then re-introducing).

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
