### PR TITLE
Remove "wrong" CHANGELOG.md heading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,8 +89,8 @@ jobs:
           source ~/.zshrc
           jbang .github/heylogs.java check CHANGELOG.md > heylogs.txt
           cat heylogs.txt
-          # We have 7 "valid" issues in CHANGELOG.md
-          grep -q "7 problems" heylogs.txt || exit 1
+          # We have 6 "valid" issues in CHANGELOG.md
+          grep -q "6 problems" heylogs.txt || exit 1
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#NUM`.
 In case, there is no issue present, the pull request implementing the feature is linked.
-
-Note that this project **does not** adhere to [Semantic Versioning](https://semver.org/).
+This changelog lists all changes of the 5.x series of JabRef.
+The changelog of JabRef 4.x is available at the [v4.3.1 tag](https://github.com/JabRef/jabref/blob/v4.3.1/CHANGELOG.md).
 
 ## [Unreleased]
 
@@ -1125,12 +1125,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
   - Copy linked files to folder: available through File menu
   - Add/move/remove from group: removed completely (functionality still available through group interface)
 - We removed the option to change the column widths in the preferences dialog. [#4546](https://github.com/JabRef/jabref/issues/4546)
-
-## Older versions
-
-The changelog of JabRef 4.x is available at the [v4.3.1 tag](https://github.com/JabRef/jabref/blob/v4.3.1/CHANGELOG.md).
-The changelog of JabRef 3.x is available at the [v3.8.2 tag](https://github.com/JabRef/jabref/blob/v3.8.2/CHANGELOG.md).
-The changelog of JabRef 2.11 and all previous versions is available as [text file in the v2.11.1 tag](https://github.com/JabRef/jabref/blob/v2.11.1/CHANGELOG).
 
 [Unreleased]: https://github.com/JabRef/jabref/compare/v5.10...HEAD
 [5.10]: https://github.com/JabRef/jabref/compare/v5.9...v5.10


### PR DESCRIPTION
Inspired by uberspace's CHANGELOG, I put the link to the older version on top (and got rid off the `Older Versions` heading). (https://manual.uberspace.de/changelog/)

![image](https://github.com/JabRef/jabref/assets/1366654/d1f9b928-8cd9-4cf6-9fef-fdb6d3d29c9f)

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
