### PR TITLE
Have GitHub commenting on pull requests in case of failed linting checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
       - main-release
-  pull_request:
   merge_group:
   workflow_dispatch:
+  # The checkers should write comments on the PR if something fails. For this, we need to have a proper GITHUB_TOKEN. This is enabled by ..._target.
+  pull_request_target:
 
 env:
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,21 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Run checkstyle using gradle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              Your code currently does not meet [JabRef's code guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
+              We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
+              The tool reviewdog already placed comments on GitHub to indicate the places. See the tab "Files" in you PR.
+              Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
+              Afterwards, please [run checkstyle locally](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#run-checkstyle) and fix the issues.
+
+
+              You can check review dog's comments at the tab "Files changed" of your pull request.
+          comment_tag: automated-test-feedback
+
   openrewrite:
     name: OpenRewrite
     runs-on: ubuntu-latest
@@ -73,6 +88,20 @@ jobs:
       - name: Run OpenRewrite
         run: |
           ./gradlew rewriteDryRun
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              Your code currently does not meet JabRef's code guidelines.
+              We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
+              The issues found can be **automatically fixed**.
+              Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
+
+
+              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "OpenRewrite".
+          comment_tag: automated-test-feedback
+
   modernizer:
     name: Modernizer
     runs-on: ubuntu-latest
@@ -96,6 +125,19 @@ jobs:
           # enable failing of this task if modernizer complains
           sed -i "s/failOnViolations = false/failOnViolations = true/" build.gradle
           ./gradlew modernizer
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              Your code currently does not meet JabRef's code guidelines.
+              We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
+              Please fix the detected errors, commit, and push.
+
+
+              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
+          comment_tag: automated-test-feedback
+
   markdown:
     name: Markdown
     runs-on: ubuntu-latest
@@ -111,6 +153,19 @@ jobs:
           globs: |
             *.md
             docs/**/*.md
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              You modified Markdown (`*.md`) files and did not meet JabRef's rules for consistently formatted Markdown files.
+              To ensure consistent styling, we have [markdown-lint](https://github.com/DavidAnson/markdownlint) in place.
+              [Markdown lint's rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules) help to keep our Markdown files consistent within this repository and consistent with the Markdown files outside here.
+
+
+              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "Markdown".
+          comment_tag: automated-test-feedback
+
   changelog:
     name: CHANGELOG.md
     runs-on: ubuntu-latest
@@ -137,6 +192,7 @@ jobs:
           # exit 1 in case of error
           # We have 1 "valid" issue in CHANGELOG.md
           grep -q "1 problem" heylogs.txt || exit 1
+
   changelog-unreleased-only:
     name: CHANGELOG.md - only unreleased touched
     runs-on: ubuntu-latest
@@ -157,6 +213,15 @@ jobs:
           diff \
             <(git show origin/main:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)')
+      - name: Add comment on pull request
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: >
+              While the PR was in progress, JabRef released a new version.
+              You have to merge `upstream/main` and move your entry in `CHANGELOG.md` up to the section `## [Unreleased]`.
+          comment_tag: automated-test-feedback
+
   tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -188,6 +253,7 @@ jobs:
       - name: Format failed test results
         if: failure()
         run: scripts/after-failure.sh
+
   databasetests:
     name: Database tests
     runs-on: ubuntu-latest
@@ -239,6 +305,7 @@ jobs:
         env:
           CI: "true"
           DBMS: "mysql"
+
   guitests:
     name: GUI tests
     runs-on: ubuntu-latest
@@ -261,6 +328,7 @@ jobs:
         run: xvfb-run --auto-servernum ./gradlew guiTest
         env:
           CI: "true"
+
   codecoverage:
     name: Code coverage
     runs-on: ubuntu-latest
@@ -320,6 +388,7 @@ jobs:
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
   # This is https://github.com/marketplace/actions/gradle-wrapper-validation
   # It ensures that the jar file is from gradle and not by a strange third party.
   gradlevalidation:
@@ -330,6 +399,7 @@ jobs:
         with:
           show-progress: 'false'
       - uses: gradle/actions/wrapper-validation@v3
+
   # This ensures that no git merge conflict markers (<<<, ...) are contained
   merge_conflict_job:
     name: Find merge conflicts
@@ -340,6 +410,7 @@ jobs:
           show-progress: 'false'
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.0
+
   other_than_main:
     name: Source branch is other than "main"
     runs-on: ubuntu-latest

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.md
@@ -104,6 +104,8 @@ Also, set the "Scan Scope" to "Only Java sources (including tests)".
 
 Save settings by clicking "Apply" and then "OK"
 
+## Run checkstyle
+
 In the lower part of IntelliJ's window, click on "Checkstyle".
 In "Rules", change to "JabRef".
 Then, you can run a check on all modified files.


### PR DESCRIPTION
Newcomers sometimes do not know, where to click in GitHub's UI. This PR should add some helpful text for them.

This is a follow-up to https://github.com/JabRef/jabref/pull/10649. The "only" fix required was to use `pull_request_target` as trigger - and not just `pull_request`.

