### PR TITLE
Add Windows Vagrant file

### DIFF
--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -13,14 +13,14 @@ This folder contains directories making use of [Vagrant](https://www.vagrantup.c
 
 ### Setup VM
 
-1. `cd` into `ubuntu`
+1. `cd` into `{vmdir}`, e..g, `cd ubuntu`
 2. Start the vm `vagrant up`
-3. Store ssh configuration: `vagrant ssh-config > default`
+3. Linux machines: Store ssh configuration: `vagrant ssh-config > default`
 
 ### Use VM
 
 You can use the UI offered by the VirtualBox client.
-You can also do `ssh -Y -F vagrant-ssh default` to SSH into the machine.
+On Linux, you can also do `ssh -Y -F vagrant-ssh default` to SSH into the machine.
 
 If asked for a password, this is `vagrant`.
 
@@ -31,8 +31,11 @@ Then, everything is removed.
 
 ## Available VMs
 
-- `ubuntu`: Ubuntu with JabRef snap and libreoffice-connection pre-installed. One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.
-- `fedora`: Fedora 39 with KDE plasma and JDK. During the build, the JabRef sources will be fetched and an initial build will be triggered. Login and then type `startx`. Now KDE Plasma should start. Open Konsole. Then `cd jabref`. Then `./gradlew run`.
+| VM                    | JabRef | Browser | LibreOffice |
+|-----------------------|--------|---------|-------------|
+| [`fedora`](fedora/)   | source | --      | --          |
+| [`ubuntu`](ubuntu/)   | snap   | Firefox | yes         |
+| [`windows`](windows/) | source | Firefox | yes         |
 
 ## Troubleshooting
 

--- a/scripts/vms/fedora/README.md
+++ b/scripts/vms/fedora/README.md
@@ -1,0 +1,6 @@
+# Fedora VM
+
+Fedora 39 with KDE plasma and JDK.
+During the build, the JabRef sources will be fetched and an initial build will be triggered.
+
+Login and then type `startx`. Now KDE Plasma should start. Open Konsole. Then `cd jabref`. Then `./gradlew run`.

--- a/scripts/vms/ubuntu/README.md
+++ b/scripts/vms/ubuntu/README.md
@@ -1,0 +1,5 @@
+# Ubuntu VM
+
+Ubuntu with JabRef snap and libreoffice-connection pre-installed.
+
+One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.

--- a/scripts/vms/windows/README.md
+++ b/scripts/vms/windows/README.md
@@ -1,32 +1,38 @@
 # Windows VM
 
-The initial setup of [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/) might take long.
+A Windows-based VM to test JabRef.
+As user, you need to ensure to have the proper Windows license to use this VM.
 
-In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destory`, and then run `vagrant up` again.
+In case you have many CPU cores, you can adapt `vb.cpus` in `Vagrantfile` to a higher number.
 
 One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.
 
 ## Troubleshooting
 
-> Repair-WinGetPackageManager : API rate limit exceeded for 194.35.188.229. (But here's the good news: Authenticated
-> requests get a higher rate limit. Check out the documentation for more details.)
->
-> `CategoryInfo          : NotSpecified: (:) [Repair-WinGetPackageManager], RateLimitExceededException`
+### "Waiting for machine to reboot..."
 
-This is a GitHub API rate limit. Either try again at a later point in time or modify `Vagrantfile` to include some GitHub API token (Based on <https://stackoverflow.com/q/33655700/873282>).
+In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destory`, and then run `vagrant up` again.
 
----
+### `fatal: early EOF`
 
-Slow downloading
-
+```console
+jabref-windows-sandbox: Cloning into 'jabref'...
+jabref-windows-sandbox: error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8)
+jabref-windows-sandbox: error: 6846 bytes of body are still expected
+jabref-windows-sandbox: fetch-pack: unexpected disconnect while reading sideband packet
+jabref-windows-sandbox: fatal: early EOF
+jabref-windows-sandbox: fatal: fetch-pack: invalid index-pack output
 ```
- Writing web request
-    Writing request stream... (Number of bytes written: 32768)
- ```
 
- This downloads winget-cli from GitHub. It seems that are GitHub rate limiters in place.
+The `git clone` command did not work.
 
- One can try to execute `Install-Module -Name WingetTools` and then `Install-WinGet` manually. This downloads an older winget-cli version.
+Login, open `cmd` and then execute following commands:
+
+```cmd
+git clone --recurse-submodules https://github.com/JabRef/jabref.git
+cd jabref
+gradlew run
+```
 
 ## Background
 
@@ -34,6 +40,8 @@ Slow downloading
 
 The most use image seems to be the [Windows 10 image by `gusztavvargadr`](https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-10).
 List of all images at <https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr>.
+
+[Chocolatey](https://chocolatey.org/) is used instead of [winget-cli](https://learn.microsoft.com/en-us/windows/package-manager/), because Chocolatey installation does not hit GitHub's rate limits during unattended installation.
 
 ## Atlernatives
 

--- a/scripts/vms/windows/README.md
+++ b/scripts/vms/windows/README.md
@@ -1,0 +1,41 @@
+# Windows VM
+
+The initial setup of [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/) might take long.
+
+In case Vagrant reports "Waiting for machine to reboot..." and nothing happens, one has to "power off" the machine, execute `vagrant destory`, and then run `vagrant up` again.
+
+One has to install the [JabRef Browser Extension](https://addons.mozilla.org/en-US/firefox/addon/jabref/) manually.
+
+## Troubleshooting
+
+> Repair-WinGetPackageManager : API rate limit exceeded for 194.35.188.229. (But here's the good news: Authenticated
+> requests get a higher rate limit. Check out the documentation for more details.)
+>
+> `CategoryInfo          : NotSpecified: (:) [Repair-WinGetPackageManager], RateLimitExceededException`
+
+This is a GitHub API rate limit. Either try again at a later point in time or modify `Vagrantfile` to include some GitHub API token (Based on <https://stackoverflow.com/q/33655700/873282>).
+
+---
+
+Slow downloading
+
+```
+ Writing web request
+    Writing request stream... (Number of bytes written: 32768)
+ ```
+
+ This downloads winget-cli from GitHub. It seems that are GitHub rate limiters in place.
+
+ One can try to execute `Install-Module -Name WingetTools` and then `Install-WinGet` manually. This downloads an older winget-cli version.
+
+## Background
+
+`Vagrantfile` is based on [SeisoLLC/windows-sandbox](https://github.com/SeisoLLC/windows-sandbox/tree/main).
+
+The most use image seems to be the [Windows 10 image by `gusztavvargadr`](https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr/windows-10).
+List of all images at <https://portal.cloud.hashicorp.com/vagrant/discover/gusztavvargadr>.
+
+## Atlernatives
+
+- Atlernative Vagrant images: <https://app.vagrantup.com/boxes/search?q=windows+10&utf8=%E2%9C%93>.
+- [Windows Sandbox](https://learn.microsoft.com/en-us/windows/security/application-security/application-isolation/windows-sandbox/windows-sandbox-overview)

--- a/scripts/vms/windows/Vagrantfile
+++ b/scripts/vms/windows/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+NAME = "jabref-windows-sandbox"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "gusztavvargadr/windows-10"
+  config.vm.box_url = "https://app.vagrantup.com/gusztavvargadr/boxes/windows-10"
+  config.vm.hostname = NAME
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = NAME
+
+    vb.memory = 6000
+    vb.cpus = 2
+
+    vb.customize ['modifyvm', :id, '--clipboard-mode', 'bidirectional']
+    vb.gui = true
+  end
+
+  config.vm.provision "shell", privileged: "true", powershell_elevated_interactive: "true", inline: <<-SHELL
+    # Source: https://github.com/microsoft/winget-cli/discussions/4065#discussioncomment-8355261
+    Install-PackageProvider -Name NuGet -Force
+    # Microsoft.WinGet.Client is the official Microsoft winget PowerShell distribution. "WingetTools" is not.
+    Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery
+    # This installs winget-cli
+    Repair-WinGetPackageManager
+
+    # winget install EclipseAdoptium.Temurin.21.JDK --accept-source-agreements  # Adoptium has issues with AWT headless
+    winget install --id=Azul.Zulu.21.JDK -e --accept-source-agreements
+    winget install -e --id Git.Git --accept-source-agreements
+
+    winget install -e --id Mozilla.Firefox --accept-source-agreements
+    winget install --id=TheDocumentFoundation.LibreOffice -e --accept-source-agreements
+  SHELL
+
+  config.vm.provision "shell", reboot: true
+
+  config.vm.provision "shell", privileged: "false", inline: <<-SHELL
+    cd \\users\\vagrant
+    git clone --recurse-submodules https://github.com/JabRef/jabref.git
+    # cd jabref
+    # .\\gradlew jar
+  SHELL
+
+  # Used to set the Vagrant machine name
+  config.vm.define NAME do |t|
+  end
+end

--- a/scripts/vms/windows/Vagrantfile
+++ b/scripts/vms/windows/Vagrantfile
@@ -18,19 +18,14 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", privileged: "true", powershell_elevated_interactive: "true", inline: <<-SHELL
-    # Source: https://github.com/microsoft/winget-cli/discussions/4065#discussioncomment-8355261
-    Install-PackageProvider -Name NuGet -Force
-    # Microsoft.WinGet.Client is the official Microsoft winget PowerShell distribution. "WingetTools" is not.
-    Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery
-    # This installs winget-cli
-    Repair-WinGetPackageManager
+    # Install chocolatey
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    choco feature enable -n=allowGlobalConfirmation
 
-    # winget install EclipseAdoptium.Temurin.21.JDK --accept-source-agreements  # Adoptium has issues with AWT headless
-    winget install --id=Azul.Zulu.21.JDK -e --accept-source-agreements
-    winget install -e --id Git.Git --accept-source-agreements
-
-    winget install -e --id Mozilla.Firefox --accept-source-agreements
-    winget install --id=TheDocumentFoundation.LibreOffice -e --accept-source-agreements
+    choco install libericajdk
+    choco install git.install -y --params "/GitAndUnixToolsOnPath /WindowsTerminal /WindowsTerminalProfile"
+    choco install firefox
+    choco install libreoffice-fresh
   SHELL
 
   config.vm.provision "shell", reboot: true


### PR DESCRIPTION
This adds a new Vagrant VM to get a clean Windows environment with git, a JDK, Firefox and LibreOffice installed. Then one can test JabRef's functionalities more easily.

Also reworked the `README.md` file(s).

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
