### PR TITLE
Improve pdf content parser for DOIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The browse button for a Custom exporter now opens in the directory of the current used exporter file. [#11717](https://github.com/JabRef/jabref/pull/11717)
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
+- We improved the DOI detection in PDF imports []()
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The browse button for a Custom exporter now opens in the directory of the current used exporter file. [#11717](https://github.com/JabRef/jabref/pull/11717)
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
-- We improved the DOI detection in PDF imports []()
+- We improved the DOI detection in PDF imports [#11782](https://github.com/JabRef/jabref/pull/11782)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The browse button for a Custom exporter now opens in the directory of the current used exporter file. [#11717](https://github.com/JabRef/jabref/pull/11717)
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
-- We improved the DOI detection in PDF imports [#11782](https://github.com/JabRef/jabref/pull/11782)
+- We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)
 
 ### Fixed
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.fileformat;
 
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,25 +9,19 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PdfContentImporterTest {
 
-    private PdfContentImporter importer;
-
-    @BeforeEach
-    void setUp() {
-        importer = new PdfContentImporter();
-    }
+    private PdfContentImporter importer = new PdfContentImporter();
 
     @Test
     void doesNotHandleEncryptedPdfs() throws Exception {
         Path file = Path.of(PdfContentImporter.class.getResource("/pdfs/encrypted.pdf").toURI());
         List<BibEntry> result = importer.importDatabase(file).getDatabase().getEntries();
-        assertEquals(Collections.emptyList(), result);
+        assertEquals(List.of(), result);
     }
 
     @Test
@@ -36,62 +29,64 @@ class PdfContentImporterTest {
         Path file = Path.of(PdfContentImporter.class.getResource("/pdfs/minimal.pdf").toURI());
         List<BibEntry> result = importer.importDatabase(file).getDatabase().getEntries();
 
-        BibEntry expected = new BibEntry(StandardEntryType.InProceedings);
-        expected.setField(StandardField.AUTHOR, "1 ");
-        expected.setField(StandardField.TITLE, "Hello World");
-        expected.setFiles(Collections.singletonList(new LinkedFile("", file.toAbsolutePath(), "PDF")));
+        BibEntry expected = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "1 ")
+                .withField(StandardField.TITLE, "Hello World")
+                .withFiles(List.of(new LinkedFile("", file.toAbsolutePath(), "PDF")));
+        assertEquals(List.of(expected), result);
 
         List<BibEntry> resultSecondImport = importer.importDatabase(file).getDatabase().getEntries();
-        assertEquals(Collections.singletonList(expected), result);
-        assertEquals(Collections.singletonList(expected), resultSecondImport);
+        assertEquals(List.of(expected), resultSecondImport);
     }
 
     @Test
     void parsingEditorWithoutPagesorSeriesInformation() {
-        BibEntry entry = new BibEntry(StandardEntryType.InProceedings);
-        entry.setField(StandardField.AUTHOR, "Anke Lüdeling and Merja Kytö (Eds.)");
-        entry.setField(StandardField.EDITOR, "Anke Lüdeling and Merja Kytö");
-        entry.setField(StandardField.PUBLISHER, "Springer");
-        entry.setField(StandardField.TITLE, "Corpus Linguistics – An International Handbook – Lüdeling, Anke, Kytö, Merja (Eds.)");
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "Anke Lüdeling and Merja Kytö (Eds.)")
+                .withField(StandardField.EDITOR, "Anke Lüdeling and Merja Kytö")
+                .withField(StandardField.PUBLISHER, "Springer")
+                .withField(StandardField.TITLE, "Corpus Linguistics – An International Handbook – Lüdeling, Anke, Kytö, Merja (Eds.)");
 
-        String firstPageContents = "Corpus Linguistics – An International Handbook – Lüdeling, Anke,\n" +
-                "Kytö, Merja (Eds.)\n" +
-                "\n" +
-                "Anke Lüdeling, Merja Kytö (Eds.)\n" +
-                "\n" +
-                "VOLUME 2\n" +
-                "\n" +
-                "This handbook provides an up-to-date survey of the field of corpus linguistics, a Handbücher zur Sprach- und\n" +
-                "field whose methodology has revolutionized much of the empirical work done in Kommunikationswissenschaft / Handbooks\n" +
-                "\n" +
-                "of Linguistics and Communication Science\n" +
-                "most fields of linguistic study over the past decade. (HSK) 29/2\n" +
-                "\n" +
-                "vii, 578 pages\n" +
-                "Corpus linguistics investigates human language by starting out from large\n";
+        String firstPageContents = """
+                Corpus Linguistics – An International Handbook – Lüdeling, Anke,
+                Kytö, Merja (Eds.)
+
+                Anke Lüdeling, Merja Kytö (Eds.)
+
+                VOLUME 2
+
+                This handbook provides an up-to-date survey of the field of corpus linguistics, a Handbücher zur Sprach- und
+                field whose methodology has revolutionized much of the empirical work done in Kommunikationswissenschaft / Handbooks
+
+                of Linguistics and Communication Science
+                most fields of linguistic study over the past decade. (HSK) 29/2
+
+                vii, 578 pages
+                Corpus linguistics investigates human language by starting out from large
+                """;
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
     }
 
     @Test
     void parsingWithoutActualDOINumber() {
-        BibEntry entry = new BibEntry(StandardEntryType.InProceedings);
-        entry.withField(StandardField.AUTHOR, "Link to record in KAR and http://kar.kent.ac.uk/51043/  and Document Version and UNSPECIFIED  and Master of Research (MRes) thesis and University of Kent")
-             .withField(StandardField.TITLE, "Kent Academic Repository Full text document (pdf) Citation for published version Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock Losses and Stakeholder Opinions. DOI")
-             .withField(StandardField.YEAR, "5104");
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.AUTHOR, "Link to record in KAR and http://kar.kent.ac.uk/51043/  and Document Version and UNSPECIFIED  and Master of Research (MRes) thesis and University of Kent")
+                .withField(StandardField.TITLE, "Kent Academic Repository Full text document (pdf) Citation for published version Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock Losses and Stakeholder Opinions. DOI")
+                .withField(StandardField.YEAR, "5104");
 
-        String firstPageContents = "Kent Academic Repository Full text document (pdf)\n" +
-                                   "Citation for published version\n" +
-                                   "Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock\n" +
-                                   "Losses and Stakeholder Opinions.\n" +
-                                   "DOI\n" +
-                                   "\n" +
-                                   "\n" +
-                                   "Link to record in KAR\n" +
-                                   "http://kar.kent.ac.uk/51043/\n" +
-                                   "Document Version\n" +
-                                   "UNSPECIFIED\n" +
-                                   "Master of Research (MRes) thesis, University of Kent,.";
+        String firstPageContents = """
+                Kent Academic Repository Full text document (pdf)
+                Citation for published version
+                Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock
+                Losses and Stakeholder Opinions.
+                DOI
+
+                Link to record in KAR
+                http://kar.kent.ac.uk/51043/
+                Document Version
+                UNSPECIFIED
+                Master of Research (MRes) thesis, University of Kent,.""";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
     }
@@ -104,26 +99,27 @@ class PdfContentImporterTest {
                 .withField(StandardField.TITLE, "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296 q The Authors")
                 .withField(StandardField.YEAR, "2008");
 
-        String firstPageContent = "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296\n" +
-                                  "q The Authors 2008\n" +
-                                  "\n" +
-                                  "Review Article\n" +
-                                  "\n" +
-                                  "Cocoa and health: a decade of research\n" +
-                                  "\n" +
-                                  "Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*\n" +
-                                  "1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland\n" +
-                                  "2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA\n" +
-                                  "3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA\n" +
-                                  "\n" +
-                                  "(Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)\n" +
-                                  "\n" +
-                                  "Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.\n" +
-                                  "\n" +
-                                  "*Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com\n" +
-                                  "\n" +
-                                  "British Journal of Nutrition\n" +
-                                  "https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press";
+        String firstPageContent = """
+                British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296
+                q The Authors 2008
+
+                Review Article
+
+                Cocoa and health: a decade of research
+
+                Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*
+                1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland
+                2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA
+                3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA
+
+                (Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)
+
+                Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.
+
+                *Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com
+
+                British Journal of Nutrition
+                https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press""";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n"));
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -55,20 +55,20 @@ class PdfContentImporterTest {
         entry.setField(StandardField.TITLE, "Corpus Linguistics – An International Handbook – Lüdeling, Anke, Kytö, Merja (Eds.)");
 
         String firstPageContents = "Corpus Linguistics – An International Handbook – Lüdeling, Anke,\n" +
-                                   "Kytö, Merja (Eds.)\n" +
-                                   "\n" +
-                                   "Anke Lüdeling, Merja Kytö (Eds.)\n" +
-                                   "\n" +
-                                   "VOLUME 2\n" +
-                                   "\n" +
-                                   "This handbook provides an up-to-date survey of the field of corpus linguistics, a Handbücher zur Sprach- und\n" +
-                                   "field whose methodology has revolutionized much of the empirical work done in Kommunikationswissenschaft / Handbooks\n" +
-                                   "\n" +
-                                   "of Linguistics and Communication Science\n" +
-                                   "most fields of linguistic study over the past decade. (HSK) 29/2\n" +
-                                   "\n" +
-                                   "vii, 578 pages\n" +
-                                   "Corpus linguistics investigates human language by starting out from large\n";
+                "Kytö, Merja (Eds.)\n" +
+                "\n" +
+                "Anke Lüdeling, Merja Kytö (Eds.)\n" +
+                "\n" +
+                "VOLUME 2\n" +
+                "\n" +
+                "This handbook provides an up-to-date survey of the field of corpus linguistics, a Handbücher zur Sprach- und\n" +
+                "field whose methodology has revolutionized much of the empirical work done in Kommunikationswissenschaft / Handbooks\n" +
+                "\n" +
+                "of Linguistics and Communication Science\n" +
+                "most fields of linguistic study over the past decade. (HSK) 29/2\n" +
+                "\n" +
+                "vii, 578 pages\n" +
+                "Corpus linguistics investigates human language by starting out from large\n";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
     }
@@ -80,17 +80,54 @@ class PdfContentImporterTest {
              .withField(StandardField.TITLE, "Kent Academic Repository Full text document (pdf) Citation for published version Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock Losses and Stakeholder Opinions. DOI")
              .withField(StandardField.YEAR, "5104");
 
-        String firstPageContents = "Kent Academic Repository Full text document (pdf)\n"
-                                   + "Citation for published version\n"
-                                   + "Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock\n"
-                                   + "Losses and Stakeholder Opinions.\n"
-                                   + "DOI\n\n\n"
-                                   + "Link to record in KAR\n"
-                                   + "http://kar.kent.ac.uk/51043/\n"
-                                   + "Document Version\n"
-                                   + "UNSPECIFIED\n"
-                                   + "Master of Research (MRes) thesis, University of Kent,.";
+        String firstPageContents = """
+                Kent Academic Repository Full text document (pdf)
+                Citation for published version
+                Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock
+                Losses and Stakeholder Opinions.
+                DOI
+
+
+                Link to record in KAR
+                http://kar.kent.ac.uk/51043/
+                Document Version
+                UNSPECIFIED
+                Master of Research (MRes) thesis, University of Kent,.""";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
+    }
+
+    @Test
+    void extractDOIFromPage1() {
+        String firstPageContent = """
+                British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296
+                q The Authors 2008
+ 
+                Review Article
+ 
+                Cocoa and health: a decade of research
+ 
+                Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*
+                1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland
+                2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA
+                3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA
+
+                (Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)
+ 
+                 Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.
+ 
+                *Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com
+ 
+                British Journal of Nutrition
+                https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press
+                """;
+
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings);
+        entry.setField(StandardField.DOI, "10.1017/S0007114507795296");
+        entry.setField(StandardField.AUTHOR, "Review Article");
+        entry.setField(StandardField.TITLE, "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296 q The Authors");
+        entry.setField(StandardField.YEAR, "2008");
+
+        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n"));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -86,8 +86,8 @@ class PdfContentImporterTest {
                 Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock
                 Losses and Stakeholder Opinions.
                 DOI
-
-
+                
+                
                 Link to record in KAR
                 http://kar.kent.ac.uk/51043/
                 Document Version
@@ -102,22 +102,22 @@ class PdfContentImporterTest {
         String firstPageContent = """
                 British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296
                 q The Authors 2008
- 
+                
                 Review Article
- 
+                
                 Cocoa and health: a decade of research
- 
+                
                 Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*
                 1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland
                 2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA
                 3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA
-
+                
                 (Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)
- 
-                 Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.
- 
+                
+                Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.
+                
                 *Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com
- 
+                
                 British Journal of Nutrition
                 https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press
                 """;

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -125,8 +125,7 @@ class PdfContentImporterTest {
                 *Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com
                 
                 British Journal of Nutrition
-                https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press
-                """;
+                https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press""";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n"));
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -80,19 +80,18 @@ class PdfContentImporterTest {
              .withField(StandardField.TITLE, "Kent Academic Repository Full text document (pdf) Citation for published version Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock Losses and Stakeholder Opinions. DOI")
              .withField(StandardField.YEAR, "5104");
 
-        String firstPageContents = """
-                Kent Academic Repository Full text document (pdf)
-                Citation for published version
-                Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock
-                Losses and Stakeholder Opinions.
-                DOI
-                
-                
-                Link to record in KAR
-                http://kar.kent.ac.uk/51043/
-                Document Version
-                UNSPECIFIED
-                Master of Research (MRes) thesis, University of Kent,.""";
+        String firstPageContents = "Kent Academic Repository Full text document (pdf)\n" +
+                                   "Citation for published version\n" +
+                                   "Smith, Lucy Anna (2014) Mortality in the Ornamental Fish Retail Sector: an Analysis of Stock\n" +
+                                   "Losses and Stakeholder Opinions.\n" +
+                                   "DOI\n" +
+                                   "\n" +
+                                   "\n" +
+                                   "Link to record in KAR\n" +
+                                   "http://kar.kent.ac.uk/51043/\n" +
+                                   "Document Version\n" +
+                                   "UNSPECIFIED\n" +
+                                   "Master of Research (MRes) thesis, University of Kent,.";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n"));
     }
@@ -105,27 +104,26 @@ class PdfContentImporterTest {
                 .withField(StandardField.TITLE, "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296 q The Authors")
                 .withField(StandardField.YEAR, "2008");
 
-        String firstPageContent = """
-                British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296
-                q The Authors 2008
-                
-                Review Article
-                
-                Cocoa and health: a decade of research
-                
-                Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*
-                1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland
-                2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA
-                3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA
-                
-                (Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)
-                
-                Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.
-                
-                *Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com
-                
-                British Journal of Nutrition
-                https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press""";
+        String firstPageContent = "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296\n" +
+                                  "q The Authors 2008\n" +
+                                  "\n" +
+                                  "Review Article\n" +
+                                  "\n" +
+                                  "Cocoa and health: a decade of research\n" +
+                                  "\n" +
+                                  "Karen A. Cooper1, Jennifer L. Donovan2, Andrew L. Waterhouse3 and Gary Williamson1*\n" +
+                                  "1Nestlé Research Center, Vers-Chez-les-Blanc, PO Box 44, CH-1000 Lausanne 26, Switzerland\n" +
+                                  "2Department of Psychiatry and Behavioural Sciences, Medical University of South Carolina, Charleston, SC 29425, USA\n" +
+                                  "3Department of Viticulture & Enology, University of California, Davis, CA 95616, USA\n" +
+                                  "\n" +
+                                  "(Received 5 December 2006 – Revised 29 May 2007 – Accepted 31 May 2007)\n" +
+                                  "\n" +
+                                  "Abbreviations: FMD, flow-mediated dilation; NO, nitirc oxide.\n" +
+                                  "\n" +
+                                  "*Corresponding author: Dr Gary Williamson, fax þ41 21 785 8544, email gary.williamson@rdls.nestle.com\n" +
+                                  "\n" +
+                                  "British Journal of Nutrition\n" +
+                                  "https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press";
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n"));
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -99,6 +99,12 @@ class PdfContentImporterTest {
 
     @Test
     void extractDOIFromPage1() {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withField(StandardField.DOI, "10.1017/S0007114507795296")
+                .withField(StandardField.AUTHOR, "Review Article")
+                .withField(StandardField.TITLE, "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296 q The Authors")
+                .withField(StandardField.YEAR, "2008");
+
         String firstPageContent = """
                 British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296
                 q The Authors 2008
@@ -121,12 +127,6 @@ class PdfContentImporterTest {
                 British Journal of Nutrition
                 https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press
                 """;
-
-        BibEntry entry = new BibEntry(StandardEntryType.InProceedings);
-        entry.setField(StandardField.DOI, "10.1017/S0007114507795296");
-        entry.setField(StandardField.AUTHOR, "Review Article");
-        entry.setField(StandardField.TITLE, "British Journal of Nutrition (2008), 99, 1–11 doi: 10.1017/S0007114507795296 q The Authors");
-        entry.setField(StandardField.YEAR, "2008");
 
         assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n"));
     }


### PR DESCRIPTION

I noticed that the extracted DOI was in the wrong format when I used PDF importer for one of the papers in the chocolate bib 
doi.org/10.1017/S0007114507795296 
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
