### PR TITLE
[WIP] Add export of com.sun.javafx.event to org.jabref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Fixed
 
 - We fixed an issue where entry type with duplicate fields prevented opening existing libraries with custom entry types [#11127](https://github.com/JabRef/jabref/issues/11127)
+- We fixed crash on opening the entry editor when auto completion is enabled. [#11188](https://github.com/JabRef/jabref/issues/11188)
 
 ### Removed
 

--- a/build.gradle
+++ b/build.gradle
@@ -393,6 +393,9 @@ compileJava {
     moduleOptions {
         // TODO: Remove access to internal api
         addExports = [
+                // Fix for https://github.com/JabRef/jabref/issues/11188
+                'javafx.base/com.sun.javafx.event' : 'org.jabref',
+
                 'javafx.controls/com.sun.javafx.scene.control' : 'org.jabref',
                 'org.controlsfx.controls/impl.org.controlsfx.skin' : 'org.jabref'
         ]


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/11188

Currently does not fix the issue (tried out locally using jPackage).

I have no clue how to continue.

It is also not about `forceMerge`, because the issue reporter says he used the release version (where our update of https://github.com/JabRef/jabref/pull/11170) is not included.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
