### PR TITLE
Fix annotation

### DIFF
--- a/src/test/java/org/jabref/architecture/MainArchitectureTest.java
+++ b/src/test/java/org/jabref/architecture/MainArchitectureTest.java
@@ -119,6 +119,7 @@ class MainArchitectureTest {
     public static void restrictUsagesInLogic(JavaClasses classes) {
         noClasses().that().resideInAPackage(PACKAGE_ORG_JABREF_LOGIC)
                    .and().areNotAnnotatedWith(AllowedToUseSwing.class)
+                   .and().areNotAssignableFrom("org.jabref.logic.search.DatabaseSearcherWithBibFilesTest")
                    .should().dependOnClassesThat().resideInAPackage(PACKAGE_JAVAX_SWING)
                    .orShould().dependOnClassesThat().haveFullyQualifiedName(CLASS_ORG_JABREF_GLOBALS)
                    .check(classes);

--- a/src/test/java/org/jabref/logic/search/DatabaseSearcherWithBibFilesTest.java
+++ b/src/test/java/org/jabref/logic/search/DatabaseSearcherWithBibFilesTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.jabref.architecture.AllowedToUseSwing;
 import org.jabref.gui.Globals;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParserResult;
@@ -38,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@AllowedToUseSwing("Makes use of Globals because of FullTextSearchRule")
 public class DatabaseSearcherWithBibFilesTest {
 
     private static BibEntry titleSentenceCased = new BibEntry(StandardEntryType.Misc)


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/10193.

The usage of the annotation `@AllowedToUseSwing` was a quick hack. Now, the "exception" is inside `MainArchitectureTest`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
