### PR TITLE
improve error handling for bibdesk files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The XMP-Exporter no longer writes the content of the `file`-field. [#11083](https://github.com/JabRef/jabref/pull/11083)
 - We added notes, checks and warnings for the case of selection of non-empty directories while starting a new Systematic Literature Review. [#600](https://github.com/koppor/jabref/issues/600)
 - Text in the import dialog (web search results) will now be wrapped to prevent horizontal scrolling. [#10931](https://github.com/JabRef/jabref/issues/10931)
+- We improved the error handling when invalid bibdesk-files are encountered [#11117](https://github.com/JabRef/jabref/issues/11117)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -758,10 +758,10 @@ public class BibtexParser implements Parser {
                             LinkedFile file = new LinkedFile("", path, "");
                             entry.addFile(file);
                         } else {
-                            LOGGER.warn("Could not parse Bibdesk file path for entry {}", entry);
+                            LOGGER.error("Could not find attribute 'relativePath' for entry {} in decoded BibDesk field bdsk-file...) ", entry);
                         }
                     } catch (Exception e) {
-                        throw new IOException("Could not parse Bibdesk files content (bdsk-file..) for entry " + entry, e);
+                        LOGGER.error("Could not parse Bibdesk files content (field: bdsk-file...) for entry {}", entry, e);
                     }
                 } else {
                     entry.setField(field, content);

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -758,7 +758,7 @@ public class BibtexParser implements Parser {
                             LinkedFile file = new LinkedFile("", path, "");
                             entry.addFile(file);
                         } else {
-                            LOGGER.warn("Could not parse Bibdesk file for entry {}", entry);
+                            LOGGER.warn("Could not parse Bibdesk file path for entry {}", entry);
                         }
                     } catch (Exception e) {
                         throw new IOException("Could not parse Bibdesk files content (bdsk-file..) for entry " + entry, e);

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -268,7 +268,7 @@ public class BibtexParser implements Parser {
                     importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
             if (bibDeskGroupTreeNode != null) {
                 metaData.getGroups().ifPresentOrElse(existingGroupTree -> {
-                          var existingGroups = meta.get(MetaData.GROUPSTREE);
+                            var existingGroups = meta.get(MetaData.GROUPSTREE);
                             // We only have one Group BibDeskGroup with n children
                             // instead of iterating through the whole group structure every time we just search in the metadata for the group name
                             var groupsToAdd = bibDeskGroupTreeNode.getChildren()
@@ -745,17 +745,23 @@ public class BibtexParser implements Parser {
             } else {
                 // If a BibDesk File Field is encountered
                 if (field.getName().length() > 10 && field.getName().startsWith("bdsk-file-")) {
-                    byte[] decodedBytes = Base64.getDecoder().decode(content);
                     try {
+                        byte[] decodedBytes = Base64.getDecoder().decode(content);
+
                         // Parse the base64 encoded binary plist to get the relative (to the .bib file) path
                         NSDictionary plist = (NSDictionary) BinaryPropertyListParser.parse(decodedBytes);
-                        NSString relativePath = (NSString) plist.objectForKey("relativePath");
-                        Path path = Path.of(relativePath.getContent());
 
-                        LinkedFile file = new LinkedFile("", path, "");
-                        entry.addFile(file);
+                        if (plist.containsKey("relativePath")) {
+                            NSString relativePath = (NSString) plist.objectForKey("relativePath");
+                            Path path = Path.of(relativePath.getContent());
+
+                            LinkedFile file = new LinkedFile("", path, "");
+                            entry.addFile(file);
+                        } else {
+                            LOGGER.warn("Could not parse Bibdesk file for entry {}", entry);
+                        }
                     } catch (Exception e) {
-                        throw new IOException();
+                        throw new IOException("Could not parse Bibdesk files content (bdsk-file..) for entry " + entry, e);
                     }
                 } else {
                     entry.setField(field, content);

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -376,7 +376,7 @@ public class FileUtil {
         Objects.requireNonNull(directory);
 
         if (detectBadFileName(fileName)) {
-            LOGGER.error("Invalid characters in path for file {} ", fileName);
+            LOGGER.error("Invalid characters in path for file {}", fileName);
             return Optional.empty();
         }
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -2218,4 +2218,26 @@ class BibtexParserTest {
 
         assertEquals(Collections.singletonList(expectedEntry), database.getEntries());
     }
+
+    @Test
+    void parseInvalidBibDeskFilesResultsInWarnings() throws IOException {
+        // the first entry is invalid base 64, the second entry is correct plist format but does not contain the key
+        String entries = """
+                @Article{Test2017,
+                    bdsk-file-1 = {////=},
+                }
+
+                @Article{Test2,
+                   bdsk-file-1 = {YnBsaXN0MDDUAQIDBAUGJCVYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoKgHCBMUFRYaIVUkbnVsbNMJCgsMDxJXTlMua2V5c1pOUy5vYmplY3RzViRjbGFzc6INDoACgAOiEBGABIAFgAdccmVsYXRpdmVQYXRoWWFsaWFzRGF0YV8QVi4uLy4uLy4uL1BhcGVycy9Bc2hlaW0yMDA1IFRoZSBHZW9ncmFwaHkgb2YgSW5ub3ZhdGlvbiBSZWdpb25hbCBJbm5vdmF0aW9uIFN5c3RlbXMucGRm0hcLGBlXTlMuZGF0YU8RAkoAAAAAAkoAAgAADE1hY2ludG9zaCBIRAAAAAAAAAAAAAAAAAAAAM6T/wtIKwAAACI+9B9Bc2hlaW0yMDA1IFRoZSBHZW9nciMyMjQ4QzkucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIkjJw6jvRAAAAAAAAAAAAAMAAgAACSAAAAAAAAAAAAAAAAAAAAAGUGFwZXJzABAACAAAzpPw+wAAABEACAAAw6jhNAAAAAEAEAAiPvQAIjTXACHV2wAHw2AAAgBQTWFjaW50b3NoIEhEOlVzZXJzOgBpbGlwcGVydDoARG9jdW1lbnRzOgBQYXBlcnM6AEFzaGVpbTIwMDUgVGhlIEdlb2dyIzIyNDhDOS5wZGYADgCOAEYAQQBzAGgAZQBpAG0AMgAwADAANQAgAFQAaABlACAARwBlAG8AZwByAGEAcABoAHkAIABvAGYAIABJAG4AbgBvAHYAYQB0AGkAbwBuACAAUgBlAGcAaQBvAG4AYQBsACAASQBuAG4AbwB2AGEAdABpAG8AbgAgAFMAeQBzAHQAZQBtAHMALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAGZVc2Vycy9pbGlwcGVydC9Eb2N1bWVudHMvUGFwZXJzL0FzaGVpbTIwMDUgVGhlIEdlb2dyYXBoeSBvZiBJbm5vdmF0aW9uIFJlZ2lvbmFsIElubm92YXRpb24gU3lzdGVtcy5wZGYAEwABLwAAFQACAA///wAAgAbSGxwdHlokY2xhc3NuYW1lWCRjbGFzc2VzXU5TTXV0YWJsZURhdGGjHR8gVk5TRGF0YVhOU09iamVjdNIbHCIjXE5TRGljdGlvbmFyeaIiIF8QD05TS2V5ZWRBcmNoaXZlctEmJ1Ryb290gAEACAARABoAIwAtADIANwBAAEYATQBVAGAAZwBqAGwAbgBxAHMAdQB3AIQAjgDnAOwA9ANCA0QDSQNUA10DawNvA3YDfwOEA5EDlAOmA6kDrgAAAAAAAAIBAAAAAAAAACgAAAAAAAAAAAAAAAAAAAOw},
+                },
+                """;
+        ParserResult result = parser.parse(new StringReader(entries));
+
+        BibEntry firstEntry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("Test2017");
+        BibEntry secondEntry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("Test2");
+
+        assertEquals(List.of(firstEntry, secondEntry), result.getDatabase().getEntries());
+    }
 }


### PR DESCRIPTION
Closes #11117

Improve error handling for bibdesk linked files parsing

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
