### PR TITLE
Fixed fulltext fetcher button invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the fulltext search button in entry editor used to disappear on click till the search is completed. [#10425](https://github.com/JabRef/jabref/issues/10508)
 - We fixed an issue where attempting to cancel the importing/generation of an entry from id is ignored. [#10508](https://github.com/JabRef/jabref/issues/10508)
 - We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where the fulltext search button in entry editor used to disappear on click till the search is completed. [#10425](https://github.com/JabRef/jabref/issues/10508)
+- We fixed an issue where the fulltext search button in entry editor used to disappear on click till the search is completed. [#10425](https://github.com/JabRef/jabref/issues/10425)
 - We fixed an issue where attempting to cancel the importing/generation of an entry from id is ignored. [#10508](https://github.com/JabRef/jabref/issues/10508)
 - We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -23,9 +23,8 @@
         <Button onAction="#fetchFulltext" styleClass="icon-button">
             <graphic>
                 <StackPane>
-                    <JabRefIconView fx:id="fulltextFetcher" glyph="FETCH_FULLTEXT" visible="false"/>
-                    <ProgressIndicator maxHeight="12.0" maxWidth="12.0"
-                                       visible="${controller.viewModel.fulltextLookupInProgress}"/>
+                    <JabRefIconView fx:id="fulltextFetcher" glyph="FETCH_FULLTEXT"/>
+                    <ProgressIndicator fx:id="progressIndicator" maxHeight="12.0" maxWidth="12.0"/>
                 </StackPane>
             </graphic>
             <tooltip>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -17,6 +17,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.control.ProgressBar;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.Tooltip;
@@ -67,6 +68,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
     @FXML private ListView<LinkedFileViewModel> listView;
     @FXML private JabRefIconView fulltextFetcher;
+    @FXML private ProgressIndicator progressIndicator;
 
     private final Field field;
     private final BibDatabaseContext databaseContext;
@@ -127,6 +129,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
         fulltextFetcher.visibleProperty().bind(viewModel.fulltextLookupInProgressProperty().not());
+        progressIndicator.visibleProperty().bind(viewModel.fulltextLookupInProgressProperty());
 
         setUpKeyBindings();
     }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Closes #10425

### Fixes
> fixed an issue where the fulltext search button in entry editor used to disappear on click till the search is completed.

### Screenshots
![image](https://github.com/JabRef/jabref/assets/44014985/abd576e6-a5be-4ba1-b1e8-742b764d7865)

> Now shows progress animation as it should when search is in progress as it should.

![image](https://github.com/JabRef/jabref/assets/44014985/162a4e05-3c19-4126-af64-b65ab025a6ae)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
