### PR TITLE
Update casing of "JabRef"

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -64,7 +64,7 @@ jobs:
           java-version: 20
           distribution: 'temurin'
           cache: 'gradle'
-      - name: setup jdk JabRef-fix mac
+      - name: setup jdk jabref-fix mac
         shell: bash
         run: |
             mkdir ${{runner.temp}}/jdk
@@ -114,8 +114,8 @@ jobs:
           --verbose \
           --mac-sign \
           --vendor JabRef \
-          --mac-package-identifier Jabref \
-          --mac-package-name JabRef \
+          --mac-package-identifier JabRef \
+          --mac-package-name "JabRef e.V." \
           --type dmg --mac-signing-key-user-name "JabRef e.V. (6792V39SK3)" \
           --mac-package-signing-prefix org.jabref \
           --mac-entitlements buildres/mac/jabref.entitlements \
@@ -135,8 +135,8 @@ jobs:
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
           --mac-sign \
-          --vendor JabRef \
-          --mac-package-identifier Jabref \
+          --vendor "JabRef e.V." \
+          --mac-package-identifier JabRef \
           --mac-package-name JabRef \
           --type pkg --mac-signing-key-user-name "JabRef e.V. (6792V39SK3)" \
           --mac-package-signing-prefix org.jabref \
@@ -148,22 +148,22 @@ jobs:
       - name: Rename files with arm64 suffix as well
         shell: bash
         run: |
-          mv build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg  build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg
-          mv build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg  build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg
+          mv build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg  build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg
+          mv build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg  build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg
       - name: Notarize dmg
         if: (startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }}))
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}" --keychain ${{runner.temp}}/keychain/notarization.keychain
-          xcrun notarytool submit build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg --keychain-profile "notarytool-profile" --keychain ${{runner.temp}}/keychain/notarization.keychain --wait
-          xcrun stapler staple build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg
+          xcrun notarytool submit build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg --keychain-profile "notarytool-profile" --keychain ${{runner.temp}}/keychain/notarization.keychain --wait
+          xcrun stapler staple build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.dmg
       - name: Notarize pkg
         if: (startsWith(github.ref, 'refs/tags/') || (${{ inputs.notarization }}))
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}" --keychain ${{runner.temp}}/keychain/notarization.keychain
-          xcrun notarytool submit build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg --keychain-profile "notarytool-profile" --keychain ${{runner.temp}}/keychain/notarization.keychain --wait
-          xcrun stapler staple build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg
+          xcrun notarytool submit build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg --keychain-profile "notarytool-profile" --keychain ${{runner.temp}}/keychain/notarization.keychain --wait
+          xcrun stapler staple build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}-arm64.pkg
       - name: Upload with rsync
         if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
         shell: bash
@@ -178,5 +178,5 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
         uses: actions/upload-artifact@v3
         with:
-          name: JabRef-${{ matrix.displayName }}
+          name: jabref-${{ matrix.displayName }}
           path: build/distribution

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -113,9 +113,9 @@ jobs:
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
           --mac-sign \
-          --vendor JabRef \
+          --vendor "JabRef e.V." \
           --mac-package-identifier JabRef \
-          --mac-package-name "JabRef e.V." \
+          --mac-package-name JabRef \
           --type dmg --mac-signing-key-user-name "JabRef e.V. (6792V39SK3)" \
           --mac-package-signing-prefix org.jabref \
           --mac-entitlements buildres/mac/jabref.entitlements \

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -58,13 +58,13 @@ jobs:
       - name: Run GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Set up JDK
+      - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           java-version: 20
           distribution: 'temurin'
           cache: 'gradle'
-      - name: setup jdk jabref-fix mac
+      - name: Setup JDK jabref-fix macOS
         shell: bash
         run: |
             mkdir ${{runner.temp}}/jdk
@@ -81,7 +81,7 @@ jobs:
       - name: Clean up keychain
         run: |
          security delete-keychain signing_temp.keychain ${{runner.temp}}/keychain/notarization.keychain || true
-      - name: Setup OSX key chain on OSX
+      - name: Setup OSX key chain on macOS
         uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.OSX_SIGNING_CERT }}
@@ -99,9 +99,9 @@ jobs:
           mkdir ${{runner.temp}}/keychain
           security create-keychain -p jabref ${{runner.temp}}/keychain/notarization.keychain
           security set-keychain-settings ${{runner.temp}}/keychain/notarization.keychain
-      - name: Prepare merged jars and modules dir (macos)
+      - name: Prepare merged jars and modules dir (macOS)
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir
-      - name: Build dmg (macos)
+      - name: Build dmg (macOS)
         shell: bash
         run: |
           ${{env.JDK21}}/Contents/Home/bin/jpackage \
@@ -123,7 +123,7 @@ jobs:
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services
-      - name: Build pkg (macos)
+      - name: Build pkg (macOS)
         shell: bash
         run: |
           ${{env.JDK21}}/Contents/Home/bin/jpackage \

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,14 +43,14 @@ jobs:
         include:
           - os: ubuntu-latest
             displayName: linux
-            archivePortable: tar -c -C build/distribution JabRef | pigz --rsyncable > build/distribution/JabRef-portable_linux.tar.gz && rm -R build/distribution/JabRef
+            archivePortable: tar -c -C build/distribution jabref | pigz --rsyncable > build/distribution/jabref-portable_linux.tar.gz && rm -R build/distribution/jabref
             eaJdk: https://files.jabref.org/jdks/jdk-linux-x64.tar.gz
           - os: windows-latest
             displayName: windows
-            archivePortable: 7z a -r build/distribution/JabRef-portable_windows.zip ./build/distribution/JabRef && rm -R build/distribution/JabRef
+            archivePortable: 7z a -r build/distribution/jabref-portable_windows.zip ./build/distribution/jabref && rm -R build/distribution/jabref
             eaJDK: https://files.jabref.org/jdks/jdk-windows-x64.zip
           - os: macos-latest
-            displayName: macOS
+            displayName: macos
             eaJDK: https://files.jabref.org/jdks/jdk-macos-x64.tar.gz
     runs-on: ${{ matrix.os }}
     name: Create installer and portable version for ${{ matrix.displayName }}
@@ -91,7 +91,7 @@ jobs:
           java-version: 20
           distribution: 'temurin'
           cache: 'gradle'
-      - name: setup jdk JabRef-fix (windows)
+      - name: setup jdk jabref-fix (windows)
         if: (matrix.os == 'windows-latest')
         shell: bash
         run: |
@@ -105,7 +105,7 @@ jobs:
          cat gradle.properties
 
          sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk JabRef-fix (ubuntu)
+      - name: setup jdk jabref-fix (ubuntu)
         if: (matrix.os == 'ubuntu-latest')
         shell: bash
         run: |
@@ -119,7 +119,7 @@ jobs:
           cat gradle.properties
 
           sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk JabRef-fix (macos)
+      - name: setup jdk jabref-fix (macos)
         if: (matrix.os == 'macos-latest')
         shell: bash
         run: |
@@ -152,13 +152,13 @@ jobs:
       - name: Build runtime image (non-macos)
         if: (matrix.os != 'macos-latest')
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
-      - name: Prepare merged jars and modules dir (macos)
-        if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
-        run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir
       - name: Build installer (non-macos)
         if: (matrix.os != 'macos-latest')
         shell: bash
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
+      - name: Prepare merged jars and modules dir (macos)
+        if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
+        run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir
       - name: Build dmg (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
@@ -168,12 +168,12 @@ jobs:
           --module-path ${{env.JDK21}}/Contents/Home/jmods/:build/jlinkbase/jlinkjars \
           --add-modules org.jabref,org.jabref.merged.module  \
           --dest build/distribution \
-          --name JabRef \
+          --name jabref \
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
           --mac-sign \
-          --vendor JabRef \
-          --mac-package-identifier Jabref \
+          --vendor "JabRef e.V." \
+          --mac-package-identifier JabRef \
           --mac-package-name JabRef \
           --type dmg --mac-signing-key-user-name "JabRef e.V. (6792V39SK3)" \
           --mac-package-signing-prefix org.jabref \
@@ -195,8 +195,8 @@ jobs:
           --app-version ${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }} \
           --verbose \
           --mac-sign \
-          --vendor JabRef \
-          --mac-package-identifier Jabref \
+          --vendor "JabRef e.V." \
+          --mac-package-identifier JabRef \
           --mac-package-name JabRef \
           --type pkg --mac-signing-key-user-name "JabRef e.V. (6792V39SK3)" \
           --mac-package-signing-prefix org.jabref \
@@ -241,14 +241,14 @@ jobs:
         if: (matrix.os == 'windows-latest') && (!startsWith(github.ref, 'refs/heads/gh-readonly-queue'))
         uses: actions/upload-artifact@v3
         with:
-          name: JabRef-${{ matrix.displayName }}
+          name: jabref-${{ matrix.displayName }}
           path: build/distribution
       - name: Upload to GitHub workflow artifacts store (macos)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES') && (!startsWith(github.ref, 'refs/heads/gh-readonly-queue'))
         uses: actions/upload-artifact@v3
         with:
           # tbn = to-be-notarized
-          name: JabRef-macOS-tbn
+          name: jabref-macos-tbn
           path: build/distribution
   notarize: # outsourced in a separate job to be able to rerun if this fails for timeouts
     name: Notarize and package Mac OS binaries
@@ -283,26 +283,26 @@ jobs:
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Get macOS binaries
+      - name: Get macos binaries
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: actions/download-artifact@master
         with:
-          name: JabRef-macOS-tbn
+          name: jabref-macos-tbn
           path: build/distribution/
       - name: Notarize dmg
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (startsWith(github.ref, 'refs/tags/') ||  inputs.notarization == true)
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"
-          xcrun notarytool submit build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg
+          xcrun notarytool submit build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg --keychain-profile "notarytool-profile" --wait
+          xcrun stapler staple build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.dmg
       - name: Notarize pkg
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (startsWith(github.ref, 'refs/tags/') ||  inputs.notarization == true)
         shell: bash
         run: |
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "vorstand@jabref.org" --team-id "6792V39SK3" --password "${{ secrets.OSX_NOTARIZATION_APP_PWD }}"
-          xcrun notarytool submit build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple build/distribution/JabRef-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg
+          xcrun notarytool submit build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg --keychain-profile "notarytool-profile" --wait
+          xcrun stapler staple build/distribution/jabref-${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}.pkg
       - name: Package application image
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (matrix.os != 'macos-latest')
         shell: bash
@@ -311,7 +311,7 @@ jobs:
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (!startsWith(github.ref, 'refs/heads/gh-readonly-queue'))
         uses: actions/upload-artifact@v3
         with:
-          name: JabRef-macOS
+          name: jabref-macos
           path: build/distribution
   upload:
     strategy:
@@ -352,19 +352,19 @@ jobs:
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: actions/download-artifact@master
         with:
-          name: JabRef-windows
+          name: jabref-windows
           path: build/distribution
-      - name: Get macOS binaries unsigned
+      - name: Get macos binaries unsigned
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (inputs.notarization == false && !startsWith(github.ref, 'refs/tags/'))
         uses: actions/download-artifact@master
         with:
-          name: JabRef-macOS-tbn
+          name: jabref-macos-tbn
           path: build/distribution/
-      - name: Get macOS binaries notarized
+      - name: Get macos binaries notarized
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (inputs.notarization == true || startsWith(github.ref, 'refs/tags/'))
         uses: actions/download-artifact@master
         with:
-          name: JabRef-macOS
+          name: jabref-macos
           path: build/distribution/
       # Upload to build server using rsync
       # The action runs on linux only (because it is a Dockerized action), therefore it is embedded in a separate workflow

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,11 +46,11 @@ jobs:
             archivePortable: tar -c -C build/distribution jabref | pigz --rsyncable > build/distribution/jabref-portable_linux.tar.gz && rm -R build/distribution/jabref
             eaJdk: https://files.jabref.org/jdks/jdk-linux-x64.tar.gz
           - os: windows-latest
-            displayName: windows
+            displayName: Windows
             archivePortable: 7z a -r build/distribution/jabref-portable_windows.zip ./build/distribution/jabref && rm -R build/distribution/jabref
             eaJDK: https://files.jabref.org/jdks/jdk-windows-x64.zip
           - os: macos-latest
-            displayName: macos
+            displayName: macOS
             eaJDK: https://files.jabref.org/jdks/jdk-macos-x64.tar.gz
     runs-on: ${{ matrix.os }}
     name: Create installer and portable version for ${{ matrix.displayName }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -85,13 +85,13 @@ jobs:
       - name: Run GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Set up JDK
+      - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           java-version: 20
           distribution: 'temurin'
           cache: 'gradle'
-      - name: setup jdk jabref-fix (windows)
+      - name: Setup JDK jabref-fix (Windows)
         if: (matrix.os == 'windows-latest')
         shell: bash
         run: |
@@ -105,7 +105,7 @@ jobs:
          cat gradle.properties
 
          sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk jabref-fix (ubuntu)
+      - name: Setup JDK jabref-fix (ubuntu)
         if: (matrix.os == 'ubuntu-latest')
         shell: bash
         run: |
@@ -119,7 +119,7 @@ jobs:
           cat gradle.properties
 
           sed -i "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: setup jdk jabref-fix (macos)
+      - name: Setup JDK jabref-fix (macOS)
         if: (matrix.os == 'macos-latest')
         shell: bash
         run: |
@@ -134,14 +134,14 @@ jobs:
           cat gradle.properties
 
           sed -i'.bak' -e "s/JavaLanguageVersion.of(20)/JavaLanguageVersion.of(21)/" build.gradle
-      - name: Setup OSX key chain (macos)
+      - name: Setup OSX key chain (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.OSX_SIGNING_CERT }}
           p12-password: ${{ secrets.OSX_CERT_PWD }}
           keychain-password: jabref
-      - name: Setup OSX key chain on OSX for app id cert (macos)
+      - name: Setup OSX key chain on OSX for app id cert (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: apple-actions/import-codesign-certs@v2
         with:
@@ -149,17 +149,17 @@ jobs:
           p12-password: ${{ secrets.OSX_CERT_PWD }}
           create-keychain: false
           keychain-password: jabref
-      - name: Build runtime image (non-macos)
+      - name: Build runtime image (non-macOS)
         if: (matrix.os != 'macos-latest')
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jlinkZip
       - name: Build installer (non-macos)
         if: (matrix.os != 'macos-latest')
         shell: bash
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" jpackage
-      - name: Prepare merged jars and modules dir (macos)
+      - name: Prepare merged jars and modules dir (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir
-      - name: Build dmg (macos)
+      - name: Build dmg (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
         run: |
@@ -182,7 +182,7 @@ jobs:
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services
-      - name: Build pkg (macos)
+      - name: Build pkg (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
         run: |
@@ -205,7 +205,7 @@ jobs:
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services
-      - name: Package application image (non-macos)
+      - name: Package application image (non-macOS)
         if: (matrix.os != 'macos-latest')
         shell: bash
         run: ${{ matrix.archivePortable }}
@@ -237,13 +237,13 @@ jobs:
           ssh_options: '-p 9922'
           src: 'build/distribution/'
           dest: jrrsync@build-upload.jabref.org:/var/www/builds.jabref.org/www/${{ steps.gitversion.outputs.branchName }}/
-      - name: Upload to GitHub workflow artifacts store (windows)
+      - name: Upload to GitHub workflow artifacts store (Windows)
         if: (matrix.os == 'windows-latest') && (!startsWith(github.ref, 'refs/heads/gh-readonly-queue'))
         uses: actions/upload-artifact@v3
         with:
           name: jabref-${{ matrix.displayName }}
           path: build/distribution
-      - name: Upload to GitHub workflow artifacts store (macos)
+      - name: Upload to GitHub workflow artifacts store (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES') && (!startsWith(github.ref, 'refs/heads/gh-readonly-queue'))
         uses: actions/upload-artifact@v3
         with:
@@ -251,7 +251,7 @@ jobs:
           name: jabref-macos-tbn
           path: build/distribution
   notarize: # outsourced in a separate job to be able to rerun if this fails for timeouts
-    name: Notarize and package Mac OS binaries
+    name: Notarize and package macOS binaries
     runs-on: macos-latest
     needs: [build]
     if: ${{ !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
@@ -348,19 +348,19 @@ jobs:
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Get windows binaries
+      - name: Get Windows binaries
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: actions/download-artifact@master
         with:
           name: jabref-windows
           path: build/distribution
-      - name: Get macos binaries unsigned
+      - name: Get macOS binaries unsigned
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (inputs.notarization == false && !startsWith(github.ref, 'refs/tags/'))
         uses: actions/download-artifact@master
         with:
           name: jabref-macos-tbn
           path: build/distribution/
-      - name: Get macos binaries notarized
+      - name: Get macOS binaries notarized
         if: (steps.checksecrets.outputs.secretspresent == 'YES') && (inputs.notarization == true || startsWith(github.ref, 'refs/tags/'))
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -283,7 +283,7 @@ jobs:
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.10.2
-      - name: Get macos binaries
+      - name: Get macOS binaries
         if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: actions/download-artifact@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ snap/.snapcraft/
 
 # flatpak
 flatpak/.buildconfig
+flatpak/jabref-portable_linux.tar.gz
 flatpak/JabRef-portable_linux.tar.gz
 
 # Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -554,7 +554,7 @@ jpackage.dependsOn deleteInstallerTemp
 jlink {
     addOptions('--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages')
     launcher {
-        name = 'JabRef'
+        name = 'jabref'
     }
 
     addOptions("--bind-services")
@@ -627,7 +627,7 @@ jlink {
                     '--icon', "${projectDir}/src/main/resources/icons/jabref.ico",
             ]
             installerOptions = [
-                    '--vendor', 'JabRef',
+                    '--vendor', 'JabRef e.V.',
                     '--app-version', "${project.version}",
                     '--verbose',
                     '--win-upgrade-uuid', 'd636b4ee-6f10-451e-bf57-c89656780e36',
@@ -649,7 +649,7 @@ jlink {
             ]
             installerOptions = [
                     '--verbose',
-                    '--vendor', 'JabRef',
+                    '--vendor', 'JabRef e.V.',
                     '--app-version', "${project.version}",
                     // '--temp', "$buildDir/installer",
                     '--resource-dir', "${projectDir}/buildres/linux",
@@ -688,7 +688,7 @@ if (OperatingSystem.current().isWindows()) {
             from("${projectDir}/buildres/windows") {
                 include "jabref-firefox.json", "jabref-chrome.json", "JabRefHost.bat", "JabRefHost.ps1"
             }
-            into "$buildDir/distribution/JabRef"
+            into "$buildDir/distribution/jabref"
         }
     }
 }
@@ -699,7 +699,7 @@ if (OperatingSystem.current().isLinux()) {
             from("${projectDir}/buildres/linux") {
                 include "native-messaging-host/**", "jabrefHost.py"
             }
-            into "$buildDir/distribution/JabRef/lib"
+            into "$buildDir/distribution/jabref/lib"
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,4 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
-rootProject.name = "JabRef"
+rootProject.name = "jabref"


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/10338.

We either need this fix - or add an explanation in the documentation how to "properly" check out the code to have IntelliJ working (one commit in https://github.com/JabRef/jabref/pull/10322 does this).

Since I more want to have the guideline "intuitive", I would like to have this change in.

The installer file names and the startup scripts will be all-lowercase now. Which I kind of like. (`bin/jabref` instead of `bin/JabRef`)

Update casing of "JabRef"

- Lowercase "jabref" in scripts and binary names
- Change vendor to JabRef e.V.
- Case "mac-package-identifier" to "JabRef"
- Group macos steps together

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
