### PR TITLE
Fix launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed usage when using running on Snapcraft. [#11465](https://github.com/JabRef/jabref/issues/11465)
+
 ### Removed
 
 

--- a/snap/local/JabRef-launcher
+++ b/snap/local/JabRef-launcher
@@ -1,3 +1,2 @@
 #! /bin/sh
-DIR="$SNAP/lib/runtime/bin"
-"$DIR/java"  -p "$DIR/../app" -m org.jabref/org.jabref.Launcher  "$@"
+"$SNAP/lib/runtime/bin/JabRef" "$@"


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/11465

Reason: In #11195, we introduced `applicationDefaultJvmArgs`, which are required to be passed to `java` launcher.

The existing script (introduced in 2020, https://github.com/JabRef/jabref/pull/6439), did pass a wrong parameter `-p`. It was not noticed, because the path was not found (one `../` was missing). Now, we need this config "somehow", because of this #11195.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
