### PR TITLE
Fix enablement of Aux dialog's "Generate" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The index directories for full text search have now more readable names to increase debugging possibilities using Apache Lucense's Lurk. [#10193](https://github.com/JabRef/jabref/issues/10193)
 - The fulltext search also indexes files ending with .pdf (but do not having an explicit file type set). [#10193](https://github.com/JabRef/jabref/issues/10193)
 - We changed the order of the lists in the "Citation relations" tab. `Cites` are now on the left and `Cited by` on the right [#10572](https://github.com/JabRef/jabref/pull/10752)
-- Sub libraries based on `aux` file can now also be generated if some citeations are not found library.
+- Sub libraries based on `aux` file can now also be generated if some citeations are not found library. [#10775](https://github.com/JabRef/jabref/pull/10775)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The index directories for full text search have now more readable names to increase debugging possibilities using Apache Lucense's Lurk. [#10193](https://github.com/JabRef/jabref/issues/10193)
 - The fulltext search also indexes files ending with .pdf (but do not having an explicit file type set). [#10193](https://github.com/JabRef/jabref/issues/10193)
 - We changed the order of the lists in the "Citation relations" tab. `Cites` are now on the left and `Cited by` on the right [#10572](https://github.com/JabRef/jabref/pull/10752)
+- Sub libraries based on `aux` file can now also be generated if some citeations are not found library.
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
+++ b/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
@@ -49,7 +49,7 @@ public class FromAuxDialog extends BaseDialog<Void> {
                   .setAsDialogPane(this);
 
         Button generateButton = (Button) this.getDialogPane().lookupButton(generateButtonType);
-        generateButton.disableProperty().bind(viewModel.parseFailedProperty().or(viewModel.notFoundList().emptyProperty().not()));
+        generateButton.disableProperty().bind(viewModel.parseFailedProperty());
         generateButton.defaultButtonProperty().bind(generateButton.disableProperty().not());
         setResultConverter(button -> {
             if (button == generateButtonType) {


### PR DESCRIPTION
When generating a sub library based on an aux file, it should also be possible if some keys are missing.

Now the Generate button is enabled even if there are one or more missing BibEntries.

![image](https://github.com/JabRef/jabref/assets/1366654/a7be8c70-16dc-454a-933b-453acab95e17)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
