### PR TITLE
Add refresh button for LaTeX citations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ## [Unreleased]
 
 ### Added
-
+- We added a refresh button for LaTeX citations. [#10584](https://github.com/JabRef/jabref/issues/10584)
 - We added the possibility to show the BibTeX source in the [web search](https://docs.jabref.org/collect/import-using-online-bibliographic-database) import screen. [#560](https://github.com/koppor/jabref/issues/560)
 - We added a fetcher for [ISIDORE](https://isidore.science/), simply paste in the link into the text field or the last 6 digits in the link that identify that paper. [#10423](https://github.com/JabRef/jabref/issues/10423)
 - When importing entries form the "Citation relations" tab, the field [cites](https://docs.jabref.org/advanced/entryeditor/entrylinks) is now filled according to the relationship between the entries. [#10572](https://github.com/JabRef/jabref/pull/10752)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added a refresh button for LaTeX citations. [#10584](https://github.com/JabRef/jabref/issues/10584)
+- We added a "refresh" button for the LaTeX citations tab in the entry editor. [#10584](https://github.com/JabRef/jabref/issues/10584)
 - We added the possibility to show the BibTeX source in the [web search](https://docs.jabref.org/collect/import-using-online-bibliographic-database) import screen. [#560](https://github.com/koppor/jabref/issues/560)
 - We added a fetcher for [ISIDORE](https://isidore.science/), simply paste in the link into the text field or the last 6 digits in the link that identify that paper. [#10423](https://github.com/JabRef/jabref/issues/10423)
 - When importing entries form the "Citation relations" tab, the field [cites](https://docs.jabref.org/advanced/entryeditor/entrylinks) is now filled according to the relationship between the entries. [#10572](https://github.com/JabRef/jabref/pull/10752)

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -93,7 +93,10 @@ public class LatexCitationsTab extends EntryEditorTab {
         Button latexDirectoryButton = new Button(Localization.lang("Set LaTeX file directory"));
         latexDirectoryButton.setGraphic(IconTheme.JabRefIcons.LATEX_FILE_DIRECTORY.getGraphicNode());
         latexDirectoryButton.setOnAction(event -> viewModel.setLatexDirectory());
-        HBox latexDirectoryBox = new HBox(10, latexDirectoryText, latexDirectoryPath, latexDirectoryButton);
+        Button latexDirectoryRefreshButton = new Button(Localization.lang("Refresh"));
+        latexDirectoryRefreshButton.setGraphic(IconTheme.JabRefIcons.REFRESH.getGraphicNode());
+        latexDirectoryRefreshButton.setOnAction(event -> viewModel.refreshLatexDirectory());
+        HBox latexDirectoryBox = new HBox(10, latexDirectoryText, latexDirectoryPath, latexDirectoryButton, latexDirectoryRefreshButton);
         latexDirectoryBox.setAlignment(Pos.CENTER);
         return latexDirectoryBox;
     }

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -170,6 +170,11 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
         init(currentEntry);
     }
 
+    public void refreshLatexDirectory() {
+        latexParserResult = null;
+        init(currentEntry);
+    }
+
     public boolean shouldShow() {
         return preferencesService.getEntryEditorPreferences().shouldShowLatexCitationsTab();
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2070,6 +2070,7 @@ No\ LaTeX\ files\ containing\ this\ entry\ were\ found.=No LaTeX files containin
 Selected\ entry\ does\ not\ have\ an\ associated\ citation\ key.=Selected entry does not have an associated citation key.
 Current\ search\ directory\:=Current search directory:
 Set\ LaTeX\ file\ directory=Set LaTeX file directory
+Refresh=Refresh
 Import\ entries\ from\ LaTeX\ files=Import entries from LaTeX files
 Import\ new\ entries=Import new entries
 Group\ color=Group color


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Fixes  #10584.

<img width="491" alt="Screenshot 2024-02-21 at 10 33 22 AM" src="https://github.com/JabRef/jabref/assets/89566409/ba2fdf00-7f38-4123-a29c-efd73a13fa5a">

- As for developer's documentation I don't think anything should change.
- As for the user's documentation I think the screenshots and GIFs [here](https://docs.jabref.org/advanced/entryeditor/latex-citations) should be replaced to include the new button. Should I make an issue in the [user-documentation](https://github.com/JabRef/user-documentation/issues) repository after the pull is merged?


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
