### PR TITLE
Fix LICENSE link

### DIFF
--- a/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -28,7 +28,7 @@ public class AboutDialogViewModel extends AbstractViewModel {
     private static final String DONATION_URL = "https://donations.jabref.org";
     private static final String LIBRARIES_URL = "https://github.com/JabRef/jabref/blob/main/external-libraries.md";
     private static final String GITHUB_URL = "https://github.com/JabRef/jabref";
-    private static final String LICENSE_URL = "https://github.com/JabRef/jabref/blob/main/LICENSE.md";
+    private static final String LICENSE_URL = "https://github.com/JabRef/jabref/blob/main/LICENSE";
     private static final String CONTRIBUTORS_URL = "https://github.com/JabRef/jabref/graphs/contributors";
     private static final String PRIVACY_POLICY_URL = "https://github.com/JabRef/jabref/blob/main/PRIVACY.md";
     private final String changelogUrl;


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Closes #11135 
This is a small fix to the link to JabRef's MIT license file, as pointed out in the issue. The license file is LICENSE and not LICENSE.md
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- ~[ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
- ~[ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- ~[ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
