### PR TITLE
Fix Suggestion Provider for Crossref during autocompletion disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)
 - We fixed an issue where the duplicate check did not take umlauts or other LaTeX-encoded characters into account. [#10744](https://github.com/JabRef/jabref/pull/10744)
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)
+- We fixed an issue where the CrossRef field did not work if autocompletion was disabled [#8145](https://github.com/JabRef/jabref/issues/8145)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -563,7 +563,8 @@ public class LibraryTab extends Tab {
             suggestionProviders = new SuggestionProviders(getDatabase(), Globals.journalAbbreviationRepository, autoCompletePreferences);
         } else {
             // Create empty suggestion providers if auto-completion is deactivated
-            suggestionProviders = new SuggestionProviders();
+//            suggestionProviders = new SuggestionProviders();
+            suggestionProviders = new SuggestionProviders(getDatabase());
         }
         searchAutoCompleter = new PersonNameSuggestionProvider(FieldFactory.getPersonNameFields(), getDatabase());
     }

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -562,8 +562,7 @@ public class LibraryTab extends Tab {
         if (autoCompletePreferences.shouldAutoComplete()) {
             suggestionProviders = new SuggestionProviders(getDatabase(), Globals.journalAbbreviationRepository, autoCompletePreferences);
         } else {
-            // Create empty suggestion providers if auto-completion is deactivated
-//            suggestionProviders = new SuggestionProviders();
+            // Create suggestion providers with database for crossref if auto-completion is deactivated
             suggestionProviders = new SuggestionProviders(getDatabase());
         }
         searchAutoCompleter = new PersonNameSuggestionProvider(FieldFactory.getPersonNameFields(), getDatabase());

--- a/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
+++ b/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
@@ -39,9 +39,6 @@ public class SuggestionProviders {
             }
             return new EmptySuggestionProvider();
         }
-//        if (isEmpty || !autoCompletePreferences.getCompleteFields().contains(field)) {
-//            return new EmptySuggestionProvider();
-//        }
 
         Set<FieldProperty> fieldProperties = field.getProperties();
         if (fieldProperties.contains(FieldProperty.PERSON_NAMES)) {

--- a/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
+++ b/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
@@ -27,6 +27,10 @@ public class SuggestionProviders {
         this.isEmpty = true;
     }
 
+    public SuggestionProviders() {
+        this.isEmpty = true;
+    }
+
     public SuggestionProvider<?> getForField(Field field) {
         if (isEmpty || !autoCompletePreferences.getCompleteFields().contains(field)) {
             Set<FieldProperty> fieldProperties = field.getProperties();
@@ -35,6 +39,9 @@ public class SuggestionProviders {
             }
             return new EmptySuggestionProvider();
         }
+//        if (isEmpty || !autoCompletePreferences.getCompleteFields().contains(field)) {
+//            return new EmptySuggestionProvider();
+//        }
 
         Set<FieldProperty> fieldProperties = field.getProperties();
         if (fieldProperties.contains(FieldProperty.PERSON_NAMES)) {

--- a/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
+++ b/src/main/java/org/jabref/gui/autocompleter/SuggestionProviders.java
@@ -22,12 +22,17 @@ public class SuggestionProviders {
         this.isEmpty = false;
     }
 
-    public SuggestionProviders() {
+    public SuggestionProviders(BibDatabase database) {
+        this.database = database;
         this.isEmpty = true;
     }
 
     public SuggestionProvider<?> getForField(Field field) {
         if (isEmpty || !autoCompletePreferences.getCompleteFields().contains(field)) {
+            Set<FieldProperty> fieldProperties = field.getProperties();
+            if (fieldProperties.contains(FieldProperty.SINGLE_ENTRY_LINK)) {
+                return new BibEntrySuggestionProvider(database);
+            }
             return new EmptySuggestionProvider();
         }
 


### PR DESCRIPTION
Closes #8145 
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Fixed the initial issue when autocompletion was disabled, the crossref field was not populating the suggestions.
Now the CrossRef field is populating the suggestions even if AutoCompletion(File > Preferences > Autocompletion) is disabled
![Auto_Disable](https://github.com/JabRef/jabref/assets/55245782/fe5f7b26-6e75-49a9-a040-08e83fb881be)
![Op1](https://github.com/JabRef/jabref/assets/55245782/78e49a13-4b14-4402-9a0d-ee5dc7400520)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
