### PR TITLE
Fix indexing task progress

### DIFF
--- a/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -110,14 +110,17 @@ public class UiTaskExecutor implements TaskExecutor {
     @Override
     public <V> Future<V> execute(BackgroundTask<V> task) {
         Task<V> javafxTask = getJavaFXTask(task);
-        if (task.showToUser()) {
-            StateManager stateManager = Injector.instantiateModelOrService(StateManager.class);
-            if (stateManager != null) {
-                stateManager.addBackgroundTask(task, javafxTask);
-            } else {
-                LOGGER.info("Background task visible without GUI");
+
+        StateManager stateManager = Injector.instantiateModelOrService(StateManager.class);
+        task.showToUserProperty().subscribe(showToUser -> {
+            if (showToUser) {
+                if (stateManager != null) {
+                    runInJavaFXThread(() -> stateManager.addBackgroundTask(task, javafxTask));
+                } else {
+                    LOGGER.info("Background task visible without GUI");
+                }
             }
-        }
+        });
         return execute(javafxTask);
     }
 

--- a/src/main/java/org/jabref/logic/search/LuceneManager.java
+++ b/src/main/java/org/jabref/logic/search/LuceneManager.java
@@ -68,7 +68,7 @@ public class LuceneManager {
                     linkedFilesIndexer.updateOnStart(this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         } else {
             linkedFilesIndexer.removeAllFromIndex();
         }
@@ -81,8 +81,7 @@ public class LuceneManager {
                 bibFieldsIndexer.updateOnStart(this);
                 return null;
             }
-        }.showToUser(true)
-         .willBeRecoveredAutomatically(true)
+        }.willBeRecoveredAutomatically(true)
          .onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexStartedEvent()))
          .executeWith(taskExecutor);
 
@@ -93,7 +92,7 @@ public class LuceneManager {
                     linkedFilesIndexer.updateOnStart(this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         }
     }
 
@@ -105,7 +104,7 @@ public class LuceneManager {
                 return null;
             }
         }.onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexAddedOrUpdatedEvent(entries)))
-         .showToUser(true).executeWith(taskExecutor);
+         .executeWith(taskExecutor);
 
         if (shouldIndexLinkedFiles.get() && !isLinkedFilesIndexerBlocked.get()) {
             new BackgroundTask<>() {
@@ -114,7 +113,7 @@ public class LuceneManager {
                     linkedFilesIndexer.addToIndex(entries, this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         }
     }
 
@@ -126,7 +125,7 @@ public class LuceneManager {
                 return null;
             }
         }.onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexRemovedEvent(entries)))
-         .showToUser(true).executeWith(taskExecutor);
+         .executeWith(taskExecutor);
 
         if (shouldIndexLinkedFiles.get()) {
             new BackgroundTask<>() {
@@ -135,7 +134,7 @@ public class LuceneManager {
                     linkedFilesIndexer.removeFromIndex(entries, this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         }
     }
 
@@ -177,7 +176,7 @@ public class LuceneManager {
                     linkedFilesIndexer.addToIndex(List.of(entry), this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         }
     }
 
@@ -189,7 +188,7 @@ public class LuceneManager {
                 return null;
             }
         }.onFinished(() -> this.databaseContext.getDatabase().postEvent(new IndexStartedEvent()))
-         .showToUser(true).executeWith(taskExecutor);
+         .executeWith(taskExecutor);
 
         if (shouldIndexLinkedFiles.get()) {
             new BackgroundTask<>() {
@@ -198,7 +197,7 @@ public class LuceneManager {
                     linkedFilesIndexer.rebuildIndex(this);
                     return null;
                 }
-            }.showToUser(true).executeWith(taskExecutor);
+            }.executeWith(taskExecutor);
         }
     }
 

--- a/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
+++ b/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
@@ -56,7 +56,10 @@ public class BibFieldsIndexer implements LuceneIndexer {
 
     @Override
     public void addToIndex(Collection<BibEntry> entries, BackgroundTask<?> task) {
-        task.setTitle(Localization.lang("Indexing bib fields for %0", libraryName));
+        if (entries.size() > 1) {
+            task.showToUser(true);
+            task.setTitle(Localization.lang("Indexing bib fields for %0", libraryName));
+        }
         int i = 1;
         long startTime = System.currentTimeMillis();
         LOGGER.debug("Adding {} entries to index", entries.size());
@@ -99,7 +102,10 @@ public class BibFieldsIndexer implements LuceneIndexer {
 
     @Override
     public void removeFromIndex(Collection<BibEntry> entries, BackgroundTask<?> task) {
-        task.setTitle(Localization.lang("Removing entries from index for %0", libraryName));
+        if (entries.size() > 1) {
+            task.showToUser(true);
+            task.setTitle(Localization.lang("Removing entries from index for %0", libraryName));
+        }
         int i = 1;
         for (BibEntry entry : entries) {
             if (task.isCancelled()) {

--- a/src/main/java/org/jabref/logic/search/indexing/DefaultLinkedFilesIndexer.java
+++ b/src/main/java/org/jabref/logic/search/indexing/DefaultLinkedFilesIndexer.java
@@ -134,6 +134,7 @@ public class DefaultLinkedFilesIndexer implements LuceneIndexer {
         }
 
         task.setTitle(Localization.lang("Indexing PDF files for %0", libraryName));
+        task.showToUser(true);
         LOGGER.debug("Adding {} files to index", linkedFiles.size());
         int i = 1;
         for (Map.Entry<String, Pair<Long, Path>> entry : linkedFiles.entrySet()) {

--- a/src/main/java/org/jabref/logic/util/BackgroundTask.java
+++ b/src/main/java/org/jabref/logic/util/BackgroundTask.java
@@ -146,6 +146,10 @@ public abstract class BackgroundTask<V> {
         return showToUser.get();
     }
 
+    public BooleanProperty showToUserProperty() {
+        return showToUser;
+    }
+
     public BackgroundTask<V> showToUser(boolean show) {
         showToUser.set(show);
         return this;


### PR DESCRIPTION
Closes #11701.
The issue will be resolved if the PR for hiding completed background tasks (#11821) is merged. 

However, this PR fixes the issue even if hiding completed tasks isn't implemented. Progress was shown with an empty title and no progress because sometimes background indexing tasks start but have no files to add to the index. 
There was no control to show the task to the user after it started executing. This PR added this option. 
Calling `task.showToUser(true)` after `executeWith` will show the task if it's still running.

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
