### PR TITLE
Fix saving preferences while AI API key is empty

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
@@ -194,7 +194,7 @@ public class AiTabViewModel implements PreferenceTabViewModel {
         this.apiKeyValidator = new FunctionBasedValidator<>(
                 currentApiKey,
                 token -> !StringUtil.isBlank(token),
-                ValidationMessage.error(Localization.lang("An API key has to be provided")));
+                ValidationMessage.warning(Localization.lang("An API key has to be provided")));
 
         this.chatModelValidator = new FunctionBasedValidator<>(
                 currentChatModel,
@@ -343,8 +343,8 @@ public class AiTabViewModel implements PreferenceTabViewModel {
 
     public boolean validateBasicSettings() {
         List<Validator> validators = List.of(
-                chatModelValidator,
-                apiKeyValidator
+                chatModelValidator
+                // apiKeyValidator -- skipped, it will generate warning, but the preferences should be able to save.
         );
 
         return validators.stream().map(Validator::getValidationStatus).allMatch(ValidationStatus::isValid);

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
@@ -194,7 +194,7 @@ public class AiTabViewModel implements PreferenceTabViewModel {
         this.apiKeyValidator = new FunctionBasedValidator<>(
                 currentApiKey,
                 token -> !StringUtil.isBlank(token),
-                ValidationMessage.warning(Localization.lang("An API key has to be provided")));
+                ValidationMessage.error(Localization.lang("An API key has to be provided")));
 
         this.chatModelValidator = new FunctionBasedValidator<>(
                 currentChatModel,


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/511.

When you accept privacy policy for AI, AI features are enabled, but API key is empty.

If in this state you go to preferences, change some other preferences that you need (for example switching language), then preferences window won't allow this to do, because there is an empty API key.

What this PR does: even if API key is empty, we allow to save it empty. All logic will work okay after that, because empty API key is handled [there](https://github.com/JabRef/jabref/blob/8a0edc251fa3158bd478810105cfeeda4854e6f7/src/main/java/org/jabref/gui/entryeditor/AiChatTab.java#L100), and as a last resort [there](https://github.com/JabRef/jabref/blob/8a0edc251fa3158bd478810105cfeeda4854e6f7/src/main/java/org/jabref/logic/ai/models/JabRefChatLanguageModel.java#L122)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
