### PR TITLE
Replace throw new RuntimeException by LOGGER / other throws

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryRelationsRepository.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/BibEntryRelationsRepository.java
@@ -6,7 +6,12 @@ import org.jabref.gui.entryeditor.citationrelationtab.semanticscholar.SemanticSc
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class BibEntryRelationsRepository {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BibEntryRelationsRepository.class);
+
     private final SemanticScholarFetcher fetcher;
     private final BibEntryRelationsCache cache;
 
@@ -25,7 +30,13 @@ public class BibEntryRelationsRepository {
 
     public List<BibEntry> getReferences(BibEntry entry) {
         if (needToRefreshReferences(entry)) {
-            List<BibEntry> references = fetcher.searchCiting(entry);
+            List<BibEntry> references;
+            try {
+                references = fetcher.searchCiting(entry);
+            } catch (FetcherException e) {
+                LOGGER.error("Error while fetching references", e);
+                references = List.of();
+            }
             cache.cacheOrMergeReferences(entry, references);
         }
 
@@ -37,7 +48,7 @@ public class BibEntryRelationsRepository {
             List<BibEntry> citations = fetcher.searchCitedBy(entry);
             cache.cacheOrMergeCitations(entry, citations);
         } catch (FetcherException e) {
-            throw new RuntimeException(e);
+            LOGGER.error("Error while fetching citations", e);
         }
     }
 
@@ -50,7 +61,13 @@ public class BibEntryRelationsRepository {
     }
 
     public void forceRefreshReferences(BibEntry entry) {
-        List<BibEntry> references = fetcher.searchCiting(entry);
+        List<BibEntry> references;
+        try {
+            references = fetcher.searchCiting(entry);
+        } catch (FetcherException e) {
+            LOGGER.error("Error while fetching references", e);
+            references = List.of();
+        }
         cache.cacheOrMergeReferences(entry, references);
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
@@ -3,7 +3,6 @@ package org.jabref.gui.entryeditor.citationrelationtab.semanticscholar;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.jabref.logic.importer.FetcherException;
@@ -50,15 +49,14 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
                                         .stream().filter(citationDataItem -> citationDataItem.getCitingPaper() != null)
                                         .map(citationDataItem -> citationDataItem.getCitingPaper().toBibEntry()).toList();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new FetcherException("Could not fetch", e);
             }
         }
-
-        return new ArrayList<>();
+        return List.of();
     }
 
     @Override
-    public List<BibEntry> searchCiting(BibEntry entry) {
+    public List<BibEntry> searchCiting(BibEntry entry) throws FetcherException {
         if (entry.getDOI().isPresent()) {
             StringBuilder urlBuilder = new StringBuilder(SEMANTIC_SCHOLAR_API)
                     .append("paper/")
@@ -82,11 +80,10 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
                                          .filter(citationDataItem -> citationDataItem.getCitedPaper() != null)
                                          .map(referenceDataItem -> referenceDataItem.getCitedPaper().toBibEntry()).toList();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new FetcherException("Could not fetch", e);
             }
         }
-
-        return new ArrayList<>();
+        return List.of();
     }
 
     @Override


### PR DESCRIPTION
We should avoid `throw new RuntimeExcption()`. I replaced **all** calls. Maybe, I replaced too much. IDK.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
