### PR TITLE
No more shown finished background tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The Pubmed/Medline Plain importer now imports the PMID field as well [#11488](https://github.com/JabRef/jabref/issues/11488)
 - The 'Check for updates' menu bar button is now always enabled. [#11485](https://github.com/JabRef/jabref/pull/11485)
 - JabRef respects the [configuration for storing files relative to the .bib file](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#directories-for-files) in more cases. [#11492](https://github.com/JabRef/jabref/pull/11492)
+- JabRef does not show finished background tasks in the status bar popup. [#11574](https://github.com/JabRef/jabref/pull/11574)
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -348,7 +348,7 @@ public class JabRefDialogService implements DialogService {
     @Override
     public <V> Optional<ButtonType> showBackgroundProgressDialogAndWait(String title, String content, StateManager stateManager) {
         TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
-        EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
+        EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getRunningBackgroundTasks());
         taskProgressView.setRetainTasks(false);
         taskProgressView.setGraphicFactory(BackgroundTask::getIcon);
 

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -186,10 +186,6 @@ public class StateManager {
         return focusOwner.get();
     }
 
-    public ObservableList<Task<?>> getBackgroundTasks() {
-        return EasyBind.map(backgroundTasks, Pair::getValue);
-    }
-
     public ObservableList<Task<?>> getRunningBackgroundTasks() {
         FilteredList<Pair<BackgroundTask<?>, Task<?>>> pairs = new FilteredList<>(backgroundTasks, task -> task.getValue().isRunning());
         return EasyBind.map(pairs, Pair::getValue);

--- a/src/main/java/org/jabref/gui/StateManager.java
+++ b/src/main/java/org/jabref/gui/StateManager.java
@@ -16,6 +16,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javafx.collections.transformation.FilteredList;
 import javafx.concurrent.Task;
 import javafx.scene.Node;
 import javafx.util.Pair;
@@ -187,6 +188,11 @@ public class StateManager {
 
     public ObservableList<Task<?>> getBackgroundTasks() {
         return EasyBind.map(backgroundTasks, Pair::getValue);
+    }
+
+    public ObservableList<Task<?>> getRunningBackgroundTasks() {
+        FilteredList<Pair<BackgroundTask<?>, Task<?>>> pairs = new FilteredList<>(backgroundTasks, task -> task.getValue().isRunning());
+        return EasyBind.map(pairs, Pair::getValue);
     }
 
     public void addBackgroundTask(BackgroundTask<?> backgroundTask, Task<?> task) {

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -45,6 +45,7 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.jabref.preferences.PreferencesService;
 
 import com.tobiasdiez.easybind.EasyBind;
+import com.tobiasdiez.easybind.Subscription;
 import org.controlsfx.control.PopOver;
 import org.controlsfx.control.TaskProgressView;
 
@@ -63,6 +64,7 @@ public class MainToolBar extends ToolBar {
 
     private PopOver entryFromIdPopOver;
     private PopOver progressViewPopOver;
+    private Subscription taskProgressSubscription;
 
     public MainToolBar(LibraryTabContainer tabContainer,
                        PushToApplicationCommand pushToApplicationCommand,
@@ -218,10 +220,11 @@ public class MainToolBar extends ToolBar {
         indicator.setOnMouseClicked(event -> {
             if ((progressViewPopOver != null) && (progressViewPopOver.isShowing())) {
                 progressViewPopOver.hide();
+                taskProgressSubscription.unsubscribe();
             }
 
             TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
-            EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
+            taskProgressSubscription = EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
             taskProgressView.setRetainTasks(false);
             taskProgressView.setGraphicFactory(BackgroundTask::getIcon);
 

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -224,7 +224,7 @@ public class MainToolBar extends ToolBar {
             }
 
             TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
-            taskProgressSubscription = EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
+            taskProgressSubscription = EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getRunningBackgroundTasks());
             taskProgressView.setRetainTasks(false);
             taskProgressView.setGraphicFactory(BackgroundTask::getIcon);
 

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -216,6 +216,10 @@ public class MainToolBar extends ToolBar {
         });
 
         indicator.setOnMouseClicked(event -> {
+            if ((progressViewPopOver != null) && (progressViewPopOver.isShowing())) {
+                progressViewPopOver.hide();
+            }
+
             TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
             EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
             taskProgressView.setRetainTasks(false);
@@ -225,14 +229,10 @@ public class MainToolBar extends ToolBar {
                 progressViewPopOver = new PopOver(taskProgressView);
                 progressViewPopOver.setTitle(Localization.lang("Background Tasks"));
                 progressViewPopOver.setArrowLocation(PopOver.ArrowLocation.RIGHT_TOP);
-                progressViewPopOver.setContentNode(taskProgressView);
-                progressViewPopOver.show(indicator);
-            } else if (progressViewPopOver.isShowing()) {
-                progressViewPopOver.hide();
-            } else {
-                progressViewPopOver.setContentNode(taskProgressView);
-                progressViewPopOver.show(indicator);
             }
+
+            progressViewPopOver.setContentNode(taskProgressView);
+            progressViewPopOver.show(indicator);
         });
 
         return new Group(indicator);

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -201,15 +201,11 @@ public class MainToolBar extends ToolBar {
             }
         });
 
-        /*
-        The label of the indicator cannot be removed with styling. Therefore,
-        hide it and clip it to a square of (width x width) each time width is updated.
-         */
+        // The label of the indicator cannot be removed with styling. Therefore,
+        // hide it and clip it to a square of (width x width) each time width is updated.
         indicator.widthProperty().addListener((observable, oldValue, newValue) -> {
-            /*
-            The indeterminate spinner is wider than the determinate spinner.
-            We must make sure they are the same width for the clipping to result in a square of the same size always.
-             */
+            // The indeterminate spinner is wider than the determinate spinner.
+            // We must make sure they are the same width for the clipping to result in a square of the same size always.
             if (!indicator.isIndeterminate()) {
                 indicator.setPrefWidth(newValue.doubleValue());
             }

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -218,7 +218,7 @@ public class MainToolBar extends ToolBar {
         indicator.setOnMouseClicked(event -> {
             TaskProgressView<Task<?>> taskProgressView = new TaskProgressView<>();
             EasyBind.bindContent(taskProgressView.getTasks(), stateManager.getBackgroundTasks());
-            taskProgressView.setRetainTasks(true);
+            taskProgressView.setRetainTasks(false);
             taskProgressView.setGraphicFactory(BackgroundTask::getIcon);
 
             if (progressViewPopOver == null) {

--- a/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -128,7 +128,7 @@ public class UiTaskExecutor implements TaskExecutor {
     public void shutdown() {
         StateManager stateManager = Injector.instantiateModelOrService(StateManager.class);
         if (stateManager != null) {
-            stateManager.getBackgroundTasks().stream().filter(task -> !task.isDone()).forEach(Task::cancel);
+            stateManager.getRunningBackgroundTasks().stream().forEach(Task::cancel);
         }
         executor.shutdownNow();
         scheduledExecutor.shutdownNow();

--- a/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -175,9 +175,14 @@ public class UiTaskExecutor implements TaskExecutor {
             javaTask.setOnRunning(event -> onRunning.run());
         }
         Consumer<V> onSuccess = task.getOnSuccess();
-        if (onSuccess != null) {
-            javaTask.setOnSucceeded(event -> onSuccess.accept(javaTask.getValue()));
-        }
+        javaTask.setOnSucceeded(event -> {
+            // Set to 100% completed on completion
+            task.updateProgress(1, 1);
+
+            if (onSuccess != null) {
+                onSuccess.accept(javaTask.getValue());
+            }
+        });
         Consumer<Exception> onException = task.getOnException();
         if (onException != null) {
             javaTask.setOnFailed(event -> onException.accept(convertToException(javaTask.getException())));


### PR DESCRIPTION
JabRef collected all run tasks. This was confusing. This PR fixes this.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
