### PR TITLE
Split Java code style checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   checkstyle:
-    name: Code style check
+    name: Checkstyle
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -52,6 +52,7 @@ jobs:
         with:
           message: >
               Your code currently does not meet JabRef's code guidelines.
+              We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
               The tool reviewdog already placed comments on GitHub to indicate the places. See the tab "Files" in you PR.
               Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
               Afterwards, please run checkstyle locally and fix the issues.
@@ -59,15 +60,69 @@ jobs:
 
               More information on code quality in JabRef is available at <https://devdocs.jabref.org/getting-into-the-code/development-strategy.html>.
           comment_tag: checkstyle
-          reactions: eyes
+  openrewrite:
+    name: OpenRewrite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          show-progress: 'false'
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21.0.1
+          distribution: 'liberica'
+          cache: 'gradle'
       - name: Run OpenRewrite
         run: |
           ./gradlew rewriteDryRun
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              Your code currently does not meet JabRef's code guidelines.
+              We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
+              The issues found can be **automatically fixed**.
+              Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
+
+
+              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "OpenRewrite".
+          comment_tag: openrewrite
+  modernizer:
+    name: Modernizer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          show-progress: 'false'
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21.0.1
+          distribution: 'liberica'
+          cache: 'gradle'
       - name: Run modernizer
         run: |
           # enable failing of this task if modernizer complains
           sed -i "s/failOnViolations = false/failOnViolations = true/" build.gradle
           ./gradlew modernizer
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              Your code currently does not meet JabRef's code guidelines.
+              We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
+              Please fix the detected errors, commit, and push.
+
+
+              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
+          comment_tag: modernizer
   markdown-checks:
     name: Markdown style check
     runs-on: ubuntu-latest

--- a/.vscode/ltex.dictionary.en-US.txt
+++ b/.vscode/ltex.dictionary.en-US.txt
@@ -1,3 +1,5 @@
+Checkstyle
+CouchDB
 JabDrive
 JabRef
-CouchDB
+OpenRewrite

--- a/docs/code-howtos/code-quality.md
+++ b/docs/code-howtos/code-quality.md
@@ -3,11 +3,25 @@ parent: Code Howtos
 ---
 # Code Quality
 
+## Code style checkers
+
+JabRef has three code style checkers in place:
+
+* [Checkstyle](https://checkstyle.sourceforge.io/) for basic checks, such as wrong import order.
+* [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) for Java library usage checks. It ensures that "modern" Java concepts are used (e.g., [one should use `Deque` instead of `Stack`](https://stackoverflow.com/a/73021741/873282)).
+* [OpenRewrite](https://docs.openrewrite.org/) for advanced rules. OpenRewrite can also automatically fix issues. JabRef's CI toolchain does NOT automatically rewrite the source code, but checks whether OpenRewrite would rewrite something. As developer, one can execute `./gradlew rewriteRun` to fix the issues.
+
+In case a check fails, [the CI](https://github.com/JabRef/jabref/blob/main/.github/workflows/tests.yml#L24C6-L24C6) automatically adds a comment on the pull request.
+
+## Monitoring
+
 We monitor the general source code quality at three places:
 
 * [codacy](https://www.codacy.com) is a hosted service to monitor code quality. It thereby combines the results of available open source code quality checkers such as [Checkstyle](https://checkstyle.sourceforge.io) or [PMD](https://pmd.github.io). The code quality analysis for JabRef is available at [https://app.codacy.com/gh/JabRef/jabref/dashboard](https://app.codacy.com/gh/JabRef/jabref/dashboard), especially the [list of open issues](https://app.codacy.com/gh/JabRef/jabref/issues/index). In case a rule feels wrong, it is most likely a PMD rule. The JabRef team can change the configuration at [https://app.codacy.com/p/306789/patterns/list?engine=9ed24812-b6ee-4a58-9004-0ed183c45b8f](https://app.codacy.com/p/306789/patterns/list?engine=9ed24812-b6ee-4a58-9004-0ed183c45b8f).
 * [codecov](https://codecov.io) is a solution to check code coverage of test cases. The code coverage metrics for JabRef are available at [https://codecov.io/github/JabRef/jabref](https://codecov.io/github/JabRef/jabref).
 * [Teamscale](https://www.cqse.eu/en/teamscale/overview/) is a popular German product analyzing code quality. The analysis results are available at <https://demo.teamscale.com/findings.html#/jabref/?>.
+
+## Background literature
 
 We strongly recommend reading following two books on code quality:
 


### PR DESCRIPTION
It is hard for newcomers to know about that we have more than checkstyle in place. See https://github.com/JabRef/jabref/pull/10496#issuecomment-1773730958.

We (currently) don't have it in the documentation. This is future work.

I think, it is more helpful, if we automatically comment on the PR to support tailored guidance. This PR tries to do it.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
