### PR TITLE
BibTeX 'Title' to MS Office 'Publicationtitle' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We Added a test case MSBibExportFormatFilesTest to ensure proper functioning of the MSBib export format.[#10864] (https://github.com/JabRef/jabref/pull/10864/commits)
 - The "Automatically open folders of attached files" preference default status has been changed to enabled on Windows. [koppor#56](https://github.com/koppor/jabref/issues/56)
 - The Custom export format now uses the custom DOI base URI in the preferences for the `DOICheck`, if activated [forum#4084](https://discourse.jabref.org/t/export-html-disregards-custom-doi-base-uri/4084)
 - The index directories for full text search have now more readable names to increase debugging possibilities using Apache Lucense's Lurk. [#10193](https://github.com/JabRef/jabref/issues/10193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We Added a test case MSBibExportFormatFilesTest to ensure proper functioning of the MSBib export format.[#10864] (https://github.com/JabRef/jabref/pull/10864/commits)
+- We Added a test case MSBibExportFormatFilesTest to ensure proper functioning of the MSBib export format.[#10864] (`https://github.com/JabRef/jabref/pull/10864/commits`)
 - The "Automatically open folders of attached files" preference default status has been changed to enabled on Windows. [koppor#56](https://github.com/koppor/jabref/issues/56)
 - The Custom export format now uses the custom DOI base URI in the preferences for the `DOICheck`, if activated [forum#4084](https://discourse.jabref.org/t/export-html-disregards-custom-doi-base-uri/4084)
 - The index directories for full text search have now more readable names to increase debugging possibilities using Apache Lucense's Lurk. [#10193](https://github.com/JabRef/jabref/issues/10193)

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -106,7 +106,7 @@ public class MSBibConverter {
         }
 
         // TODO: currently only Misc can happen
-        if ("ElectronicSource".equals(msBibType) || "Art".equals(msBibType) || "Misc".equals(msBibType)) {
+        if ("Art".equals(msBibType) || "Misc".equals(msBibType)) {
             result.publicationTitle = entry.getFieldLatexFree(StandardField.TITLE).orElse(null);
         }
 

--- a/src/test/resources/org/jabref/logic/exporter/MSBibXmlTest.bib
+++ b/src/test/resources/org/jabref/logic/exporter/MSBibXmlTest.bib
@@ -1,0 +1,16 @@
+% Encoding: UTF-8
+
+@article{example1,
+    title = {Sample Article Title},
+    author = {Steve, Smith},
+    journal = {Journal of Examples},
+    year = {2023},
+    msBibType = {Art}
+}
+
+@misc{example2,
+    title = {Miscellaneous Entry Title},
+    author = {Doe, Jane},
+    year = {2022},
+    msBibType = {Misc}
+}

--- a/src/test/resources/org/jabref/logic/exporter/MSBibXmlTest.xml
+++ b/src/test/resources/org/jabref/logic/exporter/MSBibXmlTest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xml>
+    <Publication>
+        <SourceType>Journal Article</SourceType>
+        <Title>Sample Article Title</Title>
+        <Year>2023</Year>
+    </Publication>
+    <Publication>
+        <SourceType>Miscellaneous</SourceType>
+        <Title>Miscellaneous Entry Title</Title>
+        <Year>2022</Year>
+    </Publication>
+</xml>


### PR DESCRIPTION
Fixes #10807 

<!-- 
The exported file "test.xml" mistakenly contains both, a "Title" and a "Publicationtitle" field (highlighted in bolditalic in the following file dump): #10807

## I have just replace the codes for "src/main/java/org/jabref/logic/msbib/MSBibConverter.java" to
-->" if ("Art".equals(msBibType) || "Misc".equals(msBibType)) {
     result.publicationTitle = entry.getFieldLatexFree(StandardField.TITLE).orElse(null);
  }"


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? 

