### PR TITLE
Search result mapping use UIDs instead of hashcodes of BibDatabaseContext

### DIFF
--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -61,7 +61,7 @@ public class StateManager {
     private final OptionalObjectProperty<SearchQuery> activeSearchQuery = OptionalObjectProperty.empty();
     private final OptionalObjectProperty<SearchQuery> activeGlobalSearchQuery = OptionalObjectProperty.empty();
     private final IntegerProperty globalSearchResultSize = new SimpleIntegerProperty(0);
-    private final ObservableMap<BibDatabaseContext, IntegerProperty> searchResultMap = FXCollections.observableHashMap();
+    private final ObservableMap<String, IntegerProperty> searchResultMap = FXCollections.observableHashMap();
     private final OptionalObjectProperty<Node> focusOwner = OptionalObjectProperty.empty();
     private final ObservableList<Pair<BackgroundTask<?>, Task<?>>> backgroundTasks = FXCollections.observableArrayList(task -> new Observable[] {task.getValue().progressProperty(), task.getValue().runningProperty()});
     private final EasyBinding<Boolean> anyTaskRunning = EasyBind.reduce(backgroundTasks, tasks -> tasks.map(Pair::getValue).anyMatch(Task::isRunning));
@@ -103,11 +103,11 @@ public class StateManager {
     }
 
     public void setActiveSearchResultSize(BibDatabaseContext database, IntegerProperty resultSize) {
-        searchResultMap.put(database, resultSize);
+        searchResultMap.put(database.getUid(), resultSize);
     }
 
     public IntegerProperty getSearchResultSize() {
-        return searchResultMap.getOrDefault(activeDatabase.getValue().orElse(new BibDatabaseContext()), new SimpleIntegerProperty(0));
+        return searchResultMap.getOrDefault(activeDatabase.getValue().orElse(new BibDatabaseContext()).getUid(), new SimpleIntegerProperty(0));
     }
 
     public OptionalObjectProperty<SearchQuery> activeGlobalSearchQueryProperty() {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -274,6 +274,7 @@ public class BibDatabaseContext {
                 ", mode=" + getMode() +
                 ", databasePath=" + getDatabasePath() +
                 ", biblatexMode=" + isBiblatexMode() +
+                ", uid= " + getUid() +
                 ", fulltextIndexPath=" + getFulltextIndexPath() +
                 '}';
     }
@@ -300,7 +301,7 @@ public class BibDatabaseContext {
     /**
      * Get the generated UID for the current context. Can be used to distinguish contexts with changing metadata etc
      * <p>
-     * This is requried, because of {@link #hashCode()} implementation.
+     * This is required, because of {@link #hashCode()} implementation.
      *
      * @return The generated UID in UUIDv4 format with the prefix bibdatabasecontext_
      */


### PR DESCRIPTION
Follow-up to #11400
Replace mapping of the BibDatabaseContext to use UIDs, fixing the issue of search results being 0 after updating an entry.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
