### PR TITLE
Store Citation Relations in LRU Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We made the command "Push to TexShop" more robust to allow cite commands with a character before the first slash. [forum#2699](https://discourse.jabref.org/t/push-to-texshop-mac/2699/17?u=siedlerchr)
 - We only show the notification "Saving library..." if the library contains more than 2000 entries. [#9803](https://github.com/JabRef/jabref/issues/9803)
 - We enhanced the dialog for adding new fields in the content selector with a selection box containing a list of standard fields. [#10912](https://github.com/JabRef/jabref/pull/10912)
+- We store the citation relations in an LRU cache to avoid bloating the memory and out-of-memory exceptions [#10958](https://github.com/JabRef/jabref/issues/10958)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryRelationsCache.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryRelationsCache.java
@@ -1,16 +1,18 @@
 package org.jabref.gui.entryeditor.citationrelationtab;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.identifier.DOI;
 
+import org.eclipse.jgit.util.LRUMap;
+
 public class BibEntryRelationsCache {
-    private static final Map<String, List<BibEntry>> CITATIONS_MAP = new HashMap<>();
-    private static final Map<String, List<BibEntry>> REFERENCES_MAP = new HashMap<>();
+    private static final Integer MAX_CACHED_ENTRIES = 100;
+    private static final Map<String, List<BibEntry>> CITATIONS_MAP = new LRUMap<>(MAX_CACHED_ENTRIES, MAX_CACHED_ENTRIES);
+    private static final Map<String, List<BibEntry>> REFERENCES_MAP = new LRUMap<>(MAX_CACHED_ENTRIES, MAX_CACHED_ENTRIES);
 
     public List<BibEntry> getCitations(BibEntry entry) {
         return CITATIONS_MAP.getOrDefault(entry.getDOI().map(DOI::getDOI).orElse(""), Collections.emptyList());


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Citations and References under the "Citation Relations" Tab are now saved in an LRUMap instead of a regular HashMap.
Their size is now limited to a (somewhat arbitrarily chosen) 100 entries.
I chose to initialize them at max size to avoid resizing, although I am not sure whether this works as intended. Each Map stores Lists which themselves grow and potentially lead to reallocation of memory.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
