### PR TITLE
Add new openrewrite rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,8 +253,10 @@ dependencies {
     xjc group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.2'
 
     rewrite(platform("org.openrewrite.recipe:rewrite-recipe-bom:2.2.1"))
-    rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
     rewrite("org.openrewrite.recipe:rewrite-static-analysis")
+    rewrite("org.openrewrite.recipe:rewrite-logging-frameworks")
+    rewrite("org.openrewrite.recipe:rewrite-testing-frameworks")
+    rewrite("org.openrewrite.recipe:rewrite-migrate-java")
 }
 
 clean {

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -99,7 +99,17 @@ recipeList:
   # We voted against it
   #  - org.openrewrite.staticanalysis.ExplicitInitialization
 
+  - org.openrewrite.java.migrate.io.ReplaceFileInOrOutputStreamFinalizeWithClose
+
+  - org.openrewrite.java.recipes.UseJavaParserBuilderInJavaTemplate
+
   - org.openrewrite.java.ShortenFullyQualifiedTypeReferences
+
+  - org.openrewrite.java.testing.junit5.AssertTrueInstanceofToAssertInstanceOf
+  - org.openrewrite.java.testing.junit5.RemoveTryCatchFailBlocks
+
+  # needs another openrewrite dependency
+  # - org.openrewrite.okhttp.ReorderRequestBodyCreateArguments
 
   - org.openrewrite.staticanalysis.AtomicPrimitiveEqualsUsesGet
   - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
@@ -116,6 +126,7 @@ recipeList:
 #  - org.openrewrite.staticanalysis.DefaultComesLast
   - org.openrewrite.staticanalysis.EmptyBlock
   - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  - org.openrewrite.staticanalysis.EqualsToContentEquals
   # Needs manual intervention
 #  - org.openrewrite.staticanalysis.ExplicitCharsetOnStringGetBytes
   - org.openrewrite.staticanalysis.ExternalizableHasNoArgsConstructor
@@ -150,7 +161,9 @@ recipeList:
   - org.openrewrite.staticanalysis.RemoveEmptyJavaDocParameters
   - org.openrewrite.staticanalysis.RemoveExtraSemicolons
   - org.openrewrite.staticanalysis.RemoveJavaDocAuthorTag
+  - org.openrewrite.staticanalysis.RemoveHashCodeCallsFromArrayInstances
   - org.openrewrite.staticanalysis.RemoveRedundantTypeCast
+  - org.openrewrite.staticanalysis.RemoveToStringCallsFromArrayInstances
   - org.openrewrite.staticanalysis.RemoveUnneededAssertion
   - org.openrewrite.staticanalysis.RemoveUnneededBlock
 #  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
@@ -159,12 +172,14 @@ recipeList:
   - org.openrewrite.staticanalysis.RenameMethodsNamedHashcodeEqualOrTostring
   - org.openrewrite.staticanalysis.ReplaceRedundantFormatWithPrintf
   - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
+  - org.openrewrite.staticanalysis.ReplaceWeekYearWithYear
 #  - org.openrewrite.staticanalysis.ShortenFullyQualifiedTypeReferences
 #  - org.openrewrite.staticanalysis.SimplifyConsecutiveAssignments
 #  - org.openrewrite.staticanalysis.SimplifyCompoundStatement
   - org.openrewrite.staticanalysis.SimplifyBooleanExpression
   - org.openrewrite.staticanalysis.SimplifyBooleanReturn
   - org.openrewrite.staticanalysis.SimplifyDurationCreationUnits
+  - org.openrewrite.staticanalysis.SortedSetStreamToLinkedHashSet
   - org.openrewrite.staticanalysis.StaticMethodNotFinal
   - org.openrewrite.staticanalysis.StringLiteralEquality
   - org.openrewrite.staticanalysis.TypecastParenPad

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
@@ -59,10 +59,10 @@ public class EscapeAmpersandsFormatter extends Formatter {
             }
             // If we are in a command body, see if it has ended:
             if (inCommand && (c == '}')) {
-                if ("begin".equals(commandName.toString())) {
+                if ("begin".contentEquals(commandName)) {
                     nestedEnvironments++;
                 }
-                if ((nestedEnvironments > 0) && "end".equals(commandName.toString())) {
+                if ((nestedEnvironments > 0) && "end".contentEquals(commandName)) {
                     nestedEnvironments--;
                 }
 
@@ -72,7 +72,7 @@ public class EscapeAmpersandsFormatter extends Formatter {
 
             // We add a backslash before any ampersand characters, with one exception: if
             // we are inside an \\url{...} command, we should write it as it is. Maybe.
-            if ((c == '&') && !escape && !(inCommand && "url".equals(commandName.toString()))
+            if ((c == '&') && !escape && !(inCommand && "url".contentEquals(commandName))
                     && (nestedEnvironments == 0)) {
                 result.append("\\&");
             } else {

--- a/src/test/java/org/jabref/gui/theme/ThemeManagerTest.java
+++ b/src/test/java/org/jabref/gui/theme/ThemeManagerTest.java
@@ -6,19 +6,18 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.web.WebEngine;
-import org.junit.jupiter.api.Assertions;
 
 import org.jabref.gui.util.DefaultFileUpdateMonitor;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.preferences.WorkspacePreferences;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,6 @@ import org.testfx.framework.junit5.ApplicationExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/jabref/gui/theme/ThemeManagerTest.java
+++ b/src/test/java/org/jabref/gui/theme/ThemeManagerTest.java
@@ -13,6 +13,7 @@ import javafx.collections.FXCollections;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.web.WebEngine;
+import org.junit.jupiter.api.Assertions;
 
 import org.jabref.gui.util.DefaultFileUpdateMonitor;
 import org.jabref.model.util.DummyFileUpdateMonitor;
@@ -194,11 +195,9 @@ class ThemeManagerTest {
             webEngineStyleSheetLocation.complete(webEngine.getUserStyleSheetLocation());
         });
 
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             assertEquals(webEngineStyleSheetLocation.get(), TEST_CSS_DATA);
-        } catch (InterruptedException | ExecutionException e) {
-            fail(e);
-        }
+        });
     }
 
     /**

--- a/src/test/java/org/jabref/logic/bst/BstVMVisitorTest.java
+++ b/src/test/java/org/jabref/logic/bst/BstVMVisitorTest.java
@@ -238,7 +238,7 @@ class BstVMVisitorTest {
         vm.render(Collections.emptyList());
 
         assertEquals(3, vm.getStack().pop());
-        assertTrue(vm.getStack().pop() instanceof ParseTree);
+        assertInstanceOf(ParseTree.class, vm.getStack().pop());
         assertEquals(new BstVMVisitor.Identifier("t"), vm.getStack().pop());
         assertEquals(1, vm.getStack().pop());
         assertEquals("HELLO", vm.getStack().pop());

--- a/src/test/java/org/jabref/logic/bst/BstVMVisitorTest.java
+++ b/src/test/java/org/jabref/logic/bst/BstVMVisitorTest.java
@@ -13,6 +13,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -131,7 +131,7 @@ public class URLDownloadTest {
         URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/503"));
 
         Exception exception = assertThrows(IOException.class, urlDownload::asString);
-        assertTrue(exception.getCause() instanceof FetcherServerException);
+        assertInstanceOf(FetcherServerException.class, exception.getCause());
     }
 
     @Test
@@ -139,6 +139,6 @@ public class URLDownloadTest {
         URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/429"));
 
         Exception exception = assertThrows(IOException.class, urlDownload::asString);
-        assertTrue(exception.getCause() instanceof FetcherClientException);
+        assertInstanceOf(FetcherClientException.class, exception.getCause());
     }
 }

--- a/src/test/java/org/jabref/logic/shared/DBMSProcessorTest.java
+++ b/src/test/java/org/jabref/logic/shared/DBMSProcessorTest.java
@@ -20,6 +20,7 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.DatabaseTest;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -435,13 +436,11 @@ class DBMSProcessorTest {
     // Oracle does not support multiple tuple insertion in one INSERT INTO command.
     // Therefore this function was defined to improve the readability and to keep the code short.
     private void insertMetaData(String key, String value, DBMSConnection dbmsConnection, DBMSProcessor dbmsProcessor) {
-        try {
+        Assertions.assertDoesNotThrow(() -> {
             dbmsConnection.getConnection().createStatement().executeUpdate("INSERT INTO " + escape_Table("METADATA", dbmsProcessor) + "("
                     + escape("KEY", dbmsProcessor) + ", " + escape("VALUE", dbmsProcessor) + ") VALUES("
                     + escapeValue(key) + ", " + escapeValue(value) + ")");
-        } catch (SQLException e) {
-            fail(e.getMessage());
-        }
+        });
     }
 
     private static String escape(String expression, DBMSProcessor dbmsProcessor) {


### PR DESCRIPTION
I went through the changelogs of OpenRewrite and added following rewrites:

- https://docs.openrewrite.org/recipes/java/testing/junit5/removetrycatchfailblocks
- https://docs.openrewrite.org/recipes/java/testing/junit5/asserttrueinstanceoftoassertinstanceof 
- https://docs.openrewrite.org/recipes/staticanalysis/equalstocontentequals

No efffects:

- https://docs.openrewrite.org/recipes/java/recipes/usejavaparserbuilderinjavatemplate
- https://docs.openrewrite.org/recipes/staticanalysis/replaceweekyearwithyear
- https://docs.openrewrite.org/recipes/staticanalysis/sortedsetstreamtolinkedhashset
- https://docs.openrewrite.org/recipes/java/migrate/io/replacefileinoroutputstreamfinalizewithclose
- https://docs.openrewrite.org/recipes/staticanalysis/removetostringcallsfromarrayinstances
- https://docs.openrewrite.org/recipes/staticanalysis/removehashcodecallsfromarrayinstances

---

Side comment: Created upstream issue https://github.com/openrewrite/rewrite-testing-frameworks/issues/403, because `matched` is output multiple times when running

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
