### PR TITLE
Patch: NullPointerException when accessing (absent) default CSL style file

### DIFF
--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -72,7 +72,7 @@ public class CitationStyle implements OOStyle {
             }
 
             return Optional.of(new CitationStyle(filename, title.get(), content));
-        } catch (ParserConfigurationException | SAXException | IOException e) {
+        } catch (ParserConfigurationException | SAXException | NullPointerException | IOException e) {
             LOGGER.error("Error while parsing source", e);
             return Optional.empty();
         }
@@ -118,6 +118,10 @@ public class CitationStyle implements OOStyle {
         Path internalFilePath = Path.of(internalFile);
         boolean isExternalFile = Files.exists(internalFilePath);
         try (InputStream inputStream = isExternalFile ? Files.newInputStream(internalFilePath) : CitationStyle.class.getResourceAsStream(internalFile)) {
+            if (inputStream == null) {
+                LOGGER.error("Could not find file: {}", styleFile);
+                return Optional.empty();
+            }
             return createCitationStyleFromSource(inputStream, styleFile);
         } catch (NoSuchFileException e) {
             LOGGER.error("Could not find file: {}", styleFile, e);


### PR DESCRIPTION
Addresses https://github.com/JabRef/jabref/pull/11521#issuecomment-2251824512
If, in a development setup, `csl-styles` submodules are missing, `NullPointerException` is thrown when trying to access the default (ieee) style.
- The try-catch block in context:
https://github.com/JabRef/jabref/blob/771c4cd58957c7a56586bea5efc02df2384727d9/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java#L120-L128
is using try-with-resources, which automatically closes the `InputStream`. However, if `getResourceAsStream` returns null, no exception is thrown at this point. The null `InputStream` is passed to `createCitationStyleFromSource`. This has been modified to add a null check.
- A null pointer exception has also been additionally caught and handled at the callee function `createCitationStyleFromSource`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] ~Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
- [ ] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [ ] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
