### PR TITLE
Fix NPE when opening and re-opening a library

### DIFF
--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
@@ -280,7 +280,7 @@ public class PdfIndexer {
      */
     public Set<String> getListOfFilePaths() {
         Set<String> paths = new HashSet<>();
-        try (IndexReader reader = DirectoryReader.open(indexWriter)) {
+        try (IndexReader reader = DirectoryReader.open(getIndexWriter())) {
             IndexSearcher searcher = new IndexSearcher(reader);
             MatchAllDocsQuery query = new MatchAllDocsQuery();
             TopDocs allDocs = searcher.search(query, Integer.MAX_VALUE);

--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexerManager.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexerManager.java
@@ -62,16 +62,20 @@ public class PdfIndexerManager {
                 LOGGER.debug("Problem closing PDF indexer", e);
             }
         });
+        indexerMap.clear();
+        pathFilePreferencesMap.clear();
     }
 
     public static void shutdownIndexer(BibDatabaseContext context) {
-        PdfIndexer indexer = indexerMap.get(context.getFulltextIndexPath());
+        Path fulltextIndexPath = context.getFulltextIndexPath();
+        PdfIndexer indexer = indexerMap.remove(fulltextIndexPath);
         if (indexer != null) {
             try {
                 indexer.close();
             } catch (IOException e) {
                 LOGGER.debug("Could not close indexer", e);
             }
+            pathFilePreferencesMap.remove(fulltextIndexPath);
         } else {
             LOGGER.debug("No indexer found for context {}", context);
         }


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/10193

The tests worked, but we do not have tests running opening and closing a library. Thus, this sneaked through...

Hotfix, therefore, I merge.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
