### PR TITLE
Fix detection of soffice.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,11 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We made new groups automatically to focus upon creation. [#11449](https://github.com/JabRef/jabref/issues/11449)
 
-### Changed
-
 ### Fixed
 
 - We fixed an issue where JabRef was no longer built for Intel based macs (x86) [#11468](https://github.com/JabRef/jabref/issues/11468)
 - We fixed usage when using running on Snapcraft. [#11465](https://github.com/JabRef/jabref/issues/11465)
+- We fixed detection for `soffice.exe` on Windows.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We fixed an issue where JabRef was no longer built for Intel based macs (x86) [#11468](https://github.com/JabRef/jabref/issues/11468)
 - We fixed usage when using running on Snapcraft. [#11465](https://github.com/JabRef/jabref/issues/11465)
-- We fixed detection for `soffice.exe` on Windows.
+- We fixed detection for `soffice.exe` on Windows. [#11478](https://github.com/JabRef/jabref/pull/11478)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We made new groups automatically to focus upon creation. [#11449](https://github.com/JabRef/jabref/issues/11449)
 
+### Changed
+
 ### Fixed
 
 - We fixed an issue where JabRef was no longer built for Intel based macs (x86) [#11468](https://github.com/JabRef/jabref/issues/11468)

--- a/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
+++ b/src/main/java/org/jabref/gui/openoffice/DetectOpenOfficeInstallation.java
@@ -49,7 +49,7 @@ public class DetectOpenOfficeInstallation {
         if (OS.LINUX && (System.getenv("FLATPAK_SANDBOX_DIR") != null)) {
             executablePath = OpenOfficePreferences.DEFAULT_LINUX_FLATPAK_EXEC_PATH;
         }
-        return !StringUtil.isNullOrEmpty(executablePath) && Files.exists(Path.of(executablePath));
+        return !StringUtil.isNullOrEmpty(executablePath) && Files.isRegularFile(Path.of(executablePath));
     }
 
     public boolean setOpenOfficePreferences(Path installDir) {

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -318,12 +318,12 @@ public class OpenOfficePanel {
             };
 
             taskConnectIfInstalled.setOnSucceeded(evt -> {
-                var installations = new ArrayList<>(taskConnectIfInstalled.getValue());
+                List<Path> installations = new ArrayList<>(taskConnectIfInstalled.getValue());
                 if (installations.isEmpty()) {
                     officeInstallation.selectInstallationPath().ifPresent(installations::add);
                 }
-                Optional<Path> actualFile = officeInstallation.chooseAmongInstallations(installations);
-                if (actualFile.isPresent() && officeInstallation.setOpenOfficePreferences(actualFile.get())) {
+                Optional<Path> chosenInstallationDirectory = officeInstallation.chooseAmongInstallations(installations);
+                if (chosenInstallationDirectory.isPresent() && officeInstallation.setOpenOfficePreferences(chosenInstallationDirectory.get())) {
                     connect();
                 }
             });
@@ -389,7 +389,7 @@ public class OpenOfficePanel {
             protected OOBibBase call() throws Exception {
                 updateProgress(ProgressBar.INDETERMINATE_PROGRESS, ProgressBar.INDETERMINATE_PROGRESS);
 
-                var path = Path.of(preferencesService.getOpenOfficePreferences().getExecutablePath());
+                Path path = Path.of(preferencesService.getOpenOfficePreferences().getExecutablePath());
                 return createBibBase(path);
             }
         };
@@ -399,7 +399,7 @@ public class OpenOfficePanel {
 
             ooBase.guiActionSelectDocument(true);
 
-            // Enable actions that depend on Connect:
+            // Enable actions that depend on a connection
             updateButtonAvailability();
         });
 

--- a/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
+++ b/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
@@ -55,8 +55,6 @@ public class OpenOfficeFileSearch {
                                          return Stream.empty();
                                      }
                                  })
-                                 // On Windows, the executable is nested in subdirectory "program"
-                                 .map(dir -> dir.resolve("program"))
                                  .toList();
     }
 
@@ -75,7 +73,11 @@ public class OpenOfficeFileSearch {
             sourceList.add(Path.of(progFiles));
         }
 
-        return findOpenOfficeDirectories(sourceList);
+        return findOpenOfficeDirectories(sourceList)
+                .stream()
+                // On Windows, the executable is nested in subdirectory "program"
+                .map(dir -> dir.resolve("program"))
+                .toList();
     }
 
     private static List<Path> findOSXOpenOfficeDirs() {

--- a/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
+++ b/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiPredicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jabref.logic.util.OS;
@@ -30,15 +29,16 @@ public class OpenOfficeFileSearch {
     public static List<Path> detectInstallations() {
         if (OS.WINDOWS) {
             List<Path> programDirs = findWindowsOpenOfficeDirs();
-            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.WINDOWS_EXECUTABLE, dir).isPresent()).collect(Collectors.toList());
+            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.WINDOWS_EXECUTABLE, dir).isPresent()).toList();
         } else if (OS.OS_X) {
             List<Path> programDirs = findOSXOpenOfficeDirs();
-            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.OSX_EXECUTABLE, dir).isPresent()).collect(Collectors.toList());
+            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.OSX_EXECUTABLE, dir).isPresent()).toList();
         } else if (OS.LINUX) {
             List<Path> programDirs = findLinuxOpenOfficeDirs();
-            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.LINUX_EXECUTABLE, dir).isPresent()).collect(Collectors.toList());
+            return programDirs.stream().filter(dir -> FileUtil.find(OpenOfficePreferences.LINUX_EXECUTABLE, dir).isPresent()).toList();
+        } else {
+            return List.of();
         }
-        return new ArrayList<>(0);
     }
 
     private static List<Path> findOpenOfficeDirectories(List<Path> programDirectories) {
@@ -46,14 +46,18 @@ public class OpenOfficeFileSearch {
                 attr.isDirectory() && (path.toString().toLowerCase(Locale.ROOT).contains("openoffice")
                         || path.toString().toLowerCase(Locale.ROOT).contains("libreoffice"));
 
-        return programDirectories.stream().flatMap(dirs -> {
-            try {
-                return Files.find(dirs, 1, filePredicate);
-            } catch (IOException e) {
-                LOGGER.error("Problem searching for openoffice/libreoffice install directory", e);
-                return Stream.empty();
-            }
-        }).collect(Collectors.toList());
+        return programDirectories.stream()
+                                 .flatMap(dirs -> {
+                                     try {
+                                         return Files.find(dirs, 1, filePredicate);
+                                     } catch (IOException e) {
+                                         LOGGER.error("Problem searching for openoffice/libreoffice install directory", e);
+                                         return Stream.empty();
+                                     }
+                                 })
+                                 // On Windows, the executable is nested in usb directory "program"
+                                 .map(dir -> dir.resolve("program"))
+                                 .toList();
     }
 
     private static List<Path> findWindowsOpenOfficeDirs() {

--- a/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
+++ b/src/main/java/org/jabref/logic/openoffice/OpenOfficeFileSearch.java
@@ -55,7 +55,7 @@ public class OpenOfficeFileSearch {
                                          return Stream.empty();
                                      }
                                  })
-                                 // On Windows, the executable is nested in usb directory "program"
+                                 // On Windows, the executable is nested in subdirectory "program"
                                  .map(dir -> dir.resolve("program"))
                                  .toList();
     }

--- a/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
+++ b/src/main/java/org/jabref/logic/openoffice/OpenOfficePreferences.java
@@ -11,7 +11,7 @@ import javafx.collections.ObservableList;
 
 public class OpenOfficePreferences {
 
-    public static final String DEFAULT_WIN_EXEC_PATH = "C:\\Program Files\\LibreOffice 5\\program";
+    public static final String DEFAULT_WIN_EXEC_PATH = "C:\\Program Files\\LibreOffice\\program";
     public static final String WINDOWS_EXECUTABLE = "soffice.exe";
 
     public static final String DEFAULT_OSX_EXEC_PATH = "/Applications/LibreOffice.app/Contents/MacOS/soffice";


### PR DESCRIPTION
JabRef could not detect `soffice.exe` on my machine. I fixed it.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
