### PR TITLE
Revert "Set git submodules ignore to dirty (#11148)"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "abbrv.jabref.org"]
   path = buildres/abbrv.jabref.org
   url = https://github.com/JabRef/abbrv.jabref.org.git
-  ignore = dirty
+  ignore = all
   shallow = true
 [submodule "csl-styles"]
   path = src/main/resources/csl-styles
   url = https://github.com/citation-style-language/styles.git
-  ignore = dirty
+  ignore = all
   shallow = true
 [submodule "csl-locales"]
   path = src/main/resources/csl-locales
   url = https://github.com/citation-style-language/locales.git
-  ignore = dirty
+  ignore = all
   shallow = true


### PR DESCRIPTION
This reverts commit dd2268d72e30ca64ade1548413cf127f8887b97f introduced at https://github.com/JabRef/jabref/pull/11148.

I have many diffs here in submodules when switching branches.

According to https://stackoverflow.com/questions/3240881/git-can-i-suppress-listing-of-modified-content-dirty-submodule-entries-in-sta/12527608#12527608 - `all` is better than `dirty`.

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
