### PR TITLE
Replace "fixes" by "closes"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,17 @@
 <!-- 
 Describe the changes you have made here: what, why, ... 
-Link the issues that will be closed, e.g., "Closes [#333](https://github.com/JabRef/jabref/issues/333)".	 
+Link the issue that will be closed, e.g., "Closes https://github.com/JabRef/jabref/issues/333".
 If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
 "Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
 Don't reference an issue in the PR title because GitHub does not support auto-linking there.
 -->
 
+### Mandatory checks
 
 <!-- 
 - Go through the list below. Please don't remove any items.
 - [x] done; [ ] not done / not applicable
 -->
-
-### Mandatory checks
 
 - [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
 - [ ] Tests created for changes (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- 
 Describe the changes you have made here: what, why, ... 
-Link the issue that will be closed, e.g., "Closes https://github.com/JabRef/jabref/issues/333".
+Link the issue that will be closed, e.g., "Closes #333".
 If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
 "Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
 Don't reference an issue in the PR title because GitHub does not support auto-linking there.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 <!-- 
 Describe the changes you have made here: what, why, ... 
-Link issues that are closed, e.g. "Closes #333".
-If you resolved a koppor issue, link it, e.g. "Closes https://github.com/koppor/jabref/issues/47".
-You need to stick with "Closes" as verb, because GitHub recognizes this word (and not other words).
-The title of the PR must not reference an issue, because GitHub does not support autolinking there.
+Link the issues that will be closed, e.g., "Closes [#333](https://github.com/JabRef/jabref/issues/333)".	 
+If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
+"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
+Don't reference an issue in the PR title because GitHub does not support auto-linking there.
 -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!-- 
 Describe the changes you have made here: what, why, ... 
-Link issues that are fixed, e.g. "Resolves #333".
-If you resolved a koppor issue, link it, e.g. "Resolves https://github.com/koppor/jabref/issues/47".
+Link issues that are closed, e.g. "Closes #333".
+If you resolved a koppor issue, link it, e.g. "Closes https://github.com/koppor/jabref/issues/47".
+You need to stick with "Closes" as verb, because GitHub recognizes this word (and not other words).
 The title of the PR must not reference an issue, because GitHub does not support autolinking there.
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- 
 Describe the changes you have made here: what, why, ... 
-Link issues that are fixed, e.g. "Fixes #333".
-If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
+Link issues that are fixed, e.g. "Resolves #333".
+If you resolved a koppor issue, link it, e.g. "Resolves https://github.com/koppor/jabref/issues/47".
 The title of the PR must not reference an issue, because GitHub does not support autolinking there.
 -->
 

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -298,9 +298,11 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer {
                             // Extra workaround for CodeArea, which does not inherit from TextInputControl
                             if (!(stateManager.getFocusOwner().isPresent() && (stateManager.getFocusOwner().get() instanceof CodeArea))) {
                                 event.consume();
+                                break;
                             }
                             break;
                         }
+                        break;
                     default:
                 }
             }


### PR DESCRIPTION
Multiple contributors did not use "fixes", but other words (not recognized by GitHub https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

The explanation seems to be that "fixes" is interpreted as fixing a bug only. Thus, they changed the wording. See https://github.com/koppor/jabref/issues/540#issuecomment-1778610956 for that explanation.

"Resolves" has more weight to me than "Closes". However, GitHub has "Close" at issues, therefore, I propose to use "Closes" as text.

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
