### PR TITLE
Ignore 429 at link check

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '200..=204, 429, 500' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '200,201,202,203,204,429,500' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '200..=299,403,429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '200..=204, 429, 500' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: 100..=103,200..=299,403,429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept 100..=103,200..=299,403..=403,429..=429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '100..=103, 200..=299, 403, 429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '100..=103, 200..=299, 403..=403, 429..=429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '200,204,206' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '100..=103,200,204,206' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '200..=299,403,429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '100..=103, 200..=299, 403, 429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '100..=103, 200..=299, 403..=403, 429..=429' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept '200,204,206' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept '100..=103,200,204,206' --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept=100..=103,200..=299,403,429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept=100..=103,200..=299,403..=403,429..=429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: 100..=103,200..=299,403,429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept=100..=103,200..=299,403,429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,4 +32,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.8.0
         with:
           fail: true
-          args: --accept=100..=103,200..=299,403..=403,429..=429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'
+          args: --accept 100..=103,200..=299,403..=403,429..=429 --max-concurrency 1 --cache --no-progress --exclude-all-private './**/*.md'


### PR DESCRIPTION
Our link checker reports an error at [http 429](https://de.wikipedia.org/wiki/HTTP-Statuscode#code429). 

![grafik](https://github.com/JabRef/jabref/assets/1366654/ceaaae6a-5b73-4cbc-93f7-0d40bec42708)

We should ignore it.

Sources:

- https://github.com/lycheeverse/lychee/issues/367 -- no other work around available
- Idea to add 403 to ignore list: https://github.com/lycheeverse/lychee-action/issues/39

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
