### PR TITLE
issue 10450

### DIFF
--- a/Issue10450.txt
+++ b/Issue10450.txt
@@ -1,0 +1,3 @@
+Issue 10450 url: https://github.com/JabRef/jabref/issues/10450
+JabRef indeed does not have the functionality to let user select one existing database and then
+show the import dialog but instead create a temporary database directly.


### PR DESCRIPTION
No fix for #10450 
This issue is indeed an issue as the JabRef does not provide the functionality that when clicking browser extension to import an entry and if Jabref is closed, jabRef will create a temporary database not let user to select a database and show the import the entry.