### PR TITLE
Replace cache: gradle with "odern" gradle-build-action

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
       - name: Clean up keychain
         run: |
          security delete-keychain signing_temp.keychain ${{runner.temp}}/keychain/notarization.keychain || true
@@ -85,6 +84,8 @@ jobs:
           mkdir ${{runner.temp}}/keychain
           security create-keychain -p jabref ${{runner.temp}}/keychain/notarization.keychain
           security set-keychain-settings ${{runner.temp}}/keychain/notarization.keychain
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Prepare merged jars and modules dir (macOS)
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir
       - name: Build dmg (macOS)

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -94,7 +94,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Prepare merged jars and modules dir (macOS)
         if: (matrix.os == 'macos-latest') || (steps.checksecrets.outputs.secretspresent == 'NO')
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" prepareModulesDir

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Check whether journal-list.mv can be generated (the "real" generation is done inside JabRef's build process)
         run: |
           ./gradlew generateJournalListMV

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -50,7 +50,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run fetcher tests
         run: ./gradlew fetcherTest
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
       - name: Run checkstyle reporter
         uses: nikitasavinov/checkstyle-action@master
         with:
@@ -47,6 +46,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           checkstyle_config: 'config/checkstyle/checkstyle_reviewdog.xml'
           checkstyle_version: '10.3'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run checkstyle using gradle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
   openrewrite:
@@ -63,7 +64,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run OpenRewrite
         run: |
           ./gradlew rewriteDryRun
@@ -81,7 +83,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run modernizer
         run: |
           # enable failing of this task if modernizer complains
@@ -162,7 +165,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run tests
         run: xvfb-run --auto-servernum ./gradlew check -x checkstyleJmh -x checkstyleMain -x checkstyleTest -x modernizer
         env:
@@ -197,7 +201,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run tests on PostgreSQL
         run: ./gradlew databaseTest --rerun-tasks
         env:
@@ -234,7 +239,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Run GUI tests
         run: xvfb-run --auto-servernum ./gradlew guiTest
         env:
@@ -278,7 +284,8 @@ jobs:
         with:
           java-version: 21.0.1
           distribution: 'liberica'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Update test coverage metrics
         if: (github.ref == 'refs/heads/main') && (steps.checksecrets.outputs.secretspresent == 'YES')
         run: xvfb-run --auto-servernum ./gradlew jacocoTestReport


### PR DESCRIPTION
Reasons at https://github.com/gradle/gradle-build-action#why-use-the-gradle-build-action

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
