### PR TITLE
Keep DJL on 0.29.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
       - dependency-name: com.microsoft.azure:applicationinsights-logging-log4j2
         versions:
           - ">= 2.5.a" # Blocked by https://github.com/microsoft/ApplicationInsights-Java/issues/1155
+      - dependency-name: ai.djl:api
+        versions:
+          - ">= 0.30.0" # Blocked by https://github.com/deepjavalibrary/djl/issues/3473
+      - dependency-name: ai.djl:pytorch:pytorch-model-zoo
+        versions:
+          - ">= 0.30.0"
+      - dependency-name: ai.djl:huggingface:tokenizers
+        versions:
+          - ">= 0.30.0"
   - package-ecosystem: gradle
     directory: "buildSrc/"
     schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -336,8 +336,8 @@ dependencies {
     implementation('dev.langchain4j:langchain4j-mistral-ai:0.34.0')
     implementation('dev.langchain4j:langchain4j-google-ai-gemini:0.34.0')
     implementation('dev.langchain4j:langchain4j-hugging-face:0.34.0')
-    implementation 'ai.djl:api:0.30.0'
-    implementation 'ai.djl.pytorch:pytorch-model-zoo:0.30.0'
+    implementation 'ai.djl:api:0.29.0'
+    implementation 'ai.djl.pytorch:pytorch-model-zoo:0.29.0'
     implementation 'ai.djl.huggingface:tokenizers:0.29.0'
     implementation 'io.github.stefanbratanov:jvm-openai:0.11.0'
     // openai depends on okhttp, which needs kotlin - see https://github.com/square/okhttp/issues/5299 for details


### PR DESCRIPTION
Alternative to https://github.com/JabRef/jabref/pull/11789

This reverts https://github.com/JabRef/jabref/pull/11773 and prevents dependabot updates.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
