### PR TITLE
Fix handling of chat history and deletion of messages

### DIFF
--- a/src/main/java/org/jabref/gui/ai/components/aichat/AiChatComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/aichat/AiChatComponent.java
@@ -149,8 +149,8 @@ public class AiChatComponent extends VBox {
         retryButton.setOnAction(event -> {
             userPromptTextArea.setText(userMessage);
 
-            chatVBox.getChildren().removeLast();
-            chatVBox.getChildren().removeLast();
+            removeLastMessage();
+            removeLastMessage();
 
             switchToNormalState();
 
@@ -165,6 +165,13 @@ public class AiChatComponent extends VBox {
 
         promptHBox.getChildren().add(retryButton);
         promptHBox.getChildren().add(cancelButton);
+    }
+
+    private void removeLastMessage() {
+        if (!chatVBox.getChildren().isEmpty()) {
+            ChatMessageComponent chatMessageComponent = (ChatMessageComponent) chatVBox.getChildren().getLast();
+            deleteMessage(chatMessageComponent);
+        }
     }
 
     private void switchToNormalState() {
@@ -201,9 +208,10 @@ public class AiChatComponent extends VBox {
     private void deleteMessage(ChatMessageComponent chatMessageComponent) {
         blockScroll.set(2);
 
-        aiChatLogic.getChatHistory().remove(chatMessageComponent.getChatMessage());
-
+        int index = chatVBox.getChildren().indexOf(chatMessageComponent);
         chatVBox.getChildren().remove(chatMessageComponent);
+
+        aiChatLogic.getChatHistory().remove(index);
     }
 
     private void requestUserPromptTextFieldFocus() {

--- a/src/main/java/org/jabref/logic/ai/chathistory/AiChatHistory.java
+++ b/src/main/java/org/jabref/logic/ai/chathistory/AiChatHistory.java
@@ -9,7 +9,7 @@ public interface AiChatHistory {
 
     void add(ChatMessage chatMessage);
 
-    void remove(ChatMessage chatMessage);
+    void remove(int index);
 
     void clear();
 }

--- a/src/main/java/org/jabref/logic/ai/chathistory/BibDatabaseChatHistoryManager.java
+++ b/src/main/java/org/jabref/logic/ai/chathistory/BibDatabaseChatHistoryManager.java
@@ -69,6 +69,7 @@ public class BibDatabaseChatHistoryManager {
 
                 return messages
                         .entrySet()
+                        // we need to check all keys, because upon deletion, there can be "holes" in the integer
                         .stream()
                         .sorted(Comparator.comparingInt(Map.Entry::getKey))
                         .map(entry -> entry.getValue().toLangchainMessage())

--- a/src/main/java/org/jabref/logic/ai/chathistory/InMemoryAiChatHistory.java
+++ b/src/main/java/org/jabref/logic/ai/chathistory/InMemoryAiChatHistory.java
@@ -19,8 +19,8 @@ public class InMemoryAiChatHistory implements AiChatHistory {
     }
 
     @Override
-    public void remove(ChatMessage chatMessage) {
-        chatMessages.remove(chatMessage);
+    public void remove(int index) {
+        chatMessages.remove(index);
     }
 
     @Override


### PR DESCRIPTION
When deletion of chat messages was introduced, the handling of chat history is wrong.

1) We wrongly create keys for MVStore.
2) We wrongly access messages from MVStore (it was IntRange, but it shouldn't be, because there could be gaps from deleted messages).
3) Deletion of messages was not by index, but by contents (this is just wrong, for example if you had exact same error message, when you delete it, everything became messed up).

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

c- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
