### PR TITLE
Change default CSL style to ieee-with-url

### DIFF
--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -37,7 +37,7 @@ import org.xml.sax.SAXException;
  */
 public class CitationStyle {
 
-    public static final String DEFAULT = "/ieee.csl";
+    public static final String DEFAULT = "/ieee-with-url.csl";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationStyle.class);
     private static final String STYLES_ROOT = "/csl-styles";
@@ -141,8 +141,11 @@ public class CitationStyle {
             return STYLES;
         }
 
-        URL url = CitationStyle.class.getResource(STYLES_ROOT + "/acm-siggraph.csl");
-        Objects.requireNonNull(url);
+        URL url = CitationStyle.class.getResource(STYLES_ROOT + DEFAULT);
+        if (url == null) {
+            LOGGER.error("Could not find any citation style. Tried with {}.", DEFAULT);
+            return Collections.emptyList();
+        }
 
         try {
             URI uri = url.toURI();

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -37,7 +37,7 @@ import org.xml.sax.SAXException;
  */
 public class CitationStyle {
 
-    public static final String DEFAULT = "/ieee-with-url.csl";
+    public static final String DEFAULT = "/ieee.csl";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationStyle.class);
     private static final String STYLES_ROOT = "/csl-styles";

--- a/src/main/java/org/jabref/logic/citationstyle/JabRefLocaleProvider.java
+++ b/src/main/java/org/jabref/logic/citationstyle/JabRefLocaleProvider.java
@@ -28,7 +28,6 @@ public class JabRefLocaleProvider implements LocaleProvider {
                 if (url == null) {
                     throw new IllegalArgumentException("Unable to load locale " + locale);
                 }
-
                 return CSLUtils.readURLToString(url, "UTF-8");
             } catch (IOException e) {
                 throw new UncheckedIOException("failed to read locale " + locale, e);


### PR DESCRIPTION
I had some CSL issues.

They can be fixed 

- cd src/main/resources/csl-locales
- git reset --hard
- cd ../csl-styles
- git reset --hard

I did not know that, so I improved our error code a bit..

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
