### PR TITLE
Fix year in installer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2003-2023 JabRef Authors
+Copyright © 2003-2024 JabRef Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/buildres/LICENSE_with_Privacy.md
+++ b/buildres/LICENSE_with_Privacy.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2003-2021 JabRef Authors
+Copyright © 2003-2024 JabRef Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Our installer listed an older year.

![grafik](https://github.com/JabRef/jabref/assets/1366654/4adeab74-dca4-467c-9fdb-9aea87d4bffe)


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
