### PR TITLE
fix issue arxiv and eprinttype #10474

### DIFF
--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -90,6 +90,7 @@ public class JabRefDesktop {
             return;
         } else if (StandardField.EPRINT == field) {
             IdentifierParser identifierParser = new IdentifierParser(entry);
+
             link = identifierParser.parse(StandardField.EPRINT)
                                    .flatMap(Identifier::getExternalURI)
                                    .map(URI::toASCIIString)
@@ -97,7 +98,8 @@ public class JabRefDesktop {
 
             if (Objects.equals(link, initialLink)) {
                 Optional<String> eprintTypeOpt = entry.getField(StandardField.EPRINTTYPE);
-                if (eprintTypeOpt.isEmpty()) {
+                Optional<String> archivePrefixOpt = entry.getField(StandardField.ARCHIVEPREFIX);
+                if (eprintTypeOpt.isEmpty() || archivePrefixOpt.isEmpty()) {
                     dialogService.showErrorDialogAndWait(Localization.lang("Unable to open linked eprint. Please set the eprinttype field"));
                 } else {
                     dialogService.showErrorDialogAndWait(Localization.lang("Unable to open linked eprint. Please verify that the eprint field has a valid '%0' id", eprintTypeOpt.get()));

--- a/src/main/java/org/jabref/logic/importer/util/IdentifierParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/IdentifierParser.java
@@ -44,11 +44,21 @@ public class IdentifierParser {
 
     private Optional<? extends Identifier> parseEprint(String eprint) {
         Optional<String> eprintTypeOpt = entry.getField(StandardField.EPRINTTYPE);
+        Optional<String> archivePrefixOpt = entry.getField(StandardField.ARCHIVEPREFIX);
+
         if (eprintTypeOpt.isPresent()) {
             String eprintType = eprintTypeOpt.get();
             if ("arxiv".equalsIgnoreCase(eprintType)) {
                 return ArXivIdentifier.parse(eprint);
             } else if ("ark".equalsIgnoreCase(eprintType)) {
+                return ARK.parse(eprint);
+            }
+        }
+        if (archivePrefixOpt.isPresent()) {
+            String archivePrefix = archivePrefixOpt.get();
+            if ("arxiv".equalsIgnoreCase(archivePrefix)) {
+                return ArXivIdentifier.parse(eprint);
+            } else if ("ark".equalsIgnoreCase(archivePrefix)) {
                 return ARK.parse(eprint);
             }
         }


### PR DESCRIPTION
Fixes #10474 


Short description:
the issue firstly want me to add the 'eprinttype' when we import a new arXiv entry, however later I found that, 'archivePrefix' is used in Bibtex instead of 'eprinttype', so I think it might be caused by 'parseEprint', since the converter change the biblatex to bibtex, the 'eprinttype' will convert to 'archivePrefix', the origin code only parse the 'eprinttype' filed so it will not work, when I try to parse the 'archivePrefix' filed, it succeed to go to that website.

Here is the code I add: 
<img width="718" alt="e0f2c577864daead6857370fa3d0a1b" src="https://github.com/JabRef/jabref/assets/106003523/b3271371-66fd-495e-8f3a-c12c602aaeb7">

so I do not add the eprinttype: arXiv, which is redudant, but fix a bug caused by do not consider the covertion from Biblatex to bibtex.





### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
