### PR TITLE
Try to use koppor/gradle-modules-plugin "release" (made in fork)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'me.champeau.jmh' version '0.7.2'
 
     // This is https://github.com/java9-modularity/gradle-modules-plugin/pull/282
-    id 'com.github.koppor.gradle-modules-plugin' version 'jitpack-SNAPSHOT'
+    id 'com.github.koppor.gradle-modules-plugin' version 'v1.8.15-cmd-1'
 
     id 'org.openjfx.javafxplugin' version '0.1.0'
 


### PR DESCRIPTION
JitPack has issues. https://status.jitpack.io/

```
A problem occurred configuring root project 'JabRef'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve com.github.koppor.gradle-modules-plugin:gradle-modules-plugin:jitpack-SNAPSHOT.
     Required by:
         project : > com.github.koppor:gradle-modules-plugin:jitpack-SNAPSHOT:d68df40569-1
      > Could not resolve com.github.koppor.gradle-modules-plugin:gradle-modules-plugin:jitpack-SNAPSHOT.
         > Could not get resource 'https://jitpack.io/com/github/koppor/gradle-modules-plugin/gradle-modules-plugin/jitpack-SNAPSHOT/gradle-modules-plugin-jitpack-d68df40569-1.pom'.
            > Could not HEAD 'https://jitpack.io/com/github/koppor/gradle-modules-plugin/gradle-modules-plugin/jitpack-SNAPSHOT/gradle-modules-plugin-jitpack-d68df40569-1.pom'.
               > Read timed out
> There are 6 more failures with identical causes.
```

This should be "fixed" by pinning the plugin to a concrete version.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
