### PR TITLE
Fix NPE when saving preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where an exception was thrown after changing "show preview as a tab" in the preferences. [#11508](https://github.com/JabRef/jabref/pull/11508)
+- We fixed an issue where an exception was thrown after changing "show preview as a tab" in the preferences. [#11509](https://github.com/JabRef/jabref/pull/11509)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where an exception was thrown after changing "show preview as a tab" in the preferences. [#11508](https://github.com/JabRef/jabref/pull/11508)
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -147,8 +147,6 @@ public class EntryEditor extends BorderPane {
                 activeTab.notifyAboutFocus(currentlyEditedEntry);
             }
         });
-        EasyBind.listen(preferencesService.getPreviewPreferences().showPreviewAsExtraTabProperty(),
-                (obs, oldValue, newValue) -> adaptVisibleTabs());
     }
 
     private void setupDragAndDrop(LibraryTab libraryTab) {
@@ -385,6 +383,9 @@ public class EntryEditor extends BorderPane {
             adaptVisibleTabs();
             getSelectedTab().notifyAboutFocus(currentlyEditedEntry);
         });
+
+        EasyBind.listen(preferencesService.getPreviewPreferences().showPreviewAsExtraTabProperty(),
+                (obs, oldValue, newValue) -> adaptVisibleTabs());
 
         adaptVisibleTabs();
         setupToolBar();


### PR DESCRIPTION
Follow-up to #11379.
An exception was thrown after changing "show preview as a tab" in the preferences.

<details>
<summary>Exception</summary>

```
ERROR: Uncaught exception occurred in Thread[#54,JavaFX Application Thread,5,main]: java.lang.NullPointerException: Cannot invoke "org.jabref.model.entry.BibEntry.getType()" because "entry" is null
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.RequiredFieldsTab.determineFieldsToShow(RequiredFieldsTab.java:59)
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.FieldsEditorTab.shouldShow(FieldsEditorTab.java:213)
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.RequiredFieldsTab.shouldShow(RequiredFieldsTab.java:31)
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.EntryEditor.lambda$adaptVisibleTabs$5(EntryEditor.java:352)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.LinkedList$LLSpliterator.forEachRemaining(LinkedList.java:1249)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.EntryEditor.adaptVisibleTabs(EntryEditor.java:352)
	at org.jabref@100.0.0/org.jabref.gui.entryeditor.EntryEditor.lambda$new$1(EntryEditor.java:151)
	at javafx.base@22.0.1/com.sun.javafx.binding.ExpressionHelper$Generic.fireValueChangedEvent(ExpressionHelper.java:372)
	at javafx.base@22.0.1/com.sun.javafx.binding.ExpressionHelper.fireValueChangedEvent(ExpressionHelper.java:91)
	at javafx.base@22.0.1/javafx.beans.property.BooleanPropertyBase.fireValueChangedEvent(BooleanPropertyBase.java:104)
	at javafx.base@22.0.1/javafx.beans.property.BooleanPropertyBase.markInvalid(BooleanPropertyBase.java:111)
	at javafx.base@22.0.1/javafx.beans.property.BooleanPropertyBase.set(BooleanPropertyBase.java:145)
	at org.jabref@100.0.0/org.jabref.preferences.PreviewPreferences.setShowPreviewAsExtraTab(PreviewPreferences.java:101)
	at org.jabref@100.0.0/org.jabref.gui.preferences.preview.PreviewTabViewModel.storeSettings(PreviewTabViewModel.java:207)
```

</details>

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
