### PR TITLE
Added a method to create a new link manually #11017

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,10 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 
 
-
-
+## Added – 2024-07-25
+- Manual File Entry Creation:
+  Added a new button to the LinkedFilesEditor.fxml.
+  Clicking this button displays a textbox where users can manually enter text/URLs. [#11017](...)
 
 
 ## [5.15] – 2024-07-10

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -156,7 +156,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
             return ControlHelper.truncateString(linkedFile.getDescription(), -1, "...",
                     ControlHelper.EllipsisPosition.CENTER) + " (" +
                     ControlHelper.truncateString(linkedFile.getLink(), -1, "...",
-                    ControlHelper.EllipsisPosition.CENTER) + ")";
+                            ControlHelper.EllipsisPosition.CENTER) + ")";
         }
     }
 
@@ -385,7 +385,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
     }
 
     /**
-     * @implNote Similar method {@link org.jabref.gui.linkedfile.RedownloadMissingFilesAction#redownloadMissing}
+     * @implNote Similar method {@link org.jabref.gui.linkedfile.RedownloadMissingFilesAction}
      */
     public void redownload() {
         LOGGER.info("Redownloading file from {}", linkedFile.getSourceUrl());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
+
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
          fx:controller="org.jabref.gui.fieldeditors.LinkedFilesEditor">
     <ListView fx:id="listView" prefHeight="0" HBox.hgrow="ALWAYS" maxHeight="100" />
@@ -37,6 +38,15 @@
             </graphic>
             <tooltip>
                 <Tooltip text="%Download from URL"/>
+            </tooltip>
+        </Button>
+        <!-- New Button for opening a blank text document -->
+        <Button fx:id="openBlankTxtButton" onAction="#openBlankTextFile" styleClass="icon-button">
+            <graphic>
+                <JabRefIconView glyph="ADD"/>
+            </graphic>
+            <tooltip>
+                <Tooltip text="Create a file"/>
             </tooltip>
         </Button>
     </VBox>


### PR DESCRIPTION
Manual File Entry Creation:
  Added a new button to the LinkedFilesEditor.fxml.
  Clicking this button displays a textbox where users can manually enter text/URLs. [#11017]

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
![Screenshot 2024-07-25 003202](https://github.com/user-attachments/assets/0d4d4b84-0dcb-44a8-b7c0-05c574d2b43b)
![Screenshot 2024-07-25 003213](https://github.com/user-attachments/assets/b8ddef1c-0fda-4793-8812-06a9d8c76176)
![Screenshot 2024-07-25 003239](https://github.com/user-attachments/assets/eb1d3175-352e-4971-a6bc-7bb9d1fbaec9)

