### PR TITLE
Streamline code in EntryEditor

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -559,7 +559,7 @@ public class LibraryTab extends Tab {
             stateManager.setSelectedEntries(entries);
             if (!entries.isEmpty()) {
                 // Update entry editor and preview according to selected entries
-                entryEditor.setEntry(entries.getFirst());
+                entryEditor.setCurrentlyEditedEntry(entries.getFirst());
             }
         });
     }
@@ -630,7 +630,7 @@ public class LibraryTab extends Tab {
 
         // We use != instead of equals because of performance reasons
         if (entry != showing) {
-            entryEditor.setEntry(entry);
+            entryEditor.setCurrentlyEditedEntry(entry);
             showing = entry;
         }
         entryEditor.requestFocus();
@@ -673,14 +673,14 @@ public class LibraryTab extends Tab {
     private void ensureNotShowingBottomPanel(List<BibEntry> entriesToCheck) {
         // This method is not able to close the bottom pane currently
 
-        if ((mode == PanelMode.MAIN_TABLE_AND_ENTRY_EDITOR) && (entriesToCheck.contains(entryEditor.getEntry()))) {
+        if ((mode == PanelMode.MAIN_TABLE_AND_ENTRY_EDITOR) && (entriesToCheck.contains(entryEditor.getCurrentlyEditedEntry()))) {
             closeBottomPane();
         }
     }
 
     public void updateEntryEditorIfShowing() {
         if (mode == PanelMode.MAIN_TABLE_AND_ENTRY_EDITOR) {
-            BibEntry currentEntry = entryEditor.getEntry();
+            BibEntry currentEntry = entryEditor.getCurrentlyEditedEntry();
             showAndEdit(currentEntry);
         }
     }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -126,9 +126,8 @@ public class EntryEditor extends BorderPane {
                   .load();
         setupKeyBindings();
 
-        CreateTabsResult createTabsResult = createTabs();
-        this.allPossibleTabs = createTabsResult.tabs;
-        this.previewTabs = createTabsResult.previewTabs;
+        this.allPossibleTabs = createTabs();
+        this.previewTabs = this.allPossibleTabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList()
 
         setupDragAndDrop(libraryTab);
 
@@ -255,10 +254,7 @@ public class EntryEditor extends BorderPane {
         libraryTab.selectNextEntry();
     }
 
-    private record CreateTabsResult(List<EntryEditorTab> tabs, Collection<OffersPreview> previewTabs) {
-    }
-
-    private CreateTabsResult createTabs() {
+    private List<EntryEditorTab> createTabs() {
         List<EntryEditorTab> tabs = new LinkedList<>();
 
         tabs.add(new PreviewTab(databaseContext, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor));
@@ -298,7 +294,7 @@ public class EntryEditor extends BorderPane {
         tabs.add(new LatexCitationsTab(databaseContext, preferencesService, dialogService, directoryMonitorManager));
         tabs.add(new FulltextSearchResultsTab(stateManager, preferencesService, dialogService, taskExecutor));
 
-        return new CreateTabsResult(tabs, tabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList());
+        return tabs;
     }
 
     /**

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -127,7 +127,7 @@ public class EntryEditor extends BorderPane {
         setupKeyBindings();
 
         this.allPossibleTabs = createTabs();
-        this.previewTabs = this.allPossibleTabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList()
+        this.previewTabs = this.allPossibleTabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList();
 
         setupDragAndDrop(libraryTab);
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -2,6 +2,7 @@ package org.jabref.gui.entryeditor;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -89,26 +90,16 @@ public class EntryEditor extends BorderPane {
 
     private Subscription typeSubscription;
 
-    /*
-     * Reference to the entry this editor works on.
-     */
-    private BibEntry entry;
+    private BibEntry currentlyEditedEntry;
 
     private SourceTab sourceTab;
 
-    /*
-     * tabs to be shown in GUI
-     */
     @FXML private TabPane tabbed;
-
-    /*
-     * Tabs which can apply filter, but seems non-sense
-     */
-    private final List<EntryEditorTab> tabs;
 
     @FXML private Button typeChangeButton;
     @FXML private Button fetcherButton;
     @FXML private Label typeLabel;
+
     @Inject private DialogService dialogService;
     @Inject private TaskExecutor taskExecutor;
     @Inject private PreferencesService preferencesService;
@@ -120,42 +111,47 @@ public class EntryEditor extends BorderPane {
     @Inject private KeyBindingRepository keyBindingRepository;
     @Inject private JournalAbbreviationRepository journalAbbreviationRepository;
 
-    private final List<EntryEditorTab> entryEditorTabs = new LinkedList<>();
+    private final List<EntryEditorTab> allPossibleTabs;
+    private final Collection<OffersPreview> previewTabs;
 
     public EntryEditor(LibraryTab libraryTab) {
         this.libraryTab = libraryTab;
         this.databaseContext = libraryTab.getBibDatabaseContext();
         this.directoryMonitorManager = libraryTab.getDirectoryMonitorManager();
+        this.entryEditorPreferences = preferencesService.getEntryEditorPreferences();
+        this.fileLinker = new ExternalFilesEntryLinker(preferencesService.getFilePreferences(), databaseContext, dialogService);
 
         ViewLoader.view(this)
                   .root(this)
                   .load();
+        setupKeyBindings();
 
-        this.entryEditorPreferences = preferencesService.getEntryEditorPreferences();
-        this.fileLinker = new ExternalFilesEntryLinker(preferencesService.getFilePreferences(), databaseContext, dialogService);
+        CreateTabsResult createTabsResult = createTabs();
+        this.allPossibleTabs = createTabsResult.tabs;
+        this.previewTabs = createTabsResult.previewTabs;
+
+        setupDragAndDrop(libraryTab);
 
         EasyBind.subscribe(tabbed.getSelectionModel().selectedItemProperty(), tab -> {
             EntryEditorTab activeTab = (EntryEditorTab) tab;
             if (activeTab != null) {
-                activeTab.notifyAboutFocus(entry);
+                activeTab.notifyAboutFocus(currentlyEditedEntry);
             }
         });
+        EasyBind.listen(preferencesService.getPreviewPreferences().showPreviewAsExtraTabProperty(),
+                (obs, oldValue, newValue) -> adaptVisibleTabs());
+    }
 
-        setupKeyBindings();
-
-        this.tabs = createTabs();
-
+    private void setupDragAndDrop(LibraryTab libraryTab) {
         this.setOnDragOver(event -> {
             if (event.getDragboard().hasFiles()) {
                 event.acceptTransferModes(TransferMode.COPY, TransferMode.MOVE, TransferMode.LINK);
             }
             event.consume();
         });
-
         this.setOnDragDropped(event -> {
-            BibEntry entry = this.getEntry();
+            BibEntry entry = this.getCurrentlyEditedEntry();
             boolean success = false;
-
             if (event.getDragboard().hasContent(DataFormat.FILES)) {
                 List<Path> draggedFiles = event.getDragboard().getFiles().stream().map(File::toPath).collect(Collectors.toList());
                 switch (event.getTransferMode()) {
@@ -181,7 +177,7 @@ public class EntryEditor extends BorderPane {
     }
 
     /**
-     * Set-up key bindings specific for the entry editor.
+     * Set up key bindings specific for the entry editor.
      */
     private void setupKeyBindings() {
         this.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
@@ -233,19 +229,19 @@ public class EntryEditor extends BorderPane {
 
     @FXML
     private void deleteEntry() {
-        libraryTab.delete(entry);
+        libraryTab.delete(currentlyEditedEntry);
     }
 
     @FXML
     void generateCiteKeyButton() {
-        GenerateCitationKeySingleAction action = new GenerateCitationKeySingleAction(getEntry(), databaseContext,
+        GenerateCitationKeySingleAction action = new GenerateCitationKeySingleAction(getCurrentlyEditedEntry(), databaseContext,
                 dialogService, preferencesService, undoManager);
         action.execute();
     }
 
     @FXML
     void generateCleanupButton() {
-        CleanupSingleAction action = new CleanupSingleAction(getEntry(), preferencesService, dialogService, stateManager, undoManager);
+        CleanupSingleAction action = new CleanupSingleAction(getCurrentlyEditedEntry(), preferencesService, dialogService, stateManager, undoManager);
         action.execute();
     }
 
@@ -259,48 +255,35 @@ public class EntryEditor extends BorderPane {
         libraryTab.selectNextEntry();
     }
 
-    private List<EntryEditorTab> createTabs() {
-        entryEditorTabs.add(new PreviewTab(databaseContext, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor));
+    private record CreateTabsResult(List<EntryEditorTab> tabs, Collection<OffersPreview> previewTabs) {
+    }
+
+    private CreateTabsResult createTabs() {
+        List<EntryEditorTab> tabs = new LinkedList<>();
+
+        tabs.add(new PreviewTab(databaseContext, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor));
 
         // Required, optional (important+detail), deprecated, and "other" fields
-        entryEditorTabs.add(new RequiredFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
-        entryEditorTabs.add(new ImportantOptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
-        entryEditorTabs.add(new DetailOptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
-        entryEditorTabs.add(new DeprecatedFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
-        entryEditorTabs.add(new OtherFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
+        tabs.add(new RequiredFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
+        tabs.add(new ImportantOptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
+        tabs.add(new DetailOptionalFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
+        tabs.add(new DeprecatedFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
+        tabs.add(new OtherFieldsTab(databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), bibEntryTypesManager, taskExecutor, journalAbbreviationRepository));
 
         // Comment Tab: Tab for general and user-specific comments
-        entryEditorTabs.add(new CommentsTab(preferencesService, databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor, journalAbbreviationRepository));
+        tabs.add(new CommentsTab(preferencesService, databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor, journalAbbreviationRepository));
 
-        // The preferences allow to configure tabs to show (e.g.,"General", "Abstract")
-        // These should be shown. Already hard-coded ones should be removed.
-        Map<String, Set<Field>> entryEditorTabList = new HashMap<>(entryEditorPreferences.getEntryEditorTabs());
-        entryEditorTabList.remove(PreviewTab.NAME);
-        entryEditorTabList.remove(RequiredFieldsTab.NAME);
-        entryEditorTabList.remove(ImportantOptionalFieldsTab.NAME);
-        entryEditorTabList.remove(DetailOptionalFieldsTab.NAME);
-        entryEditorTabList.remove(DeprecatedFieldsTab.NAME);
-        entryEditorTabList.remove(OtherFieldsTab.NAME);
-        entryEditorTabList.remove(CommentsTab.NAME);
-        entryEditorTabList.remove(MathSciNetTab.NAME);
-        entryEditorTabList.remove(FileAnnotationTab.NAME);
-        entryEditorTabList.remove(SciteTab.NAME);
-        // CitationRelationsTab
-        entryEditorTabList.remove(RelatedArticlesTab.NAME);
-        // SourceTab -- not listed, because it has different names for BibTeX and biblatex mode
-        entryEditorTabList.remove(LatexCitationsTab.NAME);
-        entryEditorTabList.remove(FulltextSearchResultsTab.NAME);
-
+        Map<String, Set<Field>> entryEditorTabList = getAdditionalUserConfiguredTabs();
         for (Map.Entry<String, Set<Field>> tab : entryEditorTabList.entrySet()) {
-            entryEditorTabs.add(new UserDefinedFieldsTab(tab.getKey(), tab.getValue(), databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor, journalAbbreviationRepository));
+            tabs.add(new UserDefinedFieldsTab(tab.getKey(), tab.getValue(), databaseContext, libraryTab.getSuggestionProviders(), undoManager, dialogService, preferencesService, stateManager, themeManager, libraryTab.getIndexingTaskManager(), taskExecutor, journalAbbreviationRepository));
         }
 
-        entryEditorTabs.add(new MathSciNetTab());
-        entryEditorTabs.add(new FileAnnotationTab(libraryTab.getAnnotationCache()));
-        entryEditorTabs.add(new SciteTab(preferencesService, taskExecutor, dialogService));
-        entryEditorTabs.add(new CitationRelationsTab(entryEditorPreferences, dialogService, databaseContext,
+        tabs.add(new MathSciNetTab());
+        tabs.add(new FileAnnotationTab(libraryTab.getAnnotationCache()));
+        tabs.add(new SciteTab(preferencesService, taskExecutor, dialogService));
+        tabs.add(new CitationRelationsTab(dialogService, databaseContext,
                 undoManager, stateManager, fileMonitor, preferencesService, libraryTab, taskExecutor));
-        entryEditorTabs.add(new RelatedArticlesTab(entryEditorPreferences, preferencesService, dialogService, taskExecutor));
+        tabs.add(new RelatedArticlesTab(entryEditorPreferences, preferencesService, dialogService, taskExecutor));
         sourceTab = new SourceTab(
                 databaseContext,
                 undoManager,
@@ -311,27 +294,60 @@ public class EntryEditor extends BorderPane {
                 stateManager,
                 bibEntryTypesManager,
                 keyBindingRepository);
-        entryEditorTabs.add(sourceTab);
-        entryEditorTabs.add(new LatexCitationsTab(databaseContext, preferencesService, dialogService, directoryMonitorManager));
-        entryEditorTabs.add(new FulltextSearchResultsTab(stateManager, preferencesService, dialogService, taskExecutor));
+        tabs.add(sourceTab);
+        tabs.add(new LatexCitationsTab(databaseContext, preferencesService, dialogService, directoryMonitorManager));
+        tabs.add(new FulltextSearchResultsTab(stateManager, preferencesService, dialogService, taskExecutor));
 
-        return entryEditorTabs;
+        return new CreateTabsResult(tabs, tabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList());
     }
 
-    private void recalculateVisibleTabs() {
-        List<Tab> visibleTabs = tabs.stream().filter(tab -> tab.shouldShow(entry)).collect(Collectors.toList());
+    /**
+     * The preferences allow to configure tabs to show (e.g.,"General", "Abstract")
+     * These should be shown. Already hard-coded ones (above and below this code block) should be removed.
+     * This method does this calculation.
+     *
+     * @return Map of tab names and the fields to show in them.
+     */
+    private Map<String, Set<Field>> getAdditionalUserConfiguredTabs() {
+        Map<String, Set<Field>> entryEditorTabList = new HashMap<>(entryEditorPreferences.getEntryEditorTabs());
 
-        // Start of ugly hack:
-        // We need to find out, which tabs will be shown and which not and remove and re-add the appropriate tabs
-        // to the editor. We don't want to simply remove all and re-add the complete list of visible tabs, because
-        // the tabs give an ugly animation the looks like all tabs are shifting in from the right.
+        // Same order as in org.jabref.gui.entryeditor.EntryEditor.createTabs before the call of getAdditionalUserConfiguredTabs
+        entryEditorTabList.remove(PreviewTab.NAME);
+        entryEditorTabList.remove(RequiredFieldsTab.NAME);
+        entryEditorTabList.remove(ImportantOptionalFieldsTab.NAME);
+        entryEditorTabList.remove(DetailOptionalFieldsTab.NAME);
+        entryEditorTabList.remove(DeprecatedFieldsTab.NAME);
+        entryEditorTabList.remove(OtherFieldsTab.NAME);
+        entryEditorTabList.remove(CommentsTab.NAME);
+
+        // Same order as in org.jabref.gui.entryeditor.EntryEditor.createTabs after the call of getAdditionalUserConfiguredTabs
+        entryEditorTabList.remove(MathSciNetTab.NAME);
+        entryEditorTabList.remove(FileAnnotationTab.NAME);
+        entryEditorTabList.remove(SciteTab.NAME);
+        entryEditorTabList.remove(CitationRelationsTab.NAME);
+        entryEditorTabList.remove(RelatedArticlesTab.NAME);
+        // SourceTab is not listed, because it has different names for BibTeX and biblatex mode
+        entryEditorTabList.remove(LatexCitationsTab.NAME);
+        entryEditorTabList.remove(FulltextSearchResultsTab.NAME);
+
+        return entryEditorTabList;
+    }
+
+    /**
+     * Adapt the visible tabs to the current entry type.
+     */
+    private void adaptVisibleTabs() {
+        // We need to find out, which tabs will be shown (and which not anymore) and remove and re-add the appropriate tabs
+        // to the editor. We cannot to simply remove all and re-add the complete list of visible tabs, because
+        // the tabs give an ugly animation the looks like all tabs are shifting in from the right. In other words:
         // This hack is required since tabbed.getTabs().setAll(visibleTabs) changes the order of the tabs in the editor
 
         // First, remove tabs that we do not want to show
-        List<EntryEditorTab> toBeRemoved = tabs.stream().filter(tab -> !tab.shouldShow(entry)).toList();
+        List<EntryEditorTab> toBeRemoved = allPossibleTabs.stream().filter(tab -> !tab.shouldShow(currentlyEditedEntry)).toList();
         tabbed.getTabs().removeAll(toBeRemoved);
 
         // Next add all the visible tabs (if not already present) at the right position
+        List<Tab> visibleTabs = allPossibleTabs.stream().filter(tab -> tab.shouldShow(currentlyEditedEntry)).collect(Collectors.toList());
         for (int i = 0; i < visibleTabs.size(); i++) {
             Tab toBeAdded = visibleTabs.get(i);
             Tab shown = null;
@@ -349,42 +365,31 @@ public class EntryEditor extends BorderPane {
     /**
      * @return the currently edited entry
      */
-    public BibEntry getEntry() {
-        return entry;
+    public BibEntry getCurrentlyEditedEntry() {
+        return currentlyEditedEntry;
     }
 
-    /**
-     * Sets the entry to edit.
-     */
-    public void setEntry(BibEntry entry) {
-        Objects.requireNonNull(entry);
+    public void setCurrentlyEditedEntry(BibEntry currentlyEditedEntry) {
+        this.currentlyEditedEntry = Objects.requireNonNull(currentlyEditedEntry);
 
-        // Remove subscription for old entry if existing
+        // Subscribe to type changes for rebuilding the currently visible tab
         if (typeSubscription != null) {
+            // Remove subscription for old entry if existing
             typeSubscription.unsubscribe();
         }
+        typeSubscription = EasyBind.subscribe(this.currentlyEditedEntry.typeProperty(), type -> {
+            typeLabel.setText(new TypedBibEntry(currentlyEditedEntry, databaseContext.getMode()).getTypeForDisplay());
+            adaptVisibleTabs();
+            getSelectedTab().notifyAboutFocus(currentlyEditedEntry);
+        });
 
-        this.entry = entry;
-
-        recalculateVisibleTabs();
-        EasyBind.listen(preferencesService.getPreviewPreferences().showPreviewAsExtraTabProperty(),
-                (obs, oldValue, newValue) -> recalculateVisibleTabs());
+        adaptVisibleTabs();
+        setupToolBar();
 
         if (entryEditorPreferences.showSourceTabByDefault()) {
             tabbed.getSelectionModel().select(sourceTab);
         }
-
-        // Notify current tab about new entry
-        getSelectedTab().notifyAboutFocus(entry);
-
-        setupToolBar();
-
-        // Subscribe to type changes for rebuilding the currently visible tab
-        typeSubscription = EasyBind.subscribe(this.entry.typeProperty(), type -> {
-            typeLabel.setText(new TypedBibEntry(entry, databaseContext.getMode()).getTypeForDisplay());
-            recalculateVisibleTabs();
-            getSelectedTab().notifyAboutFocus(entry);
-        });
+        getSelectedTab().notifyAboutFocus(currentlyEditedEntry);
     }
 
     private EntryEditorTab getSelectedTab() {
@@ -393,11 +398,11 @@ public class EntryEditor extends BorderPane {
 
     private void setupToolBar() {
         // Update type label
-        TypedBibEntry typedEntry = new TypedBibEntry(entry, databaseContext.getMode());
+        TypedBibEntry typedEntry = new TypedBibEntry(currentlyEditedEntry, databaseContext.getMode());
         typeLabel.setText(typedEntry.getTypeForDisplay());
 
         // Add type change menu
-        ContextMenu typeMenu = new ChangeEntryTypeMenu(Collections.singletonList(entry), databaseContext, undoManager, keyBindingRepository, bibEntryTypesManager).asContextMenu();
+        ContextMenu typeMenu = new ChangeEntryTypeMenu(Collections.singletonList(currentlyEditedEntry), databaseContext, undoManager, keyBindingRepository, bibEntryTypesManager).asContextMenu();
         typeLabel.setOnMouseClicked(event -> typeMenu.show(typeLabel, Side.RIGHT, 0, 0));
         typeChangeButton.setOnMouseClicked(event -> typeMenu.show(typeChangeButton, Side.RIGHT, 0, 0));
 
@@ -431,7 +436,7 @@ public class EntryEditor extends BorderPane {
     }
 
     private void fetchAndMerge(EntryBasedFetcher fetcher) {
-        new FetchAndMergeEntry(libraryTab.getBibDatabaseContext(), taskExecutor, preferencesService, dialogService, undoManager).fetchAndMerge(entry, fetcher);
+        new FetchAndMergeEntry(libraryTab.getBibDatabaseContext(), taskExecutor, preferencesService, dialogService, undoManager).fetchAndMerge(currentlyEditedEntry, fetcher);
     }
 
     public void setFocusToField(Field field) {
@@ -447,10 +452,10 @@ public class EntryEditor extends BorderPane {
     }
 
     public void nextPreviewStyle() {
-        this.entryEditorTabs.forEach(EntryEditorTab::nextPreviewStyle);
+        this.previewTabs.forEach(OffersPreview::nextPreviewStyle);
     }
 
     public void previousPreviewStyle() {
-        this.entryEditorTabs.forEach(EntryEditorTab::previousPreviewStyle);
+        this.previewTabs.forEach(OffersPreview::previousPreviewStyle);
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -43,18 +43,4 @@ public abstract class EntryEditorTab extends Tab {
         }
         handleFocus();
     }
-
-    /**
-     * Switch to next Preview style - should be overriden if a EntryEditorTab is actually showing a preview
-     */
-    protected void nextPreviewStyle() {
-        // do nothing by default
-    }
-
-    /**
-     * Switch to previous Preview style - should be overriden if a EntryEditorTab is actually showing a preview
-     */
-    protected void previousPreviewStyle() {
-        // do nothing by default
-    }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -46,7 +46,7 @@ import com.tobiasdiez.easybind.Subscription;
 /**
  * A single tab displayed in the EntryEditor holding several FieldEditors.
  */
-abstract class FieldsEditorTab extends EntryEditorTab {
+abstract class FieldsEditorTab extends EntryEditorTab implements OffersPreview {
     protected final BibDatabaseContext databaseContext;
     protected final Map<Field, FieldEditorFX> editors = new LinkedHashMap<>();
     protected GridPane gridPane;
@@ -213,14 +213,14 @@ abstract class FieldsEditorTab extends EntryEditorTab {
     }
 
     @Override
-    protected void nextPreviewStyle() {
+    public void nextPreviewStyle() {
         if (previewPanel != null) {
             previewPanel.nextPreviewStyle();
         }
     }
 
     @Override
-    protected void previousPreviewStyle() {
+    public void previousPreviewStyle() {
         if (previewPanel != null) {
             previewPanel.previousPreviewStyle();
         }

--- a/src/main/java/org/jabref/gui/entryeditor/OffersPreview.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OffersPreview.java
@@ -1,0 +1,14 @@
+package org.jabref.gui.entryeditor;
+
+public interface OffersPreview {
+
+    /**
+     * Switch to next Preview style - should be overriden if a EntryEditorTab is actually showing a preview
+     */
+    void nextPreviewStyle();
+
+    /**
+     * Switch to previous Preview style - should be overriden if a EntryEditorTab is actually showing a preview
+     */
+    void previousPreviewStyle();
+}

--- a/src/main/java/org/jabref/gui/entryeditor/PreviewTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/PreviewTab.java
@@ -12,7 +12,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.PreferencesService;
 
-public class PreviewTab extends EntryEditorTab {
+public class PreviewTab extends EntryEditorTab implements OffersPreview {
     public static final String NAME = "Preview";
     private final DialogService dialogService;
     private final BibDatabaseContext databaseContext;
@@ -43,14 +43,14 @@ public class PreviewTab extends EntryEditorTab {
     }
 
     @Override
-    protected void nextPreviewStyle() {
+    public void nextPreviewStyle() {
         if (previewPanel != null) {
             previewPanel.nextPreviewStyle();
         }
     }
 
     @Override
-    protected void previousPreviewStyle() {
+    public void previousPreviewStyle() {
         if (previewPanel != null) {
             previewPanel.previousPreviewStyle();
         }

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -37,27 +37,31 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * GUI for tab displaying article recommendations based on the currently selected BibEntry
+ * Tab displaying article recommendations based on the currently selected BibEntry
  */
 public class RelatedArticlesTab extends EntryEditorTab {
 
     public static final String NAME = "Related articles";
     private static final Logger LOGGER = LoggerFactory.getLogger(RelatedArticlesTab.class);
-    private final EntryEditorPreferences preferences;
+
     private final DialogService dialogService;
-    private final PreferencesService preferencesService;
     private final TaskExecutor taskExecutor;
 
-    public RelatedArticlesTab(EntryEditorPreferences preferences,
+    private final PreferencesService preferencesService;
+    private final EntryEditorPreferences entryEditorPreferences;
+
+    public RelatedArticlesTab(EntryEditorPreferences entryEditorPreferences,
                               PreferencesService preferencesService,
                               DialogService dialogService,
                               TaskExecutor taskExecutor) {
+        this.dialogService = dialogService;
         this.taskExecutor = taskExecutor;
+
+        this.preferencesService = preferencesService;
+        this.entryEditorPreferences = entryEditorPreferences;
+
         setText(Localization.lang("Related articles"));
         setTooltip(new Tooltip(Localization.lang("Related articles")));
-        this.preferences = preferences;
-        this.dialogService = dialogService;
-        this.preferencesService = preferencesService;
     }
 
     /**
@@ -236,15 +240,15 @@ public class RelatedArticlesTab extends EntryEditorTab {
 
     @Override
     public boolean shouldShow(BibEntry entry) {
-        return preferences.shouldShowRecommendationsTab();
+        return entryEditorPreferences.shouldShowRecommendationsTab();
     }
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-        // Ask for consent to send data to Mr. DLib on first time to tab
         if (preferencesService.getMrDlibPreferences().shouldAcceptRecommendations()) {
             setContent(getRelatedArticlesPane(entry));
         } else {
+            // Ask for consent to send data to Mr. DLib on first time to tab
             setContent(getPrivacyDialog(entry));
         }
     }

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -30,7 +30,6 @@ import org.jabref.gui.Globals;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.desktop.JabRefDesktop;
-import org.jabref.gui.entryeditor.EntryEditorPreferences;
 import org.jabref.gui.entryeditor.EntryEditorTab;
 import org.jabref.gui.entryeditor.citationrelationtab.semanticscholar.CitationFetcher;
 import org.jabref.gui.entryeditor.citationrelationtab.semanticscholar.SemanticScholarFetcher;
@@ -61,17 +60,15 @@ import org.slf4j.LoggerFactory;
  */
 public class CitationRelationsTab extends EntryEditorTab {
 
+    public static final String NAME = "Citation relations";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationRelationsTab.class);
 
     // Tasks used to implement asynchronous fetching of related articles
     private static BackgroundTask<List<BibEntry>> citingTask;
     private static BackgroundTask<List<BibEntry>> citedByTask;
-    private final EntryEditorPreferences preferences;
     private final DialogService dialogService;
     private final BibDatabaseContext databaseContext;
-    private final UndoManager undoManager;
-    private final StateManager stateManager;
-    private final FileUpdateMonitor fileUpdateMonitor;
     private final PreferencesService preferencesService;
     private final LibraryTab libraryTab;
     private final TaskExecutor taskExecutor;
@@ -79,16 +76,12 @@ public class CitationRelationsTab extends EntryEditorTab {
     private final CitationsRelationsTabViewModel citationsRelationsTabViewModel;
     private final DuplicateCheck duplicateCheck;
 
-    public CitationRelationsTab(EntryEditorPreferences preferences, DialogService dialogService,
+    public CitationRelationsTab(DialogService dialogService,
                                 BibDatabaseContext databaseContext, UndoManager undoManager,
                                 StateManager stateManager, FileUpdateMonitor fileUpdateMonitor,
                                 PreferencesService preferencesService, LibraryTab lTab, TaskExecutor taskExecutor) {
-        this.preferences = preferences;
         this.dialogService = dialogService;
         this.databaseContext = databaseContext;
-        this.undoManager = undoManager;
-        this.stateManager = stateManager;
-        this.fileUpdateMonitor = fileUpdateMonitor;
         this.preferencesService = preferencesService;
         this.libraryTab = lTab;
         this.taskExecutor = taskExecutor;

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
@@ -138,7 +138,7 @@ public class SharedDatabaseUIManager {
 
         libraryTab.getUndoManager().addEdit(new UndoableRemoveEntries(libraryTab.getDatabase(), event.getBibEntries()));
 
-        if (entryEditor != null && (event.getBibEntries().contains(entryEditor.getEntry()))) {
+        if (entryEditor != null && (event.getBibEntries().contains(entryEditor.getCurrentlyEditedEntry()))) {
             dialogService.showInformationDialogAndWait(Localization.lang("Shared entry is no longer present"),
                     Localization.lang("The entry you currently work on has been deleted on the shared side.")
                             + "\n"


### PR DESCRIPTION
In the context of another PR, I needed to work with the EntryEditor. I moved the refactorings out to a separate PR.

- Introduce interface OffersPreview
- Merge two lists of tabs
- Introduce method
- Rename variables

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
