### PR TITLE
Highlight search bar on wrong syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,10 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The dialog for [adding an entry using reference text](https://docs.jabref.org/collect/newentryfromplaintext) is now filled with the clipboard contents as default. [#11565](https://github.com/JabRef/jabref/pull/11565)
 - Added minimal support for [biblatex data annotation](https://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.3.7) fields in `.layout` files. [#11505](https://github.com/JabRef/jabref/issues/11505)
 - Added saving of selected options in the [Lookup -> Search for unlinked local files dialog](https://docs.jabref.org/collect/findunlinkedfiles#link-the-pdfs-to-your-bib-library). [#11439](https://github.com/JabRef/jabref/issues/11439)
-- We fixed ans issue where text in Dark mode inside "Citation information" was not readable [#11512](https://github.com/JabRef/jabref/issues/11512)
 - We enabled creating a new file link manually. [#11017](https://github.com/JabRef/jabref/issues/11017)
 - We added a toggle button to invert the selected groups. [#9073](https://github.com/JabRef/jabref/issues/9073)
 - We reintroduced the floating search in the main table. [#4237](https://github.com/JabRef/jabref/issues/4237)
-- We fixed an issue where the selection of an entry in the table lost after searching for a group. [#3176](https://github.com/JabRef/jabref/issues/3176)
+- We added a different background color to the search bar to indicate when the search syntax is wrong. [#11658](https://github.com/JabRef/jabref/pull/11658)
 
 ### Changed
 
@@ -49,6 +48,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where a new unsaved library was not marked with an asterisk. [#11519](https://github.com/JabRef/jabref/pull/11519)
 - We fixed an issue where JabRef starts without window decorations. [#11440](https://github.com/JabRef/jabref/pull/11440)
 - We fixed an issue where the entry preview highlight was not working when searching before opening the entry editor. [#11659](https://github.com/JabRef/jabref/pull/11659)
+- We fixed an issue where text in Dark mode inside "Citation information" was not readable. [#11512](https://github.com/JabRef/jabref/issues/11512)
+- We fixed an issue where the selection of an entry in the table lost after searching for a group. [#3176](https://github.com/JabRef/jabref/issues/3176)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -1132,6 +1132,10 @@ TextFlow > .tooltip-text-monospaced {
     -fx-padding: 0em 1.8em 0em 0em;
 }
 
+.global-search-bar:illegal-search {
+    -fx-background-color: derive(-jr-light-red, 70%);
+}
+
 /* The little arrow that shows up when not all tool-bar icons fit into the tool-bar.
 We want to have a look that matches our icons in the tool-bar */
 .mainToolbar .tool-bar-overflow-button > .arrow {

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -78,10 +78,8 @@ import static org.jabref.gui.actions.ActionHelper.needsDatabase;
 public class GlobalSearchBar extends HBox {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalSearchBar.class);
-
     private static final int SEARCH_DELAY = 400;
-    private static final PseudoClass CLASS_NO_RESULTS = PseudoClass.getPseudoClass("emptyResult");
-    private static final PseudoClass CLASS_RESULTS_FOUND = PseudoClass.getPseudoClass("emptyResult");
+    private static final PseudoClass ILLEGAL_SEARCH = PseudoClass.getPseudoClass("illegal-search");
 
     private final CustomTextField searchField;
     private final ToggleButton caseSensitiveButton;
@@ -126,22 +124,24 @@ public class GlobalSearchBar extends HBox {
         Label currentResults = new Label();
         // fits the standard "found x entries"-message thus hinders the searchbar to jump around while searching if the tabContainer width is too small
         currentResults.setPrefWidth(150);
-        currentResults.visibleProperty().bind(stateManager.activeSearchQuery(searchType).isPresent());
 
         currentResults.textProperty().bind(EasyBind.combine(
-                stateManager.searchResultSize(searchType), illegalSearch, invalidRegex,
-                (matched, illegal, invalid) -> {
+                stateManager.activeSearchQuery(searchType), stateManager.searchResultSize(searchType), illegalSearch, invalidRegex,
+                (searchQuery, matched, illegal, invalid) -> {
                     if (illegal) {
-                        searchField.pseudoClassStateChanged(CLASS_NO_RESULTS, true);
+                        searchField.pseudoClassStateChanged(ILLEGAL_SEARCH, true);
                         return Localization.lang("Search failed: illegal search expression");
                     } else if (invalid) {
-                        searchField.pseudoClassStateChanged(CLASS_NO_RESULTS, true);
+                        searchField.pseudoClassStateChanged(ILLEGAL_SEARCH, true);
                         return Localization.lang("Invalid regular expression");
+                    } else if (searchQuery.isEmpty()) {
+                        searchField.pseudoClassStateChanged(ILLEGAL_SEARCH, false);
+                        return "";
                     } else if (matched.intValue() == 0) {
-                        searchField.pseudoClassStateChanged(CLASS_NO_RESULTS, true);
+                        searchField.pseudoClassStateChanged(ILLEGAL_SEARCH, false);
                         return Localization.lang("No results found.");
                     } else {
-                        searchField.pseudoClassStateChanged(CLASS_RESULTS_FOUND, true);
+                        searchField.pseudoClassStateChanged(ILLEGAL_SEARCH, false);
                         return Localization.lang("Found %0 results.", String.valueOf(matched));
                     }
                 }
@@ -338,6 +338,8 @@ public class GlobalSearchBar extends HBox {
         if (searchField.getText().isEmpty()) {
             setSearchFieldHintTooltip(null);
             stateManager.activeSearchQuery(searchType).set(Optional.empty());
+            illegalSearch.set(false);
+            invalidRegex.set(false);
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/LoayGhreeb/jabref/issues/11.

![image](https://github.com/user-attachments/assets/ac688fb2-0f16-4e1d-b18d-7bf2d5564061)


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
