### PR TITLE
Refine parsing format of CSL reference marks

### DIFF
--- a/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,7 +15,7 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^((?:JABREF_\\w+ CID_\\w+(?:,\\s*)?)+)(\\s*\\w+)?$");
+    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_\\w+ CID_\\d+(?:, JABREF_\\w+ CID_\\d+)*) (\\w+)$");
     private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_(\\w+) CID_(\\w+)");
 
     private final String name;
@@ -24,7 +24,11 @@ public class ReferenceMark {
     private String uniqueId;
 
     /**
-     * @param name Format: <code>JABREF_{citationKey} CID_{citationNumber} {uniqueId}</code>
+     * @param name Allowed formats:
+     * Single entry: <code>JABREF_{citationKey} CID_{citationNumber} {uniqueId}</code>
+     * Group of entries: <code>JABREF_{citationKey1} CID_{citationNumber1}, JABREF_{citationKey2} CID_{citationNumber2}, ..., JABREF_{citationKeyN} CID_{citationNumberN} {uniqueId}</code>
+     * Disallowed: <code>JABREF_{citationKey} CID_{citationNumber}</code> (no unique ID at the end)
+     * Disallowed: <code>JABREF_{citationKey1} CID_{citationNumber1} JABREF_{citationKey2} CID_{citationNumber2} {uniqueId}</code> (no comma between entries)
      */
     public ReferenceMark(String name) {
         this.name = name;


### PR DESCRIPTION
Follow-up to: https://github.com/JabRef/jabref/pull/11712
- Use more strict regex to exactly match the format, disallow multiple whitespaces, disallow absence of unique ID, etc.
- A lot of code I wrote for https://github.com/JabRef/jabref/pull/11712 may seem like black-magic, as the fix was needed as soon as possible. I will slowly be documenting the code to aid this. Some JavaDoc is added in this PR as well.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
