### PR TITLE
refactor BstTextPrefixer.textPrefix

### DIFF
--- a/src/test/java/org/jabref/logic/bst/util/BstTextPrefixerTest.java
+++ b/src/test/java/org/jabref/logic/bst/util/BstTextPrefixerTest.java
@@ -17,6 +17,13 @@ class BstTextPrefixerTest {
         assertPrefix("{\\'e}", "{\\'e}");
         assertPrefix("{\\'{E}}doua", "{\\'{E}}douard Masterly");
         assertPrefix("Ulric", "Ulrich {\\\"{U}}nderwood and Ned {\\~N}et and Paul {\\={P}}ot");
+        assertPrefix("abcd{e}", "abcd{efg}hi");
+        assertPrefix("ab{cd}e", "ab{cd}efghi");
+        assertPrefix("ab{cd}e", "ab{cd}efghi{}");
+        assertPrefix("Hi {{\\o}}", "Hi {{\\oe   }}Hi ");
+        assertPrefix("Hi {\\{oe   }}H", "Hi {\\{oe   }}Hi ");
+        assertPrefix("Hi {\\\"oe   }H", "Hi {\\\"oe   }Hi ");
+        assertPrefix("Hi {\\{\\oe   }}H", "Hi {\\{\\oe   }}Hi ");
     }
 
     private static void assertPrefix(final String string, final String string2) {

--- a/src/test/java/org/jabref/logic/bst/util/BstTextPrefixerTest.java
+++ b/src/test/java/org/jabref/logic/bst/util/BstTextPrefixerTest.java
@@ -1,32 +1,31 @@
 package org.jabref.logic.bst.util;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class BstTextPrefixerTest {
-
-    @Test
-    void prefix() {
-        assertPrefix("i", "i");
-        assertPrefix("0I~ ", "0I~ ");
-        assertPrefix("Hi Hi", "Hi Hi ");
-        assertPrefix("{\\oe}", "{\\oe}");
-        assertPrefix("Hi {\\oe   }H", "Hi {\\oe   }Hi ");
-        assertPrefix("Jonat", "Jonathan Meyer and Charles Louis Xavier Joseph de la Vall{\\'e}e Poussin");
-        assertPrefix("{\\'e}", "{\\'e}");
-        assertPrefix("{\\'{E}}doua", "{\\'{E}}douard Masterly");
-        assertPrefix("Ulric", "Ulrich {\\\"{U}}nderwood and Ned {\\~N}et and Paul {\\={P}}ot");
-        assertPrefix("abcd{e}", "abcd{efg}hi");
-        assertPrefix("ab{cd}e", "ab{cd}efghi");
-        assertPrefix("ab{cd}e", "ab{cd}efghi{}");
-        assertPrefix("Hi {{\\o}}", "Hi {{\\oe   }}Hi ");
-        assertPrefix("Hi {\\{oe   }}H", "Hi {\\{oe   }}Hi ");
-        assertPrefix("Hi {\\\"oe   }H", "Hi {\\\"oe   }Hi ");
-        assertPrefix("Hi {\\{\\oe   }}H", "Hi {\\{\\oe   }}Hi ");
-    }
-
-    private static void assertPrefix(final String string, final String string2) {
-        assertEquals(string, BstTextPrefixer.textPrefix(5, string2));
+public class BstTextPrefixerTest {
+    @ParameterizedTest
+    @CsvSource({
+        "i, i",
+        "0I~ , 0I~ ",
+        "Hi Hi, Hi Hi ",
+        "{\\oe}, {\\oe}",
+        "Hi {\\oe   }H, Hi {\\oe   }Hi ",
+        "Jonat, Jonathan Meyer and Charles Louis Xavier Joseph de la Vall{\\'e}e Poussin",
+        "{\\'e}, {\\'e}",
+        "{\\'{E}}doua, {\\'{E}}douard Masterly",
+        "Ulric, Ulrich {\\\"{U}}nderwood and Ned {\\~N}et and Paul {\\={P}}ot",
+        "abcd{e}, abcd{efg}hi",
+        "ab{cd}e, ab{cd}efghi",
+        "ab{cd}e, ab{cd}efghi{}",
+        "Hi {{\\o}}, Hi {{\\oe   }}Hi ",
+        "Hi {\\{oe   }}H, Hi {\\{oe   }}Hi ",
+        "Hi {\\\"oe   }H, Hi {\\\"oe   }Hi ",
+        "Hi {\\{\\oe   }}H, Hi {\\{\\oe   }}Hi "
+    })
+    void assertPrefix(final String expectedResult, final String toPrefixInput) {
+        assertEquals(expectedResult, BstTextPrefixer.textPrefix(5, toPrefixInput));
     }
 }


### PR DESCRIPTION
1. add more unit test about nested brace cases
2. refactor the `textPrefix` method to make it clear
- I used a private class with public variable fields to handle multiple return value. If we prefer only use class with private fields I can refactor it later.
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
