### PR TITLE
Refine ProgressCounter

### DIFF
--- a/src/main/java/org/jabref/logic/ai/GenerateEmbeddingsTask.java
+++ b/src/main/java/org/jabref/logic/ai/GenerateEmbeddingsTask.java
@@ -65,6 +65,8 @@ public class GenerateEmbeddingsTask extends BackgroundTask<Void> {
 
         LOGGER.info("Finished embeddings generation task for entry {}", citationKey);
 
+        progressCounter.stop();
+
         return null;
     }
 

--- a/src/main/java/org/jabref/logic/ai/models/UpdateEmbeddingModelTask.java
+++ b/src/main/java/org/jabref/logic/ai/models/UpdateEmbeddingModelTask.java
@@ -74,6 +74,8 @@ public class UpdateEmbeddingModelTask extends BackgroundTask<Void> {
             throw new RuntimeException(Localization.lang("An I/O error occurred while opening the embedding model by URL %0", modelUrl), e);
         }
 
+        progressCounter.stop();
+
         return null;
     }
 

--- a/src/main/java/org/jabref/logic/ai/summarization/GenerateSummaryTask.java
+++ b/src/main/java/org/jabref/logic/ai/summarization/GenerateSummaryTask.java
@@ -98,6 +98,8 @@ public class GenerateSummaryTask extends BackgroundTask<Void> {
 
         LOGGER.info("Finished summarization task for entry {}", citationKey);
 
+        progressCounter.stop();
+
         return null;
     }
 

--- a/src/main/java/org/jabref/logic/util/ProgressCounter.java
+++ b/src/main/java/org/jabref/logic/util/ProgressCounter.java
@@ -23,7 +23,6 @@ public class ProgressCounter implements Progress {
     // The list should be sorted by ProgressMessage.maxTime, smaller first.
     private static final List<ProgressMessage> PROGRESS_MESSAGES = List.of(
             new ProgressMessage(5, Localization.lang("Estimated time left: 5 seconds.")),
-            new ProgressMessage(10, Localization.lang("Estimated time left: 10 seconds.")),
             new ProgressMessage(15, Localization.lang("Estimated time left: 15 seconds.")),
             new ProgressMessage(30, Localization.lang("Estimated time left: 30 seconds.")),
             new ProgressMessage(60, Localization.lang("Estimated time left: approx. 1 minute.")),

--- a/src/main/java/org/jabref/logic/util/ProgressCounter.java
+++ b/src/main/java/org/jabref/logic/util/ProgressCounter.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -21,6 +23,7 @@ public class ProgressCounter implements Progress {
     // The list should be sorted by ProgressMessage.maxTime, smaller first.
     private static final List<ProgressMessage> PROGRESS_MESSAGES = List.of(
             new ProgressMessage(5, Localization.lang("Estimated time left: 5 seconds.")),
+            new ProgressMessage(10, Localization.lang("Estimated time left: 10 seconds.")),
             new ProgressMessage(15, Localization.lang("Estimated time left: 15 seconds.")),
             new ProgressMessage(30, Localization.lang("Estimated time left: 30 seconds.")),
             new ProgressMessage(60, Localization.lang("Estimated time left: approx. 1 minute.")),
@@ -28,14 +31,24 @@ public class ProgressCounter implements Progress {
             new ProgressMessage(Integer.MAX_VALUE, Localization.lang("Estimated time left: more than 2 minutes."))
     );
 
+    private static final Duration PERIODIC_UPDATE_DURATION = Duration.ofSeconds(PROGRESS_MESSAGES.getFirst().maxTime);
+
     private final IntegerProperty workDone = new SimpleIntegerProperty(0);
     private final IntegerProperty workMax = new SimpleIntegerProperty(0);
     private final StringProperty message = new SimpleStringProperty("");
 
-    private Instant oneWorkTimeStart = Instant.now();
-    private Duration lastEtaCalculation = Duration.ofDays(1);
+    // Progress counter is updated on two events:
+    // 1) When workDone or workMax changes: this in normal behavior.
+    // 2) When PERIODIC_UPDATE_DURATION passes: it is used in situations where one piece of work takes too much time
+    //    (and so there are no events 1), and so the message could be "approx. 5 seconds", while it should be more.
+    private final Timeline periodicUpdate = new Timeline(new KeyFrame(new javafx.util.Duration(PERIODIC_UPDATE_DURATION.getSeconds() * 1000), e -> update()));
+
+    private final Instant workStartTime = Instant.now();
 
     public ProgressCounter() {
+        periodicUpdate.setCycleCount(Timeline.INDEFINITE);
+        periodicUpdate.play();
+
         workDone.addListener(obs -> update());
         workMax.addListener(obs -> update());
     }
@@ -79,16 +92,14 @@ public class ProgressCounter implements Progress {
     }
 
     private void update() {
-        Instant oneWorkTimeEnd = Instant.now();
-        Duration duration = Duration.between(oneWorkTimeStart, oneWorkTimeEnd);
-        oneWorkTimeStart = oneWorkTimeEnd;
+        Duration workTime = Duration.between(workStartTime, Instant.now());
+        Duration oneWorkTime = workTime.dividedBy(workDone.get() == 0 ? 1 : workDone.get());
+        Duration eta = oneWorkTime.multipliedBy(workMax.get() - workDone.get() <= 0 ? 1 : workMax.get() - workDone.get());
 
-        Duration eta = duration.multipliedBy(workMax.get() - workDone.get());
+        updateMessage(eta);
 
-        if (lastEtaCalculation.minus(eta).isPositive()) {
-            updateMessage(eta);
-
-            lastEtaCalculation = eta;
+        if (workDone.get() != 0 && workMax.get() != 0 && workDone.get() == workMax.get()) {
+            stop();
         }
     }
 
@@ -127,5 +138,9 @@ public class ProgressCounter implements Progress {
                 break;
             }
         }
+    }
+
+    public void stop() {
+        periodicUpdate.stop();
     }
 }


### PR DESCRIPTION
Changes made:
1. The algorithm calculates ETA in a different way: previously it somehow recorded time of one work (actually, it was a strange algorithm). Now it very simple: just measure how long the task was working, then using some simple math (`ONE_WORK_TIME = WORKING_TIME / WORK_DONE`) calculate final `ETA = ONE_WORK_TIME * (WORK_MAX - WORK_DONE)` (some of the variables might be zero, so I also added checks for that).
2. `ProgressCounter` will also periodically updated itself, in case one work takes too much time (previously, update happened only when amount of work is changes).

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
