### PR TITLE
Remove too many help for AI

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
@@ -26,26 +26,23 @@
         <Label styleClass="titleHeader"
                text="%AI"/>
 
-        <Label styleClass="sectionHeader"
-               text="%General"/>
-
-        <HBox alignment="CENTER_LEFT"
-              spacing="10.0">
-            <children>
-                <CheckBox
-                        fx:id="enableAi"
-                        mnemonicParsing="false"
-                        text="%Enable AI functionality (summary generation and chatting) in JabRef"
-                        HBox.hgrow="ALWAYS"
-                        maxWidth="Infinity"/>
-                <Button fx:id="enableAiHelp"
-                        prefWidth="20.0"/>
-            </children>
+        <HBox alignment="BASELINE_CENTER">
+            <Label styleClass="sectionHeader"
+                   text="%General"
+                   maxWidth="Infinity"
+                   HBox.hgrow="ALWAYS"/>
+            <Button fx:id="generalSettingsHelp"
+                    prefWidth="20.0"/>
         </HBox>
 
+        <CheckBox
+                fx:id="enableAi"
+                mnemonicParsing="false"
+                text="%Enable AI functionality (summary generation and chatting) in JabRef"
+                HBox.hgrow="ALWAYS"
+                maxWidth="Infinity"/>
+
         <HBox alignment="CENTER_LEFT"
-              layoutX="10.0"
-              layoutY="306.0"
               spacing="10.0">
             <children>
                 <Label alignment="BASELINE_CENTER"
@@ -54,8 +51,6 @@
                         fx:id="aiProviderComboBox"
                         maxWidth="1.7976931348623157E308"
                         HBox.hgrow="ALWAYS"/>
-                <Button fx:id="aiProviderHelp"
-                        prefWidth="20.0"/>
             </children>
         </HBox>
 
@@ -69,8 +64,6 @@
                         editable="true"
                         maxWidth="1.7976931348623157E308"
                         HBox.hgrow="ALWAYS"/>
-                <Button fx:id="chatModelHelp"
-                        prefWidth="20.0"/>
             </children>
             <padding>
                 <Insets left="20.0"/>
@@ -85,16 +78,21 @@
                 <CustomPasswordField
                         fx:id="apiKeyTextField"
                         HBox.hgrow="ALWAYS"/>
-                <Button fx:id="apiKeyHelp"
-                        prefWidth="20.0"/>
             </children>
             <padding>
                 <Insets left="20.0"/>
             </padding>
         </HBox>
 
-        <Label styleClass="sectionHeader"
-               text="%Expert settings"/>
+        <HBox alignment="BASELINE_LEFT">
+            <Label styleClass="sectionHeader"
+                   text="%Expert settings"
+                   maxWidth="Infinity"
+                   HBox.hgrow="ALWAYS"/>
+            <Button fx:id="expertSettingsHelp"
+                    prefWidth="20.0"/>
+        </HBox>
+
         <VBox>
             <children>
                 <Label text="%These parameters affect how the AI will answer your questions."/>
@@ -118,8 +116,6 @@
                         disable="true"
                         maxWidth="1.7976931348623157E308"
                         HBox.hgrow="ALWAYS"/>
-                <Button fx:id="apiBaseUrlHelp"
-                        prefWidth="20.0"/>
             </children>
         </HBox>
 
@@ -132,8 +128,6 @@
                         fx:id="embeddingModelComboBox"
                         maxWidth="1.7976931348623157E308"
                         HBox.hgrow="ALWAYS"/>
-                <Button fx:id="embeddingModelHelp"
-                        prefWidth="20.0"/>
             </children>
         </HBox>
 
@@ -150,8 +144,6 @@
                 <Label maxWidth="1.7976931348623157E308"
                        text="%Instruction for AI (also known as prompt or system message)"
                        HBox.hgrow="ALWAYS"/>
-                <Button fx:id="instructionHelp"
-                        prefWidth="20.0"/>
             </children>
         </HBox>
 
@@ -165,85 +157,55 @@
                 <ColumnConstraints hgrow="ALWAYS" percentWidth="50" />
             </columnConstraints>
 
-            <!-- Context Window Size -->
             <VBox spacing="10" GridPane.columnIndex="0" GridPane.rowIndex="0">
-                <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%Context window size"/>
-                    <Button fx:id="contextWindowSizeHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+                <Label HBox.hgrow="ALWAYS"
+                       maxWidth="Infinity"
+                       text="%Context window size"/>
                 <IntegerInputField
                         fx:id="contextWindowSizeTextField"
                         HBox.hgrow="ALWAYS"/>
             </VBox>
 
-            <!-- Temperature -->
             <VBox spacing="10" GridPane.columnIndex="1" GridPane.rowIndex="0">
-                <HBox spacing="10">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%Temperature"/>
-                    <Button fx:id="temperatureHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+                <Label HBox.hgrow="ALWAYS"
+                       maxWidth="Infinity"
+                       text="%Temperature"/>
                 <TextField
                         fx:id="temperatureTextField"
                         HBox.hgrow="ALWAYS"/>
             </VBox>
 
-            <!-- RAG - Maximum Results Count -->
             <VBox spacing="10" GridPane.columnIndex="0" GridPane.rowIndex="1">
-                <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%RAG - maximum results count"/>
-                    <Button fx:id="ragMaxResultsCountHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+                <Label HBox.hgrow="ALWAYS"
+                       maxWidth="Infinity"
+                       text="%RAG - maximum results count"/>
                 <IntegerInputField
                         fx:id="ragMaxResultsCountTextField"
                         HBox.hgrow="ALWAYS"/>
             </VBox>
 
-            <!-- RAG - Minimum Score -->
             <VBox spacing="10" GridPane.columnIndex="1" GridPane.rowIndex="1">
-                <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%RAG - minimum score"/>
-                    <Button fx:id="ragMinScoreHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+                <Label HBox.hgrow="ALWAYS"
+                       maxWidth="Infinity"
+                       text="%RAG - minimum score"/>
                 <TextField
                         fx:id="ragMinScoreTextField"
                         HBox.hgrow="ALWAYS"/>
             </VBox>
 
-            <!-- Document Splitter - Chunk Size -->
             <VBox spacing="10" GridPane.columnIndex="0" GridPane.rowIndex="2">
-                <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%Document splitter - chunk size"/>
-                    <Button fx:id="documentSplitterChunkSizeHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+            <Label HBox.hgrow="ALWAYS"
+                   maxWidth="Infinity"
+                   text="%Document splitter - chunk size"/>
                 <IntegerInputField
                         fx:id="documentSplitterChunkSizeTextField"
                         HBox.hgrow="ALWAYS"/>
             </VBox>
 
-            <!-- Document Splitter - Overlap Size -->
             <VBox spacing="10" GridPane.columnIndex="1" GridPane.rowIndex="2">
-                <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label HBox.hgrow="ALWAYS"
-                           maxWidth="Infinity"
-                           text="%Document splitter - overlap size"/>
-                    <Button fx:id="documentSplitterOverlapSizeHelp"
-                            prefWidth="20.0"/>
-                </HBox>
+                <Label HBox.hgrow="ALWAYS"
+                       maxWidth="Infinity"
+                       text="%Document splitter - overlap size"/>
                 <IntegerInputField
                         fx:id="documentSplitterOverlapSizeTextField"
                         HBox.hgrow="ALWAYS"/>

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTab.java
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTab.java
@@ -46,19 +46,8 @@ public class AiTab extends AbstractPreferenceTabView<AiTabViewModel> implements 
     @FXML private IntegerInputField ragMaxResultsCountTextField;
     @FXML private TextField ragMinScoreTextField;
 
-    @FXML private Button enableAiHelp;
-    @FXML private Button aiProviderHelp;
-    @FXML private Button chatModelHelp;
-    @FXML private Button apiKeyHelp;
-    @FXML private Button apiBaseUrlHelp;
-    @FXML private Button embeddingModelHelp;
-    @FXML private Button instructionHelp;
-    @FXML private Button contextWindowSizeHelp;
-    @FXML private Button temperatureHelp;
-    @FXML private Button documentSplitterChunkSizeHelp;
-    @FXML private Button documentSplitterOverlapSizeHelp;
-    @FXML private Button ragMaxResultsCountHelp;
-    @FXML private Button ragMinScoreHelp;
+    @FXML private Button generalSettingsHelp;
+    @FXML private Button expertSettingsHelp;
 
     private final ControlsFxVisualizer visualizer = new ControlsFxVisualizer();
 
@@ -185,19 +174,8 @@ public class AiTab extends AbstractPreferenceTabView<AiTabViewModel> implements 
         });
 
         ActionFactory actionFactory = new ActionFactory();
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_ENABLE, dialogService, preferences.getExternalApplicationsPreferences()), enableAiHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_PROVIDER, dialogService, preferences.getExternalApplicationsPreferences()), aiProviderHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_CHAT_MODEL, dialogService, preferences.getExternalApplicationsPreferences()), chatModelHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_API_KEY, dialogService, preferences.getExternalApplicationsPreferences()), apiKeyHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_EMBEDDING_MODEL, dialogService, preferences.getExternalApplicationsPreferences()), embeddingModelHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_API_BASE_URL, dialogService, preferences.getExternalApplicationsPreferences()), apiBaseUrlHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_INSTRUCTION, dialogService, preferences.getExternalApplicationsPreferences()), instructionHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_CONTEXT_WINDOW_SIZE, dialogService, preferences.getExternalApplicationsPreferences()), contextWindowSizeHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_TEMPERATURE, dialogService, preferences.getExternalApplicationsPreferences()), temperatureHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_DOCUMENT_SPLITTER_CHUNK_SIZE, dialogService, preferences.getExternalApplicationsPreferences()), documentSplitterChunkSizeHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_DOCUMENT_SPLITTER_OVERLAP_SIZE, dialogService, preferences.getExternalApplicationsPreferences()), documentSplitterOverlapSizeHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_RAG_MAX_RESULTS_COUNT, dialogService, preferences.getExternalApplicationsPreferences()), ragMaxResultsCountHelp);
-        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_RAG_MIN_SCORE, dialogService, preferences.getExternalApplicationsPreferences()), ragMinScoreHelp);
+        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_GENERAL_SETTINGS, dialogService, preferences.getExternalApplicationsPreferences()), generalSettingsHelp);
+        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AI_EXPERT_SETTINGS, dialogService, preferences.getExternalApplicationsPreferences()), expertSettingsHelp);
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/help/HelpFile.java
+++ b/src/main/java/org/jabref/logic/help/HelpFile.java
@@ -47,19 +47,8 @@ public enum HelpFile {
     FIND_DUPLICATES("finding-sorting-and-cleaning-entries/findduplicates"),
     SQL_DATABASE_MIGRATION("collaborative-work/sqldatabase/sqldatabasemigration"),
     PUSH_TO_APPLICATION("cite/pushtoapplications"),
-    AI_ENABLE("ai"),
-    AI_PROVIDER("ai/ai-providers-and-api-keys#what-is-an-ai-provider"),
-    AI_CHAT_MODEL("ai/preferences"),
-    AI_API_KEY("ai/ai-providers-and-api-keys#what-is-an-api-key"),
-    AI_API_BASE_URL("ai/preferences#api-base-url"),
-    AI_EMBEDDING_MODEL("ai/preferences#embedding-model"),
-    AI_INSTRUCTION("ai/preferences#instruction"),
-    AI_CONTEXT_WINDOW_SIZE("ai/preferences#context-window-size"),
-    AI_TEMPERATURE("ai/preferences#temperature"),
-    AI_DOCUMENT_SPLITTER_CHUNK_SIZE("ai/preferences#document-splitter-chunk-size"),
-    AI_DOCUMENT_SPLITTER_OVERLAP_SIZE("ai/preferences#document-splitter-chunk-overlap"),
-    AI_RAG_MAX_RESULTS_COUNT("ai/preferences#retrieval-augmented-generation-maximum-results-count"),
-    AI_RAG_MIN_SCORE("ai/preferences#retrieval-augmented-generation-minimum-score");
+    AI_GENERAL_SETTINGS("ai/preferences"),
+    AI_EXPERT_SETTINGS("ai/preferences#ai-expert-settings");
 
     private final String pageName;
 


### PR DESCRIPTION
Closes and issue with too many help buttons in AI preferences, which was raised by Carl some time ago in Skype.

New UI:
![image](https://github.com/user-attachments/assets/dbad912e-2028-4335-9511-24b364e0468e)

Old UI:
![image](https://github.com/user-attachments/assets/abaf5deb-9d01-4365-b02c-8dabce528fde)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
