### PR TITLE
Fix issue when downloading JavaFX Sources with IntelliJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jabref.build.xjc.XjcPlugin
 import org.jabref.build.xjc.XjcTask
 
@@ -319,8 +320,8 @@ dependencies {
             .configureEach {
                 attributes {
                     attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, OperatingSystem.getName()))
-                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, Architecture.getName()))
+                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, DefaultNativePlatform.getCurrentOperatingSystem().getName()))
+                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, DefaultNativePlatform.getCurrentArchitecture().getName()))
                 }
             }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 import org.gradle.internal.os.OperatingSystem
 import org.jabref.build.xjc.XjcPlugin
 import org.jabref.build.xjc.XjcTask
-import org.openjfx.gradle.JavaFXPlatform
 
 plugins {
     id 'application'
@@ -29,8 +28,6 @@ plugins {
     id 'idea'
 
     id 'org.openrewrite.rewrite' version '6.11.2'
-
-    id("com.google.osdetector") version "1.7.3"
 }
 
 // Enable following for debugging
@@ -322,8 +319,8 @@ dependencies {
             .configureEach {
                 attributes {
                     attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
-                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, JavaFXPlatform.detect(osdetector).osFamily))
-                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, JavaFXPlatform.detect(osdetector).arch))
+                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, OperatingSystem.getName()))
+                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, Architecture.getName()))
                 }
             }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 import org.jabref.build.xjc.XjcPlugin
 import org.jabref.build.xjc.XjcTask
+import org.openjfx.gradle.JavaFXPlatform
 
 plugins {
     id 'application'
@@ -28,6 +29,8 @@ plugins {
     id 'idea'
 
     id 'org.openrewrite.rewrite' version '6.11.2'
+
+    id("com.google.osdetector") version "1.7.3"
 }
 
 // Enable following for debugging
@@ -313,6 +316,16 @@ dependencies {
             select("com.google.guava:guava:0")
         }
     }
+
+    configurations
+            .matching(c -> c.name.contains("downloadSources"))
+            .configureEach {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+                    attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, JavaFXPlatform.detect(osdetector).osFamily))
+                    attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, JavaFXPlatform.detect(osdetector).arch))
+                }
+            }
 }
 
 clean {


### PR DESCRIPTION
When trying to download JavaFX sources or documentation using IntelliJ, Gradle fails this error:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ijDownloadSourcesec754862-2f9'.
> Could not resolve all files for configuration ':downloadSources_a230d098-20fe-44c1-a391-cf97fe123b54'.
   > Could not resolve org.openjfx:javafx-controls:22.0.1.
     Required by:
         project :
      > Cannot choose between the following variants of org.openjfx:javafx-controls:22.0.1:
          - linux-aarch64Runtime
          - linuxRuntime
          - mac-aarch64Runtime
          - macRuntime
          - runtime
          - winRuntime
        All of them match the consumer attributes:
          - Variant 'linux-aarch64Runtime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.native.architecture 'aarch64' but the consumer didn't ask for it
                  - Provides org.gradle.native.operatingSystem 'linux' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'linuxRuntime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.native.architecture 'x86-64' but the consumer didn't ask for it
                  - Provides org.gradle.native.operatingSystem 'linux' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'mac-aarch64Runtime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.native.architecture 'aarch64' but the consumer didn't ask for it
                  - Provides org.gradle.native.operatingSystem 'macos' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'macRuntime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.native.architecture 'x86-64' but the consumer didn't ask for it
                  - Provides org.gradle.native.operatingSystem 'macos' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'runtime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
          - Variant 'winRuntime' capability org.openjfx:javafx-controls:22.0.1:
              - Unmatched attributes:
                  - Provides org.gradle.category 'library' but the consumer didn't ask for it
                  - Provides org.gradle.libraryelements 'jar' but the consumer didn't ask for it
                  - Provides org.gradle.native.architecture 'x86-64' but the consumer didn't ask for it
                  - Provides org.gradle.native.operatingSystem 'windows' but the consumer didn't ask for it
                  - Provides org.gradle.status 'release' but the consumer didn't ask for it
                  - Provides org.gradle.usage 'java-runtime' but the consumer didn't ask for it
``` 
Fixes the issue based on https://github.com/openjfx/javafx-gradle-plugin/issues/164#issuecomment-1988247831.

### Mandatory checks
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
