### PR TITLE
Fix gh pr merge argument

### DIFF
--- a/.github/workflows/add-greeting-to-issue.yml
+++ b/.github/workflows/add-greeting-to-issue.yml
@@ -1,4 +1,4 @@
-name: GreetingFirstTimeCodeContribution
+name: Add greeting to issues for first time contributors
 
 on: 
   issues:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE}}
       - name: Merge PR
-        run: gh pr merge --auto "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}


### PR DESCRIPTION
This adds a missing `--squash` argument o `gh merge`.

It also renames the camel-cased workflow YAML file to [caterpillar-case](https://stackoverflow.com/a/21956960/873282) (AKA kebap-base)

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
