### PR TITLE
Fix NPE when tab is close during load

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -25,6 +25,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.util.Duration;
@@ -261,7 +262,12 @@ public class LibraryTab extends Tab {
     }
 
     private void setDatabaseContext(BibDatabaseContext bibDatabaseContext) {
-        if (this.getTabPane().getSelectionModel().selectedItemProperty().get().equals(this)) {
+        TabPane tabPane = this.getTabPane();
+        if (tabPane == null) {
+            LOGGER.debug("User interrupted loading. Not showing any library.");
+            return;
+        }
+        if (tabPane.getSelectionModel().selectedItemProperty().get().equals(this)) {
             LOGGER.debug("This case should not happen.");
             stateManager.setActiveDatabase(bibDatabaseContext);
         }
@@ -778,12 +784,31 @@ public class LibraryTab extends Tab {
      * Perform necessary cleanup when this Library is closed.
      */
     private void onClosed(Event event) {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
-        PdfIndexerManager.shutdownIndexer(bibDatabaseContext);
-        AutosaveManager.shutdown(bibDatabaseContext);
-        BackupManager.shutdown(bibDatabaseContext,
-                preferencesService.getFilePreferences().getBackupDirectory(),
-                preferencesService.getFilePreferences().shouldCreateBackup());
+        if (dataLoadingTask != null) {
+            dataLoadingTask.cancel();
+        }
+        try {
+            changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when closing change monitor", e);
+        }
+        try {
+            PdfIndexerManager.shutdownIndexer(bibDatabaseContext);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down PDF indexer", e);
+        }
+        try {
+            AutosaveManager.shutdown(bibDatabaseContext);
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down autosave manager", e);
+        }
+        try {
+            BackupManager.shutdown(bibDatabaseContext,
+                    preferencesService.getFilePreferences().getBackupDirectory(),
+                    preferencesService.getFilePreferences().shouldCreateBackup());
+        } catch (RuntimeException e) {
+            LOGGER.error("Problem when shutting down backup manager", e);
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/gui/util/BackgroundTask.java
+++ b/src/main/java/org/jabref/gui/util/BackgroundTask.java
@@ -22,6 +22,8 @@ import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.ImmutableMap;
 import com.tobiasdiez.easybind.EasyBind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is essentially a wrapper around {@link Task}.
@@ -36,6 +38,8 @@ public abstract class BackgroundTask<V> {
     public static ImmutableMap<String, Node> iconMap = ImmutableMap.of(
             Localization.lang("Downloading"), IconTheme.JabRefIcons.DOWNLOAD.getGraphicNode()
     );
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackgroundTask.class);
 
     private Runnable onRunning;
     private Consumer<V> onSuccess;
@@ -92,6 +96,7 @@ public abstract class BackgroundTask<V> {
     }
 
     public void cancel() {
+        LOGGER.debug("Canceling task");
         this.isCanceled.set(true);
     }
 


### PR DESCRIPTION
When a large library is loaded and the tab is close during load, there is an exception:

```
java.lang.NullPointerException: Cannot invoke "javafx.scene.control.TabPane.getSelectionModel()" because the return value of "org.jabref.gui.LibraryTab.getTabPane()" is null
	at org.jabref@100.0.0/org.jabref.gui.LibraryTab.setDatabaseContext(LibraryTab.java:264)
	at org.jabref@100.0.0/org.jabref.gui.LibraryTab.onDatabaseLoadingSucceed(LibraryTab.java:243)
```

This PR fixes that - and also adds some NPE checks at close (to enable the tab being closed despite NPEs)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
