### PR TITLE
Fix "Recent files" menu behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where unescaped braces in the arXiv fetcher were not treated. [#11704](https://github.com/JabRef/jabref/issues/11704)
 - We fixed an issue where HTML instead of the fulltext pdf was downloaded when importing arXiv entries. [#4913](https://github.com/JabRef/jabref/issues/4913)
 - We fixed an issue where the keywords and crossref fields were not properly focused. [#11177](https://github.com/JabRef/jabref/issues/11177)
+- We fixed an issue where recently opened files were not displayed in the main menu properly. [#9042](https://github.com/JabRef/jabref/issues/9042)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/frame/FileHistoryMenu.java
+++ b/src/main/java/org/jabref/gui/frame/FileHistoryMenu.java
@@ -3,6 +3,7 @@ package org.jabref.gui.frame;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import javafx.beans.InvalidationListener;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
@@ -35,6 +36,7 @@ public class FileHistoryMenu extends Menu {
         } else {
             setItems();
         }
+        history.addListener((InvalidationListener) obs -> setItems());
     }
 
     /**


### PR DESCRIPTION
Fixes #9042
"Recent files" menu was not updated in runtime. Now it should be.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
