### PR TITLE
Close pop over early

### DIFF
--- a/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
+++ b/src/main/java/org/jabref/gui/importer/GenerateEntryFromIdAction.java
@@ -58,7 +58,10 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
         BackgroundTask<Optional<BibEntry>> backgroundTask = searchAndImportEntryInBackground();
         backgroundTask.titleProperty().set(Localization.lang("Import by ID"));
         backgroundTask.showToUser(true);
-        backgroundTask.onRunning(() -> dialogService.notify("%s".formatted(backgroundTask.messageProperty().get())));
+        backgroundTask.onRunning(() -> {
+            entryFromIdPopOver.hide();
+            dialogService.notify("%s".formatted(backgroundTask.messageProperty().get()));
+        });
         backgroundTask.onFailure(exception -> {
             String fetcherExceptionMessage = exception.getMessage();
 
@@ -95,8 +98,6 @@ public class GenerateEntryFromIdAction extends SimpleCommand {
             } else {
                 dialogService.notify("No entry found or import canceled");
             }
-
-            entryFromIdPopOver.hide();
         });
         backgroundTask.executeWith(taskExecutor);
     }


### PR DESCRIPTION
Sometimes on MacOSX, the pop over **sometimes** closes without pressing enter. This is a work around to avoid "duplicate entry" dialog in case of adding a DOI.

Now, when JabRef notifies about the search, the pop over is closed.

Before, the popup was closed after the search (independent of if there was an error or not)

![image](https://github.com/JabRef/jabref/assets/1366654/c3b22b66-6226-441f-b54f-9c90761fd90c)

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
