### PR TITLE
Fix DOI Url parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
 - Fixed an issue on Windows where TeXworks path was not resolved if it was installed with MiKTeX. [#10977](https://github.com/JabRef/jabref/issues/10977)
 - We fixed an issue with where JabRef would throw an error when using MathSciNet search, as it was unable to parse the fetched JSON coreectly. [10996](https://github.com/JabRef/jabref/issues/10996)
+- We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 
 ### Removed
 

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -47,7 +47,7 @@ public class DOI implements Identifier {
             + "10"                              // directory indicator
             + "(?:\\.[0-9]+)+"                  // registrant codes
             + "[/:]"                            // divider
-            + "(?:[^\\s,;]+[^,;(\\.\\s)])"      // suffix alphanumeric without " "/","/";" and not ending on "."/","/";"
+            + "(?:[^\\s,]+[^,;(\\.\\s)])"       // suffix alphanumeric without " "/"," and not ending on "."/","/";"
             + ")";                              // end group \1
 
     // Regex (Short DOI)

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -200,7 +200,7 @@ public class DOITest {
                 Arguments.of("10.1007/s10549-018-4743-9",
                         DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9, ").get().getDOI()),
                 Arguments.of("10.1007/s10549-018-4743-9",
-                        DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9;something else").get().getDOI()),
+                        DOI.findInText("Breast Cancer Res Treat. 2018 July ; 170(1): 77–87. doi:10.1007/s10549-018-4743-9; something else").get().getDOI()),
                 Arguments.of("10.1007/s10549-018-4743-9.1234",
                         DOI.findInText("bla doi:10.1007/s10549-018-4743-9.1234 with . in doi").get().getDOI()),
 

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -319,7 +319,7 @@ public class DOITest {
 
     @Test
     public void findDoiWithSpecialCharactersInText() {
-        assertEquals(Optional.of(new DOI("10.1175/1520-0493(2002)130<1913:EDAWPO>2.0.CO;2")),
+        assertEquals(Optional.of(new DOI("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2")),
                 DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2"));
     }
 }

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -316,4 +316,10 @@ public class DOITest {
     public void rejectNullDoiParameter() {
         assertThrows(NullPointerException.class, () -> new DOI(null));
     }
+
+    @Test
+    public void findDoiWithSpecialCharactersInText() {
+        assertEquals(Optional.of(new DOI("10.1175/1520-0493(2002)130<1913:EDAWPO>2.0.CO;2")),
+                DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2"));
+    }
 }


### PR DESCRIPTION
This pull request closes #10648 
## The Issue
On attempting to use JabRef's "Import by ID" feature as described in the linked issue, while importing using DOI URLs or DOI numbers containing some special characters, such as [https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2](https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2), the following error was thrown:

![image](https://github.com/JabRef/jabref/assets/74734844/11cda8fd-6f72-4cde-a51d-8d261b7807ed)
as if, the DOI link itself was an invalid one. However, the link was perfectly fine.

## The bug
The bug was extremely subtle and tough to trace. On careful inspection it was detected that when the ```performSearchById(identifier)``` was being called somewhere along the flow, line 23 was causing the variable ```doi``` to be assigned to ```https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO```. That is, somehow the trailing "```;2```" was being truncated from the identifier variable (which held the correct link) and assigned to ```doi```. This resulted in an invalid DOI link, which was causing the HTTP status ```code 404``` to be thrown, resulting in an internal ```FetcherClientException```.
https://github.com/JabRef/jabref/blob/8d082798dbe8da0505dc86b5dea90792684b9a68/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java#L22-L23
Then, on investigating the underlying ```findInText(identifier)``` function in the ```DOI``` class, the following snippet was analyzed:
https://github.com/JabRef/jabref/blob/369b9a7b00cd9332fee7f1cd222bae7dc4db6c00/src/main/java/org/jabref/model/entry/identifier/DOI.java#L202-L222
It turns out that our input ```identifier = https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2``` was being matched (partially) with ```FIND_DOI_PATT```, which in turn contained a section that contained ```FIND_DOI_EXP```, which had the following structure:
https://github.com/JabRef/jabref/blob/369b9a7b00cd9332fee7f1cd222bae7dc4db6c00/src/main/java/org/jabref/model/entry/identifier/DOI.java#L43-L51
In line 50, we can see that the pattern forbade ```;``` to be in any part of the suffix, so everything before that in our example was being matched. Then, when the ```DOI(new DOI(matcher.group(1));``` constructor (line 208 as seen in the ```DOI.java``` snippet linked above) was being called due to the match, it was identifying the partially matched part (```https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO```) to be a valid DOI URL, and ```result``` was being assigned that. Although a partial match  in the second case was triggering the second ```if``` statement as well, the resultant matched part was ```https://doi.org/10.1175/1520-0493(2002)130```, which was not being identified as a valid DOI URL by the ```DOI(matcher.group(1))``` constructor call, and thus not overwriting ```result```. Similarly third ```if``` statement was also immaterial here due to a mismatch or a partial match resulting in an invalid DOI URL.
So, the final value of ```result``` was ```https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO```, which was an invalid DOI mistaken to be a valid one.

## The fix
The fix was relatively simpler once the investigation was done. We just had to remove the ```;``` from the forbidden characters in the expected regex structure of ```FIND_DOI_EXP```, so that our link would fully match its structure and thus the variable ```result``` would contain the correct DOI URL, without the trailing "```;2```" being truncated. ```FIND_DOI_EXP``` **had only one usage** (as per IntelliJ), **so it could be safely modified**.
A test has also been added in ```DOITest.java```.
## Result
![image](https://github.com/JabRef/jabref/assets/74734844/9b25683b-0e95-4c92-8053-15aab77a4a73)
The article was successfully retrieved using Import by ID.
### Mandatory checks



- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
