### PR TITLE
Change error dialog string

### DIFF
--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,7 +100,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set or does not exist. Please save the library."));
+            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set or does not exist.\nPlease save your library and check the preferences."));
             return;
         }
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,7 +100,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("Please save the library."));
+            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set. Please save the library."));
             return;
         }
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,7 +100,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set. Please save the library."));
+            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set or does not exist. Please save the library."));
             return;
         }
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,7 +100,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory is not set or does not exist!"));
+            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("Please save the library."));
             return;
         }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2638,4 +2638,4 @@ Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
 
-File\ directory\ needs\ to\ be\ set.\ Please\ save\ the\ library.=File directory needs to be set. Please save the library.
+File\ directory\ needs\ to\ be\ set\ or\ does\ not\ exist.\ Please\ save\ the\ library.=File directory needs to be set or does not exist. Please save the library.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2638,4 +2638,4 @@ Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
 
-Please\ save\ the\ library.=Please save the library.
+File\ directory\ needs\ to\ be\ set.\ Please\ save\ the\ library.=File directory needs to be set. Please save the library.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2637,3 +2637,5 @@ Source\ URL=Source URL
 Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
+
+Please\ save\ the\ library.=Please save the library.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2638,4 +2638,4 @@ Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
 
-File\ directory\ needs\ to\ be\ set\ or\ does\ not\ exist.\ Please\ save\ the\ library.=File directory needs to be set or does not exist. Please save the library.
+File\ directory\ needs\ to\ be\ set\ or\ does\ not\ exist.\nPlease\ save\ your\ library\ and\ check\ the\ preferences.=File directory needs to be set or does not exist.\nPlease save your library and check the preferences.


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
This addresses #11075 .

The old error dialog:
![Screenshot 2024-03-22 102145](https://github.com/JabRef/jabref/assets/74734844/f85dc628-23b2-418c-9033-1986be271bdb)

Has been updated to:
![image](https://github.com/JabRef/jabref/assets/74734844/14507bbe-a55d-4cbb-b500-e128143a8661)

Edit: On review, it has been further changed to:
![image](https://github.com/JabRef/jabref/assets/74734844/f3fc63f0-7dea-4f98-b89d-4716bfda7ca5)

The relevant localization string has also been added to ```JabRef_en.properties```.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
