### PR TITLE
Switch markdown linter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ The title of the PR must not reference an issue, because GitHub does not support
 -->
 
 ### Mandatory checks
+
 - [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
 - [ ] Tests created for changes (if applicable)
 - [ ] Manually tested changed features in running JabRef (always required)

--- a/.github/failure-csl-update.md
+++ b/.github/failure-csl-update.md
@@ -1,5 +1,0 @@
----
-title: Error while updating citation styles
-labels: code-quality, dependencies
----
-[Update of citation styles failed!](https://github.com/JabRef/jabref/actions?query=workflow%3A%22Refresh+Citation+Style+Language+Files%22) 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
 
               You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
           comment_tag: modernizer
-  markdown-checks:
+  markdown:
     name: Markdown
     runs-on: ubuntu-latest
     steps:
@@ -135,11 +135,23 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Run markdown-lint
-        uses: avto-dev/markdown-lint@v1
+      - name: markdownlint-cli2-action
+        uses: DavidAnson/markdownlint-cli2-action@v9
         with:
-          args: CHANGELOG.md CONTRIBUTING.md README.md
-          config: '.markdownlint.yml'
+          globs: |
+            *.md
+            docs/**/*.md
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              You modified Markdown (*.md) files.
+              To ensure consistent styling, we have [markdown-lint](https://github.com/DavidAnson/markdownlint) in place.
+              [Markdown lint's rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules) help to keep our Markdown files consistent within this repository and consistent with the Markdown files outside here.
+
+              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "Markdown".
+          comment_tag: markdown
   changelog-non-frozen:
     name: CHANGELOG.md
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ concurrency:
   group: tests-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 jobs:
   checkstyle:
     name: Checkstyle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1188,4 +1188,4 @@ The changelog of JabRef 2.11 and all previous versions is available as [text fil
 [5.0]: https://github.com/JabRef/jabref/compare/v5.0-beta...v5.0
 [5.0-beta]: https://github.com/JabRef/jabref/compare/v5.0-alpha...v5.0-beta
 [5.0-alpha]: https://github.com/JabRef/jabref/compare/v4.3...v5.0-alpha
-<!-- markdownlint-disable-file MD012 MD024 MD033 -->
+<!-- markdownlint-disable-file MD012 MD024 MD033 MD053 -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2003-2023 [JabRef Authors](https://github.com/JabRef/jabref/blob/master/AUTHORS)
+Copyright © 2003-2023 JabRef Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -111,10 +111,12 @@ This privacy policy is in effect as of the day mentioned as "last updated" above
 
 ## Contact
 
-If you get in touch with us, we may aks you to provide us with certain personal information (e.g. name and email address) to stay in contact with you.
+If you get in touch with us, we may ask you to provide us with certain personal information (e.g. name and email address) to stay in contact with you.
 For any questions or concerns regarding the privacy policy, please send us an email to <vorstand@jabref.org> or write to
 
 JabRef e.V.  
 Josef-Lanner-Str. 9  
 71069 Sindelfingen  
 Germany
+
+<!-- markdownlint-disable-file MD024 -->

--- a/README.md
+++ b/README.md
@@ -99,6 +99,5 @@ For IntelliJ IDEA, just import the project via a Gradle Import by pointing at th
 
 ## Sponsoring
 
-JabRef development is powered by YourKit Java Profiler [![YourKit Java Profiler](https://www.yourkit.com/images/yk_logo.svg)](https://www.yourkit.com/java/profiler/)
-
-[JabRef]: https://www.jabref.org
+JabRef development is powered by YourKit Java Profiler  
+[![YourKit Java Profiler](https://www.yourkit.com/images/yk_logo.svg)](https://www.yourkit.com/java/profiler/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Installing the latest version of ruby followed by `gem install bundler` should b
 
 Afterwards, run
 
-```terminal
+```shell
 bundle install
 jekyll serve --livereload
 ```
@@ -18,7 +18,7 @@ and go to <http://localhost:4000/> in your browser.
 
 On **Windows**, using a dockerized environment is recommended:
 
-```terminal
+```shell
 docker build . -t jrjekyll
 docker run -p 4000:4000 -it --rm --volume="C:\git-repositories\jabref\docs":/srv/jekyll jrjekyll jekyll serve -H 0.0.0.0 -t
 ```
@@ -27,3 +27,13 @@ docker run -p 4000:4000 -it --rm --volume="C:\git-repositories\jabref\docs":/srv
 * In case you get errors regarding `Gemfile.lock`, just delete `Gemfile.lock` and rerun.
 * The current `Dockerfile` is based on <https://github.com/just-the-docs/just-the-docs/blob/main/Dockerfile>.
   The [Jekyll Docker image](https://github.com/envygeeks/jekyll-docker#jekyll-docker) did not work end of 2022 (because Ruby was too new).
+
+## Execute linting action
+
+You can execute the linting action as if it was executed by GitHub by executing following command.
+
+```shell
+act --rm --platform ubuntu-latest=fwilhe2/act-runner:latest -W .github/workflows/tests.yml -j "markdown"
+```
+
+That command uses [act](https://github.com/nektos/act), which brings GitHub actions execution to the developer machine.

--- a/docs/code-howtos/error-handling.md
+++ b/docs/code-howtos/error-handling.md
@@ -9,16 +9,17 @@ Principles:
 
 * All exceptions we throw should be or extend `JabRefException`; This is especially important if the message stored in the Exception should be shown to the user. `JabRefException` has already implemented the `getLocalizedMessage()` method which should be used for such cases (see details below!).
 * Catch and wrap all API exceptions (such as `IOExceptions`) and rethrow them
-    *   Example:
+  * Example:
 
-        ```java
-           try {
-               // ...
-           } catch (IOException ioe) {
-               throw new JabRefException("Something went wrong...",
-                   Localization.lang("Something went wrong...", ioe);
-           }
-        ```
+    ```java
+        try {
+            // ...
+        } catch (IOException ioe) {
+            throw new JabRefException("Something went wrong...",
+                Localization.lang("Something went wrong...", ioe);
+        }
+    ```
+
 * Never, ever throw and catch `Exception` or `Throwable`
 * Errors should only be logged when they are finally caught (i.e., logged only once). See **Logging** for details.
 * If the Exception message is intended to be shown to the User in the UI (see below) provide also a localizedMessage (see `JabRefException`).
@@ -34,6 +35,6 @@ To show error message two different ways are usually used in JabRef:
 * showing an error dialog
 * updating the status bar at the bottom of the main window
 
-```
-TODO: Usage of status bar and Swing Dialogs
+```text
+TODO: Usage of status bar and `DialogService`
 ```

--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -17,7 +17,9 @@ Howto for Windows - other operating systems work similar:
 
 Note: If you do not do this, you get following error message:
 
-    Could not find server key store C:\Users\USERNAME\AppData\Local\org.jabref\jabref\ssl\server.p12.
+```text
+Could not find server key store C:\Users\USERNAME\AppData\Local\org.jabref\jabref\ssl\server.p12.
+```
 
 ## Start http server
 
@@ -33,13 +35,15 @@ Does not work.
 
 Current try:
 
-    ./gradlew run -Pcomment=httpserver
+```shell
+./gradlew run -Pcomment=httpserver
+```
 
-However, there are with `ForkJoin` (discussion at https://discuss.gradle.org/t/is-it-ok-to-use-collection-parallelstream-or-other-potentially-multi-threaded-code-within-gradle-plugin-code/28003)
+However, there are with `ForkJoin` (discussion at <https://discuss.gradle.org/t/is-it-ok-to-use-collection-parallelstream-or-other-potentially-multi-threaded-code-within-gradle-plugin-code/28003>)
 
 Gradle output:
 
-```
+```shell
 > Task :run
 2023-04-22 11:30:59 [main] org.jabref.http.server.Server.main()
 DEBUG: Libraries served: [C:\git-repositories\jabref-all\jabref\src\main\resources\org\jabref\http\server\http-server-demo.bib]
@@ -51,7 +55,7 @@ DEBUG: Starting server...
 
 IntelliJ output, if `org.jabref.http.server.Server#main` is executed:
 
-```
+```shell
 DEBUG: Starting server...
 2023-04-22 11:44:59 [ForkJoinPool.commonPool-worker-1] org.glassfish.grizzly.http.server.NetworkListener.start()
 INFO: Started listener bound to [localhost:6051]

--- a/docs/code-howtos/index.md
+++ b/docs/code-howtos/index.md
@@ -64,25 +64,26 @@ Global variables should be avoided. Try to pass them as dependency.
 
 ### keywords sync
 
-Database.addDatabaseChangeListener does not work as the DatabaseChangedEvent does not provide the field information. Therefore, we have to use BibtexEntry.addPropertyChangeListener(VetoableChangeListener listener)
+`Database.addDatabaseChangeListener` does not work as the `DatabaseChangedEvent` does not provide the field information.
+Therefore, we have to use `BibtexEntry.addPropertyChangeListener(VetoableChangeListener listener)`.
 
 ## Working with BibTeX data
 
 ### Working with authors
 
-You can normalize the authors using `org.jabref.model.entry.AuthorList.fixAuthor_firstNameFirst(String)`. Then the authors always look nice. The only alternative containing all data of the names is `org.jabref.model.entry.AuthorList.fixAuthor_lastNameFirst(String)`. The other `fix...` methods omit data (like the von parts or the junior information).
+You can normalize the authors using `org.jabref.model.entry.AuthorList.fixAuthor_firstNameFirst(String)`. Then the authors always look nice. The only alternative containing all data of the names is `org.jabref.model.entry.AuthorList.fixAuthor_lastNameFirst(String)`. The other `fix...` methods omit data (like the "von" parts or the junior information).
 
 ## Benchmarks
 
 * Benchmarks can be executed by running the `jmh` gradle task (this functionality uses the [JMH Gradle plugin](https://github.com/melix/jmh-gradle-plugin))
 * Best practices:
-    * Read test input from `@State` objects
-    * Return result of calculations (either explicitly or via a `BlackHole` object)
+  * Read test input from `@State` objects
+  * Return result of calculations (either explicitly or via a `BlackHole` object)
 * [List of examples](https://github.com/melix/jmh-gradle-example/tree/master/src/jmh/java/org/openjdk/jmh/samples)
 
 ## Measure performance
 
-Try out the [YourKit JAva Profiler](https://www.yourkit.com).
+Try out the [YourKit Java Profiler](https://www.yourkit.com).
 
 ## equals
 
@@ -92,7 +93,7 @@ When creating an `equals` method follow:
 2. Use the `instanceof` operator to check if the argument has the correct type. If not, return `false`.
 3. Cast the argument to the correct type.
 4. For each “significant” field in the class, check if that field of the argument matches the corresponding field of this object. If all these tests succeed, return `true` otherwise, return `false`.
-5. When you are finished writing your equals method, ask yourself three questions: Is it symmetric? Is it transitive? Is it consistent?
+5. When you are finished writing your `equals` method, ask yourself three questions: Is it symmetric? Is it transitive? Is it consistent?
 
 Also, note:
 
@@ -103,4 +104,3 @@ Also, note:
 ## Files and Paths
 
 Always try to use the methods from the nio-package. For interoperability, they provide methods to convert between file and path. [https://docs.oracle.com/javase/tutorial/essential/io/path.html](https://docs.oracle.com/javase/tutorial/essential/io/path.html) Mapping between old methods and new methods [https://docs.oracle.com/javase/tutorial/essential/io/legacy.html#mapping](https://docs.oracle.com/javase/tutorial/essential/io/legacy.html#mapping)
-

--- a/docs/code-howtos/javafx.md
+++ b/docs/code-howtos/javafx.md
@@ -128,7 +128,7 @@ public class AboutDialogView extends BaseDialog<Void>
 @Inject private DialogService dialogService;
 ```
 
-*   It is convenient to load the FXML-view directly from the controller class.
+* It is convenient to load the FXML-view directly from the controller class.
 
     The FXML file is loaded using `ViewLoader` based on the name of the class passed to `view`. To make this convention-over-configuration approach work, both the FXML file and the View class should have the same name and should be located in the same package.
 

--- a/docs/code-howtos/jpackage.md
+++ b/docs/code-howtos/jpackage.md
@@ -28,11 +28,12 @@ Sometimes issues with modularity only arise in the installed version and do not 
 
 1. Open `build.gradle`, under jlink options remove `--strip-debug`
 2. Build using `jpackageImage` (or let the CI build a new version)
-3.  Modify the `build\image\JabRef\runtime\bin\Jabref.bat` file, replace the last line with
+3. Modify the `build\image\JabRef\runtime\bin\Jabref.bat` file, replace the last line with
 
-    ```
+    ```shell
     pushd %DIR% & %JAVA_EXEC% -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n -p "%~dp0/../app" -m org.jabref/org.jabref.cli.Launcher  %* & popd
     ```
+
 4. Open your IDE and add a "Remote Debugging Configuration" for `localhost:8000`
 5. Start JabRef by running the above bat file
 6. Connect with your IDE using remote debugging

--- a/docs/code-howtos/localization.md
+++ b/docs/code-howtos/localization.md
@@ -35,9 +35,7 @@ General hints:
 
 The tests check whether translation strings appear correctly in the resource bundles.
 
-1.  Add new `Localization.lang("KEY")` to Java file. Run the `LocalizationConsistencyTest`under (src/test/org.jabref.logic.
-
-    )
+1. Add new `Localization.lang("KEY")` to Java file. Run the `org.jabref.logic.LocalizationConsistencyTest`.
 2. Tests fail. In the test output a snippet is generated which must be added to the English translation file.
 3. Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
 4. Please do not add translations for other languages directly in the properties. They will be overwritten by [Crowdin](https://crowdin.com/project/jabref)

--- a/docs/code-howtos/logging.md
+++ b/docs/code-howtos/logging.md
@@ -43,6 +43,5 @@ In the `.properties` file, this is done for `org.jabref.model.entry.BibEntry`.
 
 ## Further reading
 
-SLF4J also support parameterized logging, e.g. if you want to print out multiple arguments in a log statement use a pair of curly braces (`{}`). 
+SLF4J also support parameterized logging, e.g. if you want to print out multiple arguments in a log statement use a pair of curly braces (`{}`).
 Head to <https://www.slf4j.org/faq.html#logging_performance> for examples.
-

--- a/docs/code-howtos/openoffice/ooresult-ooerror/index.md
+++ b/docs/code-howtos/openoffice/ooresult-ooerror/index.md
@@ -99,7 +99,7 @@ with an assumption that at any time exactly one of `result` and `error` is prese
 * Since `OOResult` encodes the state `isOK` in `result.isPresent()` (and equivalently in `errror.isEmpty()`), we cannot allow construction of instances where both values are `isEmpty`.\
   In particular, `OOResult.ok(null)` and `OOResult.error(null)` are not allowed: it would make the state `isOK` ambiguous.\
   It would also break the similarity to `Optional` to allow both `isEmpty` and `isOK` to be true.
-*   Not allowing null, has a consequence on `OOResult<Void,E>`\
+* Not allowing null, has a consequence on `OOResult<Void,E>`\
     According to [baeldung.com/java-void-type](https://www.baeldung.com/java-void-type), the only possible value for `Void` is `null` which we excluded.
 
     `OOResult<Void,E>.ok(null)` would look strange: in this case we need `ok()` without arguments.

--- a/docs/code-howtos/openoffice/overview.md
+++ b/docs/code-howtos/openoffice/overview.md
@@ -65,7 +65,7 @@ A group of parenthesized citations share the parentheses around, like this:\
 
 From the user's point of view, citation groups can be created by
 
-1.  Selecting multiple entries in a bibliography database, then
+1. Selecting multiple entries in a bibliography database, then
 
     * `[click:Cite]` or
     * `[click:Cite in-text]` or
@@ -140,8 +140,8 @@ The order of appearance of citations (as considered during numbering and adding 
 
 The order of citations within a citation group is controlled by `jstyle:MultiCiteChronological`.
 
-* true asks for (year, author, title) ordering,
-* false for (author, year, title).
+* `true` asks for (year, author, title) ordering,
+* `false` for (author, year, title).
 * (There is no option for "in the order provided by the user").
 
 For author-year citation styles this ordering is used directly.
@@ -159,21 +159,21 @@ The location of each citation group in the document is provided by the user. In 
 #### Order of the citations
 
 * `globalOrder` and `localOrder` together provide the order of appearance of citations
-*   This also provides the order of first appearance of the cited sources.
+* This also provides the order of first appearance of the cited sources.
 
-    First appearance order of sources is used
+  First appearance order of sources is used
 
-    * in `jstyle:IsSortByPosition` numbered styles
-    * in author-year styles: first appearance of "Smith200a" should precede that of "Smith200b".\
-      To achieve this, the sources get the letters according the order of their first appearance.
-      * This seems to contradict the statement "The bibliography is sorted in (author, year, title) order" above.\
-        It does not. As of JabRef 5.3 both are true.\
-        Consequence: in the references Smith2000b may precede Smith2000a. ([reported](https://github.com/JabRef/jabref/issues/7805))
-    * Some author-year citation styles prescribe a higher threshold on the number of authors for switching to "FirstAuthor et al." form (`jstyle:MaxAuthors`) at the first citation of a source (`jstyle:MaxAuthorsFirst`)
+  * in `jstyle:IsSortByPosition` numbered styles
+  * in author-year styles: first appearance of "Smith200a" should precede that of "Smith200b".\
+    To achieve this, the sources get the letters according the order of their first appearance.
+    * This seems to contradict the statement "The bibliography is sorted in (author, year, title) order" above.\
+      It does not. As of JabRef 5.3 both are true.\
+      Consequence: in the references Smith2000b may precede Smith2000a. ([reported](https://github.com/JabRef/jabref/issues/7805))
+  * Some author-year citation styles prescribe a higher threshold on the number of authors for switching to "FirstAuthor et al." form (`jstyle:MaxAuthors`) at the first citation of a source (`jstyle:MaxAuthorsFirst`)
 
 ## What is stored in a document (JabRef5.2)
 
-*   Each group of citations has a reference mark.
+* Each group of citations has a reference mark.
 
     (Reference marks are shown in LibreOffice in Navigator, under "References".\
     To show the Navigator: `LibreOffice:[menu:View]/[Navigator]` or `LibreOffice:[key:F5]`)

--- a/docs/code-howtos/openoffice/problems.md
+++ b/docs/code-howtos/openoffice/problems.md
@@ -11,22 +11,22 @@ grand_parent: Code Howtos
   a `(problem)`: pageInfo strings are conceptually associated with citations, but the implementation associates them to citation groups.\
   The number of available pageInfo slots changes during`[click:Merge]` and `[click:Separate]` while the number of citations remains fixed.
   * The proposed solution was to change the association.
-    *   Not only reference marks (citation groups) need unique identifiers, but also citations.\
-        Possible encoding for reference mark names:\
-        `JR_cite{type}_{number1}_{citationKey1},{number2}_{citationKey2}`\
-        where `{type}` encodes the citation type (for the group), `{citationKey1}` is made unique by choosing an appropriate number for `{number1}`\
-        This would allow `JR_cite_{number1}_{citationKey1}` to be used as a property name for storing the pageInfo.
+    * Not only reference marks (citation groups) need unique identifiers, but also citations.\
+      Possible encoding for reference mark names:\
+      `JR_cite{type}_{number1}_{citationKey1},{number2}_{citationKey2}`\
+      where `{type}` encodes the citation type (for the group), `{citationKey1}` is made unique by choosing an appropriate number for `{number1}`\
+      This would allow `JR_cite_{number1}_{citationKey1}` to be used as a property name for storing the pageInfo.
 
-        Changes required to
+      Changes required to
 
-        * reference mark search, name generation and parsing
-        * name generation and parsing for properties storing pageInfo values
-        * in-memory representation
-          * JabRef 5.2 does not collect pageInfo values, accesses only when needed.\
-            So it would be change to code accessing them.
-          * The proposed representation does collect, to allow separation of getting from the document and processing
-        * insertion of pageInfo into citation markers: JabRef 5.2 injects a single pageInfo before the closing parenthesis, now we need to handle several values
-        * `[click:Manage citations]` should work on citations, not citation groups.
+      * reference mark search, name generation and parsing
+      * name generation and parsing for properties storing pageInfo values
+      * in-memory representation
+        * JabRef 5.2 does not collect pageInfo values, accesses only when needed.\
+          So it would be change to code accessing them.
+        * The proposed representation does collect, to allow separation of getting from the document and processing
+      * insertion of pageInfo into citation markers: JabRef 5.2 injects a single pageInfo before the closing parenthesis, now we need to handle several values
+      * `[click:Manage citations]` should work on citations, not citation groups.
 
 ## Backend
 

--- a/docs/code-howtos/testing.md
+++ b/docs/code-howtos/testing.md
@@ -24,7 +24,7 @@ Imagine you want to test the method `format(String value)` in the class `BracesF
 
 * _Placing:_ all tests should be placed in a class named `classTest`, e.g. `BracesFormatterTest`.
 * _Naming:_ the name should be descriptive enough to describe the whole test. Use the format `methodUnderTest_ expectedBehavior_context` (without the dashes). So for example `formatRemovesDoubleBracesAtBeginning`. Try to avoid naming the tests with a `test` prefix since this information is already contained in the class name. Moreover, starting the name with `test` leads often to inferior test names (see also the [Stackoverflow discussion about naming](http://stackoverflow.com/questions/155436/unit-test-naming-best-practices)).
-*   _Test only one thing per test:_ tests should be short and test only one small part of the method. So instead of
+* _Test only one thing per test:_ tests should be short and test only one small part of the method. So instead of
 
     ```java
     testFormat() {
@@ -36,14 +36,14 @@ Imagine you want to test the method `format(String value)` in the class `BracesF
 
     we would have five tests containing a single `assert` statement and named accordingly (`formatDoesNotChangeStringWithoutBraces`, `formatDoesNotRemoveSingleBrace`, , etc.). See [JUnit AntiPattern](https://exubero.com/junit/anti-patterns/#Multiple\_Assertions) for background.
 * Do _not just test happy paths_, but also wrong/weird input.
-* It is recommend to write tests _before_ you actually implement the functionality (test driven development).
+* It is recommended to write tests _before_ you actually implement the functionality (test driven development).
 * _Bug fixing:_ write a test case covering the bug and then fix it, leaving the test as a security that the bug will never reappear.
 * Do not catch exceptions in tests, instead use the `assertThrows(Exception.class, ()->doSomethingThrowsEx())` feature of [junit-jupiter](https://junit.org/junit5/docs/current/user-guide/) to the test method.
 
 ## Lists in tests
 
 * Use `assertEquals(Collections.emptyList(), actualList);` instead of `assertEquals(0, actualList.size());` to test whether a list is empty.
-*   Similarly, use `assertEquals(Arrays.asList("a", "b"), actualList);` to compare lists instead of
+* Similarly, use `assertEquals(Arrays.asList("a", "b"), actualList);` to compare lists instead of
 
     ```java
            assertEquals(2, actualList.size());
@@ -57,7 +57,7 @@ Imagine you want to test the method `format(String value)` in the class `BracesF
 
 ## Files and folders in tests
 
-*   If you need a temporary file in tests, then add the following Annotation before the class:
+* If you need a temporary file in tests, then add the following Annotation before the class:
 
     ```java
     @ExtendWith(TempDirectory.class)
@@ -112,7 +112,7 @@ To test that a preferences migration works successfully, use the mockito method 
 
 To quickly host a local PostgreSQL database, execute following statement:
 
-```
+```shell
 docker run -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres -p 5432:5432 --name db postgres:10 postgres -c log_statement=all
 ```
 
@@ -124,7 +124,7 @@ Then, all DBMS Tests (annotated with `@org.jabref.testutils.category.DatabaseTes
 
 A MySQL DBMS can be started using following command:
 
-```
+```shell
 docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=jabref -p 3800:3307 mysql:8.0 --port=3307
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,7 +65,7 @@ Add new `Localization.lang("KEY")` to a Java file. The tests will fail. In the t
 
 Example:
 
-```
+```text
 java.lang.AssertionError: DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE
 PASTE THESE INTO THE ENGLISH LANGUAGE FILE
 [
@@ -91,7 +91,7 @@ We simply ask to create a new markdown file in `docs/adr` following the template
 
 In case you want to directly add a comment to a class, simply use the following template (based on [sustainable architectural decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions)):
 
-```
+```text
 In the context of <use case/user story u>,
 facing <concern c>
 we decided for <option o>

--- a/docs/decisions/0001-use-crowdin-for-translations.md
+++ b/docs/decisions/0001-use-crowdin-for-translations.md
@@ -18,4 +18,3 @@ The JabRef UI is offered in multiple languages. It should be easy for translator
 ## Decision Outcome
 
 Chosen option: "Use Crowdin", because Crowdin is easy to use, integrates in our GitHub workflow, and is free for OSS projects.
-

--- a/docs/decisions/0002-use-slf4j-for-logging.md
+++ b/docs/decisions/0002-use-slf4j-for-logging.md
@@ -48,4 +48,3 @@ Chosen option: "SLF4J with Log4j2 binding", because comes out best \(see below\)
 * Good, because native implementation of slf4j
 * Bad, because Java 9 support only available in alpha
 * Bad, because different syntax than log4j/commons logging
-

--- a/docs/decisions/0003-use-gradle-as-build-tool.md
+++ b/docs/decisions/0003-use-gradle-as-build-tool.md
@@ -62,4 +62,3 @@ Chosen option: "Gradle", because it is lean and fits our development style.
 ## Links
 
 * GADR: [https://github.com/adr/gadr-java/blob/master/gadr-java--build-tool.md](https://github.com/adr/gadr-java/blob/master/gadr-java--build-tool.md)
-

--- a/docs/decisions/0005-fully-support-utf8-only-for-latex-files.md
+++ b/docs/decisions/0005-fully-support-utf8-only-for-latex-files.md
@@ -47,4 +47,3 @@ Chosen option: "Support UTF-8 encoding only", because comes out best \(see below
   This causes issues during compilation \(see [https://github.com/JabRef/jabref/pull/3421\#issuecomment-524532832](https://github.com/JabRef/jabref/pull/3421#issuecomment-524532832)\).
 
   Example: `error: module java.xml.bind reads package javax.activation from both java.activation and jakarta.activation`.
-

--- a/docs/decisions/0007-human-readable-changelog.md
+++ b/docs/decisions/0007-human-readable-changelog.md
@@ -24,4 +24,3 @@ Chosen option: "Keep-a-changelog format with freedom in the bullet points", beca
   We nevertheless try to follow that style.
 
 Further discussion can be found at [\#2277](https://github.com/JabRef/jabref/issues/2277).
-

--- a/docs/decisions/0013-add-native-support-biblatex-software.md
+++ b/docs/decisions/0013-add-native-support-biblatex-software.md
@@ -45,7 +45,6 @@ Chosen option: "Add a new divider", because comes out best (see below).
 
 * Good, since this gives the user a bit more clarity
 
-
 ### Support via customized entry types: A user can load a customized bib file
 
 * Good, because no code needs to be changed

--- a/docs/decisions/0027-synchronization.md
+++ b/docs/decisions/0027-synchronization.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 26
+nav_order: 27
 parent: Decision Records
 ---
 

--- a/docs/decisions/0028-http-return-bibtex-string.md
+++ b/docs/decisions/0028-http-return-bibtex-string.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 27
+nav_order: 28
 parent: Decision Records
 ---
 <!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
@@ -24,16 +24,16 @@ Chosen option: "Offer both, BibTeX string and CSL JSON", because there are many 
 
 ### Offer both, BibTeX string and CSL JSON
 
-- Good, because this follows "Backend for Frontend"
-- Good, because Word Addin works seamless with the data provided (and does not need another dependency)
-- Good, because other clients can work with BibTeX data
-- Bad, because two serializations have to be kept
+* Good, because this follows "Backend for Frontend"
+* Good, because Word Addin works seamless with the data provided (and does not need another dependency)
+* Good, because other clients can work with BibTeX data
+* Bad, because two serializations have to be kept
 
 ### Return BibTeX as is as string
 
-- Good, because we don't need to think about any conversion
-- Bad, because it is unclear how to ship BibTeX data where the entry is dependent on
-- Bad, because client needs add additional parsing logic
+* Good, because we don't need to think about any conversion
+* Bad, because it is unclear how to ship BibTeX data where the entry is dependent on
+* Bad, because client needs an additional parsing logic
 
 ### Convert BibTeX to JSON
 
@@ -41,8 +41,8 @@ More thought has to be done when converting to JSON.
 There seems to be a JSON format from [@citation-js/plugin-bibtex](https://www.npmjs.com/package/@citation-js/plugin-bibtex).
 We could do an additional self-made JSON format, but this increases the number of available JSON serializations for BibTeX.
 
-- Good, because it could flatten BibTeX data (example: `author = first # " and " # second`)
-- Bad, because conversion is difficult in BibTeX special cases. For instance, if Strings are used (example: `author = first # " and " # second`) and one doesn't want to flatten ("normalize") this.
+* Good, because it could flatten BibTeX data (example: `author = first # " and " # second`)
+* Bad, because conversion is difficult in BibTeX special cases. For instance, if Strings are used (example: `author = first # " and " # second`) and one doesn't want to flatten ("normalize") this.
 
 ## More Information
 

--- a/docs/getting-into-the-code/high-level-documentation.md
+++ b/docs/getting-into-the-code/high-level-documentation.md
@@ -24,7 +24,7 @@ Note that we are currently switching to JavaFX's observables, as this concepts s
 
 Permitted dependencies in our architecture are:
 
-```
+```monospaced
 gui --> logic --> model
 gui ------------> model
 gui ------------> preferences

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,8 @@ General information about architectural decision records is available at <https:
 
 ## FAQ
 
-*   Q: I get `java: package org.jabref.logic.journals does not exist`.
+* Q: I get `java: package org.jabref.logic.journals does not exist`.
 
-    A: You have to ignore `buildSrc/src/main` as source directory in IntelliJ as indicated in our [setup guide](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
+  A: You have to ignore `buildSrc/src/main` as source directory in IntelliJ as indicated in our [setup guide](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
 
-    Also filed as IntelliJ issue [IDEA-240250](https://youtrack.jetbrains.com/issue/IDEA-240250).
+  Also filed as IntelliJ issue [IDEA-240250](https://youtrack.jetbrains.com/issue/IDEA-240250).

--- a/docs/teaching.md
+++ b/docs/teaching.md
@@ -19,7 +19,9 @@ By using JabRef as training object in exercises and labs, students can level-up 
    There, new functionality is categorized in small, medium, and large effort.
    Moreover, categorization on the main focus (UI, logic, or both),
    implementation effort, testing effort, and "issue understanding effort".
-   The latter category is important, because some issues are "quick wins" and others need thorough thinking.   
+   The latter category is important, because some issues are "quick wins" and others need thorough thinking.
+
+
    In general, all issues of JabRef are free to take.
    Be aware that the difficulty of bugs and feature vary.
    For the brave, the [Bug Board](https://github.com/orgs/JabRef/projects/7) or the [Feature Board](https://github.com/JabRef/jabref/projects/6) provide other issue sources.
@@ -150,3 +152,5 @@ Course [Open Source Software](https://github.com/igorsteinmacher/DSL-UTFPR)
 ## References
 
 [1](teaching.md#a1): [@ayaankazerouni](https://github.com/ayaankazerouni): [Developing Procrastination Feedback for Student Software Developers](https://medium.com/@ayaankazerouni/developing-procrastination-feedback-for-student-software-developers-1652de60db7f) [2](teaching.md#a2): Lientz B., Swanson E., 1980: Software Maintenance Management. Addison Wesley, Reading, MA.
+
+<!-- markdownlint-disable-file MD012 -->


### PR DESCRIPTION
The action used to lint Markdown files was outdated. I switched to the action maintained by the author of markdown-lint - and fixed linting issues.

At https://github.com/JabRef/jabref/actions/runs/6607185856/job/17944253625?pr=10496, i noticed that commenting did not work. According to https://github.com/thollander/actions-comment-pull-request#permissions, `write` permissions have to be given to the GITHUB token. I wonder, why it worked before (at other places).

---

- fix Markdown linting issues
- siwtch to https://github.com/marketplace/actions/markdownlint-cli2-action
- remove 404 link in LICENSE.md
- Fix ADR numbering

---

```yml
markdownlint-cli2 v0.6.0 (markdownlint v0.27.0)
Finding: *.md docs/**/*.md
Linting: 80 file(s)
Summary: 0 error(s)
```

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
