### PR TITLE
Add Vagrant Linux Mint Cinnamon VM

### DIFF
--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -31,11 +31,12 @@ Then, everything is removed.
 
 ## Available VMs
 
-| VM                    | JabRef | Browser | LibreOffice |
-|-----------------------|--------|---------|-------------|
-| [`fedora`](fedora/)   | source | --      | --          |
-| [`ubuntu`](ubuntu/)   | snap   | Firefox | yes         |
-| [`windows`](windows/) | source | Firefox | yes         |
+| VM                                              | JabRef  | Browser | LibreOffice |
+|-------------------------------------------------|---------|---------|-------------|
+| [`fedora`](fedora/)                             | source  | --      | --          |
+| [`Linux Mint (Cinnamon)`](linux-mint-cinnamon/) | source  | Firefox | yes         |
+| [`ubuntu`](ubuntu/)                             | snap    | Firefox | yes         |
+| [`windows`](windows/)                           | source  | Firefox | yes         |
 
 ## Troubleshooting
 

--- a/scripts/vms/linux-mint-cinnamon/README.md
+++ b/scripts/vms/linux-mint-cinnamon/README.md
@@ -1,0 +1,23 @@
+# Linux Mint Cinnamon VM
+
+[Linux Mint](https://linuxmint.com/) with JabRef snap and libreoffice-connection pre-installed.
+
+Uses <https://portal.cloud.hashicorp.com/vagrant/discover/aaronvonawesome/linux-mint-21-cinnamon>.
+
+Start JabRef by following steps:
+
+- 1. Open termminal
+- 2. `cd jabref`
+- 3. `./gradlew run`
+
+## Alternative
+
+We could have build our own image.
+First creating an image using packer with <https://github.com/rmoesbergen/packer-linuxmint>.
+Then, building a `Vagrantfile` on top of it.
+Seemed to be too much issues for the users.
+
+1. Install packer
+2. `packer plugins install github.com/hashicorp/virtualbox`
+3. `packer plugins install github.com/hashicorp/vagrant`
+4. `packer build -var-file=mint-cinnamon-22.json core_template.json`

--- a/scripts/vms/linux-mint-cinnamon/Vagrantfile
+++ b/scripts/vms/linux-mint-cinnamon/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # https://portal.cloud.hashicorp.com/vagrant/discover/aaronvonawesome/linux-mint-21-cinnamon
+  config.vm.box = "aaronvonawesome/linux-mint-21-cinnamon"
+  config.vm.box_version = "4.0.1"
+
+  config.vm.network :forwarded_port, guest: 80, host: 8080, auto_correct: true
+
+  config.vm.provider "virtualbox" do |v|
+    v.name = "jabref-linux-mint-cinnamon"
+    v.gui = true
+    v.customize ["modifyvm", :id, "--memory", "2048", "--cpus", "2"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get install -y git
+  SHELL
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    curl -s "https://get.sdkman.io" | bash
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+    sdk install java 21.0.4-tem < /dev/null
+    git clone --recurse-submodules https://github.com/JabRef/jabref.git
+    cd jabref
+    sdk use java 21.0.4-tem
+    ./gradlew jar
+  SHELL
+
+  config.ssh.forward_x11 = true
+end

--- a/scripts/vms/ubuntu/Vagrantfile
+++ b/scripts/vms/ubuntu/Vagrantfile
@@ -28,17 +28,18 @@ Vagrant.configure("2") do |config|
     v.customize ["modifyvm", :id, "--memory", "2048", "--cpus", "2"]
   end
 
-  # Update package index
-  config.vm.provision "shell", inline: "sudo apt-get update"
-  config.vm.provision "shell", inline: "sudo apt-get upgrade -y"
+  config.vm.provision "shell", inline: <<-SHELL
+    # Update package index
+    sudo apt-get update
+    sudo apt-get upgrade -y
 
-  # Install latest development build of JabRef
-  config.vm.provision "shell", inline: "sudo snap install --edge jabref"
+    # Install latest development build of JabRef
+    sudo snap install --edge jabref
 
-  # Enable LibreOffice connection
-  config.vm.provision "shell", inline: "sudo apt-get install -y libreoffice-java-common"
-  config.vm.provision "shell", inline: "sudo mkdir -p /usr/lib/mozilla/native-messaging-hosts"
-  config.vm.provision "shell", inline: "snap connect jabref:hostfs-mozilla-native-messaging-jabref"
+    sudo apt-get install -y libreoffice-java-common
+    sudo mkdir -p /usr/lib/mozilla/native-messaging-hosts
+    snap connect jabref:hostfs-mozilla-native-messaging-jabref
+  SHELL
 
   config.ssh.forward_x11 = true
 end


### PR DESCRIPTION
Wish by @Siedlerchr 

This adds a Linux Mint VM.

This is Linux Mint 21.

Linux Mint 22 was released recently. There currently is no downloadable Vagrant image available. Only some [packer scripts](https://github.com/rmoesbergen/packer-linuxmint). I decided not to maintain a Vagrant image, but to wait that someone publishes a Linux Mint 22 image.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
