### PR TITLE
Fix tags field focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an exception when searching for unlinked files. [#11731](https://github.com/JabRef/jabref/issues/11731)
 - We fixed an issue where two contradicting notifications were shown when cutting an entry in the main table. [#11724](https://github.com/JabRef/jabref/pull/11724)
 - We fixed an issue where unescaped braces in the arXiv fetcher were not treated. [#11704](https://github.com/JabRef/jabref/issues/11704)
+- We fixed an issue where the keywords and crossref fields were not properly focused. [#11177](https://github.com/JabRef/jabref/issues/11177)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/Base.css
+++ b/src/main/java/org/jabref/gui/Base.css
@@ -1427,17 +1427,15 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-label-padding: 5 0 10 10;
 }
 
-.chips-pane > .editor {
-    -fx-pref-height: 30px;
-    -fx-padding: 0px 0px 0px -8px;
-    -fx-margin: 0em;
-    -fx-border-style: none;
-}
-
 .tags-field {
     -fx-pref-height: 30px;
     -fx-margin: 0em;
     -fx-border-style: none;
+    -fx-background-color: -fx-outer-border, -fx-control-inner-background;
+}
+
+.tags-field:focused {
+    -fx-border-color: -jr-accent;
 }
 
 .tags-field > .flow-pane > .tag-view {
@@ -1452,6 +1450,9 @@ We want to have a look that matches our icons in the tool-bar */
 
 .tags-field-editor {
     -fx-border-width: 0;
+    -fx-text-fill: -fx-focused-text-base-color;
+    -fx-highlight-text-fill: -fx-text-inner-color;
+    -fx-highlight-fill: derive(-jr-accent, 20%);
 }
 
 .searchBar:invalid {

--- a/src/main/java/org/jabref/gui/fieldeditors/KeywordsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/KeywordsEditor.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import javax.swing.undo.UndoManager;
 
 import javafx.beans.binding.Bindings;
+import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -37,15 +38,15 @@ import org.slf4j.LoggerFactory;
 
 public class KeywordsEditor extends HBox implements FieldEditorFX {
     private static final Logger LOGGER = LoggerFactory.getLogger(KeywordsEditor.class);
+    private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
 
+    @FXML private KeywordsEditorViewModel viewModel;
     @FXML private TagsField<Keyword> keywordTagsField;
 
     @Inject private CliPreferences preferences;
     @Inject private DialogService dialogService;
     @Inject private UndoManager undoManager;
     @Inject private ClipBoardManager clipBoardManager;
-
-    private final KeywordsEditorViewModel viewModel;
 
     public KeywordsEditor(Field field,
                           SuggestionProvider<?> suggestionProvider,
@@ -73,8 +74,10 @@ public class KeywordsEditor extends HBox implements FieldEditorFX {
         keywordTagsField.setNewItemProducer(searchText -> viewModel.getStringConverter().fromString(searchText));
 
         keywordTagsField.setShowSearchIcon(false);
+        keywordTagsField.setOnMouseClicked(event -> keywordTagsField.getEditor().requestFocus());
         keywordTagsField.getEditor().getStyleClass().clear();
         keywordTagsField.getEditor().getStyleClass().add("tags-field-editor");
+        keywordTagsField.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> keywordTagsField.pseudoClassStateChanged(FOCUSED, newValue));
 
         String keywordSeparator = String.valueOf(viewModel.getKeywordSeparator());
         keywordTagsField.getEditor().setOnKeyReleased(event -> {
@@ -116,11 +119,6 @@ public class KeywordsEditor extends HBox implements FieldEditorFX {
     @Override
     public Parent getNode() {
         return this;
-    }
-
-    @Override
-    public void requestFocus() {
-        keywordTagsField.requestFocus();
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import javax.swing.undo.UndoManager;
 
 import javafx.beans.binding.Bindings;
+import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -39,17 +40,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkedEntriesEditor.class);
+    private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
 
-    @FXML public TagsField<ParsedEntryLink> entryLinkField;
+    @FXML private LinkedEntriesEditorViewModel viewModel;
+    @FXML private TagsField<ParsedEntryLink> entryLinkField;
 
     @Inject private DialogService dialogService;
     @Inject private ClipBoardManager clipBoardManager;
     @Inject private UndoManager undoManager;
     @Inject private StateManager stateManager;
-
-    private final LinkedEntriesEditorViewModel viewModel;
 
     public LinkedEntriesEditor(Field field, BibDatabaseContext databaseContext, SuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
         ViewLoader.view(this)
@@ -66,9 +66,12 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
         entryLinkField.setNewItemProducer(searchText -> viewModel.getStringConverter().fromString(searchText));
         entryLinkField.setMatcher((entryLink, searchText) -> entryLink.getKey().toLowerCase().startsWith(searchText.toLowerCase()));
         entryLinkField.setComparator(Comparator.comparing(ParsedEntryLink::getKey));
+
         entryLinkField.setShowSearchIcon(false);
+        entryLinkField.setOnMouseClicked(event -> entryLinkField.getEditor().requestFocus());
         entryLinkField.getEditor().getStyleClass().clear();
         entryLinkField.getEditor().getStyleClass().add("tags-field-editor");
+        entryLinkField.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> entryLinkField.pseudoClassStateChanged(FOCUSED, newValue));
 
         String separator = EntryLinkList.SEPARATOR;
         entryLinkField.getEditor().setOnKeyReleased(event -> {

--- a/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.java
+++ b/src/main/java/org/jabref/gui/preferences/autocompletion/AutoCompletionTab.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.preferences.autocompletion;
 
+import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
@@ -18,6 +19,7 @@ import com.airhacks.afterburner.views.ViewLoader;
 import com.dlsc.gemsfx.TagsField;
 
 public class AutoCompletionTab extends AbstractPreferenceTabView<AutoCompletionTabViewModel> implements PreferencesTab {
+    private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
 
     @FXML private CheckBox enableAutoComplete;
     @FXML private TagsField<Field> autoCompleteFields;
@@ -58,8 +60,10 @@ public class AutoCompletionTab extends AbstractPreferenceTabView<AutoCompletionT
         autoCompleteFields.setConverter(viewModel.getFieldStringConverter());
         autoCompleteFields.setTagViewFactory(this::createTag);
         autoCompleteFields.setShowSearchIcon(false);
+        autoCompleteFields.setOnMouseClicked(event -> autoCompleteFields.getEditor().requestFocus());
         autoCompleteFields.getEditor().getStyleClass().clear();
         autoCompleteFields.getEditor().getStyleClass().add("tags-field-editor");
+        autoCompleteFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> autoCompleteFields.pseudoClassStateChanged(FOCUSED, newValue));
     }
 
     private Node createTag(Field field) {


### PR DESCRIPTION
Closes #11177
- Clicking anywhere in the tags field will now correctly request focus.
- The border color of the field changes when it is focused.

![image](https://github.com/user-attachments/assets/6b40e128-67e1-47d2-a658-e9e5791cac67)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
