### PR TITLE
Update runner name

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -1,4 +1,4 @@
-name: Deployment for Arm64
+name: Deployment for macOS/ARM64
 on:
   push:
     branches:
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
           - os: macos-14
-            displayName: macOS (Arm64)
+            displayName: macOS (ARM64)
             suffix: '_arm64'
     runs-on: ${{ matrix.os }}
     outputs:


### PR DESCRIPTION
JavaFX homepage (https://jdk.java.net/javafx23/) shows

macOS / AArch64 	

I was very confused. I consulted Wikipedia. They say:

![image](https://github.com/JabRef/jabref/assets/1366654/f56e127e-9baa-45eb-995d-bb6149dd4d7d)

Thus, I use ARM64. And I prefix it with "macOS" to ensure that it is clear that it is NOT for arm32bit linux or something.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
