### PR TITLE
Fix escaping of slashes for TexShop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed the arrangement of the lists in the "Citation relations" tab. `Cites` are now on the left and `Cited by` on the right [#10572](https://github.com/JabRef/jabref/pull/10752)
 - Sub libraries based on `aux` file can now also be generated if some citations are not found library. [#10775](https://github.com/JabRef/jabref/pull/10775)
 - We rearranged the tab order in the entry editor and renamed the "Scite Tab" to "Citation information". [#10821](https://github.com/JabRef/jabref/issues/10821)
+- We made the command "Push to TexShop" more robust to allow cite commands with a character before the first slash [forum#2699](https://discourse.jabref.org/t/push-to-texshop-mac/2699/17?u=siedlerchr)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/push/PushToTexShop.java
+++ b/src/main/java/org/jabref/gui/push/PushToTexShop.java
@@ -65,13 +65,17 @@ public class PushToTexShop extends AbstractPushToApplication {
     protected String[] getCommandLine(String keyString) {
         String citeCommand = getCitePrefix();
         // we need to escape the extra slashses
-        if (getCitePrefix().contains("\\")) {
-            citeCommand = "\"\\" + getCitePrefix();
+        int intSlashPosition = getCitePrefix().indexOf("\\");
+
+        if (intSlashPosition != -1) {
+            StringBuilder sb = new StringBuilder(getCitePrefix());
+            sb.insert(intSlashPosition, "\\");
+            citeCommand = sb.toString();
         }
 
         String osascriptTexShop = "osascript -e 'tell application \"TeXShop\"\n" +
                 "activate\n" +
-                "set TheString to " + citeCommand + keyString + getCiteSuffix() + "\"\n" +
+                "set TheString to \"" + citeCommand + keyString + getCiteSuffix() + "\"\n" +
                 "set content of selection of front document to TheString\n" +
                 "end tell'";
 


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/push-to-texshop-mac/2699/17?u=siedlerchr

This alllows `~\cite{key1,key2}`


<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
