### PR TITLE
docs: About OOError, Alternatives section not visible

### DIFF
--- a/docs/code-howtos/openoffice/ooresult-ooerror/index.md
+++ b/docs/code-howtos/openoffice/ooresult-ooerror/index.md
@@ -1,7 +1,7 @@
 ---
 nav_order: 5
 parent: The LibreOffice Panel
-has_children: true
+grand_parent: Code Howtos
 ---
 # About OOError, OOResult, and OOVoidResult
 

--- a/docs/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives.md
+++ b/docs/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives.md
@@ -1,5 +1,6 @@
 ---
-parent: About OOError, OOResult, and OOVoidResult
+parent: The LibreOffice Panel
+grand_parent: Code Howtos
 ---
 # Alternatives to using OOResult and OOVoidResult in OOBibBase
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

**Issue**: The sections "[OOError](https://devdocs.jabref.org/code-howtos/openoffice/ooresult-ooerror/)", and ["Alternatives to using OOResult](https://devdocs.jabref.org/code-howtos/openoffice/ooresult-ooerror/ooresult-alternatives)" are not visible in the navigation bar or the [Table of Contents of the LibreOffice](https://devdocs.jabref.org/code-howtos/openoffice/).


Does this match the expected hierarchy?
![image](https://github.com/JabRef/jabref/assets/52158423/842c61ed-ae8d-4414-bf48-356f8bae3d48)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
