### PR TITLE
setValues is not necessary at storing of preferences

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogViewModel.java
@@ -144,14 +144,12 @@ public class PreferencesDialogViewModel extends AbstractViewModel {
         if (resetPreferencesConfirmed) {
             try {
                 preferences.clear();
-
                 dialogService.showWarningDialogAndWait(Localization.lang("Reset preferences"),
                         Localization.lang("You must restart JabRef for this to come into effect."));
             } catch (BackingStoreException ex) {
                 LOGGER.error("Error while resetting preferences", ex);
                 dialogService.showErrorDialogAndWait(Localization.lang("Reset preferences"), ex);
             }
-
             setValues();
         }
     }
@@ -169,16 +167,13 @@ public class PreferencesDialogViewModel extends AbstractViewModel {
     }
 
     public void storeAllSettings() {
-        List<String> restartWarnings = new ArrayList<>();
-
-        // Run validation checks
         if (!validSettings()) {
             return;
         }
 
         // Store settings
         preferences.getInternalPreferences().setMemoryStickMode(memoryStickProperty.get());
-
+        List<String> restartWarnings = new ArrayList<>();
         for (PreferencesTab tab : preferenceTabs) {
             tab.storeSettings();
             restartWarnings.addAll(tab.getRestartWarnings());
@@ -194,8 +189,6 @@ public class PreferencesDialogViewModel extends AbstractViewModel {
 
         Injector.setModelOrService(BibEntryTypesManager.class, preferences.getCustomEntryTypesRepository());
         dialogService.notify(Localization.lang("Preferences recorded."));
-
-        setValues();
     }
 
     /**


### PR DESCRIPTION
There was a "load" of the preferences into all viewModels executed - if a preference was changed.

(It was refactored at #10659, but was there even earlier)

I think, this is not necessary.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
