### PR TITLE
Fixed slow response time when clicking on general tab in the entry editor

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -85,7 +85,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         switch (autoLinkPreferences.getCitationKeyDependency()) {
             case START -> autolinkFileStartsBibtexProperty.setValue(true);
             case EXACT -> autolinkFileExactBibtexProperty.setValue(true);
-            case REGEX -> autolinkUseRegexProperty.setValue(true) ;
+            case REGEX -> autolinkUseRegexProperty.setValue(true);
         }
 
         autolinkRegexKeyProperty.setValue(autoLinkPreferences.getRegularExpression());

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -77,7 +77,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         mainFileDirectoryProperty.setValue(filePreferences.getMainFileDirectory().orElse(Path.of("")).toString());
         useMainFileDirectoryProperty.setValue(!filePreferences.shouldStoreFilesRelativeToBibFile());
         useBibLocationAsPrimaryProperty.setValue(filePreferences.shouldStoreFilesRelativeToBibFile());
-        fulltextIndex.setValue(filePreferences.shouldFulltextIndexLinkedFiles());
+        fulltextIndex.setValue(!filePreferences.shouldFulltextIndexLinkedFiles());
         fileNamePatternProperty.setValue(filePreferences.getFileNamePattern());
         fileDirectoryPatternProperty.setValue(filePreferences.getFileDirectoryPattern());
 
@@ -85,7 +85,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         switch (autoLinkPreferences.getCitationKeyDependency()) {
             case START -> autolinkFileStartsBibtexProperty.setValue(true);
             case EXACT -> autolinkFileExactBibtexProperty.setValue(true);
-            case REGEX -> autolinkUseRegexProperty.setValue(true);
+            case REGEX -> autolinkUseRegexProperty.setValue(true) ;
         }
 
         autolinkRegexKeyProperty.setValue(autoLinkPreferences.getRegularExpression());


### PR DESCRIPTION
By default Disabled Automatic Indexing Linked Files for FullText Search. It is going to improve the performance. 
UI Path : File-> Preferences -> LinkedFiles -> Automatically index all linked files for fulltext search

![Screenshot 2024-01-23 194301](https://github.com/JabRef/jabref/assets/54927584/66bba9da-5cf7-491a-a25f-832bb7b7d242)

fixes #9800 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
