### PR TITLE
Add minimal support for biblatex data annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Added
 
 - We added support for selecting and using CSL Styles in JabRef's OpenOffice/LibreOffice integration for inserting bibliographic and in-text citations into a document. [#2146](https://github.com/JabRef/jabref/issues/2146), [#8893](https://github.com/JabRef/jabref/issues/8893)
-- Added minimal support for [biblatex data annotation](http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.3.7) fields in .layout files.
+- Added minimal support for [biblatex data annotation](https://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.3.7) fields in .layout files. [#11505](https://github.com/JabRef/jabref/issues/11505)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Added
 
 - We added support for selecting and using CSL Styles in JabRef's OpenOffice/LibreOffice integration for inserting bibliographic and in-text citations into a document. [#2146](https://github.com/JabRef/jabref/issues/2146), [#8893](https://github.com/JabRef/jabref/issues/8893)
+- Added minimal support for [biblatex data annotation](http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.3.7) fields in .layout files.
 
 ### Changed
 

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -48,7 +48,7 @@ public class LayoutHelper {
                         List<Path> fileDirForDatabase,
                         LayoutFormatterPreferences preferences,
                         JournalAbbreviationRepository abbreviationRepository) {
-        this.in = new PushbackReader(Objects.requireNonNull(in));
+        this.in = new PushbackReader(Objects.requireNonNull(in), 2);
         this.preferences = Objects.requireNonNull(preferences);
         this.abbreviationRepository = abbreviationRepository;
         this.fileDirForDatabase = fileDirForDatabase;
@@ -262,7 +262,7 @@ public class LayoutHelper {
                 endOfFile = true;
             }
 
-            if (!Character.isLetter((char) c) && (c != '_')) {
+            if (!validChar(c) && !validAnnotation(c)) {
                 unread(c);
 
                 name = buffer == null ? "" : buffer.toString();
@@ -343,6 +343,19 @@ public class LayoutHelper {
                 buffer.append((char) c);
             }
         }
+    }
+
+    private boolean validAnnotation(int c) throws IOException {
+        // Only accept annotations that are followed by a valid character
+        boolean annotation = ((c == '+') || (c == ':')) && validChar(peek());
+
+        return annotation;
+    }
+
+    private boolean validChar(int c) throws IOException {
+        boolean character = Character.isLetter((char) c) || (c == '_');
+
+        return character;
     }
 
     private int peek() throws IOException {

--- a/src/main/java/org/jabref/logic/layout/LayoutHelper.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutHelper.java
@@ -352,7 +352,7 @@ public class LayoutHelper {
         return annotation;
     }
 
-    private boolean validChar(int c) throws IOException {
+    private boolean validChar(int c) {
         boolean character = Character.isLetter((char) c) || (c == '_');
 
         return character;

--- a/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -12,6 +12,7 @@ import org.jabref.logic.layout.format.NameFormatterPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.entry.types.UnknownEntryType;
 
@@ -172,5 +173,17 @@ class LayoutTest {
         String layoutText = layout("\\begin{author}\\format[DCA]{\\author}\\end{author}", entry);
 
         assertEquals("JoeDoe and MaryJ", layoutText);
+    }
+
+    @Test
+    void annotatedField() throws IOException {
+        UnknownField annotatedField = new UnknownField("author+an");
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+            .withField(annotatedField, "1:corresponding,2:highlight")
+            .withField(StandardField.AUTHOR, "Joe Doe and Mary Jane");
+
+        String layoutText = layout("\\author: \\author \\author+an", entry);
+
+        assertEquals("Joe Doe and Mary Jane: Joe Doe and Mary Jane 1:corresponding,2:highlight", layoutText);
     }
 }


### PR DESCRIPTION
Adds support in the layout parser for special characters `+:` used in biblatex data annotations.

Fixes #11505

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
