### PR TITLE
Add deep links to code contribution howto

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,13 @@
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.
 
-Support on **code contribution** is available at <https://devdocs.jabref.org/contributing>.
+Support on **code contribution** is available at <https://devdocs.jabref.org/contributing#contribute-code>.
 
 General overview about contributing for programmers and non-programmers is available at <https://contribute.jabref.org>.
 
 ## Pull Request Process
 
-1. Understand the basics listed at <https://devdocs.jabref.org/contributing>.
+1. Understand the basics listed at <https://devdocs.jabref.org/contributing#contribute-code>.
 2. Follow the "formal requirements". They are not too hard, they merely support the maintainers to focus on supportive feedback than just stating the obvious. They also have helpful hints how to work with localization.
 3. Create a pull request. You can create a draft pull request to enable automatic checks.
 4. Wait for feedback of the developers

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,11 +18,12 @@ We welcome contributions to JabRef and encourage you to follow the GitHub workfl
    1. Fork the JabRef into your GitHub account.
    2. Clone your forked repository on your local machine.
 2. **Create a new branch** (such as `fix-for-issue-121`). Be sure to create a **separate branch** for each improvement you implement.
-3. Do your work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/getting-into-the-code/code-howtos) if you have questions about your implementation.
+3. Work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/getting-into-the-code/code-howtos) if you have questions about your implementation.
 4. Create a pull request. For an overview of pull requests, take a look at GitHub's [pull request help documentation](https://help.github.com/articles/about-pull-requests/).
-5. In case your pull request is not yet complete or not yet ready for review, consider creating a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.
+5. In case your pull request is not yet complete or not yet ready for review, create a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.
 
-In case you have any questions, do not hesitate to write one of our [JabRef developers](https://github.com/orgs/JabRef/teams/developers) an email. We should also be online at [gitter](https://gitter.im/JabRef/jabref).
+In case you have any questions, please comment on the issue - or show up in our [gitter chat](https://gitter.im/JabRef/jabref).
+Please also help others in case of general questions there.
 
 ### Formal requirements for a pull request
 

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
@@ -155,4 +155,4 @@ Press "OK".
 > The code formatting rules are imported - and the most common styling issue at imports is automatically resolved by IntelliJ.
 > Finally, you have Checkstyle running locally so that you can check for styling errors before submitting the pull request.
 
-Got it running? GREAT! You are ready to lurk the code and contribute to JabRef. Please make sure to also read our [contribution guide](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md).
+Got it running? GREAT! You are ready to lurk the code and contribute to JabRef. Please make sure to also read our [contribution guide](https://devdocs.jabref.org/contributing#contribute-code).


### PR DESCRIPTION
Two contributors worked on `main`. I think, it is because this "no-no" is too far away from the setup guide. I bring it closer by providing a deep link to https://devdocs.jabref.org/contributing#contribute-code.

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
