### PR TITLE
Update javafx to 22-ea+16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencyLocking {
 }
 
 javafx {
-    version = "21.0.1"
+    version = "22-ea+16"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web', 'javafx.swing' ]
 }
 


### PR DESCRIPTION
This updates JavaFX to an EA version to prevent crashing at start.

Refs https://github.com/JabRef/jabref/issues/10716 (I did not put "fixes", because multiple users will surely report issues)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
