### PR TITLE
Increase height of preferences dialog

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
-<DialogPane prefHeight="700.0" prefWidth="1100.0" minHeight="400" minWidth="600"
+<DialogPane prefHeight="875.0" prefWidth="1100.0" minHeight="400" minWidth="600"
             xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.jabref.gui.preferences.PreferencesDialogView">
     <content>

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -65,10 +65,6 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
         themeManager.updateFontStyle(getDialogPane().getScene());
     }
 
-    public PreferencesDialogViewModel getViewModel() {
-        return viewModel;
-    }
-
     @FXML
     private void initialize() {
         viewModel = new PreferencesDialogViewModel(dialogService, preferencesService);


### PR DESCRIPTION
Normal screen resolutions are FullHD (1920x1080) or higher. Therefore, I took the liberty to increase the preferered hight of our preference dialog.

Before:

![image](https://github.com/JabRef/jabref/assets/1366654/2855a2ea-e83d-4fc4-a75d-4687a88d00db)

After:

![image](https://github.com/JabRef/jabref/assets/1366654/5e97e709-ff7e-40e9-acab-2377f26d6278)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
