### PR TITLE
Remove comments - don't work on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,20 +49,6 @@ jobs:
           checkstyle_version: '10.3'
       - name: Run checkstyle using gradle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet JabRef's code guidelines.
-              We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
-              The tool reviewdog already placed comments on GitHub to indicate the places. See the tab "Files" in you PR.
-              Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
-              Afterwards, please run checkstyle locally and fix the issues.
-
-
-              More information on code quality in JabRef is available at <https://devdocs.jabref.org/getting-into-the-code/development-strategy.html>.
-          comment_tag: checkstyle
   openrewrite:
     name: OpenRewrite
     runs-on: ubuntu-latest
@@ -81,19 +67,6 @@ jobs:
       - name: Run OpenRewrite
         run: |
           ./gradlew rewriteDryRun
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet JabRef's code guidelines.
-              We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
-              The issues found can be **automatically fixed**.
-              Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
-
-
-              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "OpenRewrite".
-          comment_tag: openrewrite
   modernizer:
     name: Modernizer
     runs-on: ubuntu-latest
@@ -114,18 +87,6 @@ jobs:
           # enable failing of this task if modernizer complains
           sed -i "s/failOnViolations = false/failOnViolations = true/" build.gradle
           ./gradlew modernizer
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet JabRef's code guidelines.
-              We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
-              Please fix the detected errors, commit, and push.
-
-
-              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
-          comment_tag: modernizer
   markdown:
     name: Markdown
     runs-on: ubuntu-latest
@@ -141,17 +102,6 @@ jobs:
           globs: |
             *.md
             docs/**/*.md
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              You modified Markdown (*.md) files.
-              To ensure consistent styling, we have [markdown-lint](https://github.com/DavidAnson/markdownlint) in place.
-              [Markdown lint's rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules) help to keep our Markdown files consistent within this repository and consistent with the Markdown files outside here.
-
-              You can check the detailed error output at the tab "Checks", section "Tests" (on the left), subsection "Markdown".
-          comment_tag: markdown
   changelog:
     name: CHANGELOG.md
     runs-on: ubuntu-latest
@@ -198,14 +148,6 @@ jobs:
           diff \
             <(git show origin/main:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)')
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              While the PR was in progress, JabRef released a new version.
-              You have to merge `upstream/main` and move your entry in `CHANGELOG.md` to section `## [Unreleased]`.
-          comment_tag: changelog-unreleased-only
   tests:
     name: Unit tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
I thought it would be nice to have some messages at PRs when sth goes wrong.

However, only persons with access rights to this repo get these texts - others not.

Thus, I remove them.

@reviewdog can. Follow-up is to convert the output in case of errors to a format consumable to reviewdog.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
