### PR TITLE
Fix closing of JabRef in case of issues with index writer

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -778,12 +778,28 @@ public class LibraryTab extends Tab {
      * Perform necessary cleanup when this Library is closed.
      */
     private void onClosed(Event event) {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
-        PdfIndexerManager.shutdownIndexer(bibDatabaseContext);
-        AutosaveManager.shutdown(bibDatabaseContext);
-        BackupManager.shutdown(bibDatabaseContext,
-                preferencesService.getFilePreferences().getBackupDirectory(),
-                preferencesService.getFilePreferences().shouldCreateBackup());
+        try {
+            changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when closing change monitor", e);
+        }
+        try {
+            PdfIndexerManager.shutdownIndexer(bibDatabaseContext);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down PDF indexer", e);
+        }
+        try {
+            AutosaveManager.shutdown(bibDatabaseContext);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down autosave manager", e);
+        }
+        try {
+            BackupManager.shutdown(bibDatabaseContext,
+                    preferencesService.getFilePreferences().getBackupDirectory(),
+                    preferencesService.getFilePreferences().shouldCreateBackup());
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down backup manager", e);
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
@@ -296,6 +296,10 @@ public class PdfIndexer {
     }
 
     public void close() throws IOException {
+        if (indexWriter == null) {
+            LOGGER.debug("IndexWriter is null.");
+            return;
+        }
         indexWriter.close();
     }
 }

--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
@@ -63,12 +63,13 @@ public class PdfIndexer {
     private PdfIndexer(BibDatabaseContext databaseContext, Directory indexDirectory, FilePreferences filePreferences) {
         this.databaseContext = databaseContext;
         if (indexDirectory == null) {
-            LOGGER.info("Index directory must not be null. Falling back to /tmp");
+            String tmpDir = System.getProperty("java.io.tmpdir");
+            LOGGER.info("Index directory must not be null. Falling back to {}", tmpDir);
             Directory tmpIndexDirectory = null;
             try {
-                tmpIndexDirectory = new NIOFSDirectory(Path.of("/tmp"));
+                tmpIndexDirectory = new NIOFSDirectory(Path.of(tmpDir));
             } catch (IOException e) {
-                LOGGER.info("Could not use /tmp. Indexing unavailable.", e);
+                LOGGER.info("Could not use {}. Indexing unavailable.", tmpDir, e);
             }
             this.indexDirectory = tmpIndexDirectory;
         } else {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -22,6 +22,7 @@ import org.jabref.model.metadata.MetaData;
 import org.jabref.model.study.Study;
 import org.jabref.preferences.FilePreferences;
 
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -241,6 +242,7 @@ public class BibDatabaseContext {
     /**
      * @return The path to store the lucene index files. One directory for each library.
      */
+    @NonNull
     public Path getFulltextIndexPath() {
         Path appData = OS.getNativeDesktop().getFulltextIndexBaseDirectory();
         Path indexPath;


### PR DESCRIPTION
I started JabRef. Twice. Then, the **same** index is used for Lucene by the second instance. Does not work:

```
Could not initialize the IndexWriter
org.apache.lucene.store.LockObtainFailedException: Lock held by another program: /home/koppor/.local/share/jabref/lucene/99/06bf8206--y.bib/write.lock
...
Uncaught exception occurred in Thread[#60,JavaFX Application Thread,5,main]
java.lang.NullPointerException: Cannot invoke "org.apache.lucene.index.IndexWriter.getReader(boolean, boolean)" because "writer" is null
```

This PR adds a workaround by using `null` and Optionals.

This also adds a workaround for https://github.com/JabRef/jabref/issues/10781 by checking for `null`. The workaround is the first code... OK, we could also check why the `null` appears here. Sounded like bigger work for that excpetional case.

This relates to https://github.com/JabRef/jabref/pull/10841. The other PR is more on the loading task...

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
