### PR TITLE
Add "--verbose" to MV generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
 
     id 'idea'
 
-    id 'org.openrewrite.rewrite' version '6.3.2'
+    id 'org.openrewrite.rewrite' version '6.3.3'
 }
 
 // Enable following for debugging

--- a/src/main/java/org/jabref/cli/JournalListMvGenerator.java
+++ b/src/main/java/org/jabref/cli/JournalListMvGenerator.java
@@ -19,7 +19,7 @@ import org.jooq.lambda.Unchecked;
 public class JournalListMvGenerator {
 
     public static void main(String[] args) throws IOException {
-        boolean verbose = (args.length == 1) && (args[0].equals("--verbose"));
+        boolean verbose = (args.length == 1) && ("--verbose".equals(args[0]));
 
         Path abbreviationsDirectory = Path.of("buildres", "abbrv.jabref.org", "journals");
         if (!Files.exists(abbreviationsDirectory)) {

--- a/src/main/java/org/jabref/cli/JournalListMvGenerator.java
+++ b/src/main/java/org/jabref/cli/JournalListMvGenerator.java
@@ -19,6 +19,8 @@ import org.jooq.lambda.Unchecked;
 public class JournalListMvGenerator {
 
     public static void main(String[] args) throws IOException {
+        boolean verbose = (args.length == 1) && (args[0].equals("--verbose"));
+
         Path abbreviationsDirectory = Path.of("buildres", "abbrv.jabref.org", "journals");
         if (!Files.exists(abbreviationsDirectory)) {
             System.out.println("Path " + abbreviationsDirectory.toAbsolutePath() + " does not exist");
@@ -66,7 +68,9 @@ public class JournalListMvGenerator {
                                     Abbreviation::getName,
                                     abbreviation -> abbreviation,
                                     (abbreviation1, abbreviation2) -> {
-                                        System.out.println("Double entry " + abbreviation1.getName());
+                                        if (verbose) {
+                                            System.out.println("Double entry " + abbreviation1.getName());
+                                        }
                                         return abbreviation2;
                                     }));
                     fullToAbbreviation.putAll(abbreviationMap);


### PR DESCRIPTION
I got annoyed by the duplicate warnings. Not that important so that we should see it at every test. Thus, I muted that.

The clean "fix" is proposed at https://github.com/JabRef/abbrv.jabref.org/issues/149.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
