### PR TITLE
Enable `./gradlew run` on Windows if more dependencies are used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -497,6 +497,8 @@ run {
                 'javafx.controls/javafx.scene.control.skin' : 'org.controlsfx.controls',
                 'javafx.graphics/javafx.scene' : 'org.controlsfx.controls'
         ]
+
+        createCommandLineArgumentFile = true
     }
 
     if (project.hasProperty('component')){

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ plugins {
 
     id 'me.champeau.jmh' version '0.7.2'
 
-    id 'org.javamodularity.moduleplugin' version '1.8.15'
+    // This is https://github.com/java9-modularity/gradle-modules-plugin/pull/282
+    id 'com.github.koppor.gradle-modules-plugin' version 'jitpack-SNAPSHOT'
 
     id 'org.openjfx.javafxplugin' version '0.1.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,23 @@
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            // Hint from https://github.com/jitpack/jitpack.io/issues/1459#issuecomment-1279851731
+            // Updated solution at https://github.com/foodiestudio/convention-plugins?tab=readme-ov-file#convention-plugins
+            if (requested.id.id.startsWith("com.github.koppor")) {
+                // This is https://github.com/java9-modularity/gradle-modules-plugin/pull/282
+                useModule("com.github.koppor:gradle-modules-plugin:jitpack-SNAPSHOT")
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            url 'https://jitpack.io'
+        }
+        gradlePluginPortal()
+    }
+}
+
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }


### PR DESCRIPTION
We get error `206` on Windows if we add more dependencies. See https://github.com/InAnYan/jabref/issues/5 for details.

There is a fix (https://github.com/java9-modularity/gradle-modules-plugin/pull/282). This PR ports this fix to the `main` branch to enable new branches on Windows.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
