### PR TITLE
Implemented "Current selection" group option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added an exporter and improved the importer for Endnote XML format. [#11137](https://github.com/JabRef/jabref/issues/11137)
 - We added support for using BibTeX Style files (BST) in the Preview. [#11102](https://github.com/JabRef/jabref/issues/11102)
 - We added support for automatically update LaTeX citations when a LaTeX file is created, removed, or modified. [#10585](https://github.com/JabRef/jabref/issues/10585)
+- We added the ability to collect a group by your current selection. [#11449](https://github.com/JabRef/jabref/issues/11449)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added an exporter and improved the importer for Endnote XML format. [#11137](https://github.com/JabRef/jabref/issues/11137)
 - We added support for using BibTeX Style files (BST) in the Preview. [#11102](https://github.com/JabRef/jabref/issues/11102)
 - We added support for automatically update LaTeX citations when a LaTeX file is created, removed, or modified. [#10585](https://github.com/JabRef/jabref/issues/10585)
-- We added the ability to collect a group by your current selection. [#11449](https://github.com/JabRef/jabref/issues/11449)
+- We added the ability to add the current selection to a newly created group. [#11449](https://github.com/JabRef/jabref/issues/11449)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.fxml
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.fxml
@@ -99,6 +99,12 @@
                             <Tooltip text="%Group containing entries cited in a given TeX file"/>
                         </tooltip>
                     </RadioButton>
+                    <RadioButton fx:id="selectionRadioButton" toggleGroup="$type" wrapText="true"
+                                 text="%Current selection">
+                        <tooltip>
+                            <Tooltip text="%Group all entries currently selected"/>
+                        </tooltip>
+                    </RadioButton>
                 </VBox>
                 <Separator orientation="VERTICAL"/>
                 <StackPane HBox.hgrow="ALWAYS">

--- a/src/main/java/org/jabref/gui/groups/GroupDialogView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogView.java
@@ -41,6 +41,7 @@ import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.GroupHierarchyType;
 import org.jabref.model.groups.GroupTreeNode;
@@ -81,6 +82,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
     @FXML private RadioButton searchRadioButton;
     @FXML private RadioButton autoRadioButton;
     @FXML private RadioButton texRadioButton;
+    @FXML private RadioButton selectionRadioButton;
 
     // Option Groups
     @FXML private TextField keywordGroupSearchTerm;
@@ -109,6 +111,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
     private final BibDatabaseContext currentDatabase;
     private final @Nullable GroupTreeNode parentNode;
     private final @Nullable AbstractGroup editedGroup;
+    private final List<BibEntry> selectedEntries;
 
     private GroupDialogViewModel viewModel;
 
@@ -119,10 +122,12 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
     public GroupDialogView(BibDatabaseContext currentDatabase,
                            @Nullable GroupTreeNode parentNode,
                            @Nullable AbstractGroup editedGroup,
-                           GroupDialogHeader groupDialogHeader) {
+                           GroupDialogHeader groupDialogHeader,
+                           List<BibEntry> selectedEntries) {
         this.currentDatabase = currentDatabase;
         this.parentNode = parentNode;
         this.editedGroup = editedGroup;
+        this.selectedEntries = selectedEntries;
 
         ViewLoader.view(this)
                   .load()
@@ -172,7 +177,7 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
 
     @FXML
     public void initialize() {
-        viewModel = new GroupDialogViewModel(dialogService, currentDatabase, preferencesService, editedGroup, parentNode, fileUpdateMonitor);
+        viewModel = new GroupDialogViewModel(dialogService, currentDatabase, preferencesService, editedGroup, parentNode, fileUpdateMonitor, selectedEntries);
 
         setResultConverter(viewModel::resultConverter);
 
@@ -200,6 +205,8 @@ public class GroupDialogView extends BaseDialog<AbstractGroup> {
         searchRadioButton.selectedProperty().bindBidirectional(viewModel.typeSearchProperty());
         autoRadioButton.selectedProperty().bindBidirectional(viewModel.typeAutoProperty());
         texRadioButton.selectedProperty().bindBidirectional(viewModel.typeTexProperty());
+        selectionRadioButton.selectedProperty().bindBidirectional(viewModel.typeSelectionProperty());
+        selectionRadioButton.disableProperty().bind(viewModel.entriesAreSelectedProperty().not());
 
         keywordGroupSearchTerm.textProperty().bindBidirectional(viewModel.keywordGroupSearchTermProperty());
         keywordGroupSearchField.textProperty().bindBidirectional(viewModel.keywordGroupSearchFieldProperty());

--- a/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialogViewModel.java
@@ -136,7 +136,7 @@ public class GroupDialogViewModel {
         setValues();
     }
 
-    public GroupDialogViewModel (
+    public GroupDialogViewModel(
             DialogService dialogService,
             BibDatabaseContext currentDatabase,
             PreferencesService preferencesService,

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -399,7 +399,7 @@ public class GroupTreeView extends BorderPane {
     }
 
     private void selectNode(GroupNodeViewModel value) {
-        selectNode(value, false);
+        selectNode(value, true);
     }
 
     private void selectNode(GroupNodeViewModel value, boolean expandParents) {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -175,7 +175,9 @@ public class GroupTreeViewModel extends AbstractViewModel {
                     database,
                     parent.getGroupNode(),
                     null,
-                    groupDialogHeader));
+                    groupDialogHeader,
+                    stateManager.getSelectedEntries()
+            ));
 
             newGroup.ifPresent(group -> {
                 parent.addSubgroup(group);
@@ -260,7 +262,9 @@ public class GroupTreeViewModel extends AbstractViewModel {
                     database,
                     oldGroup.getGroupNode().getParent().orElse(null),
                     oldGroup.getGroupNode().getGroup(),
-                    GroupDialogHeader.SUBGROUP));
+                    GroupDialogHeader.SUBGROUP,
+                    stateManager.getSelectedEntries()
+            ));
             newGroup.ifPresent(group -> {
 
                 AbstractGroup oldGroupDef = oldGroup.getGroupNode().getGroup();

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2649,3 +2649,5 @@ Note\:\ The\ study\ directory\ should\ be\ empty.=Note: The study directory shou
 Warning\:\ The\ selected\ directory\ is\ not\ empty.=Warning: The selected directory is not empty.
 Warning\:\ Failed\ to\ check\ if\ the\ directory\ is\ empty.=Warning: Failed to check if the directory is empty.
 Warning\:\ The\ selected\ directory\ is\ not\ a\ valid\ directory.=Warning: The selected directory is not a valid directory.
+Current\ selection=Current selection
+Group\ all\ entries\ currently\ selected=Group containing all entries currently selected

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2650,4 +2650,4 @@ Warning\:\ The\ selected\ directory\ is\ not\ empty.=Warning: The selected direc
 Warning\:\ Failed\ to\ check\ if\ the\ directory\ is\ empty.=Warning: Failed to check if the directory is empty.
 Warning\:\ The\ selected\ directory\ is\ not\ a\ valid\ directory.=Warning: The selected directory is not a valid directory.
 Current\ selection=Current selection
-Group\ all\ entries\ currently\ selected=Group containing all entries currently selected
+Group\ all\ entries\ currently\ selected=Group all entries currently selected


### PR DESCRIPTION
Added new option to the "Group Options" in the GroupDialog to allow the creation of a group that contains the currently selected entries. If there are no entries selected, this option is disabled. If there is more than one entry selected, this option is selected by default.

![image](https://github.com/JabRef/jabref/assets/111776404/96bf30ed-3bc7-4268-b204-caead4167e80)

Closes https://github.com/JabRef/jabref/issues/11449.

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
