### PR TITLE
Ignore submodule changes (for normal devs)

### DIFF
--- a/.github/workflows/refresh-csl-subtrees.yml
+++ b/.github/workflows/refresh-csl-subtrees.yml
@@ -31,6 +31,11 @@ jobs:
           cd src/main/resources/csl-locales
           git checkout master
           git pull
+      - name: Persist changes
+        run: |
+          git add -f src/main/resources/csl-styles
+          git add -f src/main/resources/csl-locales
+          git diff-index --quiet HEAD || git commit -m 'Update CSL styles'
       - uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}

--- a/.github/workflows/refresh-journal-lists.yml
+++ b/.github/workflows/refresh-journal-lists.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Check whether journal-list.mv can be generated (the "real" generation is done inside JabRef's build process)
         run: |
           ./gradlew generateJournalListMV
+      - name: Persist changes
+        run: |
+          git add -f buildres/abbrv.jabref.org
+          git diff-index --quiet HEAD || git commit -m 'Update journal abbreviation lists'
       - uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,15 @@
-[submodule "buildres/abbrv.jabref.org"]
+[submodule "abbrv.jabref.org"]
   path = buildres/abbrv.jabref.org
   url = https://github.com/JabRef/abbrv.jabref.org.git
-[submodule "buildres/csl-styles"]
+  ignore = all
+  shallow = true
+[submodule "csl-styles"]
   path = src/main/resources/csl-styles
   url = https://github.com/citation-style-language/styles.git
-[submodule "buildres/csl-locales"]
+  ignore = all
+  shallow = true
+[submodule "csl-locales"]
   path = src/main/resources/csl-locales
   url = https://github.com/citation-style-language/locales.git
+  ignore = all
+  shallow = true


### PR DESCRIPTION
Via https://stackoverflow.com/a/12527608/873282, I found a solution for our "dirty" sub modules.

The GitHub workflow update is a "wild guess". I would say: Merge and fix the workflows if they don't work.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
