### PR TITLE
Remove WARNING outputs at "run"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ application {
         //   2. "deployment.yml" (macOS part)
         //   3. "deployment-arm64.yml"
 
+        // Note that the arguments are cleared for the "run" task to avoid messages like "WARNING: Unknown module: org.jabref.merged.module specified to --add-exports"
+
         // Fix for https://github.com/JabRef/jabref/issues/11188
         '--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module',
         '--add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module',
@@ -417,6 +419,11 @@ compileJava {
 
 // Configures "application > run" task
 run {
+    doFirst {
+        // Clear the default JVM arguments, to avoid messages like "WARNING: Unknown module: org.jabref.merged.module specified to --add-exports"
+        application.applicationDefaultJvmArgs = []
+    }
+
     // TODO: Remove access to internal api
     moduleOptions {
         // On a change here, also adapt "application > applicationDefaultJvmArgs"


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/11195

When running JabRef using gradle, one gets following outputs:

```
WARNING: Unknown module: org.jabref.merged.module specified to --add-exports
WARNING: Unknown module: org.jabref.merged.module specified to --add-exports
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
```

They are caused by our new `applicationDefaultJvmArgs` entry. That entry is needed for our `jpackage` task. 

However, for `run`, they are not needed. Thus, this PR adds a "hot patch" to the `run` task to avoid that output.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
