### PR TITLE
Fix-11102 by giving user option to add a bst style preview to available

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.fxml
@@ -22,6 +22,7 @@
     <CheckBox fx:id="showAsTabCheckBox" text="%Show preview as a tab in entry editor"/>
     <CheckBox fx:id="showPreviewTooltipCheckBox" text="Show preview in entry table tooltip"/>
     <HBox spacing="4.0">
+        <Button fx:id="bstFileButton" text="Select BST File" onAction="#selectBstFile" />
         <VBox spacing="4.0" HBox.hgrow="ALWAYS">
             <Label text="%Available" styleClass="sectionHeader"/>
             <CustomTextField fx:id="searchBox" promptText="%Filter" VBox.vgrow="NEVER" prefHeight="20.0"/>

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
@@ -1,10 +1,13 @@
 package org.jabref.gui.preferences.preview;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import javafx.application.Platform;
 import javafx.beans.property.ListProperty;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
@@ -18,6 +21,7 @@ import javafx.scene.input.Dragboard;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
+import javafx.stage.FileChooser;
 
 import org.jabref.gui.Globals;
 import org.jabref.gui.StateManager;
@@ -32,6 +36,7 @@ import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.gui.util.ViewModelListCellFactory;
+import org.jabref.logic.bst.BstPreviewLayout;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preview.PreviewLayout;
 import org.jabref.logic.util.TestEntry;
@@ -104,6 +109,21 @@ public class PreviewTab extends AbstractPreferenceTabView<PreviewTabViewModel> i
         return Localization.lang("Entry preview");
     }
 
+    @FXML
+    private void selectBstFile(ActionEvent event) {
+    FileChooser fileChooser = new FileChooser();
+    fileChooser.setTitle("Select BST File");
+    fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("BST Files", "*.bst"));
+
+    File selectedFile = fileChooser.showOpenDialog(null);
+    if (selectedFile != null) {
+        String filePath = selectedFile.getAbsolutePath();
+        BstPreviewLayout bstPreviewLayout = new BstPreviewLayout(Path.of(filePath));
+        viewModel.availableListProperty().add(bstPreviewLayout);
+        previewViewer.setEntry(TestEntry.getTestEntry());
+    }
+}
+    
     public void initialize() {
         this.viewModel = new PreviewTabViewModel(dialogService, preferencesService.getPreviewPreferences(), taskExecutor, stateManager);
         lastKeyPressTime = System.currentTimeMillis();

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -157,8 +157,10 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             sourceTextProperty.setValue(layout.getText().replace("__NEWLINE__", "\n"));
             selectedIsEditableProperty.setValue(true);
         } else {
-            sourceTextProperty.setValue(((CitationStylePreviewLayout) selectedLayout).getSource());
-            selectedIsEditableProperty.setValue(false);
+            if (selectedLayout instanceof CitationStylePreviewLayout) {
+                sourceTextProperty.setValue(((CitationStylePreviewLayout) selectedLayout).getSource());
+                selectedIsEditableProperty.setValue(false);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
I've tried to fix #11102 by adding a button which may be used to add the selected bst files to the available styles and tested it to work although I think for preview to function well bstvm should be used not sure how. Would like some guidence . After it works as expected may be documentation can be modified.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
