### PR TITLE
Improve document viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the Pubmed/Medline Plain importer would not respect the user defined keyword separator [#11413](https://github.com/JabRef/jabref/issues/11413)
 - We fixed an issue where the value of "Override default font settings" was not applied on startup [#11344](https://github.com/JabRef/jabref/issues/11344)
 - We fixed an issue where DatabaseChangeDetailsView was not scrollable when reviewing external metadata changes [#11220](https://github.com/JabRef/jabref/issues/11220)
-- Fixed an issue where clicking on a page number in the search results tab opens a wrong file in the document viewer. [#11432](https://github.com/JabRef/jabref/pull/11432)
+- We fixed an issue where clicking on a page number in the search results tab opens a wrong file in the document viewer. [#11432](https://github.com/JabRef/jabref/pull/11432)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the Pubmed/Medline Plain importer would not respect the user defined keyword separator [#11413](https://github.com/JabRef/jabref/issues/11413)
 - We fixed an issue where the value of "Override default font settings" was not applied on startup [#11344](https://github.com/JabRef/jabref/issues/11344)
 - We fixed an issue where DatabaseChangeDetailsView was not scrollable when reviewing external metadata changes [#11220](https://github.com/JabRef/jabref/issues/11220)
+- Fixed an issue where clicking on a page number in the search results tab opens a wrong file in the document viewer.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the Pubmed/Medline Plain importer would not respect the user defined keyword separator [#11413](https://github.com/JabRef/jabref/issues/11413)
 - We fixed an issue where the value of "Override default font settings" was not applied on startup [#11344](https://github.com/JabRef/jabref/issues/11344)
 - We fixed an issue where DatabaseChangeDetailsView was not scrollable when reviewing external metadata changes [#11220](https://github.com/JabRef/jabref/issues/11220)
-- Fixed an issue where clicking on a page number in the search results tab opens a wrong file in the document viewer.
+- Fixed an issue where clicking on a page number in the search results tab opens a wrong file in the document viewer. [#11432](https://github.com/JabRef/jabref/pull/11432)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewModel.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewModel.java
@@ -5,13 +5,9 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.ObservableList;
 
 public abstract class DocumentViewModel {
-    private IntegerProperty maxPages = new SimpleIntegerProperty();
+    private final IntegerProperty maxPages = new SimpleIntegerProperty();
 
     public abstract ObservableList<DocumentPageViewModel> getPages();
-
-    public int getMaxPages() {
-        return maxPages.get();
-    }
 
     public IntegerProperty maxPagesProperty() {
         return maxPages;

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewer.fxml
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewer.fxml
@@ -46,7 +46,7 @@
             <bottom>
                 <ToolBar>
                     <HBox alignment="CENTER" spacing="5.0" HBox.hgrow="ALWAYS">
-                        <Button onAction="#previousPage" styleClass="icon-button">
+                        <Button fx:id="previousButton" onAction="#previousPage" styleClass="icon-button">
                             <graphic>
                                 <JabRefIconView glyph="PREVIOUS_LEFT"/>
                             </graphic>
@@ -57,7 +57,7 @@
                         <TextField fx:id="currentPage" minWidth="30.0" prefWidth="40.0"/>
                         <Label text="of"/>
                         <Label fx:id="maxPages"/>
-                        <Button onAction="#nextPage" styleClass="icon-button">
+                        <Button fx:id="nextButton" onAction="#nextPage" styleClass="icon-button">
                             <graphic>
                                 <JabRefIconView glyph="NEXT_RIGHT"/>
                             </graphic>

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
@@ -118,7 +118,7 @@ public class DocumentViewerView extends BaseDialog<Void> {
                 (observable, oldValue, newValue) -> viewModel.switchToFile(newValue));
         // We always want that the first item is selected after a change
         // This also automatically selects the first file on the initial load
-        Stage stage = ((Stage) getDialogPane().getScene().getWindow());
+        Stage stage = (Stage) getDialogPane().getScene().getWindow();
         fileChoice.itemsProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue.isEmpty()) {
                 stage.close();

--- a/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
+++ b/src/main/java/org/jabref/gui/documentviewer/DocumentViewerView.java
@@ -2,6 +2,7 @@ package org.jabref.gui.documentviewer;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
@@ -9,8 +10,10 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ScrollBar;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Modality;
+import javafx.stage.Stage;
 
 import org.jabref.gui.StateManager;
 import org.jabref.gui.util.BaseDialog;
@@ -29,10 +32,13 @@ public class DocumentViewerView extends BaseDialog<Void> {
     @FXML private ScrollBar scrollBar;
     @FXML private ComboBox<LinkedFile> fileChoice;
     @FXML private BorderPane mainPane;
+    @FXML private ToggleGroup toggleGroupMode;
     @FXML private ToggleButton modeLive;
     @FXML private ToggleButton modeLock;
     @FXML private TextField currentPage;
     @FXML private Label maxPages;
+    @FXML private Button nextButton;
+    @FXML private Button previousButton;
 
     @Inject private StateManager stateManager;
     @Inject private TaskExecutor taskExecutor;
@@ -65,18 +71,22 @@ public class DocumentViewerView extends BaseDialog<Void> {
         setupModeButtons();
     }
 
-    private void setupModeButtons() throws RuntimeException {
-        viewModel.liveModeProperty().addListener((observable, oldValue, newValue) -> {
-            modeLive.setSelected(newValue);
+    private void setupModeButtons() {
+        // make sure that always one toggle is selected
+        toggleGroupMode.selectedToggleProperty().addListener((observable, oldToggle, newToggle) -> {
+            if (newToggle == null) {
+                oldToggle.setSelected(true);
+            }
         });
 
-        modeLive.setOnAction(event -> {
-            if (!viewModel.liveModeProperty().get()) {
+        modeLive.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
                 viewModel.setLiveMode(true);
             }
         });
-        modeLock.setOnAction(event -> {
-            if (viewModel.liveModeProperty().get()) {
+
+        modeLock.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue) {
                 viewModel.setLiveMode(false);
             }
         });
@@ -92,6 +102,11 @@ public class DocumentViewerView extends BaseDialog<Void> {
         viewModel.currentPageProperty().bindBidirectional(integerFormatter.valueProperty());
         currentPage.setTextFormatter(integerFormatter);
         maxPages.textProperty().bind(viewModel.maxPagesProperty().asString());
+        previousButton.setDisable(true);
+        viewModel.currentPageProperty().addListener((observable, oldValue, newValue) -> {
+            nextButton.setDisable(newValue == viewModel.maxPagesProperty().get());
+            previousButton.setDisable(newValue == 1);
+        });
     }
 
     private void setupFileChoice() {
@@ -103,8 +118,14 @@ public class DocumentViewerView extends BaseDialog<Void> {
                 (observable, oldValue, newValue) -> viewModel.switchToFile(newValue));
         // We always want that the first item is selected after a change
         // This also automatically selects the first file on the initial load
-        fileChoice.itemsProperty().addListener(
-                (observable, oldValue, newValue) -> fileChoice.getSelectionModel().selectFirst());
+        Stage stage = ((Stage) getDialogPane().getScene().getWindow());
+        fileChoice.itemsProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue.isEmpty()) {
+                stage.close();
+            } else {
+                fileChoice.getSelectionModel().selectFirst();
+            }
+        });
         fileChoice.itemsProperty().bind(viewModel.filesProperty());
     }
 
@@ -119,8 +140,12 @@ public class DocumentViewerView extends BaseDialog<Void> {
         mainPane.setCenter(viewer);
     }
 
-    public void setLiveMode(boolean liveMode) {
-        modeLive.setSelected(liveMode);
+    public void disableLiveMode() {
+        modeLock.setSelected(true);
+    }
+
+    public void switchToFile(LinkedFile file) {
+        fileChoice.getSelectionModel().select(file);
     }
 
     public void gotoPage(int pageNumber) {

--- a/src/main/java/org/jabref/gui/documentviewer/ShowDocumentViewerAction.java
+++ b/src/main/java/org/jabref/gui/documentviewer/ShowDocumentViewerAction.java
@@ -11,6 +11,8 @@ import com.airhacks.afterburner.injection.Injector;
 import static org.jabref.gui.actions.ActionHelper.needsEntriesSelected;
 
 public class ShowDocumentViewerAction extends SimpleCommand {
+    private final DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
+    private DocumentViewerView documentViewerView;
 
     public ShowDocumentViewerAction(StateManager stateManager, PreferencesService preferences) {
         this.executable.bind(needsEntriesSelected(stateManager).and(ActionHelper.isFilePresentForSelectedEntry(stateManager, preferences)));
@@ -18,7 +20,9 @@ public class ShowDocumentViewerAction extends SimpleCommand {
 
     @Override
     public void execute() {
-        DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
-        dialogService.showCustomDialog(new DocumentViewerView());
+        if (documentViewerView == null) {
+            documentViewerView = new DocumentViewerView();
+        }
+        dialogService.showCustomDialog(documentViewerView);
     }
 }


### PR DESCRIPTION
Some improvements to the document viewer and search results tab

- Clicking on the page number to open the document viewer, it was displaying the first linked file of the selected entry instead of the correct file. Also without custom CSS.
- "Open file" was open all linked files to the entry.
	![image](https://github.com/JabRef/jabref/assets/52158423/70711738-9eb2-44c0-a0d5-9dc93b990831)

- Added validation to the next and previous page buttons in the document viewer to disable them on the first and last pages.
- Close the document viewer when the selected entry does not have any linked files.
- Avoid opening multiple document viewers.
- Selecting multiple entries will add all linked files of the selected entries to the list of files.
	![image](https://github.com/JabRef/jabref/assets/52158423/54146a8a-985f-49fb-acdc-651bdcfdfa40)

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
