### PR TITLE
Add good linting of CHANGELOG.md

### DIFF
--- a/.github/heylogs.java
+++ b/.github/heylogs.java
@@ -1,0 +1,6 @@
+//DEPS com.github.nbbrd.heylogs:heylogs-cli:0.6.0
+public class heylogs {
+    public static void main(String... args) throws Exception {
+        nbbrd.heylogs.cli.HeylogsCommand.main(args);
+    }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,8 +87,7 @@ jobs:
           set -e
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
-          jbang --version
-          jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check CHANGELOG.md > heylogs.txt
+          jbang .github/heylogs.java check CHANGELOG.md > heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
           awk '$0 ~ "7 problems" { exit 1; }' < heylogs.txt
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,14 @@ jobs:
         with:
           args: CHANGELOG.md CONTRIBUTING.md README.md
           config: '.markdownlint.yml'
+      - name: Lint CHANGELOG.md
+        run: |
+          set -e
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          source ~/.zshrc
+          jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check CHANGELOG.md > build/heylogs.txt
+          # We have 7 "valid" issues in CHANGELOG.md
+          awk '$0 ~ "7 problems" { exit 1; }' < build/heylogs.txt
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,9 +87,10 @@ jobs:
           set -e
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
-          jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check CHANGELOG.md > build/heylogs.txt
+          jband --version
+          jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check CHANGELOG.md > heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
-          awk '$0 ~ "7 problems" { exit 1; }' < build/heylogs.txt
+          awk '$0 ~ "7 problems" { exit 1; }' < heylogs.txt
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
           set -e
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
-          jband --version
+          jbang --version
           jbang https://raw.githubusercontent.com/nbbrd/jbang-catalog/master/heylogs.java check CHANGELOG.md > heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
           awk '$0 ~ "7 problems" { exit 1; }' < heylogs.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,15 @@ jobs:
           # enable failing of this task if modernizer complains
           sed -i "s/failOnViolations = false/failOnViolations = true/" build.gradle
           ./gradlew modernizer
+  markdown-checks:
+    name: Markdown style check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: 'false'
+          show-progress: 'false'
       - name: Run markdown-lint
         uses: avto-dev/markdown-lint@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
           jbang .github/heylogs.java check CHANGELOG.md > heylogs.txt
+          cat heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
           awk '$0 ~ "7 problems" { exit 1; }' < heylogs.txt
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,7 @@ jobs:
           jbang .github/heylogs.java check CHANGELOG.md > heylogs.txt
           cat heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
-          awk '$0 ~ "7 problems" { exit 1; }' < heylogs.txt
+          grep -q "7 problems" heylogs.txt || exit 1
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - It is possible again to use "current table sort order" for the order of entries when saving. [#9869](https://github.com/JabRef/jabref/issues/9869)
 - Passwords can be stored in GNOME key ring. [#10274](https://github.com/JabRef/jabref/issues/10274)
-- We fixed an issue were  groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10352)
+- We fixed an issue where groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10350)
 
 ### Removed
 

--- a/config/checkstyle/checkstyle_reviewdog.xml
+++ b/config/checkstyle/checkstyle_reviewdog.xml
@@ -15,7 +15,7 @@
     </module>
 
     <module name="BeforeExecutionExclusionFileFilter">
-        <property name="fileNamePattern" value="module\-info\.java$"/>
+        <property name="fileNamePattern" value="(module\-info|heylogs)\.java$"/>
     </module>
 
     <module name="FileTabCharacter"/>


### PR DESCRIPTION
[heylogs](https://github.com/nbbrd/heylogs) is IMHO a great linter for CHANGELOG.md files. This PR adds check for it.

Example:

Faililng check:

![image](https://github.com/JabRef/jabref/assets/1366654/e2e0b4da-9212-40a2-83b9-e85b2c4f4479)

After fixing the CHANGELOG.md file (refs https://github.com/JabRef/jabref/pull/10351)

![image](https://github.com/JabRef/jabref/assets/1366654/92db0638-1a43-4ac2-b002-e1c86c437901)

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
