### PR TITLE
Fix error log on storing preferences

### DIFF
--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -3014,8 +3014,12 @@ public class JabRefPreferences implements PreferencesService {
     private void clearCustomFetcherKeys() {
         List<String> names = getStringList(FETCHER_CUSTOM_KEY_NAMES);
         try (final Keyring keyring = Keyring.create()) {
-            for (String name : names) {
-                keyring.deletePassword("org.jabref.customapikeys", name);
+            try {
+                for (String name : names) {
+                    keyring.deletePassword("org.jabref.customapikeys", name);
+                }
+            } catch (PasswordAccessException ex) {
+                // nothing to do, no password to remove
             }
         } catch (Exception ex) {
             LOGGER.error("Unable to open key store");


### PR DESCRIPTION
Exception was always thrown even when no passwords were there to remove.
This is just fixing a log message. Do we need a changelog here too for that?
Processing business logic with exceptions is bad, but there is no other way with the current implementation of KeyRing.

![grafik](https://github.com/JabRef/jabref/assets/50491877/f8b2cb58-f23d-4dda-8c19-c8caeeb80165)


- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
