### PR TITLE
Add comments to FXML localization parsing

### DIFF
--- a/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -173,9 +174,11 @@ public class LocalizationParser {
 
     /**
      * Loads the fxml file and returns all used language resources.
+     *
+     * Note: FXML prefixes localization keys with <code>%</code>.
      */
-    private static List<LocalizationEntry> getLanguageKeysInFxmlFile(Path path, LocalizationBundleForTest type) {
-        List<String> result = new ArrayList<>();
+    private static Collection<LocalizationEntry> getLanguageKeysInFxmlFile(Path path, LocalizationBundleForTest type) {
+        Collection<String> result = new ArrayList<>();
 
         // Afterburner ViewLoader forces a controller factory, but we do not need any controller
         MockedStatic<ViewLoader> viewLoader = Mockito.mockStatic(ViewLoader.class, Answers.RETURNS_DEEP_STUBS);
@@ -184,6 +187,8 @@ public class LocalizationParser {
         ResourceBundle registerUsageResourceBundle = new ResourceBundle() {
             @Override
             protected Object handleGetObject(String key) {
+                // Here, we get the key without the percent sign at the beginning.
+                // All the "magic" is done at "loader.load()" called below.
                 result.add(key);
                 return "test";
             }
@@ -215,7 +220,7 @@ public class LocalizationParser {
 
         return result.stream()
                      .map(key -> new LocalizationEntry(path, key, type))
-                     .collect(Collectors.toList());
+                     .toList();
     }
 
     private static void setStaticLoad(FXMLLoader loader) {


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/11539, where `%` were removed.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
