### PR TITLE
Downgrade JavaFX to 19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ dependencyLocking {
 }
 
 javafx {
-    version = "22"
+    version = "19"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web', 'javafx.swing' ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,7 @@ dependencies {
     }
 
     implementation 'org.controlsfx:controlsfx:11.2.1'
+    implementation 'com.github.Dansoftowner:jSystemThemeDetector:3.8'
 
     implementation 'org.jsoup:jsoup:1.17.2'
     implementation 'com.konghq:unirest-java:3.14.5'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -144,6 +144,7 @@ open module org.jabref {
     requires org.antlr.antlr4.runtime;
     requires org.libreoffice.uno;
     requires de.saxsys.mvvmfx.validation;
+    requires com.jthemedetector;
     requires dd.plist;
     requires mslinks;
     requires org.yaml.snakeyaml;

--- a/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -6,22 +6,21 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.function.Consumer;
 
-import javafx.application.ColorScheme;
-import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.web.WebEngine;
 
-import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.model.util.FileUpdateListener;
 import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.WorkspacePreferences;
 
-import com.google.common.annotations.VisibleForTesting;
+import com.jthemedetecor.OsThemeDetector;
+import com.tobiasdiez.easybind.EasyBind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +48,8 @@ public class ThemeManager {
     private final StyleSheet baseStyleSheet;
     private Theme theme;
 
+    private OsThemeDetector detector;
+
     private Scene mainWindowScene;
     private final Set<WebEngine> webEngines = Collections.newSetFromMap(new WeakHashMap<>());
 
@@ -67,19 +68,25 @@ public class ThemeManager {
         addStylesheetToWatchlist(this.baseStyleSheet, this::baseCssLiveUpdate);
         baseCssLiveUpdate();
 
-        BindingsHelper.subscribeFuture(workspacePreferences.themeProperty(), theme -> updateThemeSettings());
-        BindingsHelper.subscribeFuture(workspacePreferences.themeSyncOsProperty(), theme -> updateThemeSettings());
-        BindingsHelper.subscribeFuture(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), should -> updateFontSettings());
-        BindingsHelper.subscribeFuture(workspacePreferences.mainFontSizeProperty(), size -> updateFontSettings());
-        BindingsHelper.subscribeFuture(Platform.getPreferences().colorSchemeProperty(), colorScheme -> updateThemeSettings());
-        updateThemeSettings();
+        EasyBind.subscribe(workspacePreferences.themeProperty(), theme -> updateThemeSettings());
+        EasyBind.subscribe(workspacePreferences.themeSyncOsProperty(), theme -> updateThemeSettings());
+        EasyBind.subscribe(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), should -> updateFontSettings());
+        EasyBind.subscribe(workspacePreferences.mainFontSizeProperty(), size -> updateFontSettings());
+
+        try {
+            detector = OsThemeDetector.getDetector();
+            detector.registerListener(isDark -> updateThemeSettings());
+        } catch (Exception ex) {
+            LOGGER.error("Could not initialize Theme detector!", ex);
+            workspacePreferences.setThemeSyncOs(false);
+        }
     }
 
     private void updateThemeSettings() {
         Theme newTheme = Objects.requireNonNull(workspacePreferences.getTheme());
 
-        if (workspacePreferences.themeSyncOsProperty().getValue()) {
-            if (Platform.getPreferences().getColorScheme() == ColorScheme.DARK) {
+        if (workspacePreferences.themeSyncOsProperty().getValue() && detector != null) {
+            if (detector.isDark()) {
                 newTheme = Theme.dark();
             } else {
                 newTheme = Theme.light();
@@ -102,7 +109,7 @@ public class ThemeManager {
     }
 
     private void updateFontSettings() {
-        DefaultTaskExecutor.runInJavaFXThread(() -> updateRunner.accept(() -> updateFontStyle(mainWindowScene)));
+        DefaultTaskExecutor.runInJavaFXThread(() -> updateRunner.accept(() -> getMainWindowScene().ifPresent(this::updateFontStyle)));
     }
 
     private void removeStylesheetFromWatchList(StyleSheet styleSheet) {
@@ -160,24 +167,18 @@ public class ThemeManager {
     }
 
     private void updateBaseCss() {
-        if (mainWindowScene == null) {
-            return;
-        }
+        getMainWindowScene().ifPresent(scene -> {
+            List<String> stylesheets = scene.getStylesheets();
+            if (!stylesheets.isEmpty()) {
+                stylesheets.removeFirst();
+            }
 
-        List<String> stylesheets = mainWindowScene.getStylesheets();
-        if (!stylesheets.isEmpty()) {
-            stylesheets.removeFirst();
-        }
-
-        stylesheets.addFirst(baseStyleSheet.getSceneStylesheet().toExternalForm());
+            stylesheets.addFirst(baseStyleSheet.getSceneStylesheet().toExternalForm());
+        });
     }
 
     private void updateAdditionalCss() {
-        if (mainWindowScene == null) {
-            return;
-        }
-
-        mainWindowScene.getStylesheets().setAll(List.of(
+        getMainWindowScene().ifPresent(scene -> scene.getStylesheets().setAll(List.of(
                 baseStyleSheet.getSceneStylesheet().toExternalForm(),
                 theme.getAdditionalStylesheet().map(styleSheet -> {
                          URL stylesheetUrl = styleSheet.getSceneStylesheet();
@@ -188,7 +189,7 @@ public class ThemeManager {
                          }
                      })
                      .orElse("")
-        ));
+        )));
     }
 
     /**
@@ -228,10 +229,6 @@ public class ThemeManager {
      * @param scene is the scene, the font size should be applied to
      */
     public void updateFontStyle(Scene scene) {
-        if (scene == null) {
-            return;
-        }
-
         if (workspacePreferences.shouldOverrideDefaultFontSize()) {
             scene.getRoot().setStyle("-fx-font-size: " + workspacePreferences.getMainFontSize() + "pt;");
         } else {
@@ -242,8 +239,11 @@ public class ThemeManager {
     /**
      * @return the currently active theme
      */
-    @VisibleForTesting
-    Theme getActiveTheme() {
+    public Theme getActiveTheme() {
         return this.theme;
+    }
+
+    public Optional<Scene> getMainWindowScene() {
+        return Optional.ofNullable(mainWindowScene);
     }
 }


### PR DESCRIPTION
The commit https://github.com/openjdk/jfx/commit/cc00c8d5c7a73b9d9bc7c292ad51f8af9e63ff78 introduced something in code which could be related to https://github.com/JabRef/jabref/issues/11151.

Trying JavaFX 19 (also to answer the question https://jvm-german.slack.com/archives/C4H2FQKND/p1713255531931679?thread_ts=1713251103.620169&cid=C4H2FQKND).

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
