### PR TITLE
Fix missing external changes resolver dialog scrollbar 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We slightly improved the duplicate check if ISBNs are present. [#8885](https://github.com/JabRef/jabref/issues/8885)
 - JabRef no longer downloads HTML files of websites when a PDF was not found. [#10149](https://github.com/JabRef/jabref/issues/10149)
 - We added the HTTP message (in addition to the response code) if an error is encountered. [#11341](https://github.com/JabRef/jabref/pull/11341)
+- We made label wrap text to fit view size when reviewing external group changes. [#11220](https://github.com/JabRef/jabref/issues/11220)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the entry editor context menu was not shown correctly when JabRef is opened on a second, extended screen [#11323](https://github.com/JabRef/jabref/issues/11323), [#11174](https://github.com/JabRef/jabref/issues/11174)
 - We fixed an issue where the value of "Override default font settings" was not applied on startup [#11344](https://github.com/JabRef/jabref/issues/11344)
 - We fixed an issue when "Library changed on disk" appeared after a save by JabRef. [#4877](https://github.com/JabRef/jabref/issues/4877)  
+- We fixed an issue where the value of "Override default font settings" was not applied on startup [#11344](https://github.com/JabRef/jabref/issues/11344)
+- We fixed an issue where DatabaseChangeDetailsView was not scrollable when reviewing external metadata changes [#11220](https://github.com/JabRef/jabref/issues/11220)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsView.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.collab;
 
+import javafx.scene.Node;
 import javafx.scene.layout.AnchorPane;
 
 import org.jabref.gui.collab.entrychange.EntryChangeDetailsView;
@@ -12,5 +13,32 @@ import org.jabref.gui.collab.stringchange.BibTexStringChangeDetailsView;
 import org.jabref.gui.collab.stringdelete.BibTexStringDeleteDetailsView;
 import org.jabref.gui.collab.stringrename.BibTexStringRenameDetailsView;
 
-public sealed abstract class DatabaseChangeDetailsView extends AnchorPane permits EntryWithPreviewAndSourceDetailsView, GroupChangeDetailsView, MetadataChangeDetailsView, PreambleChangeDetailsView, BibTexStringAddDetailsView, BibTexStringChangeDetailsView, BibTexStringDeleteDetailsView, BibTexStringRenameDetailsView, EntryChangeDetailsView {
+public sealed abstract class DatabaseChangeDetailsView extends AnchorPane permits
+        EntryWithPreviewAndSourceDetailsView,
+        GroupChangeDetailsView,
+        MetadataChangeDetailsView,
+        PreambleChangeDetailsView,
+        BibTexStringAddDetailsView,
+        BibTexStringChangeDetailsView,
+        BibTexStringDeleteDetailsView,
+        BibTexStringRenameDetailsView,
+        EntryChangeDetailsView {
+
+    private static Double ANCHOR_PANE_OFFSET = 8D;
+
+    /**
+     * Set left, top, right, bottom anchors based on common offset parameter for the given child
+     * and attach it to children.
+     *
+     * @param child the child node of the implementation
+     * @see AnchorPane#getChildren()
+     * @see javafx.collections.ObservableList#setAll(Object[])
+     */
+    protected void setAllAnchorsAndAttachChild(Node child) {
+        setLeftAnchor(child, ANCHOR_PANE_OFFSET);
+        setTopAnchor(child, ANCHOR_PANE_OFFSET);
+        setRightAnchor(child, ANCHOR_PANE_OFFSET);
+        setBottomAnchor(child, ANCHOR_PANE_OFFSET);
+        this.getChildren().setAll(child);
+    }
 }

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsViewFactory.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsViewFactory.java
@@ -57,28 +57,43 @@ public class DatabaseChangeDetailsViewFactory {
     }
 
     public DatabaseChangeDetailsView create(DatabaseChange databaseChange) {
-        // TODO: Use Pattern Matching for switch once it's out of preview
-        if (databaseChange instanceof EntryChange entryChange) {
-            return new EntryChangeDetailsView(entryChange.getOldEntry(), entryChange.getNewEntry(), databaseContext, dialogService, stateManager, themeManager, preferencesService, entryTypesManager, previewViewer, taskExecutor);
-        } else if (databaseChange instanceof EntryAdd entryAdd) {
-            return new EntryWithPreviewAndSourceDetailsView(entryAdd.getAddedEntry(), databaseContext, preferencesService, entryTypesManager, previewViewer);
-        } else if (databaseChange instanceof EntryDelete entryDelete) {
-            return new EntryWithPreviewAndSourceDetailsView(entryDelete.getDeletedEntry(), databaseContext, preferencesService, entryTypesManager, previewViewer);
-        } else if (databaseChange instanceof BibTexStringAdd stringAdd) {
-            return new BibTexStringAddDetailsView(stringAdd);
-        } else if (databaseChange instanceof BibTexStringDelete stringDelete) {
-            return new BibTexStringDeleteDetailsView(stringDelete);
-        } else if (databaseChange instanceof BibTexStringChange stringChange) {
-            return new BibTexStringChangeDetailsView(stringChange);
-        } else if (databaseChange instanceof BibTexStringRename stringRename) {
-            return new BibTexStringRenameDetailsView(stringRename);
-        } else if (databaseChange instanceof MetadataChange metadataChange) {
-            return new MetadataChangeDetailsView(metadataChange, preferencesService.getCitationKeyPatternPreferences().getKeyPatterns());
-        } else if (databaseChange instanceof GroupChange groupChange) {
-            return new GroupChangeDetailsView(groupChange);
-        } else if (databaseChange instanceof PreambleChange preambleChange) {
-            return new PreambleChangeDetailsView(preambleChange);
-        }
-        throw new UnsupportedOperationException("Cannot preview the given change: " + databaseChange.getName());
+        return switch (databaseChange) {
+            case EntryChange entryChange -> new EntryChangeDetailsView(
+                entryChange.getOldEntry(),
+                entryChange.getNewEntry(),
+                databaseContext,
+                dialogService,
+                stateManager,
+                themeManager,
+                preferencesService,
+                entryTypesManager,
+                previewViewer,
+                taskExecutor
+            );
+            case EntryAdd entryAdd -> new EntryWithPreviewAndSourceDetailsView(
+                entryAdd.getAddedEntry(),
+                databaseContext,
+                preferencesService,
+                entryTypesManager,
+                previewViewer
+            );
+            case EntryDelete entryDelete -> new EntryWithPreviewAndSourceDetailsView(
+                entryDelete.getDeletedEntry(),
+                databaseContext,
+                preferencesService,
+                entryTypesManager,
+                previewViewer
+            );
+            case BibTexStringAdd stringAdd -> new BibTexStringAddDetailsView(stringAdd);
+            case BibTexStringDelete stringDelete -> new BibTexStringDeleteDetailsView(stringDelete);
+            case BibTexStringChange stringChange -> new BibTexStringChangeDetailsView(stringChange);
+            case BibTexStringRename stringRename -> new BibTexStringRenameDetailsView(stringRename);
+            case MetadataChange metadataChange -> new MetadataChangeDetailsView(
+                metadataChange,
+                preferencesService.getCitationKeyPatternPreferences().getKeyPatterns()
+            );
+            case GroupChange groupChange -> new GroupChangeDetailsView(groupChange);
+            case PreambleChange preambleChange -> new PreambleChangeDetailsView(preambleChange);
+        };
     }
 }

--- a/src/main/java/org/jabref/gui/collab/entrychange/EntryChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/entrychange/EntryChangeDetailsView.java
@@ -72,12 +72,7 @@ public final class EntryChangeDetailsView extends DatabaseChangeDetailsView {
         SplitPane split = new SplitPane(containerOld, containerNew);
         split.setOrientation(Orientation.HORIZONTAL);
 
-        setLeftAnchor(split, 8d);
-        setTopAnchor(split, 8d);
-        setRightAnchor(split, 8d);
-        setBottomAnchor(split, 8d);
-
-        this.getChildren().add(split);
+        this.setAllAnchorsAndAttachChild(split);
     }
 
     // Method adapted from:

--- a/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -15,6 +15,8 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
             labelValue = Localization.lang("%0. Accepting the change replaces the complete groups tree with the externally modified groups tree.", groupChange.getName());
         }
         Label label = new Label(labelValue);
+        label.setWrapText(true);
+
         setLeftAnchor(label, 8d);
         setTopAnchor(label, 8d);
         setRightAnchor(label, 8d);

--- a/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/groupchange/GroupChangeDetailsView.java
@@ -17,11 +17,6 @@ public final class GroupChangeDetailsView extends DatabaseChangeDetailsView {
         Label label = new Label(labelValue);
         label.setWrapText(true);
 
-        setLeftAnchor(label, 8d);
-        setTopAnchor(label, 8d);
-        setRightAnchor(label, 8d);
-        setBottomAnchor(label, 8d);
-
-        getChildren().setAll(label);
+        this.setAllAnchorsAndAttachChild(label);
     }
 }

--- a/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -25,12 +25,8 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
         }
 
         ScrollPane scrollPane = new ScrollPane(container);
-        getChildren().setAll(scrollPane);
 
-        setLeftAnchor(scrollPane, 8d);
-        setTopAnchor(scrollPane, 8d);
-        setRightAnchor(scrollPane, 8d);
-        setBottomAnchor(scrollPane, 8d);
+        this.setAllAnchorsAndAttachChild(scrollPane);
     }
 
     private String getDifferenceString(MetaDataDiff.DifferenceType changeType) {

--- a/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -25,7 +25,6 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
         }
 
         ScrollPane scrollPane = new ScrollPane(container);
-        scrollPane.setFitToWidth(true);
         getChildren().setAll(scrollPane);
 
         setLeftAnchor(scrollPane, 8d);

--- a/src/main/java/org/jabref/gui/collab/preamblechange/PreambleChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/preamblechange/PreambleChangeDetailsView.java
@@ -27,11 +27,7 @@ public final class PreambleChangeDetailsView extends DatabaseChangeDetailsView {
         } else {
             container.getChildren().add(new Label(Localization.lang("Value cleared externally")));
         }
-        setLeftAnchor(container, 8d);
-        setTopAnchor(container, 8d);
-        setRightAnchor(container, 8d);
-        setBottomAnchor(container, 8d);
 
-        getChildren().setAll(container);
+        this.setAllAnchorsAndAttachChild(container);
     }
 }

--- a/src/main/java/org/jabref/gui/collab/stringadd/BibTexStringAddDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/stringadd/BibTexStringAddDetailsView.java
@@ -17,11 +17,7 @@ public final class BibTexStringAddDetailsView extends DatabaseChangeDetailsView 
                 new Label(Localization.lang("Label: %0", stringAdd.getAddedString().getName())),
                 new Label(Localization.lang("Content: %0", stringAdd.getAddedString().getContent()))
         );
-        setLeftAnchor(container, 8d);
-        setTopAnchor(container, 8d);
-        setRightAnchor(container, 8d);
-        setBottomAnchor(container, 8d);
 
-        getChildren().setAll(container);
+        this.setAllAnchorsAndAttachChild(container);
     }
 }

--- a/src/main/java/org/jabref/gui/collab/stringchange/BibTexStringChangeDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/stringchange/BibTexStringChangeDetailsView.java
@@ -19,11 +19,7 @@ public final class BibTexStringChangeDetailsView extends DatabaseChangeDetailsVi
         );
 
         container.getChildren().add(new Label(Localization.lang("Current content: %0", stringChange.getOldString().getContent())));
-        setLeftAnchor(container, 8d);
-        setTopAnchor(container, 8d);
-        setRightAnchor(container, 8d);
-        setBottomAnchor(container, 8d);
 
-        getChildren().setAll(container);
+        this.setAllAnchorsAndAttachChild(container);
     }
 }

--- a/src/main/java/org/jabref/gui/collab/stringdelete/BibTexStringDeleteDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/stringdelete/BibTexStringDeleteDetailsView.java
@@ -17,11 +17,7 @@ public final class BibTexStringDeleteDetailsView extends DatabaseChangeDetailsVi
                 new Label(Localization.lang("Label: %0", stringDelete.getDeletedString().getName())),
                 new Label(Localization.lang("Content: %0", stringDelete.getDeletedString().getContent()))
         );
-        setLeftAnchor(container, 8d);
-        setTopAnchor(container, 8d);
-        setRightAnchor(container, 8d);
-        setBottomAnchor(container, 8d);
 
-        getChildren().setAll(container);
+        this.setAllAnchorsAndAttachChild(container);
     }
 }

--- a/src/main/java/org/jabref/gui/collab/stringrename/BibTexStringRenameDetailsView.java
+++ b/src/main/java/org/jabref/gui/collab/stringrename/BibTexStringRenameDetailsView.java
@@ -8,11 +8,7 @@ public final class BibTexStringRenameDetailsView extends DatabaseChangeDetailsVi
 
     public BibTexStringRenameDetailsView(BibTexStringRename stringRename) {
         Label label = new Label(stringRename.getNewString().getName() + " : " + stringRename.getOldString().getContent());
-        setLeftAnchor(label, 8d);
-        setTopAnchor(label, 8d);
-        setRightAnchor(label, 8d);
-        setBottomAnchor(label, 8d);
 
-        getChildren().setAll(label);
+        this.setAllAnchorsAndAttachChild(label);
     }
 }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Closes [issue 1120](https://github.com/JabRef/jabref/issues/11220)

See screenshots bellow.

And refactor some code from the **org.jabref.gui.collab** package:

- Make the anchor pane offset configuration common for all subclasses of  **org.jabref.gui.collab.DatabaseChangeDetailsView**
- Replace the pattern mathing for if statement by a pattern matching for switch statement in **org.jabref.gui.collab.DatabaseChangeDetailsViewFactory** and remove the related TODO

Please read commits one by one to make PR easier to understand.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [X] Screenshots added in PR description (for UI changes)
- [X] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [X] [Checked documentation](https://docs.jabref.org/): Is the iorg.jabref.gui.collab.DatabaseChangeDetailsViewFactorynformation available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

![scrollable-metada-changes-review](https://github.com/JabRef/jabref/assets/12486558/ed37207d-9cbb-4cf4-aec4-2a4923d51e50)
![boxed-group-tree-modification-message](https://github.com/JabRef/jabref/assets/12486558/ed6220b6-f56a-4eb3-bf0d-dc1c2af95b43)

