### PR TITLE
Fix fetcher worker execution on background thread

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -92,15 +92,15 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         btnGenerate.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> searching ? Localization.lang("Searching...") : Localization.lang("Generate")));
         btnGenerate.disableProperty().bind(viewModel.idFieldValidationStatus().validProperty().not().or(viewModel.searchingProperty()));
 
-        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), value -> {
-            if (value) {
+        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), isSuccessFull -> {
+            if (isSuccessFull) {
                 setEntryTypeForReturnAndClose(Optional.empty());
             }
         });
     }
 
-    private void addEntriesToPane(FlowPane pane, Collection<? extends BibEntryType> entries) {
-        for (BibEntryType entryType : entries) {
+    private void addEntriesToPane(FlowPane pane, Collection<? extends BibEntryType> entryTypes) {
+        for (BibEntryType entryType : entryTypes) {
             Button entryButton = new Button(entryType.getType().getDisplayName());
             entryButton.setUserData(entryType);
             entryButton.setOnAction(event -> setEntryTypeForReturnAndClose(Optional.of(entryType)));

--- a/src/main/java/org/jabref/gui/EntryTypeView.java
+++ b/src/main/java/org/jabref/gui/EntryTypeView.java
@@ -92,8 +92,8 @@ public class EntryTypeView extends BaseDialog<EntryType> {
         btnGenerate.textProperty().bind(EasyBind.map(viewModel.searchingProperty(), searching -> searching ? Localization.lang("Searching...") : Localization.lang("Generate")));
         btnGenerate.disableProperty().bind(viewModel.idFieldValidationStatus().validProperty().not().or(viewModel.searchingProperty()));
 
-        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), isSuccessFull -> {
-            if (isSuccessFull) {
+        EasyBind.subscribe(viewModel.searchSuccesfulProperty(), isSuccessful -> {
+            if (isSuccessful) {
                 setEntryTypeForReturnAndClose(Optional.empty());
             }
         });

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -16,6 +16,7 @@ import javafx.concurrent.Worker;
 
 import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.importer.NewEntryAction;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.importer.FetcherClientException;
 import org.jabref.logic.importer.FetcherException;
@@ -24,6 +25,7 @@ import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.layout.format.Default;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.strings.StringUtil;
@@ -131,7 +133,6 @@ public class EntryTypeViewModel {
 
         @Override
         protected Optional<BibEntry> call() throws FetcherException {
-            searchingProperty().setValue(true);
             storeSelectedFetcher();
             fetcher = selectedItemProperty().getValue();
             searchID = idText.getValue();
@@ -144,7 +145,8 @@ public class EntryTypeViewModel {
 
     public void runFetcherWorker() {
         searchSuccesfulProperty.set(false);
-        fetcherWorker.run();
+        searchingProperty().setValue(true);
+        taskExecutor.execute(fetcherWorker);
         fetcherWorker.setOnFailed(event -> {
             Throwable exception = fetcherWorker.getException();
             String fetcherExceptionMessage = exception.getMessage();

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -16,7 +16,6 @@ import javafx.concurrent.Worker;
 
 import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.importer.NewEntryAction;
-import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.importer.FetcherClientException;
 import org.jabref.logic.importer.FetcherException;
@@ -25,7 +24,6 @@ import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.layout.format.Default;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.strings.StringUtil;

--- a/src/main/java/org/jabref/gui/EntryTypeViewModel.java
+++ b/src/main/java/org/jabref/gui/EntryTypeViewModel.java
@@ -142,10 +142,10 @@ public class EntryTypeViewModel {
     }
 
     public void runFetcherWorker() {
-        searchSuccesfulProperty.set(false);
-        searchingProperty().setValue(true);
-        taskExecutor.execute(fetcherWorker);
+        fetcherWorker.setOnRunning(event -> searchingProperty().setValue(true));
+
         fetcherWorker.setOnFailed(event -> {
+            searchSuccesfulProperty.set(false);
             Throwable exception = fetcherWorker.getException();
             String fetcherExceptionMessage = exception.getMessage();
             String fetcher = selectedItemProperty().getValue().getName();
@@ -159,7 +159,7 @@ public class EntryTypeViewModel {
                 dialogService.showInformationDialogAndWait(Localization.lang("Failed to import by ID"), Localization.lang("Error message %0", fetcherExceptionMessage));
             }
 
-            LOGGER.error(String.format("Exception during fetching when using fetcher '%s' with entry id '%s'.", fetcher, searchId), exception);
+            LOGGER.error("Exception during fetching when using fetcher '{}' with entry id '{}'.", fetcher, searchId, exception);
 
             searchingProperty.set(false);
             fetcherWorker = new FetcherWorker();
@@ -204,10 +204,11 @@ public class EntryTypeViewModel {
                     searchSuccesfulProperty.set(true);
                 }
             }
-            fetcherWorker = new FetcherWorker();
 
             focusAndSelectAllProperty.set(true);
-            searchingProperty().setValue(false);
+            searchingProperty().set(false);
+            fetcherWorker = new FetcherWorker();
         });
+        taskExecutor.execute(fetcherWorker);
     }
 }


### PR DESCRIPTION
Import by ID in new entry was running on the FX thread (wtf?)  

Came up in the forum https://discourse.jabref.org/t/jabref-5-10-not-allowing-citations-to-be-added-into-sub-groups-with-right-click/3990/11?u=siedlerchr

<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
