### PR TITLE
ImportHandlerTest-handleDuplicatesTest

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
@@ -3,14 +3,9 @@ package org.jabref.gui.externalfiles;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.model.entry.BibEntry;
 
-public class DuplicateDecisionResult {
-    private final DuplicateResolverDialog.DuplicateResolverResult decision;
-    private final BibEntry mergedEntry;
-
-    public DuplicateDecisionResult(DuplicateResolverDialog.DuplicateResolverResult decision, BibEntry mergedEntry) {
-        this.decision = decision;
-        this.mergedEntry = mergedEntry;
-    }
+public record DuplicateDecisionResult(
+        DuplicateResolverDialog.DuplicateResolverResult decision,
+        BibEntry mergedEntry) {
 
     public DuplicateResolverDialog.DuplicateResolverResult getDecision() {
         return decision;

--- a/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
@@ -1,0 +1,23 @@
+package org.jabref.gui.externalfiles;
+
+import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
+import org.jabref.model.entry.BibEntry;
+
+public class DuplicateDecisionResult {
+    private final DuplicateResolverDialog.DuplicateResolverResult decision;
+    private final BibEntry mergedEntry;
+
+    public DuplicateDecisionResult(DuplicateResolverDialog.DuplicateResolverResult decision, BibEntry mergedEntry) {
+        this.decision = decision;
+        this.mergedEntry = mergedEntry;
+    }
+
+    public DuplicateResolverDialog.DuplicateResolverResult getDecision() {
+        return decision;
+    }
+
+    public BibEntry getMergedEntry() {
+        return mergedEntry;
+    }
+}
+

--- a/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DuplicateDecisionResult.java
@@ -6,13 +6,6 @@ import org.jabref.model.entry.BibEntry;
 public record DuplicateDecisionResult(
         DuplicateResolverDialog.DuplicateResolverResult decision,
         BibEntry mergedEntry) {
-
-    public DuplicateResolverDialog.DuplicateResolverResult getDecision() {
-        return decision;
-    }
-
-    public BibEntry getMergedEntry() {
-        return mergedEntry;
-    }
 }
+
 

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -227,7 +227,7 @@ public class ImportHandler {
 
     public BibEntry handleDuplicates(BibDatabaseContext bibDatabaseContext, BibEntry originalEntry, BibEntry duplicateEntry) {
         DuplicateDecisionResult decisionResult = getDuplicateDecision(originalEntry, duplicateEntry, bibDatabaseContext);
-        switch (decisionResult.getDecision()) {
+        switch (decisionResult.decision()) {
             case KEEP_RIGHT:
                 bibDatabaseContext.getDatabase().removeEntry(duplicateEntry);
                 break;
@@ -235,7 +235,7 @@ public class ImportHandler {
                 break;
             case KEEP_MERGE:
                 bibDatabaseContext.getDatabase().removeEntry(duplicateEntry);
-                return decisionResult.getMergedEntry();
+                return decisionResult.mergedEntry();
             case KEEP_LEFT:
             case AUTOREMOVE_EXACT:
             case BREAK:

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -195,15 +195,18 @@ public class ImportHandler {
 
     public void importEntryWithDuplicateCheck(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
         BibEntry cleanedEntry = cleanUpEntry(bibDatabaseContext, entry);
-
         Optional<BibEntry> existingDuplicateInLibrary = findDuplicate(bibDatabaseContext, cleanedEntry);
-        BibEntry entryToInsert = cleanedEntry;
 
+        BibEntry entryToInsert = cleanedEntry;
         if (existingDuplicateInLibrary.isPresent()) {
-            entryToInsert = handleDuplicates(bibDatabaseContext, cleanedEntry, existingDuplicateInLibrary.get());
-            // If handleDuplicates returned null, stop processing
-            if (entryToInsert == null) {
-                return;
+            Optional<BibEntry> entriesToInsert = Optional.of(cleanedEntry);
+            if (existingDuplicateInLibrary.isPresent()) {
+                BibEntry duplicateHandledEntry = handleDuplicates(bibDatabaseContext, cleanedEntry, existingDuplicateInLibrary.get());
+                entriesToInsert = Optional.ofNullable(duplicateHandledEntry);
+                // If handleDuplicates returns null, stop processing
+                if (entryToInsert.isEmpty()) {
+                    return;
+                }
             }
         }
 
@@ -214,7 +217,7 @@ public class ImportHandler {
 
         addEntryToGroups(entryToInsert);
 
-        downloadLinkedFiles(entry);
+        downloadLinkedFiles(entryToInsert);
     }
 
     public BibEntry cleanUpEntry(BibDatabaseContext bibDatabaseContext, BibEntry entry) {

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -204,8 +204,8 @@ public class ImportHandler {
             if (duplicateHandledEntry.isEmpty()) {
                 return;
             }
+            entryToInsert = duplicateHandledEntry.get();
         }
-
         regenerateCiteKey(entryToInsert);
         bibDatabaseContext.getDatabase().insertEntry(entryToInsert);
 

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import javax.swing.undo.CompoundEdit;
 import javax.swing.undo.UndoManager;
 
+import com.ibm.icu.impl.Pair;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
@@ -54,6 +55,8 @@ import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolverResult.*;
 
 public class ImportHandler {
 
@@ -194,54 +197,105 @@ public class ImportHandler {
     }
 
     public void importEntryWithDuplicateCheck(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
-        ImportCleanup cleanup = new ImportCleanup(bibDatabaseContext.getMode());
-        BibEntry cleanedEntry = cleanup.doPostCleanup(entry);
+        BibEntry cleanedEntry = cleanUpEntry(bibDatabaseContext, entry);
+
+        Optional<BibEntry> existingDuplicateInLibrary = findDuplicate(bibDatabaseContext, cleanedEntry);
         BibEntry entryToInsert = cleanedEntry;
 
-        Optional<BibEntry> existingDuplicateInLibrary = new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(bibDatabaseContext.getDatabase(), entryToInsert, bibDatabaseContext.getMode());
         if (existingDuplicateInLibrary.isPresent()) {
-            DuplicateResolverDialog dialog = new DuplicateResolverDialog(existingDuplicateInLibrary.get(), entryToInsert, DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK, bibDatabaseContext, stateManager, dialogService, preferencesService);
-            switch (dialogService.showCustomDialogAndWait(dialog).orElse(DuplicateResolverDialog.DuplicateResolverResult.BREAK)) {
-                case KEEP_RIGHT:
-                    bibDatabaseContext.getDatabase().removeEntry(existingDuplicateInLibrary.get());
-                    break;
-                case KEEP_BOTH:
-                    break;
-                case KEEP_MERGE:
-                    bibDatabaseContext.getDatabase().removeEntry(existingDuplicateInLibrary.get());
-                    entryToInsert = dialog.getMergedEntry();
-                    break;
-                case KEEP_LEFT:
-                case AUTOREMOVE_EXACT:
-                case BREAK:
-                default:
-                   return;
+            entryToInsert = handleDuplicates(bibDatabaseContext, cleanedEntry, existingDuplicateInLibrary.get());
+            // If handleDuplicates returned null, stop processing
+            if (entryToInsert == null) {
+                return;
             }
         }
-        // Regenerate CiteKey of imported BibEntry
-        if (preferencesService.getImporterPreferences().isGenerateNewKeyOnImport()) {
-            generateKeys(List.of(entryToInsert));
-        }
+
+        regenerateCiteKey(entryToInsert);
         bibDatabaseContext.getDatabase().insertEntry(entryToInsert);
 
-        // Set owner/timestamp
-        UpdateField.setAutomaticFields(List.of(entryToInsert),
-                                       preferencesService.getOwnerPreferences(),
-                                       preferencesService.getTimestampPreferences());
+        setAutomaticFieldsForEntry(entryToInsert);
 
-        addToGroups(List.of(entry), stateManager.getSelectedGroup(this.bibDatabaseContext));
+        addEntryToGroups(entry);
 
-        if (preferencesService.getFilePreferences().shouldDownloadLinkedFiles()) {
-                entry.getFiles().stream().filter(LinkedFile::isOnlineLink).forEach(linkedFile ->
-                        new LinkedFileViewModel(
-                                linkedFile,
-                                entry,
-                                bibDatabaseContext,
-                                taskExecutor,
-                                dialogService,
-                                preferencesService).download());
+        downloadLinkedFiles(entry);
+    }
+
+
+    public BibEntry cleanUpEntry(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
+        ImportCleanup cleanup = new ImportCleanup(bibDatabaseContext.getMode());
+        return cleanup.doPostCleanup(entry);
+    }
+
+    public Optional<BibEntry> findDuplicate(BibDatabaseContext bibDatabaseContext, BibEntry entryToCheck) {
+        return new DuplicateCheck(Globals.entryTypesManager).containsDuplicate(bibDatabaseContext.getDatabase(), entryToCheck, bibDatabaseContext.getMode());
+    }
+
+    public BibEntry handleDuplicates(BibDatabaseContext bibDatabaseContext, BibEntry originalEntry, BibEntry duplicateEntry) {
+        DuplicateDecisionResult decisionResult = getDuplicateDecision(originalEntry, duplicateEntry, bibDatabaseContext);
+        switch (decisionResult.getDecision()) {
+            case KEEP_RIGHT:
+                bibDatabaseContext.getDatabase().removeEntry(duplicateEntry);
+                break;
+            case KEEP_BOTH:
+                break;
+            case KEEP_MERGE:
+                bibDatabaseContext.getDatabase().removeEntry(duplicateEntry);
+                return decisionResult.getMergedEntry();
+            case KEEP_LEFT:
+            case AUTOREMOVE_EXACT:
+            case BREAK:
+            default:
+                return null;
+        }
+        return originalEntry;
+    }
+
+    public DuplicateDecisionResult getDuplicateDecision(BibEntry originalEntry, BibEntry duplicateEntry, BibDatabaseContext bibDatabaseContext) {
+        DuplicateResolverDialog dialog = new DuplicateResolverDialog(duplicateEntry, originalEntry, DuplicateResolverDialog.DuplicateResolverType.IMPORT_CHECK, bibDatabaseContext, stateManager, dialogService, preferencesService);
+        DuplicateResolverDialog.DuplicateResolverResult decision = dialogService.showCustomDialogAndWait(dialog).orElse(DuplicateResolverDialog.DuplicateResolverResult.BREAK);
+        return new DuplicateDecisionResult(decision, dialog.getMergedEntry());
+    }
+
+
+
+    public void regenerateCiteKey(BibEntry entry) {
+        if (preferencesService.getImporterPreferences().isGenerateNewKeyOnImport()) {
+            generateKeys(List.of(entry));
         }
     }
+    public void setAutomaticFieldsForEntry(BibEntry entry) {
+        UpdateField.setAutomaticFields(
+                List.of(entry),
+                preferencesService.getOwnerPreferences(),
+                preferencesService.getTimestampPreferences()
+        );
+    }
+    public void addEntryToGroups(BibEntry entry) {
+        addToGroups(List.of(entry), stateManager.getSelectedGroup(this.bibDatabaseContext));
+    }
+    public void downloadLinkedFiles(BibEntry entry) {
+        if (preferencesService.getFilePreferences().shouldDownloadLinkedFiles()) {
+            entry.getFiles().stream()
+                    .filter(LinkedFile::isOnlineLink)
+                    .forEach(linkedFile ->
+                            new LinkedFileViewModel(
+                                    linkedFile,
+                                    entry,
+                                    bibDatabaseContext,
+                                    taskExecutor,
+                                    dialogService,
+                                    preferencesService
+                            ).download()
+                    );
+        }
+    }
+
+
+
+
+
+
+
 
     private void addToGroups(List<BibEntry> entries, Collection<GroupTreeNode> groups) {
         for (GroupTreeNode node : groups) {

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -212,7 +212,7 @@ public class ImportHandler {
 
         setAutomaticFieldsForEntry(entryToInsert);
 
-        addEntryToGroups(entry);
+        addEntryToGroups(entryToInsert);
 
         downloadLinkedFiles(entry);
     }

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import javax.swing.undo.CompoundEdit;
 import javax.swing.undo.UndoManager;
 
-import com.ibm.icu.impl.Pair;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
@@ -55,8 +54,6 @@ import org.jabref.preferences.PreferencesService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.jabref.gui.duplicationFinder.DuplicateResolverDialog.DuplicateResolverResult.*;
 
 public class ImportHandler {
 
@@ -220,7 +217,6 @@ public class ImportHandler {
         downloadLinkedFiles(entry);
     }
 
-
     public BibEntry cleanUpEntry(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
         ImportCleanup cleanup = new ImportCleanup(bibDatabaseContext.getMode());
         return cleanup.doPostCleanup(entry);
@@ -256,13 +252,12 @@ public class ImportHandler {
         return new DuplicateDecisionResult(decision, dialog.getMergedEntry());
     }
 
-
-
     public void regenerateCiteKey(BibEntry entry) {
         if (preferencesService.getImporterPreferences().isGenerateNewKeyOnImport()) {
             generateKeys(List.of(entry));
         }
     }
+
     public void setAutomaticFieldsForEntry(BibEntry entry) {
         UpdateField.setAutomaticFields(
                 List.of(entry),
@@ -270,9 +265,11 @@ public class ImportHandler {
                 preferencesService.getTimestampPreferences()
         );
     }
+
     public void addEntryToGroups(BibEntry entry) {
         addToGroups(List.of(entry), stateManager.getSelectedGroup(this.bibDatabaseContext));
     }
+
     public void downloadLinkedFiles(BibEntry entry) {
         if (preferencesService.getFilePreferences().shouldDownloadLinkedFiles()) {
             entry.getFiles().stream()
@@ -289,13 +286,6 @@ public class ImportHandler {
                     );
         }
     }
-
-
-
-
-
-
-
 
     private void addToGroups(List<BibEntry> entries, Collection<GroupTreeNode> groups) {
         for (GroupTreeNode node : groups) {

--- a/src/main/java/org/jabref/logic/cleanup/MoveFilesCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/MoveFilesCleanup.java
@@ -25,8 +25,8 @@ public class MoveFilesCleanup implements CleanupJob {
     private final FilePreferences filePreferences;
 
     public MoveFilesCleanup(BibDatabaseContext databaseContext, FilePreferences filePreferences) {
-        this.databaseContext = Objects.requireNonNull(databaseContext, "databaseContext must not be null!");
-        this.filePreferences = Objects.requireNonNull(filePreferences, "filePreferences must not be null!");
+        this.databaseContext = Objects.requireNonNull(databaseContext);
+        this.filePreferences = Objects.requireNonNull(filePreferences);
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/cleanup/MoveFilesCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/MoveFilesCleanup.java
@@ -25,8 +25,8 @@ public class MoveFilesCleanup implements CleanupJob {
     private final FilePreferences filePreferences;
 
     public MoveFilesCleanup(BibDatabaseContext databaseContext, FilePreferences filePreferences) {
-        this.databaseContext = Objects.requireNonNull(databaseContext);
-        this.filePreferences = Objects.requireNonNull(filePreferences);
+        this.databaseContext = Objects.requireNonNull(databaseContext, "databaseContext must not be null!");
+        this.filePreferences = Objects.requireNonNull(filePreferences, "filePreferences must not be null!");
     }
 
     @Override

--- a/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.externalfiles;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.undo.UndoManager;
 
@@ -46,9 +47,8 @@ class ImportHandlerTest {
     private DuplicateCheck duplicateCheck;
 
     @BeforeEach
-
     void setUp() {
-        MockitoAnnotations.initMocks(this);  // Initialize the mocks
+        MockitoAnnotations.initMocks(this);
 
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         when(preferencesService.getImportFormatPreferences()).thenReturn(importFormatPreferences);
@@ -74,7 +74,6 @@ class ImportHandlerTest {
     }
 
     @Test
-
     void handleBibTeXData() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
 
@@ -109,7 +108,13 @@ class ImportHandlerTest {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Clear Author");
         BibEntry cleanedEntry = importHandler.cleanUpEntry(bibDatabaseContext, entry);
 
-        assertEquals("Clear Author", cleanedEntry.getField(StandardField.AUTHOR).orElse(""));
+        Optional<String> authorOptional = cleanedEntry.getField(StandardField.AUTHOR);
+
+        // Make sure the value exists in Optional
+        assertTrue(authorOptional.isPresent());
+
+        // Get and verify the actual value in Optional
+        assertEquals("Clear Author", authorOptional.get());
     }
 
     @Test

--- a/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
@@ -110,11 +110,7 @@ class ImportHandlerTest {
 
         Optional<String> authorOptional = cleanedEntry.getField(StandardField.AUTHOR);
 
-        // Make sure the value exists in Optional
-        assertTrue(authorOptional.isPresent());
-
-        // Get and verify the actual value in Optional
-        assertEquals("Clear Author", authorOptional.get());
+        assertEquals(Optional.of("Clear Author"), authorOptional);
     }
 
     @Test

--- a/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
@@ -107,7 +107,6 @@ class ImportHandlerTest {
     @Test
     void cleanUpEntryTest() {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Clear Author");
-
         BibEntry cleanedEntry = importHandler.cleanUpEntry(bibDatabaseContext, entry);
 
         assertEquals("Clear Author", cleanedEntry.getField(StandardField.AUTHOR).orElse(""));

--- a/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
@@ -143,11 +143,12 @@ class ImportHandlerTest {
         Mockito.doReturn(decisionResult).when(importHandler).getDuplicateDecision(testEntry, duplicateEntry, bibDatabaseContext);
 
         // Act
-        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry);
+        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry).get();
 
-        // Assert
-        assertFalse(bibDatabase.getEntries().contains(duplicateEntry)); // Assert that the duplicate entry was removed from the database
-        assertEquals(testEntry, result); // Assert that the original entry is returned
+        // Assert that the duplicate entry was removed from the database
+        assertFalse(bibDatabase.getEntries().contains(duplicateEntry));
+        // Assert that the original entry is returned
+        assertEquals(testEntry, result);
     }
 
     @Test
@@ -174,7 +175,7 @@ class ImportHandlerTest {
         Mockito.doReturn(decisionResult).when(importHandler).getDuplicateDecision(testEntry, duplicateEntry, bibDatabaseContext);
 
         // Act
-        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry);
+        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry).get();
 
         // Assert
         assertTrue(bibDatabase.getEntries().contains(duplicateEntry)); // Assert that the duplicate entry is still in the database
@@ -209,13 +210,14 @@ class ImportHandlerTest {
         Mockito.doReturn(decisionResult).when(importHandler).getDuplicateDecision(testEntry, duplicateEntry, bibDatabaseContext);
 
         // Act
-        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry);
+        BibEntry result = importHandler.handleDuplicates(bibDatabaseContext, testEntry, duplicateEntry)
+                                       .orElseGet(() -> {
+                                           // create and return a default BibEntry or do other computations
+                                           return new BibEntry();
+                                       });
 
         // Assert
         assertFalse(bibDatabase.getEntries().contains(duplicateEntry)); // Assert that the duplicate entry was removed from the database
         assertEquals(mergedEntry, result); // Assert that the merged entry is returned
     }
 }
-
-
-

--- a/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/ImportHandlerTest.java
@@ -1,9 +1,6 @@
 package org.jabref.gui.externalfiles;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 import javax.swing.undo.UndoManager;
 
@@ -11,24 +8,15 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.duplicationFinder.DuplicateResolverDialog;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
-import org.jabref.gui.util.TaskExecutor;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
 import org.jabref.logic.database.DuplicateCheck;
-import org.jabref.logic.externalfiles.ExternalFilesContentImporter;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.database.BibDatabaseMode;
-import org.jabref.model.entry.Author;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.Month;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.util.DummyFileUpdateMonitor;
-import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.FilePreferences;
-import org.jabref.preferences.LibraryPreferences;
 import org.jabref.preferences.PreferencesService;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,8 +26,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ImportHandlerTest {
 
@@ -53,8 +45,8 @@ class ImportHandlerTest {
     @Mock
     private DuplicateCheck duplicateCheck;
 
-
     @BeforeEach
+
     void setUp() {
         MockitoAnnotations.initMocks(this);  // Initialize the mocks
 
@@ -66,9 +58,6 @@ class ImportHandlerTest {
         BibDatabase bibDatabase = new BibDatabase();
         when(bibDatabaseContext.getDatabase()).thenReturn(bibDatabase);
         when(duplicateCheck.isDuplicate(any(), any(), any())).thenReturn(false);
-
-
-
         importHandler = new ImportHandler(
                 bibDatabaseContext,
                 preferencesService,
@@ -84,9 +73,8 @@ class ImportHandlerTest {
                 .withField(StandardField.AUTHOR, "Test Author");
     }
 
-
-
     @Test
+
     void handleBibTeXData() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
 
@@ -129,8 +117,6 @@ class ImportHandlerTest {
     void findDuplicateTest() {
         // Assume there's no duplicate initially
         assertFalse(importHandler.findDuplicate(bibDatabaseContext, testEntry).isPresent());
-
-
     }
 
     @Test
@@ -229,12 +215,6 @@ class ImportHandlerTest {
         assertFalse(bibDatabase.getEntries().contains(duplicateEntry)); // Assert that the duplicate entry was removed from the database
         assertEquals(mergedEntry, result); // Assert that the merged entry is returned
     }
-
-
-
-
-
-
 }
 
 


### PR DESCRIPTION
Write testing for issue #10372

I divided importEntryWithDuplicateCheck into several parts to facilitate testing, and added DuplicateDecisionResult.java to facilitate storage of duplicate files.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
