### PR TITLE
pin djl to 0.29.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - dependency-name: com.microsoft.azure:applicationinsights-logging-log4j2
         versions:
           - ">= 2.5.a" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
+      - dependency-name: ai.djl:bom
+        versions:
+          - ">= 0.30.0" # Blocked by https://github.com/deepjavalibrary/djl/issues/3473
   - package-ecosystem: gradle
     directory: "buildSrc/"
     schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,7 @@ dependencies {
     // YAML formatting
     implementation 'org.yaml:snakeyaml:2.3'
 
-    // AI
+    // region AI
     implementation 'dev.langchain4j:langchain4j:0.34.0'
     // Even though we use jvm-openai for LLM connection, we still need this package for tokenization.
     implementation('dev.langchain4j:langchain4j-open-ai:0.34.0') {
@@ -336,9 +336,12 @@ dependencies {
     implementation('dev.langchain4j:langchain4j-mistral-ai:0.34.0')
     implementation('dev.langchain4j:langchain4j-google-ai-gemini:0.34.0')
     implementation('dev.langchain4j:langchain4j-hugging-face:0.34.0')
-    implementation 'ai.djl:api:0.30.0'
-    implementation 'ai.djl.pytorch:pytorch-model-zoo:0.30.0'
-    implementation 'ai.djl.huggingface:tokenizers:0.29.0'
+
+    implementation platform('ai.djl:bom:0.29.0')
+    implementation 'ai.djl:api'
+    implementation 'ai.djl.huggingface:tokenizers'
+    implementation 'ai.djl.pytorch:pytorch-model-zoo'
+
     implementation 'io.github.stefanbratanov:jvm-openai:0.11.0'
     // openai depends on okhttp, which needs kotlin - see https://github.com/square/okhttp/issues/5299 for details
     implementation ('com.squareup.okhttp3:okhttp:4.12.0') {
@@ -346,6 +349,7 @@ dependencies {
     }
     // GemxFX also (transitively) depends on kotlin
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.20'
+    // endregion
 
     implementation 'commons-io:commons-io:2.16.1'
 


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref-issue-melting-pot/issues/537. Not a real fix though. Eventually we will want to upgrade to a newer Version.

Refs https://github.com/JabRef/jabref-issue-melting-pot/issues/538

Refs

Switch to `bom`. - Semantically reverts https://github.com/JabRef/jabref/commit/c280eb79da587249fa7ec477a358952baaed5bae. Does not work on my side though.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
