### PR TITLE
Remove 22 from EA builds

### DIFF
--- a/.github/workflows/deployment-jdk-ea.yml
+++ b/.github/workflows/deployment-jdk-ea.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/deployment-jdk-ea.yml
+      - build.gradle
   workflow_dispatch:
     inputs:
       notarization:

--- a/.github/workflows/deployment-jdk-ea.yml
+++ b/.github/workflows/deployment-jdk-ea.yml
@@ -37,8 +37,8 @@ jobs:
     steps:
       - id: javafx_versions
         run: |
-          curl -s "https://search.maven.org/solrsearch/select?q=g:org.openjfx+AND+a:javafx&rows=5&core=gav" > /tmp/versions.json
-          jq '[.response.docs[] | select(.v | test(".*-ea\\+.*")) | select(.v | test("^17") | not) | {version: .v}] | group_by(.version | capture("^(?<major>\\d+).*").major) | map(max_by(.version))' < /tmp/versions.json > /tmp/versions-latest.json
+          curl -s "https://search.maven.org/solrsearch/select?q=g:org.openjfx+AND+a:javafx&rows=10&core=gav" > /tmp/versions.json
+          jq '[.response.docs[] | select(.v | test(".*-ea\\+.*")) | select(.v | test("^17|^18|^19|^20|^21|^22") | not) | {version: .v}] | group_by(.version | capture("^(?<major>\\d+).*").major) | map(max_by(.version))' < /tmp/versions.json > /tmp/versions-latest.json
           versions_json=$(jq -r '[.[].version]' /tmp/versions-latest.json | jq -r tostring)
           include_json=$(jq -n '[
             {"os": "ubuntu-latest", "displayName": "linux", "archivePortable": "tar -c -C build/distribution JabRef | pigz --rsyncable > build/distribution/JabRef-portable_linux.tar.gz && rm -R build/distribution/JabRef"},
@@ -49,7 +49,7 @@ jobs:
           matrix=$(jq -n \
             --argjson versionsContent "$versions_json" \
             --argjson includeContent "$include_json" \
-            '{"os": ["ubuntu-latest", "windows-latest", "macos-latest", "buildjet-4vcpu-ubuntu-2204-arm"], "jdk": [22, 23], "javafx": $versionsContent, "include": $includeContent}')
+            '{"os": ["ubuntu-latest", "windows-latest", "macos-latest", "buildjet-4vcpu-ubuntu-2204-arm"], "jdk": [23], "javafx": $versionsContent, "include": $includeContent}')
           echo matrix=$matrix >> $GITHUB_OUTPUT
   build:
     needs: setup-matrix

--- a/build.gradle
+++ b/build.gradle
@@ -49,9 +49,9 @@ java {
 
     toolchain {
         // If this is updated, also update
-        // - .devcontainer/devcontainer.json#L34 and
         // - .gitpod.Dockerfile
-        languageVersion = JavaLanguageVersion.of(21)
+        // - .devcontainer/devcontainer.json#L34 and
+        // - .github/workflows/deployment-jdk-ea.yml#L53
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ java {
         // - .gitpod.Dockerfile
         // - .devcontainer/devcontainer.json#L34 and
         // - .github/workflows/deployment-jdk-ea.yml#L53
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
This is the "uncritical" part of https://github.com/JabRef/jabref/pull/11057.

It removes released JDK and JavaFX versions from the EA build.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
