### PR TITLE
Keep enclosing braces of authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We made the command "Push to TexShop" more robust to allow cite commands with a character before the first slash. [forum#2699](https://discourse.jabref.org/t/push-to-texshop-mac/2699/17?u=siedlerchr)
 - We only show the notification "Saving library..." if the library contains more than 2000 entries. [#9803](https://github.com/JabRef/jabref/issues/9803)
 - JabRef now keeps previous log files upon start. [#11023](https://github.com/JabRef/jabref/pull/11023)
+- When normalizing author names, complete enclosing braces are kept. [#10031](https://github.com/JabRef/jabref/issues/10031)
 - We enhanced the dialog for adding new fields in the content selector with a selection box containing a list of standard fields. [#10912](https://github.com/JabRef/jabref/pull/10912)
 - We store the citation relations in an LRU cache to avoid bloating the memory and out-of-memory exceptions. [#10958](https://github.com/JabRef/jabref/issues/10958)
 - Keywords filed are now displayed as tags. [#10910](https://github.com/JabRef/jabref/pull/10910)

--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
@@ -42,11 +42,11 @@ public class PersonNameStringConverter extends StringConverter<Author> {
         if (autoCompLF) {
             switch (autoCompleteFirstNameMode) {
                 case ONLY_ABBREVIATED:
-                    return author.getLastFirst(true);
+                    return author.getFamilyGiven(true);
                 case ONLY_FULL:
-                    return author.getLastFirst(false);
+                    return author.getFamilyGiven(false);
                 case BOTH:
-                    return author.getLastFirst(true);
+                    return author.getFamilyGiven(true);
                 default:
                     break;
             }
@@ -54,16 +54,16 @@ public class PersonNameStringConverter extends StringConverter<Author> {
         if (autoCompFF) {
             switch (autoCompleteFirstNameMode) {
                 case ONLY_ABBREVIATED:
-                    return author.getFirstLast(true);
+                    return author.getGivenFamily(true);
                 case ONLY_FULL:
-                    return author.getFirstLast(false);
+                    return author.getGivenFamily(false);
                 case BOTH:
-                    return author.getFirstLast(true);
+                    return author.getGivenFamily(true);
                 default:
                     break;
             }
         }
-        return author.getLastOnly();
+        return author.getNamePrefixAndFamilyName();
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameSuggestionProvider.java
@@ -48,7 +48,7 @@ public class PersonNameSuggestionProvider extends SuggestionProvider<Author> {
 
     @Override
     protected Equivalence<Author> getEquivalence() {
-        return Equivalence.equals().onResultOf(Author::getLastOnly);
+        return Equivalence.equals().onResultOf(Author::getNamePrefixAndFamilyName);
     }
 
     @Override
@@ -58,7 +58,7 @@ public class PersonNameSuggestionProvider extends SuggestionProvider<Author> {
 
     @Override
     protected boolean isMatch(Author candidate, AutoCompletionBinding.ISuggestionRequest request) {
-        return StringUtil.containsIgnoreCase(candidate.getLastFirst(false), request.getUserText());
+        return StringUtil.containsIgnoreCase(candidate.getFamilyGiven(false), request.getUserText());
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/bst/util/BstNameFormatter.java
+++ b/src/main/java/org/jabref/logic/bst/util/BstNameFormatter.java
@@ -102,14 +102,10 @@ public class BstNameFormatter {
                 char type = control.charAt(0);
 
                 Optional<String> tokenS = switch (type) {
-                    case 'f' ->
-                            author.getFirst();
-                    case 'v' ->
-                            author.getVon();
-                    case 'l' ->
-                            author.getLast();
-                    case 'j' ->
-                            author.getJr();
+                    case 'f' -> author.getGivenName();
+                    case 'v' -> author.getNamePrefix();
+                    case 'l' -> author.getFamilyName();
+                    case 'j' -> author.getNameSuffix();
                     default ->
                             throw new BstVMException("Internal error");
                 };

--- a/src/main/java/org/jabref/logic/exporter/MSBibExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/MSBibExporter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -36,6 +37,7 @@ class MSBibExporter extends Exporter {
     public void export(@NonNull BibDatabaseContext databaseContext,
                        @NonNull Path file,
                        @NonNull List<BibEntry> entries) throws SaveException {
+        Objects.requireNonNull(databaseContext); // required by test case
         if (entries.isEmpty()) {
             return;
         }

--- a/src/main/java/org/jabref/logic/exporter/MSBibExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/MSBibExporter.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -19,33 +18,36 @@ import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * TemplateExporter for exporting in MSBIB XML format.
  */
 class MSBibExporter extends Exporter {
 
+    private final TransformerFactory transformerFactory;
+
     public MSBibExporter() {
         super("MSBib", "MS Office 2007", StandardFileType.XML);
+        transformerFactory = TransformerFactory.newInstance();
     }
 
     @Override
-    public void export(final BibDatabaseContext databaseContext, final Path file,
-                       List<BibEntry> entries) throws SaveException {
-        Objects.requireNonNull(databaseContext);
-        Objects.requireNonNull(entries);
-
+    public void export(@NonNull BibDatabaseContext databaseContext,
+                       @NonNull Path file,
+                       @NonNull List<BibEntry> entries) throws SaveException {
         if (entries.isEmpty()) {
             return;
         }
 
         MSBibDatabase msBibDatabase = new MSBibDatabase(databaseContext.getDatabase(), entries);
 
-        // forcing to use UTF8 output format for some problems with xml export in other encodings
+        // forcing to use UTF8 output format for some problems with XML export in other encodings
         try (AtomicFileWriter ps = new AtomicFileWriter(file, StandardCharsets.UTF_8)) {
             try {
                 DOMSource source = new DOMSource(msBibDatabase.getDomForExport());
                 StreamResult result = new StreamResult(ps);
-                Transformer trans = TransformerFactory.newInstance().newTransformer();
+                Transformer trans = transformerFactory.newTransformer();
                 trans.setOutputProperty(OutputKeys.INDENT, "yes");
                 trans.transform(source, result);
             } catch (TransformerException | IllegalArgumentException | TransformerFactoryConfigurationError e) {

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -13,6 +13,9 @@ import org.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The inverse operation is "somehow" contained in {@link org.jabref.logic.openoffice.style.OOPreFormatter}
+ */
 public class HtmlToLatexFormatter extends Formatter implements LayoutFormatter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HtmlToLatexFormatter.class);

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
@@ -1,10 +1,11 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import java.util.Objects;
-
 import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
 
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
 public class RemoveBracesFormatter extends Formatter {
 
     @Override
@@ -19,8 +20,6 @@ public class RemoveBracesFormatter extends Formatter {
 
     @Override
     public String format(String value) {
-        Objects.requireNonNull(value);
-
         String formatted = value;
         while ((formatted.length() >= 2) && (formatted.charAt(0) == '{') && (formatted.charAt(formatted.length() - 1)
                 == '}')) {
@@ -50,7 +49,7 @@ public class RemoveBracesFormatter extends Formatter {
 
     /**
      * Check if a string at any point has had more ending } braces than opening { ones.
-     * Will e.g. return true for the string "DNA} blahblal {EPA"
+     * Will e.g. return true for the string "DNA} text {EPA"
      *
      * @param value The string to check.
      * @return true if at any index the brace count is negative.

--- a/src/main/java/org/jabref/logic/importer/AuthorListParser.java
+++ b/src/main/java/org/jabref/logic/importer/AuthorListParser.java
@@ -6,13 +6,14 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.strings.StringUtil;
+
+import org.jspecify.annotations.NonNull;
 
 public class AuthorListParser {
 
@@ -94,9 +95,7 @@ public class AuthorListParser {
      * @param listOfNames the String containing the person names to be parsed
      * @return a parsed list of persons
      */
-    public AuthorList parse(String listOfNames) {
-        Objects.requireNonNull(listOfNames);
-
+    public AuthorList parse(@NonNull String listOfNames) {
         // Handling of "and others"
         // Remove it from the list; it will be added at the very end of this method as special Author.OTHERS
         listOfNames = listOfNames.trim();

--- a/src/main/java/org/jabref/logic/importer/Importer.java
+++ b/src/main/java/org/jabref/logic/importer/Importer.java
@@ -36,7 +36,7 @@ public abstract class Importer implements Comparable<Importer> {
      * The effect of this method is primarily to avoid unnecessary processing of files when searching for a suitable
      * import format. If this method returns false, the import routine will move on to the next import format.
      * <p>
-     * Thus the correct behaviour is to return false if it is certain that the file is not of the suitable type, and
+     * Thus, the correct behaviour is to return false if it is certain that the file is not of the suitable type, and
      * true otherwise. Returning true is the safe choice if not certain.
      */
     public abstract boolean isRecognizedFormat(BufferedReader input) throws IOException;

--- a/src/main/java/org/jabref/logic/importer/fetcher/ZbMATH.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ZbMATH.java
@@ -71,7 +71,7 @@ public class ZbMATH implements SearchBasedParserFetcher, IdBasedParserFetcher, E
             // replace "and" by ";" as citation matching API uses ";" for separation
             AuthorList authors = AuthorList.parse(entry.getFieldOrAlias(StandardField.AUTHOR).get());
             String authorsWithSemicolon = authors.getAuthors().stream()
-                                                 .map(author -> author.getLastFirst(false))
+                                                 .map(author -> author.getFamilyGiven(false))
                                                  .collect(Collectors.joining(";"));
             uriBuilder.addParameter("a", authorsWithSemicolon);
         }

--- a/src/main/java/org/jabref/logic/importer/fileformat/MsBibImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MsBibImporter.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fileformat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.util.Objects;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -39,6 +40,7 @@ public class MsBibImporter extends Importer {
      */
     @Override
     public boolean isRecognizedFormat(BufferedReader reader) throws IOException {
+        Objects.requireNonNull(reader); // Required by test case
         Document docin;
         try {
             DocumentBuilder dbuild = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
@@ -68,6 +70,7 @@ public class MsBibImporter extends Importer {
 
     @Override
     public ParserResult importDatabase(BufferedReader reader) throws IOException {
+        Objects.requireNonNull(reader); // Required by test case
         MSBibDatabase dbase = new MSBibDatabase();
         return new ParserResult(dbase.importEntriesFromXml(reader));
     }

--- a/src/main/java/org/jabref/logic/layout/format/AuthorOrgSci.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorOrgSci.java
@@ -30,9 +30,9 @@ public class AuthorOrgSci implements LayoutFormatter {
         }
         Author first = a.getAuthor(0);
         StringBuilder sb = new StringBuilder();
-        sb.append(first.getLastFirst(true));
+        sb.append(first.getFamilyGiven(true));
         for (int i = 1; i < a.getNumberOfAuthors(); i++) {
-            sb.append(", ").append(a.getAuthor(i).getFirstLast(true));
+            sb.append(", ").append(a.getAuthor(i).getGivenFamily(true));
         }
         return sb.toString();
     }

--- a/src/main/java/org/jabref/logic/layout/format/Authors.java
+++ b/src/main/java/org/jabref/logic/layout/format/Authors.java
@@ -254,21 +254,21 @@ public class Authors extends AbstractParamLayoutFormatter {
 
     private void addSingleName(StringBuilder sb, Author a, boolean firstFirst) {
         StringBuilder lastNameSB = new StringBuilder();
-        a.getVon().filter(von -> !von.isEmpty()).ifPresent(von -> lastNameSB.append(von).append(' '));
-        a.getLast().ifPresent(lastNameSB::append);
+        a.getNamePrefix().filter(von -> !von.isEmpty()).ifPresent(von -> lastNameSB.append(von).append(' '));
+        a.getFamilyName().ifPresent(lastNameSB::append);
         String jrSeparator = " ";
-        a.getJr().filter(jr -> !jr.isEmpty()).ifPresent(jr -> lastNameSB.append(jrSeparator).append(jr));
+        a.getNameSuffix().filter(jr -> !jr.isEmpty()).ifPresent(jr -> lastNameSB.append(jrSeparator).append(jr));
 
         String firstNameResult = "";
-        if (a.getFirst().isPresent()) {
+        if (a.getGivenName().isPresent()) {
             if (abbreviate) {
-                firstNameResult = a.getFirstAbbr().orElse("");
+                firstNameResult = a.getGivenNameAbbreviated().orElse("");
 
                 if (firstInitialOnly && (firstNameResult.length() > 2)) {
                     firstNameResult = firstNameResult.substring(0, 2);
                 } else if (middleInitial) {
                     String abbr = firstNameResult;
-                    firstNameResult = a.getFirst().get();
+                    firstNameResult = a.getGivenName().get();
                     int index = firstNameResult.indexOf(' ');
                     if (index >= 0) {
                         firstNameResult = firstNameResult.substring(0, index + 1);
@@ -284,7 +284,7 @@ public class Authors extends AbstractParamLayoutFormatter {
                     firstNameResult = firstNameResult.replace(" ", "");
                 }
             } else {
-                firstNameResult = a.getFirst().get();
+                firstNameResult = a.getGivenName().get();
             }
         }
 

--- a/src/main/java/org/jabref/logic/layout/format/DocBookAuthorFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/DocBookAuthorFormatter.java
@@ -20,13 +20,13 @@ public class DocBookAuthorFormatter {
                 sb.append("<personname>");
             }
             Author a = al.getAuthor(i);
-            a.getFirst().filter(first -> !first.isEmpty()).ifPresent(first -> sb.append("<firstname>")
-                                                                                .append(XML_CHARS.format(first)).append("</firstname>"));
-            a.getVon().filter(von -> !von.isEmpty()).ifPresent(von -> sb.append("<othername>")
-                                                                        .append(XML_CHARS.format(von)).append("</othername>"));
-            a.getLast().filter(last -> !last.isEmpty()).ifPresent(last -> {
+            a.getGivenName().filter(first -> !first.isEmpty()).ifPresent(first -> sb.append("<firstname>")
+                                                                                    .append(XML_CHARS.format(first)).append("</firstname>"));
+            a.getNamePrefix().filter(von -> !von.isEmpty()).ifPresent(von -> sb.append("<othername>")
+                                                                               .append(XML_CHARS.format(von)).append("</othername>"));
+            a.getFamilyName().filter(last -> !last.isEmpty()).ifPresent(last -> {
                 sb.append("<surname>").append(XML_CHARS.format(last));
-                a.getJr().filter(jr -> !jr.isEmpty())
+                a.getNameSuffix().filter(jr -> !jr.isEmpty())
                  .ifPresent(jr -> sb.append(' ').append(XML_CHARS.format(jr)));
                 sb.append("</surname>");
                 if (version == DocBookVersion.DOCBOOK_5) {

--- a/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
@@ -24,9 +24,6 @@ public class BibTeXConverter {
 
     /**
      * Converts an {@link MSBibEntry} to a {@link BibEntry} for import
-     *
-     * @param entry The MsBibEntry to convert
-     * @return The bib entry
      */
     public static BibEntry convert(MSBibEntry entry) {
         BibEntry result;

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -2,8 +2,9 @@ package org.jabref.logic.msbib;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
-import org.jabref.model.entry.Author;
+import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Month;
@@ -17,6 +18,7 @@ public class MSBibConverter {
 
     private static final String MSBIB_PREFIX = "msbib-";
     private static final String BIBTEX_PREFIX = "BIBTEX_";
+    private static final RemoveBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveBracesFormatter();
 
     private MSBibConverter() {
     }
@@ -123,24 +125,26 @@ public class MSBibConverter {
 
     private static List<MsBibAuthor> getAuthors(BibEntry entry, String authors, Field field) {
         List<MsBibAuthor> result = new ArrayList<>();
-        boolean corporate = false;
+
         // Only one corporate author is supported
-        // We have the possible rare case that are multiple authors which start and end with latex , this is currently not considered
-        if (authors.startsWith("{") && authors.endsWith("}")) {
-            corporate = true;
+        // Heuristics: If the author is surrounded by curly braces, it is a corporate author
+        boolean corporate = !REMOVE_BRACES_FORMATTER.format(authors).equals(authors);
+
+        Optional<String> authorLatexFreeOpt = entry.getFieldLatexFree(field);
+        if (authorLatexFreeOpt.isEmpty()) {
+            return result;
         }
-        // FIXME: #4152 This is an ugly hack because the latex2unicode formatter kills of all curly braces, so no more corporate author parsing possible
-        String authorLatexFree = entry.getFieldLatexFree(field).orElse("");
+        String authorLatexFree = authorLatexFreeOpt.get();
+
+        // We re-add the curly braces to keep the corporate author as is.
+        // See https://github.com/JabRef/jabref-issue-melting-pot/issues/386 for details
         if (corporate) {
             authorLatexFree = "{" + authorLatexFree + "}";
         }
 
-        AuthorList authorList = AuthorList.parse(authorLatexFree);
-
-        for (Author author : authorList.getAuthors()) {
-            result.add(new MsBibAuthor(author, corporate));
-        }
-
-        return result;
+        return AuthorList.parse(authorLatexFree).getAuthors()
+                         .stream()
+                         .map(author -> new MsBibAuthor(author, corporate))
+                         .toList();
     }
 }

--- a/src/main/java/org/jabref/logic/msbib/MSBibEntry.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibEntry.java
@@ -28,8 +28,8 @@ import org.w3c.dom.NodeList;
  */
 class MSBibEntry {
 
-    // MSBib fields and values
     public Map<String, String> fields = new HashMap<>();
+
     public List<MsBibAuthor> authors;
     public List<MsBibAuthor> bookAuthors;
     public List<MsBibAuthor> editors;
@@ -74,7 +74,6 @@ class MSBibEntry {
      *  Matches both single locations (only city) like Berlin and full locations like Stroudsburg, PA, USA <br>
      *  tested using http://www.regexpal.com/
      */
-
     private final Pattern ADDRESS_PATTERN = Pattern.compile("\\b(\\w+)\\s?[,]?\\s?(\\w*)\\s?[,]?\\s?(\\w*)\\b");
 
     public MSBibEntry() {
@@ -82,7 +81,7 @@ class MSBibEntry {
     }
 
     /**
-     * Create a new {@link MsBibEntry} to import from an xml element
+     * Create a new {@link MSBibEntry} to import from an XML element
      */
     public MSBibEntry(Element entry) {
         populateFromXml(entry);
@@ -311,14 +310,14 @@ class MSBibEntry {
         }
         Element authorTop = document.createElementNS(MSBibDatabase.NAMESPACE, MSBibDatabase.PREFIX + entryName);
 
-        Optional<MsBibAuthor> personName = authorsLst.stream().filter(MsBibAuthor::isCorporate)
+        Optional<MsBibAuthor> personName = authorsLst.stream()
+                                                     .filter(MsBibAuthor::isCorporate)
                                                      .findFirst();
         if (personName.isPresent()) {
             MsBibAuthor person = personName.get();
-
             Element corporate = document.createElementNS(MSBibDatabase.NAMESPACE,
                     MSBibDatabase.PREFIX + "Corporate");
-            corporate.setTextContent(person.getFirstLast());
+            corporate.setTextContent(person.getLastName());
             authorTop.appendChild(corporate);
         } else {
             Element nameList = document.createElementNS(MSBibDatabase.NAMESPACE, MSBibDatabase.PREFIX + "NameList");

--- a/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
@@ -22,17 +22,9 @@ public class MSBibMapping {
 
     private static final String BIBTEX_PREFIX = "BIBTEX_";
     private static final String MSBIB_PREFIX = "msbib-";
-    private static final BiMap<Field, String> BIBLATEX_TO_MS_BIB = HashBiMap.create();
     private static final BiMap<String, Integer> LANG_TO_LCID = HashBiMap.create();
-    private static final Map<String, EntryType> MSBIB_ENTRYTYPE_MAPPING = Map.of(
-            "Book", StandardEntryType.Book,
-            "BookSection", StandardEntryType.Book,
-            "JournalArticle", StandardEntryType.Article,
-            "ArticleInAPeriodical", IEEETranEntryType.Periodical,
-            "ConferenceProceedings", StandardEntryType.InProceedings,
-            "Report", StandardEntryType.TechReport,
-            "Patent", IEEETranEntryType.Patent,
-            "InternetSite", StandardEntryType.Online);
+    private static final BiMap<Field, String> BIBLATEX_TO_MS_BIB = HashBiMap.create();
+    private static final Map<String, EntryType> MSBIB_ENTRYTYPE_MAPPING;
     private static final Map<EntryType, MSBibEntryType> BIB_ENTRYTYPE_MAPPING = new HashMap<>();
 
     static {
@@ -129,6 +121,19 @@ public class MSBibMapping {
     }
 
     static {
+        MSBIB_ENTRYTYPE_MAPPING = Map.of(
+                "Book", StandardEntryType.Book,
+                "BookSection", StandardEntryType.Book,
+                "JournalArticle", StandardEntryType.Article,
+                "ArticleInAPeriodical", IEEETranEntryType.Periodical,
+                "ConferenceProceedings", StandardEntryType.InProceedings,
+                "Report", StandardEntryType.TechReport,
+                "Patent", IEEETranEntryType.Patent,
+                "InternetSite", StandardEntryType.Online);
+    }
+
+    static {
+        // We need to add the entries "manually", because Map.of does not allow that many entries
         BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Book, MSBibEntryType.Book);
         BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.InBook, MSBibEntryType.BookSection);
         BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Booklet, MSBibEntryType.BookSection);

--- a/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
@@ -22,13 +22,21 @@ public class MSBibMapping {
 
     private static final String BIBTEX_PREFIX = "BIBTEX_";
     private static final String MSBIB_PREFIX = "msbib-";
-
     private static final BiMap<Field, String> BIBLATEX_TO_MS_BIB = HashBiMap.create();
-
-    // see https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a
     private static final BiMap<String, Integer> LANG_TO_LCID = HashBiMap.create();
+    private static final Map<String, EntryType> MSBIB_ENTRYTYPE_MAPPING = Map.of(
+            "Book", StandardEntryType.Book,
+            "BookSection", StandardEntryType.Book,
+            "JournalArticle", StandardEntryType.Article,
+            "ArticleInAPeriodical", IEEETranEntryType.Periodical,
+            "ConferenceProceedings", StandardEntryType.InProceedings,
+            "Report", StandardEntryType.TechReport,
+            "Patent", IEEETranEntryType.Patent,
+            "InternetSite", StandardEntryType.Online);
+    private static final Map<EntryType, MSBibEntryType> BIB_ENTRYTYPE_MAPPING = new HashMap<>();
 
     static {
+        // see https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/6c085406-a698-4e12-9d4d-c3b0ee3dbc4a
         LANG_TO_LCID.put("basque", 1609);
         LANG_TO_LCID.put("bulgarian", 1026);
         LANG_TO_LCID.put("catalan", 1027);
@@ -120,47 +128,36 @@ public class MSBibMapping {
         BIBLATEX_TO_MS_BIB.put(new UnknownField(MSBIB_PREFIX + "productioncompany"), "ProductionCompany");
     }
 
+    static {
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Book, MSBibEntryType.Book);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.InBook, MSBibEntryType.BookSection);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Booklet, MSBibEntryType.BookSection);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.InCollection, MSBibEntryType.BookSection);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Article, MSBibEntryType.JournalArticle);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.InProceedings, MSBibEntryType.ConferenceProceedings);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Conference, MSBibEntryType.ConferenceProceedings);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Proceedings, MSBibEntryType.ConferenceProceedings);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Collection, MSBibEntryType.ConferenceProceedings);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.TechReport, MSBibEntryType.Report);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Manual, MSBibEntryType.Report);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.MastersThesis, MSBibEntryType.Report);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.PhdThesis, MSBibEntryType.Report);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Unpublished, MSBibEntryType.Report);
+        BIB_ENTRYTYPE_MAPPING.put(IEEETranEntryType.Patent, MSBibEntryType.Patent);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Misc, MSBibEntryType.Misc);
+        BIB_ENTRYTYPE_MAPPING.put(IEEETranEntryType.Electronic, MSBibEntryType.ElectronicSource);
+        BIB_ENTRYTYPE_MAPPING.put(StandardEntryType.Online, MSBibEntryType.InternetSite);
+    }
+
     private MSBibMapping() {
     }
 
     public static EntryType getBiblatexEntryType(String msbibType) {
-        Map<String, EntryType> entryTypeMapping = new HashMap<>();
-
-        entryTypeMapping.put("Book", StandardEntryType.Book);
-        entryTypeMapping.put("BookSection", StandardEntryType.Book);
-        entryTypeMapping.put("JournalArticle", StandardEntryType.Article);
-        entryTypeMapping.put("ArticleInAPeriodical", IEEETranEntryType.Periodical);
-        entryTypeMapping.put("ConferenceProceedings", StandardEntryType.InProceedings);
-        entryTypeMapping.put("Report", StandardEntryType.TechReport);
-        entryTypeMapping.put("Patent", IEEETranEntryType.Patent);
-        entryTypeMapping.put("InternetSite", StandardEntryType.Online);
-
-        return entryTypeMapping.getOrDefault(msbibType, StandardEntryType.Misc);
+        return MSBIB_ENTRYTYPE_MAPPING.getOrDefault(msbibType, StandardEntryType.Misc);
     }
 
     public static MSBibEntryType getMSBibEntryType(EntryType bibtexType) {
-        Map<EntryType, MSBibEntryType> entryTypeMapping = new HashMap<>();
-
-        entryTypeMapping.put(StandardEntryType.Book, MSBibEntryType.Book);
-        entryTypeMapping.put(StandardEntryType.InBook, MSBibEntryType.BookSection);
-        entryTypeMapping.put(StandardEntryType.Booklet, MSBibEntryType.BookSection);
-        entryTypeMapping.put(StandardEntryType.InCollection, MSBibEntryType.BookSection);
-        entryTypeMapping.put(StandardEntryType.Article, MSBibEntryType.JournalArticle);
-        entryTypeMapping.put(StandardEntryType.InProceedings, MSBibEntryType.ConferenceProceedings);
-        entryTypeMapping.put(StandardEntryType.Conference, MSBibEntryType.ConferenceProceedings);
-        entryTypeMapping.put(StandardEntryType.Proceedings, MSBibEntryType.ConferenceProceedings);
-        entryTypeMapping.put(StandardEntryType.Collection, MSBibEntryType.ConferenceProceedings);
-        entryTypeMapping.put(StandardEntryType.TechReport, MSBibEntryType.Report);
-        entryTypeMapping.put(StandardEntryType.Manual, MSBibEntryType.Report);
-        entryTypeMapping.put(StandardEntryType.MastersThesis, MSBibEntryType.Report);
-        entryTypeMapping.put(StandardEntryType.PhdThesis, MSBibEntryType.Report);
-        entryTypeMapping.put(StandardEntryType.Unpublished, MSBibEntryType.Report);
-        entryTypeMapping.put(IEEETranEntryType.Patent, MSBibEntryType.Patent);
-        entryTypeMapping.put(StandardEntryType.Misc, MSBibEntryType.Misc);
-        entryTypeMapping.put(IEEETranEntryType.Electronic, MSBibEntryType.ElectronicSource);
-        entryTypeMapping.put(StandardEntryType.Online, MSBibEntryType.InternetSite);
-
-        return entryTypeMapping.getOrDefault(bibtexType, MSBibEntryType.Misc);
+        return BIB_ENTRYTYPE_MAPPING.getOrDefault(bibtexType, MSBibEntryType.Misc);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
+++ b/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
@@ -1,8 +1,11 @@
 package org.jabref.logic.msbib;
 
+import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
 import org.jabref.model.entry.Author;
 
 public class MsBibAuthor {
+
+    private static final RemoveBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveBracesFormatter();
 
     private String firstName;
     private String middleName;
@@ -45,7 +48,7 @@ public class MsBibAuthor {
     }
 
     public String getLastName() {
-        return author.getLastOnly();
+        return REMOVE_BRACES_FORMATTER.format(author.getLastOnly());
     }
 
     public String getFirstLast() {

--- a/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
+++ b/src/main/java/org/jabref/logic/msbib/MsBibAuthor.java
@@ -16,7 +16,7 @@ public class MsBibAuthor {
         this.author = author;
 
         StringBuilder sb = new StringBuilder();
-        author.getFirst().ifPresent(firstNames -> {
+        author.getGivenName().ifPresent(firstNames -> {
 
             String[] names = firstNames.split(" ");
             for (int i = 1; i < names.length; i++) {
@@ -37,7 +37,7 @@ public class MsBibAuthor {
         if (!"".equals(firstName)) {
             return firstName;
         }
-        return author.getFirst().orElse(null);
+        return author.getGivenName().orElse(null);
     }
 
     public String getMiddleName() {
@@ -48,15 +48,15 @@ public class MsBibAuthor {
     }
 
     public String getLastName() {
-        return REMOVE_BRACES_FORMATTER.format(author.getLastOnly());
+        return REMOVE_BRACES_FORMATTER.format(author.getNamePrefixAndFamilyName());
     }
 
     public String getFirstLast() {
-        return author.getFirstLast(false);
+        return author.getGivenFamily(false);
     }
 
     public String getLastFirst() {
-        return author.getLastFirst(false);
+        return author.getFamilyGiven(false);
     }
 
     public boolean isCorporate() {

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -46,13 +46,13 @@ class OOBibStyleGetCitationMarker {
         if (authorList.getNumberOfAuthors() > number) {
             Author author = authorList.getAuthor(number);
             // "von " if von exists
-            Optional<String> von = author.getVon();
+            Optional<String> von = author.getNamePrefix();
             if (von.isPresent() && !von.get().isEmpty()) {
                 stringBuilder.append(von.get());
                 stringBuilder.append(' ');
             }
             // last name if it exists
-            stringBuilder.append(author.getLast().map(last -> REMOVE_BRACES_FORMATTER.format(last)).orElse(""));
+            stringBuilder.append(author.getFamilyName().map(last -> REMOVE_BRACES_FORMATTER.format(last)).orElse(""));
         }
 
         return stringBuilder.toString();

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -226,9 +226,8 @@ class OOBibStyleGetCitationMarker {
                                                                        @NonNull BibDatabase database,
                                                                        @NonNull OrFields fields) {
         for (Field field : fields.getFields() /* FieldFactory.parseOrFields(fields)*/) {
-            Optional<String> optionalContent = entry.getResolvedFieldOrAlias(field, database);
-            final boolean foundSomething = optionalContent.isPresent()
-                                            && !optionalContent.get().trim().isEmpty();
+            Optional<String> optionalContent = entry.getResolvedFieldOrAliasLatexFree(field, database);
+            final boolean foundSomething = !StringUtil.isBlank(optionalContent);
             if (foundSomething) {
                 return Optional.of(new FieldAndContent(field, optionalContent.get()));
             }

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -3,7 +3,6 @@ package org.jabref.logic.openoffice.style;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.jabref.model.database.BibDatabase;
@@ -19,6 +18,8 @@ import org.jabref.model.openoffice.style.CitationMarkerNormEntry;
 import org.jabref.model.openoffice.style.NonUniqueCitationMarker;
 import org.jabref.model.openoffice.style.PageInfo;
 import org.jabref.model.strings.StringUtil;
+
+import org.jspecify.annotations.NonNull;
 
 class OOBibStyleGetCitationMarker {
 
@@ -87,12 +88,9 @@ class OOBibStyleGetCitationMarker {
      *          - andString  is only emitted if nAuthors is at least 2.
      */
     private static String formatAuthorList(OOBibStyle style,
-                                           AuthorList authorList,
+                                           @NonNull AuthorList authorList,
                                            int maxAuthors,
                                            String andString) {
-
-        Objects.requireNonNull(authorList);
-
         // Apparently maxAuthorsBeforeEtAl is always 1 for in-text citations.
         // In reference lists can be for example 7,
         // (https://www.chicagomanualofstyle.org/turabian/turabian-author-date-citation-quick-guide.html)
@@ -224,12 +222,9 @@ class OOBibStyleGetCitationMarker {
      * field (or alias) from {@code fields} found in {@code entry}.
      * Return {@code Optional.empty()} if found nothing.
      */
-    private static Optional<FieldAndContent> getRawCitationMarkerField(BibEntry entry,
-                                                                       BibDatabase database,
-                                                                       OrFields fields) {
-        Objects.requireNonNull(entry, "Entry cannot be null");
-        Objects.requireNonNull(database, "database cannot be null");
-
+    private static Optional<FieldAndContent> getRawCitationMarkerField(@NonNull BibEntry entry,
+                                                                       @NonNull BibDatabase database,
+                                                                       @NonNull OrFields fields) {
         for (Field field : fields.getFields() /* FieldFactory.parseOrFields(fields)*/) {
             Optional<String> optionalContent = entry.getResolvedFieldOrAlias(field, database);
             final boolean foundSomething = optionalContent.isPresent()
@@ -264,10 +259,8 @@ class OOBibStyleGetCitationMarker {
      *
      */
     private static String getCitationMarkerField(OOBibStyle style,
-                                                 CitationLookupResult db,
+                                                 @NonNull CitationLookupResult db,
                                                  OrFields fields) {
-        Objects.requireNonNull(db);
-
         Optional<FieldAndContent> optionalFieldAndContent =
             getRawCitationMarkerField(db.entry, db.database, fields);
 

--- a/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
+++ b/src/main/java/org/jabref/logic/openoffice/style/OOBibStyleGetCitationMarker.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
@@ -22,6 +23,8 @@ import org.jabref.model.strings.StringUtil;
 import org.jspecify.annotations.NonNull;
 
 class OOBibStyleGetCitationMarker {
+
+    private static final RemoveBracesFormatter REMOVE_BRACES_FORMATTER = new RemoveBracesFormatter();
 
     private OOBibStyleGetCitationMarker() {
     }
@@ -49,7 +52,7 @@ class OOBibStyleGetCitationMarker {
                 stringBuilder.append(' ');
             }
             // last name if it exists
-            stringBuilder.append(author.getLast().orElse(""));
+            stringBuilder.append(author.getLast().map(last -> REMOVE_BRACES_FORMATTER.format(last)).orElse(""));
         }
 
         return stringBuilder.toString();
@@ -226,7 +229,8 @@ class OOBibStyleGetCitationMarker {
                                                                        @NonNull BibDatabase database,
                                                                        @NonNull OrFields fields) {
         for (Field field : fields.getFields() /* FieldFactory.parseOrFields(fields)*/) {
-            Optional<String> optionalContent = entry.getResolvedFieldOrAliasLatexFree(field, database);
+            // NOT LaTeX free, because there is some latextohtml in org.jabref.logic.openoffice.style.OOPreFormatter
+            Optional<String> optionalContent = entry.getResolvedFieldOrAlias(field, database);
             final boolean foundSomething = !StringUtil.isBlank(optionalContent);
             if (foundSomething) {
                 return Optional.of(new FieldAndContent(field, optionalContent.get()));

--- a/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
+++ b/src/main/java/org/jabref/logic/xmp/DublinCoreExtractor.java
@@ -299,7 +299,7 @@ public class DublinCoreExtractor {
     private void fillContributor(String authors) {
         AuthorList list = AuthorList.parse(authors);
         for (Author author : list.getAuthors()) {
-            dcSchema.addContributor(author.getFirstLast(false));
+            dcSchema.addContributor(author.getGivenFamily(false));
         }
     }
 
@@ -309,7 +309,7 @@ public class DublinCoreExtractor {
     private void fillCreator(String creators) {
         AuthorList list = AuthorList.parse(creators);
         for (Author author : list.getAuthors()) {
-            dcSchema.addCreator(author.getFirstLast(false));
+            dcSchema.addCreator(author.getGivenFamily(false));
         }
     }
 

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -29,19 +29,29 @@ public class Author {
 
     /**
      * Creates the Author object. If any part of the name is absent, <CODE>null</CODE> must be passed; otherwise other methods may return erroneous results.
+     * <p>
+     * In case only the last part is passed, enclosing braces are
      *
-     * @param first     the first name of the author (may consist of several tokens, like "Charles Louis Xavier Joseph" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param firstabbr the abbreviated first name of the author (may consist of several tokens, like "C. L. X. J." in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin"). It is a responsibility of the caller to create a reasonable abbreviation of the first name.
-     * @param von       the von part of the author's name (may consist of several tokens, like "de la" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param last      the last name of the author (may consist of several tokens, like "Vall{\'e}e Poussin" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param jr        the junior part of the author's name (may consist of several tokens, like "Jr. III" in "Smith, Jr. III, John")
+     * @param firstPart     the first name of the author (may consist of several tokens, like "Charles Louis Xavier Joseph" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param firstAbbr the abbreviated first name of the author (may consist of several tokens, like "C. L. X. J." in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin"). It is a responsibility of the caller to create a reasonable abbreviation of the first name.
+     * @param vonPart       the von part of the author's name (may consist of several tokens, like "de la" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param lastPart      the last name of the author (may consist of several tokens, like "Vall{\'e}e Poussin" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param jrPart        the junior part of the author's name (may consist of several tokens, like "Jr. III" in "Smith, Jr. III, John")
      */
-    public Author(String first, String firstabbr, String von, String last, String jr) {
-        firstPart = addDotIfAbbreviation(removeStartAndEndBraces(first));
-        firstAbbr = removeStartAndEndBraces(firstabbr);
-        vonPart = removeStartAndEndBraces(von);
-        lastPart = removeStartAndEndBraces(last);
-        jrPart = removeStartAndEndBraces(jr);
+    public Author(String firstPart, String firstAbbr, String vonPart, String lastPart, String jrPart) {
+        boolean keepBracesAtLastPart = (firstPart == null) && (firstAbbr == null) && (vonPart == null) && (lastPart != null) && (jrPart == null);
+
+        this.firstPart = addDotIfAbbreviation(removeStartAndEndBraces(firstPart));
+        this.firstAbbr = removeStartAndEndBraces(firstAbbr);
+        this.vonPart = removeStartAndEndBraces(vonPart);
+        if (keepBracesAtLastPart) {
+            // We do not remove braces here to keep institutions protected
+            // https://github.com/JabRef/jabref/issues/10031
+            this.lastPart = lastPart;
+        } else {
+            this.lastPart = removeStartAndEndBraces(lastPart);
+        }
+        this.jrPart = removeStartAndEndBraces(jrPart);
     }
 
     public static String addDotIfAbbreviation(String name) {

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -39,7 +39,7 @@ public class Author {
      * @param jrPart        the junior part of the author's name (may consist of several tokens, like "Jr. III" in "Smith, Jr. III, John")
      */
     public Author(String firstPart, String firstAbbr, String vonPart, String lastPart, String jrPart) {
-        boolean keepBracesAtLastPart = (firstPart == null) && (firstAbbr == null) && (vonPart == null) && (lastPart != null) && (jrPart == null);
+        boolean keepBracesAtLastPart = StringUtil.isBlank(firstPart) && StringUtil.isBlank(firstAbbr) && StringUtil.isBlank(vonPart) && !StringUtil.isBlank(lastPart) && StringUtil.isBlank(jrPart);
 
         this.firstPart = addDotIfAbbreviation(removeStartAndEndBraces(firstPart));
         this.firstAbbr = removeStartAndEndBraces(firstAbbr);

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -193,7 +193,7 @@ public class Author {
     }
 
     /**
-     * Removes start and end brace at a string
+     * Removes start and end brace both at the complete string and at beginning/end of a word
      * <p>
      * E.g.,
      * <ul>

--- a/src/main/java/org/jabref/model/entry/Author.java
+++ b/src/main/java/org/jabref/model/entry/Author.java
@@ -20,11 +20,11 @@ public class Author {
      */
     public static final Author OTHERS = new Author("", "", null, "others", null);
 
-    private final String firstPart;
-    private final String firstAbbr;
-    private final String vonPart;
-    private final String lastPart;
-    private final String jrPart;
+    private final String givenName;
+    private final String givenNameAbbreviated;
+    private final String namePrefix;
+    private final String familyName;
+    private final String nameSuffix;
     private Author latexFreeAuthor;
 
     /**
@@ -32,26 +32,26 @@ public class Author {
      * <p>
      * In case only the last part is passed, enclosing braces are
      *
-     * @param firstPart     the first name of the author (may consist of several tokens, like "Charles Louis Xavier Joseph" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param firstAbbr the abbreviated first name of the author (may consist of several tokens, like "C. L. X. J." in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin"). It is a responsibility of the caller to create a reasonable abbreviation of the first name.
-     * @param vonPart       the von part of the author's name (may consist of several tokens, like "de la" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param lastPart      the last name of the author (may consist of several tokens, like "Vall{\'e}e Poussin" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
-     * @param jrPart        the junior part of the author's name (may consist of several tokens, like "Jr. III" in "Smith, Jr. III, John")
+     * @param givenName     the first name of the author (may consist of several tokens, like "Charles Louis Xavier Joseph" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param givenNameAbbreviated the abbreviated first name of the author (may consist of several tokens, like "C. L. X. J." in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin"). It is a responsibility of the caller to create a reasonable abbreviation of the first name.
+     * @param namePrefix       the von part of the author's name (may consist of several tokens, like "de la" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param familyName      the last name of the author (may consist of several tokens, like "Vall{\'e}e Poussin" in "Charles Louis Xavier Joseph de la Vall{\'e}e Poussin")
+     * @param nameSuffix        the junior part of the author's name (may consist of several tokens, like "Jr. III" in "Smith, Jr. III, John")
      */
-    public Author(String firstPart, String firstAbbr, String vonPart, String lastPart, String jrPart) {
-        boolean keepBracesAtLastPart = StringUtil.isBlank(firstPart) && StringUtil.isBlank(firstAbbr) && StringUtil.isBlank(vonPart) && !StringUtil.isBlank(lastPart) && StringUtil.isBlank(jrPart);
+    public Author(String givenName, String givenNameAbbreviated, String namePrefix, String familyName, String nameSuffix) {
+        boolean keepBracesAtLastPart = StringUtil.isBlank(givenName) && StringUtil.isBlank(givenNameAbbreviated) && StringUtil.isBlank(namePrefix) && !StringUtil.isBlank(familyName) && StringUtil.isBlank(nameSuffix);
 
-        this.firstPart = addDotIfAbbreviation(removeStartAndEndBraces(firstPart));
-        this.firstAbbr = removeStartAndEndBraces(firstAbbr);
-        this.vonPart = removeStartAndEndBraces(vonPart);
+        this.givenName = addDotIfAbbreviation(removeStartAndEndBraces(givenName));
+        this.givenNameAbbreviated = removeStartAndEndBraces(givenNameAbbreviated);
+        this.namePrefix = removeStartAndEndBraces(namePrefix);
         if (keepBracesAtLastPart) {
             // We do not remove braces here to keep institutions protected
             // https://github.com/JabRef/jabref/issues/10031
-            this.lastPart = lastPart;
+            this.familyName = familyName;
         } else {
-            this.lastPart = removeStartAndEndBraces(lastPart);
+            this.familyName = removeStartAndEndBraces(familyName);
         }
-        this.jrPart = removeStartAndEndBraces(jrPart);
+        this.nameSuffix = removeStartAndEndBraces(nameSuffix);
     }
 
     public static String addDotIfAbbreviation(String name) {
@@ -140,7 +140,7 @@ public class Author {
 
     @Override
     public int hashCode() {
-        return Objects.hash(firstAbbr, firstPart, jrPart, lastPart, vonPart);
+        return Objects.hash(givenNameAbbreviated, givenName, nameSuffix, familyName, namePrefix);
     }
 
     /**
@@ -155,11 +155,11 @@ public class Author {
         }
 
         if (other instanceof Author that) {
-            return Objects.equals(firstPart, that.firstPart)
-                    && Objects.equals(firstAbbr, that.firstAbbr)
-                    && Objects.equals(vonPart, that.vonPart)
-                    && Objects.equals(lastPart, that.lastPart)
-                    && Objects.equals(jrPart, that.jrPart);
+            return Objects.equals(givenName, that.givenName)
+                    && Objects.equals(givenNameAbbreviated, that.givenNameAbbreviated)
+                    && Objects.equals(namePrefix, that.namePrefix)
+                    && Objects.equals(familyName, that.familyName)
+                    && Objects.equals(nameSuffix, that.nameSuffix);
         }
 
         return false;
@@ -258,8 +258,8 @@ public class Author {
      *
      * @return first name of the author (may consist of several tokens)
      */
-    public Optional<String> getFirst() {
-        return Optional.ofNullable(firstPart);
+    public Optional<String> getGivenName() {
+        return Optional.ofNullable(givenName);
     }
 
     /**
@@ -267,17 +267,17 @@ public class Author {
      *
      * @return abbreviated first name of the author (may consist of several tokens)
      */
-    public Optional<String> getFirstAbbr() {
-        return Optional.ofNullable(firstAbbr);
+    public Optional<String> getGivenNameAbbreviated() {
+        return Optional.ofNullable(givenNameAbbreviated);
     }
 
     /**
-     * Returns the von part of the author's name stored in this object ("von").
+     * Returns the von part of the author's name stored in this object ("von", "name prefix").
      *
      * @return von part of the author's name (may consist of several tokens)
      */
-    public Optional<String> getVon() {
-        return Optional.ofNullable(vonPart);
+    public Optional<String> getNamePrefix() {
+        return Optional.ofNullable(namePrefix);
     }
 
     /**
@@ -285,17 +285,17 @@ public class Author {
      *
      * @return last name of the author (may consist of several tokens)
      */
-    public Optional<String> getLast() {
-        return Optional.ofNullable(lastPart);
+    public Optional<String> getFamilyName() {
+        return Optional.ofNullable(familyName);
     }
 
     /**
-     * Returns the junior part of the author's name stored in this object ("Jr").
+     * Returns the name suffix ("junior") part of the author's name stored in this object ("Jr").
      *
      * @return junior part of the author's name (may consist of several tokens) or null if the author does not have a Jr. Part
      */
-    public Optional<String> getJr() {
-        return Optional.ofNullable(jrPart);
+    public Optional<String> getNameSuffix() {
+        return Optional.ofNullable(nameSuffix);
     }
 
     /**
@@ -303,11 +303,11 @@ public class Author {
      *
      * @return 'von Last'
      */
-    public String getLastOnly() {
-        if (vonPart == null) {
-            return getLast().orElse("");
+    public String getNamePrefixAndFamilyName() {
+        if (namePrefix == null) {
+            return getFamilyName().orElse("");
         } else {
-            return lastPart == null ? vonPart : vonPart + ' ' + lastPart;
+            return familyName == null ? namePrefix : namePrefix + ' ' + familyName;
         }
     }
 
@@ -317,13 +317,13 @@ public class Author {
      * @param abbr <CODE>true</CODE> - abbreviate first name, <CODE>false</CODE> - do not abbreviate
      * @return 'von Last, Jr., First' (if <CODE>abbr==false</CODE>) or 'von Last, Jr., F.' (if <CODE>abbr==true</CODE>)
      */
-    public String getLastFirst(boolean abbr) {
-        StringBuilder res = new StringBuilder(getLastOnly());
-        getJr().ifPresent(jr -> res.append(", ").append(jr));
+    public String getFamilyGiven(boolean abbr) {
+        StringBuilder res = new StringBuilder(getNamePrefixAndFamilyName());
+        getNameSuffix().ifPresent(jr -> res.append(", ").append(jr));
         if (abbr) {
-            getFirstAbbr().ifPresent(firstA -> res.append(", ").append(firstA));
+            getGivenNameAbbreviated().ifPresent(firstA -> res.append(", ").append(firstA));
         } else {
-            getFirst().ifPresent(first -> res.append(", ").append(first));
+            getGivenName().ifPresent(first -> res.append(", ").append(first));
         }
         return res.toString();
     }
@@ -334,26 +334,26 @@ public class Author {
      * @param abbr <CODE>true</CODE> - abbreviate first name, <CODE>false</CODE> - do not abbreviate
      * @return 'First von Last, Jr.' (if <CODE>abbr==false</CODE>) or 'F. von Last, Jr.' (if <CODE>abbr==true</CODE>)
      */
-    public String getFirstLast(boolean abbr) {
+    public String getGivenFamily(boolean abbr) {
         StringBuilder res = new StringBuilder();
         if (abbr) {
-            getFirstAbbr().map(firstA -> firstA + ' ').ifPresent(res::append);
+            getGivenNameAbbreviated().map(firstA -> firstA + ' ').ifPresent(res::append);
         } else {
-            getFirst().map(first -> first + ' ').ifPresent(res::append);
+            getGivenName().map(first -> first + ' ').ifPresent(res::append);
         }
-        res.append(getLastOnly());
-        getJr().ifPresent(jr -> res.append(", ").append(jr));
+        res.append(getNamePrefixAndFamilyName());
+        getNameSuffix().ifPresent(jr -> res.append(", ").append(jr));
         return res.toString();
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Author{");
-        sb.append("firstPart='").append(firstPart).append('\'');
-        sb.append(", firstAbbr='").append(firstAbbr).append('\'');
-        sb.append(", vonPart='").append(vonPart).append('\'');
-        sb.append(", lastPart='").append(lastPart).append('\'');
-        sb.append(", jrPart='").append(jrPart).append('\'');
+        sb.append("givenName='").append(givenName).append('\'');
+        sb.append(", givenNameAbbreviated='").append(givenNameAbbreviated).append('\'');
+        sb.append(", namePrefix='").append(namePrefix).append('\'');
+        sb.append(", familyName='").append(familyName).append('\'');
+        sb.append(", nameSuffix='").append(nameSuffix).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -365,9 +365,9 @@ public class Author {
      */
     public String getNameForAlphabetization() {
         StringBuilder res = new StringBuilder();
-        getLast().ifPresent(res::append);
-        getJr().ifPresent(jr -> res.append(", ").append(jr));
-        getFirstAbbr().ifPresent(firstA -> res.append(", ").append(firstA));
+        getFamilyName().ifPresent(res::append);
+        getNameSuffix().ifPresent(jr -> res.append(", ").append(jr));
+        getGivenNameAbbreviated().ifPresent(firstA -> res.append(", ").append(firstA));
         while ((res.length() > 0) && (res.charAt(0) == '{')) {
             res.deleteCharAt(0);
         }
@@ -379,12 +379,12 @@ public class Author {
      */
     public Author latexFree() {
         if (latexFreeAuthor == null) {
-            String first = getFirst().map(LatexToUnicodeAdapter::format).orElse(null);
-            String firstabbr = getFirstAbbr().map(LatexToUnicodeAdapter::format).orElse(null);
-            String von = getVon().map(LatexToUnicodeAdapter::format).orElse(null);
-            String last = getLast().map(LatexToUnicodeAdapter::format).orElse(null);
-            String jr = getJr().map(LatexToUnicodeAdapter::format).orElse(null);
-            latexFreeAuthor = new Author(first, firstabbr, von, last, jr);
+            String first = getGivenName().map(LatexToUnicodeAdapter::format).orElse(null);
+            String givenNameAbbreviated = getGivenNameAbbreviated().map(LatexToUnicodeAdapter::format).orElse(null);
+            String von = getNamePrefix().map(LatexToUnicodeAdapter::format).orElse(null);
+            String last = getFamilyName().map(LatexToUnicodeAdapter::format).orElse(null);
+            String jr = getNameSuffix().map(LatexToUnicodeAdapter::format).orElse(null);
+            latexFreeAuthor = new Author(first, givenNameAbbreviated, von, last, jr);
             latexFreeAuthor.latexFreeAuthor = latexFreeAuthor;
         }
         return latexFreeAuthor;

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -316,9 +316,9 @@ public class AuthorList {
         var authors = getAuthors();
         return switch (authors.size()) {
             case 0 -> "";
-            case 1 -> authors.getFirst().getLastOnly();
-            case 2 -> authors.getFirst().getLastOnly() + " and " + authors.get(1).getLastOnly();
-            default -> authors.getFirst().getLastOnly() + " et al.";
+            case 1 -> authors.getFirst().getNamePrefixAndFamilyName();
+            case 2 -> authors.getFirst().getNamePrefixAndFamilyName() + " and " + authors.get(1).getNamePrefixAndFamilyName();
+            default -> authors.getFirst().getNamePrefixAndFamilyName() + " et al.";
         };
     }
 
@@ -338,7 +338,7 @@ public class AuthorList {
      * Oxford comma.</a>
      */
     public String getAsLastNames(boolean oxfordComma) {
-        return andCoordinatedConjunction(getAuthors(), Author::getLastOnly, oxfordComma);
+        return andCoordinatedConjunction(getAuthors(), Author::getNamePrefixAndFamilyName, oxfordComma);
     }
 
     /**
@@ -360,7 +360,7 @@ public class AuthorList {
      * Oxford comma.</a>
      */
     public String getAsLastFirstNames(boolean abbreviate, boolean oxfordComma) {
-        return andCoordinatedConjunction(getAuthors(), auth -> auth.getLastFirst(abbreviate), oxfordComma);
+        return andCoordinatedConjunction(getAuthors(), auth -> auth.getFamilyGiven(abbreviate), oxfordComma);
     }
 
     @Override
@@ -383,25 +383,25 @@ public class AuthorList {
      */
     public String getAsLastFirstNamesWithAnd(boolean abbreviate) {
         return getAuthors().stream()
-                           .map(author -> author.getLastFirst(abbreviate))
+                           .map(author -> author.getFamilyGiven(abbreviate))
                            .collect(Collectors.joining(" and "));
     }
 
     /**
-     * Returns a list of authors separated with "and". The first author is formatted with {@link Author#getLastFirst(boolean)} and each subsequent author is formatted with {@link Author#getFirstLast(boolean)}.
+     * Returns a list of authors separated with "and". The first author is formatted with {@link Author#getFamilyGiven(boolean)} and each subsequent author is formatted with {@link Author#getGivenFamily(boolean)}.
      *
      * @param abbreviate first names.
      */
     public String getAsLastFirstFirstLastNamesWithAnd(boolean abbreviate) {
         return switch (authors.size()) {
             case 0 -> "";
-            case 1 -> authors.getFirst().getLastFirst(abbreviate);
+            case 1 -> authors.getFirst().getFamilyGiven(abbreviate);
             default -> authors.stream()
                               .skip(1)
-                              .map(author -> author.getFirstLast(abbreviate))
+                              .map(author -> author.getGivenFamily(abbreviate))
                               .collect(Collectors.joining(
                                       " and ",
-                                      authors.getFirst().getLastFirst(abbreviate) + " and ",
+                                      authors.getFirst().getFamilyGiven(abbreviate) + " and ",
                                       ""));
         };
     }
@@ -425,7 +425,7 @@ public class AuthorList {
      * Oxford comma.</a>
      */
     public String getAsFirstLastNames(boolean abbreviate, boolean oxfordComma) {
-        return andCoordinatedConjunction(getAuthors(), author -> author.getFirstLast(abbreviate), oxfordComma);
+        return andCoordinatedConjunction(getAuthors(), author -> author.getGivenFamily(abbreviate), oxfordComma);
     }
 
     /**
@@ -466,7 +466,7 @@ public class AuthorList {
      */
     public String getAsFirstLastNamesWithAnd() {
         return getAuthors().stream()
-                           .map(author -> author.getFirstLast(false))
+                           .map(author -> author.getGivenFamily(false))
                            .collect(Collectors.joining(" and "));
     }
 

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.importer.AuthorListParser;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * This is an immutable class representing information of either <CODE>author</CODE> or <CODE>editor</CODE> field in bibtex record.
  * <p>
@@ -169,16 +171,11 @@ public class AuthorList {
      * @param authors The string of authors or editors in bibtex format to parse.
      * @return An AuthorList object representing the given authors.
      */
-    public static AuthorList parse(final String authors) {
-        Objects.requireNonNull(authors);
-
-        AuthorList authorList = AUTHOR_CACHE.get(authors);
-        if (authorList == null) {
+    public static AuthorList parse(@NonNull final String authors) {
+        return AUTHOR_CACHE.computeIfAbsent(authors, string -> {
             AuthorListParser parser = new AuthorListParser();
-            authorList = parser.parse(authors);
-            AUTHOR_CACHE.put(authors, authorList);
-        }
-        return authorList;
+            return parser.parse(string);
+        });
     }
 
     /**

--- a/src/main/java/org/jabref/model/groups/LastNameGroup.java
+++ b/src/main/java/org/jabref/model/groups/LastNameGroup.java
@@ -25,7 +25,7 @@ public class LastNameGroup extends KeywordGroup {
                        .map(AuthorList::latexFree)
                        .map(AuthorList::getAuthors)
                        .flatMap(Collection::stream)
-                       .map(Author::getLast)
+                       .map(Author::getFamilyName)
                        .flatMap(Optional::stream)
                        .collect(Collectors.toList());
     }

--- a/src/test/java/org/jabref/logic/exporter/MSBibExportFormatFilesTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MSBibExportFormatFilesTest.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
@@ -44,8 +43,8 @@ public class MSBibExportFormatFilesTest {
             return stream.map(n -> n.getFileName().toString())
                          .filter(n -> n.endsWith(".bib"))
                          .filter(n -> n.startsWith("MsBib"))
-                         .collect(Collectors.toList())
-                         .stream();
+                         // mapping required, because we get "source already consumed or closed" otherwise
+                         .toList().stream();
         }
     }
 
@@ -75,7 +74,7 @@ public class MSBibExportFormatFilesTest {
         String expected = String.join("\n", Files.readAllLines(expectedFile));
         String actual = String.join("\n", Files.readAllLines(exportedFile));
 
-        // The order of elements changes from Windows to Travis environment somehow
+        // The order of the XML elements changes from Windows to Travis environment somehow
         // The order does not really matter, so we ignore it.
         // Source: https://stackoverflow.com/a/16540679/873282
         assertThat(expected, isSimilarTo(actual)

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -20,6 +20,8 @@ public class NormalizeNamesFormatterTest {
     @Test
     public void normalizeAuthorList() {
         assertEquals("{Society of Automotive Engineers}", formatter.format("{Society of Automotive Engineers}"));
+        assertEquals("{Company Name, LLC}", formatter.format("{Company Name, LLC}"));
+
         assertEquals("Bilbo, Staci D.", formatter.format("Staci D Bilbo"));
         assertEquals("Bilbo, Staci D.", formatter.format("Staci D. Bilbo"));
 

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -19,6 +19,7 @@ public class NormalizeNamesFormatterTest {
 
     @Test
     public void normalizeAuthorList() {
+        assertEquals("{Society of Automotive Engineers}", formatter.format("{Society of Automotive Engineers}"));
         assertEquals("Bilbo, Staci D.", formatter.format("Staci D Bilbo"));
         assertEquals("Bilbo, Staci D.", formatter.format("Staci D. Bilbo"));
 

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -29,9 +29,11 @@ class AuthorListParserTest {
                 Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null)),
                 // parseAuthorWithFirstNameAbbreviationContainingUmlaut
                 Arguments.of("{\\OE}rjan Umlauts", new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
-                Arguments.of("{Company Name, LLC}", new Author("", "", null, "Company Name, LLC", null)),
+                Arguments.of("{Company Name, LLC}", new Author("", "", null, "{Company Name, LLC}", null)),
                 Arguments.of("{Society of Automotive Engineers}", new Author("", "", null, "{Society of Automotive Engineers}", null)),
-                Arguments.of("Society of Automotive Engineers", new Author("", "", null, "Society of Automotive Engineers", null))
+
+                // Demonstrate the "von" part parsing of a non-braced name
+                Arguments.of("Society of Automotive Engineers", new Author("Society", "S.", "of", "Automotive Engineers", null))
         );
     }
 

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -28,7 +28,8 @@ class AuthorListParserTest {
                 Arguments.of("Uhlenhaut, N Henriette", new Author("N Henriette", "N. H.", null, "Uhlenhaut", null)),
                 Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null)),
                 // parseAuthorWithFirstNameAbbreviationContainingUmlaut
-                Arguments.of("{\\OE}rjan Umlauts", new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null))
+                Arguments.of("{\\OE}rjan Umlauts", new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
+                Arguments.of("{Society of Automotive Engineers}", new Author("", "", null, "{Society of Automotive Engineers}", null))
         );
     }
 

--- a/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/AuthorListParserTest.java
@@ -20,7 +20,7 @@ class AuthorListParserTest {
                 Arguments.of("王, 军", new Author("军", "军.", null, "王", null)),
                 Arguments.of("Doe, John", new Author("John", "J.", null, "Doe", null)),
                 Arguments.of("von Berlichingen zu Hornberg, Johann Gottfried", new Author("Johann Gottfried", "J. G.", "von", "Berlichingen zu Hornberg", null)),
-                Arguments.of("{Robert and Sons, Inc.}", new Author(null, null, null, "Robert and Sons, Inc.", null)),
+                Arguments.of("{Robert and Sons, Inc.}", new Author(null, null, null, "{Robert and Sons, Inc.}", null)),
                 Arguments.of("al-Ṣāliḥ, Abdallāh", new Author("Abdallāh", "A.", null, "al-Ṣāliḥ", null)),
                 Arguments.of("de la Vallée Poussin, Jean Charles Gabriel", new Author("Jean Charles Gabriel", "J. C. G.", "de la", "Vallée Poussin", null)),
                 Arguments.of("de la Vallée Poussin, J. C. G.", new Author("J. C. G.", "J. C. G.", "de la", "Vallée Poussin", null)),
@@ -29,7 +29,9 @@ class AuthorListParserTest {
                 Arguments.of("Nu{\\~{n}}ez, Jose", new Author("Jose", "J.", null, "Nu{\\~{n}}ez", null)),
                 // parseAuthorWithFirstNameAbbreviationContainingUmlaut
                 Arguments.of("{\\OE}rjan Umlauts", new Author("{\\OE}rjan", "{\\OE}.", null, "Umlauts", null)),
-                Arguments.of("{Society of Automotive Engineers}", new Author("", "", null, "{Society of Automotive Engineers}", null))
+                Arguments.of("{Company Name, LLC}", new Author("", "", null, "Company Name, LLC", null)),
+                Arguments.of("{Society of Automotive Engineers}", new Author("", "", null, "{Society of Automotive Engineers}", null)),
+                Arguments.of("Society of Automotive Engineers", new Author("", "", null, "Society of Automotive Engineers", null))
         );
     }
 

--- a/src/test/java/org/jabref/logic/msbib/MSBibConverterTest.java
+++ b/src/test/java/org/jabref/logic/msbib/MSBibConverterTest.java
@@ -1,7 +1,5 @@
 package org.jabref.logic.msbib;
 
-import java.util.Optional;
-
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -30,13 +28,9 @@ class MSBibConverterTest {
             .withField(StandardField.TITLE, "Overcoming Open Source Project Entry Barriers with a Portal for Newcomers")
             .withField(StandardField.FILE, ":https\\://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7886910:PDF");
 
-    private BibEntry entry;
-
     @Test
     void convert() {
-        entry = BIB_ENTRY_TEST;
-        MSBibConverter.convert(entry);
-
-        assertEquals(Optional.of("english"), entry.getField(StandardField.LANGUAGE));
+        MSBibEntry result = MSBibConverter.convert(BIB_ENTRY_TEST);
+        assertEquals("1033", result.fields.get("LCID"));
     }
 }

--- a/src/test/java/org/jabref/logic/msbib/MsBibAuthorTest.java
+++ b/src/test/java/org/jabref/logic/msbib/MsBibAuthorTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class MsBibAuthorTest {
 
     @Test
-    public void getFirstName() {
+    public void getGivenNameName() {
         Author author = new Author("Gustav Peter Johann", null, null, "Bach", null);
         MsBibAuthor msBibAuthor = new MsBibAuthor(author);
         assertEquals("Gustav", msBibAuthor.getFirstName());
@@ -38,14 +38,14 @@ public class MsBibAuthorTest {
     }
 
     @Test
-    public void getLastName() {
+    public void getFamilyNameName() {
         Author author = new Author("Gustav Peter Johann", null, null, "Bach", null);
         MsBibAuthor msBibAuthor = new MsBibAuthor(author);
         assertEquals("Bach", msBibAuthor.getLastName());
     }
 
     @Test
-    public void getVonAndLastName() {
+    public void getNamePrefixAndLastName() {
         Author author = new Author("John", null, "von", "Neumann", null);
         MsBibAuthor msBibAuthor = new MsBibAuthor(author);
         assertEquals("von Neumann", msBibAuthor.getLastName());

--- a/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTest.java
@@ -372,19 +372,15 @@ class OOBibStyleTest {
                 abbreviationRepository);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
-        List<BibEntry> entries = new ArrayList<>();
-        BibDatabase database = new BibDatabase();
 
-        BibEntry entry = new BibEntry();
-        entry.setCitationKey("JabRef2016");
-        entry.setType(StandardEntryType.Article);
-        entry.setField(StandardField.AUTHOR, "{JabRef Development Team}");
-        entry.setField(StandardField.TITLE, "JabRef Manual");
-        entry.setField(StandardField.YEAR, "2016");
-        database.insertEntry(entry);
-        entries.add(entry);
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("JabRef2016")
+                .withField(StandardField.AUTHOR, "{JabRef Development Team}")
+                .withField(StandardField.TITLE, "JabRef Manual")
+                .withField(StandardField.YEAR, "2016");
+        List<BibEntry> entries = List.of(entry);
+        BibDatabase database = new BibDatabase(entries);
         entryDBMap.put(entry, database);
-
         assertEquals("[JabRef Development Team, 2016]",
                 getCitationMarker2(style,
                         entries, entryDBMap, true, null, null, null));

--- a/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTestHelper.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOBibStyleTestHelper.java
@@ -153,8 +153,8 @@ class OOBibStyleTestHelper {
         return result;
     }
 
-    /*
-     * Similar to old API. pageInfo is new, and unlimAuthors is
+    /**
+     * @implNote Similar to old API. pageInfo is new, and unlimAuthors is
      * replaced with isFirstAppearanceOfSource
      */
     static String getCitationMarker2ab(OOBibStyle style,
@@ -177,7 +177,7 @@ class OOBibStyleTestHelper {
             isFirstAppearanceOfSource = new Boolean[entries.size()];
             Arrays.fill(isFirstAppearanceOfSource, false);
         }
-        List<CitationMarkerEntry> citationMarkerEntries = new ArrayList<>();
+        List<CitationMarkerEntry> citationMarkerEntries = new ArrayList<>(entries.size());
         for (int i = 0; i < entries.size(); i++) {
             BibEntry entry = entries.get(i);
             CitationMarkerEntry e = makeCitationMarkerEntry(entry,

--- a/src/test/java/org/jabref/logic/openoffice/style/OOPreFormatterTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/style/OOPreFormatterTest.java
@@ -15,6 +15,11 @@ public class OOPreFormatterTest {
     }
 
     @Test
+    public void removeBraces() {
+        assertEquals("aaa", new OOPreFormatter().format("{aaa}"));
+    }
+
+    @Test
     public void formatAccents() {
         assertEquals("ä", new OOPreFormatter().format("{\\\"{a}}"));
         assertEquals("Ä", new OOPreFormatter().format("{\\\"{A}}"));

--- a/src/test/java/org/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListTest.java
@@ -734,38 +734,38 @@ public class AuthorListTest {
     @Test
     public void getAuthor() {
         Author author = AuthorList.parse("John Smith and von Neumann, Jr, John").getAuthor(0);
-        assertEquals(Optional.of("John"), author.getFirst());
-        assertEquals(Optional.of("J."), author.getFirstAbbr());
-        assertEquals("John Smith", author.getFirstLast(false));
-        assertEquals("J. Smith", author.getFirstLast(true));
-        assertEquals(Optional.empty(), author.getJr());
-        assertEquals(Optional.of("Smith"), author.getLast());
-        assertEquals("Smith, John", author.getLastFirst(false));
-        assertEquals("Smith, J.", author.getLastFirst(true));
-        assertEquals("Smith", author.getLastOnly());
+        assertEquals(Optional.of("John"), author.getGivenName());
+        assertEquals(Optional.of("J."), author.getGivenNameAbbreviated());
+        assertEquals("John Smith", author.getGivenFamily(false));
+        assertEquals("J. Smith", author.getGivenFamily(true));
+        assertEquals(Optional.empty(), author.getNameSuffix());
+        assertEquals(Optional.of("Smith"), author.getFamilyName());
+        assertEquals("Smith, John", author.getFamilyGiven(false));
+        assertEquals("Smith, J.", author.getFamilyGiven(true));
+        assertEquals("Smith", author.getNamePrefixAndFamilyName());
         assertEquals("Smith, J.", author.getNameForAlphabetization());
-        assertEquals(Optional.empty(), author.getVon());
+        assertEquals(Optional.empty(), author.getNamePrefix());
 
         author = AuthorList.parse("Peter Black Brown").getAuthor(0);
-        assertEquals(Optional.of("Peter Black"), author.getFirst());
-        assertEquals(Optional.of("P. B."), author.getFirstAbbr());
-        assertEquals("Peter Black Brown", author.getFirstLast(false));
-        assertEquals("P. B. Brown", author.getFirstLast(true));
-        assertEquals(Optional.empty(), author.getJr());
-        assertEquals(Optional.empty(), author.getVon());
+        assertEquals(Optional.of("Peter Black"), author.getGivenName());
+        assertEquals(Optional.of("P. B."), author.getGivenNameAbbreviated());
+        assertEquals("Peter Black Brown", author.getGivenFamily(false));
+        assertEquals("P. B. Brown", author.getGivenFamily(true));
+        assertEquals(Optional.empty(), author.getNameSuffix());
+        assertEquals(Optional.empty(), author.getNamePrefix());
 
         author = AuthorList.parse("John Smith and von Neumann, Jr, John").getAuthor(1);
-        assertEquals(Optional.of("John"), author.getFirst());
-        assertEquals(Optional.of("J."), author.getFirstAbbr());
-        assertEquals("John von Neumann, Jr", author.getFirstLast(false));
-        assertEquals("J. von Neumann, Jr", author.getFirstLast(true));
-        assertEquals(Optional.of("Jr"), author.getJr());
-        assertEquals(Optional.of("Neumann"), author.getLast());
-        assertEquals("von Neumann, Jr, John", author.getLastFirst(false));
-        assertEquals("von Neumann, Jr, J.", author.getLastFirst(true));
-        assertEquals("von Neumann", author.getLastOnly());
+        assertEquals(Optional.of("John"), author.getGivenName());
+        assertEquals(Optional.of("J."), author.getGivenNameAbbreviated());
+        assertEquals("John von Neumann, Jr", author.getGivenFamily(false));
+        assertEquals("J. von Neumann, Jr", author.getGivenFamily(true));
+        assertEquals(Optional.of("Jr"), author.getNameSuffix());
+        assertEquals(Optional.of("Neumann"), author.getFamilyName());
+        assertEquals("von Neumann, Jr, John", author.getFamilyGiven(false));
+        assertEquals("von Neumann, Jr, J.", author.getFamilyGiven(true));
+        assertEquals("von Neumann", author.getNamePrefixAndFamilyName());
         assertEquals("Neumann, Jr, J.", author.getNameForAlphabetization());
-        assertEquals(Optional.of("von"), author.getVon());
+        assertEquals(Optional.of("von"), author.getNamePrefix());
     }
 
     @Test
@@ -995,7 +995,7 @@ public class AuthorListTest {
     @Test
     public void createCorrectInitials() {
         assertEquals(Optional.of("J. G."),
-                AuthorList.parse("Hornberg, Johann Gottfried").getAuthor(0).getFirstAbbr());
+                AuthorList.parse("Hornberg, Johann Gottfried").getAuthor(0).getGivenNameAbbreviated());
     }
 
     @Test
@@ -1052,34 +1052,34 @@ public class AuthorListTest {
     public void parseFirstNameFromFirstAuthorMultipleAuthorsWithLatexNames() throws Exception {
         assertEquals("Mu{\\d{h}}ammad",
                 AuthorList.parse("Mu{\\d{h}}ammad al-Khw{\\={a}}rizm{\\={i}} and Corrado B{\\\"o}hm")
-                          .getAuthor(0).getFirst().orElse(null));
+                          .getAuthor(0).getGivenName().orElse(null));
     }
 
     @Test
     public void parseFirstNameFromSecondAuthorMultipleAuthorsWithLatexNames() throws Exception {
         assertEquals("Corrado",
                 AuthorList.parse("Mu{\\d{h}}ammad al-Khw{\\={a}}rizm{\\={i}} and Corrado B{\\\"o}hm")
-                          .getAuthor(1).getFirst().orElse(null));
+                          .getAuthor(1).getGivenName().orElse(null));
     }
 
     @Test
     public void parseLastNameFromFirstAuthorMultipleAuthorsWithLatexNames() throws Exception {
         assertEquals("al-Khw{\\={a}}rizm{\\={i}}",
                 AuthorList.parse("Mu{\\d{h}}ammad al-Khw{\\={a}}rizm{\\={i}} and Corrado B{\\\"o}hm")
-                          .getAuthor(0).getLast().orElse(null));
+                          .getAuthor(0).getFamilyName().orElse(null));
     }
 
     @Test
     public void parseLastNameFromSecondAuthorMultipleAuthorsWithLatexNames() throws Exception {
         assertEquals("B{\\\"o}hm",
                 AuthorList.parse("Mu{\\d{h}}ammad al-Khw{\\={a}}rizm{\\={i}} and Corrado B{\\\"o}hm")
-                          .getAuthor(1).getLast().orElse(null));
+                          .getAuthor(1).getFamilyName().orElse(null));
     }
 
     @Test
     public void parseInstitutionAuthorWithLatexNames() throws Exception {
         assertEquals("{The Ban\\={u} M\\={u}s\\={a} brothers}",
-                AuthorList.parse("{The Ban\\={u} M\\={u}s\\={a} brothers}").getAuthor(0).getLast().orElse(null));
+                AuthorList.parse("{The Ban\\={u} M\\={u}s\\={a} brothers}").getAuthor(0).getFamilyName().orElse(null));
     }
 
     @Test

--- a/src/test/java/org/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListTest.java
@@ -989,7 +989,7 @@ public class AuthorListTest {
         assertEquals("Poussin", AuthorList.parse("{Vall{\\'e}e} {Poussin}").getAsLastNames(false));
         assertEquals("Poussin", AuthorList.parse("Vall{\\'e}e Poussin").getAsLastNames(false));
         assertEquals("Lastname", AuthorList.parse("Firstname {Lastname}").getAsLastNames(false));
-        assertEquals("Firstname Lastname", AuthorList.parse("{Firstname Lastname}").getAsLastNames(false));
+        assertEquals("{Firstname Lastname}", AuthorList.parse("{Firstname Lastname}").getAsLastNames(false));
     }
 
     @Test
@@ -1078,7 +1078,7 @@ public class AuthorListTest {
 
     @Test
     public void parseInstitutionAuthorWithLatexNames() throws Exception {
-        assertEquals("The Ban\\={u} M\\={u}s\\={a} brothers",
+        assertEquals("{The Ban\\={u} M\\={u}s\\={a} brothers}",
                 AuthorList.parse("{The Ban\\={u} M\\={u}s\\={a} brothers}").getAuthor(0).getLast().orElse(null));
     }
 

--- a/src/test/java/org/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListTest.java
@@ -771,13 +771,13 @@ public class AuthorListTest {
     @Test
     public void companyAuthor() {
         Author author = AuthorList.parse("{JabRef Developers}").getAuthor(0);
-        Author expected = new Author(null, null, null, "JabRef Developers", null);
+        Author expected = new Author(null, null, null, "{JabRef Developers}", null);
         assertEquals(expected, author);
     }
 
     @Test
     public void companyAuthorAndPerson() {
-        Author company = new Author(null, null, null, "JabRef Developers", null);
+        Author company = new Author(null, null, null, "{JabRef Developers}", null);
         Author person = new Author("Stefan", "S.", null, "Kolb", null);
         assertEquals(Arrays.asList(company, person), AuthorList.parse("{JabRef Developers} and Stefan Kolb").getAuthors());
     }
@@ -785,7 +785,7 @@ public class AuthorListTest {
     @Test
     public void companyAuthorWithLowerCaseWord() {
         Author author = AuthorList.parse("{JabRef Developers on Fire}").getAuthor(0);
-        Author expected = new Author(null, null, null, "JabRef Developers on Fire", null);
+        Author expected = new Author(null, null, null, "{JabRef Developers on Fire}", null);
         assertEquals(expected, author);
     }
 
@@ -985,7 +985,7 @@ public class AuthorListTest {
     @Test
     public void removeStartAndEndBraces() {
         assertEquals("{A}bbb{c}", AuthorList.parse("{A}bbb{c}").getAsLastNames(false));
-        assertEquals("Vall{\\'e}e Poussin", AuthorList.parse("{Vall{\\'e}e Poussin}").getAsLastNames(false));
+        assertEquals("{Vall{\\'e}e Poussin}", AuthorList.parse("{Vall{\\'e}e Poussin}").getAsLastNames(false));
         assertEquals("Poussin", AuthorList.parse("{Vall{\\'e}e} {Poussin}").getAsLastNames(false));
         assertEquals("Poussin", AuthorList.parse("Vall{\\'e}e Poussin").getAsLastNames(false));
         assertEquals("Lastname", AuthorList.parse("Firstname {Lastname}").getAsLastNames(false));

--- a/src/test/java/org/jabref/model/entry/AuthorTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorTest.java
@@ -74,7 +74,7 @@ class AuthorTest {
 
     @Test
     void bracesKept() {
-        assertEquals(Optional.of("{Company Name, LLC}"), new Author("", "", null, "{Company Name, LLC}", null).getLast());
+        assertEquals(Optional.of("{Company Name, LLC}"), new Author("", "", null, "{Company Name, LLC}", null).getFamilyName());
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/model/entry/AuthorTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorTest.java
@@ -1,5 +1,7 @@
 package org.jabref.model.entry;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -68,6 +70,11 @@ class AuthorTest {
     @Test
     void addDotIfAbbreviationEndsWithDoubleAbbreviation() {
         assertEquals("Ameli A. A.", Author.addDotIfAbbreviation("Ameli AA"));
+    }
+
+    @Test
+    void bracesKept() {
+        assertEquals(Optional.of("{Company Name, LLC}"), new Author("", "", null, "{Company Name, LLC}", null).getLast());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/10031

Note that this PR also keeps braces inside the data model. A "better" data model would have a Boolean property with "protect", but we don't have. Thus, this is as good as it can get to fix the issue.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
