### PR TITLE
Added parent field to Hayagriva YAML export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the added protected term has unwanted leading and trailing whitespaces, where the formatted text has unwanted empty brackets and where the word at the cursor in the textbox can be added to the list. [#10415](https://github.com/JabRef/jabref/issues/10415)
 - We fixed an issue where in the merge dialog the file field of entries was not correctly merged when the first and second entry both contained values inside the file field. [#10572](https://github.com/JabRef/jabref/issues/10572)
 - We fixed some small inconsistencies in the user interface. [#10507](https://github.com/JabRef/jabref/issues/10507) [#10458](https://github.com/JabRef/jabref/issues/10458)
+- We fixed the issue where the Hayagriva YAML exporter would not include a parent field for the publisher/series
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the added protected term has unwanted leading and trailing whitespaces, where the formatted text has unwanted empty brackets and where the word at the cursor in the textbox can be added to the list. [#10415](https://github.com/JabRef/jabref/issues/10415)
 - We fixed an issue where in the merge dialog the file field of entries was not correctly merged when the first and second entry both contained values inside the file field. [#10572](https://github.com/JabRef/jabref/issues/10572)
 - We fixed some small inconsistencies in the user interface. [#10507](https://github.com/JabRef/jabref/issues/10507) [#10458](https://github.com/JabRef/jabref/issues/10458)
-- We fixed the issue where the Hayagriva YAML exporter would not include a parent field for the publisher/series
+- We fixed the issue where the Hayagriva YAML exporter would not include a parent field for the publisher/series. [#10596](https://github.com/JabRef/jabref/issues/10596)
 
 ### Removed
 

--- a/src/main/resources/resource/layout/hayagrivayaml.layout
+++ b/src/main/resources/resource/layout/hayagrivayaml.layout
@@ -6,11 +6,24 @@
     - \format[Authors(LastFirst, MiddleInitial, Sep =\n    - , LastSep =\n    - )]{\author}
 \end{author}
 \begin{date}  date: \date\end{date}
+\begin{journal}
+  parent:
+    type: periodical
+    title: \journal
+\end{journal}
+    \begin{journal&&volume}volume: \volume\end{journal&&volume}
+    \begin{journal&&number}issue: \number\end{journal&&number}
+    \begin{journal&&publisher}publisher: \publisher\end{journal&&publisher}
+\begin{series}
+  parent:
+    type: book
+    title: "\series"
+\end{series}
+\begin{editor&&number}  issue: \number\end{editor&&number}
+\begin{editor&&publisher}  publisher: \publisher\end{editor&&publisher}
 \begin{editor}  editor: \editor\end{editor}
-\begin{publisher}  publisher: \publisher\end{publisher}
 \begin{address}  location: \address\end{address}
 \begin{institution}  organization: \institution\end{institution}
-\begin{volume}  volume: \volume\end{volume}
 \begin{edition}  edition: \edition\end{edition}
 \begin{pages}  page-range: \pages\end{pages}
 \begin{url}  url: \url\end{url}

--- a/src/test/java/org/jabref/logic/exporter/HayagrivaYamlExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HayagrivaYamlExporterTest.java
@@ -183,4 +183,35 @@ public class HayagrivaYamlExporterTest {
                 "---");
         assertEquals(expected, Files.readAllLines(file));
     }
+
+    @Test
+    public final void exportsCorrectParentField(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.JOURNAL, "Test Publisher")
+                .withField(StandardField.URL, "http://example.com")
+                .withField(StandardField.DATE, "2020-10-14");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        hayagrivaYamlExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "---",
+                "test:",
+                "  type: article",
+                "  title: \"Test Title\"",
+                "  author:",
+                "    - Author, Test",
+                "  date: 2020-10-14",
+                "  parent:",
+                "    type: periodical",
+                "    title: Test Publisher",
+                "  url: http://example.com",
+                "---");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Closes #10596 

The parent field is added to the Hayagriva YAML exporter, which was introduced in #10451 

Previously, the exporter neglected some fields, addressing two specific cases:
1. **Case 1 (entry type: article):**
   - The journal field is now included under the parent field in addition to volume, issue, and publisher (if present).
2. **Case 2 (entry type: book):**
   - The series field is now included under the parent field.
   - The issue and publisher are also added for books

I confirmed that the exported .yaml file works with the typst system by using `hayagriva literature.yaml reference` as stated in their [documentation](https://github.com/typst/hayagriva/tree/main).

Also, I compared the exports of the typst system with the exports from jabref and they contained the same fields.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
