### PR TITLE
fix-casing-in-cli-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Changed
 
 - The Pubmed/Medline Plain importer now imports the PMID field as well [#11488](https://github.com/JabRef/jabref/issues/11488)
+- Renamed command line paramter `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`.
 - The 'Check for updates' menu bar button is now always enabled. [#11485](https://github.com/JabRef/jabref/pull/11485)
 - JabRef respects the [configuration for storing files relative to the .bib file](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#directories-for-files) in more cases. [#11492](https://github.com/JabRef/jabref/pull/11492)
 - JabRef does not show finished background tasks in the status bar popup. [#11574](https://github.com/JabRef/jabref/pull/11574)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Changed
 
 - The Pubmed/Medline Plain importer now imports the PMID field as well [#11488](https://github.com/JabRef/jabref/issues/11488)
-- Renamed command line paramter `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`.
 - The 'Check for updates' menu bar button is now always enabled. [#11485](https://github.com/JabRef/jabref/pull/11485)
 - JabRef respects the [configuration for storing files relative to the .bib file](https://docs.jabref.org/finding-sorting-and-cleaning-entries/filelinks#directories-for-files) in more cases. [#11492](https://github.com/JabRef/jabref/pull/11492)
 - JabRef does not show finished background tasks in the status bar popup. [#11574](https://github.com/JabRef/jabref/pull/11574)
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
+- ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -239,22 +239,22 @@ public class ArgumentProcessor {
             automaticallySetFileLinks(loaded);
         }
 
-        if ((cli.isWriteXMPtoPdf() && cli.isEmbeddBibfileInPdf()) || (cli.isWriteMetadatatoPdf() && (cli.isWriteXMPtoPdf() || cli.isEmbeddBibfileInPdf()))) {
-            System.err.println("Give only one of [writeXMPtoPdf, embeddBibfileInPdf, writeMetadatatoPdf]");
+        if ((cli.isWriteXmpToPdf() && cli.isEmbedBibFileInPdf()) || (cli.isWriteMetadataToPdf() && (cli.isWriteXmpToPdf() || cli.isEmbedBibFileInPdf()))) {
+            System.err.println("Give only one of [writeXmpToPdf, embedBibFileInPdf, writeMetadataToPdf]");
         }
 
-        if (cli.isWriteMetadatatoPdf() || cli.isWriteXMPtoPdf() || cli.isEmbeddBibfileInPdf()) {
+        if (cli.isWriteMetadataToPdf() || cli.isWriteXmpToPdf() || cli.isEmbedBibFileInPdf()) {
             if (!loaded.isEmpty()) {
                 writeMetadataToPdf(loaded,
-                        cli.getWriteMetadatatoPdf(),
+                        cli.getWriteMetadataToPdf(),
                         preferencesService.getXmpPreferences(),
                         preferencesService.getFilePreferences(),
                         preferencesService.getLibraryPreferences().getDefaultBibDatabaseMode(),
                         Injector.instantiateModelOrService(BibEntryTypesManager.class),
                         preferencesService.getFieldPreferences(),
                         Injector.instantiateModelOrService(JournalAbbreviationRepository.class),
-                        cli.isWriteXMPtoPdf() || cli.isWriteMetadatatoPdf(),
-                        cli.isEmbeddBibfileInPdf() || cli.isWriteMetadatatoPdf());
+                        cli.isWriteXmpToPdf() || cli.isWriteMetadataToPdf(),
+                        cli.isEmbedBibFileInPdf() || cli.isWriteMetadataToPdf());
             }
         }
 
@@ -379,7 +379,7 @@ public class ArgumentProcessor {
                 if (embeddedBibFilePdfExporter.exportToAllFilesOfEntry(databaseContext, filePreferences, entry, List.of(entry), abbreviationRepository)) {
                     System.out.printf("Successfully embedded metadata on at least one linked file of %s%n", citeKey);
                 } else {
-                    System.out.printf("Cannot embedd metadata on any linked files of %s. Make sure there is at least one linked file and the path is correct.%n", citeKey);
+                    System.out.printf("Cannot embed metadata on any linked files of %s. Make sure there is at least one linked file and the path is correct.%n", citeKey);
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -33,7 +33,6 @@ public class JabRefCLI {
 
     public JabRefCLI(String[] args) throws ParseException {
         Options options = getOptions();
-
         this.cl = new DefaultParser().parse(options, args, true);
         this.leftOver = cl.getArgList();
     }
@@ -153,21 +152,21 @@ public class JabRefCLI {
         return cl.hasOption("automaticallySetFileLinks");
     }
 
-    public boolean isWriteXMPtoPdf() {
-        return cl.hasOption("writeXMPtoPdf");
+    public boolean isWriteXmpToPdf() {
+        return cl.hasOption("writeXmpToPdf");
     }
 
-    public boolean isEmbeddBibfileInPdf() {
-        return cl.hasOption("embeddBibfileInPdf");
+    public boolean isEmbedBibFileInPdf() {
+        return cl.hasOption("embedBibFileInPdf");
     }
 
-    public boolean isWriteMetadatatoPdf() {
-        return cl.hasOption("writeMetadatatoPdf");
+    public boolean isWriteMetadataToPdf() {
+        return cl.hasOption("writeMetadataToPdf");
     }
 
-    public String getWriteMetadatatoPdf() {
-        return cl.hasOption("writeMetadatatoPdf") ? cl.getOptionValue("writeMetadatatoPdf") :
-                cl.hasOption("writeXMPtoPdf") ? cl.getOptionValue("writeXMPtoPdf") :
+    public String getWriteMetadataToPdf() {
+        return cl.hasOption("writeMetadatatoPdf") ? cl.getOptionValue("writeMetadataToPdf") :
+                cl.hasOption("writeXMPtoPdf") ? cl.getOptionValue("writeXmpToPdf") :
                         cl.hasOption("embeddBibfileInPdf") ? cl.getOptionValue("embeddBibfileInPdf") : null;
     }
 
@@ -273,15 +272,15 @@ public class JabRefCLI {
 
         options.addOption(Option
                 .builder()
-                .longOpt("writeXMPtoPdf")
-                .desc("%s: '%s'".formatted(Localization.lang("Write BibTeXEntry as XMP metadata to PDF."), "-w pathToMyOwnPaper.pdf"))
+                .longOpt("writeXmpToPdf")
+                .desc("%s: '%s'".formatted(Localization.lang("Write BibTeX as XMP metadata to PDF."), "-w pathToMyOwnPaper.pdf"))
                 .hasArg()
                 .argName("CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all")
                 .build());
 
         options.addOption(Option
                 .builder()
-                .longOpt("embeddBibfileInPdf")
+                .longOpt("embedBibFileInPdf")
                 .desc("%s: '%s'".formatted(Localization.lang("Embed BibTeX as attached file in PDF."), "-w pathToMyOwnPaper.pdf"))
                 .hasArg()
                 .argName("CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all")
@@ -289,8 +288,8 @@ public class JabRefCLI {
 
         options.addOption(Option
                 .builder("w")
-                .longOpt("writeMetadatatoPdf")
-                .desc("%s: '%s'".formatted(Localization.lang("Write BibTeXEntry as metadata to PDF."), "-w pathToMyOwnPaper.pdf"))
+                .longOpt("writeMetadataToPdf")
+                .desc("%s: '%s'".formatted(Localization.lang("Write BibTeX to PDF (XMP and embedded)"), "-w pathToMyOwnPaper.pdf"))
                 .hasArg()
                 .argName("CITEKEY1[,CITEKEY2][,CITEKEYn] | PDF1[,PDF2][,PDFn] | all")
                 .build());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -217,7 +217,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
         acceptAutoLinkedFile.getStyleClass().setAll("icon-button");
 
         Button writeMetadataToPdf = IconTheme.JabRefIcons.PDF_METADATA_WRITE.asButton();
-        writeMetadataToPdf.setTooltip(new Tooltip(Localization.lang("Write BibTeXEntry metadata to PDF.")));
+        writeMetadataToPdf.setTooltip(new Tooltip(Localization.lang("Write BibTeX to PDF (XMP and embedded)")));
         writeMetadataToPdf.visibleProperty().bind(linkedFile.isOfflinePdfProperty());
         writeMetadataToPdf.getStyleClass().setAll("icon-button");
         WriteMetadataToSinglePdfAction writeMetadataToSinglePdfAction = new WriteMetadataToSinglePdfAction(

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -964,10 +964,11 @@ Write\ metadata\ for\ all\ PDFs\ in\ current\ library?=Write metadata for all PD
 Writing\ metadata...=Writing metadata...
 
 Embed\ BibTeX\ as\ attached\ file\ in\ PDF.=Embed BibTeX as attached file in PDF.
-File\ '%0'\ is\ write\ protected.=File '%0' is write protected.
-Write\ BibTeXEntry\ as\ XMP\ metadata\ to\ PDF.=Write BibTeXEntry as XMP metadata to PDF.
-Write\ BibTeXEntry\ metadata\ to\ PDF.=Write BibTeXEntry metadata to PDF.
+Write\ BibTeX\ as\ XMP\ metadata\ to\ PDF.=Write BibTeX as XMP metadata to PDF.
+Write\ BibTeX\ to\ PDF\ (XMP\ and\ embedded).=Write BibTeX to PDF (XMP and embedded)
 Write\ metadata\ to\ PDF\ files=Write metadata to PDF files
+
+File\ '%0'\ is\ write\ protected.=File '%0' is write protected.
 
 XMP-annotated\ PDF=XMP-annotated PDF
 XMP\ export\ privacy\ settings=XMP export privacy settings

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -959,13 +959,12 @@ Whatever\ option\ you\ choose,\ Mr.\ DLib\ may\ share\ its\ data\ with\ research
 
 Will\ write\ metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write metadata to the PDFs linked from selected entries.
 
-Write\ BibTeXEntry\ as\ metadata\ to\ PDF.=Write BibTeXEntry as metadata to PDF.
 Write\ metadata\ for\ all\ PDFs\ in\ current\ library?=Write metadata for all PDFs in current library?
 Writing\ metadata...=Writing metadata...
 
 Embed\ BibTeX\ as\ attached\ file\ in\ PDF.=Embed BibTeX as attached file in PDF.
 Write\ BibTeX\ as\ XMP\ metadata\ to\ PDF.=Write BibTeX as XMP metadata to PDF.
-Write\ BibTeX\ to\ PDF\ (XMP\ and\ embedded).=Write BibTeX to PDF (XMP and embedded)
+Write\ BibTeX\ to\ PDF\ (XMP\ and\ embedded)=Write BibTeX to PDF (XMP and embedded)
 Write\ metadata\ to\ PDF\ files=Write metadata to PDF files
 
 File\ '%0'\ is\ write\ protected.=File '%0' is write protected.


### PR DESCRIPTION
The CLI options were strange. I never had a clue, what was wrong. But the IntelliJ spell checker guided me.

Should be a bit better understandable now

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.