### PR TITLE
Exclude check for ampersand (&) at verbatim fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,12 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - The export formats `listrefs`, `tablerefs`, `tablerefsabsbib`, now use the ISO date format in the footer [#10383](https://github.com/JabRef/jabref/pull/10383).
 - When searching for an identifier in the "Web search", the title of the search window is now "Identifier-based Web Search". [#10391](https://github.com/JabRef/jabref/pull/10391)
+- The ampersand checker now skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 
 ### Fixed
 
 - It is possible again to use "current table sort order" for the order of entries when saving. [#9869](https://github.com/JabRef/jabref/issues/9869)
 - Passwords can be stored in GNOME key ring. [#10274](https://github.com/JabRef/jabref/issues/10274)
-- The ampersand checker skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 - We fixed an issue where groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10350)
 - We fixed an issue where the JabRef browser extension could not communicate with JabRef under macOS due to missing files. You should use the `.pkg` for the first installation as it updates all necessary files for the extension [#10308](https://github.com/JabRef/jabref/issues/10308)
 - We fixed an issue where the ISBN fetcher returned the entrytype `misc` for certain ISBN numbers [#10348](https://github.com/JabRef/jabref/issues/10348)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - It is possible again to use "current table sort order" for the order of entries when saving. [#9869](https://github.com/JabRef/jabref/issues/9869)
 - Passwords can be stored in GNOME key ring. [#10274](https://github.com/JabRef/jabref/issues/10274)
+- The ampersand checker skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 - We fixed an issue where groups based on an aux file could not be created due to an exception [#10350](https://github.com/JabRef/jabref/issues/10350)
 - We fixed an issue where the JabRef browser extension could not communicate with JabRef under macOS due to missing files. You should use the `.pkg` for the first installation as it updates all necessary files for the extension [#10308](https://github.com/JabRef/jabref/issues/10308)
 - We fixed an issue where the ISBN fetcher returned the entrytype `misc` for certain ISBN numbers [#10348](https://github.com/JabRef/jabref/issues/10348)

--- a/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
@@ -1,17 +1,16 @@
 package org.jabref.logic.integrity;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
 
 import com.google.common.base.CharMatcher;
+import org.jooq.lambda.tuple.Tuple2;
 
 /**
  * Checks if the BibEntry contains unescaped ampersands.
@@ -23,24 +22,22 @@ public class AmpersandChecker implements EntryChecker {
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        List<IntegrityMessage> results = new ArrayList<>();
-
-        for (Map.Entry<Field, String> field : entry.getFieldMap().entrySet()) {
-            if (field.getKey().getProperties().contains(FieldProperty.VERBATIM)) {
-                continue;
-            }
-            // counts the number of even \ occurrences preceding an &
-            long unescapedAmpersands = BACKSLASH_PRECEDED_AMPERSAND.matcher(field.getValue())
-                    .results()
-                    .map(MatchResult::group)
-                    .filter(m -> CharMatcher.is('\\').countIn(m) % 2 == 0)
-                    .count();
-
-            if (unescapedAmpersands > 0) {
-                results.add(new IntegrityMessage(Localization.lang("Found %0 unescaped '&'", unescapedAmpersands), entry, field.getKey()));
-                // note: when changing the message - also do so in tests
-            }
-        }
-        return results;
+        return entry.getFieldMap().entrySet().stream()
+                    .filter(field -> !field.getKey().getProperties().contains(FieldProperty.VERBATIM))
+                    // We use "flatMap" instead of filtering later, because we assume there won't be that much error messages - and construction of Stream.empty() is faster than construction of a new Tuple2 (including lifting long to Long)
+                    .flatMap(field -> {
+                        // counts the number of even \ occurrences preceding an &
+                        long unescapedAmpersands = BACKSLASH_PRECEDED_AMPERSAND.matcher(field.getValue())
+                                                                               .results()
+                                                                               .map(MatchResult::group)
+                                                                               .filter(m -> CharMatcher.is('\\').countIn(m) % 2 == 0)
+                                                                               .count();
+                        if (unescapedAmpersands == 0) {
+                            return Stream.empty();
+                        }
+                        return Stream.of(new Tuple2<>(field.getKey(), unescapedAmpersands));
+                    })
+                    .map(tuple -> new IntegrityMessage(Localization.lang("Found %0 unescaped '&'", tuple.v2()), entry, tuple.v1()))
+                    .toList();
     }
 }

--- a/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
@@ -1,16 +1,20 @@
 package org.jabref.logic.integrity;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
+
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
 
 import com.google.common.base.CharMatcher;
-import org.jooq.lambda.tuple.Tuple2;
 
 /**
  * Checks if the BibEntry contains unescaped ampersands.
@@ -25,19 +29,23 @@ public class AmpersandChecker implements EntryChecker {
         return entry.getFieldMap().entrySet().stream()
                     .filter(field -> !field.getKey().getProperties().contains(FieldProperty.VERBATIM))
                     // We use "flatMap" instead of filtering later, because we assume there won't be that much error messages - and construction of Stream.empty() is faster than construction of a new Tuple2 (including lifting long to Long)
-                    .flatMap(field -> {
-                        // counts the number of even \ occurrences preceding an &
-                        long unescapedAmpersands = BACKSLASH_PRECEDED_AMPERSAND.matcher(field.getValue())
-                                                                               .results()
-                                                                               .map(MatchResult::group)
-                                                                               .filter(m -> CharMatcher.is('\\').countIn(m) % 2 == 0)
-                                                                               .count();
-                        if (unescapedAmpersands == 0) {
-                            return Stream.empty();
-                        }
-                        return Stream.of(new Tuple2<>(field.getKey(), unescapedAmpersands));
-                    })
-                    .map(tuple -> new IntegrityMessage(Localization.lang("Found %0 unescaped '&'", tuple.v2()), entry, tuple.v1()))
+                    .flatMap(getUnescapedAmpersandsWithCount())
+                    .map(tuple -> new IntegrityMessage(Localization.lang("Found %0 unescaped '&'", tuple.getValue()), entry, tuple.getKey()))
                     .toList();
+    }
+
+    private static Function<Map.Entry<Field, String>, Stream<? extends Pair<Field, Long>>> getUnescapedAmpersandsWithCount() {
+        return field -> {
+            // counts the number of even \ occurrences preceding an &
+            long unescapedAmpersands = BACKSLASH_PRECEDED_AMPERSAND.matcher(field.getValue())
+                                                                   .results()
+                                                                   .map(MatchResult::group)
+                                                                   .filter(m -> CharMatcher.is('\\').countIn(m) % 2 == 0)
+                                                                   .count();
+            if (unescapedAmpersands == 0) {
+                return Stream.empty();
+            }
+            return Stream.of(new Pair<>(field.getKey(), unescapedAmpersands));
+        };
     }
 }

--- a/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
@@ -2,7 +2,6 @@ package org.jabref.logic.integrity;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;

--- a/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/AmpersandChecker.java
@@ -9,11 +9,13 @@ import java.util.regex.Pattern;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldProperty;
 
 import com.google.common.base.CharMatcher;
 
 /**
  * Checks if the BibEntry contains unescaped ampersands.
+ * This is done in nonverbatim fields. Similar to {@link HTMLCharacterChecker}
  */
 public class AmpersandChecker implements EntryChecker {
     // matches for an & preceded by any number of \
@@ -24,6 +26,9 @@ public class AmpersandChecker implements EntryChecker {
         List<IntegrityMessage> results = new ArrayList<>();
 
         for (Map.Entry<Field, String> field : entry.getFieldMap().entrySet()) {
+            if (field.getKey().getProperties().contains(FieldProperty.VERBATIM)) {
+                continue;
+            }
             // counts the number of even \ occurrences preceding an &
             long unescapedAmpersands = BACKSLASH_PRECEDED_AMPERSAND.matcher(field.getValue())
                     .results()

--- a/src/main/java/org/jabref/logic/integrity/HTMLCharacterChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/HTMLCharacterChecker.java
@@ -1,14 +1,10 @@
 package org.jabref.logic.integrity;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
 
 /**
@@ -20,18 +16,10 @@ public class HTMLCharacterChecker implements EntryChecker {
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        List<IntegrityMessage> results = new ArrayList<>();
-        for (Map.Entry<Field, String> field : entry.getFieldMap().entrySet()) {
-            if (field.getKey().getProperties().contains(FieldProperty.VERBATIM)) {
-                continue;
-            }
-
-            Matcher characterMatcher = HTML_CHARACTER_PATTERN.matcher(field.getValue());
-            if (characterMatcher.find()) {
-                results.add(
-                        new IntegrityMessage(Localization.lang("HTML encoded character found"), entry, field.getKey()));
-            }
-        }
-        return results;
+        return entry.getFieldMap().entrySet().stream()
+                    .filter(field -> !field.getKey().getProperties().contains(FieldProperty.VERBATIM))
+                    .filter(field -> HTML_CHARACTER_PATTERN.matcher(field.getValue()).find())
+                    .map(field -> new IntegrityMessage(Localization.lang("HTML encoded character found"), entry, field.getKey()))
+                    .toList();
     }
 }

--- a/src/test/java/org/jabref/logic/integrity/AmpersandCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/AmpersandCheckerTest.java
@@ -65,4 +65,18 @@ public class AmpersandCheckerTest {
         entry.setField(StandardField.AFTERWORD, "May the force be with you & live long \\\\& prosper \\& to infinity \\\\\\& beyond & assemble \\\\\\\\& excelsior!");
         assertEquals(List.of(new IntegrityMessage("Found 4 unescaped '&'", entry, StandardField.AFTERWORD)), checker.check(entry));
     }
+
+    static Stream<Arguments> entryWithVerabitmFieldsNotCausingMessages() {
+        return Stream.of(
+                Arguments.of(StandardField.FILE, "one & another.pdf"),
+                Arguments.of(StandardField.URL, "https://example.org?key=value&key2=value2")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void entryWithVerabitmFieldsNotCausingMessages(Field field, String value) {
+        entry.setField(field, value);
+        assertEquals(List.of(), checker.check(entry));
+    }
 }

--- a/src/test/java/org/jabref/logic/integrity/HTMLCharacterCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/HTMLCharacterCheckerTest.java
@@ -2,11 +2,16 @@ package org.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -58,5 +63,19 @@ public class HTMLCharacterCheckerTest {
     void journalDoesNotAcceptHTMLEncodedCharacters() {
         entry.setField(StandardField.JOURNAL, "&Auml;rling Str&ouml;m for &#8211; &#x2031;");
         assertEquals(List.of(new IntegrityMessage("HTML encoded character found", entry, StandardField.JOURNAL)), checker.check(entry));
+    }
+
+    static Stream<Arguments> entryWithVerabitmFieldsNotCausingMessages() {
+        return Stream.of(
+                Arguments.of(StandardField.FILE, "one &amp; another.pdf"),
+                Arguments.of(StandardField.URL, "https://example.org?key=value&key2=value2")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void entryWithVerabitmFieldsNotCausingMessages(Field field, String value) {
+        entry.setField(field, value);
+        assertEquals(List.of(), checker.check(entry));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/koppor/jabref/issues/585#issuecomment-1735461242

Refs https://github.com/JabRef/jabref/issues/8712#issuecomment-1731114692

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
