### PR TITLE
Fix for wrong path in org.jabref.jabref.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
+- We fixed an issue with the path specified in the org.jabref.jabref.json file that is to be downloaded under the macOS heading for installing the  JabRef Browser Extension. [JabRef-Browser-Extension#605](https://github.com/JabRef/JabRef-Browser-Extension/issues/605)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
-- We fixed an issue with the path specified in the org.jabref.jabref.json file that is to be downloaded under the macOS heading for installing the  JabRef Browser Extension. [JabRef-Browser-Extension#605](https://github.com/JabRef/JabRef-Browser-Extension/issues/605)
+- We fixed an issue with the path specified in the org.jabref.jabref.json file that is to be downloaded under the macOS heading for installing the JabRef Browser Extension. [JabRef-Browser-Extension#605](https://github.com/JabRef/JabRef-Browser-Extension/issues/605)
 
 ### Removed
 

--- a/buildres/mac/native-messaging-host/firefox/org.jabref.jabref.json
+++ b/buildres/mac/native-messaging-host/firefox/org.jabref.jabref.json
@@ -1,7 +1,7 @@
 {
   "name": "org.jabref.jabref",
   "description": "JabRef",
-  "path": "/Applications/JabRef.app/Contents/jabrefHost.py",
+  "path": "/Applications/JabRef.app/Contents/Resources/jabrefHost.py",
   "type": "stdio",
   "allowed_extensions": ["browserextension@jabref.org", "@jabfox"]
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
This fixes [issue #605](https://github.com/JabRef/JabRef-Browser-Extension/issues/605) of the JabRref-Browser-Extension repoitory.
Currently, the extension throws an error if the existent file is used, due to a wrong path.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
