### PR TITLE
Change text prompt color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue with colors in the search bar when dark theme is enabled. [#11569](https://github.com/JabRef/jabref/issues/11569)
 - We fixed an issue where a new unsaved library was not marked with an asterisk. [#11519](https://github.com/JabRef/jabref/pull/11519)
 - We fixed an issue where JabRef starts without window decorations. [#11440](https://github.com/JabRef/jabref/pull/11440)
-- We fixed an issue when prompt text had similar color to entered text. Now it became a bit lighter.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue with colors in the search bar when dark theme is enabled. [#11569](https://github.com/JabRef/jabref/issues/11569)
 - We fixed an issue where a new unsaved library was not marked with an asterisk. [#11519](https://github.com/JabRef/jabref/pull/11519)
 - We fixed an issue where JabRef starts without window decorations. [#11440](https://github.com/JabRef/jabref/pull/11440)
+- We fixed an issue when prompt text had similar color to entered text. Now it became a bit lighter.
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -868,7 +868,7 @@ TextFlow > .tooltip-text-monospaced {
 .text-input {
     -fx-background-color: -fx-outer-border, -fx-control-inner-background;
     -fx-background-insets: 0, 1;
-    -fx-prompt-text-fill: -fx-mid-text-color;
+    -fx-prompt-text-fill: -jr-gray-2;
 }
 
 .text-input:focused {


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Attempts to fix https://github.com/InAnYan/jabref/issues/153.

In this PR I changed the color of prompt text in `TextField`s to be lighter.

Previously, basic text and prompt text had similar colors, so it may appear like user has already entered some text. Especially it was a problem in entering chat model for Hugging Face.

Was:

![image](https://github.com/user-attachments/assets/7972143f-c64e-4409-849b-100d33312831)
![image](https://github.com/user-attachments/assets/39638c43-65e6-4c6c-a731-42f182031a63)

Became:

![image](https://github.com/user-attachments/assets/21b83861-5cb9-4bda-ae7d-04cf6d164917)
![image](https://github.com/user-attachments/assets/594ee65c-e828-4f6f-ae79-b749a353bf48)

This change may affect other JabRef style, so I made a separate PR. We can discuss the change there.

If it's not a good change, then I'll revert it and will only change the style of chat model prompt text (will not touch other JabRef style).

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
