### PR TITLE
Streamline test output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,6 +357,9 @@ tasks.register('generateCitaviSource', XjcTask) {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+
+    // hint by https://docs.gradle.org/current/userguide/performance.html#run_the_compiler_as_a_separate_process
+    options.fork = true
 }
 
 compileJava {
@@ -443,9 +446,15 @@ test {
 }
 
 testlogger {
-    theme 'standard-parallel'
+    // See https://github.com/radarsh/gradle-test-logger-plugin#configuration for configuration options
+
+    theme 'standard'
+
     showPassed false
     showSkipped false
+
+    showCauses false
+    showStackTraces false
 }
 
 tasks.register('databaseTest', Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -357,9 +357,6 @@ tasks.register('generateCitaviSource', XjcTask) {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-
-    // hint by https://docs.gradle.org/current/userguide/performance.html#run_the_compiler_as_a_separate_process
-    options.fork = true
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -461,23 +461,11 @@ tasks.register('databaseTest', Test) {
     useJUnitPlatform {
         includeTags 'DatabaseTest'
     }
-
-    testLogging {
-        // set options for log level LIFECYCLE
-        events = ["FAILED"]
-        exceptionFormat "full"
-    }
 }
 
 tasks.register('fetcherTest', Test) {
     useJUnitPlatform {
         includeTags 'FetcherTest'
-    }
-
-    testLogging {
-        // set options for log level LIFECYCLE
-        events = ["FAILED"]
-        exceptionFormat "full"
     }
 }
 


### PR DESCRIPTION
Our fetcher tests output the test results twice:

```
> Task :fetcherTest
org.jabref.logic.importer.fetcher.ACSTest

  Test findByDOI() FAILED

  org.opentest4j.AssertionFailedError: expected: <Optional[https://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014]> but was: <Optional.empty>


ACSTest > findByDOI() FAILED
    org.opentest4j.AssertionFailedError: expected: <Optional[https://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014]> but was: <Optional.empty>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
```

This was unreadable. 

---

We have the plugin [gradle-test-logger-plugin](https://github.com/radarsh/gradle-test-logger-plugin) enabled for that. Today, I found the solution (refs https://github.com/radarsh/gradle-test-logger-plugin/issues/252#issuecomment-1023247582).

> Configure the plugin correctly :)

---

New output (excerpt)

```
  Test findManyEntries() FAILED (1.2s)

  org.jabref.logic.importer.FetcherException: Error while fetching from Google Scholar


org.jabref.logic.importer.fetcher.GrobidCitationFetcherTest

  grobidPerformSearchCorrectResultTest(String, BibEntry, String)

    Test example1 FAILED (42.2s)

    org.opentest4j.AssertionFailedError: expected: <[@article{-1,
      author = {Derwing, Tracey and Rossiter, Marian and Munro, Murray},
      date = {2002-09},
      doi = {10.1080/01434630208666468},
      journal = {Journal of Multilingual and Multicultural Development},
      month = {9},
      number = {4},
      pages = {245-259},
      publisher = {Informa UK Limited},
      title = {Teaching Native Speakers to Listen to Foreign-accented Speech},
      volume = {23},
      year = {2002},
      _jabref_shared = {sharedId: -1, version: 1}
    }]> but was: <[]>
```

---

Follow-up to https://github.com/JabRef/jabref/pull/5676.

---

The output of `org.jabref.logic.l10n.LocalizationConsistencyTest#findMissingLocalizationKeys` is still showing instructions (in IntelliJ)

```
DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE
PASTE THESE INTO THE ENGLISH LANGUAGE FILE

%0\ matches\ the\ term\ <b>%1</b>=%0 matches the term <b>%1</b>
```

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
