### PR TITLE
Enable collecting GitHub build artifacts for forks

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -224,6 +224,13 @@ jobs:
           # tbn = to-be-notarized
           name: JabRef-macOS-tbn
           path: build/distribution
+      - name: Upload to GitHub workflow artifacts store
+        if: (steps.checksecrets.outputs.secretspresent != 'YES')
+        uses: actions/upload-artifact@v3
+        with:
+          # tbn = to-be-notarized
+          name: JabRef-${{ matrix.os }}
+          path: build/distribution
   announce:
     name: Comment on pull request
     runs-on: ubuntu-latest
@@ -242,7 +249,7 @@ jobs:
         env:
           BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
       - name: Comment PR
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
+        if: (steps.checksecrets.outputs.secretspresent == 'YES')
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |


### PR DESCRIPTION
Forks currently don't get any binary. This should fix it.

If build runs through, I'll merge (to be able to work on https://github.com/koppor/jabref/pull/660)

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
