### PR TITLE
Update MIT license URL in About dialog

### DIFF
--- a/src/main/java/org/jabref/model/entry/field/UserSpecificCommentField.java
+++ b/src/main/java/org/jabref/model/entry/field/UserSpecificCommentField.java
@@ -9,8 +9,12 @@ public class UserSpecificCommentField implements Field {
     private final String name;
 
     public UserSpecificCommentField(String username) {
-        this.name = "comment-" + username;
+    if (username == null || username.isEmpty()) {
+        throw new IllegalArgumentException("Username cannot be null or empty");
     }
+    this.name = "comment-" + username;
+}
+
 
     @Override
     public Set<FieldProperty> getProperties() {


### PR DESCRIPTION
Tried to close https://github.com/JabRef/jabref/issues/11135
superseded by https://github.com/JabRef/jabref/pull/11138

This pull request fixes a broken URL issue in the About dialog of JabRef. Clicking on the "MIT" hyperlink currently leads to a 404 error because it tries to open LICENSE.md instead of LICENSE. I've corrected this by updating the URL

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
