### PR TITLE
Minor refactor (Bibliography body paragraph format)

### DIFF
--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -148,7 +148,7 @@ public class CSLCitationOOAdapter {
 
         OOText title = OOFormat.paragraph(OOText.fromString(CSLFormatUtils.DEFAULT_BIBLIOGRAPHY_TITLE), CSLFormatUtils.DEFAULT_BIBLIOGRAPHY_HEADER_PARAGRAPH_FORMAT);
         OOTextIntoOO.write(document, cursor, OOText.fromString(title.toString()));
-        OOText ooBreak = OOFormat.paragraph(OOText.fromString(""), "Body Text");
+        OOText ooBreak = OOFormat.paragraph(OOText.fromString(""), CSLFormatUtils.DEFAULT_BIBLIOGRAPHY_BODY_PARAGRAPH_FORMAT);
         OOTextIntoOO.write(document, cursor, ooBreak);
 
         String style = selectedStyle.getSource();

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -29,6 +29,8 @@ public class CSLFormatUtils {
     public static final String DEFAULT_BIBLIOGRAPHY_TITLE = "References";
     public static final String DEFAULT_BIBLIOGRAPHY_HEADER_PARAGRAPH_FORMAT = "Heading 2";
 
+    public static final String DEFAULT_BIBLIOGRAPHY_BODY_PARAGRAPH_FORMAT = "Body Text";
+
     public static final CitationStyleOutputFormat OUTPUT_FORMAT = CitationStyleOutputFormat.HTML;
     private static final Pattern YEAR_IN_CITATION_PATTERN = Pattern.compile("(.)(.*), (\\d{4}.*)");
 


### PR DESCRIPTION
Nitpick: Refactored hardcoded magic string into a format utility constant for uniformity.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
