### PR TITLE
Update latex citations status in JavaFx thread

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -92,14 +92,14 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
             @Override
             public void onStart(FileAlterationObserver observer) {
                 if (!updateStatusOnCreate.get()) {
-                    status.set(Status.IN_PROGRESS);
+                    DefaultTaskExecutor.runInJavaFXThread(() -> status.set(Status.IN_PROGRESS));
                 }
             }
 
             @Override
             public void onStop(FileAlterationObserver observer) {
                 if (!updateStatusOnCreate.get()) {
-                    updateStatusOnCreate.set(true);
+                    DefaultTaskExecutor.runInJavaFXThread(() -> updateStatusOnCreate.set(true));
                     updateStatus();
                 }
             }

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -99,7 +99,7 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
             @Override
             public void onStop(FileAlterationObserver observer) {
                 if (!updateStatusOnCreate.get()) {
-                    DefaultTaskExecutor.runInJavaFXThread(() -> updateStatusOnCreate.set(true));
+                    updateStatusOnCreate.set(true);
                     updateStatus();
                 }
             }


### PR DESCRIPTION
An exception is thrown when switching from the "search result" tab to the "latex citations" tab

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
