### PR TITLE
Add text wrapping to the import dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Importer/Exporter for CFF format now supports JabRef `cites` and `related` relationships, as well as all fields from the CFF specification. [#10993](https://github.com/JabRef/jabref/issues/10993)
 - The XMP-Exporter no longer writes the content of the `file`-field. [#11083](https://github.com/JabRef/jabref/pull/11083)
 - We added notes, checks and warnings for the case of selection of non-empty directories while starting a new Systematic Literature Review. [#600](https://github.com/koppor/jabref/issues/600)
+- We added text wrapping to the import dialog (web search results) to prevent horizontal scrolling. [#10931](https://github.com/JabRef/jabref/issues/10931)
 
 ### Fixed
 
@@ -84,6 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue with where JabRef would throw an error when using MathSciNet search, as it was unable to parse the fetched JSON coreectly. [10996](https://github.com/JabRef/jabref/issues/10996)
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
+- We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Importer/Exporter for CFF format now supports JabRef `cites` and `related` relationships, as well as all fields from the CFF specification. [#10993](https://github.com/JabRef/jabref/issues/10993)
 - The XMP-Exporter no longer writes the content of the `file`-field. [#11083](https://github.com/JabRef/jabref/pull/11083)
 - We added notes, checks and warnings for the case of selection of non-empty directories while starting a new Systematic Literature Review. [#600](https://github.com/koppor/jabref/issues/600)
-- We added text wrapping to the import dialog (web search results) to prevent horizontal scrolling. [#10931](https://github.com/JabRef/jabref/issues/10931)
+- Text in the import dialog (web search results) will now be wrapped to prevent horizontal scrolling. [#10931](https://github.com/JabRef/jabref/issues/10931)
 
 ### Fixed
 

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,7 @@ dependencies {
         exclude group: 'org.apache.logging.log4j'
     }
 
-    implementation 'org.controlsfx:controlsfx:11.2.0'
+    implementation 'org.controlsfx:controlsfx:11.2.1'
 
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.konghq:unirest-java:3.14.5'

--- a/external-libraries.md
+++ b/external-libraries.md
@@ -782,7 +782,7 @@ org.apache.pdfbox:xmpbox:3.0.1
 org.bouncycastle:bcprov-jdk18on:1.77
 org.checkerframework:checker-qual:3.37.0
 org.codehaus.woodstox:stax2-api:4.2
-org.controlsfx:controlsfx:11.2.0
+org.controlsfx:controlsfx:11.2.1
 org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r
 org.fxmisc.flowless:flowless:0.7.2
 org.fxmisc.richtext:richtextfx:0.11.2

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.css
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.css
@@ -10,11 +10,3 @@
 .entry-container {
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
-
-.list-cell:default {
-    -fx-padding: 0.5em 0.1em 0.5em 0em;
-}
-
-.list-cell:selected {
-    -fx-background-color: derive(-jr-selected, 60%);
-}

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.css
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.css
@@ -10,11 +10,3 @@
 .entry-container {
     -fx-padding: 0.5em 0em 0.5em 0em;
 }
-
-.list-cell:default {
-    -fx-padding: 0.5em 0.1em 0.5em 0em;
-}
-
-.list-cell:selected {
-    -fx-background-color: derive(-jr-selected, 60%);
-}

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.css
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesDialog.css
@@ -8,18 +8,13 @@
 }
 
 .entry-container {
-    /*-fx-padding: 0.5em 0em 0.5em 0em;*/
+    -fx-padding: 0.5em 0em 0.5em 0em;
 }
 
-.list-cell .summary > Text {
-    -fx-padding: 0.5em 0 1em 0.5em;
-    -fx-fill: -js-summary-text-color;
+.list-cell:default {
+    -fx-padding: 0.5em 0.1em 0.5em 0em;
 }
 
-.list-cell:entry-selected {
-    -fx-background-color: derive(-jr-selected, 35%);
-}
-
-.list-cell:entry-selected .summary > Text {
-    -fx-fill: js-summary-text-color-selected;
+.list-cell:selected {
+    -fx-background-color: derive(-jr-selected, 60%);
 }


### PR DESCRIPTION
- Fixes #10931.

	![image](https://github.com/JabRef/jabref/assets/52158423/5522bc30-3b5f-4a39-b5a8-4268de00bdd9)
- Fixes #11081. This was a bug in controlsfx, which was fixed in https://github.com/controlsfx/controlsfx/pull/1541. Just updated to version 11.2.1.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
