### PR TITLE
Add check for frozen CHANGELOG.md sections

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,7 +152,8 @@ jobs:
     steps:
       - name: Check
         run: |
-          brew install niclasvaneyk/keepac/keepac
+          wget https://github.com/NiclasvanEyk/keepac/releases/download/0.0.9/keepac_0.0.9_linux_amd64.deb
+          dpkg -i keepac_0.0.9_linux_amd64.deb
           diff \
             <(git show main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,12 +157,8 @@ jobs:
           BRANCH=`git rev-parse HEAD`
           git checkout main
 
-          echo "TEST"
-
           # run heylogs verification
           jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt || true
-
-          echo "TEST3"
 
           # improve output
           sed -i 's/consistent-separator/consistent-separator (ignored)/' heylogs.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,8 +152,8 @@ jobs:
     steps:
       - name: Check
         run: |
-          wget https://github.com/NiclasvanEyk/keepac/releases/download/0.0.9/keepac_0.0.9_linux_amd64.deb
-          dpkg -i keepac_0.0.9_linux_amd64.deb
+          wget -qq https://github.com/NiclasvanEyk/keepac/releases/download/0.0.9/keepac_0.0.9_linux_amd64.deb
+          sudo dpkg -i keepac_0.0.9_linux_amd64.deb
           diff \
             <(git show main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
           echo "TEST"
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
 
           echo "TEST3"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,6 +150,11 @@ jobs:
     name: Changelog right section
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: 'false'
+          show-progress: 'false'
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,8 @@ jobs:
           echo BRANCH: $BRANCH
           git diff main $BRANCH -- CHANGELOG.md
 
+          git log
+
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
           echo "TEST"
 
           # run heylogs verification
-          jbang --verbose --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
 
           echo "TEST3"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
           echo "TEST"
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
+          jbang --verbose --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
 
           echo "TEST3"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,8 @@ jobs:
           submodules: 'false'
           show-progress: 'false'
           fetch-depth: 0
+      - run: git show main:CHANGELOG.md
+      - run: git show HEAD:CHANGELOG.md
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,15 +152,15 @@ jobs:
           set -e
 
           # ensure that refs are available
+          BRANCH=`git rev-parse --abbrev-ref HEAD`
           git checkout main
-          git checkout ${GITHUB_REF##*/}
 
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...${GITHUB_REF##*/} | tee heylogs.txt
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
 
           # exit 1 in case of error
           # We have 2 "valid" issues in CHANGELOG.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,6 +155,10 @@ jobs:
           BRANCH=`git rev-parse --abbrev-ref HEAD`
           git checkout main
 
+          # debug
+          echo BRANCH: $BRANCH
+          git diff main $BRANCH -- CHANGELOG.md
+
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,7 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
+          fetch-depth: 0
       - name: Run markdown-lint
         uses: avto-dev/markdown-lint@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-          fetch-depth: 1000
+      - run: git fetch --depth=1 origin/main
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,14 +152,13 @@ jobs:
           set -e
 
           # ensure that refs are available
-          BRANCH=`git rev-parse --abbrev-ref HEAD`
+          BRANCH=`git rev-parse HEAD`
+          echo BRANCH: $BRANCH
+          git log | head
           git checkout main
 
           # debug
-          echo BRANCH: $BRANCH
           git diff main $BRANCH -- CHANGELOG.md
-
-          git log
 
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,8 +163,8 @@ jobs:
           jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
 
           # improve output
-          sed -i 's/consistent-separator/consistent-separator (ignored)' heylogs.txt
-          sed -i 's/all-h2-contain-a-version/all-h2-contain-a-version (ignored)' heylogs.txt
+          sed -i 's/consistent-separator/consistent-separator (ignored)/' heylogs.txt
+          sed -i 's/all-h2-contain-a-version/all-h2-contain-a-version (ignored)/' heylogs.txt
 
           cat heylogs.txt
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,17 +149,18 @@ jobs:
           fetch-depth: 0
       - name: Lint CHANGELOG.md
         run: |
+          # Install jbang
+          curl -s "https://get.sdkman.io" | bash
+          source ~/.bash_profile
+
+          sdk install java
+          sdk install jbang
+
           # ensure that refs are available
           BRANCH=`git rev-parse HEAD`
           git checkout main
 
           echo "TEST"
-
-          # install jbang
-          curl -Ls https://sh.jbang.dev | bash -s - app setup
-          source ~/.bash_profile
-
-          echo "TEST2"
 
           # run heylogs verification
           jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,10 @@ jobs:
           # run heylogs verification
           jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
 
+          # improve output
+          sed -i 's/consistent-separator/consistent-separator (ignored)' heylogs.txt
+          sed -i 's/all-h2-contain-a-version/all-h2-contain-a-version (ignored)' heylogs.txt
+
           # exit 1 in case of error
           # We have 2 "valid" issues in CHANGELOG.md
           grep -q "2 problems" heylogs.txt || exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,8 +152,8 @@ jobs:
     steps:
       - name: Check
         run: |
-          wget -qq https://github.com/NiclasvanEyk/keepac/releases/download/0.0.9/keepac_0.0.9_linux_amd64.deb
-          sudo dpkg -i keepac_0.0.9_linux_amd64.deb
+          curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb
+          sudo dpkg -i clparse_0.8.1_amd64.deb
           diff \
             <(git show main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,12 +153,7 @@ jobs:
 
           # ensure that refs are available
           BRANCH=`git rev-parse HEAD`
-          echo BRANCH: $BRANCH
-          git log | head
           git checkout main
-
-          # debug
-          git diff main $BRANCH -- CHANGELOG.md
 
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,11 +150,8 @@ jobs:
       - name: Lint CHANGELOG.md
         run: |
           # Install jbang
-          curl -s "https://get.sdkman.io" | bash
-          source "/home/runner/.sdkman/bin/sdkman-init.sh"
-
-          sdk install java
-          sdk install jbang
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          export PATH=$PATH:$HOME/.jbang/bin
 
           # ensure that refs are available
           BRANCH=`git rev-parse HEAD`
@@ -163,7 +160,7 @@ jobs:
           echo "TEST"
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt || true
 
           echo "TEST3"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,12 +153,18 @@ jobs:
           BRANCH=`git rev-parse HEAD`
           git checkout main
 
+          echo "TEST"
+
           # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup
-          source ~/.zshrc
+          source ~/.bash_profile
+
+          echo "TEST2"
 
           # run heylogs verification
           jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
+
+          echo "TEST3"
 
           # improve output
           sed -i 's/consistent-separator/consistent-separator (ignored)/' heylogs.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-          fetch-depth: 0
       - name: Run markdown-lint
         uses: avto-dev/markdown-lint@v1
         with:
@@ -156,6 +155,7 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
+          fetch-depth: 1000
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,24 @@ jobs:
           cat heylogs.txt
           # We have 7 "valid" issues in CHANGELOG.md
           grep -q "7 problems" heylogs.txt || exit 1
+  changelog-non-frozen:
+    name: Changelog right section
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        run: |
+          brew install niclasvaneyk/keepac/keepac
+          diff \
+            <(git show main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
+            <(git show HEAD:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)')
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              While the PR was in progress, JabRef released a new version.
+              You have to merge `upstream/main` and move your entry in `CHANGELOG.md` to section `## [Unreleased]`.
+          comment_tag: changelog
   tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,8 +149,6 @@ jobs:
           fetch-depth: 0
       - name: Lint CHANGELOG.md
         run: |
-          set -e
-
           # ensure that refs are available
           BRANCH=`git rev-parse HEAD`
           git checkout main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,9 +150,19 @@ jobs:
       - name: Lint CHANGELOG.md
         run: |
           set -e
+
+          # ensure that refs are available
+          git checkout main
+          git checkout ${GITHUB_REF##*/}
+
+          # install jbang
           curl -Ls https://sh.jbang.dev | bash -s - app setup
           source ~/.zshrc
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...add-changelog-diff-check | tee heylogs.txt
+
+          # run heylogs verification
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...${GITHUB_REF##*/} | tee heylogs.txt
+
+          # exit 1 in case of error
           # We have 2 "valid" issues in CHANGELOG.md
           grep -q "2 problems" heylogs.txt || exit 1
       - name: Add comment on pull request

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,7 @@ jobs:
           git checkout main
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt || true
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check CHANGELOG.md --gitdiff main...$BRANCH > heylogs.txt || true
 
           # improve output
           sed -i 's/consistent-separator/consistent-separator (ignored)/' heylogs.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,6 +156,8 @@ jobs:
           submodules: 'false'
           show-progress: 'false'
           fetch-depth: 0
+      - run: git remote -v
+      - run: git show origin/main:CHANGELOG.md
       - run: git show main:CHANGELOG.md
       - run: git show HEAD:CHANGELOG.md
       - name: Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           # Install jbang
           curl -s "https://get.sdkman.io" | bash
-          source ~/.bash_profile
+          source "/home/runner/.sdkman/bin/sdkman-init.sh"
 
           sdk install java
           sdk install jbang

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,11 +160,13 @@ jobs:
           source ~/.zshrc
 
           # run heylogs verification
-          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH | tee heylogs.txt
+          jbang --repos jitpack,central -m nbbrd.heylogs.cli.HeylogsCommand com.github.koppor.heylogs:heylogs-cli:jitpack-SNAPSHOT check --debug CHANGELOG.md  --gitdiff main...$BRANCH > heylogs.txt
 
           # improve output
           sed -i 's/consistent-separator/consistent-separator (ignored)' heylogs.txt
           sed -i 's/all-h2-contain-a-version/all-h2-contain-a-version (ignored)' heylogs.txt
+
+          cat heylogs.txt
 
           # exit 1 in case of error
           # We have 2 "valid" issues in CHANGELOG.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - run: git fetch --depth=1 origin/main
+          fetch-depth: 0
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,14 +158,13 @@ jobs:
           fetch-depth: 0
       - run: git remote -v
       - run: git show origin/main:CHANGELOG.md
-      - run: git show main:CHANGELOG.md
       - run: git show HEAD:CHANGELOG.md
       - name: Check
         run: |
           curl -LO https://github.com/marcaddeo/clparse/releases/download/0.8.1/clparse_0.8.1_amd64.deb
           sudo dpkg -i clparse_0.8.1_amd64.deb
           diff \
-            <(git show main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
+            <(git show origin/main:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json - | jq '.releases[] | select(.version != null)')
       - name: Add comment on pull request
         if: ${{ failure() }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- This is some test - to be removed
 - We added the ability to sort subgroups in Z-A order, as well as by ascending and descending number of subgroups. [#10249](https://github.com/JabRef/jabref/issues/10249)
 - We added the possibility to find (and add) papers that cite or are cited by a given paper. [#6187](https://github.com/JabRef/jabref/issues/6187)
 - We added an error-specific message for when a download from a URL fails. [#9826](https://github.com/JabRef/jabref/issues/9826)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- This is some test - to be removed
 - We added the ability to sort subgroups in Z-A order, as well as by ascending and descending number of subgroups. [#10249](https://github.com/JabRef/jabref/issues/10249)
 - We added the possibility to find (and add) papers that cite or are cited by a given paper. [#6187](https://github.com/JabRef/jabref/issues/6187)
 - We added an error-specific message for when a download from a URL fails. [#9826](https://github.com/JabRef/jabref/issues/9826)


### PR DESCRIPTION
This uses [clparse](https://github.com/marcaddeo/clparse) to detect updates to sections of `CHANGELOG.md` of released versions. This happens if PRs are longer-lasting than releases.

It implements the suggestion of https://github.com/NiclasvanEyk/keepac/issues/20#issuecomment-1712944920

This PR cannot use [heylogs](https://github.com/nbbrd/heylogs), because https://github.com/nbbrd/heylogs/pull/146 is not merged (and thus the functionality is not available).

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
