### PR TITLE
Added ability to change zoom using Ctrl + Scroll in Document Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
+- We added the ability to zoom in and out in the document viewer using <kbd>Ctrl</kbd> + <kbd>Scroll</kbd>.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the possibility to redownload files that had been present but are no longer in the specified location. [#10848](https://github.com/JabRef/jabref/issues/10848)
 - We added the citation key pattern `[camelN]`. Equivalent to the first N words of the `[camel]` pattern.
 - We added ability to export in CFF (Citation File Format) [#10661](https://github.com/JabRef/jabref/issues/10661).
-- We added the ability to zoom in and out in the document viewer using <kbd>Ctrl</kbd> + <kbd>Scroll</kbd>.
+- We added the ability to zoom in and out in the document viewer using <kbd>Ctrl</kbd> + <kbd>Scroll</kbd>. [#10964](https://github.com/JabRef/jabref/pull/10964)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
@@ -140,7 +140,16 @@ public class DocumentViewerControl extends StackPane {
 
     public void changePageWidth(int delta) {
         // Assuming the current page is A4 (or has same aspect ratio)
-        setPageWidth(desiredPageDimension.getWidth(Math.sqrt(2)) + delta);
+        int newWidth = desiredPageDimension.getWidth(Math.sqrt(2)) + delta;
+        // Limit zoom out to ~1 page due to occasional display errors when zooming out further
+        int minWidth = (int) (flow.getHeight() / 2 * Math.sqrt(2));
+        if (newWidth < minWidth) {
+            if (newWidth - delta == minWidth) {  // Attempting to zoom out when already at minWidth
+                return;
+            }
+            newWidth = minWidth;
+        }
+        setPageWidth(newWidth);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
@@ -14,6 +14,7 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
@@ -76,6 +77,16 @@ public class DocumentViewerControl extends StackPane {
         flow.estimatedScrollYProperty().addListener((observable, oldValue, newValue) -> scrollY.setValue(newValue));
         scrollY.addListener((observable, oldValue, newValue) -> flow.estimatedScrollYProperty().setValue((double) newValue));
         flow.totalLengthEstimateProperty().addListener((observable, oldValue, newValue) -> scrollYMax.setValue(newValue));
+        flow.addEventFilter(ScrollEvent.SCROLL, (ScrollEvent event) -> {
+            if (event.isControlDown()) {
+                event.consume();
+                if (event.getDeltaY() > 0) {
+                    changePageWidth(100);
+                } else {
+                    changePageWidth(-100);
+                }
+            }
+        });
     }
 
     private void updateCurrentPage(ObservableList<DocumentViewerPage> visiblePages) {
@@ -91,7 +102,8 @@ public class DocumentViewerControl extends StackPane {
                 // Successful hit
                 inMiddleOfViewport = Optional.of(hit.getCell());
             }
-        } catch (NoSuchElementException exception) {
+        } catch (
+                NoSuchElementException exception) {
             // Sometimes throws exception if no page is found -> ignore
         }
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerControl.java
@@ -102,8 +102,7 @@ public class DocumentViewerControl extends StackPane {
                 // Successful hit
                 inMiddleOfViewport = Optional.of(hit.getCell());
             }
-        } catch (
-                NoSuchElementException exception) {
+        } catch (NoSuchElementException exception) {
             // Sometimes throws exception if no page is found -> ignore
         }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
I have added the ability to change the zoom level using Ctrl + Scroll in the PDF Document Viewer.
Additionally, I have limited the zoom-out to ~1 page by setting a minWidth, as an unlimited zoom-out led to following problems:
- Occasional display errors (e.g. no text displayed for certain pages)
- No content can be seen if zoomed out too far, might be unclear to the user what happened and that zooming in will fix problem

The Document Viewer is still not very user friendly in my opinion and I am not sure how much further development time should be invested in its current state.
It might be a better option to get rid of it alltogether and always use the "Open file (F4)" option when a user wants to open a PDF.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
