### PR TITLE
Fix regression from adding tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
+- Fixed a regression in the linked file redownload process that caused the source url to be overwritten.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
-- Fixed a regression in the linked file redownload process that caused the source url to be overwritten.
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -160,7 +160,11 @@ public class DownloadLinkedFileAction extends SimpleCommand {
             if (newLinkedFile.getDescription().isEmpty() && !linkedFile.getDescription().isEmpty()) {
                 newLinkedFile.setDescription((linkedFile.getDescription()));
             }
-            newLinkedFile.setSourceURL(linkedFile.getLink());
+            if (linkedFile.getSourceUrl().isEmpty() && LinkedFile.isOnlineLink(linkedFile.getLink())) {
+                newLinkedFile.setSourceURL(linkedFile.getLink());
+            } else {
+                newLinkedFile.setSourceURL(linkedFile.getSourceUrl());
+            }
             entry.replaceDownloadedFile(linkedFile.getLink(), newLinkedFile);
             isHtml = newLinkedFile.getFileType().equals(StandardExternalFileType.URL.getName());
         }


### PR DESCRIPTION
I just noticed that using the "Redownload file" funcionality from linked files copied the current path to the sourceURL, which made it so that the actual source URL was lost upon the second download of a file. To reproduce:

1. Create an entry
2. Download a file to the entry with the Download button on the right of the Files section in the General tab
3. Right-click on the file, choose Edit, and observe that the "Link" points to the local file's path, and sourceURL points to the url used for the download
4. Delete the downloaded file from the download directory
5. Right-click again on the file and choose "Redownload file"
6. When the download is finished, right-click the linked file, choose Edit, and notice that both Link and sourceURL point to the local path

Through git blame, the changes were introduced by @calixtus when adding tests in commit 8f3f55b. I do have a question about those changes that I would like to understand better:
In my original implementation, I had made it so that the LinkedFile in the BibEntry wasn't changed, just updated with the new information. The changes introduced in that commit reverted that change to what was done previously, which is call BibEntry.replaceDownloadedFile. What is the reason for that? i.e. why is that better?

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
