### PR TITLE
Remove unused generateSymmetricHighlighting

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
+++ b/src/main/java/org/jabref/gui/mergeentries/DiffHighlighting.java
@@ -9,12 +9,8 @@ import javafx.scene.text.Text;
 
 import com.github.difflib.DiffUtils;
 import com.github.difflib.patch.AbstractDelta;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DiffHighlighting {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DiffHighlighting.class);
 
     private DiffHighlighting() {
     }
@@ -75,37 +71,5 @@ public class DiffHighlighting {
         Text node = new Text(text);
         node.getStyleClass().add("text-removed");
         return node;
-    }
-
-    public static List<Text> generateSymmetricHighlighting(String baseString, String modifiedString, String separator) {
-        List<String> stringList = Arrays.asList(baseString.split(separator));
-        List<Text> result = stringList.stream().map(text -> DiffHighlighting.forUnchanged(text + separator)).collect(Collectors.toList());
-        List<AbstractDelta<String>> deltaList = DiffUtils.diff(stringList, Arrays.asList(modifiedString.split(separator))).getDeltas();
-        Collections.reverse(deltaList);
-        for (AbstractDelta<String> delta : deltaList) {
-            int startPos = delta.getSource().getPosition();
-            List<String> lines = delta.getSource().getLines();
-            int offset = 0;
-            switch (delta.getType()) {
-                case CHANGE:
-                    for (String line : lines) {
-                        result.set(startPos + offset, forChanged(line + separator));
-                        offset++;
-                    }
-                    break;
-                case DELETE:
-                    for (String line : lines) {
-                        result.set(startPos + offset, forAdded(line + separator));
-                        offset++;
-                    }
-                    break;
-                case INSERT:
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        return result;
     }
 }

--- a/src/test/java/org/jabref/gui/mergeentries/DiffHighlightingTest.java
+++ b/src/test/java/org/jabref/gui/mergeentries/DiffHighlightingTest.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.mergeentries;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -93,85 +92,5 @@ class DiffHighlightingTest {
                         DiffHighlighting.forRemoved("r")
                 ),
                 DiffHighlighting.generateDiffHighlighting("foobar", "foo", ""));
-    }
-
-    @Test
-    void generateSymmetricHighlightingSingleWordAddTextWordDiff() {
-        assertEquals(
-                Collections.singletonList(DiffHighlighting.forChanged("foo ")),
-                DiffHighlighting.generateSymmetricHighlighting("foo", "foobar", " "));
-    }
-
-    @Test
-    void generateSymmetricHighlightingSingleWordAddTextCharacterDiff() {
-        assertEquals(
-                Arrays.asList(
-                        DiffHighlighting.forUnchanged("f"),
-                        DiffHighlighting.forUnchanged("o"),
-                        DiffHighlighting.forUnchanged("o")
-                ),
-                DiffHighlighting.generateSymmetricHighlighting("foo", "foobar", ""));
-    }
-
-    @Test
-    void generateSymmetricHighlightingSingleWordDeleteTextWordDiff() {
-        assertEquals(
-                Collections.singletonList(DiffHighlighting.forChanged("foobar ")),
-                DiffHighlighting.generateSymmetricHighlighting("foobar", "foo", " "));
-    }
-
-    @Test
-    void generateSymmetricHighlightingSingleWordDeleteTextCharacterDiff() {
-        assertEquals(
-                Arrays.asList(
-                        DiffHighlighting.forUnchanged("f"),
-                        DiffHighlighting.forUnchanged("o"),
-                        DiffHighlighting.forUnchanged("o"),
-                        DiffHighlighting.forAdded("b"),
-                        DiffHighlighting.forAdded("a"),
-                        DiffHighlighting.forAdded("r")
-                ),
-                DiffHighlighting.generateSymmetricHighlighting("foobar", "foo", ""));
-    }
-
-    @Test
-    void generateSymmetricHighlightingMultipleWordsDeleteTextCharacterDiff() {
-        assertEquals(
-                Arrays.asList(
-                        DiffHighlighting.forUnchanged("f"),
-                        DiffHighlighting.forUnchanged("o"),
-                        DiffHighlighting.forUnchanged("o"),
-                        DiffHighlighting.forAdded("b"),
-                        DiffHighlighting.forAdded("a"),
-                        DiffHighlighting.forAdded("r"),
-                        DiffHighlighting.forUnchanged(" "),
-                        DiffHighlighting.forUnchanged("a"),
-                        DiffHighlighting.forUnchanged("n"),
-                        DiffHighlighting.forUnchanged("d"),
-                        DiffHighlighting.forUnchanged(" "),
-                        DiffHighlighting.forAdded("s"),
-                        DiffHighlighting.forAdded("o"),
-                        DiffHighlighting.forAdded("m"),
-                        DiffHighlighting.forAdded("e"),
-                        DiffHighlighting.forUnchanged("t"),
-                        DiffHighlighting.forUnchanged("h"),
-                        DiffHighlighting.forUnchanged("i"),
-                        DiffHighlighting.forUnchanged("n"),
-                        DiffHighlighting.forUnchanged("g")
-                ),
-                DiffHighlighting.generateSymmetricHighlighting("foobar and something", "foo and thing", ""));
-    }
-
-    @Test
-    void generateSymmetricHighlightingMultipleWordsDeleteTextWordDiff() {
-        assertEquals(
-                Arrays.asList(
-                        DiffHighlighting.forUnchanged("foo "),
-                        DiffHighlighting.forAdded("bar "),
-                        DiffHighlighting.forUnchanged("and "),
-                        DiffHighlighting.forAdded("some "),
-                        DiffHighlighting.forUnchanged("thing ")
-                ),
-                DiffHighlighting.generateSymmetricHighlighting("foo bar and some thing", "foo and thing", " "));
     }
 }


### PR DESCRIPTION
Our diffs now work differently. No one complained while using the new MergeEntriesDialog. @HoussemNasri @Siedlerchr 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
