### PR TITLE
Add New Group Sorting Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ## [Unreleased]
 
 ### Added
-
+- We added the ability to sort subgroups in Z-A order, as well as in ascending and descending order of subgroups. 
 - We added the possibility to find (and add) papers that cite or are cited by a given paper. [#6187](https://github.com/JabRef/jabref/issues/6187)
 - We added an error-specific message for when a download from a URL fails. [#9826](https://github.com/JabRef/jabref/issues/9826)
 - We added support for customizing the citation command (e.g., `[@key1,@key2]`) when [pushing to external applications](https://docs.jabref.org/cite/pushtoapplications). [#10133](https://github.com/JabRef/jabref/issues/10133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ## [Unreleased]
 
 ### Added
-- We added the ability to sort subgroups in Z-A order, as well as in ascending and descending order of subgroups. 
+
+- We added the ability to sort subgroups in Z-A order, as well as by ascending and descending number of subgroups. [#10249](https://github.com/JabRef/jabref/issues/10249)
 - We added the possibility to find (and add) papers that cite or are cited by a given paper. [#6187](https://github.com/JabRef/jabref/issues/6187)
 - We added an error-specific message for when a download from a URL fails. [#9826](https://github.com/JabRef/jabref/issues/9826)
 - We added support for customizing the citation command (e.g., `[@key1,@key2]`) when [pushing to external applications](https://docs.jabref.org/cite/pushtoapplications). [#10133](https://github.com/JabRef/jabref/issues/10133)

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -188,6 +188,9 @@ public enum StandardActions implements Action {
     GROUP_SUBGROUP_ADD(Localization.lang("Add subgroup")),
     GROUP_SUBGROUP_REMOVE(Localization.lang("Remove subgroups")),
     GROUP_SUBGROUP_SORT(Localization.lang("Sort subgroups A-Z")),
+    GROUP_SUBGROUP_SORT_REVERSE(Localization.lang("Sort subgroups Z-A")),
+    GROUP_SUBGROUP_SORT_SUB(Localization.lang("Sort subgroups by # of groups (Descending)")),
+    GROUP_SUBGROUP_SORT_SUB_REVERSE(Localization.lang("Sort subgroups by # of groups (Ascending)")),
     GROUP_ENTRIES_ADD(Localization.lang("Add selected entries to this group")),
     GROUP_ENTRIES_REMOVE(Localization.lang("Remove selected entries from this group"));
 

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -189,8 +189,8 @@ public enum StandardActions implements Action {
     GROUP_SUBGROUP_REMOVE(Localization.lang("Remove subgroups")),
     GROUP_SUBGROUP_SORT(Localization.lang("Sort subgroups A-Z")),
     GROUP_SUBGROUP_SORT_REVERSE(Localization.lang("Sort subgroups Z-A")),
-    GROUP_SUBGROUP_SORT_SUB(Localization.lang("Sort subgroups by # of groups (Descending)")),
-    GROUP_SUBGROUP_SORT_SUB_REVERSE(Localization.lang("Sort subgroups by # of groups (Ascending)")),
+    GROUP_SUBGROUP_SORT_ENTRIES(Localization.lang("Sort subgroups by # of entries (Descending)")),
+    GROUP_SUBGROUP_SORT_ENTRIES_REVERSE(Localization.lang("Sort subgroups by # of entries (Ascending)")),
     GROUP_ENTRIES_ADD(Localization.lang("Add selected entries to this group")),
     GROUP_ENTRIES_REMOVE(Localization.lang("Remove selected entries from this group"));
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -505,6 +505,9 @@ public class GroupTreeView extends BorderPane {
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_ADD, new ContextAction(StandardActions.GROUP_SUBGROUP_ADD, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_REMOVE, new ContextAction(StandardActions.GROUP_SUBGROUP_REMOVE, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_SUB, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_SUB, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_SUB_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_SUB_REVERSE, group)),
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_ADD, new ContextAction(StandardActions.GROUP_ENTRIES_ADD, group)),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_REMOVE, new ContextAction(StandardActions.GROUP_ENTRIES_REMOVE, group))
@@ -616,6 +619,12 @@ public class GroupTreeView extends BorderPane {
                         viewModel.removeSubgroups(group);
                 case GROUP_SUBGROUP_SORT ->
                         viewModel.sortAlphabeticallyRecursive(group.getGroupNode());
+                case GROUP_SUBGROUP_SORT_REVERSE ->
+                        viewModel.sortReverseAlphabeticallyRecursive(group.getGroupNode());
+                case GROUP_SUBGROUP_SORT_SUB ->
+                        viewModel.sortSubgroupsRecursive(group.getGroupNode());
+                case GROUP_SUBGROUP_SORT_SUB_REVERSE ->
+                        viewModel.sortReverseSubgroupsRecursive(group.getGroupNode());
                 case GROUP_ENTRIES_ADD ->
                         viewModel.addSelectedEntries(group);
                 case GROUP_ENTRIES_REMOVE ->

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -506,8 +506,8 @@ public class GroupTreeView extends BorderPane {
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_REMOVE, new ContextAction(StandardActions.GROUP_SUBGROUP_REMOVE, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_SUB, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_SUB, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_SUB_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_SUB_REVERSE, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, group)),
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_ADD, new ContextAction(StandardActions.GROUP_ENTRIES_ADD, group)),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_REMOVE, new ContextAction(StandardActions.GROUP_ENTRIES_REMOVE, group))
@@ -621,10 +621,10 @@ public class GroupTreeView extends BorderPane {
                         viewModel.sortAlphabeticallyRecursive(group.getGroupNode());
                 case GROUP_SUBGROUP_SORT_REVERSE ->
                         viewModel.sortReverseAlphabeticallyRecursive(group.getGroupNode());
-                case GROUP_SUBGROUP_SORT_SUB ->
-                        viewModel.sortSubgroupsRecursive(group.getGroupNode());
-                case GROUP_SUBGROUP_SORT_SUB_REVERSE ->
-                        viewModel.sortReverseSubgroupsRecursive(group.getGroupNode());
+                case GROUP_SUBGROUP_SORT_ENTRIES ->
+                        viewModel.sortEntriesRecursive(group.getGroupNode());
+                case GROUP_SUBGROUP_SORT_ENTRIES_REVERSE ->
+                        viewModel.sortReverseEntriesRecursive(group.getGroupNode());
                 case GROUP_ENTRIES_ADD ->
                         viewModel.addSelectedEntries(group);
                 case GROUP_ENTRIES_REMOVE ->

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -1,6 +1,11 @@
 package org.jabref.gui.groups;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -29,7 +29,15 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.groups.*;
+import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
+import org.jabref.model.groups.ExplicitGroup;
+import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.groups.RegexKeywordGroup;
+import org.jabref.model.groups.SearchGroup;
+import org.jabref.model.groups.TexGroup;
+import org.jabref.model.groups.WordKeywordGroup;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.preferences.PreferencesService;
 
@@ -565,12 +573,15 @@ public class GroupTreeViewModel extends AbstractViewModel {
     public void sortAlphabeticallyRecursive(GroupTreeNode group) {
         group.sortChildren(compAlphabetIgnoreCase, true);
     }
+
     public void sortReverseAlphabeticallyRecursive(GroupTreeNode group) {
         group.sortChildren(compAlphabetIgnoreCaseReverse, true);
     }
+
     public void sortSubgroupsRecursive(GroupTreeNode group) {
         group.sortChildren(compSubGroup, true);
     }
+
     public void sortReverseSubgroupsRecursive(GroupTreeNode group) {
         group.sortChildren(compSubGroupReverse, true);
     }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -60,12 +60,12 @@ public class GroupTreeViewModel extends AbstractViewModel {
     private final Comparator<GroupTreeNode> compAlphabetIgnoreCaseReverse = (GroupTreeNode v1, GroupTreeNode v2) -> v2
             .getName()
             .compareToIgnoreCase(v1.getName());
-    private final Comparator<GroupTreeNode> compSubGroup = (GroupTreeNode v1, GroupTreeNode v2) -> {
+    private final Comparator<GroupTreeNode> compEntries = (GroupTreeNode v1, GroupTreeNode v2) -> {
         int numChildren1 = v1.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         int numChildren2 = v2.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         return Integer.compare(numChildren2, numChildren1);
     };
-    private final Comparator<GroupTreeNode> compSubGroupReverse = (GroupTreeNode v1, GroupTreeNode v2) -> {
+    private final Comparator<GroupTreeNode> compEntriesReverse = (GroupTreeNode v1, GroupTreeNode v2) -> {
         int numChildren1 = v1.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         int numChildren2 = v2.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         return Integer.compare(numChildren1, numChildren2);
@@ -578,11 +578,11 @@ public class GroupTreeViewModel extends AbstractViewModel {
         group.sortChildren(compAlphabetIgnoreCaseReverse, true);
     }
 
-    public void sortSubgroupsRecursive(GroupTreeNode group) {
-        group.sortChildren(compSubGroup, true);
+    public void sortEntriesRecursive(GroupTreeNode group) {
+        group.sortChildren(compEntries, true);
     }
 
-    public void sortReverseSubgroupsRecursive(GroupTreeNode group) {
-        group.sortChildren(compSubGroupReverse, true);
+    public void sortReverseEntriesRecursive(GroupTreeNode group) {
+        group.sortChildren(compEntriesReverse, true);
     }
 }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -1,11 +1,6 @@
 package org.jabref.gui.groups;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -61,13 +56,13 @@ public class GroupTreeViewModel extends AbstractViewModel {
             .getName()
             .compareToIgnoreCase(v1.getName());
     private final Comparator<GroupTreeNode> compSubGroup = (GroupTreeNode v1, GroupTreeNode v2) -> {
-        int numChildren1 = v1.getNumberOfChildren();
-        int numChildren2 = v2.getNumberOfChildren();
+        int numChildren1 = v1.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
+        int numChildren2 = v2.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         return Integer.compare(numChildren2, numChildren1);
     };
     private final Comparator<GroupTreeNode> compSubGroupReverse = (GroupTreeNode v1, GroupTreeNode v2) -> {
-        int numChildren1 = v1.getNumberOfChildren();
-        int numChildren2 = v2.getNumberOfChildren();
+        int numChildren1 = v1.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
+        int numChildren2 = v2.getEntriesInGroup(this.currentDatabase.get().getEntries()).size();
         return Integer.compare(numChildren1, numChildren2);
     };
     private Optional<BibDatabaseContext> currentDatabase = Optional.empty();

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -29,15 +29,7 @@ import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.groups.AbstractGroup;
-import org.jabref.model.groups.AutomaticKeywordGroup;
-import org.jabref.model.groups.AutomaticPersonsGroup;
-import org.jabref.model.groups.ExplicitGroup;
-import org.jabref.model.groups.GroupTreeNode;
-import org.jabref.model.groups.RegexKeywordGroup;
-import org.jabref.model.groups.SearchGroup;
-import org.jabref.model.groups.TexGroup;
-import org.jabref.model.groups.WordKeywordGroup;
+import org.jabref.model.groups.*;
 import org.jabref.model.metadata.MetaData;
 import org.jabref.preferences.PreferencesService;
 
@@ -57,6 +49,19 @@ public class GroupTreeViewModel extends AbstractViewModel {
     private final Comparator<GroupTreeNode> compAlphabetIgnoreCase = (GroupTreeNode v1, GroupTreeNode v2) -> v1
             .getName()
             .compareToIgnoreCase(v2.getName());
+    private final Comparator<GroupTreeNode> compAlphabetIgnoreCaseReverse = (GroupTreeNode v1, GroupTreeNode v2) -> v2
+            .getName()
+            .compareToIgnoreCase(v1.getName());
+    private final Comparator<GroupTreeNode> compSubGroup = (GroupTreeNode v1, GroupTreeNode v2) -> {
+        int numChildren1 = v1.getNumberOfChildren();
+        int numChildren2 = v2.getNumberOfChildren();
+        return Integer.compare(numChildren2, numChildren1);
+    };
+    private final Comparator<GroupTreeNode> compSubGroupReverse = (GroupTreeNode v1, GroupTreeNode v2) -> {
+        int numChildren1 = v1.getNumberOfChildren();
+        int numChildren2 = v2.getNumberOfChildren();
+        return Integer.compare(numChildren1, numChildren2);
+    };
     private Optional<BibDatabaseContext> currentDatabase = Optional.empty();
 
     public GroupTreeViewModel(StateManager stateManager, DialogService dialogService, PreferencesService preferencesService, TaskExecutor taskExecutor, CustomLocalDragboard localDragboard) {
@@ -145,8 +150,8 @@ public class GroupTreeViewModel extends AbstractViewModel {
             }
             selectedGroups.setAll(
                     stateManager.getSelectedGroup(newDatabase.get()).stream()
-                                .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup, localDragboard, preferences))
-                                .collect(Collectors.toList()));
+                            .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup, localDragboard, preferences))
+                            .collect(Collectors.toList()));
         } else {
             rootGroup.setValue(null);
         }
@@ -410,7 +415,7 @@ public class GroupTreeViewModel extends AbstractViewModel {
                 GroupTreeNode groupNode = eachNode.getGroupNode();
 
                 groupNode.getParent()
-                         .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
+                        .ifPresent(parent -> groupNode.moveAllChildrenTo(parent, parent.getIndexOfChild(groupNode).get()));
                 groupNode.removeFromParent();
             });
 
@@ -559,5 +564,14 @@ public class GroupTreeViewModel extends AbstractViewModel {
 
     public void sortAlphabeticallyRecursive(GroupTreeNode group) {
         group.sortChildren(compAlphabetIgnoreCase, true);
+    }
+    public void sortReverseAlphabeticallyRecursive(GroupTreeNode group) {
+        group.sortChildren(compAlphabetIgnoreCaseReverse, true);
+    }
+    public void sortSubgroupsRecursive(GroupTreeNode group) {
+        group.sortChildren(compSubGroup, true);
+    }
+    public void sortReverseSubgroupsRecursive(GroupTreeNode group) {
+        group.sortChildren(compSubGroupReverse, true);
     }
 }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -886,7 +886,7 @@ SourceTab\ error=SourceTab error
 User\ input\ via\ entry-editor\ in\ `{}bibtex\ source`\ tab\ led\ to\ failure.=User input via entry-editor in `{}bibtex source` tab led to failure.
 
 Sort\ subgroups\ A-Z=Sort subgroups A-Z
-Sort\ subgroups\ Z-A=Sort subgroups A-Z
+Sort\ subgroups\ Z-A=Sort subgroups Z-A
 Sort\ subgroups\ by\ #\ of\ groups\ (Descending)=Sort subgroups by # of groups (Descending)
 Sort\ subgroups\ by\ #\ of\ groups\ (Ascending)=Sort subgroups by # of groups (Ascending)
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -887,8 +887,8 @@ User\ input\ via\ entry-editor\ in\ `{}bibtex\ source`\ tab\ led\ to\ failure.=U
 
 Sort\ subgroups\ A-Z=Sort subgroups A-Z
 Sort\ subgroups\ Z-A=Sort subgroups Z-A
-Sort\ subgroups\ by\ #\ of\ groups\ (Descending)=Sort subgroups by # of groups (Descending)
-Sort\ subgroups\ by\ #\ of\ groups\ (Ascending)=Sort subgroups by # of groups (Ascending)
+Sort\ subgroups\ by\ #\ of\ entries\ (Descending)=Sort subgroups by # of entries (Descending)
+Sort\ subgroups\ by\ #\ of\ entries\ (Ascending)=Sort subgroups by # of entries (Ascending)
 
 source\ edit=source edit
 Special\ name\ formatters=Special name formatters

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -886,6 +886,9 @@ SourceTab\ error=SourceTab error
 User\ input\ via\ entry-editor\ in\ `{}bibtex\ source`\ tab\ led\ to\ failure.=User input via entry-editor in `{}bibtex source` tab led to failure.
 
 Sort\ subgroups\ A-Z=Sort subgroups A-Z
+Sort\ subgroups\ Z-A=Sort subgroups A-Z
+Sort\ subgroups\ by\ #\ of\ groups\ (Descending)=Sort subgroups by # of groups (Descending)
+Sort\ subgroups\ by\ #\ of\ groups\ (Ascending)=Sort subgroups by # of groups (Ascending)
 
 source\ edit=source edit
 Special\ name\ formatters=Special name formatters


### PR DESCRIPTION
I have added an option to further sort subgroups on Z-A order, and also by ascending and descending number of subgroups. Currently only the option to sort from A-Z exists. 

Fixes #10249

### Mandatory checks
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
![new PR](https://github.com/JabRef/jabref/assets/141889843/a75db7a1-173e-402f-a8ab-2ddd50f60c38)
