### PR TITLE
New method FileUtil#relativize

### DIFF
--- a/docs/code-howtos/index.md
+++ b/docs/code-howtos/index.md
@@ -35,11 +35,24 @@ For accessing or putting data into the Clipboard use the `ClipboardManager`.
 
 ## Get Absolute Filename or Path for file in File directory
 
+JabRef stores files relative to one of [multiple possible directories](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#directories-for-files).
+The convert the relative path to an absolute one, there is the `find` method in `FileUtil`:
+
 ```java
-Optional<Path> file = FileHelper.expandFilename(database, fileText, preferences.getFilePreferences());
+org.jabref.logic.util.io.FileUtil.find(org.jabref.model.database.BibDatabaseContext, java.lang.String, org.jabref.preferences.FilePreferences)
 ```
 
 `String path` Can be the files name or a relative path to it. The Preferences should only be directly accessed in the GUI. For the usage in logic pass them as parameter
+
+## Get a relative filename (or path) for a file
+
+[JabRef offers multiple directories per library to store a file.](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#directories-for-files).
+When adding a file to a library, the path should be stored relative to "the best matching" directory of these.
+This is implemented in `FileUtil`:
+
+```java
+org.jabref.logic.util.io.FileUtil.relativize(java.nio.file.Path, org.jabref.model.database.BibDatabaseContext, org.jabref.preferences.FilePreferences)
+```
 
 ## Setting a Database Directory for a .bib File
 

--- a/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -70,7 +70,7 @@ public class ExternalFilesEntryLinker {
             FileUtil.getFileExtension(file).ifPresent(ext -> {
                 ExternalFileType type = ExternalFileTypes.getExternalFileTypeByExt(ext, filePreferences)
                                                          .orElse(new UnknownExternalFileType(ext));
-                Path relativePath = FileUtil.relativize(file, bibDatabaseContext.getFileDirectories(filePreferences));
+                Path relativePath = FileUtil.relativize(file, bibDatabaseContext, filePreferences);
                 LinkedFile linkedfile = new LinkedFile("", relativePath, type.getName());
                 entry.addFile(linkedfile);
             });

--- a/src/main/java/org/jabref/gui/externalfiletype/CustomExternalFileType.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/CustomExternalFileType.java
@@ -9,6 +9,8 @@ import org.jabref.gui.icon.JabRefIcon;
  * This class defines a type of external files that can be linked to from JabRef.
  * The class contains enough information to provide an icon, a standard extension
  * and a link to which application handles files of this type.
+ *
+ * TODO: Move to model (and then adapt {@link org.jabref.gui.fieldeditors.LinkedFilesEditorViewModel#fromFile(java.nio.file.Path, java.util.List, org.jabref.preferences.FilePreferences)}).
  */
 public class CustomExternalFileType implements ExternalFileType {
 

--- a/src/main/java/org/jabref/gui/linkedfile/LinkedFilesEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/linkedfile/LinkedFilesEditDialogViewModel.java
@@ -3,7 +3,6 @@ package org.jabref.gui.linkedfile;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -147,7 +146,6 @@ public class LinkedFilesEditDialogViewModel extends AbstractViewModel {
     }
 
     private String relativize(Path filePath) {
-        List<Path> fileDirectories = database.getFileDirectories(filePreferences);
-        return FileUtil.relativize(filePath, fileDirectories).toString();
+        return FileUtil.relativize(filePath, database, filePreferences).toString();
     }
 }

--- a/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -39,7 +39,7 @@ public class RelativePathsCleanup implements CleanupJob {
             } else {
                 // only try to transform local file path to relative one
                 newFileName = FileUtil
-                        .relativize(Path.of(oldFileName), databaseContext.getFileDirectories(filePreferences))
+                        .relativize(Path.of(oldFileName), databaseContext, filePreferences)
                         .toString();
             }
             LinkedFile newFileEntry = fileEntry;

--- a/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
+++ b/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -72,7 +71,7 @@ public class LinkedFileHandler {
         Files.move(oldFile.get(), targetPath);
 
         // Update path
-        fileEntry.setLink(relativize(targetPath));
+        fileEntry.setLink(FileUtil.relativize(targetPath, databaseContext, filePreferences).toString());
         return true;
     }
 
@@ -110,14 +109,9 @@ public class LinkedFileHandler {
         }
 
         // Update path
-        fileEntry.setLink(relativize(newPath));
+        fileEntry.setLink(FileUtil.relativize(newPath, databaseContext, filePreferences).toString());
 
         return true;
-    }
-
-    private String relativize(Path path) {
-        List<Path> fileDirectories = databaseContext.getFileDirectories(filePreferences);
-        return FileUtil.relativize(path, fileDirectories).toString();
     }
 
     public String getSuggestedFileName() {

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -259,6 +259,17 @@ public class FileUtil {
     }
 
     /**
+     * Converts an absolute file to a relative one, if possible. Returns the parameter file itself if no shortening is
+     * possible.
+     *
+     * @param path the file path to be shortened
+     */
+    public static Path relativize(Path path, BibDatabaseContext databaseContext, FilePreferences filePreferences) {
+        List<Path> fileDirectories = databaseContext.getFileDirectories(filePreferences);
+        return relativize(path, fileDirectories);
+    }
+
+    /**
      * Returns the list of linked files. The files have the absolute filename
      *
      * @param bes      list of BibTeX entries


### PR DESCRIPTION
While reviewing https://github.com/JabRef/jabref/pull/11327, I missed a method in `FileUtil` - and also noticed outdated documentation. This PR fixes that.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
