### PR TITLE
Added tests to verify proper output from getErrorMessage()

### DIFF
--- a/src/test/java/org/jabref/logic/importer/ParserResultTest.java
+++ b/src/test/java/org/jabref/logic/importer/ParserResultTest.java
@@ -7,6 +7,7 @@ import org.jabref.model.entry.BibEntry;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,5 +25,27 @@ class ParserResultTest {
         BibDatabase bibDatabase = new BibDatabase(List.of(bibEntry));
         ParserResult parserResult = new ParserResult(bibDatabase);
         assertFalse(parserResult.isEmpty());
+    }
+
+    @Test
+    public void warningsAddedMatchErrorMessage() {
+        ParserResult parserResult = new ParserResult();
+        parserResult.addWarning("Warning 1 ");
+        parserResult.addWarning("Warning 2 ");
+        assertEquals("Warning 1 \nWarning 2 ", parserResult.getErrorMessage());
+    }
+
+    @Test
+    public void hasEmptyMessageForNoWarnings() {
+        ParserResult parserResult = new ParserResult();
+        assertEquals("", parserResult.getErrorMessage());
+    }
+
+    @Test
+    public void doesNotHaveDuplicateWarnings() {
+        ParserResult parserResult = new ParserResult();
+        parserResult.addWarning("Duplicate Warning");
+        parserResult.addWarning("Duplicate Warning");
+        assertEquals("Duplicate Warning", parserResult.getErrorMessage());
     }
 }


### PR DESCRIPTION
Tests were added as requested from the conversation in the merged pull request #10700. The three tests added aim to verify the correct output from the getErrorMessage function. Specifically when the ParserResult is empty, not empty, or has duplicate messages added, 

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ x ] Tests created for changes (if applicable)
- [ x ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
