### PR TITLE
Fix black text in Dark mode inside "Citation information"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When converting the references section of a paper (PDF file), more than the last page is treated. [#11522](https://github.com/JabRef/jabref/pull/11522)
 - Added minimal support for [biblatex data annotation](https://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.3.7) fields in `.layout` files. [#11505](https://github.com/JabRef/jabref/issues/11505)
 - Added saving of selected options in the [Lookup -> Search for unlinked local files dialog](https://docs.jabref.org/collect/findunlinkedfiles#link-the-pdfs-to-your-bib-library). [#11439](https://github.com/JabRef/jabref/issues/11439)
+- We fixed black text in Dark mode inside "Citation information" [#11512](https://github.com/JabRef/jabref/issues/11512)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -126,7 +126,6 @@
     -fx-fill: #7800A9 ;
     -fx-font-size: 1.2em;
     -fx-font-weight: bolder;
-
 }
 
 #citationsPane {
@@ -134,7 +133,7 @@
     -fx-background-color: -fx-control-inner-background;
 }
 
-#citationsPane * {
+#citationsPane .scite-message-content{
     -fx-fill: -fx-text-background-color;
 }
 
@@ -158,7 +157,6 @@
 .scite-message-box {
     -fx-padding: 30 0 0 30;
 }
-
 .scite-error-label {
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;

--- a/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 
 import org.jabref.gui.DialogService;
@@ -55,7 +56,7 @@ public class SciteTab extends EntryEditorTab {
         column.setHalignment(HPos.CENTER);
 
         sciteResultsPane.getColumnConstraints().setAll(column);
-        sciteResultsPane.setId("scitePane");
+        sciteResultsPane.setId("citationsPane");
         setContent(sciteResultsPane);
 
         EasyBind.subscribe(viewModel.statusProperty(), status -> {
@@ -85,6 +86,7 @@ public class SciteTab extends EntryEditorTab {
         Label titleLabel = new Label(Localization.lang("Error"));
         titleLabel.getStyleClass().add("scite-error-label");
         Text errorMessageText = new Text(viewModel.searchErrorProperty().get());
+        errorMessageText.getStyleClass().add("scite-message-content");
         VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
         errorMessageBox.getStyleClass().add("scite-error-box");
         return errorMessageBox;
@@ -101,7 +103,7 @@ public class SciteTab extends EntryEditorTab {
                 tallModel.unclassified(),
                 tallModel.citingPublications()
         ));
-
+        message.getStyleClass().add("scite-message-content");
         String url = SCITE_REPORTS_URL_BASE + URLEncoder.encode(tallModel.doi(), StandardCharsets.UTF_8);
         VBox messageBox = getMessageBox(url, titleLabel, message);
         messageBox.getStyleClass().add("scite-message-box");


### PR DESCRIPTION
Closes #11512

## UI screenshots

![image](https://github.com/user-attachments/assets/87b253f9-ce2a-469b-a8c2-d4d2f0237c45)

![image](https://github.com/user-attachments/assets/dffbf89a-2d2c-4204-b92d-7b8f03c2eb5f)

## Changes made

 - Added a class `scite-message-content` for text which are shown in black
 - Changed `#citationsPane` universal selecter to class selector to select `.scite-message-content`.