### PR TITLE
Copy browser extension files for mac

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -109,6 +109,8 @@ jobs:
           --module-path ${{env.JDK21}}/Contents/Home/jmods/:build/jlinkbase/jlinkjars \
           --add-modules org.jabref,org.jabref.merged.module  \
           --dest build/distribution \
+          --app-content buildres/mac/jabrefHost.py \
+          --app-content buildres/mac/native-messaging-host \
           --name JabRef \
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
@@ -131,6 +133,8 @@ jobs:
           --module-path ${{env.JDK21}}/Contents/Home/jmods/:build/jlinkbase/jlinkjars \
           --add-modules org.jabref,org.jabref.merged.module  \
           --dest build/distribution \
+          --app-content buildres/mac/jabrefHost.py \
+          --app-content buildres/mac/native-messaging-host \
           --name JabRef \
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -168,6 +168,8 @@ jobs:
           --module-path ${{env.JDK21}}/Contents/Home/jmods/:build/jlinkbase/jlinkjars \
           --add-modules org.jabref,org.jabref.merged.module  \
           --dest build/distribution \
+          --app-content buildres/mac/jabrefHost.py \
+          --app-content buildres/mac/native-messaging-host \
           --name JabRef \
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
@@ -191,6 +193,8 @@ jobs:
           --module-path ${{env.JDK21}}/Contents/Home/jmods/:build/jlinkbase/jlinkjars \
           --add-modules org.jabref,org.jabref.merged.module  \
           --dest build/distribution \
+          --app-content buildres/mac/jabrefHost.py \
+          --app-content buildres/mac/native-messaging-host \
           --name JabRef \
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - It is possible again to use "current table sort order" for the order of entries when saving. [#9869](https://github.com/JabRef/jabref/issues/9869)
 - Passwords can be stored in GNOME key ring. [#10274](https://github.com/JabRef/jabref/issues/10274)
 - We fixed an issue where groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10350)
-- We fixed an issue where the JabRef browser extension could not communicate with JabRef under macOS due to missing files [#10308](https://github.com/JabRef/jabref/issues/10308)
+- We fixed an issue where the JabRef browser extension could not communicate with JabRef under macOS due to missing files. You should use the `.pkg` for the first installation as it updates all necessary files for the extension [#10308](https://github.com/JabRef/jabref/issues/10308)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - It is possible again to use "current table sort order" for the order of entries when saving. [#9869](https://github.com/JabRef/jabref/issues/9869)
 - Passwords can be stored in GNOME key ring. [#10274](https://github.com/JabRef/jabref/issues/10274)
-- We fixed an issue were  groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10352)
+- We fixed an issue where groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10350)
+- We fixed an issue where the JabRef browser extension could not communicate with JabRef under macOS due to missing files [#10308](https://github.com/JabRef/jabref/issues/10308)
 
 ### Removed
 

--- a/buildres/mac/jabrefHost.py
+++ b/buildres/mac/jabrefHost.py
@@ -14,6 +14,10 @@ from pathlib import Path
 # Note that the package structure is different when installed as a .app bundle on MacOs, so the path must be altered.
 script_dir = Path(__file__).resolve().parent.parent
 JABREF_PATH = script_dir / "bin/JabRef"
+
+# on mac we must only go one folder upwards
+if sys.platform.startswith('darwin'):
+    script_dir = Path(__file__).resolve().parent
 if not JABREF_PATH.exists():
     JABREF_PATH = script_dir / "MacOS/JabRef"
 

--- a/buildres/mac/native-messaging-host/chromium/org.jabref.jabref.json
+++ b/buildres/mac/native-messaging-host/chromium/org.jabref.jabref.json
@@ -1,7 +1,7 @@
 {
   "name": "org.jabref.jabref",
   "description": "JabRef",
-  "path": "/Applications/JabRef.app/Contents/Resources/jabrefHost.py",
+  "path": "/Applications/JabRef.app/Contents/jabrefHost.py",
   "type": "stdio",
   "allowed_origins": [
     "chrome-extension://bifehkofibaamoeaopjglfkddgkijdlh/",

--- a/buildres/mac/native-messaging-host/firefox/org.jabref.jabref.json
+++ b/buildres/mac/native-messaging-host/firefox/org.jabref.jabref.json
@@ -1,10 +1,7 @@
 {
   "name": "org.jabref.jabref",
   "description": "JabRef",
-  "path": "/Applications/JabRef.app/Contents/Resources/jabrefHost.py",
+  "path": "/Applications/JabRef.app/Contents/jabrefHost.py",
   "type": "stdio",
-  "allowed_extensions": [
-    "browserextension@jabref.org",
-    "@jabfox"
-  ]
+  "allowed_extensions": ["browserextension@jabref.org", "@jabfox"]
 }

--- a/buildres/mac/postinstall
+++ b/buildres/mac/postinstall
@@ -6,15 +6,15 @@ chmod +r "APP_LOCATION/"*.jar
 # Trigger an auto-install of the browser addon for chrome/chromium browsers
 # First create the necessary path, then copy the autoinstall file.
 install -d /Library/Application\ Support/Google/Chrome/External\ Extensions/
-install -m0644 /Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/bifehkofibaamoeaopjglfkddgkijdlh.json /Library/Application\ Support/Google/Chrome/External\ Extensions/bifehkofibaamoeaopjglfkddgkijdlh.json
+install -m0644 /Applications/JabRef.app/Contents/native-messaging-host/chromium/bifehkofibaamoeaopjglfkddgkijdlh.json /Library/Application\ Support/Google/Chrome/External\ Extensions/bifehkofibaamoeaopjglfkddgkijdlh.json
 # Install the native-messaging host script for firefox/chrome/chromium
 install -d /Library/Application\ Support/Mozilla/NativeMessagingHosts/
-install -m0755 /Applications/JabRef.app/Contents/Resources/native-messaging-host/firefox/org.jabref.jabref.json /Library/Application\ Support/Mozilla/NativeMessagingHosts/org.jabref.jabref.json
+install -m0755 /Applications/JabRef.app/Contents/native-messaging-host/firefox/org.jabref.jabref.json /Library/Application\ Support/Mozilla/NativeMessagingHosts/org.jabref.jabref.json
 install -d /Library/Application\ Support/Chromium/NativeMessagingHosts/
-install -m0755 /Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/org.jabref.jabref.json /Library/Application\ Support/Chromium/NativeMessagingHosts/org.jabref.jabref.json
+install -m0755 /Applications/JabRef.app/Contents/native-messaging-host/chromium/org.jabref.jabref.json /Library/Application\ Support/Chromium/NativeMessagingHosts/org.jabref.jabref.json
 install -d /Library/Google/Chrome/NativeMessagingHosts/
-install -m0755 /Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/org.jabref.jabref.json /Library/Google/Chrome/NativeMessagingHosts/org.jabref.jabref.json
+install -m0755 /Applications/JabRef.app/Contents/native-messaging-host/chromium/org.jabref.jabref.json /Library/Google/Chrome/NativeMessagingHosts/org.jabref.jabref.json
 install -d /Library/Microsoft/Edge/NativeMessagingHosts/
-install -m0755 /Applications/JabRef.app/Contents/Resources/native-messaging-host/chromium/org.jabref.jabref.json /Library/Microsoft/Edge/NativeMessagingHosts/org.jabref.jabref.json
+install -m0755 /Applications/JabRef.app/Contents/native-messaging-host/chromium/org.jabref.jabref.json /Library/Microsoft/Edge/NativeMessagingHosts/org.jabref.jabref.json
 
 exit 0


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/10308

I found out about "add-content", however that only copies to the root dir, so I adjusted the scripts:
Need testing if the python path still works

<img width="613" alt="grafik" src="https://github.com/JabRef/jabref/assets/320228/eae5962e-7c7a-4f35-bb6a-ec7cd73d2c6c">


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
