### PR TITLE
Add feature relinking moved file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When pasting HTML into the abstract or a comment field, the hypertext is automatically converted to Markdown. [#10558](https://github.com/JabRef/jabref/issues/10558)
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
+- We added file relinking functionality after a file is moved when clicking the "Automatically set file links" button. Implementation based and improved upon work done in closed issue [#10526]. [#9798]
 
 ### Changed
 

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -1,5 +1,6 @@
 package org.jabref.cli;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -188,7 +189,7 @@ public class ArgumentProcessor {
         }
     }
 
-    public void processArguments() {
+    public void processArguments() throws FileNotFoundException {
         uiCommands.clear();
 
         if ((startupMode == Mode.INITIAL_START) && cli.isShowVersion()) {
@@ -711,7 +712,7 @@ public class ArgumentProcessor {
         }
     }
 
-    private void automaticallySetFileLinks(List<ParserResult> loaded) {
+    private void automaticallySetFileLinks(List<ParserResult> loaded) throws FileNotFoundException {
         for (ParserResult parserResult : loaded) {
             BibDatabase database = parserResult.getDatabase();
             LOGGER.info(Localization.lang("Automatically setting file links"));

--- a/src/main/java/org/jabref/gui/externalfiles/AutoLinkFilesAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/AutoLinkFilesAction.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.externalfiles;
 
+import java.io.FileNotFoundException;
 import java.util.List;
 
 import javax.swing.undo.UndoManager;
@@ -55,7 +56,7 @@ public class AutoLinkFilesAction extends SimpleCommand {
 
         Task<AutoSetFileLinksUtil.LinkFilesResult> linkFilesTask = new Task<>() {
             @Override
-            protected AutoSetFileLinksUtil.LinkFilesResult call() {
+            protected AutoSetFileLinksUtil.LinkFilesResult call() throws FileNotFoundException {
                 return util.linkAssociatedFiles(entries, nc);
             }
 

--- a/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
+++ b/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
@@ -159,13 +159,16 @@ public class AutoSetFileLinksUtil {
             Path path = Path.of(file.getLink());
             if (!Files.exists(path)) {
                 Path filePath = Path.of(file.getLink());
+                // May need to put some limit since it can cause considerable performance problems.
                 String directoryPath = filePath.getParent().getParent().toString();
 
                 String fileNameString = filePath.getFileName().toString();
 
-                List<String> fileLocations = searchFileInDirectoryAndSubdirectories(Path.of(directoryPath), fileNameString);
+                List<Path> fileLocations = searchFileInDirectoryAndSubdirectories(Path.of(directoryPath), fileNameString);
                 if (!fileLocations.isEmpty()) {
-                    file.setLink(fileLocations.get(0));
+                    // File locations is a list but as stated in the link below, it is a rare case. But can be solved if time allows.
+                    // https://github.com/JabRef/jabref/issues/9798#issuecomment-1524155132
+                    file.setLink(fileLocations.get(0).toString());
                     changedFiles.add(file);
                 } else {
                     exceptions.add(fileNameString);
@@ -176,7 +179,7 @@ public class AutoSetFileLinksUtil {
         return new RelinkedResults(changedFiles, exceptions);
     }
 
-    public List<String> searchFileInDirectoryAndSubdirectories(Path directory, String targetFileName) {
+    public List<Path> searchFileInDirectoryAndSubdirectories(Path directory, String targetFileName) {
         List<Path> paths = new ArrayList<>();
         try {
             Files.walk(directory, Integer.MAX_VALUE, FileVisitOption.FOLLOW_LINKS)
@@ -186,9 +189,9 @@ public class AutoSetFileLinksUtil {
         } catch (IOException e) {
             // Handle any exceptions here
         }
-        List<String> output = new ArrayList<>();
+        List<Path> output = new ArrayList<>();
         for (Path p : paths) {
-            output.add(p.toString());
+            output.add(p);
         }
         return output;
     }

--- a/src/main/java/org/jabref/gui/remote/CLIMessageHandler.java
+++ b/src/main/java/org/jabref/gui/remote/CLIMessageHandler.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.remote;
 
+import java.io.FileNotFoundException;
 import java.util.Arrays;
 
 import javafx.application.Platform;
@@ -42,6 +43,9 @@ public class CLIMessageHandler implements RemoteMessageHandler {
             Platform.runLater(() -> JabRefGUI.getMainFrame().handleUiCommands(argumentProcessor.getUiCommands()));
         } catch (ParseException e) {
             LOGGER.error("Error when parsing CLI args", e);
+        } catch (
+                FileNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -88,7 +88,7 @@ public class AutoSetFileLinksUtilTest {
         Files.createDirectory(B);
         Path filePath = A.resolve("Test.pdf");
         Files.createFile(filePath);
-        entry.setCitationKey("CiteKey");
+        entry.setCitationKey("Test");
 
         LinkedFile linkedFile = new LinkedFile("desc", filePath, "PDF");
         List<LinkedFile> listLinked = new ArrayList<>();
@@ -110,9 +110,30 @@ public class AutoSetFileLinksUtilTest {
         listLinked2.add(linkedDestFile);
         entry.setFiles(listLinked2);
         assertEquals(entry.getFiles(), list);
-    }
 
+
+        // After this point, tested different extension along with the case where document has multiple file references
+        Path filePath2 = B.resolve("Test1.txt");
+        Files.createFile(filePath2);
+        linkedFile = new LinkedFile("desc", filePath2, "TXT");
+        listLinked.add(linkedFile);
+        entry.setFiles(listLinked);
+
+        destination = A.resolve("Test1.txt");
+        Files.move(B.resolve("Test1.txt"), destination, StandardCopyOption.REPLACE_EXISTING);
+        util = new AutoSetFileLinksUtil(databaseContext, filePreferences, autoLinkPrefs);
+        results = util.relinkingFiles(entry.getFiles());
+        list = results.relinkedFiles();
+        exceptions = results.exceptions();
+
+        listLinked2.clear();
+        listLinked2.add(new LinkedFile("desc", B.resolve("Test.pdf"), "PDF"));
+        listLinked2.add(new LinkedFile("desc", A.resolve("Test1.txt"), "TXT"));
+
+        assertEquals(listLinked2, list);
+    }
     // todo There should be another test where the file stays the same
     // In test code, it is very OK to have duplicated code fragments.
+
 
 }

--- a/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -111,7 +111,6 @@ public class AutoSetFileLinksUtilTest {
         entry.setFiles(listLinked2);
         assertEquals(entry.getFiles(), list);
 
-
         // After this point, tested different extension along with the case where document has multiple file references
         Path filePath2 = B.resolve("Test1.txt");
         Files.createFile(filePath2);
@@ -132,8 +131,4 @@ public class AutoSetFileLinksUtilTest {
 
         assertEquals(listLinked2, list);
     }
-    // todo There should be another test where the file stays the same
-    // In test code, it is very OK to have duplicated code fragments.
-
-
 }

--- a/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -1,7 +1,10 @@
 package org.jabref.gui.externalfiles;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeSet;
@@ -26,7 +29,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AutoSetFileLinksUtilTest {
-
     private final FilePreferences filePreferences = mock(FilePreferences.class);
     private final AutoLinkPreferences autoLinkPrefs = new AutoLinkPreferences(
             AutoLinkPreferences.CitationKeyDependency.START,
@@ -36,10 +38,16 @@ public class AutoSetFileLinksUtilTest {
     private final BibDatabaseContext databaseContext = mock(BibDatabaseContext.class);
     private final BibEntry entry = new BibEntry(StandardEntryType.Article);
     private Path path = null;
+    private Path A;
+    private Path B;
 
     @BeforeEach
     public void setUp(@TempDir Path folder) throws Exception {
-        path = folder.resolve("CiteKey.pdf");
+        A = folder.resolve("A");
+        Files.createDirectory(A);
+        B = folder.resolve("B");
+        Files.createDirectory(B);
+        path = A.resolve("CiteKey.pdf");
         Files.createFile(path);
         entry.setCitationKey("CiteKey");
         when(filePreferences.getExternalFileTypes())
@@ -47,7 +55,7 @@ public class AutoSetFileLinksUtilTest {
     }
 
     @Test
-    public void findAssociatedNotLinkedFilesSuccess() throws Exception {
+    public void testFindAssociatedNotLinkedFilesSuccess() throws Exception {
         when(databaseContext.getFileDirectories(any())).thenReturn(Collections.singletonList(path.getParent()));
         List<LinkedFile> expected = Collections.singletonList(new LinkedFile("", Path.of("CiteKey.pdf"), "PDF"));
         AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, filePreferences, autoLinkPrefs);
@@ -56,10 +64,37 @@ public class AutoSetFileLinksUtilTest {
     }
 
     @Test
-    public void findAssociatedNotLinkedFilesForEmptySearchDir() throws Exception {
+    public void testFindAssociatedNotLinkedFilesForEmptySearchDir() throws Exception {
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(false);
         AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, filePreferences, autoLinkPrefs);
         List<LinkedFile> actual = util.findAssociatedNotLinkedFiles(entry);
         assertEquals(Collections.emptyList(), actual);
+    }
+
+    @Test
+    public void testFileLinksAfterMoving() throws Exception {
+        // Run "Automatically set file links" - check that the bib file was not modified
+        LinkedFile linkedFile = new LinkedFile("desc", path, "PDF");
+        List<LinkedFile> listLinked = new ArrayList<>();
+        listLinked.add(linkedFile);
+        entry.setFiles(listLinked);
+
+        // Copy Bib file from A to B
+        Path destination = B.resolve("CiteKey.pdf");
+        Files.copy(A.resolve("CiteKey.pdf"), destination, StandardCopyOption.REPLACE_EXISTING);
+        Files.deleteIfExists(A.resolve("CiteKey.pdf"));
+
+        AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, filePreferences, autoLinkPrefs);
+        AutoSetFileLinksUtil.RelinkedResults results = util.relinkingFiles(entry.getFiles());
+        List<LinkedFile> list = results.relinkedFiles();
+        List<IOException> exceptions = results.exceptions();
+        assertEquals(Collections.emptyList(), exceptions);
+
+        // Change Entry to match required result and run method on bib
+        LinkedFile linkedDestFile = new LinkedFile("desc", B.resolve("CiteKey.pdf"), "PDF");
+        List<LinkedFile> listLinked2 = new ArrayList<>();
+        listLinked2.add(linkedDestFile);
+        entry.setFiles(listLinked2);
+        assertEquals(entry.getFiles(), list);
     }
 }


### PR DESCRIPTION
Closes #9798 

We implemented a solution for the first implementation mentioned in the issue. This implementation is based on the work made in closed issue #10526. Their code was incomplete based on the suggestions made and we implemented those changes. Refactored the code and associated classes to allow for a FileNotFoundException. The class performs a move operation more traditionally than copying and deleting as previously. The relinkingFiles method now returns a list of not found file names. The test setup has been altered to not affect all tests. The searchFileInDirectoryAndSubdirectories method now returns List<path> instead of string. Additional tests were made for the class.

Changes were produced primarily through test-driven development, wherein functionality was added or adapted after testing its associated mechanics.

We would love to hear your feedback on what is done so far. Were there limitations with the work done in issue #10526? After all we saw the comment about implementing a FileWatcher system recently, and were curious if that is a path worth pursuing still? 

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
