### PR TITLE
Remove outdated pdf indexed files from Lucene index

### DIFF
--- a/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
+++ b/src/main/java/org/jabref/logic/pdf/search/PdfIndexer.java
@@ -205,7 +205,7 @@ public class PdfIndexer {
 
     private void doCommit() {
         try {
-            getIndexWriter().ifPresent(Unchecked.consumer(writer -> writer.commit()));
+            getIndexWriter().ifPresent(Unchecked.consumer(IndexWriter::commit));
         } catch (UncheckedIOException e) {
             LOGGER.warn("Could not commit changes to the index.", e);
         }
@@ -274,7 +274,6 @@ public class PdfIndexer {
             LOGGER.debug("Could not find {}", linkedFile.getLink());
             return;
         }
-        LOGGER.debug("Adding {} to index", linkedFile.getLink());
         try {
             // Check if a document with this path is already in the index
             try {
@@ -283,17 +282,21 @@ public class PdfIndexer {
                 TopDocs topDocs = searcher.search(query, 1);
                 // If a document was found, check if is less current than the one in the FS
                 if (topDocs.scoreDocs.length > 0) {
-                    Document doc = reader.document(topDocs.scoreDocs[0].doc);
+                    Document doc = reader.storedFields().document(topDocs.scoreDocs[0].doc);
                     long indexModificationTime = Long.parseLong(doc.getField(SearchFieldConstants.MODIFIED).stringValue());
                     BasicFileAttributes attributes = Files.readAttributes(resolvedPath.get(), BasicFileAttributes.class);
                     if (indexModificationTime >= attributes.lastModifiedTime().to(TimeUnit.SECONDS)) {
-                        LOGGER.debug("File {} is already indexed", linkedFile.getLink());
+                        LOGGER.debug("File {} is already indexed and up-to-date.", linkedFile.getLink());
                         return;
+                    } else {
+                        LOGGER.debug("File {} is already indexed but outdated. Removing from index.", linkedFile.getLink());
+                        removeFromIndex(linkedFile.getLink());
                     }
                 }
             } catch (IndexNotFoundException e) {
                 LOGGER.debug("Index not found. Continuing.", e);
             }
+            LOGGER.debug("Adding {} to index", linkedFile.getLink());
             // If no document was found, add the new one
             Optional<List<Document>> pages = new DocumentReader(entry, filePreferences).readLinkedPdf(this.databaseContext, linkedFile);
             if (pages.isPresent()) {
@@ -328,7 +331,7 @@ public class PdfIndexer {
             MatchAllDocsQuery query = new MatchAllDocsQuery();
             TopDocs allDocs = searcher.search(query, Integer.MAX_VALUE);
             for (ScoreDoc scoreDoc : allDocs.scoreDocs) {
-                Document doc = reader.document(scoreDoc.doc);
+                Document doc = reader.storedFields().document(scoreDoc.doc);
                 paths.add(doc.getField(SearchFieldConstants.PATH).stringValue());
             }
         } catch (IOException e) {


### PR DESCRIPTION
Addressed an issue where outdated pdf files were not being removed from the Lucene index.

The duplicate checker checks for the modification time of the pdf but doesn't remove it from the index if it is outdated.

This causes a lot of duplication in the index every time a library opens, the pdf will be added to the index again.
This also led to incorrect search results when using old keywords.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
