### PR TITLE
Enable auto merge of CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,4 @@ gradlew text eol=lf
 *.java text eol=lf
 *.properties text eol=lf
 
-# disable after a release (otherwise, duplicate CHANGELOG.md entries will be generated)
-# CHANGELOG.md merge=union
+CHANGELOG.md merge=union


### PR DESCRIPTION
Lines in CHANGELOG.md should be automerged by keeping both.

With our check that CHANGELOG.md entries should go into `Unreleased` only (see https://github.com/JabRef/jabref/blame/967b6518d1b74568d270b4ac758c3ac6ffbd15c7/.github/workflows/tests.yml#L134), this auto merge should work without issues.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
