### PR TITLE
Remove obsolete "Comments" tab configuration

### DIFF
--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -550,7 +550,7 @@ public class PreferencesMigrations {
     }
 
     /**
-     * The tab "Comments" is now hard coded using {@link CommentsTab} (and thus hard-wired in {@link EntryEditor#createTabs()}.
+     * The tab "Comments" is hard coded using {@link CommentsTab} since v5.10 (and thus hard-wired in {@link EntryEditor#createTabs()}.
      * Thus, the configuration ih the preferences is obsolete
      */
     static void removeCommentsFromCustomEditorTabs(JabRefPreferences preferences) {

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 
 import javafx.scene.control.TableColumn;
 
+import org.jabref.gui.entryeditor.CommentsTab;
+import org.jabref.gui.entryeditor.EntryEditor;
 import org.jabref.gui.maintable.ColumnPreferences;
 import org.jabref.gui.maintable.MainTableColumnModel;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPattern;
@@ -64,6 +66,7 @@ public class PreferencesMigrations {
         restoreVariablesForBackwardCompatibility(preferences);
         upgradeCleanups(preferences);
         moveApiKeysToKeyring(preferences);
+        removeCommentsFromCustomEditorTabs(preferences);
     }
 
     /**
@@ -544,5 +547,13 @@ public class PreferencesMigrations {
                 LOGGER.error("Unable to open key store", ex);
             }
         }
+    }
+
+    /**
+     * The tab "Comments" is now hard coded using {@link CommentsTab} (and thus hard-wired in {@link EntryEditor#createTabs()}.
+     * Thus, the configuration ih the preferences is obsolete
+     */
+    static void removeCommentsFromCustomEditorTabs(JabRefPreferences preferences) {
+        preferences.getEntryEditorPreferences().getEntryEditorTabs().remove("Comments");
     }
 }

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -57,7 +57,7 @@ public class PreferencesMigrations {
         addCrossRefRelatedFieldsForAutoComplete(preferences);
         upgradePreviewStyle(preferences);
         // changeColumnVariableNamesFor51 needs to be run before upgradeColumnPre50Preferences to ensure
-        // backwardcompatibility, as it copies the old values to new variable names and keeps th old sored with the old
+        // backward compatibility, as it copies the old values to new variable names and keeps th old sored with the old
         // variable names. However, the variables from 5.0 need to be copied to the new variable name too.
         changeColumnVariableNamesFor51(preferences);
         upgradeColumnPreferences(preferences);

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SequencedMap;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -835,10 +836,6 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(CUSTOM_TAB_FIELDS + "_def1", StandardField.ABSTRACT.getName());
         defaults.put(CUSTOM_TAB_NAME + "_def1", Localization.lang("Abstract"));
 
-        // Entry editor tab 2: Comments Field - used for research comments, etc.
-        defaults.put(CUSTOM_TAB_FIELDS + "_def2", StandardField.COMMENT.getName());
-        defaults.put(CUSTOM_TAB_NAME + "_def2", Localization.lang("Comments"));
-
         defaults.put(EMAIL_SUBJECT, Localization.lang("References"));
     }
 
@@ -1508,7 +1505,7 @@ public class JabRefPreferences implements PreferencesService {
         List<String> tabFields = getSeries(CUSTOM_TAB_FIELDS);
 
         if (tabNames.isEmpty() || (tabNames.size() != tabFields.size())) {
-            // Nothing set, so we use the default values
+            // Nothing set (or wrong configuration), then we use default values
             tabNames = getSeries(CUSTOM_TAB_NAME + "_def");
             tabFields = getSeries(CUSTOM_TAB_FIELDS + "_def");
         }
@@ -1543,8 +1540,8 @@ public class JabRefPreferences implements PreferencesService {
         getEntryEditorTabs();
     }
 
-    private Map<String, Set<Field>> getDefaultEntryEditorTabs() {
-        Map<String, Set<Field>> customTabsMap = new LinkedHashMap<>();
+    private SequencedMap<String, Set<Field>> getDefaultEntryEditorTabs() {
+        SequencedMap<String, Set<Field>> customTabsMap = new LinkedHashMap<>();
 
         int defNumber = 0;
         while (true) {


### PR DESCRIPTION
The default preferences contain configuration for a tab "Comments":

![image](https://github.com/JabRef/jabref/assets/1366654/54a56321-039e-4878-bca2-cd120be1c71b)

This became obsolete with the PR adding user-specific comment fields (https://github.com/JabRef/jabref/pull/9727)

After this PR:

![image](https://github.com/JabRef/jabref/assets/1366654/c5c4d820-4771-4359-9004-06b256c3042a)

Added a migration

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
