### PR TITLE
Springer search encoding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
 - Fixed an issue on Windows where TeXworks path was not resolved if it was installed with MiKTeX. [#10977](https://github.com/JabRef/jabref/issues/10977)
 - We fixed an issue with where JabRef would throw an error when using MathSciNet search, as it was unable to parse the fetched JSON coreectly. [10996](https://github.com/JabRef/jabref/issues/10996)
-- We fixed a bug in Springer Web Search where the names of authors would not be displayed correctly.
+- We fixed a bug in Springer Web Search where the fields with different character-encoding would not be displayed correctly.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
 - We fixed an issue with where JabRef would throw an error when using MathSciNet search, as it was unable to parse the fetched JSON coreectly. [10996](https://github.com/JabRef/jabref/issues/10996)
+- We fixed a bug in Springer Web Search where the names of authors would not be displayed correctly.
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -64,7 +64,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
      */
     public static BibEntry parseSpringerJSONtoBibtex(JSONObject springerJsonEntry) {
         // Fields that are directly accessible at the top level Json object
-        Field[] singleFieldStrings = {StandardField.ISSN, StandardField.VOLUME, StandardField.ABSTRACT, StandardField.DOI, StandardField.TITLE, StandardField.NUMBER,
+        Field[] singleFieldStrings = {StandardField.ISSN, StandardField.VOLUME, StandardField.DOI, StandardField.NUMBER,
                 StandardField.PUBLISHER};
 
         BibEntry entry = new BibEntry();
@@ -86,14 +86,10 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
         // Authors
         if (springerJsonEntry.has("creators")) {
             JSONArray authors = springerJsonEntry.getJSONArray("creators");
-            List<String> authorList = new ArrayList<>();
-            for (int i = 0; i < authors.length(); i++) {
-                if (authors.getJSONObject(i).has("creator")) {
-                    authorList.add(fixStringEncoding(authors.getJSONObject(i).getString("creator")));
-                } else {
-                    LOGGER.info("Empty author name.");
-                }
-            }
+            List<String> authorList = authors.toList().stream()
+                                             .filter(author -> ((JSONObject) author).has("creator"))
+                                             .map(author -> fixStringEncoding(((JSONObject) author).getString("creator")))
+                                             .collect(Collectors.toList());
             entry.setField(StandardField.AUTHOR, String.join(" and ", authorList));
         } else {
             LOGGER.info("No author found.");
@@ -109,6 +105,21 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
             }
         }
 
+        // Title
+        if (springerJsonEntry.has("title")) {
+            entry.setField(StandardField.TITLE, fixStringEncoding(springerJsonEntry.getString("title")));
+        }
+
+        // Abstract
+        if (springerJsonEntry.has("abstract")) {
+            String abstractText = fixStringEncoding(springerJsonEntry.getString("abstract"));
+            // Clean up abstract (often starting with Abstract)
+            if (abstractText.startsWith("Abstract")) {
+                abstractText = abstractText.substring(8);
+            }
+            entry.setField(StandardField.ABSTRACT, abstractText);
+        }
+
         // Page numbers
         if (springerJsonEntry.has("startingPage") && !springerJsonEntry.getString("startingPage").isEmpty()) {
             if (springerJsonEntry.has("endingPage") && !springerJsonEntry.getString("endingPage").isEmpty()) {
@@ -121,7 +132,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
 
         // Journal
         if (springerJsonEntry.has("publicationName")) {
-            entry.setField(nametype, springerJsonEntry.getString("publicationName"));
+            entry.setField(nametype, fixStringEncoding(springerJsonEntry.getString("publicationName")));
         }
 
         // Online file
@@ -152,13 +163,6 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
             Optional<Month> month = Month.getMonthByNumber(Integer.parseInt(dateparts[1]));
             month.ifPresent(entry::setMonth);
         }
-
-        // Clean up abstract (often starting with Abstract)
-        entry.getField(StandardField.ABSTRACT).ifPresent(abstractContents -> {
-            if (abstractContents.startsWith("Abstract")) {
-                entry.setField(StandardField.ABSTRACT, abstractContents.substring(8));
-            }
-        });
 
         return entry;
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -5,6 +5,8 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +89,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
             List<String> authorList = new ArrayList<>();
             for (int i = 0; i < authors.length(); i++) {
                 if (authors.getJSONObject(i).has("creator")) {
-                    authorList.add(authors.getJSONObject(i).getString("creator"));
+                    authorList.add(fixStringEncoding(authors.getJSONObject(i).getString("creator")));
                 } else {
                     LOGGER.info("Empty author name.");
                 }
@@ -159,6 +161,10 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
         });
 
         return entry;
+    }
+
+    private static String fixStringEncoding(String value) {
+        return new String(value.getBytes(Charset.forName("windows-1252")), StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
@@ -209,6 +209,27 @@ class SpringerFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSear
                           .map(Optional::get).forEach(authorField -> assertTrue(authorField.contains("Redmiles")));
     }
 
+    @Test
+    void searchByQueryFindsCorrectlyEncoded() throws Exception {
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Carvalho, Érica C. R. and Carvalho, José Pedro G. and Bernardino, Heder S. and Lemonge, Afonso C. C. and Hallak, Patrícia H. and Vargas, Dênis E. C.")
+                .withField(StandardField.DATE, "2024-04-01")
+                .withField(StandardField.DOI, "10.1016/j.engappai.2023.105678")
+                .withField(StandardField.FILE, ":https\\://linkinghub.elsevier.com/retrieve/pii/S0952197623001240:PDF")
+                .withField(StandardField.ISSN, "0952-1976")
+                .withField(StandardField.JOURNAL, "Engineering Applications of Artificial Intelligence")
+                .withField(StandardField.MONTH, "#apr#")
+                .withField(StandardField.PAGES, "105678")
+                .withField(StandardField.PUBLISHER, "Elsevier BV")
+                .withField(StandardField.TITLE, "Solving multi-objective truss structural optimization problems considering natural frequencies of vibration and automatic member grouping")
+                .withField(StandardField.VOLUME, "117")
+                .withField(StandardField.YEAR, "2024")
+                .withField(StandardField.ABSTRACT, "Designing truss structures considering multiple objectives can be a challenging task, mainly when the objectives are conflicting, such as minimizing weight and maximizing structural frequency. Additionally, when automatic member grouping is considered, the optimization process becomes even more complex. This paper presents an approach to solve multi-objective truss structural optimization problems considering natural frequencies and automatic member grouping. The Jaya algorithm is applied to solve this problem, and the results are compared with those found by the Non-dominated Sorting Genetic Algorithm II (NSGA-II). Computational experiments are carried out using four benchmark problems. The results show that the Jaya algorithm is competitive when compared to the NSGA-II.");
+
+        List<BibEntry> fetchedEntries = fetcher.performSearch("Solving multi-objective truss structural optimization problems considering natural frequencies of vibration and automatic member grouping");
+        assertEquals(List.of(expected), fetchedEntries);
+    }
+
     @Override
     public SearchBasedFetcher getFetcher() {
         return fetcher;

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
@@ -214,17 +214,18 @@ class SpringerFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSear
         BibEntry expected = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Carvalho, Érica C. R. and Carvalho, José Pedro G. and Bernardino, Heder S. and Lemonge, Afonso C. C. and Hallak, Patrícia H. and Vargas, Dênis E. C.")
                 .withField(StandardField.DATE, "2024-04-01")
-                .withField(StandardField.DOI, "10.1016/j.engappai.2023.105678")
-                .withField(StandardField.FILE, ":https\\://linkinghub.elsevier.com/retrieve/pii/S0952197623001240:PDF")
-                .withField(StandardField.ISSN, "0952-1976")
-                .withField(StandardField.JOURNAL, "Engineering Applications of Artificial Intelligence")
+                .withField(StandardField.DOI, "10.1007/s12065-022-00804-0")
+                .withField(StandardField.FILE, ":http\\://link.springer.com/openurl/pdf?id=doi\\:10.1007/s12065-022-00804-0:PDF")
+                .withField(StandardField.ISSN, "1864-5909")
+                .withField(StandardField.JOURNAL, "Evolutionary Intelligence")
                 .withField(StandardField.MONTH, "#apr#")
-                .withField(StandardField.PAGES, "105678")
-                .withField(StandardField.PUBLISHER, "Elsevier BV")
+                .withField(StandardField.PAGES, "653--678")
+                .withField(StandardField.NUMBER, "2")
+                .withField(StandardField.PUBLISHER, "Springer")
                 .withField(StandardField.TITLE, "Solving multi-objective truss structural optimization problems considering natural frequencies of vibration and automatic member grouping")
-                .withField(StandardField.VOLUME, "117")
+                .withField(StandardField.VOLUME, "17")
                 .withField(StandardField.YEAR, "2024")
-                .withField(StandardField.ABSTRACT, "Designing truss structures considering multiple objectives can be a challenging task, mainly when the objectives are conflicting, such as minimizing weight and maximizing structural frequency. Additionally, when automatic member grouping is considered, the optimization process becomes even more complex. This paper presents an approach to solve multi-objective truss structural optimization problems considering natural frequencies and automatic member grouping. The Jaya algorithm is applied to solve this problem, and the results are compared with those found by the Non-dominated Sorting Genetic Algorithm II (NSGA-II). Computational experiments are carried out using four benchmark problems. The results show that the Jaya algorithm is competitive when compared to the NSGA-II.");
+                .withField(StandardField.ABSTRACT, "Minimizing the mass of a structure and maximizing its first natural frequency of vibration are conflicting objectives of real interest in structural design. To avoid problems with resonance, which can lead to their collapse, structures can be designed by making the first natural frequency of vibration high. Furthermore, it is crucial to stay away from excitation frequencies. Here we formulate and solve multi-objective structural optimization problems of trusses with these conflicting objectives. This type of problem is uncommon in the literature, since the natural frequencies of vibration are generally set as constraints rather than as objective functions. The generalized differential evolution 3 (GDE3), the nondominated sorting genetic algorithm II (NSGA-II), decision space-based niching (DN-NSGA-II), the competitive mechanism-based multi-objective particle swarm optimizer (CMOPSO), and the MOPSO with multiple search strategies (MMOPSO) are the algorithms used in this paper. Additionally, cardinality constraints are used to manage the difficulty of discovering the best member grouping, which is very effective in addressing the problems analyzed in this paper. The experiments refer to the 10-, 25-, 72-, and 200-bar trusses. Each involves two analyses, taking into account the performance indicators and the use of a multi tournament decision (MTD) method to extract the desired solutions. Furthermore, the design variables of each extracted solution, including its optimized topology, are provided.");
 
         List<BibEntry> fetchedEntries = fetcher.performSearch("Solving multi-objective truss structural optimization problems considering natural frequencies of vibration and automatic member grouping");
         assertEquals(List.of(expected), fetchedEntries);


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
It was observed that while using Springer Web Search, the fetcher wasn't parsing the "authors" sometimes in their correct encoding format. This was especially true in case of authors whose names contained accented characters.

For instance, if we consider this entry:
![Screenshot 2024-03-22 100003](https://github.com/JabRef/jabref/assets/74734844/1d27485a-b59c-4fc7-bc01-fa4ded5ed057)

Which, on importing and expansion, became:
![Screenshot 2024-03-21 093748](https://github.com/JabRef/jabref/assets/74734844/cc998ecc-d95b-4aec-be52-957e6c3decf8)
(For purposes of replication, you can search for "multi-objective truss" to obtain this exact result).

These were the expected author names:
![Screenshot 2024-03-21 093811](https://github.com/JabRef/jabref/assets/74734844/ba8b3d4f-5ac4-4685-8bd4-ff31effdcf6b)

To fix this, the first character-set conversion I tried was from the ```ISO-8859-1``` character set to ```UTF-8```. However, this seemed to partially fix the problem:
![Screenshot 2024-03-22 102332](https://github.com/JabRef/jabref/assets/74734844/7bcb7042-e267-4665-97f7-d894c3ca51b5)

Realizing it needed a more universal character-set to accommodate and convert, I finally went with ```"windows-1252"``` character set, which is a superset of ISO-8859-1 and includes additional characters. This finally fixed the problem completely:
![Screenshot 2024-03-22 181302](https://github.com/JabRef/jabref/assets/74734844/79c889b6-3854-470e-a58d-3fab7d193698)

![Screenshot 2024-03-22 181515](https://github.com/JabRef/jabref/assets/74734844/0faa9822-82c8-4545-8b67-77f2dd2a50af)

UPDATE: Turns out the issue is not limited to authors, but fields like title, abstract, etc. too. Will be generalizing the pull request.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
