### PR TITLE
Fix the preview panel showing the wrong entry (an entry that is not selected in the entry table)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
+
 ### Removed
 
 ## [5.12] – 2023-12-24

--- a/src/main/java/org/jabref/gui/preview/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/preview/PreviewPanel.java
@@ -156,8 +156,8 @@ public class PreviewPanel extends VBox {
 
     public void setEntry(BibEntry entry) {
         this.entry = entry;
-        previewView.setLayout(previewPreferences.getSelectedPreviewLayout());
         previewView.setEntry(entry);
+        previewView.setLayout(previewPreferences.getSelectedPreviewLayout());
     }
 
     public void print() {


### PR DESCRIPTION
Fix https://github.com/JabRef/jabref/issues/9172

## Bug Summary
In `PreviewViewer`, both `setEntry` and `setLayout` will assign the entry and layout fields respectively and call the `update` method to reflect the new UI state. The thing is that `update` would start a background task to update the UI. The `setLayout` method would run the update UI background task on the previous entry because the entry field assignment happens in `setEntry`. While `setEntry` would run the task with the new entry. The bug happens when the task started by the `setLayout` method finishes last which will result in the overriding of the display of the new entry preview made by `setEntry`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
