### PR TITLE
Fix atomic outputstream closed channels exceptions (and update JavaFX)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ dependencyLocking {
 }
 
 javafx {
-    version = "22"
+    version = "22.0.1"
     modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.web', 'javafx.swing' ]
 }
 

--- a/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -166,7 +166,7 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     private void cleanup() {
         try {
-            if (temporaryFileLock != null && temporaryFileLock.isValid() ) {
+            if (temporaryFileLock != null && temporaryFileLock.isValid()) {
                 temporaryFileLock.release();
             }
         } catch (IOException exception) {

--- a/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
+++ b/src/main/java/org/jabref/logic/exporter/AtomicFileOutputStream.java
@@ -166,12 +166,11 @@ public class AtomicFileOutputStream extends FilterOutputStream {
 
     private void cleanup() {
         try {
-            if (temporaryFileLock != null) {
+            if (temporaryFileLock != null && temporaryFileLock.isValid() ) {
                 temporaryFileLock.release();
             }
         } catch (IOException exception) {
-            // Currently, we always get the exception:
-            // Unable to release lock on file C:\Users\koppor\AppData\Local\Temp\junit11976839611279549873\error-during-save.txt.tmp: java.nio.channels.ClosedChannelException
+            // In case we still get an exception
             LOGGER.debug("Unable to release lock on file {}", temporaryFile, exception);
         }
         try {


### PR DESCRIPTION
fix atomic outputstream closed channels exceptions

Release notes:
https://github.com/openjdk/jfx22u/commit/bbad35849e5d855fc84a3693c9c41e96cd555dd0

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
