### PR TITLE
Fix automerge PR

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,7 +6,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  automerge:
     runs-on: ubuntu-latest
     if: ${{ (github.actor == 'dependabot[bot]') || (github.actor == 'koppor' && startsWith(github.event.pull_request.title, '[Bot]')) }}
     steps:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-merge
+name: Auto Merge
 on: pull_request
 
 permissions:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,5 +1,5 @@
 name: Auto Merge
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 permissions:
   contents: write
@@ -8,7 +8,7 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: ${{ (github.actor == 'dependabot[bot]') || (github.actor == 'koppor' && startsWith(github.event.pull_request.title, '[Bot]')) }}
+    if: ${{ (github.actor == 'dependabot[bot]') || ((github.actor == 'koppor' || github.actor == 'github-actions') && startsWith(github.event.pull_request.title, '[Bot]')) }}
     steps:
       - name: Approve PR
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
At https://github.com/JabRef/jabref/pull/10387, there was no automerge. Investigating.

I changed the title of the action from "Dependabot auto-merge" to "Auto Merge", because this workflows merges more than dependabot PRs.

The last committer on the journal-list workflow was dependabot (https://github.com/JabRef/jabref/commit/01d019fd783624689dcfcf730bb057a32ca3edda). Thus, the actor is not me, but dependabot.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
