### PR TITLE
Upgrade to StAX parsing for CSL style titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
 - ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 - The browse button for a Custom theme now opens in the directory of the current used CSS file [#11597](https://github.com/JabRef/jabref/pull/11597)
+- We upgraded from DOM to StAX parser for CSL style titles. [11604](https://github.com/JabRef/jabref/pull/11604)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
 - ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 - The browse button for a Custom theme now opens in the directory of the current used CSS file [#11597](https://github.com/JabRef/jabref/pull/11597)
-- We upgraded from DOM to StAX parser for CSL style titles. [11604](https://github.com/JabRef/jabref/pull/11604)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -83,7 +83,7 @@ public class CitationStyle implements OOStyle {
 
             boolean inInfo = false;
             boolean hasBibliography = false;
-            String title = null;
+            String title = "";
 
             while (reader.hasNext()) {
                 int event = reader.next();

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -76,8 +76,8 @@ public class CitationStyle implements OOStyle {
     }
 
     private static Optional<String> getTitle(String filename, String content) {
-
         FACTORY.setProperty(XMLInputFactory.IS_COALESCING, true);
+
         try {
             XMLStreamReader reader = FACTORY.createXMLStreamReader(new StringReader(content));
 

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -107,7 +107,6 @@ public class CitationStyle implements OOStyle {
             }
 
             if (hasBibliography && title != null) {
-                System.out.println("HELLOOOOOO" + title);
                 return Optional.of(title);
             } else {
                 LOGGER.debug("No valid title or bibliography found for file {}", filename);

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -41,7 +40,7 @@ public class CitationStyle implements OOStyle {
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationStyle.class);
     private static final String STYLES_ROOT = "/csl-styles";
     private static final List<CitationStyle> STYLES = new ArrayList<>();
-    private static final DocumentBuilderFactory FACTORY = DocumentBuilderFactory.newInstance();
+    private static final XMLInputFactory FACTORY = XMLInputFactory.newInstance();
 
     private final String filePath;
     private final String title;
@@ -77,10 +76,10 @@ public class CitationStyle implements OOStyle {
     }
 
     private static Optional<String> getTitle(String filename, String content) {
-        XMLInputFactory factory = XMLInputFactory.newInstance();
-        factory.setProperty(XMLInputFactory.IS_COALESCING, true);
+
+        FACTORY.setProperty(XMLInputFactory.IS_COALESCING, true);
         try {
-            XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(content));
+            XMLStreamReader reader = FACTORY.createXMLStreamReader(new StringReader(content));
 
             boolean inInfo = false;
             boolean hasBibliography = false;


### PR DESCRIPTION
[**Subsidiary PR for the GSoC '24 CSL4LibreOffice Project**]

Upgrade parser of CSL style titles from DOM to StAX

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [ ] ~Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
