### PR TITLE
CSL - Fix bug when inserting reference coalescing  before first entry

### DIFF
--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLReferenceMarkManager.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLReferenceMarkManager.java
@@ -175,7 +175,13 @@ public class CSLReferenceMarkManager {
 
         while (matcher.find()) {
             result.append(currentText, lastEnd, matcher.start(2));
-            result.append(newNumbers.get(numberIndex++));
+            if (numberIndex < newNumbers.size()) {
+                result.append(newNumbers.get(numberIndex));
+            } else {
+                // If we've run out of new numbers, increment the last used number
+                result.append(newNumbers.getLast() + (numberIndex - newNumbers.size() + 1));
+            }
+            numberIndex++;
             lastEnd = matcher.end(2);
         }
         result.append(currentText.substring(lastEnd));


### PR DESCRIPTION
Fixes the following edge-case bugs:
1. Inserting a new reference just before the reference numbered "1" without any space or line break or text in between (coalescing case 1)

https://github.com/user-attachments/assets/9996ea14-404e-45ed-a33d-b01b6627ec69

2. Inserting a new reference before the reference numbered "1" with a paragraph break [shift+enter] (not a line break [enter]) (coalescing case 2)

https://github.com/user-attachments/assets/a9bb72ef-a237-411e-9ea1-16bd7799a8bd

Both cases used to throw an exception and did not update the old "1" after the new reference to "2".
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
