### PR TITLE
Remove application insights writer from meta inf

### DIFF
--- a/src/main/resources/META-INF/services/org.tinylog.writers.Writer
+++ b/src/main/resources/META-INF/services/org.tinylog.writers.Writer
@@ -1,2 +1,1 @@
-org.jabref.gui.logging.ApplicationInsightsWriter
 org.jabref.gui.logging.GuiWriter

--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -1,7 +1,6 @@
 level = info
 writer = gui
 writerConsole = console
-writerAzure = application insights
 
 # More shrunk exception logs. See https://tinylog.org/v2/configuration/#strip-stack-trace-elements for details
 exception = strip: jdk.internal

--- a/src/test/java/module-info.test
+++ b/src/test/java/module-info.test
@@ -21,9 +21,3 @@
 
 --add-modules
    org.kordamp.ikonli.core,org.kordamp.ikonli.javafx,org.kordamp.ikonli.materialdesign2
-
---add-reads
-   org.kordamp.ikonli.IkonHandler=org.jabref.gui.icon.JabRefIkonHandler
-
---add-reads
-   org.kordamp.ikonli.IkonProvider=org.jabref.gui.icon.JabrefIconProvider


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/313
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/312

>LOGGER ERROR: Service implementation 'org.jabref.gui.logging.ApplicationInsightsWriter' not found 


<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->


<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
