### PR TITLE
Fix run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -445,6 +445,8 @@ run {
         addOpens = [
                 'javafx.controls/javafx.scene.control' : 'org.jabref',
                 'javafx.controls/com.sun.javafx.scene.control' : 'org.jabref',
+                'org.controlsfx.controls/impl.org.controlsfx.skin' : 'org.jabref',
+                'org.controlsfx.controls/org.controlsfx.control.textfield' : 'org.jabref',
 
                 'javafx.controls/javafx.scene.control.skin' : 'org.controlsfx.controls',
                 'javafx.graphics/javafx.scene' : 'org.controlsfx.controls'


### PR DESCRIPTION
Follow up to https://github.com/JabRef/jabref/pull/11195

I got following error (when doing gradle run from IntelliJ):

- `java.lang.reflect.InaccessibleObjectException`:
- Unable to make private static void `org.controlsfx.control.textfield.TextFields.setupClearButtonField(javafx.scene.control.TextField,javafx.beans.property.ObjectProperty)` accessible:
- module `org.controlsfx.controls` does not "`opens org.controlsfx.control.textfield`" to module `org.jabref`

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
