### PR TITLE
OOffice: New plain citation mode added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a fetcher for [ISIDORE](https://isidore.science/), simply paste in the link into the text field or the last 6 digits in the link that identify that paper. [#10423](https://github.com/JabRef/jabref/issues/10423)
 - When importing entries form the "Citation relations" tab, the field [cites](https://docs.jabref.org/advanced/entryeditor/entrylinks) is now filled according to the relationship between the entries. [#10572](https://github.com/JabRef/jabref/pull/10752)
 - We added a new group icon column to the main table showing the icons of the entry's groups. [#10801](https://github.com/JabRef/jabref/pull/10801)
-- We added a new boolean to the style files for Openoffice/Libreoffice integration to switch between ZERO_WIDTH_SPACE (default) and no space. [#10843](https://github.com/JabRef/jabref/pull/10843)
+- We added a new boolean to the style files for Openoffice/Libreoffice integration to switch between ZERO_WIDTH_SPACE (default) and no space.
+- We added a plain author year citation mode (without brackets) for Openoffice/Libreoffice integration. 
 
 ### Changed
 
@@ -37,7 +38,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)
 - We fixed an issue where the duplicate check did not take umlauts or other LaTeX-encoded characters into account. [#10744](https://github.com/JabRef/jabref/pull/10744)
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)
-- We fixed an issue where the CrossRef field did not work if autocompletion was disabled [#8145](https://github.com/JabRef/jabref/issues/8145)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -77,6 +77,7 @@ public class OpenOfficePanel {
     private final Button setStyleFile = new Button(Localization.lang("Select style"));
     private final Button pushEntries = new Button(Localization.lang("Cite"));
     private final Button pushEntriesInt = new Button(Localization.lang("Cite in-text"));
+    private final Button pushEntriesPlain = new Button(Localization.lang("Cite plain"));
     private final Button pushEntriesEmpty = new Button(Localization.lang("Insert empty citation"));
     private final Button pushEntriesAdvanced = new Button(Localization.lang("Cite special"));
     private final Button update;
@@ -205,6 +206,9 @@ public class OpenOfficePanel {
         pushEntriesInt.setTooltip(new Tooltip(Localization.lang("Cite selected entries with in-text citation")));
         pushEntriesInt.setOnAction(e -> pushEntries(CitationType.AUTHORYEAR_INTEXT, false));
         pushEntriesInt.setMaxWidth(Double.MAX_VALUE);
+        pushEntriesPlain.setTooltip(new Tooltip(Localization.lang("Cite selected entries without brackets")));
+        pushEntriesPlain.setOnAction(e -> pushEntries(CitationType.AUTHORYEAR_PLAIN, false));
+        pushEntriesPlain.setMaxWidth(Double.MAX_VALUE);
         pushEntriesEmpty.setTooltip(new Tooltip(Localization.lang("Insert a citation without text (the entry will appear in the reference list)")));
         pushEntriesEmpty.setOnAction(e -> pushEntries(CitationType.INVISIBLE_CIT, false));
         pushEntriesEmpty.setMaxWidth(Double.MAX_VALUE);
@@ -257,7 +261,7 @@ public class OpenOfficePanel {
         flow.setVgap(4);
         flow.setHgap(4);
         flow.setPrefWrapLength(200);
-        flow.getChildren().addAll(setStyleFile, pushEntries, pushEntriesInt);
+        flow.getChildren().addAll(setStyleFile, pushEntries, pushEntriesInt, pushEntriesPlain);
         flow.getChildren().addAll(pushEntriesAdvanced, pushEntriesEmpty, merge, unmerge);
         flow.getChildren().addAll(manageCitations, exportCitations, settingsB);
 
@@ -367,6 +371,7 @@ public class OpenOfficePanel {
 
         boolean canCite = isConnectedToDocument && hasStyle && hasSelectedBibEntry;
         pushEntriesInt.setDisable(!canCite);
+        pushEntriesPlain.setDisable(!canCite);
         pushEntriesEmpty.setDisable(!canCite);
         pushEntriesAdvanced.setDisable(!canCite);
 
@@ -438,9 +443,12 @@ public class OpenOfficePanel {
      * @param withText      False means invisible citation (no text).
      * @param inParenthesis True means "(Au and Thor 2000)". False means "Au and Thor (2000)".
      */
-    private static CitationType citationTypeFromOptions(boolean withText, boolean inParenthesis) {
+    private static CitationType citationTypeFromOptions(boolean withText, boolean inParenthesis, boolean isPlain) {
         if (!withText) {
             return CitationType.INVISIBLE_CIT;
+        }
+        if (isPlain) {
+            return CitationType.AUTHORYEAR_PLAIN;
         }
         return inParenthesis
                 ? CitationType.AUTHORYEAR_PAR
@@ -481,6 +489,7 @@ public class OpenOfficePanel {
         String pageInfo = null;
         if (addPageInfo) {
             boolean withText = citationType.withText();
+            boolean isPlain = citationType.plainCit();
 
             Optional<AdvancedCiteDialogViewModel> citeDialogViewModel = dialogService.showCustomDialogAndWait(new AdvancedCiteDialogView());
             if (citeDialogViewModel.isPresent()) {
@@ -488,7 +497,7 @@ public class OpenOfficePanel {
                 if (!model.pageInfoProperty().getValue().isEmpty()) {
                     pageInfo = model.pageInfoProperty().getValue();
                 }
-                citationType = citationTypeFromOptions(withText, model.citeInParProperty().getValue());
+                citationType = citationTypeFromOptions(withText, model.citeInParProperty().getValue(), isPlain);
             } else {
                 // user canceled
                 return;

--- a/src/main/java/org/jabref/logic/openoffice/action/EditInsert.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditInsert.java
@@ -89,7 +89,8 @@ public class EditInsert {
         } else {
             citeText = style.createCitationMarker(citations,
                     citationType.inParenthesis(),
-                    NonUniqueCitationMarker.FORGIVEN);
+                    NonUniqueCitationMarker.FORGIVEN,
+                    citationType.plainCit());
         }
 
         if (StringUtil.isBlank(OOText.toString(citeText))) {

--- a/src/main/java/org/jabref/logic/openoffice/backend/Codec52.java
+++ b/src/main/java/org/jabref/logic/openoffice/backend/Codec52.java
@@ -20,8 +20,8 @@ class Codec52 {
     private static final String BIB_CITATION = "JR_cite";
     private static final Pattern CITE_PATTERN =
             // Pattern.compile(BIB_CITATION + "(\\d*)_(\\d*)_(.*)");
-            // citationType is always "1" "2" or "3"
-            Pattern.compile(BIB_CITATION + "(\\d*)_([123])_(.*)");
+            // citationType is always "1" "2" "3" or "4"
+            Pattern.compile(BIB_CITATION + "(\\d*)_([1234])_(.*)");
 
     private Codec52() {
     }
@@ -60,6 +60,7 @@ class Codec52 {
             case 1 -> CitationType.AUTHORYEAR_PAR;
             case 2 -> CitationType.AUTHORYEAR_INTEXT;
             case 3 -> CitationType.INVISIBLE_CIT;
+            case 4 -> CitationType.AUTHORYEAR_PLAIN;
             default -> throw new IllegalArgumentException("Invalid CitationType code");
         };
     }
@@ -69,6 +70,7 @@ class Codec52 {
             case AUTHORYEAR_PAR -> 1;
             case AUTHORYEAR_INTEXT -> 2;
             case INVISIBLE_CIT -> 3;
+            case AUTHORYEAR_PLAIN -> 4;
         };
     }
 

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyle.java
@@ -703,7 +703,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     }
 
     public OOText getNormalizedCitationMarker(CitationMarkerNormEntry entry) {
-        return OOBibStyleGetCitationMarker.getNormalizedCitationMarker(this, entry, Optional.empty());
+        return OOBibStyleGetCitationMarker.getNormalizedCitationMarker(this, entry, Optional.empty(), false);
     }
 
     /**
@@ -739,11 +739,13 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      */
     public OOText createCitationMarker(List<CitationMarkerEntry> citationMarkerEntries,
                                        boolean inParenthesis,
-                                       NonUniqueCitationMarker nonUniqueCitationMarkerHandling) {
+                                       NonUniqueCitationMarker nonUniqueCitationMarkerHandling,
+                                       boolean isPlain) {
         return OOBibStyleGetCitationMarker.createCitationMarker(this,
                                                                 citationMarkerEntries,
                                                                 inParenthesis,
-                                                                nonUniqueCitationMarkerHandling);
+                                                                nonUniqueCitationMarkerHandling,
+                                                                isPlain);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -371,7 +371,8 @@ class OOBibStyleGetCitationMarker {
                                                           AuthorYearMarkerPurpose purpose,
                                                           List<CitationMarkerEntry> entries,
                                                           boolean[] startsNewGroup,
-                                                          Optional<Integer> maxAuthorsOverride) {
+                                                          Optional<Integer> maxAuthorsOverride,
+                                                          boolean isPlain) {
 
         boolean inParenthesis = purpose == AuthorYearMarkerPurpose.IN_PARENTHESIS
                                  || purpose == AuthorYearMarkerPurpose.NORMALIZED;
@@ -465,7 +466,9 @@ class OOBibStyleGetCitationMarker {
                 stringBuilder.append(yearSep);
 
                 if (!inParenthesis) {
+                  if (!isPlain) {
                     stringBuilder.append(startBrace); // parenthesis before year
+                  }
                 }
 
                 String year = getCitationMarkerField(style, db, yearFieldNames);
@@ -485,7 +488,9 @@ class OOBibStyleGetCitationMarker {
                 }
 
                 if (!inParenthesis && endingAGroup) {
+                  if (!isPlain) {
                     stringBuilder.append(endBrace);  // parenthesis after year
+                  }
                 }
             }
         } // for j
@@ -546,26 +551,30 @@ class OOBibStyleGetCitationMarker {
      */
     static OOText getNormalizedCitationMarker(OOBibStyle style,
                                               CitationMarkerNormEntry normEntry,
-                                              Optional<Integer> maxAuthorsOverride) {
+                                              Optional<Integer> maxAuthorsOverride,
+                                              boolean isPlain) {
         boolean[] startsNewGroup = {true};
         CitationMarkerEntry entry = new CitationMarkerNormEntryWrap(normEntry);
         return getAuthorYearParenthesisMarker2(style,
                                                AuthorYearMarkerPurpose.NORMALIZED,
                                                Collections.singletonList(entry),
                                                startsNewGroup,
-                                               maxAuthorsOverride);
+                                               maxAuthorsOverride,
+                                               isPlain);
     }
 
     private static List<OOText>
     getNormalizedCitationMarkers(OOBibStyle style,
                                  List<CitationMarkerEntry> citationMarkerEntries,
-                                 Optional<Integer> maxAuthorsOverride) {
+                                 Optional<Integer> maxAuthorsOverride,
+                                 boolean isPlain) {
 
         List<OOText> normalizedMarkers = new ArrayList<>(citationMarkerEntries.size());
         for (CitationMarkerEntry citationMarkerEntry : citationMarkerEntries) {
             OOText normalized = getNormalizedCitationMarker(style,
                                                             citationMarkerEntry,
-                                                            maxAuthorsOverride);
+                                                            maxAuthorsOverride,
+                                                            isPlain);
             normalizedMarkers.add(normalized);
         }
         return normalizedMarkers;
@@ -604,7 +613,8 @@ class OOBibStyleGetCitationMarker {
     createCitationMarker(OOBibStyle style,
                          List<CitationMarkerEntry> citationMarkerEntries,
                          boolean inParenthesis,
-                         NonUniqueCitationMarker nonUniqueCitationMarkerHandling) {
+                         NonUniqueCitationMarker nonUniqueCitationMarkerHandling,
+                         boolean isPlain) {
 
         final int nEntries = citationMarkerEntries.size();
 
@@ -625,7 +635,8 @@ class OOBibStyleGetCitationMarker {
 
         List<OOText> normalizedMarkers = getNormalizedCitationMarkers(style,
                                                                       citationMarkerEntries,
-                                                                      Optional.empty());
+                                                                      Optional.empty(),
+                                                                      isPlain);
 
         // How many authors would be emitted without grouping.
         int[] nAuthorsToEmit = new int[nEntries];
@@ -697,9 +708,9 @@ class OOBibStyleGetCitationMarker {
                             // prevShown >= need
                             // Check with extended normalizedMarkers.
                             OOText nmx1 =
-                                getNormalizedCitationMarker(style, ce1, Optional.of(prevShown));
+                                getNormalizedCitationMarker(style, ce1, Optional.of(prevShown), isPlain);
                             OOText nmx2 =
-                                getNormalizedCitationMarker(style, ce2, Optional.of(prevShown));
+                                getNormalizedCitationMarker(style, ce2, Optional.of(prevShown), isPlain);
                             boolean extendedMarkersDiffer = !nmx2.equals(nmx1);
                             nAuthorsShownInhibitsJoin = extendedMarkersDiffer;
                         }
@@ -763,6 +774,7 @@ class OOBibStyleGetCitationMarker {
                                                : AuthorYearMarkerPurpose.IN_TEXT),
                                               filteredCitationMarkerEntries,
                                               startsNewGroup,
-                                              Optional.empty());
+                                              Optional.empty(),
+                                              isPlain);
     }
 }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOProcessAuthorYearMarkers.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOProcessAuthorYearMarkers.java
@@ -142,13 +142,15 @@ class OOProcessAuthorYearMarkers {
 
         for (CitationGroup group : citationGroups.getCitationGroupsInGlobalOrder()) {
             final boolean inParenthesis = group.citationType == CitationType.AUTHORYEAR_PAR;
+            final boolean plainCit = group.citationType == CitationType.AUTHORYEAR_PLAIN;
             final NonUniqueCitationMarker strictlyUnique = NonUniqueCitationMarker.THROWS;
 
             List<Citation> cits = group.getCitationsInLocalOrder();
             List<CitationMarkerEntry> citationMarkerEntries = OOListUtil.map(cits, e -> e);
             OOText citMarker = style.createCitationMarker(citationMarkerEntries,
                                                           inParenthesis,
-                                                          strictlyUnique);
+                                                          strictlyUnique,
+                                                          plainCit);
             group.setCitationMarker(Optional.of(citMarker));
         }
     }

--- a/src/main/java/org/jabref/model/openoffice/style/CitationType.java
+++ b/src/main/java/org/jabref/model/openoffice/style/CitationType.java
@@ -7,12 +7,20 @@ public enum CitationType {
 
     AUTHORYEAR_PAR,
     AUTHORYEAR_INTEXT,
+    AUTHORYEAR_PLAIN,
     INVISIBLE_CIT;
 
     public boolean inParenthesis() {
         return switch (this) {
             case AUTHORYEAR_PAR, INVISIBLE_CIT -> true;
-            case AUTHORYEAR_INTEXT -> false;
+            case AUTHORYEAR_INTEXT, AUTHORYEAR_PLAIN -> false;
+        };
+    }
+
+    public boolean plainCit() {
+        return switch (this) {
+            case AUTHORYEAR_PAR, INVISIBLE_CIT, AUTHORYEAR_INTEXT -> false;
+            case AUTHORYEAR_PLAIN -> true;
         };
     }
 


### PR DESCRIPTION
New plain citation mode for Libreoffice/Openoffice integration added (without any brackets). This is useful if citation is pasted into brackets in the text like in the following example:
![grafik](https://github.com/JabRef/jabref/assets/47115057/afbcabee-b159-4e56-90ec-9da94f7bee3d)

The plain mode can be selected as "Cite", "Cite in-text" ... in the menu:
![grafik](https://github.com/JabRef/jabref/assets/47115057/ad482ee4-bc23-4300-bfa9-887bcc06e0c1)


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
