### PR TITLE
Fix issue in comments Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)
 - We fixed an issue where the CrossRef field did not work if autocompletion was disabled [#8145](https://github.com/JabRef/jabref/issues/8145)
 - We fixed an issue where exporting`@electronic` and `@online` entry types to the Office XMl would duplicate the field `title`  [#10807](https://github.com/JabRef/jabref/issues/10807)
+- We fixed an issue where the `CommentsTab` was not properly formatted when the `defaultOwner` contained capital or special letters. [#10870](https://github.com/JabRef/jabref/issues/10870)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
@@ -2,6 +2,7 @@ package org.jabref.gui.entryeditor;
 
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedSet;
@@ -64,7 +65,7 @@ public class CommentsTab extends FieldsEditorTab {
                 journalAbbreviationRepository,
                 indexingTaskManager
         );
-        this.defaultOwner = preferences.getOwnerPreferences().getDefaultOwner().toLowerCase().replaceAll("[^a-z0-9]", "-");
+        this.defaultOwner = preferences.getOwnerPreferences().getDefaultOwner().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "-");
         setText(Localization.lang("Comments"));
         setGraphic(IconTheme.JabRefIcons.COMMENT.getGraphicNode());
 

--- a/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
@@ -80,14 +80,14 @@ public class CommentsTab extends FieldsEditorTab {
         comments.add(StandardField.COMMENT);
 
         // Also show comment field of the current user (if enabled in the preferences)
-        if (entryEditorPreferences.shouldShowUserCommentsFields()) {
+        if (entry.hasField(userSpecificCommentField) || entryEditorPreferences.shouldShowUserCommentsFields()) {
             comments.add(userSpecificCommentField);
         }
 
         // Show all non-empty comment fields (otherwise, they are completely hidden)
         comments.addAll(entry.getFields().stream()
                 .filter(field -> (field instanceof UserSpecificCommentField && !field.equals(userSpecificCommentField))
-                        && field.getName().toLowerCase().contains("comment"))
+                        || field.getName().toLowerCase().contains("comment"))
                 .sorted(Comparator.comparing(Field::getName))
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
         return comments;

--- a/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java
@@ -64,7 +64,7 @@ public class CommentsTab extends FieldsEditorTab {
                 journalAbbreviationRepository,
                 indexingTaskManager
         );
-        this.defaultOwner = preferences.getOwnerPreferences().getDefaultOwner();
+        this.defaultOwner = preferences.getOwnerPreferences().getDefaultOwner().toLowerCase().replaceAll("[^a-z0-9]", "-");
         setText(Localization.lang("Comments"));
         setGraphic(IconTheme.JabRefIcons.COMMENT.getGraphicNode());
 
@@ -80,14 +80,14 @@ public class CommentsTab extends FieldsEditorTab {
         comments.add(StandardField.COMMENT);
 
         // Also show comment field of the current user (if enabled in the preferences)
-        if (entry.hasField(userSpecificCommentField) || entryEditorPreferences.shouldShowUserCommentsFields()) {
+        if (entryEditorPreferences.shouldShowUserCommentsFields()) {
             comments.add(userSpecificCommentField);
         }
 
         // Show all non-empty comment fields (otherwise, they are completely hidden)
         comments.addAll(entry.getFields().stream()
                 .filter(field -> (field instanceof UserSpecificCommentField && !field.equals(userSpecificCommentField))
-                        || field.getName().toLowerCase().contains("comment"))
+                        && field.getName().toLowerCase().contains("comment"))
                 .sorted(Comparator.comparing(Field::getName))
                 .collect(Collectors.toCollection(LinkedHashSet::new)));
         return comments;


### PR DESCRIPTION
Fixes #10870

This issue occurs when the `defaultOwner` contains capital letters. 
For example, if `defaultOwner = Test`, the `userSpecificCommentField.name` will be `comment-Test`, after saving it to the .bib file, it will be written as `comment-test`. As a result, every time the `commentsTab` is opened, it will contain both `comment-Test` and `comment-test` fields.

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
