### PR TITLE
fix for Library is marked as unsaved (*) after accepting changes from the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Clicking on the crossref and related tags in the entry editor jumps to the linked entry. [#5484](https://github.com/JabRef/jabref/issues/5484) [#9369](https://github.com/JabRef/jabref/issues/9369)
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
+- We fixed an issue where Library is unsaved and marked (*) after accepting changes made externally to the file. [#11027](https://github.com/JabRef/jabref/issues/11027)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -910,7 +910,8 @@ public class LibraryTab extends Tab {
                 taskExecutor,
                 dialogService,
                 preferencesService,
-                databaseNotificationPane));
+                databaseNotificationPane,
+                this));
     }
 
     public void copy() {

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -31,18 +31,21 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
     private final TaskExecutor taskExecutor;
     private final DialogService dialogService;
     private final PreferencesService preferencesService;
+    private final LibraryTab libraryTab;
 
     public DatabaseChangeMonitor(BibDatabaseContext database,
                                  FileUpdateMonitor fileMonitor,
                                  TaskExecutor taskExecutor,
                                  DialogService dialogService,
                                  PreferencesService preferencesService,
-                                 LibraryTab.DatabaseNotification notificationPane) {
+                                 LibraryTab.DatabaseNotification notificationPane,
+                                 LibraryTab libraryTab) {
         this.database = database;
         this.fileMonitor = fileMonitor;
         this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;
         this.preferencesService = preferencesService;
+        this.libraryTab = libraryTab;
 
         this.listeners = new ArrayList<>();
 
@@ -59,7 +62,7 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
                 Localization.lang("The library has been modified by another program."),
                 List.of(new Action(Localization.lang("Dismiss changes"), event -> notificationPane.hide()),
                         new Action(Localization.lang("Review changes"), event -> {
-                            dialogService.showCustomDialogAndWait(new DatabaseChangesResolverDialog(changes, database, Localization.lang("External Changes Resolver")));
+                            dialogService.showCustomDialogAndWait(new DatabaseChangesResolverDialog(changes, database, Localization.lang("External Changes Resolver"),libraryTab));
                             notificationPane.hide();
                         })),
                 Duration.ZERO));

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangesResolverDialog.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangesResolverDialog.java
@@ -15,7 +15,9 @@ import javafx.scene.control.TableView;
 import javafx.scene.layout.BorderPane;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
+import org.jabref.gui.exporter.SaveDatabaseAction;
 import org.jabref.gui.preview.PreviewViewer;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
@@ -52,6 +54,7 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
     private final BibDatabaseContext database;
 
     private ExternalChangesResolverViewModel viewModel;
+    private final LibraryTab libraryTab;
 
     @Inject private UndoManager undoManager;
     @Inject private StateManager stateManager;
@@ -68,9 +71,10 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
      * @param changes The list of changes
      * @param database The database to apply the changes to
      */
-    public DatabaseChangesResolverDialog(List<DatabaseChange> changes, BibDatabaseContext database, String dialogTitle) {
+    public DatabaseChangesResolverDialog(List<DatabaseChange> changes, BibDatabaseContext database, String dialogTitle,  LibraryTab libraryTab) {
         this.changes = changes;
         this.database = database;
+        this.libraryTab = libraryTab;
 
         this.setTitle(dialogTitle);
         ViewLoader.view(this)
@@ -114,6 +118,8 @@ public class DatabaseChangesResolverDialog extends BaseDialog<Boolean> {
         EasyBind.subscribe(viewModel.areAllChangesResolvedProperty(), isResolved -> {
             if (isResolved) {
                 viewModel.applyChanges();
+                SaveDatabaseAction saveAction = new SaveDatabaseAction(libraryTab,dialogService,preferencesService,entryTypesManager);
+                saveAction.save();
                 close();
             }
         });

--- a/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
+++ b/src/main/java/org/jabref/gui/dialogs/BackupUIManager.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import javafx.scene.control.ButtonType;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.LibraryTab;
 import org.jabref.gui.autosaveandbackup.BackupManager;
 import org.jabref.gui.backup.BackupResolverDialog;
 import org.jabref.gui.collab.DatabaseChange;
@@ -41,7 +42,8 @@ public class BackupUIManager {
     public static Optional<ParserResult> showRestoreBackupDialog(DialogService dialogService,
                                                                  Path originalPath,
                                                                  PreferencesService preferencesService,
-                                                                 FileUpdateMonitor fileUpdateMonitor) {
+                                                                 FileUpdateMonitor fileUpdateMonitor,
+                                                                 LibraryTab libraryTab) {
         var actionOpt = showBackupResolverDialog(
                 dialogService,
                 preferencesService.getExternalApplicationsPreferences(),
@@ -52,7 +54,7 @@ public class BackupUIManager {
                 BackupManager.restoreBackup(originalPath, preferencesService.getFilePreferences().getBackupDirectory());
                 return Optional.empty();
             } else if (action == BackupResolverDialog.REVIEW_BACKUP) {
-                return showReviewBackupDialog(dialogService, originalPath, preferencesService, fileUpdateMonitor);
+                return showReviewBackupDialog(dialogService, originalPath, preferencesService, fileUpdateMonitor, libraryTab);
             }
             return Optional.empty();
         });
@@ -70,7 +72,8 @@ public class BackupUIManager {
             DialogService dialogService,
             Path originalPath,
             PreferencesService preferencesService,
-            FileUpdateMonitor fileUpdateMonitor) {
+            FileUpdateMonitor fileUpdateMonitor,
+            LibraryTab libraryTab) {
         try {
             ImportFormatPreferences importFormatPreferences = preferencesService.getImportFormatPreferences();
 
@@ -88,12 +91,13 @@ public class BackupUIManager {
                 List<DatabaseChange> changes = DatabaseChangeList.compareAndGetChanges(originalDatabase, backupDatabase, changeResolverFactory);
                 DatabaseChangesResolverDialog reviewBackupDialog = new DatabaseChangesResolverDialog(
                         changes,
-                        originalDatabase, "Review Backup"
+                        originalDatabase, "Review Backup",
+                        libraryTab
                 );
                 var allChangesResolved = dialogService.showCustomDialogAndWait(reviewBackupDialog);
                 if (allChangesResolved.isEmpty() || !allChangesResolved.get()) {
                     // In case not all changes are resolved, start from scratch
-                    return showRestoreBackupDialog(dialogService, originalPath, preferencesService, fileUpdateMonitor);
+                    return showRestoreBackupDialog(dialogService, originalPath, preferencesService, fileUpdateMonitor, libraryTab);
                 }
 
                 // This does NOT return the original ParserResult, but a modified version with all changes accepted or rejected

--- a/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -219,7 +219,7 @@ public class OpenDatabaseAction extends SimpleCommand {
         if (BackupManager.backupFileDiffers(fileToLoad, backupDir)) {
             // In case the backup differs, ask the user what to do.
             // In case the user opted for restoring a backup, the content of the backup is contained in parserResult.
-            parserResult = BackupUIManager.showRestoreBackupDialog(dialogService, fileToLoad, preferencesService, fileUpdateMonitor)
+            parserResult = BackupUIManager.showRestoreBackupDialog(dialogService, fileToLoad, preferencesService, fileUpdateMonitor, tabContainer.getCurrentLibraryTab())
                                           .orElse(null);
         }
 


### PR DESCRIPTION
<!-- 
Library will be saved along with accepting external changes in the bibTex file.
modified the code to save library upon clicking accept button in the review changes dialog box.
Closes #11027
Closes https://github.com/JabRef/jabref/issues/11027
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
