### PR TITLE
Document app freeze with wrong password prompt integration.

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/trouble-shooting.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/trouble-shooting.md
@@ -83,3 +83,9 @@ Another indication is following output
 ```text
 java.lang.UnsupportedClassVersionError: org/javamodularity/moduleplugin/ModuleSystemPlugin has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 ```
+
+## Attempts to open preferences panel freezes application
+
+This is likely caused by improper integration of your OS or Desktop Environment with your password prompting program or password manager. Ensure that these are working properly, then restart your machine and attempt to run the program. 
+
+For reference, see issue [#11766](https://github.com/JabRef/jabref/issues/11766).


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Closes https://github.com/JabRef/jabref/issues/11766

Document freezes in preferences panel resulting from improper password prompter integration on dev machine for developers.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
