### PR TITLE
Test case for ioob (and some code cleanup)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,12 +92,6 @@ repositories {
 
 configurations {
     antlr4
-    // TODO: Remove the following workaround for split error messages such as
-    // error: module java.xml.bind reads package javax.annotation from both jsr305 and java.annotation
-    compile {
-        extendsFrom implementation
-        exclude group: "javax.activation"
-    }
 }
 
 dependencyLocking {

--- a/build.gradle
+++ b/build.gradle
@@ -302,10 +302,10 @@ tasks.register('generateSource') {
 }
 
 tasks.register("generateBstGrammarSource", JavaExec) {
-    main = "org.antlr.v4.Tool"
-    classpath = configurations.antlr4
     group = "JabRef"
     description = 'Generates BstLexer.java and BstParser.java from the Bst.g grammar file using antlr4.'
+    classpath = configurations.antlr4
+    mainClass = "org.antlr.v4.Tool"
 
     inputs.dir('src/main/antlr4/org/jabref/bst/')
     outputs.dir("src-gen/main/java/org/jabref/logic/bst/")
@@ -316,7 +316,7 @@ tasks.register("generateSearchGrammarSource", JavaExec) {
     group = 'JabRef'
     description = "Generates java files for Search.g antlr4."
     classpath = configurations.antlr4
-    main = "org.antlr.v4.Tool"
+    mainClass = "org.antlr.v4.Tool"
 
     inputs.dir("src/main/antlr4/org/jabref/search/")
     outputs.dir("src-gen/main/java/org/jabref/search/")
@@ -327,7 +327,7 @@ tasks.register("generateJournalAbbreviationList", JavaExec) {
     group = "JabRef"
     description = "Converts the comma-separated journal abbreviation file to a H2 MVStore"
     classpath = sourceSets.main.runtimeClasspath
-    main = "org.jabref.cli.JournalListMvGenerator"
+    mainClass = "org.jabref.cli.JournalListMvGenerator"
 }
 jar.dependsOn "generateJournalAbbreviationList"
 test.dependsOn "generateJournalAbbreviationList"

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -285,7 +285,6 @@ public class SourceTab extends EntryEditorTab {
 
             if (parserResult.hasWarnings()) {
                 // put the warning into as exception text -> it will be displayed to the user
-
                 throw new IllegalStateException(parserResult.getErrorMessage());
             }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/AbstractEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/AbstractEditorViewModel.java
@@ -65,8 +65,7 @@ public class AbstractEditorViewModel extends AbstractViewModel {
                 fieldBinding,
                 newValue -> {
                     if (newValue != null) {
-                        // Controlsfx uses hardcoded \n for multiline fields, but JabRef stores them in OS Newlines format
-                        String oldValue = entry.getField(field).map(value -> value.replace(OS.NEWLINE, "\n").trim()).orElse(null);
+                        String oldValue = entry.getField(field).map(String::trim).orElse("");
                         // Autosave and save action trigger the entry editor to reload the fields, so we have to
                         // check for changes here, otherwise the cursor position is annoyingly reset every few seconds
                         if (!(newValue.trim()).equals(oldValue)) {

--- a/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -28,7 +28,7 @@ import com.tobiasdiez.easybind.EasyBind;
 
 public class MainTableDataModel {
     private final FilteredList<BibEntryTableViewModel> entriesFiltered;
-    private final SortedList<BibEntryTableViewModel> entriesSorted;
+    private final SortedList<BibEntryTableViewModel> entriesFilteredAndSorted;
     private final ObjectProperty<MainTableFieldValueFormatter> fieldValueFormatter;
     private final GroupsPreferences groupsPreferences;
     private final NameDisplayPreferences nameDisplayPreferences;
@@ -57,7 +57,7 @@ public class MainTableDataModel {
         resultSize.bind(Bindings.size(entriesFiltered));
         stateManager.setActiveSearchResultSize(context, resultSize);
         // We need to wrap the list since otherwise sorting in the table does not work
-        entriesSorted = new SortedList<>(entriesFiltered);
+        entriesFilteredAndSorted = new SortedList<>(entriesFiltered);
     }
 
     private boolean isMatched(ObservableList<GroupTreeNode> groups, Optional<SearchQuery> query, BibEntryTableViewModel entry) {
@@ -93,7 +93,7 @@ public class MainTableDataModel {
     }
 
     public SortedList<BibEntryTableViewModel> getEntriesFilteredAndSorted() {
-        return entriesSorted;
+        return entriesFilteredAndSorted;
     }
 
     public void refresh() {

--- a/src/main/java/org/jabref/gui/maintable/PersistenceVisualStateTable.java
+++ b/src/main/java/org/jabref/gui/maintable/PersistenceVisualStateTable.java
@@ -49,8 +49,9 @@ public class PersistenceVisualStateTable {
      * {@link org.jabref.preferences.JabRefPreferences#getColumnSortTypesAsStringList(ColumnPreferences)}
      */
     private void updateColumns() {
-        LOGGER.debug("Updating columns");
-        preferences.setColumns(toList(table.getColumns()));
+        List<MainTableColumnModel> list = toList(table.getColumns());
+        LOGGER.debug("Updating columns to {}", list);
+        preferences.setColumns(list);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
+++ b/src/main/java/org/jabref/logic/bibtex/comparator/EntryComparator.java
@@ -99,12 +99,12 @@ public class EntryComparator implements Comparator<BibEntry> {
             if (f1 == null) {
                 return next == null ? idCompare(e1, e2) : next.compare(e1, e2);
             } else {
-                return -1;
+                return 1;
             }
         }
 
         if (f1 == null) { // f2 != null here automatically
-            return 1;
+            return -1;
         }
 
         int result;

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -80,12 +80,12 @@ public class BibDatabase {
     }
 
     /**
+     * Returns a text with references resolved according to an optionally given database.
+     *
      * @param toResolve maybenull The text to resolve.
      * @param database  maybenull The database to use for resolving the text.
      * @return The resolved text or the original text if either the text or the database are null
      * @deprecated use  {@link BibDatabase#resolveForStrings(String)}
-     * <p>
-     * Returns a text with references resolved according to an optionally given database.
      */
     @Deprecated
     public static String getText(String toResolve, BibDatabase database) {
@@ -176,11 +176,6 @@ public class BibDatabase {
         return result;
     }
 
-    /**
-     * Inserts the entry.
-     *
-     * @param entry entry to insert
-     */
     public synchronized void insertEntry(BibEntry entry) {
         insertEntry(entry, EntriesEventSource.LOCAL);
     }

--- a/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
+++ b/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
@@ -1,0 +1,45 @@
+package org.jabref.gui.maintable;
+
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+
+import org.jabref.logic.bibtex.comparator.EntryComparator;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+
+import com.tobiasdiez.easybind.EasyBind;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MainTableDataModelTest {
+
+    @Test
+    void additionToObersvableMapTriggersUpdate() {
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
+        ObservableList<BibEntry> entries = FXCollections.synchronizedObservableList(FXCollections.observableArrayList(BibEntry::getObservables));
+        ObservableList<BibEntry> allEntries = FXCollections.unmodifiableObservableList(entries);
+        NameDisplayPreferences nameDisplayPreferences = new NameDisplayPreferences(NameDisplayPreferences.DisplayStyle.AS_IS, NameDisplayPreferences.AbbreviationStyle.FULL);
+        SimpleObjectProperty<MainTableFieldValueFormatter> fieldValueFormatter = new SimpleObjectProperty<>(new MainTableFieldValueFormatter(nameDisplayPreferences, bibDatabaseContext));
+        ObservableList<BibEntryTableViewModel> entriesViewModel = EasyBind.mapBacked(allEntries, entry ->
+                new BibEntryTableViewModel(entry, bibDatabaseContext, fieldValueFormatter));
+        FilteredList<BibEntryTableViewModel> entriesFiltered = new FilteredList<>(entriesViewModel);
+        IntegerProperty resultSize = new SimpleIntegerProperty();
+        resultSize.bind(Bindings.size(entriesFiltered));
+        SortedList<BibEntryTableViewModel> entriesFilteredAndSorted = new SortedList<>(entriesFiltered);
+        EntryComparator entryComparator = new EntryComparator(false, false, StandardField.AUTHOR);
+        entriesFilteredAndSorted.setComparator((o1, o2) -> entryComparator.compare(o1.getEntry(), o2.getEntry()));
+
+        BibEntry bibEntry = new BibEntry().withField(StandardField.AUTHOR, "Test");
+        entries.add(bibEntry);
+        bibEntry.setField(StandardField.YEAR, "2023");
+    }
+}

--- a/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/comparator/EntryComparatorTest.java
@@ -47,7 +47,7 @@ class EntryComparatorTest {
                 .withField(StandardField.COMMENTATOR, "Some Commentator");
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.TITLE);
 
-        assertEquals(-1, entryComparator.compare(entry1, entry2));
+        assertEquals(1, entryComparator.compare(entry1, entry2));
     }
 
     @Test
@@ -59,7 +59,7 @@ class EntryComparatorTest {
 
         EntryComparator entryComparator = new EntryComparator(false, false, StandardField.TITLE);
 
-        assertEquals(1, entryComparator.compare(entry1, entry2));
+        assertEquals(-1, entryComparator.compare(entry1, entry2));
     }
 
     @Test
@@ -89,8 +89,8 @@ class EntryComparatorTest {
         BibEntry e1 = new BibEntry()
                 .withCitationKey("Mayer2019b");
         BibEntry e2 = new BibEntry();
-        assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
-        assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
+        assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
+        assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }
 
     @Test
@@ -99,8 +99,8 @@ class EntryComparatorTest {
                 .withCitationKey("Mayer2019b");
         BibEntry e2 = new BibEntry()
                 .withCitationKey(" ");
-        assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
-        assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
+        assertEquals(1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e1, e2));
+        assertEquals(-1, new EntryComparator(false, false, InternalField.KEY_FIELD).compare(e2, e1));
     }
 
     @Test
@@ -131,7 +131,7 @@ class EntryComparatorTest {
     }
 
     @Test
-    void testPresentFieldsWithoutKeyField() {
+    void withAuthorIsBeforeWithEmptyAuthorWhenSortingWithNonExistentKey() {
         BibEntry e1 = new BibEntry()
             .withField(StandardField.AUTHOR, "Stephen King");
         BibEntry e2 = new BibEntry()
@@ -140,12 +140,20 @@ class EntryComparatorTest {
     }
 
     @Test
-    void testPresentFieldsWithKeyField() {
+    void withAuthorIsBeforeEmptyAuthorWhenSortingWithAuthor() {
         BibEntry e1 = new BibEntry()
             .withField(StandardField.AUTHOR, "Stephen King");
         BibEntry e2 = new BibEntry()
             .withField(StandardField.AUTHOR, "");
         assertEquals(-1, new EntryComparator(true, false, StandardField.AUTHOR).compare(e1, e2));
+    }
+
+    @Test
+    void withAuthorIsBeforeWithoutAuthorWhenSortingWithAuthor() {
+        BibEntry e1 = new BibEntry()
+            .withField(StandardField.AUTHOR, "Stephen King");
+        BibEntry e2 = new BibEntry();
+        assertEquals(1, new EntryComparator(false, false, StandardField.AUTHOR).compare(e1, e2));
     }
 }
 


### PR DESCRIPTION
This adds `src/test/java/org/jabref/gui/maintable/MainTableDataModelTest` for checking that in a "controlled" environment, all listeners are installed correctly. - It is a copy of the UI code. However, in JabRef, the UI does not behave the same.

While I was on it, some minor code improvements were made.

Follow up to https://github.com/JabRef/jabref/pull/10389


### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
