### PR TITLE
Merge split localization string

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -160,8 +160,7 @@ public class GroupDialogViewModel {
                     return true;
                 },
                 ValidationMessage.warning(
-                    Localization.lang("There exists already a group with the same name.") + "\n" +
-                    Localization.lang("If you use it, it will inherit all entries from this other group.")
+                        Localization.lang("There already exists a group with the same name. \nIf you use it, it will inherit all entries from this other group.")
                 )
         );
 

--- a/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -160,7 +160,7 @@ public class GroupDialogViewModel {
                     return true;
                 },
                 ValidationMessage.warning(
-                        Localization.lang("There already exists a group with the same name. \nIf you use it, it will inherit all entries from this other group.")
+                        Localization.lang("There already exists a group with the same name.\nIf you use it, it will inherit all entries from this other group.")
                 )
         );
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1866,8 +1866,6 @@ Delete\ '%0'\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ 
 Delete\ '%0'=Delete '%0'
 Delete\ from\ disk=Delete from disk
 Remove\ from\ entry=Remove from entry
-There\ exists\ already\ a\ group\ with\ the\ same\ name.=There exists already a group with the same name.
-If\ you\ use\ it,\ it\ will\ inherit\ all\ entries\ from\ this\ other\ group.=If you use it, it will inherit all entries from this other group.
 
 Copy\ linked\ file=Copy linked file
 Copy\ linked\ file\ to\ folder...=Copy linked file to folder...
@@ -1899,6 +1897,7 @@ Invalid\ identifier\:\ '%0'.=Invalid identifier: '%0'.
 empty\ citation\ key=empty citation key
 Aux\ file=Aux file
 Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Group containing entries cited in a given TeX file
+There\ already\ exists\ a\ group\ with\ the\ same\ name.\nIf\ you\ use\ it,\ it\ will\ inherit\ all\ entries\ from\ this\ other\ group.=There already exists a group with the same name.\nIf you use it, it will inherit all entries from this other group.
 
 Any\ file=Any file
 


### PR DESCRIPTION
Newlines have to be inside the localization strings, not outside.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
