### PR TITLE
Fix predatory journal loading resoures

### DIFF
--- a/src/main/java/org/jabref/gui/MainApplication.java
+++ b/src/main/java/org/jabref/gui/MainApplication.java
@@ -10,10 +10,15 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.JabRefPreferences;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * JabRef's main class to process command line options and to start the UI
  */
 public class MainApplication extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MainApplication.class);
+
     private static List<ParserResult> parserResults;
     private static boolean isBlank;
     private static JabRefPreferences preferences;
@@ -43,5 +48,10 @@ public class MainApplication extends Application {
         OOBibBaseConnect.closeOfficeConnection();
         Globals.stopBackgroundTasks();
         Globals.shutdownThreadPools();
+        try {
+            Globals.predatoryJournalRepository.close();
+        } catch (Exception e) {
+            LOGGER.warn("Cloud not shut down predatoryJournalRepository", e);
+        }
     }
 }

--- a/src/main/java/org/jabref/logic/journals/predatory/PredatoryJournalListLoader.java
+++ b/src/main/java/org/jabref/logic/journals/predatory/PredatoryJournalListLoader.java
@@ -2,6 +2,7 @@ package org.jabref.logic.journals.predatory;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.slf4j.Logger;
@@ -12,8 +13,6 @@ public class PredatoryJournalListLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(PredatoryJournalListLoader.class);
 
     public static PredatoryJournalRepository loadRepository() {
-        PredatoryJournalRepository repository = new PredatoryJournalRepository();
-
         Path path;
         try {
             URL resource = PredatoryJournalRepository.class.getResource("/journals/predatory-journals.mv");
@@ -22,11 +21,14 @@ public class PredatoryJournalListLoader {
                 return new PredatoryJournalRepository();
             }
             path = Path.of(resource.toURI());
+            if (!Files.exists(path)) {
+                LOGGER.error("predatoryJournal-list.mv not found. Using demo list.");
+                return new PredatoryJournalRepository();
+            }
         } catch (URISyntaxException e) {
             LOGGER.error("Could not determine path to predatoryJournal-list.mv. Using demo list.");
             return new PredatoryJournalRepository();
         }
-
         return new PredatoryJournalRepository(path);
     }
 }

--- a/src/main/java/org/jabref/logic/journals/predatory/PredatoryJournalListLoader.java
+++ b/src/main/java/org/jabref/logic/journals/predatory/PredatoryJournalListLoader.java
@@ -15,11 +15,13 @@ public class PredatoryJournalListLoader {
     public static PredatoryJournalRepository loadRepository() {
         PredatoryJournalRepository repository = new PredatoryJournalRepository();
         // Initialize with built-in list
+        // We cannot use PredatoryJournalRepository.class.getResource, because this is null in JPackage, thus we need "getResourceAsStream"
         try (InputStream resourceAsStream = PredatoryJournalListLoader.class.getResourceAsStream("/journals/predatory-journals.mv")) {
             if (resourceAsStream == null) {
                 LOGGER.warn("There is no predatory-journal.mv. We use a default predatory dummy list");
                 repository = new PredatoryJournalRepository();
             } else {
+                // MVStore does not support loading from stream. Thus, we need to have a file copy of the stream.
                 Path tempDir = Files.createTempDirectory("jabref-journal");
                 Path tempJournalList = tempDir.resolve("predatory-journals.mv");
                 Files.copy(resourceAsStream, tempJournalList);

--- a/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.integrity;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -14,6 +13,7 @@ import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.predatory.PredatoryJournalListLoader;
+import org.jabref.logic.journals.predatory.PredatoryJournalRepository;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
@@ -47,28 +47,28 @@ import static org.mockito.Mockito.when;
 class IntegrityCheckTest {
 
     @Test
-    void bibTexAcceptsStandardEntryType() {
+    void bibTexAcceptsStandardEntryType() throws Exception {
         assertCorrect(withMode(createContext(StandardField.TITLE, "sometitle", StandardEntryType.Article), BibDatabaseMode.BIBTEX));
     }
 
     @Test
-    void bibTexDoesNotAcceptIEEETranEntryType() {
+    void bibTexDoesNotAcceptIEEETranEntryType() throws Exception {
         assertWrong(withMode(createContext(StandardField.TITLE, "sometitle", IEEETranEntryType.Patent), BibDatabaseMode.BIBTEX));
     }
 
     @Test
-    void bibLaTexAcceptsIEEETranEntryType() {
+    void bibLaTexAcceptsIEEETranEntryType() throws Exception {
         assertCorrect((withMode(createContext(StandardField.TITLE, "sometitle", IEEETranEntryType.Patent), BibDatabaseMode.BIBLATEX)));
     }
 
     @Test
-    void bibLaTexAcceptsStandardEntryType() {
+    void bibLaTexAcceptsStandardEntryType() throws Exception {
         assertCorrect(withMode(createContext(StandardField.TITLE, "sometitle", StandardEntryType.Article), BibDatabaseMode.BIBLATEX));
     }
 
     @ParameterizedTest
     @MethodSource("provideCorrectFormat")
-    void authorNameChecksCorrectFormat(String input) {
+    void authorNameChecksCorrectFormat(String input) throws Exception {
         for (Field field : FieldFactory.getPersonNameFields()) {
             assertCorrect(withMode(createContext(field, input), BibDatabaseMode.BIBLATEX));
         }
@@ -76,7 +76,7 @@ class IntegrityCheckTest {
 
     @ParameterizedTest
     @MethodSource("provideIncorrectFormat")
-    void authorNameChecksIncorrectFormat(String input) {
+    void authorNameChecksIncorrectFormat(String input) throws Exception {
         for (Field field : FieldFactory.getPersonNameFields()) {
             assertWrong(withMode(createContext(field, input), BibDatabaseMode.BIBLATEX));
         }
@@ -94,7 +94,7 @@ class IntegrityCheckTest {
     }
 
     @Test
-    void testFileChecks() {
+    void testFileChecks() throws Exception {
         MetaData metaData = mock(MetaData.class);
         Mockito.when(metaData.getDefaultFileDirectory()).thenReturn(Optional.of("."));
         Mockito.when(metaData.getUserFileDirectory(any(String.class))).thenReturn(Optional.empty());
@@ -107,7 +107,7 @@ class IntegrityCheckTest {
     }
 
     @Test
-    void fileCheckFindsFilesRelativeToBibFile(@TempDir Path testFolder) throws IOException {
+    void fileCheckFindsFilesRelativeToBibFile(@TempDir Path testFolder) throws Exception {
         Path bibFile = testFolder.resolve("lit.bib");
         Files.createFile(bibFile);
         Path pdfFile = testFolder.resolve("file.pdf");
@@ -120,7 +120,7 @@ class IntegrityCheckTest {
     }
 
     @Test
-    void testEntryIsUnchangedAfterChecks() {
+    void testEntryIsUnchangedAfterChecks() throws Exception {
         BibEntry entry = new BibEntry();
 
         // populate with all known fields
@@ -137,12 +137,14 @@ class IntegrityCheckTest {
         bibDatabase.insertEntry(entry);
         BibDatabaseContext context = new BibDatabaseContext(bibDatabase);
 
-        new IntegrityCheck(context,
-                mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
-                JournalAbbreviationLoader.loadBuiltInRepository(),
-                PredatoryJournalListLoader.loadRepository(), false)
-                .check();
+        try (PredatoryJournalRepository predatoryJournalRepository = PredatoryJournalListLoader.loadRepository()) {
+            new IntegrityCheck(context,
+                    mock(FilePreferences.class),
+                    createCitationKeyPatternPreferences(),
+                    JournalAbbreviationLoader.loadBuiltInRepository(),
+                    predatoryJournalRepository, false)
+                    .check();
+        }
 
         assertEquals(clonedEntry, entry);
     }
@@ -169,25 +171,31 @@ class IntegrityCheckTest {
         return createContext(field, value, metaData);
     }
 
-    private void assertWrong(BibDatabaseContext context) {
-        List<IntegrityMessage> messages = new IntegrityCheck(context,
-                mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
-                JournalAbbreviationLoader.loadBuiltInRepository(),
-                PredatoryJournalListLoader.loadRepository(), false)
-                .check();
+    private void assertWrong(BibDatabaseContext context) throws Exception {
+        List<IntegrityMessage> messages;
+        try (PredatoryJournalRepository predatoryJournalRepository = PredatoryJournalListLoader.loadRepository()) {
+            messages = new IntegrityCheck(context,
+                    mock(FilePreferences.class),
+                    createCitationKeyPatternPreferences(),
+                    JournalAbbreviationLoader.loadBuiltInRepository(),
+                    predatoryJournalRepository, false)
+                    .check();
+        }
         assertNotEquals(Collections.emptyList(), messages);
     }
 
-    private void assertCorrect(BibDatabaseContext context) {
+    private void assertCorrect(BibDatabaseContext context) throws Exception {
         FilePreferences filePreferencesMock = mock(FilePreferences.class);
         when(filePreferencesMock.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
-        List<IntegrityMessage> messages = new IntegrityCheck(context,
-                filePreferencesMock,
-                createCitationKeyPatternPreferences(),
-                JournalAbbreviationLoader.loadBuiltInRepository(),
-                PredatoryJournalListLoader.loadRepository(), false)
-                .check();
+        List<IntegrityMessage> messages;
+        try (PredatoryJournalRepository predatoryJournalRepository = PredatoryJournalListLoader.loadRepository()) {
+            messages = new IntegrityCheck(context,
+                    filePreferencesMock,
+                    createCitationKeyPatternPreferences(),
+                    JournalAbbreviationLoader.loadBuiltInRepository(),
+                    predatoryJournalRepository, false)
+                    .check();
+        }
         assertEquals(Collections.emptyList(), messages);
     }
 

--- a/src/test/java/org/jabref/logic/integrity/PredatoryJournalCheckerTest.java
+++ b/src/test/java/org/jabref/logic/integrity/PredatoryJournalCheckerTest.java
@@ -4,9 +4,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.journals.predatory.PredatoryJournalListLoader;
+import org.jabref.logic.journals.predatory.PredatoryJournalRepository;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +17,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class PredatoryJournalCheckerTest {
 
     static PredatoryJournalChecker checker;
+    static PredatoryJournalRepository predatoryJournalRepository = PredatoryJournalListLoader.loadRepository();
 
     @BeforeAll
     static void initChecker() {
-        checker = new PredatoryJournalChecker(PredatoryJournalListLoader.loadRepository(),
+        checker = new PredatoryJournalChecker(predatoryJournalRepository,
                 List.of(StandardField.JOURNAL, StandardField.PUBLISHER, StandardField.BOOKTITLE));
+    }
+
+    @AfterAll
+    static void close() throws Exception {
+        predatoryJournalRepository.close();
     }
 
     @Test


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/jabref-always-displaying-full-screen-on-ubuntu-not-in-gnome-windown/4090/3

Seems like there is a problem with the path in the jlink module stuff package when opening a File resource instead of a stream 

Copy code from JournalAbbrev

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
