### PR TITLE
Fix html content handling when fetching IEEE papers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Clicking on the crossref and related tags in the entry editor jumps to the linked entry. [#5484](https://github.com/JabRef/jabref/issues/5484) [#9369](https://github.com/JabRef/jabref/issues/9369)
 - We fixed an issue where JabRef could not parse absolute file paths from Zotero exports. [#10959](https://github.com/JabRef/jabref/issues/10959)
 - We fixed an issue where an exception occured when toggling between "Live" or "Locked" in the internal Document Viewer. [#10935](https://github.com/JabRef/jabref/issues/10935)
+- When fetching article information fom IEEE Xplore, the em dash is now converted correctly. [koppor#286](https://github.com/koppor/jabref/issues/286)
 - Fixed an issue on Windows where the browser extension reported failure to send an entry to JabRef even though it was sent properly. [JabRef-Browser-Extension#493](https://github.com/JabRef/JabRef-Browser-Extension/issues/493)
 - Fixed an issue on Windows where TeXworks path was not resolved if it was installed with MiKTeX. [#10977](https://github.com/JabRef/jabref/issues/10977)
 - We fixed an issue with where JabRef would throw an error when using MathSciNet search, as it was unable to parse the fetched JSON coreectly. [10996](https://github.com/JabRef/jabref/issues/10996)

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -70,8 +70,8 @@ public class HtmlToLatexFormatter extends Formatter implements LayoutFormatter {
         while (m.find()) {
             int num = Integer.decode(m.group(1).replace("x", "#") + m.group(3));
             if (HTMLUnicodeConversionMaps.NUMERICAL_LATEX_CONVERSION_MAP.containsKey(num)) {
-                result = result.replace("&#" + m.group(1) + m.group(2) + m.group(3) + ";",
-                        HTMLUnicodeConversionMaps.NUMERICAL_LATEX_CONVERSION_MAP.get(num));
+                result = result.replaceAll("\\\\?&#" + m.group(1) + m.group(2) + m.group(3) + ";",
+                        Matcher.quoteReplacement(HTMLUnicodeConversionMaps.NUMERICAL_LATEX_CONVERSION_MAP.get(num)));
             }
         }
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.cleanup.FieldFormatterCleanup;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
+import org.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedFetcher;
@@ -177,6 +178,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
     private void doPostCleanup(BibEntry entry) {
         new FieldFormatterCleanup(StandardField.PAGES, new NormalizePagesFormatter()).cleanup(entry);
         new FieldFormatterCleanup(StandardField.URL, new ClearFormatter()).cleanup(entry);
+        new FieldFormatterCleanup(StandardField.TITLE, new HtmlToLatexFormatter()).cleanup(entry);
     }
 
     private void updateCrossrefAPIRate(URLConnection existingConnection) {

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
@@ -23,6 +23,11 @@ public class HtmlToLatexFormatterTest {
     }
 
     @Test
+    public void formatIeeeHtml() {
+        assertEquals("Towards situation-aware adaptive workflows: SitOPT --- A general purpose situation-aware workflow management system", formatter.format("Towards situation-aware adaptive workflows: SitOPT &amp;#x2014; A general purpose situation-aware workflow management system"));
+    }
+
+    @Test
     public void formatMultipleHtmlCharacters() {
         assertEquals("{{\\aa}}{\\\"{a}}{\\\"{o}}", formatter.format("&aring;&auml;&ouml;"));
     }
@@ -38,7 +43,7 @@ public class HtmlToLatexFormatterTest {
     }
 
     @Test
-    public void hTML() {
+    public void html() {
         assertEquals("{\\\"{a}}", formatter.format("&auml;"));
         assertEquals("{\\\"{a}}", formatter.format("&#228;"));
         assertEquals("{\\\"{a}}", formatter.format("&#xe4;"));
@@ -46,12 +51,12 @@ public class HtmlToLatexFormatterTest {
     }
 
     @Test
-    public void hTMLRemoveTags() {
+    public void htmlRemoveTags() {
         assertEquals("aaa", formatter.format("<b>aaa</b>"));
     }
 
     @Test
-    public void hTMLCombiningAccents() {
+    public void htmlCombiningAccents() {
         assertEquals("{\\\"{a}}", formatter.format("a&#776;"));
         assertEquals("{\\\"{a}}", formatter.format("a&#x308;"));
         assertEquals("{\\\"{a}}b", formatter.format("a&#776;b"));


### PR DESCRIPTION
- Fixes https://github.com/koppor/jabref/issues/286
- Closes https://github.com/JabRef/jabref/pull/11078

While commenting on PR https://github.com/JabRef/jabref/pull/11078, I learned that we could simply using our `HtmlToLatexFormatter`. I needed to teach it to understand `\` in front, but it worked well.

Thanks to @InAnYan who found out where to put the cleanup. Thus, I added him to `Co-authored-by`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
