### PR TITLE
Add options to auto generate embeddings and summaries

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -166,6 +166,7 @@ public class JabRefGUI extends Application {
         Injector.setModelOrService(ClipBoardManager.class, clipBoardManager);
 
         JabRefGUI.aiService = new AiService(
+                stateManager,
                 preferences.getAiPreferences(),
                 preferences.getFilePreferences(),
                 dialogService,
@@ -173,6 +174,7 @@ public class JabRefGUI extends Application {
         Injector.setModelOrService(AiService.class, aiService);
 
         JabRefGUI.chatHistoryService = new ChatHistoryService(
+                stateManager,
                 preferences.getCitationKeyPatternPreferences(),
                 dialogService);
         Injector.setModelOrService(ChatHistoryService.class, chatHistoryService);

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
@@ -43,6 +43,21 @@
             </children>
         </HBox>
 
+        <CheckBox fx:id="autoGenerateEmbeddings"
+                  mnemonicParsing="false"
+                  text="%Automatically generate embeddings for new entries"
+                  HBox.hgrow="ALWAYS"
+                  maxWidth="Infinity"/>
+
+        <CheckBox fx:id="autoGenerateSummaries"
+                  mnemonicParsing="false"
+                  text="%Automatically generate summaries for new entries"
+                  HBox.hgrow="ALWAYS"
+                  maxWidth="Infinity"/>
+
+        <Label styleClass="sectionHeader"
+               text="%Connection"/>
+
         <HBox alignment="CENTER_LEFT"
               layoutX="10.0"
               layoutY="306.0"

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTab.java
@@ -29,6 +29,8 @@ public class AiTab extends AbstractPreferenceTabView<AiTabViewModel> implements 
     private static final String HUGGING_FACE_CHAT_MODEL_PROMPT = "TinyLlama/TinyLlama_v1.1 (or any other model name)";
 
     @FXML private CheckBox enableAi;
+    @FXML private CheckBox autoGenerateEmbeddings;
+    @FXML private CheckBox autoGenerateSummaries;
 
     @FXML private ComboBox<AiProvider> aiProviderComboBox;
     @FXML private ComboBox<String> chatModelComboBox;
@@ -72,6 +74,10 @@ public class AiTab extends AbstractPreferenceTabView<AiTabViewModel> implements 
         this.viewModel = new AiTabViewModel(preferences);
 
         enableAi.selectedProperty().bindBidirectional(viewModel.enableAi());
+        autoGenerateSummaries.selectedProperty().bindBidirectional(viewModel.autoGenerateSummaries());
+        autoGenerateSummaries.disableProperty().bind(viewModel.disableAutoGenerateSummaries());
+        autoGenerateEmbeddings.selectedProperty().bindBidirectional(viewModel.autoGenerateEmbeddings());
+        autoGenerateEmbeddings.disableProperty().bind(viewModel.disableAutoGenerateEmbeddings());
 
         new ViewModelListCellFactory<AiProvider>()
                 .withText(AiProvider::toString)

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTabViewModel.java
@@ -37,6 +37,10 @@ public class AiTabViewModel implements PreferenceTabViewModel {
     private final Locale oldLocale;
 
     private final BooleanProperty enableAi = new SimpleBooleanProperty();
+    private final BooleanProperty autoGenerateEmbeddings = new SimpleBooleanProperty();
+    private final BooleanProperty disableAutoGenerateEmbeddings = new SimpleBooleanProperty();
+    private final BooleanProperty autoGenerateSummaries = new SimpleBooleanProperty();
+    private final BooleanProperty disableAutoGenerateSummaries = new SimpleBooleanProperty();
 
     private final ListProperty<AiProvider> aiProvidersList =
             new SimpleListProperty<>(FXCollections.observableArrayList(AiProvider.values()));
@@ -295,6 +299,8 @@ public class AiTabViewModel implements PreferenceTabViewModel {
         huggingFaceChatModel.setValue(aiPreferences.getHuggingFaceChatModel());
 
         enableAi.setValue(aiPreferences.getEnableAi());
+        autoGenerateSummaries.setValue(aiPreferences.getAutoGenerateSummaries());
+        autoGenerateEmbeddings.setValue(aiPreferences.getAutoGenerateEmbeddings());
 
         selectedAiProvider.setValue(aiPreferences.getAiProvider());
 
@@ -313,6 +319,8 @@ public class AiTabViewModel implements PreferenceTabViewModel {
     @Override
     public void storeSettings() {
         aiPreferences.setEnableAi(enableAi.get());
+        aiPreferences.setAutoGenerateEmbeddings(autoGenerateEmbeddings.get());
+        aiPreferences.setAutoGenerateSummaries(autoGenerateSummaries.get());
 
         aiPreferences.setAiProvider(selectedAiProvider.get());
 
@@ -405,6 +413,22 @@ public class AiTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty enableAi() {
         return enableAi;
+    }
+
+    public BooleanProperty autoGenerateEmbeddings() {
+        return autoGenerateEmbeddings;
+    }
+
+    public BooleanProperty disableAutoGenerateEmbeddings() {
+        return disableAutoGenerateEmbeddings;
+    }
+
+    public BooleanProperty autoGenerateSummaries() {
+        return autoGenerateSummaries;
+    }
+
+    public BooleanProperty disableAutoGenerateSummaries() {
+        return disableAutoGenerateSummaries;
     }
 
     public ReadOnlyListProperty<AiProvider> aiProvidersProperty() {

--- a/src/main/java/org/jabref/logic/ai/AiDefaultPreferences.java
+++ b/src/main/java/org/jabref/logic/ai/AiDefaultPreferences.java
@@ -52,6 +52,8 @@ public class AiDefaultPreferences {
     );
 
     public static final boolean ENABLE_CHAT = false;
+    public static final boolean AUTO_GENERATE_EMBEDDINGS = false;
+    public static final boolean AUTO_GENERATE_SUMMARIES = false;
 
     public static final AiProvider PROVIDER = AiProvider.OPEN_AI;
 

--- a/src/main/java/org/jabref/logic/ai/AiPreferences.java
+++ b/src/main/java/org/jabref/logic/ai/AiPreferences.java
@@ -31,6 +31,8 @@ public class AiPreferences {
     private static final String KEYRING_AI_SERVICE_ACCOUNT = "apiKey";
 
     private final BooleanProperty enableAi;
+    private final BooleanProperty autoGenerateEmbeddings;
+    private final BooleanProperty autoGenerateSummaries;
 
     private final ObjectProperty<AiProvider> aiProvider;
 
@@ -58,6 +60,8 @@ public class AiPreferences {
     private Runnable apiKeyChangeListener;
 
     public AiPreferences(boolean enableAi,
+                         boolean autoGenerateEmbeddings,
+                         boolean autoGenerateSummaries,
                          AiProvider aiProvider,
                          String openAiChatModel,
                          String mistralAiChatModel,
@@ -78,6 +82,8 @@ public class AiPreferences {
                          double ragMinScore
     ) {
         this.enableAi = new SimpleBooleanProperty(enableAi);
+        this.autoGenerateEmbeddings = new SimpleBooleanProperty(autoGenerateEmbeddings);
+        this.autoGenerateSummaries = new SimpleBooleanProperty(autoGenerateSummaries);
 
         this.aiProvider = new SimpleObjectProperty<>(aiProvider);
 
@@ -141,6 +147,30 @@ public class AiPreferences {
 
     public void setEnableAi(boolean enableAi) {
         this.enableAi.set(enableAi);
+    }
+
+    public BooleanProperty autoGenerateEmbeddingsProperty() {
+        return autoGenerateEmbeddings;
+    }
+
+    public boolean getAutoGenerateEmbeddings() {
+        return autoGenerateEmbeddings.get();
+    }
+
+    public void setAutoGenerateEmbeddings(boolean autoGenerateEmbeddings) {
+        this.autoGenerateEmbeddings.set(autoGenerateEmbeddings);
+    }
+
+    public BooleanProperty autoGenerateSummariesProperty() {
+        return autoGenerateSummaries;
+    }
+
+    public boolean getAutoGenerateSummaries() {
+        return autoGenerateSummaries.get();
+    }
+
+    public void setAutoGenerateSummaries(boolean autoGenerateSummaries) {
+        this.autoGenerateSummaries.set(autoGenerateSummaries);
     }
 
     public ObjectProperty<AiProvider> aiProviderProperty() {

--- a/src/main/java/org/jabref/logic/ai/AiService.java
+++ b/src/main/java/org/jabref/logic/ai/AiService.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 
+import org.jabref.gui.StateManager;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.ai.chatting.AiChatService;
 import org.jabref.logic.ai.chatting.model.JabRefChatLanguageModel;
@@ -52,7 +53,8 @@ public class AiService implements AutoCloseable {
     private final IngestionService ingestionService;
     private final SummariesService summariesService;
 
-    public AiService(AiPreferences aiPreferences,
+    public AiService(StateManager stateManager,
+                     AiPreferences aiPreferences,
                      FilePreferences filePreferences,
                      NotificationService notificationService,
                      TaskExecutor taskExecutor
@@ -64,8 +66,11 @@ public class AiService implements AutoCloseable {
         this.mvStoreSummariesStorage = new MVStoreSummariesStorage(Directories.getAiFilesDirectory().resolve(SUMMARIES_FILE_NAME), notificationService);
 
         this.jabRefEmbeddingModel = new JabRefEmbeddingModel(aiPreferences, notificationService, taskExecutor);
+
         this.aiChatService = new AiChatService(aiPreferences, jabRefChatLanguageModel, jabRefEmbeddingModel, mvStoreEmbeddingStore, cachedThreadPool);
+
         this.ingestionService = new IngestionService(
+                stateManager,
                 aiPreferences,
                 shutdownSignal,
                 jabRefEmbeddingModel,
@@ -74,7 +79,16 @@ public class AiService implements AutoCloseable {
                 filePreferences,
                 taskExecutor
         );
-        this.summariesService = new SummariesService(aiPreferences, mvStoreSummariesStorage, jabRefChatLanguageModel, shutdownSignal, filePreferences, taskExecutor);
+
+        this.summariesService = new SummariesService(
+                stateManager,
+                aiPreferences,
+                mvStoreSummariesStorage,
+                jabRefChatLanguageModel,
+                shutdownSignal,
+                filePreferences,
+                taskExecutor
+        );
     }
 
     public JabRefChatLanguageModel getChatLanguageModel() {

--- a/src/main/java/org/jabref/logic/ai/ingestion/IngestionService.java
+++ b/src/main/java/org/jabref/logic/ai/ingestion/IngestionService.java
@@ -1,9 +1,7 @@
 package org.jabref.logic.ai.ingestion;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.TreeMap;
 
 import javafx.beans.property.ReadOnlyBooleanProperty;
@@ -18,11 +16,8 @@ import org.jabref.logic.ai.processingstatus.ProcessingState;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.event.EntriesAddedEvent;
-import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
-import org.jabref.model.entry.event.FieldAddedOrRemovedEvent;
 import org.jabref.model.entry.event.FieldChangedEvent;
-import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.entry.field.StandardField;
 
 import com.google.common.eventbus.Subscribe;

--- a/src/main/java/org/jabref/logic/ai/summarization/SummariesService.java
+++ b/src/main/java/org/jabref/logic/ai/summarization/SummariesService.java
@@ -1,9 +1,11 @@
 package org.jabref.logic.ai.summarization;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.ListChangeListener;
@@ -11,13 +13,18 @@ import javafx.collections.ListChangeListener;
 import org.jabref.gui.StateManager;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.ai.AiPreferences;
+import org.jabref.logic.ai.ingestion.IngestionService;
 import org.jabref.logic.ai.processingstatus.ProcessingInfo;
 import org.jabref.logic.ai.processingstatus.ProcessingState;
 import org.jabref.logic.ai.util.CitationKeyCheck;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.database.event.EntriesAddedEvent;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.event.FieldChangedEvent;
+import org.jabref.model.entry.field.StandardField;
 
+import com.google.common.eventbus.Subscribe;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,9 +41,8 @@ import org.slf4j.LoggerFactory;
 public class SummariesService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SummariesService.class);
 
-    private final Map<BibEntry, ProcessingInfo<BibEntry, Summary>> summariesStatusMap = new HashMap<>();
+    private final TreeMap<BibEntry, ProcessingInfo<BibEntry, Summary>> summariesStatusMap = new TreeMap<>(Comparator.comparing(BibEntry::getId));
 
-    private final StateManager stateManager;
     private final AiPreferences aiPreferences;
     private final SummariesStorage summariesStorage;
     private final ChatLanguageModel chatLanguageModel;
@@ -52,13 +58,14 @@ public class SummariesService {
                             FilePreferences filePreferences,
                             TaskExecutor taskExecutor
     ) {
-        this.stateManager = stateManager;
         this.aiPreferences = aiPreferences;
         this.summariesStorage = summariesStorage;
         this.chatLanguageModel = chatLanguageModel;
         this.shutdownSignal = shutdownSignal;
         this.filePreferences = filePreferences;
         this.taskExecutor = taskExecutor;
+
+        configureDatabaseListeners(stateManager);
     }
 
     private void configureDatabaseListeners(StateManager stateManager) {
@@ -72,17 +79,32 @@ public class SummariesService {
     }
 
     private void configureDatabaseListeners(BibDatabaseContext bibDatabaseContext) {
-        bibDatabaseContext.getDatabase().getEntries().addListener((ListChangeListener<BibEntry>) change -> {
-            while (change.next()) {
-                if (change.wasAdded()) {
-                    change.getAddedSubList().forEach(entry -> {
-                        if (aiPreferences.getAutoGenerateEmbeddings()) {
-                            summarize(entry, bibDatabaseContext);
-                        }
-                    });
+        // GC was eating the listeners, so we have to fall back to the event bus.
+        bibDatabaseContext.getDatabase().registerListener(new EntriesChangedListener(bibDatabaseContext));
+    }
+
+    private class EntriesChangedListener {
+        private final BibDatabaseContext bibDatabaseContext;
+
+        public EntriesChangedListener(BibDatabaseContext bibDatabaseContext) {
+            this.bibDatabaseContext = bibDatabaseContext;
+        }
+
+        @Subscribe
+        public void listen(EntriesAddedEvent e) {
+            e.getBibEntries().forEach(entry -> {
+                if (aiPreferences.getAutoGenerateSummaries()) {
+                    summarize(entry, bibDatabaseContext);
                 }
+            });
+        }
+
+        @Subscribe
+        public void listen(FieldChangedEvent e) {
+            if (e.getField() == StandardField.FILE && aiPreferences.getAutoGenerateSummaries()) {
+                summarize(e.getBibEntry(), bibDatabaseContext);
             }
-        });
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/logic/ai/summarization/SummariesService.java
+++ b/src/main/java/org/jabref/logic/ai/summarization/SummariesService.java
@@ -2,8 +2,6 @@ package org.jabref.logic.ai.summarization;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
@@ -13,7 +11,6 @@ import javafx.collections.ListChangeListener;
 import org.jabref.gui.StateManager;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.ai.AiPreferences;
-import org.jabref.logic.ai.ingestion.IngestionService;
 import org.jabref.logic.ai.processingstatus.ProcessingInfo;
 import org.jabref.logic.ai.processingstatus.ProcessingState;
 import org.jabref.logic.ai.util.CitationKeyCheck;

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -340,6 +340,8 @@ public class JabRefCliPreferences implements CliPreferences {
     private static final String REMOTE_SERVER_PORT = "remoteServerPort";
 
     private static final String AI_ENABLED = "aiEnabled";
+    private static final String AI_AUTO_GENERATE_EMBEDDINGS = "aiAutoGenerateEmbeddings";
+    private static final String AI_AUTO_GENERATE_SUMMARIES = "aiAutoGenerateSummaries";
     private static final String AI_PROVIDER = "aiProvider";
     private static final String AI_OPEN_AI_CHAT_MODEL = "aiOpenAiChatModel";
     private static final String AI_MISTRAL_AI_CHAT_MODEL = "aiMistralAiChatModel";
@@ -620,6 +622,8 @@ public class JabRefCliPreferences implements CliPreferences {
 
         // region:AI
         defaults.put(AI_ENABLED, AiDefaultPreferences.ENABLE_CHAT);
+        defaults.put(AI_AUTO_GENERATE_EMBEDDINGS, AiDefaultPreferences.AUTO_GENERATE_EMBEDDINGS);
+        defaults.put(AI_AUTO_GENERATE_SUMMARIES, AiDefaultPreferences.AUTO_GENERATE_SUMMARIES);
         defaults.put(AI_PROVIDER, AiDefaultPreferences.PROVIDER.name());
         defaults.put(AI_OPEN_AI_CHAT_MODEL, AiDefaultPreferences.CHAT_MODELS.get(AiProvider.OPEN_AI));
         defaults.put(AI_MISTRAL_AI_CHAT_MODEL, AiDefaultPreferences.CHAT_MODELS.get(AiProvider.MISTRAL_AI));
@@ -1811,6 +1815,8 @@ public class JabRefCliPreferences implements CliPreferences {
 
         aiPreferences = new AiPreferences(
                 aiEnabled,
+                getBoolean(AI_AUTO_GENERATE_EMBEDDINGS),
+                getBoolean(AI_AUTO_GENERATE_SUMMARIES),
                 AiProvider.valueOf(get(AI_PROVIDER)),
                 get(AI_OPEN_AI_CHAT_MODEL),
                 get(AI_MISTRAL_AI_CHAT_MODEL),
@@ -1831,6 +1837,8 @@ public class JabRefCliPreferences implements CliPreferences {
                 getDouble(AI_RAG_MIN_SCORE));
 
         EasyBind.listen(aiPreferences.enableAiProperty(), (obs, oldValue, newValue) -> putBoolean(AI_ENABLED, newValue));
+        EasyBind.listen(aiPreferences.autoGenerateEmbeddingsProperty(), (obs, oldValue, newValue) -> putBoolean(AI_AUTO_GENERATE_EMBEDDINGS, newValue));
+        EasyBind.listen(aiPreferences.autoGenerateSummariesProperty(), (obs, oldValue, newValue) -> putBoolean(AI_AUTO_GENERATE_SUMMARIES, newValue));
 
         EasyBind.listen(aiPreferences.aiProviderProperty(), (obs, oldValue, newValue) -> put(AI_PROVIDER, newValue.name()));
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2633,6 +2633,9 @@ RAG\ minimum\ score\ must\ be\ a\ number=RAG minimum score must be a number
 RAG\ minimum\ score\ must\ be\ greater\ than\ 0\ and\ less\ than\ 1=RAG minimum score must be greater than 0 and less than 1
 Temperature\ must\ be\ a\ number=Temperature must be a number
 If\ you\ have\ chosen\ %0\ as\ an\ AI\ provider,\ the\ privacy\ policy\ of\ %0\ applies.\ You\ find\ it\ at\ %1.=If you have chosen %0 as an AI provider, the privacy policy of %0 applies. You find it at %1.
+Automatically\ generate\ embeddings\ for\ new\ entries=Automatically generate embeddings for new entries
+Automatically\ generate\ summaries\ for\ new\ entries=Automatically generate summaries for new entries
+Connection=Connection
 
 Link=Link
 Source\ URL=Source URL


### PR DESCRIPTION
Partially closes https://github.com/JabRef/jabref-issue-melting-pot/issues/546.

New options:
![image](https://github.com/user-attachments/assets/a82b3108-febd-4f20-a6ec-d3318fa67365)

I think this space after "Enable AI" is because of the help button.

I'll address the help buttons in other PR.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
