### PR TITLE
Add manual migration for search syntax when automatic migration fails

### DIFF
--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -270,9 +270,11 @@ Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Dynamicall
 Each\ line\ must\ be\ of\ the\ following\ form\:\ \'tab\:field1;field2;...;fieldN\'.=Each line must be of the following form\: 'tab\:field1;field2;...;fieldN'.
 
 Search\ groups\ migration\ of\ %0=Search groups migration of %0
-The\ search\ groups\ syntax\ is\ outdated.\ Do\ you\ want\ to\ migrate\ to\ the\ new\ syntax?= The search groups syntax is outdated. Do you want to migrate to the new syntax?
+The\ search\ groups\ syntax\ is\ outdated.\ Do\ you\ want\ to\ migrate\ to\ the\ new\ syntax?=The search groups syntax is outdated. Do you want to migrate to the new syntax?
 Migrate=Migrate
 Keep\ as\ is=Keep as is
+Search\ group\ migration\ failed=Search group migration failed
+The\ search\ group\ '%0'\ could\ not\ be\ migrated.\ Please\ enter\ the\ new\ search\ expression.=The search group '%0' could not be migrated. Please enter the new search expression.
 Edit=Edit
 
 Edit\ file\ type=Edit file type


### PR DESCRIPTION
If the automatic migration fails, display a dialog allowing users to manually migrate the group or keep the existing query.
![image](https://github.com/user-attachments/assets/52f24916-90c9-413f-ad77-1a4b95defe1b)

Closes #11752

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
