### PR TITLE
Fix typo in Intellij code style documentation

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
@@ -139,7 +139,8 @@ Press "OK".
 ## Disable too advanced code folding
 
 Go to **File > Settings... > Editor > General > Code Folding**.
-At "Java", disable "General > File header", "General > Imports", and "Java > One-line methods".
+
+Disable "General > File header", "General > Imports", and "Java > One-line methods".
 
 {% figure caption:"Code foldings disabled" %}
 ![Code foldings disabled](guidelines-settings-intellij-code-foldings.png)


### PR DESCRIPTION
Removed the "At Java" part from the [Code folding section](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#disable-too-advanced-code-folding) in the Developer documentation, since it was a bit misleading to me 😅 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
