### PR TITLE
Upgrade EndNote XML exporter to StAX

### DIFF
--- a/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.exporter;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -104,7 +105,7 @@ public class EndnoteXmlExporter extends Exporter {
             return;
         }
 
-        try (var os = Files.newOutputStream(file)) {
+        try (OutputStream os = Files.newOutputStream(file)) {
             XMLStreamWriter writer = OUTPUT_FACTORY.createXMLStreamWriter(os, StandardCharsets.UTF_8.name());
             try {
                 writer.writeStartDocument(StandardCharsets.UTF_8.name(), "1.0");

--- a/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
@@ -276,33 +276,41 @@ public class EndnoteXmlExporter extends Exporter {
     }
 
     private void writeUrls(XMLStreamWriter writer, BibEntry entry) throws XMLStreamException {
-        writer.writeStartElement("urls");
 
-        entry.getFieldOrAlias(StandardField.FILE).ifPresent(fileField -> {
-            try {
-                writer.writeStartElement("pdf-urls");
-                writer.writeStartElement("url");
-                writer.writeCharacters(fileField);
-                writer.writeEndElement();
-                writer.writeEndElement(); // pdf-urls
-            } catch (XMLStreamException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        boolean hasUrls = entry.getFieldOrAlias(StandardField.FILE).isPresent()
+                || entry.getFieldOrAlias(StandardField.URL).isPresent();
 
-        entry.getFieldOrAlias(StandardField.URL).ifPresent(url -> {
-            try {
-                writer.writeStartElement("web-urls");
-                writer.writeStartElement("url");
-                writer.writeCharacters(url);
-                writer.writeEndElement();
-                writer.writeEndElement(); // web-urls
-            } catch (XMLStreamException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        if (hasUrls) {
+            writer.writeStartElement("urls");
 
-        writer.writeEndElement(); // urls
+            entry.getFieldOrAlias(StandardField.FILE).ifPresent(fileField -> {
+                try {
+                    writer.writeStartElement("pdf-urls");
+                    writer.writeStartElement("url");
+                    writer.writeCharacters(fileField);
+                    writer.writeEndElement();
+                    writer.writeEndElement(); // pdf-urls
+                } catch (
+                        XMLStreamException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            entry.getFieldOrAlias(StandardField.URL).ifPresent(url -> {
+                try {
+                    writer.writeStartElement("web-urls");
+                    writer.writeStartElement("url");
+                    writer.writeCharacters(url);
+                    writer.writeEndElement();
+                    writer.writeEndElement(); // web-urls
+                } catch (
+                        XMLStreamException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            writer.writeEndElement(); // urls
+        }
     }
 
     private void writeDates(XMLStreamWriter writer, BibEntry entry) throws XMLStreamException {

--- a/src/test/java/org/jabref/logic/exporter/EndnoteXmlExporterFilesTest.java
+++ b/src/test/java/org/jabref/logic/exporter/EndnoteXmlExporterFilesTest.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.jabref.logic.bibtex.BibEntryAssert;
@@ -39,7 +40,7 @@ class EndnoteXmlExporterFilesTest {
     private EndnoteXmlImporter endnoteXmlImporter;
 
     @BeforeEach
-    void setUp(@TempDir Path testFolder) throws Exception {
+    void setUp(@TempDir Path testFolder) {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         when(importFormatPreferences.bibEntryPreferences()).thenReturn(mock(BibEntryPreferences.class));
         when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
@@ -53,7 +54,7 @@ class EndnoteXmlExporterFilesTest {
 
     static Stream<String> fileNames() throws IOException, URISyntaxException {
         // we have to point it to one existing file, otherwise it will return the default class path
-        Path resourceDir = Path.of(EndnoteXmlExporterFilesTest.class.getResource("EndnoteXmlExportTestSingleBookEntry.bib").toURI()).getParent();
+        Path resourceDir = Path.of(Objects.requireNonNull(EndnoteXmlExporterFilesTest.class.getResource("EndnoteXmlExportTestSingleBookEntry.bib")).toURI()).getParent();
         try (Stream<Path> stream = Files.list(resourceDir)) {
             return stream.map(n -> n.getFileName().toString())
                          .filter(n -> n.endsWith(".bib"))
@@ -66,13 +67,13 @@ class EndnoteXmlExporterFilesTest {
     @ParameterizedTest
     @MethodSource("fileNames")
     final void performExport(String filename) throws Exception {
-        bibFileToExport = Path.of(EndnoteXmlExporterFilesTest.class.getResource(filename).toURI());
+        bibFileToExport = Path.of(Objects.requireNonNull(EndnoteXmlExporterFilesTest.class.getResource(filename)).toURI());
         List<BibEntry> entries = bibtexImporter.importDatabase(bibFileToExport).getDatabase().getEntries();
         exporter.export(databaseContext, exportFile, entries);
         String actual = String.join("\n", Files.readAllLines(exportFile));
 
         String xmlFileName = filename.replace(".bib", ".xml");
-        Path expectedFile = Path.of(ModsExportFormatFilesTest.class.getResource(xmlFileName).toURI());
+        Path expectedFile = Path.of(Objects.requireNonNull(ModsExportFormatFilesTest.class.getResource(xmlFileName)).toURI());
         String expected = String.join("\n", Files.readAllLines(expectedFile));
 
         // The order of the XML elements changes
@@ -87,7 +88,7 @@ class EndnoteXmlExporterFilesTest {
     @ParameterizedTest
     @MethodSource("fileNames")
     final void exportAsEndnoteAndThenImportAsEndnote(String filename) throws Exception {
-        bibFileToExport = Path.of(EndnoteXmlExporterFilesTest.class.getResource(filename).toURI());
+        bibFileToExport = Path.of(Objects.requireNonNull(EndnoteXmlExporterFilesTest.class.getResource(filename)).toURI());
         List<BibEntry> entries = bibtexImporter.importDatabase(bibFileToExport).getDatabase().getEntries();
 
         exporter.export(databaseContext, exportFile, entries);


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Follow-up to https://github.com/JabRef/jabref/pull/11157

## Upgrade EndNote XML exporter
Refs. https://github.com/JabRef/jabref/pull/11157#issuecomment-2043417540
- Upgrades existing EndNote XML exporter to **StAX** for better memory efficiency.
- Removes transformer to improve memory efficiency further (like Zotero).

**Note:** In the existing lambdas, now `XMLStreamException` is caught and thrown as `RuntimeException`  as lambdas don't allow checked exceptions to be directly thrown from them.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
