### PR TITLE
Enable Slf4jBestPractices

### DIFF
--- a/rewrite.yml
+++ b/rewrite.yml
@@ -206,3 +206,6 @@ recipeList:
   - org.openrewrite.java.testing.junit5.RemoveTryCatchFailBlocks
   - org.openrewrite.java.testing.junit5.LifecycleNonPrivate
   - org.openrewrite.java.testing.junit5.StaticImports
+
+  # Logging
+  - org.openrewrite.java.logging.slf4j.Slf4jBestPractices

--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -110,7 +110,7 @@ public class ClipBoardManager {
                 try {
                     return (String) contents.getTransferData(DataFlavor.stringFlavor);
                 } catch (UnsupportedFlavorException | IOException e) {
-                    LOGGER.warn(e.getMessage());
+                    LOGGER.warn("", e);
                 }
             }
         }

--- a/src/main/java/org/jabref/gui/FallbackExceptionHandler.java
+++ b/src/main/java/org/jabref/gui/FallbackExceptionHandler.java
@@ -19,7 +19,7 @@ public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler
 
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
-        LOGGER.error("Uncaught exception occurred in " + thread, exception);
+        LOGGER.error("Uncaught exception occurred in {}", thread, exception);
         UiTaskExecutor.runInJavaFXThread(() -> {
                     DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
                     dialogService.showErrorDialogAndWait("Uncaught exception occurred in " + thread, exception);

--- a/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
+++ b/src/main/java/org/jabref/gui/copyfiles/CopyFilesTask.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 
 public class CopyFilesTask extends Task<List<CopyFilesResultItemViewModel>> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CopyFilesAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CopyFilesTask.class);
     private static final String LOGFILE_PREFIX = "copyFileslog_";
     private static final String LOGFILE_EXT = ".log";
     private final BibDatabaseContext databaseContext;

--- a/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -130,7 +130,7 @@ public abstract class NativeDesktop {
             try {
                 hostName = InetAddress.getLocalHost().getHostName();
             } catch (UnknownHostException e) {
-                LoggerFactory.getLogger(OS.class).info("Hostname not found. Using \"localhost\" as fallback.", e);
+                LoggerFactory.getLogger(NativeDesktop.class).info("Hostname not found. Using \"localhost\" as fallback.", e);
                 hostName = "localhost";
             }
         }

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -146,7 +146,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
                     try {
                         JabRefDesktop.openBrowser(entry.getField(StandardField.URL).get(), preferencesService.getFilePreferences());
                     } catch (IOException e) {
-                        LOGGER.error("Error opening the browser to: " + entry.getField(StandardField.URL).get(), e);
+                        LOGGER.error("Error opening the browser to: {}", entry.getField(StandardField.URL).get(), e);
                         dialogService.showErrorDialogAndWait(e);
                     }
                 }

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -97,7 +97,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
         try {
             fileMonitor.addListenerForFile(currentFile, fileListener);
         } catch (IOException e) {
-            LOGGER.error("Problem while watching file for changes " + currentFile, e);
+            LOGGER.error("Problem while watching file for changes {}", currentFile, e);
         }
     }
 

--- a/src/main/java/org/jabref/gui/exporter/WriteMetadataToLinkedPdfsAction.java
+++ b/src/main/java/org/jabref/gui/exporter/WriteMetadataToLinkedPdfsAction.java
@@ -198,7 +198,7 @@ public class WriteMetadataToLinkedPdfsAction extends SimpleCommand {
                     String.valueOf(entriesChanged), String.valueOf(skipped), String.valueOf(errors)));
 
             if (!failedWrittenFiles.isEmpty()) {
-                LOGGER.error("Failed to write XMP data to PDFs:\n" + failedWrittenFiles);
+                LOGGER.error("Failed to write XMP data to PDFs:\n{}", failedWrittenFiles);
             }
 
             return null;

--- a/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -107,8 +107,7 @@ public class IconTheme {
     public static URL getIconUrl(String name) {
         String key = Objects.requireNonNull(name, "icon name");
         if (!KEY_TO_ICON.containsKey(key)) {
-            LOGGER.warn("Could not find icon url by name " + name + ", so falling back on default icon "
-                        + DEFAULT_ICON_PATH);
+            LOGGER.warn("Could not find icon url by name {}, so falling back on default icon {}", name, DEFAULT_ICON_PATH);
         }
         String path = KEY_TO_ICON.getOrDefault(key, DEFAULT_ICON_PATH);
         return Objects.requireNonNull(IconTheme.class.getResource(path), "Path must not be null for key " + key);

--- a/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/LookupIdentifierAction.java
@@ -82,7 +82,7 @@ public class LookupIdentifierAction<T extends Identifier> extends SimpleCommand 
             try {
                 identifier = fetcher.findIdentifier(bibEntry);
             } catch (FetcherException e) {
-                LOGGER.error("Could not fetch " + fetcher.getIdentifierName(), e);
+                LOGGER.error("Could not fetch {}", fetcher.getIdentifierName(), e);
             }
             if (identifier.isPresent() && !bibEntry.hasField(identifier.get().getDefaultField())) {
                 Optional<FieldChange> fieldChange = bibEntry.setField(identifier.get().getDefaultField(), identifier.get().getNormalized());

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -69,7 +69,7 @@ public class AbbreviateAction extends SimpleCommand {
             case ABBREVIATE_DEFAULT -> abbreviationType = AbbreviationType.DEFAULT;
             case ABBREVIATE_DOTLESS -> abbreviationType = AbbreviationType.DOTLESS;
             case ABBREVIATE_SHORTEST_UNIQUE -> abbreviationType = AbbreviationType.SHORTEST_UNIQUE;
-            default -> LOGGER.debug("Unknown action: " + action.name());
+            default -> LOGGER.debug("Unknown action: {}", action.name());
         }
 
         this.executable.bind(ActionHelper.needsEntriesSelected(stateManager));
@@ -92,7 +92,7 @@ public class AbbreviateAction extends SimpleCommand {
                                   .onSuccess(dialogService::notify)
                                   .executeWith(taskExecutor));
         } else {
-            LOGGER.debug("Unknown action: " + action.name());
+            LOGGER.debug("Unknown action: {}", action.name());
         }
     }
 

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -20,7 +20,6 @@ import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.LibraryTab;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 
 public class DownloadLinkedFileAction extends SimpleCommand {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LibraryTab.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DownloadLinkedFileAction.class);
 
     private final DialogService dialogService;
     private final BibEntry entry;

--- a/src/main/java/org/jabref/gui/linkedfile/RedownloadMissingFilesAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/RedownloadMissingFilesAction.java
@@ -21,7 +21,7 @@ import static org.jabref.gui.actions.ActionHelper.needsDatabase;
 
 public class RedownloadMissingFilesAction extends SimpleCommand {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LibraryTab.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedownloadMissingFilesAction.class);
 
     private final StateManager stateManager;
     private final DialogService dialogService;

--- a/src/main/java/org/jabref/gui/linkedfile/RedownloadMissingFilesAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/RedownloadMissingFilesAction.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.util.TaskExecutor;

--- a/src/main/java/org/jabref/gui/maintable/NewLibraryFromPdfAction.java
+++ b/src/main/java/org/jabref/gui/maintable/NewLibraryFromPdfAction.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  */
 public abstract class NewLibraryFromPdfAction extends SimpleCommand {
-    private static final Logger LOGGER = LoggerFactory.getLogger(NewLibraryFromPdfAction .class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NewLibraryFromPdfAction.class);
 
     protected final PreferencesService preferencesService;
 

--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
@@ -8,7 +8,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import org.jabref.gui.DialogService;
-import org.jabref.gui.exporter.CreateModifyExporterDialogViewModel;
 import org.jabref.gui.externalfiletype.ExternalFileType;
 import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.preferences.PreferenceTabViewModel;

--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CreateModifyExporterDialogViewModel.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExternalFileTypesTabViewModel.class);
     private final ObservableList<ExternalFileTypeItemViewModel> fileTypes = FXCollections.observableArrayList();
 
     private final FilePreferences filePreferences;

--- a/src/main/java/org/jabref/gui/preview/CopyCitationAction.java
+++ b/src/main/java/org/jabref/gui/preview/CopyCitationAction.java
@@ -170,7 +170,7 @@ public class CopyCitationAction extends SimpleCommand {
                 case HTML -> content = processHtml(citations);
                 case TEXT -> content = processText(citations);
                 default -> {
-                    LOGGER.warn("unknown output format: '" + outputFormat + "', processing it via the default.");
+                    LOGGER.warn("unknown output format: '{}', processing it via the default.", outputFormat);
                     content = processText(citations);
                 }
             }

--- a/src/main/java/org/jabref/gui/texparser/ParseLatexDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/texparser/ParseLatexDialogViewModel.java
@@ -162,7 +162,7 @@ public class ParseLatexDialogViewModel extends AbstractViewModel {
         try (Stream<Path> filesStream = Files.list(directory)) {
             fileListPartition = filesStream.collect(Collectors.partitioningBy(path -> path.toFile().isDirectory()));
         } catch (IOException e) {
-            LOGGER.error("%s while searching files: %s".formatted(e.getClass().getName(), e.getMessage()));
+            LOGGER.error("%s while searching files: %s".formatted(e.getClass().getName(), e.getMessage()), e);
             return parent;
         }
 

--- a/src/main/java/org/jabref/gui/theme/StyleSheet.java
+++ b/src/main/java/org/jabref/gui/theme/StyleSheet.java
@@ -40,9 +40,9 @@ abstract class StyleSheet {
             try {
                 styleSheetUrl = Optional.of(Path.of(name).toUri().toURL());
             } catch (InvalidPathException e) {
-                LOGGER.warn("Cannot load additional css {} because it is an invalid path: {}", name, e.getLocalizedMessage());
+                LOGGER.warn("Cannot load additional css {} because it is an invalid path: {}", name, e.getLocalizedMessage(), e);
             } catch (MalformedURLException e) {
-                LOGGER.warn("Cannot load additional css url {} because it is a malformed url: {}", name, e.getLocalizedMessage());
+                LOGGER.warn("Cannot load additional css url {} because it is a malformed url: {}", name, e.getLocalizedMessage(), e);
             }
         }
 

--- a/src/main/java/org/jabref/logic/ai/ingestion/GenerateEmbeddingsForSeveralTask.java
+++ b/src/main/java/org/jabref/logic/ai/ingestion/GenerateEmbeddingsForSeveralTask.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * And it also will store the embeddings.
  */
 public class GenerateEmbeddingsForSeveralTask extends BackgroundTask<Void> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateEmbeddingsTask.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateEmbeddingsForSeveralTask.class);
 
     private final StringProperty name;
     private final List<ProcessingInfo<LinkedFile, Void>> linkedFiles;

--- a/src/main/java/org/jabref/logic/bst/BstVMVisitor.java
+++ b/src/main/java/org/jabref/logic/bst/BstVMVisitor.java
@@ -273,8 +273,8 @@ class BstVMVisitor extends BstBaseVisitor<Integer> {
                 }
             } catch (BstVMException e) {
                 bstVMContext.path().ifPresentOrElse(
-                        path -> LOGGER.error("{} ({})", e.getMessage(), path),
-                        () -> LOGGER.error(e.getMessage()));
+                        path -> LOGGER.error("{} ({})", e.getMessage(), path, e),
+                        () -> LOGGER.error("", e));
                 throw e;
             }
         }

--- a/src/main/java/org/jabref/logic/bst/util/BstCaseChanger.java
+++ b/src/main/java/org/jabref/logic/bst/util/BstCaseChanger.java
@@ -110,7 +110,7 @@ public final class BstCaseChanger {
                 sb.append(c[i]);
                 i++;
                 if (braceLevel == 0) {
-                    LOGGER.warn("Too many closing braces in string: " + s);
+                    LOGGER.warn("Too many closing braces in string: {}", s);
                 } else {
                     braceLevel--;
                 }
@@ -125,7 +125,7 @@ public final class BstCaseChanger {
             i++;
         }
         if (braceLevel > 0) {
-            LOGGER.warn("No enough closing braces in string: " + s);
+            LOGGER.warn("No enough closing braces in string: {}", s);
         }
         return sb.toString();
     }
@@ -204,7 +204,7 @@ public final class BstCaseChanger {
                 }
                 break;
             default:
-                LOGGER.info("convertAccented - Unknown format: " + format);
+                LOGGER.info("convertAccented - Unknown format: {}", format);
                 break;
         }
         return pos;
@@ -222,7 +222,7 @@ public final class BstCaseChanger {
                 pos++;
             }
             default ->
-                    LOGGER.info("convertNonControl - Unknown format: " + format);
+                    LOGGER.info("convertNonControl - Unknown format: {}", format);
         }
         return pos;
     }
@@ -247,7 +247,7 @@ public final class BstCaseChanger {
             case ALL_UPPERS ->
                     sb.append(Character.toUpperCase(c[i]));
             default ->
-                    LOGGER.info("convertCharIfBraceLevelIsZero - Unknown format: " + format);
+                    LOGGER.info("convertCharIfBraceLevelIsZero - Unknown format: {}", format);
         }
         i++;
         return i;

--- a/src/main/java/org/jabref/logic/bst/util/BstWidthCalculator.java
+++ b/src/main/java/org/jabref/logic/bst/util/BstWidthCalculator.java
@@ -227,14 +227,14 @@ public class BstWidthCalculator {
                 if (braceLevel > 0) {
                     braceLevel--;
                 } else {
-                    LOGGER.warn("Too many closing braces in string: " + toMeasure);
+                    LOGGER.warn("Too many closing braces in string: {}", toMeasure);
                 }
             }
             result += BstWidthCalculator.getCharWidth(c[i]);
             i++;
         }
         if (braceLevel > 0) {
-            LOGGER.warn("No enough closing braces in string: " + toMeasure);
+            LOGGER.warn("No enough closing braces in string: {}", toMeasure);
         }
         return result;
     }

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -124,7 +124,7 @@ public class CitationStyle implements OOStyle {
                 return Optional.empty();
             }
         } catch (XMLStreamException e) {
-            LOGGER.error("Error parsing XML for file {}: {}", filename, e.getMessage());
+            LOGGER.error("Error parsing XML for file {}: {}", filename, e.getMessage(), e);
             return Optional.empty();
         }
     }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -106,7 +106,7 @@ public class HtmlToLatexFormatter extends Formatter implements LayoutFormatter {
         // Find non-covered special characters with alphabetic codes
         m = ESCAPED_PATTERN4.matcher(result);
         while (m.find()) {
-            LOGGER.warn("HTML escaped char not converted: " + m.group(1));
+            LOGGER.warn("HTML escaped char not converted: {}", m.group(1));
         }
 
         return result.trim();

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -63,7 +63,7 @@ public class UnicodeToLatexFormatter extends Formatter implements LayoutFormatte
         for (int i = 0; i <= (result.length() - 1); i++) {
             int cp = result.codePointAt(i);
             if (cp >= 129) {
-                LOGGER.warn("Unicode character not converted: " + cp);
+                LOGGER.warn("Unicode character not converted: {}", cp);
             }
         }
         return result;

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -392,7 +392,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
      */
     protected class ArXiv implements FulltextFetcher, PagedSearchBasedFetcher, IdBasedFetcher, IdFetcher<ArXivIdentifier> {
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(ArXivFetcher.ArXiv.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(ArXiv.class);
 
         private static final String API_URL = "https://export.arxiv.org/api/query";
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
@@ -106,7 +106,7 @@ public class GoogleScholar implements FulltextFetcher, PagedSearchBasedFetcher {
                 if (!target.isEmpty() && new URLDownload(target).isPdf()) {
                     // TODO: check title inside pdf + length?
                     // TODO: report error function needed?! query -> result
-                    LOGGER.info("Fulltext PDF found @ Google: " + target);
+                    LOGGER.info("Fulltext PDF found @ Google: {}", target);
                     pdfLink = Optional.of(new URL(target));
                     break;
                 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MedlineFetcher.java
@@ -204,8 +204,7 @@ public class MedlineFetcher implements IdBasedParserFetcher, SearchBasedFetcher 
                 return Collections.emptyList();
             }
             if (numberOfResultsFound > NUMBER_TO_FETCH) {
-                LOGGER.info(
-                        numberOfResultsFound + " results found. Only 50 relevant results will be fetched by default.");
+                LOGGER.info("{} results found. Only 50 relevant results will be fetched by default.", numberOfResultsFound);
             }
 
             // pass the list of ids to fetchMedline to download them. like a id fetcher for mutliple ids

--- a/src/main/java/org/jabref/logic/importer/fetcher/OpenAccessDoi.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/OpenAccessDoi.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * API is documented at http://unpaywall.org/api/v2
  */
 public class OpenAccessDoi implements FulltextFetcher {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FulltextFetcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenAccessDoi.class);
 
     private static final String API_URL = "https://api.oadoi.org/v2/";
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -95,7 +95,7 @@ public class MarcXmlParser implements Parser {
         List<Element> datafields = getChildren("datafield", element);
         for (Element datafield : datafields) {
             String tag = datafield.getAttribute("tag");
-            LOGGER.debug("tag: " + tag);
+            LOGGER.debug("tag: {}", tag);
 
             if ("020".equals(tag)) {
                 putIsbn(bibEntry, datafield);
@@ -146,7 +146,7 @@ public class MarcXmlParser implements Parser {
 
         int length = isbn.length();
         if (length != 10 && length != 13) {
-            LOGGER.debug("Malformed ISBN recieved, length: " + length);
+            LOGGER.debug("Malformed ISBN recieved, length: {}", length);
             return;
         }
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/MrDLibImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MrDLibImporter.java
@@ -83,7 +83,7 @@ public class MrDLibImporter extends Importer {
                 stringBuilder.append(line);
             }
         } catch (Exception e) {
-            LOGGER.error(e.getMessage());
+            LOGGER.error("", e);
         }
         return stringBuilder.toString();
     }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
@@ -98,7 +98,7 @@ public class PicaXmlParser implements Parser {
         List<Element> datafields = getChildren("datafield", e);
         for (Element datafield : datafields) {
             String tag = datafield.getAttribute("tag");
-            LOGGER.debug("tag: " + tag);
+            LOGGER.debug("tag: {}", tag);
 
             // genre/type of the entry https://swbtools.bsz-bw.de/cgi-bin/k10plushelp.pl?cmd=kat&val=0500&katalog=Standard
             if ("002@".equals(tag)) {

--- a/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/LatexIntegrityChecker.java
@@ -37,7 +37,7 @@ import static uk.ac.ed.ph.snuggletex.definitions.Globals.TEXT_MODE_ONLY;
  */
 public class LatexIntegrityChecker implements EntryChecker {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SnuggleSession.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(LatexIntegrityChecker.class);
     private static final SnuggleEngine ENGINE = new SnuggleEngine();
     private static final SnuggleSession SESSION;
     private static final ResourceBundle ERROR_MESSAGES = ENGINE.getPackages().getFirst().getErrorMessageBundle();

--- a/src/main/java/org/jabref/logic/l10n/Localization.java
+++ b/src/main/java/org/jabref/logic/l10n/Localization.java
@@ -84,7 +84,7 @@ public class Localization {
             createResourceBundles(locale);
         } catch (MissingResourceException ex) {
             // should not happen as we have scripts to enforce this
-            LoggerFactory.getLogger(Localization.class).warn("Could not find bundles for language " + locale + ", switching to full english language", ex);
+            LoggerFactory.getLogger(Localization.class).warn("Could not find bundles for language {}, switching to full english language", locale, ex);
             setLanguage(Language.ENGLISH);
         }
     }

--- a/src/main/java/org/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/org/jabref/logic/layout/LayoutEntry.java
@@ -236,9 +236,7 @@ class LayoutEntry {
         if (InternalField.TYPE_HEADER.getName().equals(text)) {
             fieldEntry = bibtex.getType().getDisplayName();
         } else if (InternalField.OBSOLETE_TYPE_HEADER.getName().equals(text)) {
-            LOGGER.warn("'" + InternalField.OBSOLETE_TYPE_HEADER
-                    + "' is an obsolete name for the entry type. Please update your layout to use '"
-                    + InternalField.TYPE_HEADER + "' instead.");
+            LOGGER.warn("'{}' is an obsolete name for the entry type. Please update your layout to use '{}' instead.", InternalField.OBSOLETE_TYPE_HEADER, InternalField.TYPE_HEADER);
             fieldEntry = bibtex.getType().getDisplayName();
         } else {
             // changed section begin - arudert

--- a/src/main/java/org/jabref/logic/layout/format/RTFChars.java
+++ b/src/main/java/org/jabref/logic/layout/format/RTFChars.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RTFChars implements LayoutFormatter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LayoutFormatter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RTFChars.class);
 
     private static final RtfCharMap RTF_CHARS = new RtfCharMap();
 
@@ -130,7 +130,7 @@ public class RTFChars implements LayoutFormatter {
                             i += part.i;
                             sb.append("{\\b ").append(part.s).append('}');
                         } else {
-                            LOGGER.info("Unknown command " + command);
+                            LOGGER.info("Unknown command {}", command);
                         }
                         if (c == ' ') {
                             // command was separated with the content by ' '

--- a/src/main/java/org/jabref/logic/openoffice/backend/Backend52.java
+++ b/src/main/java/org/jabref/logic/openoffice/backend/Backend52.java
@@ -199,8 +199,7 @@ public class Backend52 {
                         cit.setPageInfo(pageInfo);
                     } else {
                         if (pageInfo.isPresent()) {
-                            LOGGER.warn("dataModel JabRef52"
-                                    + " only supports pageInfo for the last citation of a group");
+                            LOGGER.warn("dataModel JabRef52" + " only supports pageInfo for the last citation of a group");
                         }
                     }
                     break;

--- a/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
+++ b/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class FileAnnotationCache {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileAnnotation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileAnnotationCache.class);
     // cache size in entries
     private final static int CACHE_SIZE = 10;
 

--- a/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
+++ b/src/main/java/org/jabref/logic/pdf/PdfAnnotationImporter.java
@@ -72,7 +72,7 @@ public class PdfAnnotationImporter implements AnnotationImporter {
             return false;
         }
         if ("Link".equals(annotation.getSubtype()) || "Widget".equals(annotation.getSubtype())) {
-            LOGGER.debug(annotation.getSubtype() + " is excluded from the supported file annotations");
+            LOGGER.debug("{} is excluded from the supported file annotations", annotation.getSubtype());
             return false;
         }
         try {

--- a/src/main/java/org/jabref/logic/shared/DBMSConnection.java
+++ b/src/main/java/org/jabref/logic/shared/DBMSConnection.java
@@ -39,7 +39,7 @@ public class DBMSConnection implements DatabaseConnection {
         } catch (SQLException e) {
             // Some systems like PostgreSQL retrieves 0 to every exception.
             // Therefore a stable error determination is not possible.
-            LOGGER.error("Could not connect to database: {} - Error code: {}", e.getMessage(), e.getErrorCode());
+            LOGGER.error("Could not connect to database: {} - Error code: {}", e.getMessage(), e.getErrorCode(), e);
             throw e;
         }
     }

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -366,7 +366,7 @@ public class FileUtil {
                              .filter(f -> f.getFileName().toString().equals(filename))
                              .findFirst();
         } catch (UncheckedIOException | IOException ex) {
-            LOGGER.error("Error trying to locate the file " + filename + " inside the directory " + rootDirectory);
+            LOGGER.error("Error trying to locate the file {} inside the directory {}", filename, rootDirectory);
         }
         return Optional.empty();
     }

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -181,7 +181,7 @@ public class XmpUtilWriter {
             serializer.serialize(meta, os, true);
             return os.toString(StandardCharsets.UTF_8);
         } catch (TransformerException e) {
-            LOGGER.warn("Transformation into XMP not possible: " + e.getMessage(), e);
+            LOGGER.warn("Transformation into XMP not possible: {}", e.getMessage(), e);
             return "";
         } catch (UnsupportedEncodingException e) {
             LOGGER.warn("Unsupported encoding to UTF-8 of bib entries in XMP metadata.", e);

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -242,18 +242,14 @@ public class PreferencesMigrations {
                 oldStylePattern.equals(preferenceFileNamePattern)) {
             // Upgrade the old-style File Name pattern to new one:
             mainPrefsNode.put(JabRefPreferences.IMPORT_FILENAMEPATTERN, newStylePattern);
-            LOGGER.info("migrated old style " + JabRefPreferences.IMPORT_FILENAMEPATTERN +
-                    " value \"" + oldStylePattern + "\" to new value \"" +
-                    newStylePattern + "\" in the preference file");
+            LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the preference file", JabRefPreferences.IMPORT_FILENAMEPATTERN, oldStylePattern, newStylePattern);
 
             if (prefs.hasKey(JabRefPreferences.IMPORT_FILENAMEPATTERN)) {
                 // Update also the key in the current application settings, if necessary:
                 String fileNamePattern = prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN);
                 if (oldStylePattern.equals(fileNamePattern)) {
                     prefs.put(JabRefPreferences.IMPORT_FILENAMEPATTERN, newStylePattern);
-                    LOGGER.info("migrated old style " + JabRefPreferences.IMPORT_FILENAMEPATTERN +
-                            " value \"" + oldStylePattern + "\" to new value \"" +
-                            newStylePattern + "\" in the running application");
+                    LOGGER.info("migrated old style {} value \"{}\" to new value \"{}\" in the running application", JabRefPreferences.IMPORT_FILENAMEPATTERN, oldStylePattern, newStylePattern);
                 }
             }
         }

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -268,7 +268,7 @@ public class DOI implements Identifier {
             return Optional.of(uri);
         } catch (URISyntaxException e) {
             // should never happen
-            LOGGER.error(doi + " could not be encoded as URI.", e);
+            LOGGER.error("{} could not be encoded as URI.", doi, e);
             return Optional.empty();
         }
     }

--- a/src/main/java/org/jabref/model/entry/identifier/IacrEprint.java
+++ b/src/main/java/org/jabref/model/entry/identifier/IacrEprint.java
@@ -66,7 +66,7 @@ public class IacrEprint implements Identifier {
             return Optional.of(uri);
         } catch (URISyntaxException e) {
             // should never happen
-            LOGGER.error(iacrEprint + " could not be encoded as URI.", e);
+            LOGGER.error("{} could not be encoded as URI.", iacrEprint, e);
             return Optional.empty();
         }
     }

--- a/src/main/java/org/jabref/model/groups/SearchGroup.java
+++ b/src/main/java/org/jabref/model/groups/SearchGroup.java
@@ -91,8 +91,7 @@ public class SearchGroup extends AbstractGroup {
         } catch (Throwable t) {
             // this should never happen, because the constructor obviously
             // succeeded in creating _this_ instance!
-            LOGGER.error("Internal error in SearchGroup.deepCopy(). "
-                    + "Please report this on https://github.com/JabRef/jabref/issues", t);
+            LOGGER.error("Internal error in SearchGroup.deepCopy(). " + "Please report this on https://github.com/JabRef/jabref/issues", t);
             return null;
         }
     }


### PR DESCRIPTION
Finally, we can use [SLF4J Logging Best Practices](https://docs.openrewrite.org/recipes/java/logging/slf4j/slf4jbestpractices)

- No more String concatenation for Logger parameters
- Always right class names for loggers (we had at least two where the wrong class was used)

---

The workaround for https://github.com/openrewrite/rewrite/issues/4054 seems to work.