### PR TITLE
Citavi: Fix closing of input file

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/CitaviXmlImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/CitaviXmlImporter.java
@@ -1,12 +1,9 @@
 package org.jabref.logic.importer.fileformat;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PushbackInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -55,6 +52,8 @@ import org.jabref.model.strings.StringUtil;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -431,7 +430,7 @@ public class CitaviXmlImporter extends Importer implements Parser {
     @Override
     public ParserResult importDatabase(BufferedReader reader) throws IOException {
         Objects.requireNonNull(reader);
-        throw new UnsupportedOperationException("CitaviXmlImporter does not support importDatabase(BufferedReader reader)."
+        throw new UnsupportedOperationException("CitaviXmlImporter does not support importDatabase(BufferedReader reader). "
                                                 + "Instead use importDatabase(Path filePath, Charset defaultEncoding).");
     }
 
@@ -447,39 +446,25 @@ public class CitaviXmlImporter extends Importer implements Parser {
     }
 
     private BufferedReader getReaderFromZip(Path filePath) throws IOException {
-        ZipInputStream zis = new ZipInputStream(new FileInputStream(filePath.toFile()));
-        ZipEntry zipEntry = zis.getNextEntry();
-
         Path newFile = Files.createTempFile("citavicontent", ".xml");
+        newFile.toFile().deleteOnExit();
 
-        while (zipEntry != null) {
-            Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
-
-            zipEntry = zis.getNextEntry();
-        }
-
-        zis.closeEntry();
-
-        InputStream stream = Files.newInputStream(newFile, StandardOpenOption.READ);
-
-        // check and delete the utf-8 BOM bytes
-        InputStream newStream = checkForUtf8BOMAndDiscardIfAny(stream);
-
-        // clean up the temp file
-        Files.delete(newFile);
-
-        return new BufferedReader(new InputStreamReader(newStream, StandardCharsets.UTF_8));
-    }
-
-    private static InputStream checkForUtf8BOMAndDiscardIfAny(InputStream inputStream) throws IOException {
-        PushbackInputStream pushbackInputStream = new PushbackInputStream(new BufferedInputStream(inputStream), 3);
-        byte[] bom = new byte[3];
-        if (pushbackInputStream.read(bom) != -1) {
-            if (!((bom[0] == (byte) 0xEF) && (bom[1] == (byte) 0xBB) && (bom[2] == (byte) 0xBF))) {
-                pushbackInputStream.unread(bom);
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(filePath))) {
+            ZipEntry zipEntry = zis.getNextEntry();
+            while (zipEntry != null) {
+                Files.copy(zis, newFile, StandardCopyOption.REPLACE_EXISTING);
+                zipEntry = zis.getNextEntry();
             }
         }
-        return pushbackInputStream;
+
+        // Citavi XML files sometimes contains BOM markers. We just discard them.
+        // Solution inspired by https://stackoverflow.com/a/37445972/873282
+        return new BufferedReader(
+                new InputStreamReader(
+                        new BOMInputStream(
+                                Files.newInputStream(newFile, StandardOpenOption.READ),
+                                false,
+                                ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_32LE)));
     }
 
     private String clean(String input) {

--- a/src/test/java/org/jabref/logic/importer/fileformat/ImporterTestEngine.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ImporterTestEngine.java
@@ -52,8 +52,7 @@ public class ImporterTestEngine {
         if (parserResult.isInvalid()) {
             throw new ImportException(parserResult.getErrorMessage());
         }
-        List<BibEntry> entries = parserResult.getDatabase()
-                                             .getEntries();
+        List<BibEntry> entries = parserResult.getDatabase().getEntries();
         BibEntryAssert.assertEquals(ImporterTestEngine.class, fileName.replaceAll(fileType, ".bib"), entries);
     }
 


### PR DESCRIPTION
While "reviewing" https://github.com/JabRef/jabref/pull/11552, I made some fixes to the CitaviCode.

We had luck, that this ever worked. The input file was deleted before it is processed 🤣

I also use a library for the BOM removal instead of some hand-crafted stuff.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
