### PR TITLE
Use StringUtil.intValueOf instead of StringUtil.intValueOfOptional or custom code

### DIFF
--- a/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
+++ b/src/main/java/org/jabref/gui/util/comparator/NumericFieldComparator.java
@@ -12,54 +12,52 @@ public class NumericFieldComparator implements Comparator<String> {
 
     @Override
     public int compare(String val1, String val2) {
-        Integer valInt1 = parseInt(val1);
-        Integer valInt2 = parseInt(val2);
+        if ((val1 == null) && (val2 == null)) {
+            return 0;
+        }
 
-        if (valInt1 == null && valInt2 == null) {
-            if (val1 != null && val2 != null) {
-                return val1.compareTo(val2);
-            } else {
-                return 0;
-            }
-        } else if (valInt1 == null) {
+        // Similar implementation as in {@link org.jabref.logic.bibtex.comparator.FieldComparator.compare}.
+        int i1;
+        boolean i1present;
+        try {
+            i1 = StringUtil.intValueOf(val1);
+            i1present = true;
+        } catch (NumberFormatException ex) {
+            i1 = 0;
+            i1present = false;
+        }
+        int i2;
+        boolean i2present;
+        try {
+            i2 = StringUtil.intValueOf(val2);
+            i2present = true;
+        } catch (NumberFormatException ex) {
+            i2 = 0;
+            i2present = false;
+        }
+
+        if (i1present && i2present) {
+            return i1 - i2;
+        } else if (i1present) {
+            // The first one was parsable, but not the second one.
+            // This means we consider one < two
+            // We assume that "null" is "less than" any other value.
+            return 1;
+        } else if (i2present) {
+            // The second one was parsable, but not the first one.
+            // This means we consider one > two
             // We assume that "null" is "less than" any other value.
             return -1;
-        } else if (valInt2 == null) {
-            return 1;
-        }
-
-        // If we arrive at this stage then both values are actually numeric !
-        return valInt1 - valInt2;
-    }
-
-    private static Integer parseInt(String number) {
-        if (!isNumber(number)) {
-            return null;
-        }
-
-        try {
-            return Integer.valueOf(number.trim());
-        } catch (NumberFormatException ignore) {
-            return null;
-        }
-    }
-
-    private static boolean isNumber(String number) {
-        if (StringUtil.isNullOrEmpty(number)) {
-            return false;
-        }
-        if (number.length() == 1 && (number.charAt(0) == '-' || number.charAt(0) == '+')) {
-            return false;
-        }
-        for (int i = 0; i < number.length(); i++) {
-            char c = number.charAt(i);
-            if (i == 0 && (c == '-' || c == '+')) {
-                continue;
-            } else if (!Character.isDigit(c)) {
-                return false;
+        } else {
+            if (val1 != null && val2 != null) {
+                return val1.compareTo(val2);
+            } else if (val1 == null) {
+                return -1;
+            } else if (val2 == null) {
+                return 1;
+            } else {
+                return CharSequence.compare(val1, val2);
             }
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
While stumbling on an OpenRewrite issue (https://github.com/openrewrite/rewrite/issues/3913), I found WTF code inside JabRef. We use that code for performance reasons. 

Thus, I thought, let's really use it to gain performance. Here is my (first) change. In a follow-up PR, I will rewrite all `Integer.parseInt` to `StringUtil.valueOf`. This takes a bit time, since I don't know how to use [refaster in OpenRewrite](https://docs.openrewrite.org/authoring-recipes/types-of-recipes#refaster-templates) or how we can use [error prone's refaster templates](https://errorprone.info/docs/refaster) here.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
