### PR TITLE
Vagrant Windows image: Add C++ redistributable

### DIFF
--- a/scripts/vms/README.md
+++ b/scripts/vms/README.md
@@ -36,7 +36,7 @@ Then, everything is removed.
 | [`fedora`](fedora/)                             | source  | --      | --          |
 | [`Linux Mint (Cinnamon)`](linux-mint-cinnamon/) | source  | Firefox | yes         |
 | [`ubuntu`](ubuntu/)                             | snap    | Firefox | yes         |
-| [`windows`](windows/)                           | source  | Firefox | yes         |
+| [`windows`](windows/)                           | source  | Edge    | --          |
 
 ## Troubleshooting
 

--- a/scripts/vms/windows/Vagrantfile
+++ b/scripts/vms/windows/Vagrantfile
@@ -24,8 +24,12 @@ Vagrant.configure("2") do |config|
 
     choco install libericajdk
     choco install git.install -y --params "/GitAndUnixToolsOnPath /WindowsTerminal /WindowsTerminalProfile"
-    choco install firefox
-    choco install libreoffice-fresh
+
+    # Required by AI functionaltiy
+    choco choco install vcredist140
+
+    # choco install firefox
+    # choco install libreoffice-fresh
   SHELL
 
   config.vm.provision "shell", reboot: true


### PR DESCRIPTION
Adds C++ redistributable required by AI feature

Removes firefox and libreoffice to reduce installation time.