### PR TITLE
Add test cases for "UnicodeToLatex" and "LatexToUnicode"

### DIFF
--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -26,6 +26,9 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
         // Standard symbols
         for (Map.Entry<String, String> unicodeLatexPair : HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP
                 .entrySet()) {
+            if (HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS.containsKey(unicodeLatexPair.getKey())) {
+                continue;
+            }
             result = result.replace(unicodeLatexPair.getKey(), unicodeLatexPair.getValue());
         }
 
@@ -55,6 +58,12 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
             sb.append((char) result.codePointAt(result.length() - 1));
         }
         result = sb.toString();
+
+        // conversions after combining accents
+        for (Map.Entry<String, String> unicodeLatexPair : HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS
+                .entrySet()) {
+            result = result.replace(unicodeLatexPair.getKey(), unicodeLatexPair.getValue());
+        }
 
         // Check if any symbols is not converted
         for (int i = 0; i <= (result.length() - 1); i++) {

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatter {
 
+    public static final NormalizeUnicodeFormatter UNICODE_NORMALIZER = new NormalizeUnicodeFormatter();
     private static final Logger LOGGER = LoggerFactory.getLogger(UnicodeToLatexFormatter.class);
 
     @Override
@@ -23,8 +24,7 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
             return result;
         }
 
-        NormalizeUnicodeFormatter normalizer = new NormalizeUnicodeFormatter();
-        result = normalizer.format(result);
+        result = UNICODE_NORMALIZER.format(result);
 
         // Standard symbols
         for (Map.Entry<String, String> unicodeLatexPair : HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -23,12 +23,12 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
             return result;
         }
 
+        NormalizeUnicodeFormatter normalizer = new NormalizeUnicodeFormatter();
+        result = normalizer.format(result);
+
         // Standard symbols
         for (Map.Entry<String, String> unicodeLatexPair : HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP
                 .entrySet()) {
-            if (HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS.containsKey(unicodeLatexPair.getKey())) {
-                continue;
-            }
             result = result.replace(unicodeLatexPair.getKey(), unicodeLatexPair.getValue());
         }
 
@@ -58,12 +58,6 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
             sb.append((char) result.codePointAt(result.length() - 1));
         }
         result = sb.toString();
-
-        // conversions after combining accents
-        for (Map.Entry<String, String> unicodeLatexPair : HTMLUnicodeConversionMaps.UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS
-                .entrySet()) {
-            result = result.replace(unicodeLatexPair.getKey(), unicodeLatexPair.getValue());
-        }
 
         // Check if any symbols is not converted
         for (int i = 0; i <= (result.length() - 1); i++) {

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -16,6 +16,7 @@ public class HTMLUnicodeConversionMaps {
     public static final Map<String, String> UNICODE_LATEX_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_HTML_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_UNICODE_CONVERSION_MAP = new HashMap<>();
+
     /*   Portions © International Organization for Standardization 1986:
      Permission to copy in any form is granted for use with
      conforming SGML systems and applications as defined in

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -16,8 +16,6 @@ public class HTMLUnicodeConversionMaps {
     public static final Map<String, String> UNICODE_LATEX_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_HTML_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_UNICODE_CONVERSION_MAP = new HashMap<>();
-    public static final Map<String, String> UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS = new HashMap<>();
-
     /*   Portions © International Organization for Standardization 1986:
      Permission to copy in any form is granted for use with
      conforming SGML systems and applications as defined in
@@ -904,8 +902,6 @@ public class HTMLUnicodeConversionMaps {
         // Support a special version of apostrophe
         LATEX_HTML_CONVERSION_MAP.put("textquotesingle", "&#39;");
         LATEX_UNICODE_CONVERSION_MAP.put("textquotesingle", "'"); // apostrophe, U+00027
-        // conversions after combining accents
-        UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS.put(String.valueOf(Character.toChars(Integer.decode("305"))), "\\i");
     }
 
     private HTMLUnicodeConversionMaps() {

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -16,6 +16,7 @@ public class HTMLUnicodeConversionMaps {
     public static final Map<String, String> UNICODE_LATEX_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_HTML_CONVERSION_MAP = new HashMap<>();
     public static final Map<String, String> LATEX_UNICODE_CONVERSION_MAP = new HashMap<>();
+    public static final Map<String, String> UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS = new HashMap<>();
 
     /*   Portions © International Organization for Standardization 1986:
      Permission to copy in any form is granted for use with
@@ -292,6 +293,12 @@ public class HTMLUnicodeConversionMaps {
             {"978", "upsih", "{{$\\Upsilon$}}"}, // greek upsilon with hook symbol,
             //                                   U+03D2 NEW
             {"982", "piv", "$\\varphi$"}, // greek pi symbol, U+03D6 ISOgrk3
+            /* Letters with Dot Below */
+            {"7751", "", "{\\d{n}}"}, // Latin Small Letter N with Dot Below, U+1E47
+            {"7789", "", "{\\d{t}}"}, // Latin Small Letter T with Dot Below, U+1E6D
+            {"7717", "", "{\\d{h}}"}, // Latin Small Letter H with Dot Below, U+1E25
+            {"7747", "", "{\\d{m}}"}, // Latin Small Letter M with Dot Below, U+1E43
+            {"7771", "", "{\\d{r}}"}, // Latin Small Letter R with Dot Below, U+1E5B
 
             /* General Punctuation */
             {"8211", "ndash", "$\\textendash$"},
@@ -897,6 +904,8 @@ public class HTMLUnicodeConversionMaps {
         // Support a special version of apostrophe
         LATEX_HTML_CONVERSION_MAP.put("textquotesingle", "&#39;");
         LATEX_UNICODE_CONVERSION_MAP.put("textquotesingle", "'"); // apostrophe, U+00027
+        // conversions after combining accents
+        UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS.put(String.valueOf(Character.toChars(Integer.decode("305"))), "\\i");
     }
 
     private HTMLUnicodeConversionMaps() {

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -26,9 +26,10 @@ class UnicodeToLatexFormatterTest {
                          Arguments.of("", "\u0081"), // high code point unicode, boundary case: cp = 129
                          Arguments.of("", "\u0080"), // high code point unicode, boundary case: cp = 128 < 129
                          Arguments.of("M{\\\"{o}}nch", new UnicodeToLatexFormatter().getExampleInput()),
-                         Arguments.of("\\i", "ı"),
-                         Arguments.of("\\i {\\={\\i}}", "ı ı̄"),
-                         Arguments.of("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}", "Puṇya-pattana-vidyā-pı̄ṭhādhi-kṛtaiḥ prā-kaśyaṃ nı̄taḥ")
+                         Arguments.of("{\\i}", "ı"),
+                         Arguments.of("{\\i} {\\={\\i}}", "ı ī"),
+                         Arguments.of("{\\={\\i}}{\\={\\i}}", "\u0069\u0304\u0069\u0304"),
+                         Arguments.of("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}", "Puṇya-pattana-vidyā-pīṭhādhi-kṛtaiḥ prā-kaśyaṃ nītaḥ")
         );
     }
 

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -25,7 +25,11 @@ class UnicodeToLatexFormatterTest {
                          Arguments.of("{{\\aa}}{\\\"{a}}{\\\"{o}}", "\u00E5\u00E4\u00F6"), // multiple unicodes input
                          Arguments.of("", "\u0081"), // high code point unicode, boundary case: cp = 129
                          Arguments.of("", "\u0080"), // high code point unicode, boundary case: cp = 128 < 129
-                         Arguments.of("M{\\\"{o}}nch", new UnicodeToLatexFormatter().getExampleInput()));
+                         Arguments.of("M{\\\"{o}}nch", new UnicodeToLatexFormatter().getExampleInput()),
+                         Arguments.of("\\i", "ı"),
+                         Arguments.of("\\i {\\={\\i}}", "ı ı̄"),
+                         Arguments.of("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}", "Puṇya-pattana-vidyā-pı̄ṭhādhi-kṛtaiḥ prā-kaśyaṃ nı̄taḥ")
+        );
     }
 
     @ParameterizedTest()

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -2,6 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,10 +22,14 @@ class LatexToUnicodeFormatterTest {
         assertEquals("Ä", formatter.format("{\\\"{A}}"));
     }
 
-    @Test
-    void smallIwithoutDot() {
-        assertEquals("ı", formatter.format("\\i"));
-        assertEquals("ı", formatter.format("{\\i}"));
+    @ParameterizedTest
+    @CsvSource({
+            "ı, \\i",
+            "ı, {\\i}"
+    })
+
+    void smallIwithoutDot(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -21,6 +21,12 @@ class LatexToUnicodeFormatterTest {
     }
 
     @Test
+    void smallIwithoutDot() {
+        assertEquals("ı", formatter.format("\\i"));
+        assertEquals("ı", formatter.format("{\\i}"));
+    }
+
+    @Test
     void preserveUnknownCommand() {
         assertEquals("\\mbox{-}", formatter.format("\\mbox{-}"));
     }
@@ -161,6 +167,11 @@ class LatexToUnicodeFormatterTest {
     @Test
     void conversionOfUnderscoreWithBraces() {
         assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
+    }
+
+    @Test
+    void twoDifferentMacrons() {
+        assertEquals("Puṇya-pattana-vidyā-pı̄ṭhādhi-kṛtaiḥ prā-kaśyaṃ nı̄taḥ", formatter.format("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -27,7 +27,6 @@ class LatexToUnicodeFormatterTest {
             "ı, \\i",
             "ı, {\\i}"
     })
-
     void smallIwithoutDot(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }
@@ -175,6 +174,9 @@ class LatexToUnicodeFormatterTest {
         assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
     }
 
+    /**
+     * <a href="https://github.com/JabRef/jabref/issues/5547">Issue 5547</a>
+     */
     @Test
     void twoDifferentMacrons() {
         assertEquals("Puṇya-pattana-vidyā-pı̄ṭhādhi-kṛtaiḥ prā-kaśyaṃ nı̄taḥ", formatter.format("Pu{\\d{n}}ya-pattana-vidy{\\={a}}-p{\\={\\i}}{\\d{t}}h{\\={a}}dhi-k{\\d{r}}tai{\\d{h}} pr{\\={a}}-ka{{\\'{s}}}ya{\\d{m}} n{\\={\\i}}ta{\\d{h}}"));


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

I added the test case mentioned in [#5547](https://github.com/JabRef/jabref/issues/5547#issuecomment-554067764) and other test cases to ensure reliability. 


The problem with the test case was that ```ı̄``` is not one character it's a combination of ```ı  +   ̄``` unlike ```ā```. What was happennig is that ```ı``` was being converted to ```\i``` and then ```  ̄ ``` was being converted to ```{\={}}``` so the result would be ```{\i{\={}}}```.

I made it that we deal with such characters that cause conflict after combining accents. They are stored in a new variable called ```UNICODE_LATEX_CONVERSION_MAP_AFTER_COMBINING_ACCENTS``` I think this will be the base to deal with such cases.

I also added some of the underdot characters as the previous implementation didn't handle them.



### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
