### PR TITLE
Simplify code of LaTeX citations

### DIFF
--- a/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultFileUpdateMonitor.java
@@ -72,7 +72,7 @@ public class DefaultFileUpdateMonitor implements Runnable, FileUpdateMonitor {
             JabRefException exception = new WatchServiceUnavailableException(
                     e.getMessage(), e.getLocalizedMessage(), e.getCause());
             filesystemMonitorFailure.set(Optional.of(exception));
-            LOGGER.warn(exception.getLocalizedMessage(), e);
+            LOGGER.warn("Error during watching", e);
         }
     }
 

--- a/src/main/java/org/jabref/logic/texparser/DefaultLatexParser.java
+++ b/src/main/java/org/jabref/logic/texparser/DefaultLatexParser.java
@@ -77,7 +77,7 @@ public class DefaultLatexParser implements LatexParser {
 
         for (Path file : latexFiles) {
             if (!file.toFile().exists()) {
-                LOGGER.error(String.format("File does not exist: %s", file));
+                LOGGER.error("File does not exist: {}", file);
                 continue;
             }
 
@@ -151,17 +151,15 @@ public class DefaultLatexParser implements LatexParser {
     /**
      * Find inputs and includes along a specific line and store them for parsing later.
      */
-    private void matchNestedFile(Path file, List<Path> texFiles, List<Path> referencedFiles, String line) {
+    private void matchNestedFile(Path texFile, List<Path> texFiles, List<Path> referencedFiles, String line) {
         Matcher includeMatch = INCLUDE_PATTERN.matcher(line);
 
         while (includeMatch.find()) {
-            String include = includeMatch.group(INCLUDE_GROUP);
-
-            Path nestedFile = file.getParent().resolve(
-                    include.endsWith(TEX_EXT)
-                            ? include
-                            : String.format("%s%s", include, TEX_EXT));
-
+            String filenamePassedToInclude = includeMatch.group(INCLUDE_GROUP);
+            String texFileName = filenamePassedToInclude.endsWith(TEX_EXT)
+                    ? filenamePassedToInclude
+                    : String.format("%s%s", filenamePassedToInclude, TEX_EXT);
+            Path nestedFile = texFile.getParent().resolve(texFileName);
             if (nestedFile.toFile().exists() && !texFiles.contains(nestedFile)) {
                 referencedFiles.add(nestedFile);
             }


### PR DESCRIPTION
"LaTeX citations" did not work here. Needed to understand why. While I was on it, I polished the code.

Filed the internal issue https://github.com/JabRef/jabref-issue-melting-pot/issues/298 for a work-around of my issue.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
