### PR TITLE
Refinement of .mv generation tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,22 +331,26 @@ tasks.register("generateSearchGrammarSource", JavaExec) {
 
 tasks.register("generateJournalListMV", JavaExec) {
     group = "JabRef"
-    description = "Converts the comma-separated journal abbreviation file to a H2 MVStore"
+    description = "Converts the comma-separated journal abbreviation file to an H2 MVStore"
     classpath = sourceSets.main.runtimeClasspath
     mainClass = "org.jabref.cli.JournalListMvGenerator"
+    inputs.dir('buildres/abbrv.jabref.org/journals')
+    outputs.file("build/resources/main/journals/journal-list.mv")
+    // Required, because build/resources is input for JavaExec and thus this task would always be exectued
     onlyIf {
         !file("build/resources/main/journals/journal-list.mv").exists()
     }
 }
 
 tasks.register("generatePredatoryJournalListMV", JavaExec) {
-        group = "JabRef"
-        description = "Load predatory journal information from online sources to a H2 MVStore"
-        classpath = sourceSets.main.runtimeClasspath
-        mainClass = "org.jabref.cli.PredatoryJournalsMvGenerator"
-        onlyIf {
-            !file("build/resources/main/journals/predatory-journals.mv").exists()
-        }
+    group = "JabRef"
+    description = "Load predatory journal information from online sources to a H2 MVStore"
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = "org.jabref.cli.PredatoryJournalsMvGenerator"
+    outputs.file("build/resources/main/journals/predatory-journals.mv")
+    onlyIf {
+        !file("build/resources/main/journals/predatory-journals.mv").exists()
+    }
 }
 
 jar.dependsOn("generateJournalListMV", "generatePredatoryJournalListMV")


### PR DESCRIPTION
Small build script improvement to get rid of following warning:

```
Task ':generateJournalListMV' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
```

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
