### PR TITLE
Fix setting of ClipboardManager at injector

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -149,7 +149,7 @@ public class JabRefGUI extends Application {
         Injector.setModelOrService(DialogService.class, dialogService);
 
         JabRefGUI.clipBoardManager = new ClipBoardManager();
-        Injector.setModelOrService(TaskExecutor.class, taskExecutor);
+        Injector.setModelOrService(ClipBoardManager.class, clipBoardManager);
     }
 
     private void setupProxy() {


### PR DESCRIPTION
I think, the instance of ClipboardManager is only required at `org.jabref.gui.maintable.MainTable#copy`. All other use the `static` helper methods such as `org.jabref.gui.ClipBoardManager#getContents`.

Maybe, we should either rewrite all methods not to be `static` any more - or convert `setContent` to a `static` method, too.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
