### PR TITLE
Switch to ZGC garbage collector

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -122,7 +122,8 @@ jobs:
           --icon src/main/resources/icons/jabref.icns \
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
-          --jlink-options --bind-services
+          --jlink-options --bind-services \
+          --java-options -Xmx4g -XX:+UseZGC
       - name: Build pkg (macos)
         shell: bash
         run: |
@@ -144,7 +145,8 @@ jobs:
           --icon src/main/resources/icons/jabref.icns \
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
-          --jlink-options --bind-services
+          --jlink-options --bind-services \
+          --java-options -Xmx4g -XX:+UseZGC
       - name: Rename files with arm64 suffix as well
         shell: bash
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -181,7 +181,8 @@ jobs:
           --icon src/main/resources/icons/jabref.icns \
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
-          --jlink-options --bind-services
+          --jlink-options --bind-services \
+          --java-options -Xmx4g -XX:+UseZGC
       - name: Build pkg (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
@@ -204,7 +205,8 @@ jobs:
           --icon src/main/resources/icons/jabref.icns \
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
-          --jlink-options --bind-services
+          --jlink-options --bind-services \
+          --java-options -Xmx4g -XX:+UseZGC
       - name: Package application image (non-macos)
         if: (matrix.os != 'macos-latest')
         shell: bash

--- a/build.gradle
+++ b/build.gradle
@@ -552,6 +552,7 @@ jlink {
     addOptions('--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages')
     launcher {
         name = 'JabRef'
+        jvmArgs = ['-Xmx4g', '-XX:+UseZGC']
     }
 
     addOptions("--bind-services")


### PR DESCRIPTION
The ZGC garbage collector seems to make an application more responsive.

It runs on 64bit Java only. I assume, we are only shipping a 64bit release.

![ellinger_shenandoah_6 tif_fmt1](https://github.com/JabRef/jabref/assets/1366654/bfe7c7aa-1bf1-4d1d-a31c-e7aa045a59eb)

If we ship 32bit releases, we could use the "Shendoah" GC, because we rely on a non-oracle JDK: https://stackoverflow.com/a/69231190/873282

The configuration option was found at https://badass-jlink-plugin.beryx.org/releases/latest/.

More background at https://wiki.openjdk.org/display/zgc/Main. Even more information (in German): https://entwickler.de/java/kurze-pause

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
