### PR TITLE
Initial Vagrant config

### DIFF
--- a/scripts/vms/.gitignore
+++ b/scripts/vms/.gitignore
@@ -1,0 +1,2 @@
+**/.vagrant
+**/vagrant-ssh

--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -1,0 +1,41 @@
+# Virtual Machines for testing JabRef
+
+This folder contains directories making use of [Vagrant](https://www.vagrantup.com/) to install virtual machines on [VirtualBox](https://www.virtualbox.org/)
+
+## Usage
+
+### Prerequisites
+
+1. [Install VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+    - Windows: `winget install -e --id Oracle.VirtualBox`
+2. [Install Vagrant](https://developer.hashicorp.com/vagrant/install?product_intent=vagrant)
+    - Windows: `winget install  -e --id Hashicorp.Vagrant`
+
+### Setup VM
+
+1. `cd` into `ubuntu`
+2. Start the vm `vagrant up`
+3. Store ssh configuration: `vagrant ssh-config > default`
+
+### Use VM
+
+You can use the UI offered by the VirtualBox client.
+You can also do `ssh -Y -F vagrant-ssh default` to SSH into the machine.
+
+If asked for a password, this is `vagrant`.
+
+### Remove VM
+
+Execute `vagrant destroy`.
+Then, everything is removed.
+
+## Trouble shooting
+
+> VBoxManage.exe: error: Could not rename the directory '`C:\Users\$username\VirtualBox VMs\output-ubuntu_source_1720167378145_42641_1720548095320_67904`' to '`C:\Users\$username\VirtualBox VMs\jabref-ubuntu`' to save the settings file (`VERR_ALREADY_EXISTS`)
+
+Solution: Delete folder `C:\Users\$username\VirtualBox VMs\jabref-ubuntu`
+
+> How to use another JabRef snap image?
+
+Solution: `snap refresh --edge jabref` (or `--stable`, ...).
+More info on snaps is available at <https://snapcraft.io/docs/quickstart-tour>.

--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -29,7 +29,11 @@ If asked for a password, this is `vagrant`.
 Execute `vagrant destroy`.
 Then, everything is removed.
 
-## Trouble shooting
+## Available VMs
+
+- `ubuntu`: Ubuntu with JabRef snap and libreoffice-connection pre-installed. One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.
+
+## Troubleshooting
 
 > VBoxManage.exe: error: Could not rename the directory '`C:\Users\$username\VirtualBox VMs\output-ubuntu_source_1720167378145_42641_1720548095320_67904`' to '`C:\Users\$username\VirtualBox VMs\jabref-ubuntu`' to save the settings file (`VERR_ALREADY_EXISTS`)
 

--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -32,6 +32,7 @@ Then, everything is removed.
 ## Available VMs
 
 - `ubuntu`: Ubuntu with JabRef snap and libreoffice-connection pre-installed. One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.
+- `fedora`: Fedora 39 with KDE plasma and JDK. During the build, the JabRef sources will be fetched and an initial build will be triggered. Login and then type `startx`. Now KDE Plasma should start. Open Konsole. Then `cd jabref`. Then `./gradlew run`.
 
 ## Troubleshooting
 

--- a/scripts/vms/fedora/Vagrantfile
+++ b/scripts/vms/fedora/Vagrantfile
@@ -17,8 +17,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: "sudo dnf update -y"
   config.vm.provision "shell", inline: "sudo dnf install -y @kde-desktop-environment"
-  # X11 seems to be required by the Clipboard functionality (Java AWT)
-  config.vm.provision "shell", inline: "sudo dnf install -y kwin-x11 plasma-workspace-x11"
+
+  # Following X11 packages are NOT required even the clipboard functionality seems to ask for (cf. https://github.com/JabRef/jabref/issues/11464)
+  # config.vm.provision "shell", inline: "sudo dnf install -y kwin-x11 plasma-workspace-x11"
 
   # We need exactly the java version required by JabRef. Auto download does not work on Fedora.
   config.vm.provision "shell", inline: "sudo dnf install -y git java-21-openjdk-devel.x86_64"

--- a/scripts/vms/fedora/Vagrantfile
+++ b/scripts/vms/fedora/Vagrantfile
@@ -1,0 +1,35 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "fedora/39-cloud-base"
+
+  config.vm.network :forwarded_port, guest: 80, host: 8080, auto_correct: true
+  config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true
+  config.vm.network :forwarded_port, guest: 5000, host: 5000, auto_correct: true
+
+  config.vm.provider "virtualbox" do |v|
+    v.name = "jabref-fedora"
+    v.gui = true
+    v.customize ["modifyvm", :id, "--memory", "4096", "--cpus", "2"]
+  end
+
+  config.vm.provision "shell", inline: "sudo dnf update -y"
+  config.vm.provision "shell", inline: "sudo dnf install -y @kde-desktop-environment"
+  # X11 seems to be required by the Clipboard functionality (Java AWT)
+  config.vm.provision "shell", inline: "sudo dnf install -y kwin-x11 plasma-workspace-x11"
+
+  # We need exactly the java version required by JabRef. Auto download does not work on Fedora.
+  config.vm.provision "shell", inline: "sudo dnf install -y git java-21-openjdk-devel.x86_64"
+
+  config.vm.provision "shell", inline: "sudo systemctl set-default graphical.target"
+
+  config.vm.provision "shell", inline: "git clone --recurse-submodules https://github.com/JabRef/jabref.git", privileged: false
+  config.vm.provision "shell", inline: "cd jabref && ./gradlew jar || true", privileged: false
+
+  # config.vm.provision "shell", inline: "sudo systemctl enable sddm"
+  config.vm.provision "shell", inline: "sudo reboot"
+
+  config.ssh.forward_x11 = true
+end

--- a/scripts/vms/ubuntu/Vagrantfile
+++ b/scripts/vms/ubuntu/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # config.vm.box = "ubuntu/trusty64"
+  # config.vm.box = "ubuntu/jammy64"
+  # config.vm.box = "alvistack/ubuntu-24.04"
+
+  # https://app.vagrantup.com/caspermeijn/boxes/ubuntu-desktop-24.04
+  # GitHub: https://github.com/caspermeijn/vagrant-ubuntu-desktop/tree/main/ubuntu-desktop-24.04
+  # Here, the ubuntu-desktop works without usses
+  config.vm.box = "caspermeijn/ubuntu-desktop-24.04"
+
+  config.vm.network :forwarded_port, guest: 80, host: 8080, auto_correct: true
+  config.vm.network :forwarded_port, guest: 9000, host: 9000, auto_correct: true
+  config.vm.network :forwarded_port, guest: 5000, host: 5000, auto_correct: true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "C:/TEMP/JabRef", "/tmp/jabref"
+
+  config.vm.provider "virtualbox" do |v|
+    v.name = "jabref-ubuntu"
+    v.gui = true
+    v.customize ["modifyvm", :id, "--memory", "2048", "--cpus", "2"]
+  end
+
+  config.vm.provision "shell", inline: "sudo apt-get update"
+  config.vm.provision "shell", inline: "sudo apt-get upgrade -y"
+
+  # Enable LibreOffice connection
+  config.vm.provision "shell", inline: "sudo apt-get install -y libreoffice-java-common"
+
+  config.vm.provision "shell", inline: "sudo snap install --edge jabref"
+
+  config.ssh.forward_x11 = true
+end

--- a/scripts/vms/ubuntu/Vagrantfile
+++ b/scripts/vms/ubuntu/Vagrantfile
@@ -28,13 +28,17 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--memory", "2048", "--cpus", "2"]
   end
 
+  # Update package index
   config.vm.provision "shell", inline: "sudo apt-get update"
   config.vm.provision "shell", inline: "sudo apt-get upgrade -y"
 
+  # Install latest development build of JabRef
+  config.vm.provision "shell", inline: "sudo snap install --edge jabref"
+
   # Enable LibreOffice connection
   config.vm.provision "shell", inline: "sudo apt-get install -y libreoffice-java-common"
-
-  config.vm.provision "shell", inline: "sudo snap install --edge jabref"
+  config.vm.provision "shell", inline: "sudo mkdir -p /usr/lib/mozilla/native-messaging-hosts"
+  config.vm.provision "shell", inline: "snap connect jabref:hostfs-mozilla-native-messaging-jabref"
 
   config.ssh.forward_x11 = true
 end

--- a/scripts/vms/ubuntu/Vagrantfile
+++ b/scripts/vms/ubuntu/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "C:/TEMP/JabRef", "/tmp/jabref"
+  # config.vm.synced_folder "C:/TEMP/JabRef", "/tmp/jabref"
 
   config.vm.provider "virtualbox" do |v|
     v.name = "jabref-ubuntu"


### PR DESCRIPTION
To have "the same" virtual machines ready to try out things, here is a proposal based on [Vagrant](https://developer.hashicorp.com/vagrant/install?product_intent=vagrant).

- Refs https://github.com/JabRef/jabref/issues/11465 (provides an Ubuntu where `snap` can be executed.)
- Refs https://github.com/JabRef/jabref/issues/11464 (provides a Fedora39 with a Java JDK available)

---

Follow up:

- Install JabRef Firefox plugin automatically - https://askubuntu.com/questions/73474/how-to-install-firefox-addon-from-command-line-in-scripts

---

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
