### PR TITLE
Remove non-existing recipe

### DIFF
--- a/rewrite.yml
+++ b/rewrite.yml
@@ -103,8 +103,6 @@ recipeList:
   - org.openrewrite.java.migrate.lang.StringFormatted
   - org.openrewrite.java.migrate.util.SequencedCollection
 
-  - org.openrewrite.java.recipes.UseJavaParserBuilderInJavaTemplate
-
   - org.openrewrite.java.RemoveObjectsIsNull
   - org.openrewrite.java.ShortenFullyQualifiedTypeReferences
 


### PR DESCRIPTION
Fixes openrewrite output

    recipe validation error in org.jabref.config.rewrite.cleanup.recipeList[4] (in file:/C:/git-repositories/JabRef/rewrite.yml): recipe 'org.openrewrite.java.recipes.UseJavaParserBuilderInJavaTemplate' does not exist.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
