### PR TITLE
Migrate to new URI API

### DIFF
--- a/rewrite.yml
+++ b/rewrite.yml
@@ -100,6 +100,8 @@ recipeList:
   #  - org.openrewrite.staticanalysis.ExplicitInitialization
 
   - org.openrewrite.java.migrate.io.ReplaceFileInOrOutputStreamFinalizeWithClose
+  - org.openrewrite.java.migrate.net.JavaNetAPIs
+  - org.openrewrite.java.migrate.net.URLConstructorsToURIRecipes
   - org.openrewrite.java.migrate.util.SequencedCollection
   - org.openrewrite.java.migrate.lang.StringFormatted
 

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -100,8 +100,8 @@ recipeList:
   #  - org.openrewrite.staticanalysis.ExplicitInitialization
 
   - org.openrewrite.java.migrate.io.ReplaceFileInOrOutputStreamFinalizeWithClose
-  - org.openrewrite.java.migrate.lang.StringFormatted
   - org.openrewrite.java.migrate.util.SequencedCollection
+  - org.openrewrite.java.migrate.lang.StringFormatted
 
   - org.openrewrite.java.RemoveObjectsIsNull
   - org.openrewrite.java.ShortenFullyQualifiedTypeReferences

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.fieldeditors;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -241,7 +242,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
 
     public boolean downloadFile(String urlText) {
         try {
-            URL url = new URL(urlText);
+            URL url = URI.create(urlText).toURL();
             addFromURLAndDownload(url);
             return true;
         } catch (MalformedURLException exception) {

--- a/src/main/java/org/jabref/gui/fieldeditors/URLUtil.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/URLUtil.java
@@ -79,7 +79,7 @@ public class URLUtil {
         try {
             URI.create(url).toURL();
             return true;
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException | IllegalArgumentException e) {
             return false;
         }
     }

--- a/src/main/java/org/jabref/gui/fieldeditors/URLUtil.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/URLUtil.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -38,7 +39,7 @@ public class URLUtil {
         }
         // Extract destination URL
         try {
-            URL searchURL = new URL(url);
+            URL searchURL = URI.create(url).toURL();
             // URL parameters
             String query = searchURL.getQuery();
             // no parameters
@@ -76,7 +77,7 @@ public class URLUtil {
      */
     public static boolean isURL(String url) {
         try {
-            new URL(url);
+            URI.create(url).toURL();
             return true;
         } catch (MalformedURLException e) {
             return false;
@@ -95,7 +96,7 @@ public class URLUtil {
         String strippedLink = link;
         try {
             // Try to strip the query string, if any, to get the correct suffix:
-            URL url = new URL(link);
+            URL url = URI.create(link).toURL();
             if ((url.getQuery() != null) && (url.getQuery().length() < (link.length() - 1))) {
                 strippedLink = link.substring(0, link.length() - url.getQuery().length() - 1);
             }

--- a/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.linkedfile;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -60,7 +61,7 @@ public class AttachFileFromURLAction extends SimpleCommand {
         }
 
         try {
-            URL url = new URL(urlforDownload.get());
+            URL url = URI.create(urlforDownload.get()).toURL();
             LinkedFileViewModel onlineFile = new LinkedFileViewModel(
                              new LinkedFile(url, ""),
                              entry,

--- a/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
@@ -2,7 +2,6 @@ package org.jabref.gui.linkedfile;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.regex.Pattern;

--- a/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.linkedfile;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -139,7 +140,7 @@ public class LinkedFileEditDialogViewModel extends AbstractViewModel {
 
         if (LinkedFile.isOnlineLink(link.getValue())) {
             try {
-                return new LinkedFile(description.getValue(), new URL(link.getValue()), fileType, sourceUrl.getValue());
+                return new LinkedFile(description.getValue(), URI.create(link.getValue()).toURL(), fileType, sourceUrl.getValue());
             } catch (MalformedURLException e) {
                 return new LinkedFile(description.getValue(), link.getValue(), fileType, sourceUrl.getValue());
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ACS.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ACS.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,7 +53,7 @@ public class ACS implements FulltextFetcher {
 
         if (link != null) {
             LOGGER.info("Fulltext PDF found @ ACS.");
-            return Optional.of(new URL(source.replaceFirst("/abs/", "/pdf/")));
+            return Optional.of(URI.create(source.replaceFirst("/abs/", "/pdf/")).toURL());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ApsFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ApsFetcher.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Objects;
@@ -47,7 +48,7 @@ public class ApsFetcher implements FulltextFetcher {
             if (code == 200) {
                 LOGGER.info("Fulltext PDF found @ APS.");
                 try {
-                    return Optional.of(new URL(pdfRequestUrl));
+                    return Optional.of(URI.create(pdfRequestUrl).toURL());
                 } catch (MalformedURLException e) {
                     LOGGER.warn("APS returned malformed URL, cannot find PDF.");
                 }
@@ -76,7 +77,7 @@ public class ApsFetcher implements FulltextFetcher {
 
         URLConnection con;
         try {
-            con = new URL(doiRequest).openConnection();
+            con = URI.create(doiRequest).toURL().openConnection();
             con.connect();
             con.getInputStream();
             String[] urlParts = con.getURL().toString().split("abstract/");

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -709,7 +710,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                     if (linkTitle.equals(Optional.of("pdf"))) {
                         pdfUrlParsed = XMLUtil.getAttributeContent(linkNode, "href").map(url -> {
                             try {
-                                return new URL(url);
+                                return URI.create(url).toURL();
                             } catch (MalformedURLException e) {
                                 return null;
                             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/BibsonomyScraper.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BibsonomyScraper.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class BibsonomyScraper {
             String cleanURL = entryUrl.replace("%", "%25").replace(":", "%3A").replace("/", "%2F").replace("?", "%3F")
                                       .replace("&", "%26").replace("=", "%3D");
 
-            URL url = new URL(BibsonomyScraper.BIBSONOMY_SCRAPER + cleanURL + BibsonomyScraper.BIBSONOMY_SCRAPER_POST);
+            URL url = URI.create(BibsonomyScraper.BIBSONOMY_SCRAPER + cleanURL + BibsonomyScraper.BIBSONOMY_SCRAPER_POST).toURL();
             String bibtex = new URLDownload(url).asString();
             return BibtexParser.singleFromString(bibtex, importFormatPreferences);
         } catch (IOException | FetcherException ex) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/CiteSeer.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CiteSeer.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
@@ -102,13 +103,13 @@ public class CiteSeer implements SearchBasedFetcher, FulltextFetcher {
         Optional<String> id = entry.getField(StandardField.DOI);
         if (id.isPresent()) {
             String source = PDF_URL.formatted(id.get());
-            return Optional.of(new URL(source));
+            return Optional.of(URI.create(source).toURL());
         }
 
         // if using id fails, we can try the source URL
         Optional<String> urlString = entry.getField(StandardField.URL);
         if (urlString.isPresent()) {
-            return Optional.of(new URL(urlString.get()));
+            return Optional.of(URI.create(urlString.get()).toURL());
         }
 
         return Optional.empty();

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Collections;
@@ -121,7 +122,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
 
         URL doiURL;
         try {
-            doiURL = new URL(doi.get().getURIAsASCIIString());
+            doiURL = URI.create(doi.get().getURIAsASCIIString()).toURL();
         } catch (MalformedURLException e) {
             throw new FetcherException("Malformed URL", e);
         }
@@ -218,7 +219,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
     public Optional<String> getAgency(DOI doi) throws FetcherException, MalformedURLException {
         Optional<String> agency = Optional.empty();
         try {
-            URLDownload download = getUrlDownload(new URL(DOI.AGENCY_RESOLVER + "/" + doi.getDOI()));
+            URLDownload download = getUrlDownload(URI.create(DOI.AGENCY_RESOLVER + "/" + doi.getDOI()).toURL());
             JSONObject response = new JSONArray(download.asString()).getJSONObject(0);
             if (response != null) {
                 agency = Optional.ofNullable(response.optString("RA"));

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -61,7 +61,7 @@ public class DoiResolution implements FulltextFetcher {
 
         String doiLink;
         if (doiPreferences.isUseCustom()) {
-            base = new URL(doiPreferences.getDefaultBaseURI());
+            base = URI.create(doiPreferences.getDefaultBaseURI()).toURL();
             doiLink = doi.get()
                          .getExternalURIWithCustomBase(base.toString())
                          .map(URI::toASCIIString)
@@ -110,11 +110,11 @@ public class DoiResolution implements FulltextFetcher {
                 // See https://github.com/lehner/LocalCopy for more scrape ideas
                 // link with "PDF" in title tag
                 if (element.attr("title").toLowerCase(Locale.ENGLISH).contains("pdf") && new URLDownload(href).isPdf()) {
-                    return Optional.of(new URL(href));
+                    return Optional.of(URI.create(href).toURL());
                 }
 
                 if (href.contains("pdf") || hrefText.contains("pdf") && new URLDownload(href).isPdf()) {
-                    links.add(new URL(href));
+                    links.add(URI.create(href).toURL());
                 }
             }
 
@@ -128,7 +128,7 @@ public class DoiResolution implements FulltextFetcher {
         } catch (UnsupportedMimeTypeException type) {
             // this might be the PDF already as we follow redirects
             if (type.getMimeType().startsWith("application/pdf")) {
-                return Optional.of(new URL(type.getUrl()));
+                return Optional.of(URI.create(type.getUrl()).toURL());
             }
             LOGGER.warn("DoiResolution fetcher failed: ", type);
         } catch (IOException e) {
@@ -148,7 +148,7 @@ public class DoiResolution implements FulltextFetcher {
 
         if (citationPdfUrl.isPresent()) {
             try {
-                return Optional.of(new URL(citationPdfUrl.get()));
+                return Optional.of(URI.create(citationPdfUrl.get()).toURL());
             } catch (MalformedURLException e) {
                 return Optional.empty();
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/GoogleScholar.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -107,7 +108,7 @@ public class GoogleScholar implements FulltextFetcher, PagedSearchBasedFetcher {
                     // TODO: check title inside pdf + length?
                     // TODO: report error function needed?! query -> result
                     LOGGER.info("Fulltext PDF found @ Google: {}", target);
-                    pdfLink = Optional.of(new URL(target));
+                    pdfLink = Optional.of(URI.create(target).toURL());
                     break;
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -118,7 +119,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         entry.setField(StandardField.ISSN, jsonEntry.optString("issn"));
         entry.setField(StandardField.ISSUE, jsonEntry.optString("issue"));
         try {
-            entry.addFile(new LinkedFile(new URL(jsonEntry.optString("pdf_url")), "PDF"));
+            entry.addFile(new LinkedFile(URI.create(jsonEntry.optString("pdf_url")).toURL(), "PDF"));
         } catch (MalformedURLException e) {
             LOGGER.error("Fetched PDF URL String is malformed.");
         }
@@ -203,7 +204,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
             LOGGER.debug("Full text document found on IEEE Xplore");
             URL value;
             try {
-                value = new URL(matcher.group(1));
+                value = URI.create(matcher.group(1)).toURL();
             } catch (MalformedURLException e) {
                 throw new FetcherException("Malformed URL", e);
             }

--- a/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IacrEprintFetcher.java
@@ -173,7 +173,7 @@ public class IacrEprintFetcher implements FulltextFetcher, IdBasedFetcher {
             // getRequiredValueBetween refuses to match across the line break.
             fulltextLinkAsInHtml = fulltextLinkAsInHtml.replaceFirst(".*href=\"/", "").trim();
             String fulltextLink = FULLTEXT_URL_PREFIX + fulltextLinkAsInHtml + ".pdf";
-            return Optional.of(new URL(fulltextLink));
+            return Optional.of(URI.create(fulltextLink).toURL());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/jabref/logic/importer/fetcher/JstorFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/JstorFetcher.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -65,10 +66,10 @@ public class JstorFetcher implements SearchBasedParserFetcher, FulltextFetcher, 
 
         if (identifier.contains("/")) {
             // if identifier links to a entry with a valid doi
-            return new URL(start + identifier);
+            return URI.create(start + identifier).toURL();
         }
         // else use default doi start.
-        return new URL(start + "10.2307/" + identifier);
+        return URI.create(start + "10.2307/" + identifier).toURL();
     }
 
     @Override
@@ -125,7 +126,7 @@ public class JstorFetcher implements SearchBasedParserFetcher, FulltextFetcher, 
         }
 
         String url = elements.getFirst().attr("href");
-        return Optional.of(new URL(url));
+        return Optional.of(URI.create(url).toURL());
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/Medra.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
@@ -103,7 +104,7 @@ public class Medra implements IdBasedParserFetcher {
 
     @Override
     public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException {
-        return new URL(API_URL + "/" + identifier);
+        return URI.create(API_URL + "/" + identifier).toURL();
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/OpenAccessDoi.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/OpenAccessDoi.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
@@ -66,7 +67,7 @@ public class OpenAccessDoi implements FulltextFetcher {
                        .map(location -> location.optString("url"))
                        .flatMap(url -> {
                            try {
-                               return Optional.of(new URL(url));
+                               return Optional.of(URI.create(url).toURL());
                            } catch (MalformedURLException e) {
                                LOGGER.debug("Could not determine URL to fetch full text from", e);
                                return Optional.empty();

--- a/src/main/java/org/jabref/logic/importer/fetcher/ResearchGate.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ResearchGate.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -76,7 +77,7 @@ public class ResearchGate implements FulltextFetcher, EntryBasedFetcher, SearchB
         LOGGER.debug("PDF link: {}", link);
 
         if (link.contains("researchgate.net")) {
-            return Optional.of(new URL(link));
+            return Optional.of(URI.create(link).toURL());
         }
         return Optional.empty();
     }
@@ -253,7 +254,7 @@ public class ResearchGate implements FulltextFetcher, EntryBasedFetcher, SearchB
 
     private BufferedReader getInputStream(String urlString) {
         try {
-            URL url = new URL(urlString);
+            URL url = URI.create(urlString).toURL();
             return new BufferedReader(new InputStreamReader(url.openStream()));
         } catch (IOException e) {
             LOGGER.debug("Wrong URL", e);

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,7 +72,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
         Elements metaLinks = html.getElementsByAttributeValue("name", "citation_pdf_url");
         if (!metaLinks.isEmpty()) {
             String link = metaLinks.first().attr("content");
-            return Optional.of(new URL(link));
+            return Optional.of(URI.create(link).toURL());
         }
 
         // We use the ScienceDirect web page which contains the article (presented using HTML).
@@ -102,7 +103,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
         String fullLinkToPdf;
         if (pdfDownload.has("linkToPdf")) {
             String linkToPdf = pdfDownload.getString("linkToPdf");
-            URL url = new URL(urlFromDoi);
+            URL url = URI.create(urlFromDoi).toURL();
             fullLinkToPdf = "%s://%s%s".formatted(url.getProtocol(), url.getAuthority(), linkToPdf);
         } else if (pdfDownload.has("urlMetadata")) {
             JSONObject urlMetadata = pdfDownload.getJSONObject("urlMetadata");
@@ -122,7 +123,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
 
         LOGGER.info("Fulltext PDF found at ScienceDirect at {}.", fullLinkToPdf);
         try {
-            return Optional.of(new URL(fullLinkToPdf));
+            return Optional.of(URI.create(fullLinkToPdf).toURL());
         } catch (MalformedURLException e) {
             LOGGER.error("malformed URL", e);
             return Optional.empty();

--- a/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SemanticScholar.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class SemanticScholar implements FulltextFetcher, PagedSearchBasedParserF
             return Optional.empty();
         }
         LOGGER.info("Fulltext PDF found @ SemanticScholar. Link: {}", link);
-        return Optional.of(new URL(link));
+        return Optional.of(URI.create(link).toURL());
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fetcher;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -132,7 +133,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
                     JSONObject url = (JSONObject) data;
                     if ("pdf".equalsIgnoreCase(url.optString("format"))) {
                         try {
-                            entry.addFile(new LinkedFile(new URL(url.optString("value")), "PDF"));
+                            entry.addFile(new LinkedFile(URI.create(url.optString("value")).toURL(), "PDF"));
                         } catch (MalformedURLException e) {
                             LOGGER.info("Malformed URL: {}", url.optString("value"));
                         }

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
@@ -1,6 +1,8 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.Optional;
@@ -62,10 +64,10 @@ public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
 
                 if (results > 0) {
                     LOGGER.info("Fulltext PDF found @ Springer.");
-                    return Optional.of(new URL("http", CONTENT_HOST, "/content/pdf/%s.pdf".formatted(doi.get().getDOI())));
+                    return Optional.of(new URI("http", null, CONTENT_HOST, -1, "/content/pdf/%s.pdf".formatted(doi.get().getDOI()), null, null).toURL());
                 }
             }
-        } catch (UnirestException e) {
+        } catch (UnirestException | URISyntaxException e) {
             LOGGER.warn("SpringerLink API request failed", e);
         }
         return Optional.empty();

--- a/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.time.DateTimeException;
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer.fileformat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.time.DateTimeException;
 import java.util.Arrays;
@@ -383,7 +384,7 @@ public class MarcXmlParser implements Parser {
 
             if ("Volltext".equals(fulltext)) {
                 try {
-                    LinkedFile linkedFile = new LinkedFile(new URL(resource), "PDF");
+                    LinkedFile linkedFile = new LinkedFile(URI.create(resource).toURL(), "PDF");
                     bibEntry.setField(StandardField.FILE, linkedFile.toString());
                 } catch (MalformedURLException e) {
                     LOGGER.info("Malformed URL: {}", resource);
@@ -405,7 +406,7 @@ public class MarcXmlParser implements Parser {
 
             if ("Volltext".equals(fulltext) && StringUtil.isNotBlank(resource)) {
                 try {
-                    LinkedFile linkedFile = new LinkedFile(new URL(resource), "PDF");
+                    LinkedFile linkedFile = new LinkedFile(URI.create(resource).toURL(), "PDF");
                     bibEntry.setField(StandardField.FILE, linkedFile.toString());
                 } catch (MalformedURLException e) {
                     LOGGER.info("Malformed URL: {}", resource);

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.util;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.util;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -59,7 +60,7 @@ public class FileFieldParser {
         if (LinkedFile.isOnlineLink(value.trim())) {
             // needs to be modifiable
             try {
-                return List.of(new LinkedFile(new URL(value), ""));
+                return List.of(new LinkedFile(URI.create(value).toURL(), ""));
             } catch (MalformedURLException e) {
                 LOGGER.error("invalid url", e);
                 return files;
@@ -157,7 +158,7 @@ public class FileFieldParser {
         LinkedFile field = null;
         if (LinkedFile.isOnlineLink(entry.get(1))) {
             try {
-                field = new LinkedFile(entry.getFirst(), new URL(entry.get(1)), entry.get(2));
+                field = new LinkedFile(entry.getFirst(), URI.create(entry.get(1)).toURL(), entry.get(2));
             } catch (MalformedURLException e) {
                 // in case the URL is malformed, store it nevertheless
                 field = new LinkedFile(entry.getFirst(), entry.get(1), entry.get(2));

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -15,6 +15,7 @@ import java.net.CookiePolicy;
 import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -86,7 +87,7 @@ public class URLDownload {
      * @throws MalformedURLException if no protocol is specified in the source, or an unknown protocol is found
      */
     public URLDownload(String source) throws MalformedURLException {
-        this(new URL(source));
+        this(URI.create(source).toURL());
     }
 
     /**
@@ -153,7 +154,7 @@ public class URLDownload {
 
         // Try to resolve local URIs
         try {
-            URLConnection connection = new URL(source.toString()).openConnection();
+            URLConnection connection = URI.create(source.toString()).toURL().openConnection();
             contentType = connection.getContentType();
             if (!StringUtil.isNullOrEmpty(contentType)) {
                 return Optional.of(contentType);

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -106,7 +107,7 @@ public class Version {
      * Grabs all the available releases from the GitHub repository
      */
     public static List<Version> getAllAvailableVersions() throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(JABREF_GITHUB_RELEASES).openConnection();
+        HttpURLConnection connection = (HttpURLConnection) URI.create(JABREF_GITHUB_RELEASES).toURL().openConnection();
         connection.setRequestProperty("Accept-Charset", "UTF-8");
         try (BufferedReader rd = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
             JSONArray objects = new JSONArray(rd.readLine());

--- a/src/main/java/org/jabref/logic/util/Version.java
+++ b/src/main/java/org/jabref/logic/util/Version.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -5,6 +5,7 @@ import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -197,7 +198,7 @@ class LinkedFileViewModelTest {
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
         databaseContext.setDatabasePath(tempFile);
 
-        URL url = new URL("https://www.google.com/");
+        URL url = URI.create("https://www.google.com/").toURL();
         String fileType = StandardExternalFileType.URL.getName();
         linkedFile = new LinkedFile(url, fileType);
 
@@ -274,7 +275,7 @@ class LinkedFileViewModelTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void downloadPdfFileWhenLinkedFilePointsToPdfUrl(boolean keepHtml) throws MalformedURLException {
-        linkedFile = new LinkedFile(new URL("http://arxiv.org/pdf/1207.0408v1"), "pdf");
+        linkedFile = new LinkedFile(URI.create("http://arxiv.org/pdf/1207.0408v1").toURL(), "pdf");
         // Needed Mockito stubbing methods to run test
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");

--- a/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
+++ b/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
@@ -3,6 +3,7 @@ package org.jabref.gui.linkedfile;
 import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -93,7 +94,7 @@ class DownloadLinkedFileActionTest {
     void replacesLinkedFiles(@TempDir Path tempFolder) throws Exception {
         String url = "http://arxiv.org/pdf/1207.0408v1";
 
-        LinkedFile linkedFile = new LinkedFile(new URL(url), "");
+        LinkedFile linkedFile = new LinkedFile(URI.create(url).toURL(), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -118,7 +119,7 @@ class DownloadLinkedFileActionTest {
     void doesntReplaceSourceURL(boolean keepHtml) throws Exception {
         String url = "http://arxiv.org/pdf/1207.0408v1";
 
-        LinkedFile linkedFile = new LinkedFile(new URL(url), "");
+        LinkedFile linkedFile = new LinkedFile(URI.create(url).toURL(), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -173,7 +174,7 @@ class DownloadLinkedFileActionTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html; charset=utf-8")));
 
-        LinkedFile linkedFile = new LinkedFile(new URL("http://localhost:2331/html"), "");
+        LinkedFile linkedFile = new LinkedFile(URI.create("http://localhost:2331/html").toURL(), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -209,7 +210,7 @@ class DownloadLinkedFileActionTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html; charset=utf-8")));
 
-        LinkedFile linkedFile = new LinkedFile(new URL("http://localhost:2331/html"), "");
+        LinkedFile linkedFile = new LinkedFile(URI.create("http://localhost:2331/html").toURL(), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");

--- a/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
+++ b/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
@@ -4,7 +4,6 @@ import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;

--- a/src/test/java/org/jabref/logic/help/HelpFileTest.java
+++ b/src/test/java/org/jabref/logic/help/HelpFileTest.java
@@ -2,6 +2,7 @@ package org.jabref.logic.help;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -24,7 +25,7 @@ class HelpFileTest {
     @ParameterizedTest
     @MethodSource("getAllHelpFiles")
     void referToValidPage(HelpFile help) throws IOException {
-        URL url = new URL(jabrefHelp + help.getPageName());
+        URL url = URI.create(jabrefHelp + help.getPageName()).toURL();
         HttpURLConnection http = (HttpURLConnection) url.openConnection();
         http.setRequestProperty("User-Agent", URLDownload.USER_AGENT);
         assertEquals(200, http.getResponseCode(), "Wrong URL: " + url.toString());

--- a/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 import java.util.Set;
@@ -32,7 +33,7 @@ class FulltextFetchersTest {
 
     @Test
     void acceptPdfUrls() throws MalformedURLException {
-        URL pdfUrl = new URL("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf");
+        URL pdfUrl = URI.create("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf").toURL();
         FulltextFetcherWithTrustLevel finder = e -> Optional.of(pdfUrl);
         FulltextFetchers fetcher = new FulltextFetchers(Set.of(finder));
         assertEquals(Optional.of(pdfUrl), fetcher.findFullTextPDF(new BibEntry()));
@@ -40,7 +41,7 @@ class FulltextFetchersTest {
 
     @Test
     void rejectNonPdfUrls() throws MalformedURLException {
-        URL pdfUrl = new URL("https://github.com/JabRef/jabref/blob/master/README.md");
+        URL pdfUrl = URI.create("https://github.com/JabRef/jabref/blob/master/README.md").toURL();
         FulltextFetcherWithTrustLevel finder = e -> Optional.of(pdfUrl);
         FulltextFetchers fetcher = new FulltextFetchers(Set.of(finder));
 
@@ -49,7 +50,7 @@ class FulltextFetchersTest {
 
     @Test
     void noTrustLevel() throws MalformedURLException {
-        URL pdfUrl = new URL("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf");
+        URL pdfUrl = URI.create("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf").toURL();
         FulltextFetcherWithTrustLevel finder = e -> Optional.of(pdfUrl);
         FulltextFetchers fetcher = new FulltextFetchers(Set.of(finder));
 
@@ -63,12 +64,12 @@ class FulltextFetchersTest {
 
         FulltextFetcher finderHigh = mock(FulltextFetcher.class);
         when(finderHigh.getTrustLevel()).thenReturn(TrustLevel.SOURCE);
-        final URL highUrl = new URL("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf");
+        final URL highUrl = URI.create("http://docs.oasis-open.org/wsbpel/2.0/OS/wsbpel-v2.0-OS.pdf").toURL();
         when(finderHigh.findFullText(entry)).thenReturn(Optional.of(highUrl));
 
         FulltextFetcher finderLow = mock(FulltextFetcher.class);
         when(finderLow.getTrustLevel()).thenReturn(TrustLevel.UNKNOWN);
-        final URL lowUrl = new URL("http://docs.oasis-open.org/opencsa/sca-bpel/sca-bpel-1.1-spec-cd-01.pdf");
+        final URL lowUrl = URI.create("http://docs.oasis-open.org/opencsa/sca-bpel/sca-bpel-1.1-spec-cd-01.pdf").toURL();
         when(finderLow.findFullText(entry)).thenReturn(Optional.of(lowUrl));
 
         FulltextFetchers fetchers = new FulltextFetchers(Set.of(finderLow, finderHigh));

--- a/src/test/java/org/jabref/logic/importer/fetcher/ACSTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ACSTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -23,7 +24,7 @@ class ACSTest {
         // DOI randomly chosen from https://pubs.acs.org/toc/acscii/0/0
         BibEntry entry = new BibEntry().withField(StandardField.DOI, "10.1021/acscentsci.4c00971");
         assertEquals(
-                Optional.of(new URL("https://pubs.acs.org/doi/pdf/10.1021/acscentsci.4c00971")),
+                Optional.of(URI.create("https://pubs.acs.org/doi/pdf/10.1021/acscentsci.4c00971").toURL()),
                 fetcher.findFullText(entry)
         );
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/ACSTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ACSTest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.logic.importer.FulltextFetcher;

--- a/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -25,13 +26,13 @@ class ApsFetcherTest {
     @Test
     void findFullTextFromDoi() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.DOI, "10.1103/PhysRevLett.116.061102");
-        assertEquals(Optional.of(new URL("https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.116.061102")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.116.061102").toURL()), finder.findFullText(entry));
     }
 
     @Test
     void findFullTextFromLowercaseDoi() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.DOI, "10.1103/physrevlett.124.029002");
-        assertEquals(Optional.of(new URL("https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.124.029002")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.124.029002").toURL()), finder.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -198,19 +199,19 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.DOI, "10.1529/biophysj.104.047340");
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/cond-mat/0406246v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
     void findFullTextByEprint() throws IOException {
         entry.setField(StandardField.EPRINT, "1603.06570");
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/1603.06570v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/1603.06570v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
     void findFullTextByEprintWithPrefix() throws IOException {
         entry.setField(StandardField.EPRINT, "arXiv:1603.06570");
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/1603.06570v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/1603.06570v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
@@ -218,21 +219,21 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.DOI, "10.1529/unknown");
         entry.setField(StandardField.EPRINT, "1603.06570");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/1603.06570v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/1603.06570v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
     void findFullTextByTitle() throws IOException {
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/cond-mat/0406246v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
     void findFullTextByTitleWithCurlyBracket() throws IOException {
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2010.15942v3")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/2010.15942v3").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
@@ -240,7 +241,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
         entry.setField(StandardField.JOURNAL, "arXiv:2002.10248v4 [cs]");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/2002.10248v4").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
@@ -248,7 +249,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.TITLE, "Bayes-TrEx: a Bayesian Sampling Approach to Model Transparency by Example");
         entry.setField(StandardField.URL, "http://arxiv.org/abs/2002.10248v4");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2002.10248v4")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/2002.10248v4").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
@@ -256,7 +257,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.TITLE, "Pause Point Spectra in DNA Constant-Force Unzipping");
         entry.setField(StandardField.AUTHOR, "Weeks and Lucks");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/cond-mat/0406246v1")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/cond-mat/0406246v1").toURL()), fetcher.findFullText(entry));
     }
 
     @Test
@@ -264,7 +265,7 @@ class ArXivFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
         entry.setField(StandardField.TITLE, "Machine versus {Human} {Attention} in {Deep} {Reinforcement} {Learning} {Tasks}");
         entry.setField(StandardField.AUTHOR, "Zhang, Ruohan and Guo");
 
-        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/2010.15942v3")), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create("http://arxiv.org/pdf/2010.15942v3").toURL()), fetcher.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivFetcherTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/org/jabref/logic/importer/fetcher/CiteSeerTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CiteSeerTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Iterator;
@@ -100,7 +101,7 @@ class CiteSeerTest {
     void findByIdAsDOI() throws FetcherException, IOException {
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.DOI, "c16e0888b17cb2c689e5dfa4e2be4fdffb23869e");
-        Optional<URL> expected = Optional.of(new URL("https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c16e0888b17cb2c689e5dfa4e2be4fdffb23869e"));
+        Optional<URL> expected = Optional.of(URI.create("https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c16e0888b17cb2c689e5dfa4e2be4fdffb23869e").toURL());
         assertEquals(expected, fetcher.findFullText(entry));
     }
 
@@ -109,7 +110,7 @@ class CiteSeerTest {
         BibEntry entry = new BibEntry(StandardEntryType.Misc)
                 .withField(StandardField.DOI, "")
                 .withField(StandardField.URL, "http://intl.psychosomaticmedicine.org/content/55/3/234.full.pdf");
-        Optional<URL> expected = Optional.of(new URL("http://intl.psychosomaticmedicine.org/content/55/3/234.full.pdf"));
+        Optional<URL> expected = Optional.of(URI.create("http://intl.psychosomaticmedicine.org/content/55/3/234.full.pdf").toURL());
         assertEquals(expected, fetcher.findFullText(entry));
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.logic.preferences.DOIPreferences;

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -35,7 +36,7 @@ class DoiResolutionTest {
     void linkWithPdfInTitleTag() throws IOException {
         entry.setField(StandardField.DOI, "10.1051/0004-6361/201527330");
         assertEquals(
-                Optional.of(new URL("https://www.aanda.org/articles/aa/pdf/2016/01/aa27330-15.pdf")),
+                Optional.of(URI.create("https://www.aanda.org/articles/aa/pdf/2016/01/aa27330-15.pdf").toURL()),
                 finder.findFullText(entry)
         );
     }
@@ -44,13 +45,13 @@ class DoiResolutionTest {
     @Test
     void linkWithPdfStringLeadsToFulltext() throws IOException {
         entry.setField(StandardField.DOI, "10.1002/acr2.11101");
-        assertEquals(Optional.of(new URL("https://onlinelibrary.wiley.com/doi/pdf/10.1002/acr2.11101")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://onlinelibrary.wiley.com/doi/pdf/10.1002/acr2.11101").toURL()), finder.findFullText(entry));
     }
 
     @Test
     void citationMetaTagLeadsToFulltext() throws IOException {
         entry.setField(StandardField.DOI, "10.1007/978-3-319-89963-3_28");
-        assertEquals(Optional.of(new URL("https://link.springer.com/content/pdf/10.1007/978-3-319-89963-3_28.pdf")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://link.springer.com/content/pdf/10.1007/978-3-319-89963-3_28.pdf").toURL()), finder.findFullText(entry));
     }
 
     @Test
@@ -65,7 +66,7 @@ class DoiResolutionTest {
         // even if the user does not have access
         // We cannot easily handle this case, because other publisher return the wrong media type.
         entry.setField(StandardField.DOI, "10.1007/978-3-319-62594-2_12");
-        assertEquals(Optional.of(new URL("https://link.springer.com/content/pdf/10.1007/978-3-319-62594-2_12.pdf")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://link.springer.com/content/pdf/10.1007/978-3-319-62594-2_12.pdf").toURL()), finder.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -42,7 +43,7 @@ class GoogleScholarTest implements SearchBasedFetcherCapabilityTest, PagedSearch
         entry.setField(StandardField.TITLE, "Towards Application Portability in Platform as a Service");
 
         assertEquals(
-                Optional.of(new URL("https://www.uni-bamberg.de/fileadmin/uni/fakultaeten/wiai_lehrstuehle/praktische_informatik/Dateien/Publikationen/sose14-towards-application-portability-in-paas.pdf")),
+                Optional.of(URI.create("https://www.uni-bamberg.de/fileadmin/uni/fakultaeten/wiai_lehrstuehle/praktische_informatik/Dateien/Publikationen/sose14-towards-application-portability-in-paas.pdf").toURL()),
                 finder.findFullText(entry)
         );
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
@@ -75,7 +76,7 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
     @Disabled("IEEE seems to block us")
     void findByDOI() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.DOI, "10.1109/ACCESS.2016.2535486");
-        assertEquals(Optional.of(new URL("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=")),
+        assertEquals(Optional.of(URI.create("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=").toURL()),
                 fetcher.findFullText(entry));
     }
 
@@ -83,7 +84,7 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
     @Disabled("IEEE seems to block us")
     void findByDocumentUrl() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.URL, "https://ieeexplore.ieee.org/document/7421926/");
-        assertEquals(Optional.of(new URL("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=")),
+        assertEquals(Optional.of(URI.create("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=").toURL()),
                 fetcher.findFullText(entry));
     }
 
@@ -91,7 +92,7 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
     @Disabled("IEEE seems to block us")
     void findByURL() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.URL, "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=7421926&ref=");
-        assertEquals(Optional.of(new URL("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=")),
+        assertEquals(Optional.of(URI.create("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=").toURL()),
                 fetcher.findFullText(entry));
     }
 
@@ -99,7 +100,7 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
     @Disabled("IEEE blocks us - works in browser")
     void findByOldURL() throws Exception {
         BibEntry entry = new BibEntry().withField(StandardField.URL, "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=7421926");
-        assertEquals(Optional.of(new URL("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=")),
+        assertEquals(Optional.of(URI.create("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=").toURL()),
                 fetcher.findFullText(entry));
     }
 
@@ -109,7 +110,7 @@ class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTe
         BibEntry entry = new BibEntry()
                 .withField(StandardField.DOI, "10.1109/ACCESS.2016.2535486")
                 .withField(StandardField.URL, "http://dx.doi.org/10.1109/ACCESS.2016.2535486");
-        assertEquals(Optional.of(new URL("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=")),
+        assertEquals(Optional.of(URI.create("https://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf?tp=&arnumber=7421926&isnumber=7419931&ref=").toURL()),
                 fetcher.findFullText(entry));
     }
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/JstorFetcherTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.importer.fetcher;
 
+import java.net.URI;
 import java.net.URL;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -79,7 +80,7 @@ public class JstorFetcherTest implements SearchBasedFetcherCapabilityTest {
     @Test
     void fetchPDF() throws Exception {
         Optional<URL> url = fetcher.findFullText(bibEntry);
-        assertEquals(Optional.of(new URL("https://www.jstor.org/stable/pdf/90002164.pdf")), url);
+        assertEquals(Optional.of(URI.create("https://www.jstor.org/stable/pdf/90002164.pdf").toURL()), url);
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/importer/fetcher/OpenAccessDoiTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/OpenAccessDoiTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;

--- a/src/test/java/org/jabref/logic/importer/fetcher/OpenAccessDoiTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/OpenAccessDoiTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -28,7 +29,7 @@ class OpenAccessDoiTest {
     @Test
     void findByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/s12993-024-00248-9");
-        assertEquals(Optional.of(new URL("https://behavioralandbrainfunctions.biomedcentral.com/counter/pdf/10.1186/s12993-024-00248-9")), finder.findFullText(entry));
+        assertEquals(Optional.of(URI.create("https://behavioralandbrainfunctions.biomedcentral.com/counter/pdf/10.1186/s12993-024-00248-9").toURL()), finder.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +46,7 @@ class ResearchGateTest {
     @Test
     @DisabledOnCIServer("CI server is unreliable")
     void fullTextFoundByDOI() throws IOException, FetcherException {
-        assertEquals(Optional.of(new URL(URL_PDF)), fetcher.findFullText(entry));
+        assertEquals(Optional.of(URI.create(URL_PDF).toURL()), fetcher.findFullText(entry));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ResearchGateTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import javafx.collections.FXCollections;

--- a/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ScienceDirectTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -39,7 +40,7 @@ class ScienceDirectTest {
         entry.setField(StandardField.DOI, "10.1016/j.jrmge.2015.08.004");
 
         assertEquals(
-                Optional.of(new URL("https://www.sciencedirect.com/science/article/pii/S1674775515001079/pdfft?md5=2b19b19a387cffbae237ca6a987279df&pid=1-s2.0-S1674775515001079-main.pdf")),
+                Optional.of(URI.create("https://www.sciencedirect.com/science/article/pii/S1674775515001079/pdfft?md5=2b19b19a387cffbae237ca6a987279df&pid=1-s2.0-S1674775515001079-main.pdf").toURL()),
                 finder.findFullText(entry)
         );
     }
@@ -50,7 +51,7 @@ class ScienceDirectTest {
         entry.setField(StandardField.DOI, "10.1016/j.aasri.2014.09.002");
 
         assertEquals(
-                Optional.of(new URL("https://www.sciencedirect.com/science/article/pii/S2212671614001024/pdf?md5=4e2e9a369b4d5b3db5100aba599bef8b&pid=1-s2.0-S2212671614001024-main.pdf")),
+                Optional.of(URI.create("https://www.sciencedirect.com/science/article/pii/S2212671614001024/pdf?md5=4e2e9a369b4d5b3db5100aba599bef8b&pid=1-s2.0-S2212671614001024-main.pdf").toURL()),
                 finder.findFullText(entry)
         );
     }
@@ -62,7 +63,7 @@ class ScienceDirectTest {
         entry.setField(StandardField.DOI, "https://doi.org/10.1016/j.bone.2020.115226");
 
         assertEquals(
-                Optional.of(new URL("https://www.sciencedirect.com/science/article/pii/S8756328220300065/pdfft?md5=0ad75ff155637dec358e5c9fb8b90afd&pid=1-s2.0-S8756328220300065-main.pdf")),
+                Optional.of(URI.create("https://www.sciencedirect.com/science/article/pii/S8756328220300065/pdfft?md5=0ad75ff155637dec358e5c9fb8b90afd&pid=1-s2.0-S8756328220300065-main.pdf").toURL()),
                 finder.findFullText(entry)
         );
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
@@ -2,7 +2,6 @@ package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.util.Optional;
 
 import javafx.collections.FXCollections;

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.importer.fetcher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Optional;
 
@@ -49,7 +50,7 @@ class SpringerLinkTest {
     void findByDOI() throws IOException {
         entry.setField(StandardField.DOI, "10.1186/s13677-015-0042-8");
         assertEquals(
-                Optional.of(new URL("http://link.springer.com/content/pdf/10.1186/s13677-015-0042-8.pdf")),
+                Optional.of(URI.create("http://link.springer.com/content/pdf/10.1186/s13677-015-0042-8.pdf").toURL()),
                 finder.findFullText(entry));
     }
 

--- a/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.importer.util;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -65,7 +66,7 @@ class FileFieldParserTest {
 
                 // parseCorrectOnlineInput
                 Arguments.of(
-                        Collections.singletonList(new LinkedFile(new URL("http://arxiv.org/pdf/2010.08497v1"), "PDF")),
+                        Collections.singletonList(new LinkedFile(URI.create("http://arxiv.org/pdf/2010.08497v1").toURL(), "PDF")),
                         ":http\\://arxiv.org/pdf/2010.08497v1:PDF"
                 ),
 
@@ -164,24 +165,24 @@ class FileFieldParserTest {
 
                 // url
                 Arguments.of(
-                         Collections.singletonList(new LinkedFile(new URL("https://books.google.de/"), "")),
+                         Collections.singletonList(new LinkedFile(URI.create("https://books.google.de/").toURL(), "")),
                          "https://books.google.de/"
                 ),
 
                 // url with www
                 Arguments.of(
-                             Collections.singletonList(new LinkedFile(new URL("https://www.google.de/"), "")),
+                             Collections.singletonList(new LinkedFile(URI.create("https://www.google.de/").toURL(), "")),
                              "https://www.google.de/"
                 ),
 
                 // url as file
                 Arguments.of(
-                             Collections.singletonList(new LinkedFile("", new URL("http://ceur-ws.org/Vol-438"), "URL")),
+                             Collections.singletonList(new LinkedFile("", URI.create("http://ceur-ws.org/Vol-438").toURL(), "URL")),
                              ":http\\://ceur-ws.org/Vol-438:URL"
                 ),
                 // url as file with desc
                 Arguments.of(
-                             Collections.singletonList(new LinkedFile("desc", new URL("http://ceur-ws.org/Vol-438"), "URL")),
+                             Collections.singletonList(new LinkedFile("desc", URI.create("http://ceur-ws.org/Vol-438").toURL(), "URL")),
                              "desc:http\\://ceur-ws.org/Vol-438:URL"
                 ),
                 // link with source url

--- a/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.util;
 
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.net;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/test/java/org/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/org/jabref/logic/net/URLDownloadTest.java
@@ -2,6 +2,7 @@ package org.jabref.logic.net;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -36,14 +37,14 @@ class URLDownloadTest {
 
     @Test
     void stringDownloadWithSetEncoding() throws Exception {
-        URLDownload dl = new URLDownload(new URL("http://www.google.com"));
+        URLDownload dl = new URLDownload(URI.create("http://www.google.com").toURL());
 
         assertTrue(dl.asString().contains("Google"), "google.com should contain google");
     }
 
     @Test
     void stringDownload() throws Exception {
-        URLDownload dl = new URLDownload(new URL("http://www.google.com"));
+        URLDownload dl = new URLDownload(URI.create("http://www.google.com").toURL());
 
         assertTrue(dl.asString(StandardCharsets.UTF_8).contains("Google"), "google.com should contain google");
     }
@@ -52,7 +53,7 @@ class URLDownloadTest {
     void fileDownload() throws Exception {
         File destination = File.createTempFile("jabref-test", ".html");
         try {
-            URLDownload dl = new URLDownload(new URL("http://www.google.com"));
+            URLDownload dl = new URLDownload(URI.create("http://www.google.com").toURL());
             dl.toFile(destination.toPath());
             assertTrue(destination.exists(), "file must exist");
         } finally {
@@ -65,14 +66,14 @@ class URLDownloadTest {
 
     @Test
     void determineMimeType() throws Exception {
-        URLDownload dl = new URLDownload(new URL("http://www.google.com"));
+        URLDownload dl = new URLDownload(URI.create("http://www.google.com").toURL());
 
         assertTrue(dl.getMimeType().get().startsWith("text/html"));
     }
 
     @Test
     void downloadToTemporaryFilePathWithoutFileSavesAsTmpFile() throws Exception {
-        URLDownload google = new URLDownload(new URL("http://www.google.com"));
+        URLDownload google = new URLDownload(URI.create("http://www.google.com").toURL());
 
         String path = google.toTemporaryFile().toString();
         assertTrue(path.endsWith(".tmp"), path);
@@ -80,7 +81,7 @@ class URLDownloadTest {
 
     @Test
     void downloadToTemporaryFileKeepsName() throws Exception {
-        URLDownload google = new URLDownload(new URL("https://github.com/JabRef/jabref/blob/main/LICENSE"));
+        URLDownload google = new URLDownload(URI.create("https://github.com/JabRef/jabref/blob/main/LICENSE").toURL());
 
         String path = google.toTemporaryFile().toString();
         assertTrue(path.contains("LICENSE"), path);
@@ -89,7 +90,7 @@ class URLDownloadTest {
     @Test
     @DisabledOnCIServer("CI Server is apparently blocked")
     void downloadOfFTPSucceeds() throws Exception {
-        URLDownload ftp = new URLDownload(new URL("ftp://ftp.informatik.uni-stuttgart.de/pub/library/ncstrl.ustuttgart_fi/INPROC-2016-15/INPROC-2016-15.pdf"));
+        URLDownload ftp = new URLDownload(URI.create("ftp://ftp.informatik.uni-stuttgart.de/pub/library/ncstrl.ustuttgart_fi/INPROC-2016-15/INPROC-2016-15.pdf").toURL());
 
         Path path = ftp.toTemporaryFile();
         assertNotNull(path);
@@ -97,7 +98,7 @@ class URLDownloadTest {
 
     @Test
     void downloadOfHttpSucceeds() throws Exception {
-        URLDownload ftp = new URLDownload(new URL("http://www.jabref.org"));
+        URLDownload ftp = new URLDownload(URI.create("http://www.jabref.org").toURL());
 
         Path path = ftp.toTemporaryFile();
         assertNotNull(path);
@@ -105,7 +106,7 @@ class URLDownloadTest {
 
     @Test
     void downloadOfHttpsSucceeds() throws Exception {
-        URLDownload ftp = new URLDownload(new URL("https://www.jabref.org"));
+        URLDownload ftp = new URLDownload(URI.create("https://www.jabref.org").toURL());
 
         Path path = ftp.toTemporaryFile();
         assertNotNull(path);
@@ -113,21 +114,21 @@ class URLDownloadTest {
 
     @Test
     void checkConnectionSuccess() throws MalformedURLException {
-        URLDownload google = new URLDownload(new URL("http://www.google.com"));
+        URLDownload google = new URLDownload(URI.create("http://www.google.com").toURL());
 
         assertTrue(google.canBeReached());
     }
 
     @Test
     void checkConnectionFail() throws MalformedURLException {
-        URLDownload nonsense = new URLDownload(new URL("http://nonsenseadddress"));
+        URLDownload nonsense = new URLDownload(URI.create("http://nonsenseadddress").toURL());
 
         assertThrows(UnirestException.class, nonsense::canBeReached);
     }
 
     @Test
     void connectTimeoutIsNeverNull() throws MalformedURLException {
-        URLDownload urlDownload = new URLDownload(new URL("http://www.example.com"));
+        URLDownload urlDownload = new URLDownload(URI.create("http://www.example.com").toURL());
         assertNotNull(urlDownload.getConnectTimeout(), "there's a non-null default by the constructor");
 
         urlDownload.setConnectTimeout(null);
@@ -136,13 +137,13 @@ class URLDownloadTest {
 
     @Test
     void test503ErrorThrowsFetcherServerException() throws Exception {
-        URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/503"));
+        URLDownload urlDownload = new URLDownload(URI.create("http://httpstat.us/503").toURL());
         assertThrows(FetcherServerException.class, urlDownload::asString);
     }
 
     @Test
     void test429ErrorThrowsFetcherClientException() throws Exception {
-        URLDownload urlDownload = new URLDownload(new URL("http://httpstat.us/429"));
+        URLDownload urlDownload = new URLDownload(URI.create("http://httpstat.us/429").toURL());
         assertThrows(FetcherClientException.class, urlDownload::asString);
     }
 
@@ -162,7 +163,7 @@ class URLDownloadTest {
                         .withHeader("Content-Type", "application/pdf")
                         .withBody(pdfContent)));
 
-        URLDownload urlDownload = new URLDownload(new URL("http://localhost:2222/redirect"));
+        URLDownload urlDownload = new URLDownload(URI.create("http://localhost:2222/redirect").toURL());
         Path downloadedFile = tempDir.resolve("download.pdf");
         urlDownload.toFile(downloadedFile);
         byte[] actual = Files.readAllBytes(downloadedFile);

--- a/src/test/java/org/jabref/logic/util/ExternalLinkCreatorTest.java
+++ b/src/test/java/org/jabref/logic/util/ExternalLinkCreatorTest.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.util;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Optional;
@@ -22,7 +23,7 @@ class ExternalLinkCreatorTest {
     private boolean urlIsValid(String url) {
         try {
             // This will throw on non-compliance to RFC2396.
-            new URL(url).toURI();
+            URI.create(url).toURL().toURI();
             return true;
         } catch (MalformedURLException | URISyntaxException e) {
             return false;

--- a/src/test/java/org/jabref/logic/util/ExternalLinkCreatorTest.java
+++ b/src/test/java/org/jabref/logic/util/ExternalLinkCreatorTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.util;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -1,7 +1,6 @@
 package org.jabref.model.entry;
 
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -1,5 +1,6 @@
 package org.jabref.model.entry;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -259,7 +260,7 @@ class BibEntryTest {
     void replaceOfLinkWorks() throws Exception {
         List<LinkedFile> files = new ArrayList<>();
         String urlAsString = "https://www.example.org/file.pdf";
-        files.add(new LinkedFile(new URL(urlAsString), ""));
+        files.add(new LinkedFile(URI.create(urlAsString).toURL(), ""));
         entry.setFiles(files);
 
         LinkedFile linkedFile = new LinkedFile("", Path.of("file.pdf", ""), "");


### PR DESCRIPTION
Applies https://docs.openrewrite.org/recipes/java/migrate/net/urlconstructorstourirecipes

This reduces compilation warnings.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
