### PR TITLE
Disable GUI debug log

### DIFF
--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -12,4 +12,4 @@ exception = strip: jdk.internal
 
 level@org.jabref.http.server.Server = debug
 
-level@org.jabref.gui.JabRefGUI = debug
+#level@org.jabref.gui.JabRefGUI = debug


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/pull/11441

These logs are no longer needed, so disabling them:
![image](https://github.com/user-attachments/assets/72067214-4848-43a1-82eb-55627c1ac092)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] ~Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
- [ ] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
