### PR TITLE
Fix missing add opens for javafx on mac

### DIFF
--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -130,6 +130,7 @@ jobs:
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
       - name: Build pkg (macOS)
         if: (steps.checksecrets.outputs.secretspresent == 'YES')

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -131,7 +131,13 @@ jobs:
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
-          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref \
+          --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref
       - name: Build pkg (macOS)
         if: (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
@@ -161,7 +167,13 @@ jobs:
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
-          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref \
+          --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref
       - name: Rename files with arm64 suffix as well
         if: (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -142,6 +142,7 @@ jobs:
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
       - name: Build pkg (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
@@ -172,6 +173,7 @@ jobs:
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
       - name: Build runtime image and installer (linux, Windows)
         if: (matrix.os != 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -143,7 +143,13 @@ jobs:
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
-          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref \
+          --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref
       - name: Build pkg (macOS)
         if: (matrix.os == 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash
@@ -174,7 +180,13 @@ jobs:
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module \
-          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref \
+          --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref \
+          --java-options --add-opens=javafx.controls/javafx.scene.control=org.jabref \
+          --java-options --add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref
       - name: Build runtime image and installer (linux, Windows)
         if: (matrix.os != 'macos-latest') && (steps.checksecrets.outputs.secretspresent == 'YES')
         shell: bash


### PR DESCRIPTION
fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/428

Does this issue also occur under windows/linux`

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
