### PR TITLE
Fix: Auto-sync bibliography for JStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the entry preview highlight was not working when searching before opening the entry editor. [#11659](https://github.com/JabRef/jabref/pull/11659)
 - We fixed an issue where text in Dark mode inside "Citation information" was not readable. [#11512](https://github.com/JabRef/jabref/issues/11512)
 - We fixed an issue where the selection of an entry in the table lost after searching for a group. [#3176](https://github.com/JabRef/jabref/issues/3176)
-- We fixed the non-functionality of the option "Automatically sync bibliography when inserting citations" when enabled in case of JStyles. [#11684](https://github.com/JabRef/jabref/issues/11684)
+- We fixed the non-functionality of the option "Automatically sync bibliography when inserting citations" in the OpenOffice panel, when enabled in case of JStyles. [#11684](https://github.com/JabRef/jabref/issues/11684)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the entry preview highlight was not working when searching before opening the entry editor. [#11659](https://github.com/JabRef/jabref/pull/11659)
 - We fixed an issue where text in Dark mode inside "Citation information" was not readable. [#11512](https://github.com/JabRef/jabref/issues/11512)
 - We fixed an issue where the selection of an entry in the table lost after searching for a group. [#3176](https://github.com/JabRef/jabref/issues/3176)
+- We fixed the non-functionality of the option "Automatically sync bibliography when inserting citations" when enabled in case of JStyles. [#11684](https://github.com/JabRef/jabref/issues/11684)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -583,8 +583,7 @@ public class OOBibBase {
             }
         }
 
-        syncOptions
-                .map(e -> e.setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages)); // TODO: Provide option to user: this is always false
+        syncOptions.map(e -> e.setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages)); // TODO: Provide option to user: this is always false
 
         try {
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -577,10 +577,7 @@ public class OOBibBase {
         OOResult<FunctionalTextViewCursor, OOError> fcursor = null;
         if (syncOptions.isPresent()) {
             fcursor = getFunctionalTextViewCursor(doc, errorTitle);
-            if (testDialog(errorTitle, fcursor.asVoidResult())) {
-                return;
-            }
-            if (testDialog(databaseIsRequired(syncOptions.get().databases,
+            if (testDialog(errorTitle, fcursor.asVoidResult()) || testDialog(databaseIsRequired(syncOptions.get().databases,
                     OOError::noDataBaseIsOpenForSyncingAfterCitation))) {
                 return;
             }

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -68,11 +68,8 @@ public class OOBibBase {
 
     private final DialogService dialogService;
 
-    // After inserting a citation, if ooPrefs.getSyncWhenCiting() returns true, shall we also update the bibliography?
-    private final boolean refreshBibliographyDuringSyncWhenCiting;
-
     // Shall we add "Cited on pages: ..." to resolved bibliography entries?
-    private final boolean alwaysAddCitedOnPages;
+    private final boolean alwaysAddCitedOnPages; // TODO (see comment above)
 
     private final OOBibBaseConnect connection;
 
@@ -86,7 +83,6 @@ public class OOBibBase {
         this.dialogService = dialogService;
         this.connection = new OOBibBaseConnect(loPath, dialogService);
 
-        this.refreshBibliographyDuringSyncWhenCiting = false;
         this.alwaysAddCitedOnPages = false;
     }
 
@@ -576,7 +572,7 @@ public class OOBibBase {
         }
 
         /*
-         * For sync we need a FunctionalTextViewCursor.
+         * For sync we need a FunctionalTextViewCursor and an open database.
          */
         OOResult<FunctionalTextViewCursor, OOError> fcursor = null;
         if (syncOptions.isPresent()) {
@@ -584,18 +580,14 @@ public class OOBibBase {
             if (testDialog(errorTitle, fcursor.asVoidResult())) {
                 return;
             }
-        }
-
-        syncOptions
-                .map(e -> e.setUpdateBibliography(this.refreshBibliographyDuringSyncWhenCiting))
-                .map(e -> e.setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages));
-
-        if (syncOptions.isPresent()) {
             if (testDialog(databaseIsRequired(syncOptions.get().databases,
                     OOError::noDataBaseIsOpenForSyncingAfterCitation))) {
                 return;
             }
         }
+
+        syncOptions
+                .map(e -> e.setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages)); // TODO: Provide option to user: this is always false
 
         try {
 
@@ -873,7 +865,7 @@ public class OOBibBase {
                     Update.SyncOptions syncOptions = new Update.SyncOptions(databases);
                     syncOptions
                             .setUpdateBibliography(true)
-                            .setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages);
+                            .setAlwaysAddCitedOnPages(this.alwaysAddCitedOnPages); // TODO: Provide option to user: this is always false
 
                     unresolvedKeys = Update.synchronizeDocument(doc, frontend, jStyle, fcursor.get(), syncOptions);
                 } finally {

--- a/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/org/jabref/gui/openoffice/OpenOfficePanel.java
@@ -553,6 +553,10 @@ public class OpenOfficePanel {
                         ? Optional.of(new Update.SyncOptions(getBaseList()))
                         : Optional.empty();
 
+        // Sync options are non-null only when "Automatically sync bibliography when inserting citations" is enabled
+        if (syncOptions.isPresent() && preferencesService.getOpenOfficePreferences().getSyncWhenCiting()) {
+            syncOptions.get().setUpdateBibliography(true);
+        }
         ooBase.guiActionInsertEntry(entries,
                 bibDatabaseContext,
                 entryTypesManager,


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/11684

Cause of issue: See removed comment in (old) line 71 of `OOBibBase.java` in changed files. `boolean refreshBibliographyDuringSyncWhenCiting` was always set to false, which rendered the feature non-functional.
- This is now set properly at the time of citing with JStyles, and the overwrite to `false` has been removed.
- Some miscellaneous refactoring
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
