### PR TITLE
More logging for  fullscreen and maximized

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -182,13 +182,16 @@ public class JabRefGUI extends Application {
 
         GuiPreferences guiPreferences = preferencesService.getGuiPreferences();
 
+        LOGGER.debug("Reading from prefs: isMaximized {}", guiPreferences.isWindowMaximised());
+        LOGGER.debug("Reading from prefs: isFullScreen {}", guiPreferences.isWindowFullscreen());
+
         mainStage.setMinHeight(330);
         mainStage.setMinWidth(580);
         mainStage.setFullScreen(guiPreferences.isWindowFullscreen());
         mainStage.setMaximized(guiPreferences.isWindowMaximised());
         if ((Screen.getScreens().size() == 1) && isWindowPositionOutOfBounds()) {
             // corrects the Window, if it is outside the mainscreen
-            LOGGER.debug("The Jabref window is outside the main screen");
+            LOGGER.info("The Jabref window is outside the main screen. Setting size to 1024x768");
             mainStage.setX(0);
             mainStage.setY(0);
             mainStage.setWidth(1024);
@@ -227,7 +230,7 @@ public class JabRefGUI extends Application {
 
         // Open last edited databases
         if (uiCommands.stream().noneMatch(UiCommand.BlankWorkspace.class::isInstance)
-            && preferencesService.getWorkspacePreferences().shouldOpenLastEdited()) {
+                && preferencesService.getWorkspacePreferences().shouldOpenLastEdited()) {
             mainFrame.openLastEditedDatabases();
         }
     }
@@ -242,8 +245,10 @@ public class JabRefGUI extends Application {
         if (!correctedWindowPos) {
             // saves the window position only if its not corrected -> the window will rest at the old Position,
             // if the external Screen is connected again.
+            LOGGER.debug("Save window positions");
             saveWindowState();
         }
+        LOGGER.debug("NOT saving window position ");
 
         preferencesService.flush();
 
@@ -257,26 +262,26 @@ public class JabRefGUI extends Application {
         preferences.setPositionY(mainStage.getY());
         preferences.setSizeX(mainStage.getWidth());
         preferences.setSizeY(mainStage.getHeight());
+
         preferences.setWindowMaximised(mainStage.isMaximized());
         preferences.setWindowFullScreen(mainStage.isFullScreen());
         debugLogWindowState(mainStage);
     }
 
     /**
-     * outprints the Data from the Screen (only in debug mode)
+     * print out the Data from the Screen (only in debug mode)
      *
      * @param mainStage JabRefs stage
      */
     private void debugLogWindowState(Stage mainStage) {
-        if (LOGGER.isDebugEnabled()) {
             String debugLogString = "SCREEN DATA:" +
                     "mainStage.WINDOW_MAXIMISED: " + mainStage.isMaximized() + "\n" +
+                    "mainStage.FULL_SCREEN: " + mainStage.isFullScreen() + "\n" +
                     "mainStage.POS_X: " + mainStage.getX() + "\n" +
                     "mainStage.POS_Y: " + mainStage.getY() + "\n" +
                     "mainStage.SIZE_X: " + mainStage.getWidth() + "\n" +
                     "mainStages.SIZE_Y: " + mainStage.getHeight() + "\n";
             LOGGER.debug(debugLogString);
-        }
     }
 
     /**

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -527,7 +527,8 @@ public class JabRefPreferences implements PreferencesService {
             if (new File("jabref.xml").exists()) {
                 importPreferences(Path.of("jabref.xml"));
             }
-        } catch (JabRefException e) {
+        } catch (
+                JabRefException e) {
             LOGGER.warn("Could not import preferences from jabref.xml: {}", e.getMessage(), e);
         }
 
@@ -1052,13 +1053,15 @@ public class JabRefPreferences implements PreferencesService {
         if (getBoolean(MEMORY_STICK_MODE)) {
             try {
                 exportPreferences(Path.of("jabref.xml"));
-            } catch (JabRefException e) {
+            } catch (
+                    JabRefException e) {
                 LOGGER.warn("Could not export preferences for memory stick mode: {}", e.getMessage(), e);
             }
         }
         try {
             prefs.flush();
-        } catch (BackingStoreException ex) {
+        } catch (
+                BackingStoreException ex) {
             LOGGER.warn("Cannot communicate with backing store", ex);
         }
     }
@@ -1069,7 +1072,8 @@ public class JabRefPreferences implements PreferencesService {
 
         try {
             addPrefsRecursively(this.prefs, result);
-        } catch (BackingStoreException e) {
+        } catch (
+                BackingStoreException e) {
             LOGGER.info("could not retrieve preference keys", e);
         }
         return result;
@@ -1092,13 +1096,16 @@ public class JabRefPreferences implements PreferencesService {
     private Object getObject(Preferences prefs, String key) {
         try {
             return prefs.get(key, (String) defaults.get(key));
-        } catch (ClassCastException e) {
+        } catch (
+                ClassCastException e) {
             try {
                 return prefs.getBoolean(key, getBooleanDefault(key));
-            } catch (ClassCastException e2) {
+            } catch (
+                    ClassCastException e2) {
                 try {
                     return prefs.getInt(key, getIntDefault(key));
-                } catch (ClassCastException e3) {
+                } catch (
+                        ClassCastException e3) {
                     return prefs.getDouble(key, getDoubleDefault(key));
                 }
             }
@@ -1142,8 +1149,10 @@ public class JabRefPreferences implements PreferencesService {
         LOGGER.debug("Exporting preferences {}", path.toAbsolutePath());
         try (OutputStream os = Files.newOutputStream(path)) {
             prefs.exportSubtree(os);
-        } catch (BackingStoreException
-                 | IOException ex) {
+        } catch (
+                BackingStoreException
+                |
+                IOException ex) {
             throw new JabRefException(
                     "Could not export preferences",
                     Localization.lang("Could not export preferences"),
@@ -1161,8 +1170,10 @@ public class JabRefPreferences implements PreferencesService {
     public void importPreferences(Path file) throws JabRefException {
         try (InputStream is = Files.newInputStream(file)) {
             Preferences.importPreferences(is);
-        } catch (InvalidPreferencesFormatException
-                 | IOException ex) {
+        } catch (
+                InvalidPreferencesFormatException
+                |
+                IOException ex) {
             throw new JabRefException(
                     "Could not import preferences",
                     Localization.lang("Could not import preferences"),
@@ -1236,7 +1247,8 @@ public class JabRefPreferences implements PreferencesService {
                   .map(key -> prefsNode.get(key, null))
                   .filter(Objects::nonNull)
                   .forEach(typeString -> MetaDataParser.parseCustomEntryType(typeString).ifPresent(storedEntryTypes::add));
-        } catch (BackingStoreException e) {
+        } catch (
+                BackingStoreException e) {
             LOGGER.info("Parsing customized entry types failed.", e);
         }
         return storedEntryTypes;
@@ -1253,7 +1265,8 @@ public class JabRefPreferences implements PreferencesService {
             Preferences prefsNode = getPrefsNodeForCustomizedEntryTypes(mode);
             prefsNode.clear();
             prefsNode.flush();
-        } catch (BackingStoreException e) {
+        } catch (
+                BackingStoreException e) {
             LOGGER.error("Resetting customized entry types failed.", e);
         }
     }
@@ -1276,7 +1289,8 @@ public class JabRefPreferences implements PreferencesService {
             bibEntryTypes.forEach(type -> prefsNode.put(type.getType().getName(), MetaDataSerializer.serializeCustomEntryTypes(type)));
 
             prefsNode.flush();
-        } catch (BackingStoreException e) {
+        } catch (
+                BackingStoreException e) {
             LOGGER.info("Updating stored custom entry types failed.", e);
         }
     }
@@ -1304,13 +1318,14 @@ public class JabRefPreferences implements PreferencesService {
         // Reassign currentStyle if it is not a CSL style
         if (CitationStyle.isCitationStyleFile(currentStylePath)) {
             currentStyle = CitationStyle.createCitationStyleFromFile(currentStylePath) // Assigns CSL Style
-                         .orElse(CitationStyle.getDefault());
+                                        .orElse(CitationStyle.getDefault());
         } else {
             // For now, must be a JStyle. In future, make separate cases for JStyles (.jstyle) and BibTeX (.bst) styles
             try {
                 currentStyle = new JStyle(currentStylePath, getLayoutFormatterPreferences(),
                         Injector.instantiateModelOrService(JournalAbbreviationRepository.class));
-            } catch (IOException ex) {
+            } catch (
+                    IOException ex) {
                 LOGGER.warn("Could not create JStyle", ex);
             }
         }
@@ -1588,7 +1603,8 @@ public class JabRefPreferences implements PreferencesService {
             if (!newValue) {
                 try (final Keyring keyring = Keyring.create()) {
                     keyring.deletePassword("org.jabref", "proxy");
-                } catch (Exception ex) {
+                } catch (
+                        Exception ex) {
                     LOGGER.warn("Unable to remove proxy credentials");
                 }
             }
@@ -1604,9 +1620,11 @@ public class JabRefPreferences implements PreferencesService {
                         keyring.getPassword("org.jabref", "proxy"),
                         getInternalPreferences().getUserAndHost())
                         .decrypt();
-            } catch (PasswordAccessException ex) {
+            } catch (
+                    PasswordAccessException ex) {
                 LOGGER.warn("JabRef uses proxy password from key store but no password is stored");
-            } catch (Exception ex) {
+            } catch (
+                    Exception ex) {
                 LOGGER.warn("JabRef could not open the key store", ex);
             }
         }
@@ -1624,7 +1642,8 @@ public class JabRefPreferences implements PreferencesService {
                             getInternalPreferences().getUserAndHost())
                             .encrypt());
                 }
-            } catch (Exception ex) {
+            } catch (
+                    Exception ex) {
                 LOGGER.warn("Unable to open key store", ex);
             }
         }
@@ -1657,7 +1676,8 @@ public class JabRefPreferences implements PreferencesService {
                         EntryTypeFactory.parse(key),
                         preferences.get(key, null));
             }
-        } catch (BackingStoreException ex) {
+        } catch (
+                BackingStoreException ex) {
             LOGGER.info("BackingStoreException in JabRefPreferences.getKeyPattern", ex);
         }
 
@@ -1677,7 +1697,8 @@ public class JabRefPreferences implements PreferencesService {
         Preferences preferences = PREFS_NODE.node(CITATION_KEY_PATTERNS_NODE);
         try {
             preferences.clear(); // We remove all old entries.
-        } catch (BackingStoreException ex) {
+        } catch (
+                BackingStoreException ex) {
             LOGGER.info("BackingStoreException in JabRefPreferences::putKeyPattern", ex);
         }
 
@@ -1917,7 +1938,8 @@ public class JabRefPreferences implements PreferencesService {
                 .map(string -> {
                     try {
                         return Double.parseDouble(string);
-                    } catch (NumberFormatException e) {
+                    } catch (
+                            NumberFormatException e) {
                         LOGGER.error("Exception while parsing column widths. Choosing default.", e);
                         return defaultWidth;
                     }
@@ -2074,7 +2096,8 @@ public class JabRefPreferences implements PreferencesService {
             if (!newValue) {
                 try {
                     Files.deleteIfExists(Path.of("jabref.xml"));
-                } catch (IOException e) {
+                } catch (
+                        IOException e) {
                     LOGGER.warn("Error accessing filesystem", e);
                 }
             }
@@ -2526,9 +2549,11 @@ public class JabRefPreferences implements PreferencesService {
             try {
                 SidePaneType type = Enum.valueOf(SidePaneType.class, name);
                 preferredPositions.put(type, Integer.parseInt(componentPositions.get(i)));
-            } catch (NumberFormatException e) {
+            } catch (
+                    NumberFormatException e) {
                 LOGGER.debug("Invalid number format for side pane component '{}'", name, e);
-            } catch (IllegalArgumentException e) {
+            } catch (
+                    IllegalArgumentException e) {
                 LOGGER.debug("Following component is not a side pane: '{}'", name, e);
             }
         }
@@ -2627,8 +2652,14 @@ public class JabRefPreferences implements PreferencesService {
         EasyBind.listen(guiPreferences.positionYProperty(), (obs, oldValue, newValue) -> putDouble(POS_Y, newValue.doubleValue()));
         EasyBind.listen(guiPreferences.sizeXProperty(), (obs, oldValue, newValue) -> putDouble(SIZE_X, newValue.doubleValue()));
         EasyBind.listen(guiPreferences.sizeYProperty(), (obs, oldValue, newValue) -> putDouble(SIZE_Y, newValue.doubleValue()));
-        EasyBind.listen(guiPreferences.windowMaximisedProperty(), (obs, oldValue, newValue) -> putBoolean(WINDOW_MAXIMISED, newValue));
-        EasyBind.listen(guiPreferences.windowFullScreenProperty(), (obs, oldValue, newValue) -> putBoolean(WINDOW_FULLSCREEN, newValue));
+        EasyBind.listen(guiPreferences.windowMaximisedProperty(), (obs, oldValue, newValue) -> {
+            LOGGER.info("WINDOW_MAXIMIZED changed in prefs from {} to {}", oldValue, newValue);
+            putBoolean(WINDOW_MAXIMISED, newValue);
+        });
+        EasyBind.listen(guiPreferences.windowFullScreenProperty(), (obs, oldValue, newValue) -> {
+            LOGGER.info("WINDOW_FULLSCREEN changed in prefs from {} to {}", oldValue, newValue);
+            putBoolean(WINDOW_FULLSCREEN, newValue);
+        });
         guiPreferences.getLastFilesOpened().addListener((ListChangeListener<Path>) change -> {
             if (change.getList().isEmpty()) {
                 prefs.remove(LAST_EDITED);
@@ -2725,7 +2756,8 @@ public class JabRefPreferences implements PreferencesService {
         SearchDisplayMode searchDisplayMode;
         try {
             searchDisplayMode = SearchDisplayMode.valueOf(get(SEARCH_DISPLAY_MODE));
-        } catch (IllegalArgumentException ex) {
+        } catch (
+                IllegalArgumentException ex) {
             // Should only occur when the searchmode is set directly via preferences.put and the enum was not used
             searchDisplayMode = SearchDisplayMode.valueOf((String) defaults.get(SEARCH_DISPLAY_MODE));
         }
@@ -2940,7 +2972,8 @@ public class JabRefPreferences implements PreferencesService {
                     // Old format: name, cliId, className, basePath
                     importers.add(new CustomImporter(importerString.get(3), importerString.get(2)));
                 }
-            } catch (Exception e) {
+            } catch (
+                    Exception e) {
                 LOGGER.warn("Could not load {} from preferences. Will ignore.", importerString.getFirst(), e);
             }
         }
@@ -2984,12 +3017,14 @@ public class JabRefPreferences implements PreferencesService {
                             keyring.getPassword("org.jabref.customapikeys", fetcher),
                             getInternalPreferences().getUserAndHost())
                             .decrypt());
-                } catch (PasswordAccessException ex) {
+                } catch (
+                        PasswordAccessException ex) {
                     LOGGER.debug("No api key stored for {} fetcher", fetcher);
                     keys.add("");
                 }
             }
-        } catch (Exception ex) {
+        } catch (
+                Exception ex) {
             LOGGER.warn("JabRef could not open the key store");
         }
 
@@ -3023,7 +3058,8 @@ public class JabRefPreferences implements PreferencesService {
                 if (StringUtil.isNullOrEmpty(keys.get(i))) {
                     try {
                         keyring.deletePassword("org.jabref.customapikeys", names.get(i));
-                    } catch (PasswordAccessException ex) {
+                    } catch (
+                            PasswordAccessException ex) {
                         // Already removed
                     }
                 } else {
@@ -3033,7 +3069,8 @@ public class JabRefPreferences implements PreferencesService {
                             .encrypt());
                 }
             }
-        } catch (Exception ex) {
+        } catch (
+                Exception ex) {
             LOGGER.error("Unable to open key store", ex);
         }
     }
@@ -3045,10 +3082,12 @@ public class JabRefPreferences implements PreferencesService {
                 for (String name : names) {
                     keyring.deletePassword("org.jabref.customapikeys", name);
                 }
-            } catch (PasswordAccessException ex) {
+            } catch (
+                    PasswordAccessException ex) {
                 // nothing to do, no password to remove
             }
-        } catch (Exception ex) {
+        } catch (
+                Exception ex) {
             LOGGER.error("Unable to open key store");
         }
     }

--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -10,4 +10,5 @@ exception = strip: jdk.internal
 #level@org.jabref.model.entry.BibEntry = debug
 #level@org.jabref.gui.maintable.PersistenceVisualStateTable = debug
 
+level@org.jabref.gui.JabRefGui = debug
 level@org.jabref.http.server.Server = debug


### PR DESCRIPTION
Refs #10731 
We need to find out what is saved when and where 

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
