### PR TITLE
 Change the popup to enter types to the combo box for custom entry types

### DIFF
--- a/src/main/java/org/jabref/gui/DialogService.java
+++ b/src/main/java/org/jabref/gui/DialogService.java
@@ -14,6 +14,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.ChoiceDialog;
 import javafx.scene.control.DialogPane;
 import javafx.scene.control.TextInputDialog;
+import javafx.util.StringConverter;
 
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
@@ -40,6 +41,12 @@ public interface DialogService {
      */
     default <T> Optional<T> showChoiceDialogAndWait(String title, String content, String okButtonLabel, Collection<T> choices) {
         return showChoiceDialogAndWait(title, content, okButtonLabel, null, choices);
+    }
+
+    <T> Optional<T> showEditableChoiceDialogAndWait(String title, String content, String okButtonLabel, T defaultChoice, Collection<T> choices, StringConverter<T> converter);
+
+    default <T> Optional<T> showEditableChoiceDialogAndWait(String title, String content, String okButtonLabel, Collection<T> choices, StringConverter<T> converter) {
+        return showEditableChoiceDialogAndWait(title, content, okButtonLabel, null, choices, converter);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -23,6 +23,7 @@ import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceDialog;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.DialogPane;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
@@ -35,6 +36,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 import javafx.util.Duration;
+import javafx.util.StringConverter;
 
 import org.jabref.gui.help.ErrorConsoleAction;
 import org.jabref.gui.icon.IconTheme;
@@ -129,8 +131,7 @@ public class JabRefDialogService implements DialogService {
         return (dialogMessage.substring(0, Math.min(dialogMessage.length(), JabRefDialogService.DIALOG_SIZE_LIMIT)) + "...").trim();
     }
 
-    @Override
-    public <T> Optional<T> showChoiceDialogAndWait(String title, String content, String okButtonLabel, T defaultChoice, Collection<T> choices) {
+    private <T> ChoiceDialog<T> createChoiceDialog(String title, String content, String okButtonLabel, T defaultChoice, Collection<T> choices) {
         ChoiceDialog<T> choiceDialog = new ChoiceDialog<>(defaultChoice, choices);
         ((Stage) choiceDialog.getDialogPane().getScene().getWindow()).getIcons().add(IconTheme.getJabRefImage());
         ButtonType okButtonType = new ButtonType(okButtonLabel, ButtonBar.ButtonData.OK_DONE);
@@ -139,6 +140,20 @@ public class JabRefDialogService implements DialogService {
         choiceDialog.setTitle(title);
         choiceDialog.setContentText(content);
         choiceDialog.initOwner(mainWindow);
+        return choiceDialog;
+    }
+
+    @Override
+    public <T> Optional<T> showChoiceDialogAndWait(String title, String content, String okButtonLabel, T defaultChoice, Collection<T> choices) {
+        return createChoiceDialog(title, content, okButtonLabel, defaultChoice, choices).showAndWait();
+    }
+
+    @Override
+    public <T> Optional<T> showEditableChoiceDialogAndWait(String title, String content, String okButtonLabel, T defaultChoice, Collection<T> choices, StringConverter<T> converter) {
+        ChoiceDialog<T> choiceDialog = createChoiceDialog(title, content, okButtonLabel, defaultChoice, choices);
+        ComboBox<T> comboBox = (ComboBox<T>) choiceDialog.getDialogPane().lookup(".combo-box");
+        comboBox.setEditable(true);
+        comboBox.setConverter(converter);
         return choiceDialog.showAndWait();
     }
 

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -154,6 +154,7 @@ public class JabRefDialogService implements DialogService {
         ComboBox<T> comboBox = (ComboBox<T>) choiceDialog.getDialogPane().lookup(".combo-box");
         comboBox.setEditable(true);
         comboBox.setConverter(converter);
+        EasyBind.subscribe(comboBox.getEditor().textProperty(), text -> comboBox.setValue(converter.fromString(text)));
         return choiceDialog.showAndWait();
     }
 

--- a/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModel.java
@@ -23,6 +23,7 @@ import javafx.collections.FXCollections;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.libraryproperties.PropertiesTabViewModel;
+import org.jabref.gui.util.FieldsUtil;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.field.Field;
@@ -126,8 +127,11 @@ public class ContentSelectorViewModel implements PropertiesTabViewModel {
     }
 
     void showInputFieldNameDialog() {
-        dialogService.showInputDialogAndWait(Localization.lang("Add new field name"), Localization.lang("Field name"))
-                     .map(FieldFactory::parseField)
+        dialogService.showEditableChoiceDialogAndWait(Localization.lang("Add new field name"),
+                             Localization.lang("Field name"),
+                             Localization.lang("Add"),
+                             FXCollections.observableArrayList(FieldFactory.getStandardFieldsWithCitationKey()),
+                             FieldsUtil.FIELD_STRING_CONVERTER)
                      .ifPresent(this::addFieldIfUnique);
     }
 

--- a/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
+++ b/src/main/java/org/jabref/gui/preferences/customentrytypes/CustomEntryTypesTab.java
@@ -87,7 +87,7 @@ public class CustomEntryTypesTab extends AbstractPreferenceTabView<CustomEntryTy
         setupFieldsTable();
 
         addNewEntryTypeButton.disableProperty().bind(viewModel.entryTypeValidationStatus().validProperty().not());
-        addNewFieldButton.disableProperty().bind(viewModel.fieldValidationStatus().validProperty().not());
+        addNewFieldButton.disableProperty().bind(viewModel.fieldValidationStatus().validProperty().not().or(viewModel.selectedEntryTypeProperty().isNull()));
 
         Platform.runLater(() -> {
             visualizer.initVisualization(viewModel.entryTypeValidationStatus(), addNewEntryType, true);

--- a/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
+++ b/src/test/java/org/jabref/gui/libraryproperties/contentselectors/ContentSelectorViewModelTest.java
@@ -9,9 +9,11 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.util.FieldsUtil;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 
@@ -146,10 +148,13 @@ public class ContentSelectorViewModelTest {
     }
 
     private void addField(Field field) {
-        when(dialogService.showInputDialogAndWait(
-                Localization.lang("Add new field name"), Localization.lang("Field name")))
-                .thenReturn(Optional.of(field.getDisplayName()));
-
+        when(dialogService.showEditableChoiceDialogAndWait(
+                Localization.lang("Add new field name"),
+                Localization.lang("Field name"),
+                Localization.lang("Add"),
+                FXCollections.observableArrayList(FieldFactory.getStandardFieldsWithCitationKey()),
+                FieldsUtil.FIELD_STRING_CONVERTER))
+                .thenReturn(Optional.of(field));
         viewModel.showInputFieldNameDialog();
     }
 


### PR DESCRIPTION
Implemented task 3 from #10560. 

![preview](https://github.com/JabRef/jabref/assets/52158423/a30f11fa-3e62-4814-af57-a53b9008aa4b)

Disabled the add field button if the entry type is not selected to prevent exceptions.

![image](https://github.com/JabRef/jabref/assets/52158423/deb42eed-6308-4b4c-b8c9-4bca8dc2dd07)

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
