### PR TITLE
Integrate DOI parsing special character test in existing parameterized test

### DIFF
--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -225,7 +225,11 @@ public class DOITest {
                 Arguments.of("10/abcde", DOI.findInText("other stuff https://www.doi.org/abcde end").get().getDOI()),
                 Arguments.of("10/abcde", DOI.findInText("other stuff https://doi.org/abcde end").get().getDOI()),
                 Arguments.of("10.5220/0010404301780189", DOI.findInText("https://www.scitepress.org/Link.aspx?doi=10.5220/0010404301780189").get().getDOI()),
-                Arguments.of("10.5220/0010404301780189", DOI.findInText("10.5220/0010404301780189").get().getDOI())
+                Arguments.of("10.5220/0010404301780189", DOI.findInText("10.5220/0010404301780189").get().getDOI()),
+
+                // findDoiWithSpecialCharactersInText
+                Arguments.of(new DOI("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2").getDOI(),
+                        DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2").get().getDOI())
         );
     }
 
@@ -315,11 +319,5 @@ public class DOITest {
     @Test
     public void rejectNullDoiParameter() {
         assertThrows(NullPointerException.class, () -> new DOI(null));
-    }
-
-    @Test
-    public void findDoiWithSpecialCharactersInText() {
-        assertEquals(Optional.of(new DOI("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2")),
-                DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2"));
     }
 }

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -228,7 +228,7 @@ public class DOITest {
                 Arguments.of("10.5220/0010404301780189", DOI.findInText("10.5220/0010404301780189").get().getDOI()),
 
                 // findDoiWithSpecialCharactersInText
-                Arguments.of(new DOI("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2").getDOI(),
+                Arguments.of("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2"),
                         DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2").get().getDOI())
         );
     }

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -228,7 +228,7 @@ public class DOITest {
                 Arguments.of("10.5220/0010404301780189", DOI.findInText("10.5220/0010404301780189").get().getDOI()),
 
                 // findDoiWithSpecialCharactersInText
-                Arguments.of("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2"),
+                Arguments.of("10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2",
                         DOI.findInText("https://doi.org/10.1175/1520-0493(2002)130%3C1913:EDAWPO%3E2.0.CO;2").get().getDOI())
         );
     }


### PR DESCRIPTION
**Follow-up to:** https://github.com/JabRef/jabref/pull/11084
Integrates test for the DOI URL parsing (for the case of special characters) into existing parameterized test.
Refs https://github.com/JabRef/jabref/pull/11084#discussion_r1536927292

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] ~Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
