### PR TITLE
Remove warnings shown when importing search entries in unsaved libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
 - We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
+- We fixed a bug where the "Directory not set" warning would come up multiple times when importing multiple entries without saving library, and would not come up at all for some fetchers if there was no pdf associated. [#10075](https://github.com/JabRef/jabref/issues/11075)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
 - We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
-- When a new library is unsaved, there is now a warning when fetching PDFs. [#11075](https://github.com/JabRef/jabref/issues/11075)
+- When a new library is unsaved, there is now an improved warning when fetching entries. [#11075](https://github.com/JabRef/jabref/issues/11075)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
 - We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
-- We fixed a bug where the "Directory not set" warning would come up multiple times when importing multiple entries without saving library, and would not come up at all for some fetchers if there was no pdf associated. [#10075](https://github.com/JabRef/jabref/issues/11075)
+- We fixed a bug where the "Directory not set" warning would come up multiple times when importing multiple entries without saving library, and would not come up at all for some fetchers if there was no pdf associated. [#11075](https://github.com/JabRef/jabref/issues/11075)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
 - We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
-- We fixed a bug where the "Directory not set" warning would come up multiple times when importing multiple entries without saving library, and would not come up at all for some fetchers if there was no pdf associated. [#11075](https://github.com/JabRef/jabref/issues/11075)
+- When a new library is unsaved, there is now a warning when fetching PDFs. [#11075](https://github.com/JabRef/jabref/issues/11075)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Import by ID" function would throw an error when a DOI that contains URL-encoded characters was entered. [#10648](https://github.com/JabRef/jabref/issues/10648)
 - We fixed an issue with handling of an "overflow" of authors at `[authIniN]`. [#11087](https://github.com/JabRef/jabref/issues/11087)
 - We fixed an issue where an exception occurred when selecting entries in the web search results. [#11081](https://github.com/JabRef/jabref/issues/11081)
-- When a new library is unsaved, there is now an improved warning when fetching entries. [#11075](https://github.com/JabRef/jabref/issues/11075)
+- When a new library is unsaved, there is now no warning when fetching entries with PDFs. [#11075](https://github.com/JabRef/jabref/issues/11075)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.importer;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -140,6 +141,11 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean shouldDownloadFiles) {
         // Remember the selection in the dialog
         preferences.getFilePreferences().setDownloadLinkedFiles(shouldDownloadFiles);
+
+        Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(preferences.getFilePreferences());
+        if (targetDirectory.isEmpty()) {
+            dialogService.showErrorDialogAndWait(Localization.lang("Import entries"), Localization.lang("File directory needs to be set or does not exist.\nPlease save your library and check the preferences."));
+        }
 
         new DatabaseMerger(preferences.getBibEntryPreferences().getKeywordSeparator()).mergeStrings(
                 databaseContext.getDatabase(),

--- a/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -2,7 +2,6 @@ package org.jabref.gui.importer;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -141,11 +140,6 @@ public class ImportEntriesViewModel extends AbstractViewModel {
     public void importEntries(List<BibEntry> entriesToImport, boolean shouldDownloadFiles) {
         // Remember the selection in the dialog
         preferences.getFilePreferences().setDownloadLinkedFiles(shouldDownloadFiles);
-
-        Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(preferences.getFilePreferences());
-        if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Import entries"), Localization.lang("File directory needs to be set or does not exist.\nPlease save your library and check the preferences."));
-        }
 
         new DatabaseMerger(preferences.getBibEntryPreferences().getKeywordSeparator()).mergeStrings(
                 databaseContext.getDatabase(),

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,6 +100,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
+            LOGGER.warn("File directory not available while downloading {}. Storing as URL in file field.", downloadUrl);
             return;
         }
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -100,7 +100,6 @@ public class DownloadLinkedFileAction extends SimpleCommand {
 
         Optional<Path> targetDirectory = databaseContext.getFirstExistingFileDir(filePreferences);
         if (targetDirectory.isEmpty()) {
-            dialogService.showErrorDialogAndWait(Localization.lang("Download file"), Localization.lang("File directory needs to be set or does not exist.\nPlease save your library and check the preferences."));
             return;
         }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2638,8 +2638,6 @@ Redownload\ file=Redownload file
 Redownload\ missing\ files=Redownload missing files
 Redownload\ missing\ files\ for\ current\ library?=Redownload missing files for current library?
 
-File\ directory\ needs\ to\ be\ set\ or\ does\ not\ exist.\nPlease\ save\ your\ library\ and\ check\ the\ preferences.=File directory needs to be set or does not exist.\nPlease save your library and check the preferences.
-
 Note\:\ The\ study\ directory\ should\ be\ empty.=Note: The study directory should be empty.
 Warning\:\ The\ selected\ directory\ is\ not\ empty.=Warning: The selected directory is not empty.
 Warning\:\ Failed\ to\ check\ if\ the\ directory\ is\ empty.=Warning: Failed to check if the directory is empty.


### PR DESCRIPTION
Closes #11075.

This is an attempt to make JabRef's handling of imports with an unsaved library more newcomer-friendly.
## Description
Earlier, if there was an attempt to import entries via web search, with the source being Springer, Arxiv, etc. (any source that allows associated pdfs to be downloaded), we would get the following dialog if the library was not saved:

![316248837-f3fc63f0-7dea-4f98-b89d-4716bfda7ca5](https://github.com/JabRef/jabref/assets/74734844/8e4f7604-5838-46d8-9981-0a203378a3e3)

The problem was that: 
**(1)** This dialog was not good UX (as pointed out by @koppor).
**(2)** This dialog would pop up multiple times - for example, if the user had selected 25 entries and clicked on import (without having saved the library), the dialog would come up and needed to be closed 25 times before returning to functionality. This was very inconvenient, especially for people who are new to JabRef.


https://github.com/JabRef/jabref/assets/74734844/998b3d02-3a46-43a6-bca9-42fbc7e07213




### Changes

- The warning is no longer shown.


https://github.com/JabRef/jabref/assets/74734844/790bc4f7-93da-4753-acff-ba1ccf5953f2


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- ~[] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
