### PR TITLE
Fix error on browser extension import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Clicking on the crossref and related tags in the entry editor jumps to the linked entry. [#5484](https://github.com/JabRef/jabref/issues/5484) [#9369](https://github.com/JabRef/jabref/issues/9369)
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
+- Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
 
 ### Removed
 

--- a/buildres/windows/JabRefHost.ps1
+++ b/buildres/windows/JabRefHost.ps1
@@ -36,8 +36,8 @@ try {
     # WriteAllLines should write the file as UTF-8 without BOM
     # unlike Out-File which writes UTF-16 with BOM in ps5.1
     [IO.File]::WriteAllLines($tempfile, $messageText)
-    $output = & $jabRefExe -importToOpen $tempfile *>&1
-    Remove-Item $tempfile
+    $output = & $jabRefExe -importToOpen $tempfile *>$null
+    Remove-Item $tempfile *>$null
     # For debugging: uncomment the following lines to get the output of JabRef be displayed as a popup 
     #$wshell = New-Object -ComObject Wscript.Shell
     #$wshell.Popup("Input: $messageText; Output: $output", 0, "JabRef", 0x0 + 0x30)

--- a/buildres/windows/JabRefHost.ps1
+++ b/buildres/windows/JabRefHost.ps1
@@ -36,7 +36,7 @@ try {
     # WriteAllLines should write the file as UTF-8 without BOM
     # unlike Out-File which writes UTF-16 with BOM in ps5.1
     [IO.File]::WriteAllLines($tempfile, $messageText)
-    $output = & $jabRefExe -importToOpen $tempfile *>$null
+    $output = & $jabRefExe -importToOpen $tempfile *>&1
     Remove-Item $tempfile *>$null
     # For debugging: uncomment the following lines to get the output of JabRef be displayed as a popup 
     #$wshell = New-Object -ComObject Wscript.Shell


### PR DESCRIPTION
This implements the solution suggested by https://github.com/JabRef/JabRef-Browser-Extension/issues/493#issuecomment-1428073766

Closes https://github.com/JabRef/JabRef-Browser-Extension/issues/493

I found the issue to be the `Remove-Item` call, because the temporary file is being accessed by the running JabRef instance, so it results in the error message:

```
Cannot remove item ...\AppData\Local\Temp\1\tmp7642.tmp: The process cannot access the file '...\AppData\Local\Temp\1\tmp7642.tmp' because it is being used by another process.
```

By redirecting the output of that to $null, that error is not sent to the plugin and so the issue is patched.

I will create a separate issue in this repository to track the remaining problem of the temporary files not being deleted when the script is run.

### Mandatory checks

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
