### PR TITLE
Custom export format: Browse opens selected template folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
 - ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 - The browse button for a Custom theme now opens in the directory of the current used CSS file. [#11597](https://github.com/JabRef/jabref/pull/11597)
+- The browse button for a Custom exporter now opens in the directory of the current used exporter file
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We enhanced the indexing speed. [#11502](https://github.com/JabRef/jabref/pull/11502)
 - ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 - The browse button for a Custom theme now opens in the directory of the current used CSS file. [#11597](https://github.com/JabRef/jabref/pull/11597)
-- The browse button for a Custom exporter now opens in the directory of the current used exporter file
+- The browse button for a Custom exporter now opens in the directory of the current used exporter file. [#11717](https://github.com/JabRef/jabref/pull/11717)
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 
 ### Fixed

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialog.fxml
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialog.fxml
@@ -6,48 +6,49 @@
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity"
-            minWidth="-Infinity" prefHeight="300.0" prefWidth="480.0" xmlns="http://javafx.com/javafx/8.0.171"
+<?import org.jabref.gui.icon.JabRefIconView?>
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/8.0.171"
             fx:controller="org.jabref.gui.exporter.CreateModifyExporterDialogView">
     <content>
-        <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="320.0">
-            <children>
-                <GridPane prefWidth="480.0" scaleShape="false">
-                    <columnConstraints>
-                        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
-                    </columnConstraints>
-                    <rowConstraints>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                    </rowConstraints>
-                    <children>
-                        <TextField fx:id="name" GridPane.rowIndex="1"/>
-                        <Label text="%Main layout file:" GridPane.rowIndex="2"/>
-                        <TextField fx:id="fileName" GridPane.rowIndex="3"/>
-                        <TextField fx:id="extension" GridPane.rowIndex="6"/>
-                        <Label alignment="TOP_LEFT" text="%Export format name:">
-                            <GridPane.margin>
-                                <Insets/>
-                            </GridPane.margin>
-                        </Label>
-                        <Label text="%File extension:" GridPane.rowIndex="5"/>
-                        <Button text="%Browse" onAction="#browse" GridPane.rowIndex="4"/>
-                    </children>
-                    <padding>
-                        <Insets bottom="30.0" left="30.0" right="30.0" top="30.0"/>
-                    </padding>
-                </GridPane>
-            </children>
-        </AnchorPane>
+        <HBox>
+            <GridPane hgap="4.0" vgap="4.0" HBox.hgrow="ALWAYS">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+                    <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints vgrow="SOMETIMES" />
+                    <RowConstraints vgrow="SOMETIMES" />
+                    <RowConstraints vgrow="SOMETIMES" />
+                </rowConstraints>
+                <Label text="%Export format name:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+                <TextField fx:id="name" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+                <Label text="%Main layout file:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                <HBox spacing="4.0" GridPane.rowIndex="1" GridPane.columnIndex="1" alignment="CENTER">
+                    <TextField fx:id="fileName" HBox.hgrow="ALWAYS" />
+                    <Button onAction="#browse" styleClass="icon-button,narrow" prefHeight="20.0" prefWidth="20.0">
+                        <graphic>
+                            <JabRefIconView glyph="OPEN"/>
+                        </graphic>
+                        <tooltip>
+                            <Tooltip text="%Browse"/>
+                        </tooltip>
+                    </Button>
+                </HBox>
+
+                <Label text="%File extension:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
+                <TextField fx:id="extension" GridPane.rowIndex="2" GridPane.columnIndex="1"/>
+                <padding>
+                    <Insets bottom="30.0" left="30.0" right="30.0" top="30.0"/>
+                </padding>
+            </GridPane>
+        </HBox>
     </content>
     <ButtonType fx:id="saveExporter" text="%Save exporter"/>
     <ButtonType fx:constant="CANCEL"/>

--- a/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/exporter/CreateModifyExporterDialogViewModel.java
@@ -73,10 +73,14 @@ public class CreateModifyExporterDialogViewModel extends AbstractViewModel {
     }
 
     public void browse() {
+        String fileDir = layoutFile.getValue().isEmpty()
+                ? preferences.getExportPreferences().getExportWorkingDirectory().toString()
+                : layoutFile.getValue();
+
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                 .addExtensionFilter(Localization.lang("Custom layout file"), StandardFileType.LAYOUT)
                 .withDefaultExtension(Localization.lang("Custom layout file"), StandardFileType.LAYOUT)
-                .withInitialDirectory(preferences.getExportPreferences().getExportWorkingDirectory()).build();
+                .withInitialDirectory(fileDir).build();
         dialogService.showFileOpenDialog(fileDialogConfiguration).ifPresent(f -> layoutFile.set(f.toAbsolutePath().toString()));
     }
 


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/519

Also some visual adjustments

before
<img width="498" alt="Bildschirmfoto 2024-08-27 um 23 19 43" src="https://github.com/user-attachments/assets/7cf522cf-72c8-4643-8689-36016241ff6c">

after
![grafik](https://github.com/user-attachments/assets/d39b1c7d-369e-4025-b3ba-bd119218025a)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
