### PR TITLE
Add check for PRs from "main"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -336,11 +336,11 @@ jobs:
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.0
   other_than_main:
-    name: Check source branch is other than "main"
+    name: Source branch is other than "main"
     runs-on: ubuntu-latest
     steps:
       - if: github.head_ref == 'main'
         uses: actions/github-script@v6
         with:
           script: |
-              core.setFailed('Changes to staging should merge from staging')
+              core.setFailed('Pull requests should come from a branch other than "main"')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -343,4 +343,4 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-              core.setFailed('Pull requests should come from a branch other than "main"\n\nPlease read https://devdocs.jabref.org/contributing carefully again.')
+              core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read https://devdocs.jabref.org/contributing carefully again. 👈')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -343,4 +343,4 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-              core.setFailed('Pull requests should come from a branch other than "main"')
+              core.setFailed('Pull requests should come from a branch other than "main"\n\nPlease read https://devdocs.jabref.org/contributing carefully again.')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -343,4 +343,4 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-              core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read https://devdocs.jabref.org/contributing carefully again. 👈')
+              core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read https://devdocs.jabref.org/contributing again carefully. 👈')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -335,3 +335,12 @@ jobs:
           show-progress: 'false'
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.0
+  other_than_main:
+    name: Check source branch is other than "main"
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.head_ref == 'main'
+        uses: actions/github-script@v6
+        with:
+          script: |
+              core.setFailed('Changes to staging should merge from staging')


### PR DESCRIPTION
We see PRs coming from "main". It seems not all contributors follow our guidelines. We do have at the first page of https://devdocs.jabref.org/contributing#contribute-code a bold hint not to use main. Could be made even better (refs https://github.com/JabRef/jabref-issue-melting-pot/issues/416)

This PR adds a check if the PR originates from `main`. I do post from `koppor/main` to check for the effects.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
