### PR TITLE
Update intellij-12-build.md to Fix Minor Typos

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
@@ -42,7 +42,7 @@ Click "OK" to store the changes.
 
 ## Configure the Build System
 
-Navigate to **File > Settings... > Build, Execution, Deployment > Build Tools > Gradle** and select the "Project SDK" as the Gradle JVM at the bottom. If that does not exist, just select a JDK 21.
+Navigate to **File > Settings... > Build, Execution, Deployment > Build Tools > Gradle** and select the "Project SDK" as the Gradle JVM at the bottom. If that does not exist, just select JDK 21.
 
 {% figure caption:"Gradle JVM is project SDK (showing JDK 21 as example)" %}
 ![Gradle JVM is project SDK](guidelines-intellij-settings-gradle-gradlejvm-is-projectjvm.png)
@@ -66,14 +66,14 @@ Then double click inside the cell "Compilation options" and enter following para
 ```
 
 Press <kbd>Enter</kbd> to have the value really stored.
-Otherwise, it seems like the setting is stored, but it is not there if you re-open this preference dialog.
+Otherwise, it seems like the setting is stored, but it is not there if you reopen this preference dialog.
 Then click on "Apply" to store the setting.
 
 {% figure caption:"Resulting settings for module JabRef.main" %}
 ![Overridden compiler parameters](guidelines-overridden-compiler-parameters.png)
 {% endfigure %}
 
-If this step is omited, you will get: `java: package com.sun.javafx.scene.control is not visible (package com.sun.javafx.scene.control is declared in module javafx.controls, which does not export it to module org.jabref)`.
+If this step is omitted, you will get: `java: package com.sun.javafx.scene.control is not visible (package com.sun.javafx.scene.control is declared in module javafx.controls, which does not export it to module org.jabref)`.
 
 Enable annotation processors by navigating to **Build, Execution, Deployment > Compiler > Annotation processors** and check "Enable annotation processing"
 
@@ -84,7 +84,7 @@ Enable annotation processors by navigating to **Build, Execution, Deployment > C
 ## Using Gradle from within IntelliJ IDEA
 
 {: .note }
-Ensuring JabRef builds with Gradle should always the first step because, e.g. it generates additional sources that are required for compiling the code.
+Ensuring JabRef builds with Gradle should always be the first step because, e.g. it generates additional sources that are required for compiling the code.
 
 Open the Gradle Tool Window with the small button that can usually be found on the right side of IDEA or navigate to **View > Tool Windows > Gradle**.
 In the Gradle Tool Window, press the "Reload All Gradle Projects" button to ensure that all settings are up-to-date with the setting changes.
@@ -93,7 +93,7 @@ In the Gradle Tool Window, press the "Reload All Gradle Projects" button to ensu
 ![Highlighted reload button](guidelines-gradle-tool-windows-refresh.png)
 {% endfigure %}
 
-After that, you can use the Gradle Tool Window to build all parts JabRef and run it.
+After that, you can use the Gradle Tool Window to build all parts of JabRef and run it.
 To do so, expand the JabRef project in the Gradle Tool Window and navigate to Tasks.
 From there, you can build and run JabRef by double-clicking **JabRef > Tasks > application > run**.
 
@@ -102,7 +102,7 @@ From there, you can build and run JabRef by double-clicking **JabRef > Tasks > a
 {% endfigure %}
 
 The Gradle run window opens, shows compilation and then the output of JabRef.
-The spinner will run as long as JabRef is opened.
+The spinner will run as long as JabRef is open.
 
 {% figure caption:"Gradle run Window" %}
 ![Gradle run window](guidelines-gradle-run-output.png)
@@ -129,7 +129,7 @@ In case there are difficulties later, this is the place to switch back to gradle
 
 Click "OK" to close the preference dialog.
 
-In the menubar, select **Build > Rebuild project**.
+In the menu bar, select **Build > Rebuild project**.
 
 IntelliJ now compiles JabRef.
 This should happen without any error.
@@ -143,7 +143,7 @@ To run an example test from IntelliJ, we let IntelliJ create a launch configurat
 Locate the class `BibEntryTest`:
 Press <kbd>Ctrl</kbd>+<kbd>N</kbd>.
 Then, the "Search for classes dialog" pops up.
-Enter `bibenrytest`.
+Enter `bibentrytest`.
 Now, `BibEntryTest` should appear first:
 
 {% figure caption:"IntelliJ search for class “BibEntryTest”" %}
@@ -177,7 +177,7 @@ You can also click on the debug symbol next to it to enable stopping at breakpoi
 
 The tests are green after the run.
 You can also use the play button there to re-execute the tests.
-A right-click on "BibEntryTests" enables to start the debugger.
+A right-click on "BibEntryTests" enables the debugger to start.
 
 {% figure caption:"Run window for the BibEntry test case" %}
 ![Run window for the BibEntry test case](guidelines-intellij-tests-are-green.png)


### PR DESCRIPTION
Typo in line no. 45: select a JDK 21
Correction: select JDK 21

Typo in line no. 69: you re-open
Correction: you reopen

Typo in line no. 76: omited
Correction: omitted

Typo in line no. 87 : always the
Correction: always be the

Typo in line no. 96 : parts JabRef
Correction: parts of JabRef

Typo in line no. 105: JabRef is opened
Correction: JabRef is open

Typo in line no. 132 : In the menubar
Correction: In the menu bar

Typo in line no. 146: Enter 'bibenrytest'
Correction: Enter 'bibentrytest'

Typo in line no. 180 : enables to start the debugger
Correction: enables the debugger to start.

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
