### PR TITLE
Use .COMMENT instead of outdated .REVIEW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The ampersand checker now skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 - If no existing document is selected for exporting "XMP annotated pdf" JabRef will now create a new PDF file with a sample text and the metadata. [#10102](https://github.com/JabRef/jabref/issues/10102)
 - We modified the DOI cleanup to infer the DOI from an ArXiV ID if it's present. [10426](https://github.com/JabRef/jabref/issues/10426)
-- The Medline importer uses the field `comment` for notes (instead of `review).
+- The ISI importer uses the field `comment` for notes (instead of `review).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The ampersand checker now skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 - If no existing document is selected for exporting "XMP annotated pdf" JabRef will now create a new PDF file with a sample text and the metadata. [#10102](https://github.com/JabRef/jabref/issues/10102)
 - We modified the DOI cleanup to infer the DOI from an ArXiV ID if it's present. [10426](https://github.com/JabRef/jabref/issues/10426)
+- The Medline importer uses the field `comment` for notes (instead of `review).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When searching for an identifier in the "Web search", the title of the search window is now "Identifier-based Web Search". [#10391](https://github.com/JabRef/jabref/pull/10391)
 - The ampersand checker now skips verbatim fields (`file`, `url`, ...). [#10419](https://github.com/JabRef/jabref/pull/10419)
 - If no existing document is selected for exporting "XMP annotated pdf" JabRef will now create a new PDF file with a sample text and the metadata. [#10102](https://github.com/JabRef/jabref/issues/10102)
-- We modified the DOI cleanup to infer the DOI from an ArXiV ID if it's present. [10426](https://github.com/JabRef/jabref/issues/10426)
-- The ISI importer uses the field `comment` for notes (instead of `review).
+- We modified the DOI cleanup to infer the DOI from an ArXiV ID if it's present. [#10426](https://github.com/JabRef/jabref/issues/10426)
+- The ISI importer uses the field `comment` for notes (instead of `review). [#10478](https://github.com/JabRef/jabref/pull/10478)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/IsiImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/IsiImporter.java
@@ -97,7 +97,7 @@ public class IsiImporter extends Importer {
     }
 
     public static void processSubSup(Map<Field, String> map) {
-        Field[] subsup = {StandardField.TITLE, StandardField.ABSTRACT, StandardField.REVIEW, new UnknownField("notes")};
+        Field[] subsup = {StandardField.TITLE, StandardField.ABSTRACT, StandardField.COMMENT, new UnknownField("notes")};
 
         for (Field aSubsup : subsup) {
             if (map.containsKey(aSubsup)) {

--- a/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
@@ -98,9 +98,9 @@ public class IsiImporterTest {
         IsiImporter.processSubSup(subs);
         assertEquals("$_3$", subs.get(StandardField.ABSTRACT));
 
-        subs.put(StandardField.REVIEW, "/sub 31/");
+        subs.put(StandardField.COMMENT, "/sub 31/");
         IsiImporter.processSubSup(subs);
-        assertEquals("$_{31}$", subs.get(StandardField.REVIEW));
+        assertEquals("$_{31}$", subs.get(StandardField.COMMENT));
 
         subs.put(StandardField.TITLE, "/sup 3/");
         IsiImporter.processSubSup(subs);
@@ -114,9 +114,9 @@ public class IsiImporterTest {
         IsiImporter.processSubSup(subs);
         assertEquals("$^3$", subs.get(StandardField.ABSTRACT));
 
-        subs.put(StandardField.REVIEW, "/sup 31/");
+        subs.put(StandardField.COMMENT, "/sup 31/");
         IsiImporter.processSubSup(subs);
-        assertEquals("$^{31}$", subs.get(StandardField.REVIEW));
+        assertEquals("$^{31}$", subs.get(StandardField.COMMENT));
 
         subs.put(StandardField.TITLE, "/sub $Hello/");
         IsiImporter.processSubSup(subs);


### PR DESCRIPTION
The ISI importer used the .REVIEW field which we migrate away on load.

Refs https://github.com/JabRef/jabref/issues/10370

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
