### PR TITLE
Change "Key bindings" to "Keyboard shortcuts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We replaced "Key bindings" by "Keyboard shortcuts" in the Preferences tab related to key bindings.
+- We replaced the word "Key bindings" with "Keyboard shortcuts" in the Preferences tab. [#11153](https://github.com/JabRef/jabref/pull/11153)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We replaced "Key bindings" by "Keyboard shortcuts" in the Preferences tab related to key bindings.
+
 ### Fixed
 
 - We fixed an issue where entry type with duplicate fields prevented opening existing libraries with custom entry types [#11127](https://github.com/JabRef/jabref/issues/11127)

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -119,8 +119,7 @@ public enum StandardActions implements Action {
     CITATION_KEY_PATTERN(Localization.lang("Citation key patterns")),
     SHOW_PREFS(Localization.lang("Preferences"), IconTheme.JabRefIcons.PREFERENCES),
     MANAGE_JOURNALS(Localization.lang("Manage journal abbreviations")),
-    CUSTOMIZE_KEYBINDING(Localization.lang("Customize key bindings"), IconTheme.JabRefIcons.KEY_BINDINGS),
-
+    CUSTOMIZE_KEYBINDING(Localization.lang("Customize keyboard shortcuts"), IconTheme.JabRefIcons.KEY_BINDINGS),
     EDIT_ENTRY(Localization.lang("Open entry editor"), IconTheme.JabRefIcons.EDIT_ENTRY, KeyBinding.EDIT_ENTRY),
     SHOW_PDF_VIEWER(Localization.lang("Open document viewer"), IconTheme.JabRefIcons.PDF_FILE),
     NEXT_PREVIEW_STYLE(Localization.lang("Next preview style"), KeyBinding.NEXT_PREVIEW_LAYOUT),

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
@@ -12,7 +12,7 @@
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.keybindings.KeyBindingsTab">
 
-    <Label styleClass="titleHeader" text="%Key bindings"/>
+    <Label styleClass="titleHeader" text="%Keyboard shortcuts"/>
 
     <TreeTableView fx:id="keyBindingsTable" showRoot="false" styleClass="keybinding-table">
         <columns>

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -41,7 +41,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
 
     @Override
     public String getTabName() {
-        return Localization.lang("Key bindings");
+        return Localization.lang("Keyboard shortcuts");
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -88,13 +88,13 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
         preferences.storeKeyBindingRepository(keyBindingRepository);
 
         if (!keyBindingRepository.equals(initialKeyBindingRepository)) {
-            restartWarning.add(Localization.lang("Key bindings changed"));
+            restartWarning.add(Localization.lang("Keyboard shortcuts changed"));
         }
     }
 
     public void resetToDefault() {
-        String title = Localization.lang("Resetting all key bindings");
-        String content = Localization.lang("All key bindings will be reset to their defaults.");
+        String title = Localization.lang("Resetting all keyboard shortcuts");
+        String content = Localization.lang("All keyboard shortcuts will be reset to their defaults.");
         ButtonType resetButtonType = new ButtonType("Reset", ButtonBar.ButtonData.OK_DONE);
         dialogService.showCustomButtonDialogAndWait(Alert.AlertType.INFORMATION, title, content, resetButtonType,
                 ButtonType.CANCEL).ifPresent(response -> {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -513,6 +513,8 @@ Key\ bindings\ changed=Key bindings changed
 
 Key\ pattern=Key pattern
 
+Keyboard\ shortcuts=Keyboard shortcuts
+
 keys\ in\ library=keys in library
 
 Keyword=Keyword

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -219,7 +219,7 @@ Custom\ entry\ types\ found\ in\ file=Custom entry types found in file
 
 Customize\ entry\ types=Customize entry types
 
-Customize\ key\ bindings=Customize key bindings
+Customize\ keyboard\ shortcuts=Customize keyboard shortcuts
 
 Cut=Cut
 
@@ -507,13 +507,11 @@ Keep\ both=Keep both
 
 Keep\ subgroups=Keep subgroups
 
-Key\ bindings=Key bindings
-
-Key\ bindings\ changed=Key bindings changed
-
 Key\ pattern=Key pattern
 
 Keyboard\ shortcuts=Keyboard shortcuts
+
+Keyboard\ shortcuts\ changed=Keyboard shortcuts changed
 
 keys\ in\ library=keys in library
 
@@ -1249,13 +1247,13 @@ You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=You have to choose exac
 
 Add\ timestamp\ to\ modified\ entries\ (field\ "modificationdate")=Add timestamp to modified entries (field "modificationdate")
 Add\ timestamp\ to\ new\ entries\ (field\ "creationdate")=Add timestamp to new entries (field "creationdate")
-All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=All key bindings will be reset to their defaults.
+All\ keyboard\ shortcuts\ will\ be\ reset\ to\ their\ defaults.=All keyboard shortcuts will be reset to their defaults.
 
 Automatically\ set\ file\ links=Automatically set file links
 Finished\ automatically\ setting\ external\ links.=Finished automatically setting external links.
 Changed\ %0\ entries.=Changed %0 entries.
 
-Resetting\ all\ key\ bindings=Resetting all key bindings
+Resetting\ all\ keyboard\ shortcuts=Resetting all keyboard shortcuts
 
 Open\ folder=Open folder
 Export\ sort\ order=Export sort order


### PR DESCRIPTION
This PR updates the Preferences tab for **Key bindings**, renaming it to **Keyboard shortcuts**. It updates the tab title, the page title and the messages when changing keyboard shortcuts. This follows a request from @koppor on the Gitter channel.
This PR updates the file in `resources/l10n/JabRef_en.properties` to replace all occurrences of `key\ bindings` with `keyboard\ shortcuts`. 
 
<img width="1538" alt="Capture d’écran 2024-04-05 à 16 35 11" src="https://github.com/JabRef/jabref/assets/66010389/4b2ff7fc-523f-44b4-b27e-b0c19d0c9b8e">

### Mandatory checks
- [ ] ~Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
- [ ] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
