### PR TITLE
Fix "Other fields" tab respecting custom tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
 - We fixed an issue where HTML-reserved characters like '&' and '<', in addition to HTML entities like '&amp;' were not rendered correctly in entry preview. [#10677](https://github.com/JabRef/jabref/issues/10677)
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)
-- The entry editor respects the configured additional tabs when showing "Other fields".
+- The entry editor respects the configured custom tabs when showing "Other fields".
 - The default owner of an entry can be changed again. [#10924](https://github.com/JabRef/jabref/issues/10924)
 - We fixed an issue where the duplicate check did not take umlauts or other LaTeX-encoded characters into account. [#10744](https://github.com/JabRef/jabref/pull/10744)
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
 - We fixed an issue where HTML-reserved characters like '&' and '<', in addition to HTML entities like '&amp;' were not rendered correctly in entry preview. [#10677](https://github.com/JabRef/jabref/issues/10677)
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)
-- The entry editor respects the configured custom tabs when showing "Other fields".
+- The entry editor respects the configured custom tabs when showing "Other fields". [#11012](https://github.com/JabRef/jabref/pull/11012)
 - The default owner of an entry can be changed again. [#10924](https://github.com/JabRef/jabref/issues/10924)
 - We fixed an issue where the duplicate check did not take umlauts or other LaTeX-encoded characters into account. [#10744](https://github.com/JabRef/jabref/pull/10744)
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the preview panel showing the wrong entry (an entry that is not selected in the entry table). [#9172](https://github.com/JabRef/jabref/issues/9172)
 - We fixed an issue where HTML-reserved characters like '&' and '<', in addition to HTML entities like '&amp;' were not rendered correctly in entry preview. [#10677](https://github.com/JabRef/jabref/issues/10677)
 - The last page of a PDF is now indexed by the full text search. [#10193](https://github.com/JabRef/jabref/issues/10193)
+- The entry editor respects the configured additional tabs when showing "Other fields".
 - The default owner of an entry can be changed again. [#10924](https://github.com/JabRef/jabref/issues/10924)
 - We fixed an issue where the duplicate check did not take umlauts or other LaTeX-encoded characters into account. [#10744](https://github.com/JabRef/jabref/pull/10744)
 - We fixed the colors of the icon on hover for unset special fields. [#10431](https://github.com/JabRef/jabref/issues/10431)

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -64,7 +64,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
 
         this.entryTypesManager = entryTypesManager;
         this.customTabFieldNames = new ArrayList<>();
-        preferences.getEntryEditorPreferences().getDefaultEntryEditorTabs().values().forEach(customTabFieldNames::addAll);
+        preferences.getEntryEditorPreferences().getEntryEditorTabs().values().forEach(customTabFieldNames::addAll);
 
         setText(Localization.lang("Other fields"));
         setTooltip(new Tooltip(Localization.lang("Show remaining fields")));

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -26,7 +26,6 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.BibField;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
@@ -36,7 +35,7 @@ import org.jabref.preferences.PreferencesService;
 public class OtherFieldsTab extends FieldsEditorTab {
 
     public static final String NAME = "Other fields";
-    private final List<Field> customTabFieldNames;
+    private final List<Field> customTabsFieldNames;
     private final BibEntryTypesManager entryTypesManager;
 
     public OtherFieldsTab(BibDatabaseContext databaseContext,
@@ -63,8 +62,8 @@ public class OtherFieldsTab extends FieldsEditorTab {
                 indexingTaskManager);
 
         this.entryTypesManager = entryTypesManager;
-        this.customTabFieldNames = new ArrayList<>();
-        preferences.getEntryEditorPreferences().getEntryEditorTabs().values().forEach(customTabFieldNames::addAll);
+        this.customTabsFieldNames = new ArrayList<>();
+        preferences.getEntryEditorPreferences().getEntryEditorTabs().values().forEach(customTabsFieldNames::addAll);
 
         setText(Localization.lang("Other fields"));
         setTooltip(new Tooltip(Localization.lang("Show remaining fields")));
@@ -76,15 +75,21 @@ public class OtherFieldsTab extends FieldsEditorTab {
         BibDatabaseMode mode = databaseContext.getMode();
         Optional<BibEntryType> entryType = entryTypesManager.enrich(entry.getType(), mode);
         if (entryType.isPresent()) {
+            // Get all required and optional fields configured for the entry
             Set<Field> allKnownFields = entryType.get().getAllFields();
+            // Remove all fields being required or optional
             SequencedSet<Field> otherFields = entry.getFields().stream()
-                                          .filter(field -> !allKnownFields.contains(field) &&
-                                                  !(field.equals(StandardField.COMMENT) || field instanceof UserSpecificCommentField))
+                                          .filter(field -> !allKnownFields.contains(field))
                                           .collect(Collectors.toCollection(LinkedHashSet::new));
-            otherFields.removeAll(entryType.get().getDeprecatedFields(mode));
-            otherFields.removeAll(entryType.get().getOptionalFields().stream().map(BibField::field).toList());
+            // The key field is in the required tab, but has a special treatment
             otherFields.remove(InternalField.KEY_FIELD);
-            customTabFieldNames.forEach(otherFields::remove);
+            // Remove all fields contained in JabRef's tab "Deprecated"
+            otherFields.removeAll(entryType.get().getDeprecatedFields(mode));
+            // Remove all fields contained in the custom tabs
+            customTabsFieldNames.forEach(otherFields::remove);
+            // Remove all user-comment fields (tab org.jabref.gui.entryeditor.CommentsTab)
+            otherFields.removeIf(field -> field.equals(StandardField.COMMENT));
+            otherFields.removeIf(field -> field instanceof UserSpecificCommentField);
             return otherFields;
         } else {
             // Entry type unknown -> treat all fields as required (thus no other fields)


### PR DESCRIPTION
Before: Field shown twice:

![image](https://github.com/JabRef/jabref/assets/1366654/2b79b223-e280-4106-a2e2-26123ad1587a)

![image](https://github.com/JabRef/jabref/assets/1366654/1e390ac3-a489-4713-a933-200f382910de)

After:

"Other fields" not shown.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
