### PR TITLE
Use tags editor for auto completion preferences

### DIFF
--- a/src/main/java/org/jabref/gui/autocompleter/AutoCompletePreferences.java
+++ b/src/main/java/org/jabref/gui/autocompleter/AutoCompletePreferences.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
 
 import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.FieldFactory;
 
 public class AutoCompletePreferences {
 
@@ -79,9 +78,5 @@ public class AutoCompletePreferences {
      */
     public ObservableSet<Field> getCompleteFields() {
         return completeFields;
-    }
-
-    public String getCompleteNamesAsString() {
-        return FieldFactory.serializeFieldsList(completeFields);
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.fxml
@@ -4,10 +4,10 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import com.dlsc.gemsfx.TagsField?>
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.autocompletion.AutoCompletionTab">
@@ -22,11 +22,11 @@
     <VBox spacing="10.0">
         <HBox spacing="4.0">
             <Label text="%Affected fields" disable="${!enableAutoComplete.selected}"/>
-            <TextField fx:id="autoCompleteFields" HBox.hgrow="ALWAYS" disable="${!enableAutoComplete.selected}">
+            <TagsField fx:id="autoCompleteFields" HBox.hgrow="ALWAYS" disable="${!enableAutoComplete.selected}">
                 <HBox.margin>
                     <Insets top="-4.0"/>
                 </HBox.margin>
-            </TextField>
+            </TagsField>
         </HBox>
         <Label text="%Name format" disable="${!enableAutoComplete.selected}"/>
         <RadioButton fx:id="autoCompleteFirstLast" text="%Autocomplete names in 'Firstname Lastname' format only"

--- a/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.java
+++ b/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.java
@@ -1,20 +1,26 @@
 package org.jabref.gui.preferences.autocompletion;
 
 import javafx.fxml.FXML;
+import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
-import javafx.scene.control.TextField;
 
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
+import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
+import com.dlsc.gemsfx.TagsField;
 
 public class AutoCompletionTab extends AbstractPreferenceTabView<AutoCompletionTabViewModel> implements PreferencesTab {
 
     @FXML private CheckBox enableAutoComplete;
-    @FXML private TextField autoCompleteFields;
+    @FXML private TagsField<Field> autoCompleteFields;
     @FXML private RadioButton autoCompleteFirstLast;
     @FXML private RadioButton autoCompleteLastFirst;
     @FXML private RadioButton autoCompleteBoth;
@@ -35,14 +41,33 @@ public class AutoCompletionTab extends AbstractPreferenceTabView<AutoCompletionT
 
     public void initialize() {
         viewModel = new AutoCompletionTabViewModel(preferencesService.getAutoCompletePreferences());
-
+        setupTagsFiled();
         enableAutoComplete.selectedProperty().bindBidirectional(viewModel.enableAutoCompleteProperty());
-        autoCompleteFields.textProperty().bindBidirectional(viewModel.autoCompleteFieldsProperty());
         autoCompleteFirstLast.selectedProperty().bindBidirectional(viewModel.autoCompleteFirstLastProperty());
         autoCompleteLastFirst.selectedProperty().bindBidirectional(viewModel.autoCompleteLastFirstProperty());
         autoCompleteBoth.selectedProperty().bindBidirectional(viewModel.autoCompleteBothProperty());
         firstNameModeAbbreviated.selectedProperty().bindBidirectional(viewModel.firstNameModeAbbreviatedProperty());
         firstNameModeFull.selectedProperty().bindBidirectional(viewModel.firstNameModeFullProperty());
         firstNameModeBoth.selectedProperty().bindBidirectional(viewModel.firstNameModeBothProperty());
+    }
+
+    private void setupTagsFiled() {
+        autoCompleteFields.setCellFactory(new ViewModelListCellFactory<Field>().withText(Field::getDisplayName));
+        autoCompleteFields.setSuggestionProvider(request -> viewModel.getSuggestions(request.getUserText()));
+        autoCompleteFields.tagsProperty().bindBidirectional(viewModel.autoCompleteFieldsProperty());
+        autoCompleteFields.setConverter(viewModel.getFieldStringConverter());
+        autoCompleteFields.setTagViewFactory(this::createTag);
+        autoCompleteFields.setShowSearchIcon(false);
+        autoCompleteFields.getEditor().getStyleClass().clear();
+        autoCompleteFields.getEditor().getStyleClass().add("tags-field-editor");
+    }
+
+    private Node createTag(Field field) {
+        Label tagLabel = new Label();
+        tagLabel.setText(field.getDisplayName());
+        tagLabel.setGraphic(IconTheme.JabRefIcons.REMOVE_TAGS.getGraphicNode());
+        tagLabel.getGraphic().setOnMouseClicked(event -> autoCompleteFields.removeTags(field));
+        tagLabel.setContentDisplay(ContentDisplay.RIGHT);
+        return tagLabel;
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTabViewModel.java
@@ -140,7 +140,7 @@ public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
     }
 
     public List<Field> getSuggestions(String request) {
-        return FieldFactory.getStandardFields().stream()
+        return FieldFactory.getAllFieldsWithOutInternal().stream()
                            .filter(field -> field.getDisplayName().toLowerCase().contains(request.toLowerCase()))
                            .collect(Collectors.toList());
     }

--- a/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTabViewModel.java
@@ -2,22 +2,26 @@ package org.jabref.gui.preferences.autocompletion;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.collections.FXCollections;
+import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteFirstNameMode;
 import org.jabref.gui.autocompleter.AutoCompletePreferences;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
 
 public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty enableAutoCompleteProperty = new SimpleBooleanProperty();
-    private final StringProperty autoCompleteFieldsProperty = new SimpleStringProperty();
+    private final ListProperty<Field> autoCompleteFieldsProperty = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final BooleanProperty autoCompleteFirstLastProperty = new SimpleBooleanProperty();
     private final BooleanProperty autoCompleteLastFirstProperty = new SimpleBooleanProperty();
     private final BooleanProperty autoCompleteBothProperty = new SimpleBooleanProperty();
@@ -36,8 +40,7 @@ public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
     @Override
     public void setValues() {
         enableAutoCompleteProperty.setValue(autoCompletePreferences.shouldAutoComplete());
-        autoCompleteFieldsProperty.setValue(autoCompletePreferences.getCompleteNamesAsString());
-
+        autoCompleteFieldsProperty.setValue(FXCollections.observableArrayList(autoCompletePreferences.getCompleteFields()));
         if (autoCompletePreferences.getNameFormat() == AutoCompletePreferences.NameFormat.FIRST_LAST) {
             autoCompleteFirstLastProperty.setValue(true);
         } else if (autoCompletePreferences.getNameFormat() == AutoCompletePreferences.NameFormat.LAST_FIRST) {
@@ -82,7 +85,7 @@ public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
         }
 
         autoCompletePreferences.getCompleteFields().clear();
-        autoCompletePreferences.getCompleteFields().addAll(FieldFactory.parseFieldList(autoCompleteFieldsProperty.getValue()));
+        autoCompletePreferences.getCompleteFields().addAll(autoCompleteFieldsProperty.getValue());
     }
 
     @Override
@@ -94,7 +97,7 @@ public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
         return enableAutoCompleteProperty;
     }
 
-    public StringProperty autoCompleteFieldsProperty() {
+    public ListProperty<Field> autoCompleteFieldsProperty() {
         return autoCompleteFieldsProperty;
     }
 
@@ -120,5 +123,25 @@ public class AutoCompletionTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty firstNameModeBothProperty() {
         return firstNameModeBothProperty;
+    }
+
+    public StringConverter<Field> getFieldStringConverter() {
+        return new StringConverter<>() {
+            @Override
+            public String toString(Field field) {
+                return field.getDisplayName();
+            }
+
+            @Override
+            public Field fromString(String string) {
+                return FieldFactory.parseField(string);
+            }
+        };
+    }
+
+    public List<Field> getSuggestions(String request) {
+        return FieldFactory.getStandardFields().stream()
+                           .filter(field -> field.getDisplayName().toLowerCase().contains(request.toLowerCase()))
+                           .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -150,13 +150,6 @@ public class FieldFactory {
     }
 
     /**
-     * Returns a List with all standard fields
-     */
-    public static List<Field> getStandardFields() {
-        return new ArrayList<>(EnumSet.allOf(StandardField.class));
-    }
-
-    /**
      * Returns a sorted Set of Fields (by {@link Field#getDisplayName} with all fields without internal ones
      */
     public static Set<Field> getAllFieldsWithOutInternal() {

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -150,6 +150,13 @@ public class FieldFactory {
     }
 
     /**
+     * Returns a List with all standard fields
+     */
+    public static List<Field> getStandardFields() {
+        return new ArrayList<>(EnumSet.allOf(StandardField.class));
+    }
+
+    /**
      * Returns a sorted Set of Fields (by {@link Field#getDisplayName} with all fields without internal ones
      */
     public static Set<Field> getAllFieldsWithOutInternal() {


### PR DESCRIPTION
Closes #10952 
Use tags editor for auto-completion preferences with suggestions for all standard BibTeX and BibLaTeX fields.

![image](https://github.com/JabRef/jabref/assets/52158423/9dde3eb1-24e9-4681-96e2-c4fd9dfc23c7)

- Should users be able to add a field that is not a standard Bib(La)TeX field, i.e., a field not suggested?
- Why is it important to always add `crossref`, `related`, and `entryset` fields?  https://github.com/JabRef/jabref/blob/79ba1f0d461268fbafa4196e6a4b5fec0a114b95/src/main/java/org/jabref/migrations/PreferencesMigrations.java#L297-L304


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
