### PR TITLE
Apply OpenRewrite (without module-info.java)

### DIFF
--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -322,7 +322,7 @@ public class JabRefCLI {
                 .map(format -> new Pair<>(format.getName(), format.getId()))
                 .toList();
         String importFormatsIntro = Localization.lang("Available import formats");
-        String importFormatsList = String.format("%s:%n%s%n", importFormatsIntro, alignStringTable(importFormats));
+        String importFormatsList = "%s:%n%s%n".formatted(importFormatsIntro, alignStringTable(importFormats));
 
         ExporterFactory exporterFactory = ExporterFactory.create(
                 preferencesService,
@@ -332,7 +332,7 @@ public class JabRefCLI {
                 .map(format -> new Pair<>(format.getName(), format.getId()))
                 .toList();
         String outFormatsIntro = Localization.lang("Available export formats");
-        String outFormatsList = String.format("%s:%n%s%n", outFormatsIntro, alignStringTable(exportFormats));
+        String outFormatsList = "%s:%n%s%n".formatted(outFormatsIntro, alignStringTable(exportFormats));
 
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";
 

--- a/src/main/java/org/jabref/gui/DialogService.java
+++ b/src/main/java/org/jabref/gui/DialogService.java
@@ -12,6 +12,7 @@ import javafx.print.PrinterJob;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ChoiceDialog;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogPane;
 import javafx.scene.control.TextInputDialog;
 import javafx.util.StringConverter;
@@ -208,7 +209,7 @@ public interface DialogService {
      * @param dialog dialog to show
      * @param <R>    type of result
      */
-    <R> Optional<R> showCustomDialogAndWait(javafx.scene.control.Dialog<R> dialog);
+    <R> Optional<R> showCustomDialogAndWait(Dialog<R> dialog);
 
     /**
      * Constructs and shows a cancelable {@link ProgressDialog}.

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -24,6 +24,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceDialog;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogPane;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
@@ -282,7 +283,7 @@ public class JabRefDialogService implements DialogService {
     }
 
     @Override
-    public <R> Optional<R> showCustomDialogAndWait(javafx.scene.control.Dialog<R> dialog) {
+    public <R> Optional<R> showCustomDialogAndWait(Dialog<R> dialog) {
         if (dialog.getOwner() == null) {
             dialog.initOwner(mainWindow);
         }
@@ -291,7 +292,7 @@ public class JabRefDialogService implements DialogService {
 
     @Override
     public Optional<String> showPasswordDialogAndWait(String title, String header, String content) {
-        javafx.scene.control.Dialog<String> dialog = new javafx.scene.control.Dialog<>();
+        Dialog<String> dialog = new Dialog<>();
         dialog.setTitle(title);
         dialog.setHeaderText(header);
 

--- a/src/main/java/org/jabref/gui/collab/entrychange/EntryChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/entrychange/EntryChangeDetailsView.java
@@ -87,8 +87,8 @@ public final class EntryChangeDetailsView extends DatabaseChangeDetailsView {
         webView.addEventHandler(Event.ANY, event -> {
             if (!scrolling) {
                 scrolling = true;
-                if (event instanceof MouseEvent) {
-                    if (((MouseEvent) event).isPrimaryButtonDown()) {
+                if (event instanceof MouseEvent mouseEvent) {
+                    if (mouseEvent.isPrimaryButtonDown()) {
                         int value = (Integer) webView.getEngine().executeScript("window.scrollY");
                         otherWebView.getEngine().executeScript("window.scrollTo(0, " + value + ")");
                     }

--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
@@ -73,7 +73,7 @@ public class CitationKeyPatternsPanel extends TableView<CitationKeyPatternsPanel
         new ValueTableCellFactory<CitationKeyPatternsPanelItemModel, EntryType>()
                 .withGraphic(entryType -> IconTheme.JabRefIcons.REFRESH.getGraphicNode())
                 .withTooltip(entryType ->
-                        String.format(Localization.lang("Reset %s to default value"), entryType.getDisplayName()))
+                        Localization.lang("Reset %s to default value").formatted(entryType.getDisplayName()))
                 .withOnMouseClickedEvent(item -> evt ->
                         viewModel.setItemToDefaultPattern(this.getFocusModel().getFocusedItem()))
                 .install(actionsColumn);

--- a/src/main/java/org/jabref/gui/commonfxcontrols/SaveOrderConfigPanel.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/SaveOrderConfigPanel.java
@@ -55,7 +55,7 @@ public class SaveOrderConfigPanel extends VBox {
             while (change.next()) {
                 if (change.wasReplaced()) {
                         clearCriterionRow(change.getFrom());
-                        createCriterionRow(change.getAddedSubList().get(0), change.getFrom());
+                        createCriterionRow(change.getAddedSubList().getFirst(), change.getFrom());
                 } else if (change.wasAdded()) {
                     for (SortCriterionViewModel criterionViewModel : change.getAddedSubList()) {
                         int row = change.getFrom() + change.getAddedSubList().indexOf(criterionViewModel);

--- a/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTabViewModel.java
@@ -167,7 +167,7 @@ public class LatexCitationsTabViewModel extends AbstractViewModel {
 
         if (citationKey.isPresent()) {
             citationList.setAll(latexFiles.getCitationsByKey(citationKey.get()));
-            if (!status.get().equals(Status.IN_PROGRESS)) {
+            if (status.get() != Status.IN_PROGRESS) {
                 updateStatus();
             }
         } else {

--- a/src/main/java/org/jabref/gui/entryeditor/MathSciNetTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/MathSciNetTab.java
@@ -3,6 +3,7 @@ package org.jabref.gui.entryeditor;
 import java.util.Optional;
 
 import javafx.scene.control.ProgressIndicator;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.web.WebView;
 
@@ -31,7 +32,7 @@ public class MathSciNetTab extends EntryEditorTab {
         WebView browser = WebViewStore.get();
 
         // Quick hack to disable navigating
-        browser.addEventFilter(javafx.scene.input.MouseEvent.ANY, javafx.scene.input.MouseEvent::consume);
+        browser.addEventFilter(MouseEvent.ANY, MouseEvent::consume);
         browser.setContextMenuEnabled(false);
 
         root.getChildren().addAll(browser, progress);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -294,7 +294,7 @@ public class SourceTab extends EntryEditorTab {
             }
 
             NamedCompound compound = new NamedCompound(Localization.lang("source edit"));
-            BibEntry newEntry = database.getEntries().get(0);
+            BibEntry newEntry = database.getEntries().getFirst();
             String newKey = newEntry.getCitationKey().orElse(null);
 
             if (newKey != null) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FulltextSearchResultsTab.java
@@ -131,7 +131,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
         Tooltip fileLinkTooltip = new Tooltip(resolvedPath.toAbsolutePath().toString());
         Tooltip.install(fileLinkText, fileLinkTooltip);
         fileLinkText.setOnMouseClicked(event -> {
-            if (MouseButton.PRIMARY.equals(event.getButton())) {
+            if (MouseButton.PRIMARY == event.getButton()) {
                 try {
                     JabRefDesktop.openBrowser(resolvedPath.toUri(), preferencesService.getFilePreferences());
                 } catch (IOException e) {
@@ -149,7 +149,7 @@ public class FulltextSearchResultsTab extends EntryEditorTab {
         pageLink.setStyle("-fx-font-style: italic; -fx-font-weight: bold;");
 
         pageLink.setOnMouseClicked(event -> {
-            if (MouseButton.PRIMARY.equals(event.getButton())) {
+            if (MouseButton.PRIMARY == event.getButton()) {
                 documentViewerView.gotoPage(pageNumber);
                 documentViewerView.setLiveMode(false);
                 documentViewerView.show();

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -9,12 +9,13 @@ import java.util.function.Supplier;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextArea;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.Globals;
 import org.jabref.gui.fieldeditors.contextmenu.EditorContextAction;
 
-public class EditorTextArea extends javafx.scene.control.TextArea implements Initializable, ContextMenuAddable {
+public class EditorTextArea extends TextArea implements Initializable, ContextMenuAddable {
 
     private final ContextMenu contextMenu = new ContextMenu();
     /**

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
@@ -15,7 +16,7 @@ import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.Globals;
 import org.jabref.gui.fieldeditors.contextmenu.EditorContextAction;
 
-public class EditorTextField extends javafx.scene.control.TextField implements Initializable, ContextMenuAddable {
+public class EditorTextField extends TextField implements Initializable, ContextMenuAddable {
 
     private final ContextMenu contextMenu = new ContextMenu();
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -90,7 +90,7 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
         tagLabel.getGraphic().setOnMouseClicked(event -> entryLinkField.removeTags(entryLink));
         tagLabel.setContentDisplay(ContentDisplay.RIGHT);
         tagLabel.setOnMouseClicked(event -> {
-            if ((event.getClickCount() == 2 || event.isControlDown()) && event.getButton().equals(MouseButton.PRIMARY)) {
+            if ((event.getClickCount() == 2 || event.isControlDown()) && event.getButton() == MouseButton.PRIMARY) {
                 viewModel.jumpToEntry(entryLink);
             }
         });

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -463,7 +463,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
                 if (parserResult.isInvalid() || parserResult.isEmpty() || !parserResult.getDatabase().hasEntries()) {
                     return null;
                 }
-                return parserResult.getDatabase().getEntries().get(0);
+                return parserResult.getDatabase().getEntries().getFirst();
             } catch (IOException e) {
                 return null;
             }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -300,7 +300,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     }
 
     private void handleItemMouseClick(LinkedFileViewModel linkedFile, MouseEvent event) {
-        if (event.getButton().equals(MouseButton.PRIMARY) && (event.getClickCount() == 2)) {
+        if (event.getButton() == MouseButton.PRIMARY && (event.getClickCount() == 2)) {
             // Double click -> open
             linkedFile.open();
         }

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -216,7 +216,7 @@ public class MainToolBar extends ToolBar {
         });
 
         indicator.setOnMouseClicked(event -> {
-            TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<Task<?>>();
+            TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
             EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
             taskProgressView.setRetainTasks(true);
             taskProgressView.setGraphicFactory(BackgroundTask::getIcon);

--- a/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -246,7 +246,7 @@ public class GroupDialogViewModel {
                             return false;
                         }
                         return FileUtil.getFileExtension(input)
-                                .map(extension -> extension.equalsIgnoreCase("aux"))
+                                .map(extension -> "aux".equalsIgnoreCase(extension))
                                 .orElse(false);
                     }
                 },

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -499,7 +499,7 @@ public class GroupTreeView extends BorderPane {
             return;
         }
 
-        double heightOfOneNode = groupTree.getChildrenUnmodifiable().get(0).getLayoutBounds().getHeight();
+        double heightOfOneNode = groupTree.getChildrenUnmodifiable().getFirst().getLayoutBounds().getHeight();
         // heightOfOneNode is the size of text. We need including surroundings.
         // We found no way to get this. We can only do a heuristics here.
         // 2.0 is backed by measurement using the screen ruler utility (https://learn.microsoft.com/en-us/windows/powertoys/screen-ruler)
@@ -519,7 +519,7 @@ public class GroupTreeView extends BorderPane {
     private Optional<ScrollBar> getVerticalScrollbar() {
         for (Node node : groupTree.lookupAll(".scroll-bar")) {
             if (node instanceof ScrollBar scrollbar
-                    && scrollbar.getOrientation().equals(Orientation.VERTICAL)) {
+                    && scrollbar.getOrientation() == Orientation.VERTICAL) {
                 return Optional.of(scrollbar);
             }
         }

--- a/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
+++ b/src/main/java/org/jabref/gui/icon/InternalMaterialDesignIcon.java
@@ -46,8 +46,8 @@ public class InternalMaterialDesignIcon implements JabRefIcon {
 
         // Override the default color from the css files
         color.ifPresent(color -> fontIcon.setStyle(fontIcon.getStyle() +
-                String.format("-fx-fill: %s;", ColorUtil.toRGBCode(color)) +
-                String.format("-fx-icon-color: %s;", ColorUtil.toRGBCode(color))));
+                "-fx-fill: %s;".formatted(ColorUtil.toRGBCode(color)) +
+                "-fx-icon-color: %s;".formatted(ColorUtil.toRGBCode(color))));
 
         return fontIcon;
     }
@@ -73,6 +73,6 @@ public class InternalMaterialDesignIcon implements JabRefIcon {
 
     @Override
     public Ikon getIkon() {
-        return icons.get(0);
+        return icons.getFirst();
     }
 }

--- a/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/WebSearchPaneViewModel.java
@@ -64,7 +64,7 @@ public class WebSearchPaneViewModel {
         SidePanePreferences sidePanePreferences = preferencesService.getSidePanePreferences();
         int defaultFetcherIndex = sidePanePreferences.getWebSearchFetcherSelected();
         if ((defaultFetcherIndex <= 0) || (defaultFetcherIndex >= fetchers.size())) {
-            selectedFetcherProperty().setValue(fetchers.get(0));
+            selectedFetcherProperty().setValue(fetchers.getFirst());
         } else {
             selectedFetcherProperty().setValue(fetchers.get(defaultFetcherIndex));
         }

--- a/src/main/java/org/jabref/gui/libraryproperties/keypattern/KeyPatternPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/keypattern/KeyPatternPropertiesViewModel.java
@@ -41,7 +41,7 @@ public class KeyPatternPropertiesViewModel implements PropertiesTabViewModel {
 
         patternListProperty.forEach(item -> {
             String patternString = item.getPattern();
-            if (!item.getEntryType().getName().equals("default")) {
+            if (!"default".equals(item.getEntryType().getName())) {
                 if (!patternString.trim().isEmpty()) {
                     newKeyPattern.addCitationKeyPattern(item.getEntryType(), patternString);
                 }

--- a/src/main/java/org/jabref/gui/linkedfile/AttachFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/AttachFileAction.java
@@ -51,7 +51,7 @@ public class AttachFileAction extends SimpleCommand {
 
         BibDatabaseContext databaseContext = stateManager.getActiveDatabase().get();
 
-        BibEntry entry = stateManager.getSelectedEntries().get(0);
+        BibEntry entry = stateManager.getSelectedEntries().getFirst();
 
         Path workingDirectory = databaseContext.getFirstExistingFileDir(filePreferences)
                                                .orElse(filePreferences.getWorkingDirectory());

--- a/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
@@ -51,7 +51,7 @@ public class AttachFileFromURLAction extends SimpleCommand {
 
         BibDatabaseContext databaseContext = stateManager.getActiveDatabase().get();
 
-        BibEntry entry = stateManager.getSelectedEntries().get(0);
+        BibEntry entry = stateManager.getSelectedEntries().getFirst();
 
         Optional<String> urlforDownload = getUrlForDownloadFromClipBoardOrEntry(dialogService, entry);
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -18,7 +18,6 @@ import javax.net.ssl.SSLSocketFactory;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import kong.unirest.UnirestException;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
@@ -44,6 +43,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.preferences.FilePreferences;
 
 import com.tobiasdiez.easybind.EasyBind;
+import kong.unirest.UnirestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -18,6 +18,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
+import kong.unirest.UnirestException;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
@@ -222,7 +223,7 @@ public class DownloadLinkedFileAction extends SimpleCommand {
     private boolean checkSSLHandshake(URLDownload urlDownload) {
         try {
             urlDownload.canBeReached();
-        } catch (kong.unirest.UnirestException ex) {
+        } catch (UnirestException ex) {
             if (ex.getCause() instanceof SSLHandshakeException) {
                 if (dialogService.showConfirmationDialogAndWait(Localization.lang("Download file"),
                         Localization.lang("Unable to find valid certification path to requested target(%0), download anyway?",

--- a/src/main/java/org/jabref/gui/maintable/OpenFolderAction.java
+++ b/src/main/java/org/jabref/gui/maintable/OpenFolderAction.java
@@ -53,7 +53,7 @@ public class OpenFolderAction extends SimpleCommand {
                 if (entry == null) {
                     stateManager.getSelectedEntries().stream().filter(entry -> !entry.getFiles().isEmpty()).forEach(entry -> {
                         LinkedFileViewModel linkedFileViewModel = new LinkedFileViewModel(
-                                entry.getFiles().get(0),
+                                entry.getFiles().getFirst(),
                                 entry,
                                 databaseContext,
                                 taskExecutor,

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -64,7 +64,7 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
                 .withOnMouseClickedEvent((entry, linkedFiles) -> event -> {
                     if ((event.getButton() == MouseButton.PRIMARY) && (linkedFiles.size() == 1)) {
                         // Only one linked file -> open directly
-                        LinkedFileViewModel linkedFileViewModel = new LinkedFileViewModel(linkedFiles.get(0),
+                        LinkedFileViewModel linkedFileViewModel = new LinkedFileViewModel(linkedFiles.getFirst(),
                                 entry.getEntry(),
                                 database,
                                 taskExecutor,

--- a/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/SpecialFieldColumn.java
@@ -100,10 +100,10 @@ public class SpecialFieldColumn extends MainTableColumn<Optional<SpecialFieldVal
         }
 
         ranking.addEventFilter(MouseEvent.MOUSE_CLICKED, event -> {
-            if (event.getButton().equals(MouseButton.PRIMARY) && event.getClickCount() == 2) {
+            if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
                 ranking.setRating(0);
                 event.consume();
-            } else if (event.getButton().equals(MouseButton.SECONDARY)) {
+            } else if (event.getButton() == MouseButton.SECONDARY) {
                 event.consume();
             }
         });

--- a/src/main/java/org/jabref/gui/mergeentries/DiffHighlightingEllipsingTextFlow.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffHighlightingEllipsingTextFlow.java
@@ -55,7 +55,7 @@ public class DiffHighlightingEllipsingTextFlow extends TextFlow {
     }
 
     private void adjustText() {
-        if (allChildren.size() == 0) {
+        if (allChildren.isEmpty()) {
             return;
         }
         // remove listeners
@@ -85,12 +85,12 @@ public class DiffHighlightingEllipsingTextFlow extends TextFlow {
     private boolean fillUntilOverflowing() {
         while (getHeight() <= getMaxHeight() && getWidth() <= getMaxWidth()) {
             if (super.getChildren().size() == allChildren.size()) {
-                if (allChildren.size() > 0) {
+                if (!allChildren.isEmpty()) {
                     // all Texts are displayed, let's make sure all chars are as well
                     Node lastChildAsShown = super.getChildren().get(super.getChildren().size() - 1);
-                    Node lastChild = allChildren.get(allChildren.size() - 1);
-                    if (lastChildAsShown instanceof Text && ((Text) lastChildAsShown).getText().length() < ((Text) lastChild).getText().length()) {
-                        ((Text) lastChildAsShown).setText(((Text) lastChild).getText());
+                    Node lastChild = allChildren.getLast();
+                    if (lastChildAsShown instanceof Text text && text.getText().length() < ((Text) lastChild).getText().length()) {
+                        text.setText(((Text) lastChild).getText());
                     } else {
                         // nothing to fill the space with
                         return false;

--- a/src/main/java/org/jabref/gui/mergeentries/MergeWithFetchedEntryAction.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeWithFetchedEntryAction.java
@@ -48,7 +48,7 @@ public class MergeWithFetchedEntryAction extends SimpleCommand {
                     Localization.lang("This operation requires exactly one item to be selected."));
         }
 
-        BibEntry originalEntry = stateManager.getSelectedEntries().get(0);
+        BibEntry originalEntry = stateManager.getSelectedEntries().getFirst();
         new FetchAndMergeEntry(stateManager.getActiveDatabase().get(), taskExecutor, preferencesService, dialogService, undoManager).fetchAndMerge(originalEntry);
     }
 }

--- a/src/main/java/org/jabref/gui/openoffice/Bootstrap.java
+++ b/src/main/java/org/jabref/gui/openoffice/Bootstrap.java
@@ -40,6 +40,7 @@ import com.sun.star.comp.helper.ComponentContext;
 import com.sun.star.comp.helper.ComponentContextEntry;
 import com.sun.star.comp.loader.JavaLoader;
 import com.sun.star.comp.servicemanager.ServiceManager;
+import com.sun.star.connection.NoConnectException;
 import com.sun.star.container.XSet;
 import com.sun.star.lang.XInitialization;
 import com.sun.star.lang.XMultiComponentFactory;
@@ -314,7 +315,7 @@ public class Bootstrap {
                         throw new BootstrapException("no component context!");
                     }
                     break;
-                } catch (com.sun.star.connection.NoConnectException ex) {
+                } catch (NoConnectException ex) {
                     // Wait 500 ms, then try to connect again, but do not wait
                     // longer than 5 min (= 600 * 500 ms) total:
                     if (i == 600) {

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -128,6 +128,6 @@ public class StyleSelectDialogViewModel {
     }
 
     private StyleSelectItemViewModel getStyleOrDefault(String stylePath) {
-        return styles.stream().filter(style -> style.getStylePath().equals(stylePath)).findFirst().orElse(styles.get(0));
+        return styles.stream().filter(style -> style.getStylePath().equals(stylePath)).findFirst().orElse(styles.getFirst());
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -76,8 +76,7 @@ class PreferencesSearchHandler {
         ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap = ArrayListMultimap.create();
         for (PreferencesTab preferencesTab : preferenceTabs) {
             Node builder = preferencesTab.getBuilder();
-            if (builder instanceof Parent) {
-                Parent parentBuilder = (Parent) builder;
+            if (builder instanceof Parent parentBuilder) {
                 scanLabeledControls(parentBuilder, prefsTabLabelMap, preferencesTab);
             }
         }

--- a/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTabViewModel.java
@@ -73,7 +73,7 @@ public class CitationKeyPatternTabViewModel implements PreferenceTabViewModel {
                 new GlobalCitationKeyPatterns(keyPatternPreferences.getKeyPatterns().getDefaultValue());
         patternListProperty.forEach(item -> {
             String patternString = item.getPattern();
-            if (!item.getEntryType().getName().equals("default")) {
+            if (!"default".equals(item.getEntryType().getName())) {
                 if (!patternString.trim().isEmpty()) {
                     newKeyPattern.addCitationKeyPattern(item.getEntryType(), patternString);
                 }

--- a/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/customexporter/CustomExporterTabViewModel.java
@@ -58,7 +58,7 @@ public class CustomExporterTabViewModel implements PreferenceTabViewModel {
             return;
         }
 
-        ExporterViewModel exporterToModify = selectedExporters.get(0);
+        ExporterViewModel exporterToModify = selectedExporters.getFirst();
         CreateModifyExporterDialogView dialog = new CreateModifyExporterDialogView(exporterToModify);
         Optional<ExporterViewModel> exporter = dialogService.showCustomDialogAndWait(dialog);
         if ((exporter != null) && exporter.isPresent()) {

--- a/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTabViewModel.java
@@ -82,7 +82,7 @@ public class JournalAbbreviationsTabViewModel implements PreferenceTabViewModel 
                 isFileRemovable.set(!newValue.isBuiltInListProperty().get());
                 abbreviations.bindBidirectional(newValue.abbreviationsProperty());
                 if (!abbreviations.isEmpty()) {
-                    currentAbbreviation.set(abbreviations.get(abbreviations.size() - 1));
+                    currentAbbreviation.set(abbreviations.getLast());
                 }
             } else {
                 isFileRemovable.set(false);
@@ -90,15 +90,15 @@ public class JournalAbbreviationsTabViewModel implements PreferenceTabViewModel 
                     currentAbbreviation.set(null);
                     abbreviations.clear();
                 } else {
-                    currentFile.set(journalFiles.get(0));
+                    currentFile.set(journalFiles.getFirst());
                 }
             }
         });
         journalFiles.addListener((ListChangeListener<AbbreviationsFileViewModel>) lcl -> {
             if (lcl.next()) {
                 if (!lcl.wasReplaced()) {
-                    if (lcl.wasAdded() && !lcl.getAddedSubList().get(0).isBuiltInListProperty().get()) {
-                        currentFile.set(lcl.getAddedSubList().get(0));
+                    if (lcl.wasAdded() && !lcl.getAddedSubList().getFirst().isBuiltInListProperty().get()) {
+                        currentFile.set(lcl.getAddedSubList().getFirst());
                     }
                 }
             }

--- a/src/main/java/org/jabref/gui/preferences/network/NetworkTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/network/NetworkTabViewModel.java
@@ -146,11 +146,11 @@ public class NetworkTabViewModel implements PreferenceTabViewModel {
             sslCertificatesChanged.set(true);
             while (c.next()) {
                 if (c.wasAdded()) {
-                    CustomCertificateViewModel certificate = c.getAddedSubList().get(0);
+                    CustomCertificateViewModel certificate = c.getAddedSubList().getFirst();
                     certificate.getPath().ifPresent(path -> trustStoreManager
                             .addCertificate(formatCustomAlias(certificate.getThumbprint()), Path.of(path)));
                 } else if (c.wasRemoved()) {
-                    CustomCertificateViewModel certificate = c.getRemoved().get(0);
+                    CustomCertificateViewModel certificate = c.getRemoved().getFirst();
                     trustStoreManager.deleteCertificate(formatCustomAlias(certificate.getThumbprint()));
                 }
             }

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
@@ -214,7 +214,7 @@ public class PreviewTab extends AbstractPreferenceTabView<PreviewTabViewModel> i
 
         readOnlyLabel.visibleProperty().bind(viewModel.selectedIsEditableProperty().not());
         resetDefaultButton.disableProperty().bind(viewModel.selectedIsEditableProperty().not());
-        contextMenu.getItems().get(0).disableProperty().bind(viewModel.selectedIsEditableProperty().not());
+        contextMenu.getItems().getFirst().disableProperty().bind(viewModel.selectedIsEditableProperty().not());
         contextMenu.getItems().get(2).disableProperty().bind(viewModel.selectedIsEditableProperty().not());
         editArea.editableProperty().bind(viewModel.selectedIsEditableProperty());
 

--- a/src/main/java/org/jabref/gui/preferences/table/TableTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/table/TableTabViewModel.java
@@ -177,8 +177,8 @@ public class TableTabViewModel implements PreferenceTabViewModel {
     }
 
     private void removeSpecialFieldColumns() {
-        columnsListProperty.getValue().removeIf(column -> column.getType().equals(MainTableColumnModel.Type.SPECIALFIELD));
-        availableColumnsProperty.getValue().removeIf(column -> column.getType().equals(MainTableColumnModel.Type.SPECIALFIELD));
+        columnsListProperty.getValue().removeIf(column -> column.getType() == MainTableColumnModel.Type.SPECIALFIELD);
+        availableColumnsProperty.getValue().removeIf(column -> column.getType() == MainTableColumnModel.Type.SPECIALFIELD);
     }
 
     private void insertExtraFileColumns() {
@@ -189,8 +189,8 @@ public class TableTabViewModel implements PreferenceTabViewModel {
     }
 
     private void removeExtraFileColumns() {
-        columnsListProperty.getValue().removeIf(column -> column.getType().equals(MainTableColumnModel.Type.EXTRAFILE));
-        availableColumnsProperty.getValue().removeIf(column -> column.getType().equals(MainTableColumnModel.Type.EXTRAFILE));
+        columnsListProperty.getValue().removeIf(column -> column.getType() == MainTableColumnModel.Type.EXTRAFILE);
+        availableColumnsProperty.getValue().removeIf(column -> column.getType() == MainTableColumnModel.Type.EXTRAFILE);
     }
 
     public void insertColumnInList() {

--- a/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/xmp/XmpPrivacyTabViewModel.java
@@ -40,7 +40,7 @@ public class XmpPrivacyTabViewModel implements PreferenceTabViewModel {
 
         xmpFilterListValidator = new FunctionBasedValidator<>(
                 xmpFilterListProperty,
-                input -> input.size() > 0,
+                input -> !input.isEmpty(),
                 ValidationMessage.error("%s > %s %n %n %s".formatted(
                         Localization.lang("XMP metadata"),
                         Localization.lang("Filter List"),

--- a/src/main/java/org/jabref/gui/push/PushToApplicationCommand.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationCommand.java
@@ -85,10 +85,10 @@ public class PushToApplicationCommand extends SimpleCommand {
         this.application = Objects.requireNonNull(application);
 
         reconfigurableControls.forEach(object -> {
-            if (object instanceof MenuItem) {
-                factory.configureMenuItem(application.getAction(), this, (MenuItem) object);
-            } else if (object instanceof ButtonBase) {
-                factory.configureIconButton(application.getAction(), this, (ButtonBase) object);
+            if (object instanceof MenuItem item) {
+                factory.configureMenuItem(application.getAction(), this, item);
+            } else if (object instanceof ButtonBase base) {
+                factory.configureIconButton(application.getAction(), this, base);
             }
         });
     }

--- a/src/main/java/org/jabref/gui/search/rules/describer/GrammarBasedSearchRuleDescriber.java
+++ b/src/main/java/org/jabref/gui/search/rules/describer/GrammarBasedSearchRuleDescriber.java
@@ -56,7 +56,7 @@ public class GrammarBasedSearchRuleDescriber implements SearchDescriber {
         @Override
         public List<Text> visitUnaryExpression(SearchParser.UnaryExpressionContext context) {
             List<Text> textList = visit(context.expression());
-            textList.add(0, TooltipTextUtil.createText(Localization.lang("not").concat(" "), TooltipTextUtil.TextType.NORMAL));
+            textList.addFirst(TooltipTextUtil.createText(Localization.lang("not").concat(" "), TooltipTextUtil.TextType.NORMAL));
             return textList;
         }
 

--- a/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
+++ b/src/main/java/org/jabref/gui/sidepane/SidePaneViewModel.java
@@ -65,9 +65,9 @@ public class SidePaneViewModel extends AbstractViewModel {
         getPanes().addListener((ListChangeListener<? super SidePaneType>) change -> {
             while (change.next()) {
                 if (change.wasAdded()) {
-                    preferencesService.getSidePanePreferences().visiblePanes().add(change.getAddedSubList().get(0));
+                    preferencesService.getSidePanePreferences().visiblePanes().add(change.getAddedSubList().getFirst());
                 } else if (change.wasRemoved()) {
-                    preferencesService.getSidePanePreferences().visiblePanes().remove(change.getRemoved().get(0));
+                    preferencesService.getSidePanePreferences().visiblePanes().remove(change.getRemoved().getFirst());
                 }
             }
         });

--- a/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
+++ b/src/main/java/org/jabref/gui/texparser/CitationsDisplay.java
@@ -49,7 +49,7 @@ public class CitationsDisplay extends ListView<Citation> {
         HBox contextBox = new HBox(8, citationIcon, contextText);
         contextBox.getStyleClass().add("contextBox");
 
-        Label fileNameLabel = new Label(String.format("%s", basePath.get().relativize(item.path())));
+        Label fileNameLabel = new Label("%s".formatted(basePath.get().relativize(item.path())));
         fileNameLabel.setGraphic(IconTheme.JabRefIcons.LATEX_FILE.getGraphicNode());
         Label positionLabel = new Label("(%s:%s-%s)".formatted(item.line(), item.colStart(), item.colEnd()));
         positionLabel.setGraphic(IconTheme.JabRefIcons.LATEX_LINE.getGraphicNode());

--- a/src/main/java/org/jabref/gui/texparser/ReferenceViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ReferenceViewModel.java
@@ -34,12 +34,12 @@ public class ReferenceViewModel {
      * Return a string for displaying an entry key and its number of uses.
      */
     public String getDisplayText() {
-        return String.format("%s (%s)", entry, citationList.size());
+        return "%s (%s)".formatted(entry, citationList.size());
     }
 
     @Override
     public String toString() {
-        return String.format("ReferenceViewModel{entry='%s', highlighted=%s, citationList=%s}",
+        return "ReferenceViewModel{entry='%s', highlighted=%s, citationList=%s}".formatted(
                 this.entry,
                 this.highlighted,
                 this.citationList);

--- a/src/main/java/org/jabref/gui/util/ColorUtil.java
+++ b/src/main/java/org/jabref/gui/util/ColorUtil.java
@@ -12,7 +12,7 @@ public class ColorUtil {
     }
 
     public static String toRGBACode(Color color) {
-        return String.format("rgba(%d,%d,%d,%f)",
+        return "rgba(%d,%d,%d,%f)".formatted(
                 (int) (color.getRed() * 255),
                 (int) (color.getGreen() * 255),
                 (int) (color.getBlue() * 255),

--- a/src/main/java/org/jabref/gui/util/ControlHelper.java
+++ b/src/main/java/org/jabref/gui/util/ControlHelper.java
@@ -33,8 +33,8 @@ public class ControlHelper {
 
     public static boolean childIsFocused(Parent node) {
         return node.isFocused() || node.getChildrenUnmodifiable().stream().anyMatch(child -> {
-            if (child instanceof Parent) {
-                return childIsFocused((Parent) child);
+            if (child instanceof Parent parent) {
+                return childIsFocused(parent);
             } else {
                 return child.isFocused();
             }

--- a/src/main/java/org/jabref/gui/util/FileNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/util/FileNodeViewModel.java
@@ -90,7 +90,7 @@ public class FileNodeViewModel {
 
     @Override
     public String toString() {
-        return String.format("FileNodeViewModel{path=%s, children=%s, fileCount=%s}",
+        return "FileNodeViewModel{path=%s, children=%s, fileCount=%s}".formatted(
                 this.path,
                 this.children,
                 this.fileCount);

--- a/src/main/java/org/jabref/gui/util/OptionalObjectProperty.java
+++ b/src/main/java/org/jabref/gui/util/OptionalObjectProperty.java
@@ -35,7 +35,7 @@ public class OptionalObjectProperty<T> extends SimpleObjectProperty<Optional<T>>
     }
 
     public BooleanExpression isPresent() {
-        return BooleanExpression.booleanExpression(new PreboundBinding<Boolean>(this) {
+        return BooleanExpression.booleanExpression(new PreboundBinding<>(this) {
             @Override
             protected Boolean computeValue() {
                 return OptionalObjectProperty.this.getValue().isPresent();

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeCellFactory.java
@@ -60,13 +60,13 @@ public class ViewModelTreeCellFactory<T> implements Callback<TreeView<T>, TreeCe
     public TreeCell<T> call(TreeView<T> tree) {
         Callback<TreeItem<T>, ObservableValue<Boolean>> getSelectedProperty =
                 item -> {
-                    if (item instanceof CheckBoxTreeItem<?>) {
-                        return ((CheckBoxTreeItem<?>) item).selectedProperty();
+                    if (item instanceof CheckBoxTreeItem<?> treeItem) {
+                        return treeItem.selectedProperty();
                     }
                     return null;
                 };
 
-        StringConverter<TreeItem<T>> converter = new StringConverter<TreeItem<T>>() {
+        StringConverter<TreeItem<T>> converter = new StringConverter<>() {
             @Override
             public String toString(TreeItem<T> treeItem) {
                 return treeItem == null || treeItem.getValue() == null || toText == null ?

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -26,11 +26,12 @@ import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.OrFields;
 import org.jabref.model.strings.StringUtil;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BibEntryWriter {
 
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(BibEntryWriter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BibEntryWriter.class);
 
     private final BibEntryTypesManager entryTypesManager;
     private final FieldWriter fieldWriter;

--- a/src/main/java/org/jabref/logic/git/SlrGitHandler.java
+++ b/src/main/java/org/jabref/logic/git/SlrGitHandler.java
@@ -71,7 +71,7 @@ public class SlrGitHandler extends GitHandler {
                     formatter.setRepository(git.getRepository());
                     List<DiffEntry> entries = formatter.scan(oldTreeIter, newTreeIter);
                     for (DiffEntry entry : entries) {
-                        if (entry.getChangeType().equals(DiffEntry.ChangeType.MODIFY)) {
+                        if (entry.getChangeType() == DiffEntry.ChangeType.MODIFY) {
                             formatter.format(entry);
                         }
                     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
@@ -99,7 +99,7 @@ public class BiodiversityLibrary implements SearchBasedParserFetcher, Customizab
 
     public BibEntry parseBibJSONtoBibtex(JSONObject item, BibEntry entry) throws IOException, URISyntaxException {
         if (item.has("BHLType")) {
-            if (item.getString("BHLType").equals("Part")) {
+            if ("Part".equals(item.getString("BHLType"))) {
                 URL url = getPartMetadataURL(item.getString("PartID"));
                 JSONObject itemsDetails = getDetails(url);
                 entry.setField(StandardField.LANGUAGE, itemsDetails.optString("Language", ""));
@@ -112,7 +112,7 @@ public class BiodiversityLibrary implements SearchBasedParserFetcher, Customizab
                 entry.setField(StandardField.URL, itemsDetails.optString("PartUrl", ""));
             }
 
-            if (item.getString("BHLType").equals("Item")) {
+            if ("Item".equals(item.getString("BHLType"))) {
                 URL url = getItemMetadataURL(item.getString("ItemID"));
                 JSONObject itemsDetails = getDetails(url);
                 entry.setField(StandardField.EDITOR, itemsDetails.optString("Sponsor", ""));

--- a/src/main/java/org/jabref/logic/importer/fetcher/DOABFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DOABFetcher.java
@@ -98,9 +98,9 @@ public class DOABFetcher implements SearchBasedParserFetcher {
             JSONArray array = bitstreamObject.getJSONArray("metadata");
             for (int k = 0; k < array.length(); k++) {
                 JSONObject metadataInBitstreamObject = array.getJSONObject(k);
-                if (metadataInBitstreamObject.getString("key").equals("dc.identifier.isbn")) {
+                if ("dc.identifier.isbn".equals(metadataInBitstreamObject.getString("key"))) {
                     entry.setField(StandardField.ISBN, metadataInBitstreamObject.getString("value"));
-                } else if (metadataInBitstreamObject.getString("key").equals("oapen.relation.isbn")) {
+                } else if ("oapen.relation.isbn".equals(metadataInBitstreamObject.getString("key"))) {
                     entry.setField(StandardField.ISBN, metadataInBitstreamObject.getString("value"));
                 }
             }
@@ -117,8 +117,7 @@ public class DOABFetcher implements SearchBasedParserFetcher {
                     }
                 }
                 case "dc.type" -> entry.setType(StandardEntryType.Book);
-                case "dc.date.issued" -> entry.setField(StandardField.DATE, String.valueOf(
-                        dataObject.getString("value")));
+                case "dc.date.issued" -> entry.setField(StandardField.DATE, dataObject.getString("value"));
                 case "oapen.identifier.doi" -> entry.setField(StandardField.DOI,
                         dataObject.getString("value"));
                 case "dc.title" -> entry.setField(StandardField.TITLE,

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -108,9 +108,9 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
             JSONObject urlMetadata = pdfDownload.getJSONObject("urlMetadata");
             JSONObject queryParamsObject = urlMetadata.getJSONObject("queryParams");
             String queryParameters = queryParamsObject.keySet().stream()
-                                                      .map(key -> String.format("%s=%s", key, queryParamsObject.getString(key)))
+                                                      .map(key -> "%s=%s".formatted(key, queryParamsObject.getString(key)))
                                                       .collect(Collectors.joining("&"));
-            fullLinkToPdf = String.format("https://www.sciencedirect.com/%s/%s%s?%s",
+            fullLinkToPdf = "https://www.sciencedirect.com/%s/%s%s?%s".formatted(
                     urlMetadata.getString("path"),
                     urlMetadata.getString("pii"),
                     urlMetadata.getString("pdfExtension"),
@@ -150,7 +150,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
 
             for (int i = 0; i < links.length(); i++) {
                 JSONObject link = links.getJSONObject(i);
-                if (link.getString("@rel").equals("scidir")) {
+                if ("scidir".equals(link.getString("@rel"))) {
                     sciLink = link.getString("@href");
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -25,6 +25,7 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
+import com.google.common.base.Strings;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 import org.apache.http.client.utils.URIBuilder;
@@ -70,7 +71,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
 
         // Guess publication type
         String isbn = springerJsonEntry.optString("isbn");
-        if (com.google.common.base.Strings.isNullOrEmpty(isbn)) {
+        if (Strings.isNullOrEmpty(isbn)) {
             // Probably article
             entry.setType(StandardEntryType.Article);
             nametype = StandardField.JOURNAL;
@@ -130,7 +131,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
             } else {
                 urls.forEach(data -> {
                     JSONObject url = (JSONObject) data;
-                    if (url.optString("format").equalsIgnoreCase("pdf")) {
+                    if ("pdf".equalsIgnoreCase(url.optString("format"))) {
                         try {
                             entry.addFile(new LinkedFile(new URL(url.optString("value")), "PDF"));
                         } catch (MalformedURLException e) {

--- a/src/main/java/org/jabref/logic/importer/fileformat/mods/package-info.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/mods/package-info.java
@@ -7,7 +7,11 @@
 
 // This needs to be in the src/main/java to ensure that the Namespace is mapped to the prefix "mods"
 // this cannot be done by a gradle task at the moment
-@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://www.loc.gov/mods/v3", xmlns = {
-        @jakarta.xml.bind.annotation.XmlNs(prefix = "mods", namespaceURI = "http://www.loc.gov/mods/v3")}, elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@XmlSchema(namespace = "http://www.loc.gov/mods/v3", xmlns = {
+        @XmlNs(prefix = "mods", namespaceURI = "http://www.loc.gov/mods/v3")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.jabref.logic.importer.fileformat.mods;
+
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlNsForm;
+import jakarta.xml.bind.annotation.XmlSchema;
 

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -32,6 +32,7 @@ import org.jabref.model.search.rules.SearchRules.SearchFlags;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.FileUpdateMonitor;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -39,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GroupsParser {
 
-    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(GroupsParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GroupsParser.class);
 
     private GroupsParser() {
     }

--- a/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
@@ -40,11 +40,11 @@ public class LatexIntegrityChecker implements EntryChecker {
     private static final Logger LOGGER = LoggerFactory.getLogger(SnuggleSession.class);
     private static final SnuggleEngine ENGINE = new SnuggleEngine();
     private static final SnuggleSession SESSION;
-    private static final ResourceBundle ERROR_MESSAGES = ENGINE.getPackages().get(0).getErrorMessageBundle();
+    private static final ResourceBundle ERROR_MESSAGES = ENGINE.getPackages().getFirst().getErrorMessageBundle();
     private static final Set<ErrorCode> EXCLUDED_ERRORS = new HashSet<>();
 
     static {
-        SnugglePackage snugglePackage = ENGINE.getPackages().get(0);
+        SnugglePackage snugglePackage = ENGINE.getPackages().getFirst();
         snugglePackage.addComplexCommand("textgreater", false, 0, TEXT_MODE_ONLY, null, null, null);
         snugglePackage.addComplexCommand("textless", false, 0, TEXT_MODE_ONLY, null, null, null);
         snugglePackage.addComplexCommand("textbackslash", false, 0, TEXT_MODE_ONLY, null, null, null);
@@ -87,7 +87,7 @@ public class LatexIntegrityChecker implements EntryChecker {
         // Retrieve the first error only because it is likely to be more meaningful.
         // Displaying all (subsequent) faults may lead to confusion.
         // We further get a slight performance benefit from failing fast (see static config in class header).
-        InputError error = SESSION.getErrors().get(0);
+        InputError error = SESSION.getErrors().getFirst();
         return Stream.of(new Pair<>(entry.getKey(), error));
     }
 

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -163,7 +163,7 @@ public class URLDownload {
         String contentType;
         // Try to use HEAD request to avoid downloading the whole file
         try {
-            contentType = Unirest.head(source.toString()).asString().getHeaders().get("Content-Type").get(0);
+            contentType = Unirest.head(source.toString()).asString().getHeaders().get("Content-Type").getFirst();
             if ((contentType != null) && !contentType.isEmpty()) {
                 return contentType;
             }
@@ -173,7 +173,7 @@ public class URLDownload {
 
         // Use GET request as alternative if no HEAD request is available
         try {
-            contentType = Unirest.get(source.toString()).asString().getHeaders().get("Content-Type").get(0);
+            contentType = Unirest.get(source.toString()).asString().getHeaders().get("Content-Type").getFirst();
             if ((contentType != null) && !contentType.isEmpty()) {
                 return contentType;
             }

--- a/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
@@ -181,9 +181,9 @@ public class EditMerge {
             int textOrder = UnoTextRange.compareStarts(state.prevRange, currentRange);
             if (textOrder != -1) {
                 String msg =
-                        String.format("MergeCitationGroups:"
-                                        + " \"%s\" supposed to be followed by \"%s\","
-                                        + " but %s",
+                        ("MergeCitationGroups:"
+                                + " \"%s\" supposed to be followed by \"%s\","
+                                + " but %s").formatted(
                                 state.prevRange.getString(),
                                 currentRange.getString(),
                                 (textOrder == 0

--- a/src/main/java/org/jabref/logic/openoffice/action/EditSeparate.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditSeparate.java
@@ -17,6 +17,7 @@ import org.jabref.model.openoffice.uno.UnoScreenRefresh;
 import com.sun.star.beans.IllegalTypeException;
 import com.sun.star.beans.NotRemoveableException;
 import com.sun.star.beans.PropertyVetoException;
+import com.sun.star.lang.IllegalArgumentException;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.text.XTextCursor;
 import com.sun.star.text.XTextDocument;
@@ -38,7 +39,7 @@ public class EditSeparate {
             NotRemoveableException,
             PropertyVetoException,
             WrappedTargetException,
-            com.sun.star.lang.IllegalArgumentException {
+            IllegalArgumentException {
 
         boolean madeModifications = false;
 

--- a/src/main/java/org/jabref/logic/openoffice/action/Update.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/Update.java
@@ -13,6 +13,7 @@ import org.jabref.model.openoffice.uno.CreationException;
 import org.jabref.model.openoffice.uno.NoDocumentException;
 import org.jabref.model.openoffice.uno.UnoScreenRefresh;
 
+import com.sun.star.lang.IllegalArgumentException;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.text.XTextDocument;
 
@@ -38,7 +39,7 @@ public class Update {
             CreationException,
             NoDocumentException,
             WrappedTargetException,
-            com.sun.star.lang.IllegalArgumentException {
+            IllegalArgumentException {
 
         final boolean useLockControllers = true;
 
@@ -100,7 +101,7 @@ public class Update {
             CreationException,
             NoDocumentException,
             WrappedTargetException,
-            com.sun.star.lang.IllegalArgumentException {
+            IllegalArgumentException {
 
         return Update.updateDocument(doc,
                 frontend,
@@ -122,7 +123,7 @@ public class Update {
             CreationException,
             NoDocumentException,
             WrappedTargetException,
-            com.sun.star.lang.IllegalArgumentException {
+            IllegalArgumentException {
 
         OOFrontend frontend = new OOFrontend(doc);
 

--- a/src/main/java/org/jabref/logic/openoffice/backend/NamedRangeReferenceMark.java
+++ b/src/main/java/org/jabref/logic/openoffice/backend/NamedRangeReferenceMark.java
@@ -346,8 +346,8 @@ class NamedRangeReferenceMark implements NamedRange {
         if (leftLength > 0) {
             alpha.goLeft(leftLength, true);
             if (!left.equals(alpha.getString())) {
-                String msg = String.format("checkFillCursor:"
-                                + " ('%s') is not prefixed with REFERENCE_MARK_LEFT_BRACKET, has '%s'",
+                String msg = ("checkFillCursor:"
+                        + " ('%s') is not prefixed with REFERENCE_MARK_LEFT_BRACKET, has '%s'").formatted(
                         cursor.getString(), alpha.getString());
                 throw new IllegalStateException(msg);
             }
@@ -358,8 +358,8 @@ class NamedRangeReferenceMark implements NamedRange {
         if (rightLength > 0) {
             omega.goRight(rightLength, true);
             if (!right.equals(omega.getString())) {
-                String msg = String.format("checkFillCursor:"
-                                + " ('%s') is not followed by REFERENCE_MARK_RIGHT_BRACKET, has '%s'",
+                String msg = ("checkFillCursor:"
+                        + " ('%s') is not followed by REFERENCE_MARK_RIGHT_BRACKET, has '%s'").formatted(
                         cursor.getString(), omega.getString());
                 throw new IllegalStateException(msg);
             }

--- a/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
+++ b/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
@@ -80,7 +80,7 @@ public class PdfAnnotationImporter implements AnnotationImporter {
                 return false;
             }
         } catch (IllegalArgumentException e) {
-            LOGGER.debug(String.format("Could not parse the FileAnnotation %s into any known FileAnnotationType. It was %s!", annotation, annotation.getSubtype()));
+            LOGGER.debug("Could not parse the FileAnnotation {} into any known FileAnnotationType. It was {}.", annotation, annotation.getSubtype());
         }
         return true;
     }

--- a/src/main/java/org/jabref/logic/pdf/TextExtractor.java
+++ b/src/main/java/org/jabref/logic/pdf/TextExtractor.java
@@ -78,11 +78,11 @@ public final class TextExtractor {
     }
 
     private float toFloat(Object cosNumber) {
-        if (cosNumber instanceof COSFloat) {
-            return ((COSFloat) cosNumber).floatValue();
+        if (cosNumber instanceof COSFloat float1) {
+            return float1.floatValue();
         }
-        if (cosNumber instanceof COSInteger) {
-            return ((COSInteger) cosNumber).floatValue();
+        if (cosNumber instanceof COSInteger integer) {
+            return integer.floatValue();
         }
         throw new IllegalArgumentException("The number type of the annotation is not supported!");
     }

--- a/src/main/java/org/jabref/logic/util/io/FileHistory.java
+++ b/src/main/java/org/jabref/logic/util/io/FileHistory.java
@@ -45,7 +45,7 @@ public class FileHistory extends ModifiableObservableListBase<Path> {
      */
     public void newFile(Path file) {
         removeItem(file);
-        this.add(0, file);
+        this.addFirst(file);
         while (size() > HISTORY_SIZE) {
             history.remove(HISTORY_SIZE);
         }

--- a/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
+++ b/src/main/java/org/jabref/model/openoffice/ootext/OOTextIntoOO.java
@@ -34,6 +34,7 @@ import com.sun.star.beans.XMultiPropertyStates;
 import com.sun.star.beans.XPropertySet;
 import com.sun.star.beans.XPropertySetInfo;
 import com.sun.star.beans.XPropertyState;
+import com.sun.star.lang.IllegalArgumentException;
 import com.sun.star.lang.Locale;
 import com.sun.star.lang.WrappedTargetException;
 import com.sun.star.style.CaseMap;
@@ -372,7 +373,7 @@ public class OOTextIntoOO {
             if (knownToFail.contains(p.Name)) {
                 continue;
             }
-            LOGGER.warn(String.format("OOTextIntoOO.removeDirectFormatting failed on '%s'", p.Name));
+            LOGGER.warn("OOTextIntoOO.removeDirectFormatting failed on '%s'".formatted(p.Name));
         }
     }
 
@@ -749,7 +750,7 @@ public class OOTextIntoOO {
             return PASS;
         } catch (UnknownPropertyException
                 | PropertyVetoException
-                | com.sun.star.lang.IllegalArgumentException
+                | IllegalArgumentException
                 | WrappedTargetException ex) {
             return FAIL;
         }
@@ -758,7 +759,7 @@ public class OOTextIntoOO {
     private static void insertParagraphBreak(XText text, XTextCursor cursor) {
         try {
             text.insertControlCharacter(cursor, ControlCharacter.PARAGRAPH_BREAK, true);
-        } catch (com.sun.star.lang.IllegalArgumentException ex) {
+        } catch (IllegalArgumentException ex) {
             // Assuming it means wrong code for ControlCharacter.
             // https://api.libreoffice.org/docs/idl/ref/  does not tell.
             // If my assumption is correct, we never get here.

--- a/src/main/java/org/jabref/model/openoffice/rangesort/FunctionalTextViewCursor.java
+++ b/src/main/java/org/jabref/model/openoffice/rangesort/FunctionalTextViewCursor.java
@@ -11,6 +11,7 @@ import com.sun.star.lang.XServiceInfo;
 import com.sun.star.text.XTextDocument;
 import com.sun.star.text.XTextRange;
 import com.sun.star.text.XTextViewCursor;
+import com.sun.star.uno.RuntimeException;
 
 /*
  * A problem with XTextViewCursor: if it is not in text, then we get a crippled version that does
@@ -79,7 +80,7 @@ public class FunctionalTextViewCursor {
                 initialPosition = UnoCursor.createTextCursorByRange(viewCursor);
                 viewCursor.getStart();
                 return OOResult.ok(new FunctionalTextViewCursor(initialPosition, initialSelection, viewCursor));
-            } catch (com.sun.star.uno.RuntimeException ex) {
+            } catch (RuntimeException ex) {
                 // bad cursor
                 viewCursor = null;
                 initialPosition = null;
@@ -106,7 +107,7 @@ public class FunctionalTextViewCursor {
 
         try {
             viewCursor.getStart();
-        } catch (com.sun.star.uno.RuntimeException ex) {
+        } catch (RuntimeException ex) {
             restore(doc, initialPosition, initialSelection);
             String errorMessage = "The view cursor failed the functionality test";
             return OOResult.error(errorMessage);

--- a/src/main/java/org/jabref/model/openoffice/uno/UnoCrossRef.java
+++ b/src/main/java/org/jabref/model/openoffice/uno/UnoCrossRef.java
@@ -10,6 +10,7 @@ import com.sun.star.text.ReferenceFieldSource;
 import com.sun.star.text.XTextContent;
 import com.sun.star.text.XTextDocument;
 import com.sun.star.text.XTextRange;
+import com.sun.star.uno.Exception;
 import com.sun.star.util.XRefreshable;
 
 public class UnoCrossRef {
@@ -46,7 +47,7 @@ public class UnoCrossRef {
         try {
             String name = "com.sun.star.text.textfield.GetReference";
             xFieldProps = UnoCast.cast(XPropertySet.class, msf.createInstance(name)).get();
-        } catch (com.sun.star.uno.Exception e) {
+        } catch (Exception e) {
             throw new CreationException(e.getMessage());
         }
 

--- a/src/main/java/org/jabref/model/openoffice/uno/UnoNamed.java
+++ b/src/main/java/org/jabref/model/openoffice/uno/UnoNamed.java
@@ -5,6 +5,7 @@ import org.jabref.model.openoffice.DocumentAnnotation;
 import com.sun.star.container.XNamed;
 import com.sun.star.lang.XMultiServiceFactory;
 import com.sun.star.text.XTextContent;
+import com.sun.star.uno.Exception;
 
 public class UnoNamed {
 
@@ -28,7 +29,7 @@ public class UnoNamed {
         Object xObject;
         try {
             xObject = msf.createInstance(service);
-        } catch (com.sun.star.uno.Exception e) {
+        } catch (Exception e) {
             throw new CreationException(e.getMessage());
         }
 

--- a/src/main/java/org/jabref/model/pdf/FileAnnotationType.java
+++ b/src/main/java/org/jabref/model/pdf/FileAnnotationType.java
@@ -47,7 +47,7 @@ public enum FileAnnotationType {
         try {
             return FileAnnotationType.valueOf(annotation.getSubtype().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            LOGGER.info(String.format("FileAnnotationType %s is not supported and was converted into 'Unknown'!", annotation.getSubtype()));
+            LOGGER.info("FileAnnotationType %s is not supported and was converted into 'Unknown'!".formatted(annotation.getSubtype()));
             return UNKNOWN;
         }
     }

--- a/src/main/java/org/jabref/model/schema/DublinCoreSchemaCustom.java
+++ b/src/main/java/org/jabref/model/schema/DublinCoreSchemaCustom.java
@@ -1,7 +1,6 @@
 package org.jabref.model.schema;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
@@ -28,7 +27,7 @@ public class DublinCoreSchemaCustom extends DublinCoreSchema {
     }
 
     public static DublinCoreSchema copyDublinCoreSchema(DublinCoreSchema dcSchema) {
-        if (Objects.isNull(dcSchema)) {
+        if (dcSchema == null) {
             return null;
         }
 
@@ -51,15 +50,15 @@ public class DublinCoreSchemaCustom extends DublinCoreSchema {
     @Override
     public List<String> getUnqualifiedSequenceValueList(String seqName) {
         AbstractField abstractProperty = getAbstractProperty(seqName);
-        if (abstractProperty instanceof ArrayProperty) {
+        if (abstractProperty instanceof ArrayProperty property) {
             if ("date".equals(seqName)) {
-                return ((ArrayProperty) abstractProperty).getContainer()
+                return property.getContainer()
                         .getAllProperties()
                         .stream()
                         .map(field -> (String) ((DateType) field).getRawValue())
                         .collect(Collectors.toList());
             }
-            return ((ArrayProperty) abstractProperty).getElementsAsString();
+            return property.getElementsAsString();
         }
         return null;
     }

--- a/src/main/java/org/jabref/model/texparser/LatexParserResult.java
+++ b/src/main/java/org/jabref/model/texparser/LatexParserResult.java
@@ -63,7 +63,7 @@ public class LatexParserResult {
 
     @Override
     public String toString() {
-        return String.format("TexParserResult{path=%s, citations=%s, nestedFiles=%s, bibFiles=%s}",
+        return "TexParserResult{path=%s, citations=%s, nestedFiles=%s, bibFiles=%s}".formatted(
                 this.path,
                 this.citations,
                 this.nestedFiles,


### PR DESCRIPTION
I found a workaround to get OpenRewrite applying more recipes (https://github.com/openrewrite/rewrite/issues/4054#issuecomment-2133222528)

    ./gradlew rewriteRun --info -x compileJava -x compileTestJava -x compileJmhJava

Not everything is rewritten yet (https://github.com/openrewrite/rewrite-logging-frameworks/issues/149), but we get closer ^^.


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
