### PR TITLE
Fix labeling of PRs for newcomers

### DIFF
--- a/.github/workflows/add-greeting-to-issue.yml
+++ b/.github/workflows/add-greeting-to-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
      types:
        - labeled
+  pull_request:
+    types: 
+       - labeled
     
 jobs:
   GreetingFirstTimeCodeContribution:
@@ -15,7 +18,7 @@ jobs:
     - name: GreetingFirstTimeCodeContribution
       uses: peter-evans/create-or-update-comment@v3
       with:
-        issue-number: ${{ github.event.issue.number }}
+        issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
         body: |
             As a general advice for newcomers: check out [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) for a start. Also, [guidelines for setting up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) is worth having a look at.
             

--- a/.github/workflows/add-greeting-to-issue.yml
+++ b/.github/workflows/add-greeting-to-issue.yml
@@ -1,13 +1,13 @@
 name: Add greeting to issues for first time contributors
 
-on: 
+on:
   issues:
      types:
        - labeled
-  pull_request:
-    types: 
+  pull_request_target:
+    types:
        - labeled
-    
+
 jobs:
   GreetingFirstTimeCodeContribution:
     if: ${{ github.event.label.name == 'FirstTimeCodeContribution' }}
@@ -21,5 +21,5 @@ jobs:
         issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
         body: |
             As a general advice for newcomers: check out [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) for a start. Also, [guidelines for setting up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) is worth having a look at.
-            
+
             Feel free to ask here at GitHub, if you have any issue related questions. If you have questions about how to setup your workspace use JabRef's [Gitter](https://gitter.im/JabRef/jabref) chat. Try to open a (draft) pull-request early on, so that people can see you are working on the issue and so that they can see the direction the pull request is heading towards. This way, you will likely receive valuable feedback.


### PR DESCRIPTION
This should fix labeling using our label.

We need to use `pull_request_target`, so that the action is triggered with **our** code and **our** secrets. See https://stackoverflow.com/a/74959635/873282 for a longer explanation. Source: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
