### PR TITLE
Space before citations in Openoffice/Libreoffice integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a fetcher for [ISIDORE](https://isidore.science/), simply paste in the link into the text field or the last 6 digits in the link that identify that paper. [#10423](https://github.com/JabRef/jabref/issues/10423)
 - When importing entries form the "Citation relations" tab, the field [cites](https://docs.jabref.org/advanced/entryeditor/entrylinks) is now filled according to the relationship between the entries. [#10572](https://github.com/JabRef/jabref/pull/10752)
 - We added a new group icon column to the main table showing the icons of the entry's groups. [#10801](https://github.com/JabRef/jabref/pull/10801)
-- We added a new boolean to the style files for Openoffice/Libreoffice integration to switch between ZERO_WIDTH_SPACE (default) and no space.
+- We added a new boolean to the style files for Openoffice/Libreoffice integration to switch between ZERO_WIDTH_SPACE (default) and no space. [#10843](https://github.com/JabRef/jabref/pull/10843)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a fetcher for [ISIDORE](https://isidore.science/), simply paste in the link into the text field or the last 6 digits in the link that identify that paper. [#10423](https://github.com/JabRef/jabref/issues/10423)
 - When importing entries form the "Citation relations" tab, the field [cites](https://docs.jabref.org/advanced/entryeditor/entrylinks) is now filled according to the relationship between the entries. [#10572](https://github.com/JabRef/jabref/pull/10752)
 - We added a new group icon column to the main table showing the icons of the entry's groups. [#10801](https://github.com/JabRef/jabref/pull/10801)
+- We added a new boolean to the style files for Openoffice/Libreoffice integration to switch between ZERO_WIDTH_SPACE (default) and no space.
 
 ### Changed
 

--- a/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/frontend/UpdateCitationMarkers.java
@@ -78,8 +78,11 @@ public class UpdateCitationMarkers {
 
         if (withText) {
             OOText citationText2 = style.decorateCitationMarker(citationText);
-            // inject a ZERO_WIDTH_SPACE to hold the initial character format
-            final String ZERO_WIDTH_SPACE = "\u200b";
+            String ZERO_WIDTH_SPACE = "";
+            if (style.spaceBeforeCitation()) {
+              // inject a ZERO_WIDTH_SPACE to hold the initial character format
+              ZERO_WIDTH_SPACE = "\u200b";
+            }
             citationText2 = OOText.fromString(ZERO_WIDTH_SPACE + citationText2.toString());
             OOTextIntoOO.write(doc, cursor, citationText2);
         } else {

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
@@ -109,6 +109,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     private static final String AUTHOR_FIELD = "AuthorField";
     private static final String BRACKET_AFTER = "BracketAfter";
     private static final String BRACKET_BEFORE = "BracketBefore";
+    private static final String SPACE_BEFORE = "SpaceBefore";
     private static final String IS_NUMBER_ENTRIES = "IsNumberEntries";
     private static final String IS_SORT_BY_POSITION = "IsSortByPosition";
     private static final String SORT_ALGORITHM = "SortAlgorithm";
@@ -203,6 +204,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         citProperties.put(IN_TEXT_YEAR_SEPARATOR, " ");
         citProperties.put(BRACKET_BEFORE, "(");
         citProperties.put(BRACKET_AFTER, ")");
+        citProperties.put(SPACE_BEFORE, Boolean.TRUE);
         citProperties.put(CITATION_SEPARATOR, "; ");
         citProperties.put(PAGE_INFO_SEPARATOR, "; ");
         citProperties.put(GROUPED_NUMBERS_SEPARATOR, "-");
@@ -491,6 +493,10 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      */
     public boolean isFormatCitations() {
         return (Boolean) citProperties.get(FORMAT_CITATIONS);
+    }
+
+    public boolean spaceBeforeCitation() {
+        return (Boolean) citProperties.get(SPACE_BEFORE);
     }
 
     public boolean isCitationKeyCiteMarkers() {

--- a/src/test/resources/org/jabref/logic/openoffice/style/test.jstyle
+++ b/src/test/resources/org/jabref/logic/openoffice/style/test.jstyle
@@ -27,6 +27,7 @@ FormatCitations="false"
 CitationCharacterFormat="Default"
 PageInfoSeparator="; "
 OxfordComma=","
+SpaceBefore="true"
 
 LAYOUT
 article=<b>\format[Authors(LastFirst,Semicolon)]{\author}</b> (<b>\year\uniq</b>). <i>\title</i>, \journal \volume\begin{pages} : \format[FormatPagesForHTML]{\pages}\end{pages}.

--- a/src/test/resources/org/jabref/logic/openoffice/style/testWithDefaultAtFirstLIne.jstyle
+++ b/src/test/resources/org/jabref/logic/openoffice/style/testWithDefaultAtFirstLIne.jstyle
@@ -27,6 +27,7 @@ FormatCitations="false"
 CitationCharacterFormat="Default"
 PageInfoSeparator="; "
 OxfordComma=","
+SpaceBefore="true"
 
 LAYOUT
 


### PR DESCRIPTION
By default, zero width space is added in front of each citation in the text in Openoffice/Libreoffice. This causes ugly line breaks if new line starts with a citation:

![grafik](https://github.com/JabRef/jabref/assets/47115057/65e5f1b4-2327-4ce0-8ccb-2c5a7f2026f8)


To allow changing if a zero width space is added to each citation, a new boolean in the style file can be used:
SpaceBefore="true" -> Default behaviour with the zero width space
SpaceBefore="false" -> No space is added:

![grafik](https://github.com/JabRef/jabref/assets/47115057/446cf805-45e3-4472-862d-301327320d59)


Pull request to documentation added.


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
