### PR TITLE
Paging support for fetchers #5507

### DIFF
--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -14,7 +14,7 @@
 <?import javafx.scene.control.ComboBox?>
 <?import org.fxmisc.richtext.CodeArea?>
 <DialogPane prefHeight="700.0" prefWidth="1000.0" xmlns="http://javafx.com/javafx/10.0.2-internal"
-            xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.importer.WebImportEntriesDialog">
+            xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.importer.ImportEntriesDialog">
     <content>
         <VBox spacing="10.0">
             <Label text="%Select the entries to be imported:"/>
@@ -25,9 +25,7 @@
                         <Button onAction="#selectAllNewEntries"  text="%Select all new entries"/>
                         <Button onAction="#selectAllEntries"  text="%Select all entries"/>
                         <Button onAction="#unselectAll"  text="%Unselect all"/>
-                        <Button fx:id="previousButton"  text="Previous" />
-                        <Button fx:id="nextButton" text="Next" />
-<!--                        <Label fx:id="pageLabel"/>-->
+
                     </HBox>
                     <VBox fx:id="bibTeXDataBox" visible="false" managed="false">
                         <Label fx:id="bibTeXDataLabel"/>

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.java
@@ -62,10 +62,6 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
     public CheckListView<BibEntry> entriesListView;
     public ComboBox<BibDatabaseContext> libraryListView;
     public ButtonType importButton;
-    public Button previousButton;
-    public Button nextButton;
-    @FXML
-    public Label pageLabel;
     public Label totalItems;
     public Label selectedItems;
     public Label bibTeXDataLabel;
@@ -76,9 +72,6 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
     private final BackgroundTask<ParserResult> task;
     private final BibDatabaseContext database;
     private ImportEntriesViewModel viewModel;
-    // private final int entriesPerPage = 20;
-   // private final ObservableList<BibEntry> allEntries;
-   // private final IntegerProperty currentPage = new SimpleIntegerProperty(1);
     @Inject private TaskExecutor taskExecutor;
     @Inject private DialogService dialogService;
     @Inject private UndoManager undoManager;
@@ -96,7 +89,6 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
     public ImportEntriesDialog(BibDatabaseContext database, BackgroundTask<ParserResult> task) {
         this.database = database;
         this.task = task;
-      //  this.allEntries = FXCollections.observableArrayList();
         ViewLoader.view(this)
                   .load()
                   .setAsDialogPane(this);
@@ -106,9 +98,6 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
         btn.disableProperty().bind(booleanBind);
 
         downloadLinkedOnlineFiles.setSelected(preferences.getFilePreferences().shouldDownloadLinkedFiles());
-
-//        allEntries.addAll(database.getEntries());
-//        setEntries(Collections.emptyList());
 
         setResultConverter(button -> {
             if (button == importButton) {
@@ -197,31 +186,7 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
         totalItems.textProperty().bind(Bindings.size(entriesListView.getItems()).asString());
         entriesListView.setSelectionModel(new NoSelectionModel<>());
         initBibTeX();
-      //  addPagination();
     }
-
-//    public void setEntries(List<BibEntry> entries) {
-//        this.allEntries.setAll(entries);
-//        currentPage.set(1);
-//    }
-//
-//    public void addPagination() {
-//        previousButton.setOnAction(event -> {
-//            if (currentPage.get() > 1) {
-//                currentPage.set(currentPage.get() - 1);
-//            }
-//        });
-//
-//        nextButton.setOnAction(event -> {
-//            int totalPages = calculateTotalPages();
-//            if (currentPage.get() < totalPages) {
-//                currentPage.set(currentPage.get() + 1);
-//            }
-//        });
-//       currentPage.addListener(((observable, oldValue, newValue) -> updatePageEntries()));
-//
-//        updatePageEntries();
-//    }
 
     private void displayBibTeX(BibEntry entry, String bibTeX) {
         if (entriesListView.getCheckModel().isChecked(entry)) {
@@ -299,15 +264,4 @@ public class ImportEntriesDialog extends BaseDialog<Boolean> {
         unselectAll();
         entriesListView.getCheckModel().checkAll();
     }
-
-//    private void updatePageEntries() {
-//        int startIndex = (currentPage.get() - 1) * entriesPerPage;
-//        int endIndex = Math.min(startIndex + entriesPerPage, allEntries.size());
-//        this.entriesListView.setItems(FXCollections.observableArrayList(allEntries.subList(startIndex, endIndex)));
-//        pageLabel.setText(String.valueOf(currentPage.get()));
-//    }
-
-//    private int calculateTotalPages() {
-//        return (int) Math.ceil((double) allEntries.size() / entriesPerPage);
-//    }
 }

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -56,7 +56,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private final PreferencesService preferences;
     private final BibEntryTypesManager entryTypesManager;
     private final ObjectProperty<BibDatabaseContext> selectedDb;
-    // private final IntegerProperty totalNumberOfEntries = new SimpleIntegerProperty(0);
 
     /**
      * @param databaseContext the database to import into
@@ -96,8 +95,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             LOGGER.error("Error importing", ex);
             dialogService.showErrorDialogAndWait(ex);
         }).executeWith(taskExecutor);
-
-        // totalNumberOfEntries.set(getTotalNumberOfEntries());
     }
 
     public String getMessage() {
@@ -119,10 +116,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public ObservableList<BibEntry> getEntries() {
         return entries;
     }
-
-//    public int getTotalNumberOfEntries() {
-//        return databaseContext.getDatabase().getEntries().size();
-//    }
 
     public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent() ||
@@ -199,8 +192,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
                 parserResult.getMetaData(),
                 parserResult.getPath().map(path -> path.getFileName().toString()).orElse("unknown"),
                 parserResult.getDatabase().getEntries());
-
-//        JabRefGUI.getMainFrame().getCurrentLibraryTab().markBaseChanged();
     }
 
     private void buildImportHandlerThenImportEntries(List<BibEntry> entriesToImport) {

--- a/src/main/java/org/jabref/gui/importer/WebImportEntriesDialog.fxml
+++ b/src/main/java/org/jabref/gui/importer/WebImportEntriesDialog.fxml
@@ -27,7 +27,7 @@
                         <Button onAction="#unselectAll"  text="%Unselect all"/>
                         <Button fx:id="previousButton"  text="Previous" />
                         <Button fx:id="nextButton" text="Next" />
-<!--                        <Label fx:id="pageLabel"/>-->
+                        <Label fx:id="pageLabel"/>
                     </HBox>
                     <VBox fx:id="bibTeXDataBox" visible="false" managed="false">
                         <Label fx:id="bibTeXDataLabel"/>

--- a/src/main/java/org/jabref/gui/importer/WebimportEntriesViewmodel.java
+++ b/src/main/java/org/jabref/gui/importer/WebimportEntriesViewmodel.java
@@ -40,9 +40,9 @@ import org.jabref.preferences.PreferencesService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ImportEntriesViewModel extends AbstractViewModel {
+public class WebimportEntriesViewmodel extends AbstractViewModel {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImportEntriesViewModel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebimportEntriesViewmodel.class);
 
     private final StringProperty message;
     private final TaskExecutor taskExecutor;
@@ -56,13 +56,12 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     private final PreferencesService preferences;
     private final BibEntryTypesManager entryTypesManager;
     private final ObjectProperty<BibDatabaseContext> selectedDb;
-    // private final IntegerProperty totalNumberOfEntries = new SimpleIntegerProperty(0);
 
     /**
      * @param databaseContext the database to import into
      * @param task            the task executed for parsing the selected files(s).
      */
-    public ImportEntriesViewModel(BackgroundTask<ParserResult> task,
+    public WebimportEntriesViewmodel(BackgroundTask<ParserResult> task,
                                   TaskExecutor taskExecutor,
                                   BibDatabaseContext databaseContext,
                                   DialogService dialogService,
@@ -90,14 +89,12 @@ public class ImportEntriesViewModel extends AbstractViewModel {
             // fill in the list for the user, where one can select the entries to import
             entries.addAll(parserResult.getDatabase().getEntries());
             if (entries.isEmpty()) {
-               task.updateMessage(Localization.lang("No entries corresponding to given query"));
+                task.updateMessage(Localization.lang("No entries corresponding to given query"));
             }
         }).onFailure(ex -> {
             LOGGER.error("Error importing", ex);
             dialogService.showErrorDialogAndWait(ex);
         }).executeWith(taskExecutor);
-
-        // totalNumberOfEntries.set(getTotalNumberOfEntries());
     }
 
     public String getMessage() {
@@ -120,14 +117,10 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         return entries;
     }
 
-//    public int getTotalNumberOfEntries() {
-//        return databaseContext.getDatabase().getEntries().size();
-//    }
-
     public boolean hasDuplicate(BibEntry entry) {
         return findInternalDuplicate(entry).isPresent() ||
                 new DuplicateCheck(entryTypesManager)
-                .containsDuplicate(selectedDb.getValue().getDatabase(), entry, selectedDb.getValue().getMode()).isPresent();
+                        .containsDuplicate(selectedDb.getValue().getDatabase(), entry, selectedDb.getValue().getMode()).isPresent();
     }
 
     public String getSourceString(BibEntry entry) {

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -15,7 +15,7 @@ import javafx.collections.ObservableList;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.Telemetry;
-import org.jabref.gui.importer.ImportEntriesDialog;
+import org.jabref.gui.importer.WebImportEntriesDialog;
 import org.jabref.gui.util.BackgroundTask;
 import org.jabref.logic.importer.CompositeIdFetcher;
 import org.jabref.logic.importer.ParserResult;
@@ -47,7 +47,6 @@ public class WebSearchPaneViewModel {
     private final DialogService dialogService;
     private final PreferencesService preferencesService;
     private final StateManager stateManager;
-
     private final Validator searchQueryValidator;
     private final SyntaxParser parser = new StandardSyntaxParser();
 
@@ -68,6 +67,7 @@ public class WebSearchPaneViewModel {
         } else {
             selectedFetcherProperty().setValue(fetchers.get(defaultFetcherIndex));
         }
+
         EasyBind.subscribe(selectedFetcherProperty(), newFetcher -> {
             int newIndex = fetchers.indexOf(newFetcher);
             sidePanePreferences.setWebSearchFetcherSelected(newIndex);
@@ -163,8 +163,9 @@ public class WebSearchPaneViewModel {
                              .withInitialMessage(Localization.lang("Processing %0", query));
         task.onFailure(dialogService::showErrorDialogAndWait);
 
-        ImportEntriesDialog dialog = new ImportEntriesDialog(stateManager.getActiveDatabase().get(), task);
+        WebImportEntriesDialog dialog = new WebImportEntriesDialog(stateManager.getActiveDatabase().get(), task);
         dialog.setTitle(finalFetcherName);
+
         dialogService.showCustomDialogAndWait(dialog);
     }
 


### PR DESCRIPTION
### **Description**

Fixes #5507
This pull request adds a next button, a previous button and pagination for the Fetchers.

### **Changes Made**

- Added  new classes `WebImportEntriesDialog`, and, `WebImportViewModel` that adds the previous button, next button and pagination.
- Added the disable feature to the `Previous` button. The previous button will be disabled at first.
-  Implemented the logic so that the Fetcher only shows 20 data per page
- Added `WebImportEntriesDialog.FXML` file which shows the buttons and the pagination