### PR TITLE
ArXiv Parsing: Move Specified Fields to eprint Fields in BibTeX Entries

### DIFF
--- a/src/main/java/org/jabref/preferences/PreferencesManager.java
+++ b/src/main/java/org/jabref/preferences/PreferencesManager.java
@@ -1,0 +1,22 @@
+// PreferencesManager.java
+package org.jabref.preferences;
+
+import java.util.prefs.Preferences;
+
+public class PreferencesManager {
+
+    private static final int DEFAULT_MAX_HITS = 5;
+    private Preferences prefs;
+
+    public PreferencesManager() {
+        prefs = Preferences.userNodeForPackage(PreferencesManager.class);
+    }
+
+    public int getMaxHits() {
+        return prefs.getInt("maxHits", DEFAULT_MAX_HITS);
+    }
+
+    public void setMaxHits(int maxHits) {
+        prefs.putInt("maxHits", maxHits);
+    }
+}

--- a/src/test/java/org/jabref/logic/cleanup/EprintCleanupTest.java
+++ b/src/test/java/org/jabref/logic/cleanup/EprintCleanupTest.java
@@ -27,4 +27,22 @@ class EprintCleanupTest {
 
         assertEquals(expected, input);
     }
+
+    @Test
+    void cleanupWithVersionInstitutionAndEid() {
+        BibEntry input = new BibEntry()
+                .withField(StandardField.NOTE, "arXiv:1503.05173")
+                .withField(StandardField.VERSION, "v1")
+                .withField(StandardField.INSTITUTION, "arxiv")
+                .withField(StandardField.EID, "arXiv:1503.05173");
+
+        BibEntry expected = new BibEntry()
+                .withField(StandardField.EPRINT, "1503.05173")
+                .withField(StandardField.EPRINTTYPE, "arxiv");
+
+        EprintCleanup cleanup = new EprintCleanup();
+        cleanup.cleanup(input);
+
+        assertEquals(expected, input);
+    }
 }


### PR DESCRIPTION
Description:
Currently, in JabRef's ArXiv parsing functionality, certain specified fields from the metadata are not correctly mapped to the eprint fields as intended. This issue aims to enhance the ArXiv parsing mechanism by ensuring that the relevant metadata fields, such as identifier numbers or codes, are appropriately transferred and stored in the eprint fields within the BibTeX entry. This improvement will ensure better organization and standardization of ArXiv entries within JabRef, aligning with BibTeX conventions and enhancing the usability of the software for managing academic references.

Tasks:

Identify Relevant Fields: Review and identify which specific metadata fields need to be moved to the eprint fields.

Code Modification: Implement changes in the ArXiv parsing code to correctly transfer identified fields to the appropriate eprint fields in BibTeX entries.

Testing and Validation: Ensure thorough testing to verify that the changes do not introduce regressions and that the transferred fields are correctly handled under various scenarios.

Documentation: Update relevant documentation and user guides to reflect the enhanced ArXiv parsing functionality, providing clear instructions on usage and benefits.

Expected Outcome:
Users will experience improved handling of ArXiv entries in JabRef, with better integration of metadata into BibTeX format, thereby enhancing the overall efficiency and usability of the software for academic reference management.