### PR TITLE
Change package of TypedBibEntry

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -45,7 +45,7 @@ import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
-import org.jabref.logic.TypedBibEntry;
+import org.jabref.logic.bibtex.TypedBibEntry;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -14,7 +14,6 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.jabref.logic.TypedBibEntry;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.util.OS;
 import org.jabref.model.database.BibDatabaseMode;

--- a/src/main/java/org/jabref/logic/bibtex/TypedBibEntry.java
+++ b/src/main/java/org/jabref/logic/bibtex/TypedBibEntry.java
@@ -1,4 +1,4 @@
-package org.jabref.logic;
+package org.jabref.logic.bibtex;
 
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -9,7 +9,7 @@ import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.jabref.logic.TypedBibEntry;
+import org.jabref.logic.bibtex.TypedBibEntry;
 import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseMode;

--- a/src/test/java/org/jabref/logic/TypedBibEntryTest.java
+++ b/src/test/java/org/jabref/logic/TypedBibEntryTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic;
 
+import org.jabref.logic.bibtex.TypedBibEntry;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;


### PR DESCRIPTION
Since `TypedBibEntry` is more a wrapper in comparison to core BibEntry java class, we put it in a separate package. However, I don't like it to be floating around in the general package `org.jabref.logic`. I moved it into `org.jabref.logic.bibtex`. Users will note that it needs `BibEntry` to work.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
