### PR TITLE
Use custom doi now in Template exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- The Custom export format now uses the custom DOI base URI in the preferences for the `DOICheck`, if activated [forum#4084](https://discourse.jabref.org/t/export-html-disregards-custom-doi-base-uri/4084)
+
 ### Fixed
 
 - We fixed an issue where attempting to cancel the importing/generation of an entry from id is ignored. [#10508](https://github.com/JabRef/jabref/issues/10508)

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class DoiResolution implements FulltextFetcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DoiResolution.class);
-    private DOIPreferences doiPreferences;
+    private final DOIPreferences doiPreferences;
 
     public DoiResolution(DOIPreferences doiPreferences) {
         super();

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -443,7 +443,7 @@ class LayoutEntry {
             case "CreateDocBook5Editors" -> new CreateDocBook5Editors();
             case "CurrentDate" -> new CurrentDate();
             case "DateFormatter" -> new DateFormatter();
-            case "DOICheck" -> new DOICheck();
+            case "DOICheck" -> new DOICheck(preferences.getDoiPreferences());
             case "DOIStrip" -> new DOIStrip();
             case "EntryTypeFormatter" -> new EntryTypeFormatter();
             case "FirstPage" -> new FirstPage();

--- a/src/main/java/org/jabref/logic/layout/LayoutFormatterPreferences.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutFormatterPreferences.java
@@ -7,17 +7,22 @@ import java.util.Optional;
 import javafx.beans.property.StringProperty;
 
 import org.jabref.logic.layout.format.NameFormatterPreferences;
+import org.jabref.logic.preferences.DOIPreferences;
 
 public class LayoutFormatterPreferences {
 
     private final NameFormatterPreferences nameFormatterPreferences;
+
+    private final DOIPreferences doiPreferences;
     private final StringProperty mainFileDirectoryProperty;
     private final Map<String, String> customExportNameFormatters = new HashMap<>();
 
     public LayoutFormatterPreferences(NameFormatterPreferences nameFormatterPreferences,
+                                      DOIPreferences doiPreferences,
                                       StringProperty mainFileDirectoryProperty) {
         this.nameFormatterPreferences = nameFormatterPreferences;
         this.mainFileDirectoryProperty = mainFileDirectoryProperty;
+        this.doiPreferences = doiPreferences;
     }
 
     public NameFormatterPreferences getNameFormatterPreferences() {
@@ -38,5 +43,9 @@ public class LayoutFormatterPreferences {
 
     public void putCustomExportNameFormatter(String formatterName, String contents) {
         customExportNameFormatters.put(formatterName, contents);
+    }
+
+    public DOIPreferences getDoiPreferences() {
+        return doiPreferences;
     }
 }

--- a/src/main/java/org/jabref/logic/layout/format/DOICheck.java
+++ b/src/main/java/org/jabref/logic/layout/format/DOICheck.java
@@ -1,14 +1,25 @@
 package org.jabref.logic.layout.format;
 
+import java.net.URI;
+
 import org.jabref.logic.layout.LayoutFormatter;
+import org.jabref.logic.preferences.DOIPreferences;
 import org.jabref.model.entry.identifier.DOI;
 
 /**
  * Used to fix [ 1588028 ] export HTML table DOI URL.
  * <p>
- * Will prepend "http://doi.org/" if only DOI and not an URL is given.
+ * Will prepend "<a href="http://doi.org/">http://doi.org/</a>" or the DOI url with a custom base URL defined in the {@link DOIPreferences}
+ * if only DOI and not an URL is given.
  */
 public class DOICheck implements LayoutFormatter {
+
+    private final DOIPreferences doiPreferences;
+
+    public DOICheck(DOIPreferences doiPreferences) {
+        this.doiPreferences = doiPreferences;
+    }
+
     @Override
     public String format(String fieldText) {
         if (fieldText == null) {
@@ -18,6 +29,14 @@ public class DOICheck implements LayoutFormatter {
         if (result.startsWith("/")) {
             result = result.substring(1);
         }
+
+        if (doiPreferences.isUseCustom()) {
+            var base = URI.create(doiPreferences.getDefaultBaseURI());
+            return DOI.parse(result).flatMap(doi -> doi.getExternalURIFromBase(base))
+                      .map(URI::toASCIIString)
+                      .orElse(result);
+        }
+
         return DOI.parse(result).map(DOI::getURIAsASCIIString).orElse(result);
     }
 }

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -262,7 +262,7 @@ public class DOI implements Identifier {
         return getExternalURIFromBase(URI.create(customBase));
     }
 
-    private Optional<URI> getExternalURIFromBase(URI base) {
+    public Optional<URI> getExternalURIFromBase(URI base) {
         try {
             URI uri = new URI(base.getScheme(), base.getHost(), "/" + doi, null);
             return Optional.of(uri);

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -1178,6 +1178,7 @@ public class JabRefPreferences implements PreferencesService {
     public LayoutFormatterPreferences getLayoutFormatterPreferences() {
         return new LayoutFormatterPreferences(
                 getNameFormatterPreferences(),
+                getDOIPreferences(),
                 getFilePreferences().mainFileDirectoryProperty());
     }
 

--- a/src/test/java/org/jabref/logic/layout/format/DOICheckTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/DOICheckTest.java
@@ -3,21 +3,33 @@ package org.jabref.logic.layout.format;
 import java.util.stream.Stream;
 
 import org.jabref.logic.layout.LayoutFormatter;
+import org.jabref.logic.preferences.DOIPreferences;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DOICheckTest {
 
-    private LayoutFormatter layoutFormatter = new DOICheck();
+    private final DOIPreferences doiPreferences = mock(DOIPreferences.class);
+    private final LayoutFormatter layoutFormatter = new DOICheck(doiPreferences);
 
     @ParameterizedTest
     @MethodSource("provideDOI")
     void formatDOI(String formattedDOI, String originalDOI) {
         assertEquals(formattedDOI, layoutFormatter.format(originalDOI));
+    }
+
+    @Test
+    void formatDOIWithCustomBase() {
+        when(doiPreferences.isUseCustom()).thenReturn(true);
+        when(doiPreferences.getDefaultBaseURI()).thenReturn("http://example.org");
+        assertEquals("http://example.org/10.1000/ISBN1-900512-44-0", layoutFormatter.format("10.1000/ISBN1-900512-44-0"));
     }
 
     private static Stream<Arguments> provideDOI() {


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/341
Fixes https://discourse.jabref.org/t/export-html-disregards-custom-doi-base-uri/4084
<!-- 

Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
