### PR TITLE
Remove comment on PR again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,9 @@ on:
     branches:
       - main
       - main-release
+  pull_request:
   merge_group:
   workflow_dispatch:
-  # The checkers should write comments on the PR if something fails. For this, we need to have a proper GITHUB_TOKEN. This is enabled by ..._target.
-  pull_request_target:
 
 env:
   SpringerNatureAPIKey: ${{ secrets.SpringerNatureAPIKey }}
@@ -52,20 +51,7 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Run checkstyle using gradle
         run: ./gradlew checkstyleMain checkstyleTest checkstyleJmh
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet [JabRef's code guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
-              We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
-              The tool reviewdog already placed comments on GitHub to indicate the places. See the tab "Files" in you PR.
-              Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
-              Afterwards, please [run checkstyle locally](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#run-checkstyle) and fix the issues.
 
-
-              You can check review dog's comments at the tab "Files changed" of your pull request.
-          comment_tag: automated-test-feedback
 
   openrewrite:
     name: OpenRewrite
@@ -88,19 +74,6 @@ jobs:
       - name: Run OpenRewrite
         run: |
           ./gradlew rewriteDryRun
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet JabRef's code guidelines.
-              We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
-              The issues found can be **automatically fixed**.
-              Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
-
-
-              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "OpenRewrite".
-          comment_tag: automated-test-feedback
 
   modernizer:
     name: Modernizer
@@ -125,18 +98,6 @@ jobs:
           # enable failing of this task if modernizer complains
           sed -i "s/failOnViolations = false/failOnViolations = true/" build.gradle
           ./gradlew modernizer
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              Your code currently does not meet JabRef's code guidelines.
-              We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
-              Please fix the detected errors, commit, and push.
-
-
-              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
-          comment_tag: automated-test-feedback
 
   markdown:
     name: Markdown
@@ -153,18 +114,6 @@ jobs:
           globs: |
             *.md
             docs/**/*.md
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              You modified Markdown (`*.md`) files and did not meet JabRef's rules for consistently formatted Markdown files.
-              To ensure consistent styling, we have [markdown-lint](https://github.com/DavidAnson/markdownlint) in place.
-              [Markdown lint's rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#rules) help to keep our Markdown files consistent within this repository and consistent with the Markdown files outside here.
-
-
-              You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "Markdown".
-          comment_tag: automated-test-feedback
 
   changelog:
     name: CHANGELOG.md
@@ -213,14 +162,6 @@ jobs:
           diff \
             <(git show origin/main:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)') \
             <(git show HEAD:CHANGELOG.md | clparse --format=json --separator=– - | jq '.releases[] | select(.version != null)')
-      - name: Add comment on pull request
-        if: ${{ failure() }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: >
-              While the PR was in progress, JabRef released a new version.
-              You have to merge `upstream/main` and move your entry in `CHANGELOG.md` up to the section `## [Unreleased]`.
-          comment_tag: automated-test-feedback
 
   tests:
     name: Unit tests


### PR DESCRIPTION
partially revert
https://github.com/JabRef/jabref/pull/11556 



<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
