### PR TITLE
Fix triggering workflows

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -5,16 +5,10 @@ on:
     - cron: '1 2 1,15 * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   publish:
     name: Refresh Citation Style Language Files
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # for peter-evans/create-pull-request to create branch
-      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: (github.repository == 'JabRef/jabref')
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +46,7 @@ jobs:
           cp buildres/csl/csl-locales/locales-en-US.xml src/main/resources/csl-locales/
       - uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}
           branch: refresh-csl
           title: "[Bot] Update CSL styles"
           commit-message: Update CSL styles

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -5,16 +5,10 @@ on:
     - cron: '1 2 2,16 * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   publish:
     name: Refresh Journal List Files
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # for peter-evans/create-pull-request to create branch
-      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: (github.repository == 'JabRef/jabref')
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +38,7 @@ jobs:
           ./gradlew generateJournalListMV
       - uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}
           branch: update-journal-lists
           title: "[Bot] Update journal abbreviation lists"
           commit-message: Update journal abbreviation lists


### PR DESCRIPTION
On https://github.com/JabRef/jabref/pull/10432, there was no triggering of actions.

Reading https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs, it cannot work with the GITHUB_TOKEN.

Let's try with our token for updating the gradle wrapper.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
