### PR TITLE
Fix CSL bibliography ordering for non-numeric styles

### DIFF
--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -153,29 +153,35 @@ public class CSLCitationOOAdapter {
 
         String style = selectedStyle.getSource();
 
-        // Sort entries based on their order of appearance in the document
-        entries.sort(Comparator.comparingInt(entry -> markManager.getCitationNumber(entry.getCitationKey().orElse(""))));
-        for (BibEntry entry : entries) {
-            String citation = CitationStyleGenerator.generateCitation(List.of(entry), style, CSLFormatUtils.OUTPUT_FORMAT, bibDatabaseContext, bibEntryTypesManager).getFirst();
-            String citationKey = entry.getCitationKey().orElse("");
-            int currentNumber = markManager.getCitationNumber(citationKey);
+        if (selectedStyle.isNumericStyle()) {
+            // Sort entries based on their order of appearance in the document
+            entries.sort(Comparator.comparingInt(entry -> markManager.getCitationNumber(entry.getCitationKey().orElse(""))));
 
-            String formattedCitation;
-            if (selectedStyle.isNumericStyle()) {
-                formattedCitation = CSLFormatUtils.updateSingleBibliographyNumber(CSLFormatUtils.transformHTML(citation), currentNumber);
-            } else {
-                formattedCitation = CSLFormatUtils.transformHTML(citation);
+            for (BibEntry entry : entries) {
+                String citation = CitationStyleGenerator.generateCitation(List.of(entry), style, CSLFormatUtils.OUTPUT_FORMAT, bibDatabaseContext, bibEntryTypesManager).getFirst();
+                String citationKey = entry.getCitationKey().orElse("");
+                int currentNumber = markManager.getCitationNumber(citationKey);
+
+                String formattedCitation = CSLFormatUtils.updateSingleBibliographyNumber(CSLFormatUtils.transformHTML(citation), currentNumber);
+                OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
+
+                OOTextIntoOO.write(document, cursor, ooText);
+                    // Select the paragraph break
+                    cursor.goLeft((short) 1, true);
+
+                    // Delete the selected content (paragraph break)
+                    cursor.setString("");
             }
-            OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
+        } else {
+            // Ordering will be according to citeproc item data provider (default)
+            List<String> citations = CitationStyleGenerator.generateCitation(entries, style, CSLFormatUtils.OUTPUT_FORMAT, bibDatabaseContext, bibEntryTypesManager);
 
-            OOTextIntoOO.write(document, cursor, ooText);
-            if (selectedStyle.isNumericStyle()) {
-                // Select the paragraph break
-                cursor.goLeft((short) 1, true);
-
-                // Delete the selected content (paragraph break)
-                cursor.setString("");
+            for (String citation : citations) {
+                String formattedCitation = CSLFormatUtils.transformHTML(citation);
+                OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
+                OOTextIntoOO.write(document, cursor, ooText);
             }
+            cursor.collapseToEnd();
         }
     }
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->
Follow-up to #11577 
## Issue
In PR-C, we solved the issue of resetting citation index for numeric CSL styles by introducing reference marks and overriding the default order of citations as provided by JabRef's `ItemDataProvider` (used by citeproc-java functions).

However, this had an unintended side-effect, as in the case of many non-numeric styles such as APA, the reference list was generated with the entries ordered according to the order in which the citations appeared in the document, whereas the APA style specifies that there must be an alphabetic ordering of entries in the list.

## Fix
Use the default ordering as per citeproc-java's item data provider for non-numeric styles when generating CSL bibliography.
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
