### PR TITLE
Set git submodules ignore to dirty

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "abbrv.jabref.org"]
   path = buildres/abbrv.jabref.org
   url = https://github.com/JabRef/abbrv.jabref.org.git
-  ignore = all
+  ignore = dirty
   shallow = true
 [submodule "csl-styles"]
   path = src/main/resources/csl-styles
   url = https://github.com/citation-style-language/styles.git
-  ignore = all
+  ignore = dirty
   shallow = true
 [submodule "csl-locales"]
   path = src/main/resources/csl-locales
   url = https://github.com/citation-style-language/locales.git
-  ignore = all
+  ignore = dirty
   shallow = true


### PR DESCRIPTION
Let's see if this would work.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
