### PR TITLE
Less toolbar spacing option

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,9 +7,6 @@ open module org.jabref {
     requires java.sql.rowset;
 
     // region JavaFX
-    requires javafx.base;
-    requires javafx.graphics;
-    requires javafx.controls;
     requires javafx.web;
     requires javafx.fxml;
 
@@ -189,5 +186,6 @@ open module org.jabref {
     requires org.antlr.antlr4.runtime;
     requires org.libreoffice.uno;
     requires langchain4j.google.ai.gemini;
+    requires net.synedra.validatorfx;
     // endregion
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,6 +7,9 @@ open module org.jabref {
     requires java.sql.rowset;
 
     // region JavaFX
+    requires javafx.base;
+    requires javafx.graphics;
+    requires javafx.controls;
     requires javafx.web;
     requires javafx.fxml;
 
@@ -186,6 +189,5 @@ open module org.jabref {
     requires org.antlr.antlr4.runtime;
     requires org.libreoffice.uno;
     requires langchain4j.google.ai.gemini;
-    requires net.synedra.validatorfx;
     // endregion
 }

--- a/src/main/java/org/jabref/gui/WorkspacePreferences.java
+++ b/src/main/java/org/jabref/gui/WorkspacePreferences.java
@@ -19,6 +19,7 @@ public class WorkspacePreferences {
     private final BooleanProperty shouldOverrideDefaultFontSize;
     private final IntegerProperty mainFontSize;
     private final IntegerProperty defaultFontSize;
+    private final BooleanProperty useLessSpacingInToolbar;
     private final ObjectProperty<Theme> theme;
     private final BooleanProperty themeSyncOs;
     private final BooleanProperty shouldOpenLastEdited;
@@ -31,6 +32,7 @@ public class WorkspacePreferences {
                                 boolean shouldOverrideDefaultFontSize,
                                 int mainFontSize,
                                 int defaultFontSize,
+                                boolean useLessSpacingInToolbar,
                                 Theme theme,
                                 boolean themeSyncOs,
                                 boolean shouldOpenLastEdited,
@@ -42,6 +44,7 @@ public class WorkspacePreferences {
         this.shouldOverrideDefaultFontSize = new SimpleBooleanProperty(shouldOverrideDefaultFontSize);
         this.mainFontSize = new SimpleIntegerProperty(mainFontSize);
         this.defaultFontSize = new SimpleIntegerProperty(defaultFontSize);
+        this.useLessSpacingInToolbar = new SimpleBooleanProperty(useLessSpacingInToolbar);
         this.theme = new SimpleObjectProperty<>(theme);
         this.themeSyncOs = new SimpleBooleanProperty(themeSyncOs);
         this.shouldOpenLastEdited = new SimpleBooleanProperty(shouldOpenLastEdited);
@@ -89,6 +92,18 @@ public class WorkspacePreferences {
 
     public IntegerProperty mainFontSizeProperty() {
         return mainFontSize;
+    }
+
+    public void setUseLessSpacingInToolbar(boolean useLessSpacingInToolbar) {
+        this.useLessSpacingInToolbar.set(useLessSpacingInToolbar);
+    }
+
+    public BooleanProperty useLessSpacingInToolbarProperty() {
+        return useLessSpacingInToolbar;
+    }
+
+    public boolean getUseLessSpacingInToolbar() {
+        return useLessSpacingInToolbar.get();
     }
 
     public Theme getTheme() {

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -111,18 +111,23 @@ public class MainToolBar extends ToolBar {
         // Therefore, the condition of enablement is "only" if a library is opened. (Parameter "false")
         Button newEntryFromPlainTextOnlineButton = factory.createIconButton(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new ExtractBibtexActionOnline(dialogService, preferences, stateManager, false));
 
-        getItems().addAll(
+        getItems().add(
                 new HBox(
                         factory.createIconButton(StandardActions.NEW_LIBRARY, new NewDatabaseAction(frame, preferences)),
                         factory.createIconButton(StandardActions.OPEN_LIBRARY, new OpenDatabaseAction(frame, preferences, aiService, dialogService, stateManager, fileUpdateMonitor, entryTypesManager, undoManager, clipBoardManager, taskExecutor)),
-                        factory.createIconButton(StandardActions.SAVE_LIBRARY, new SaveAction(SaveAction.SaveMethod.SAVE, frame::getCurrentLibraryTab, dialogService, preferences, stateManager))),
+                        factory.createIconButton(StandardActions.SAVE_LIBRARY, new SaveAction(SaveAction.SaveMethod.SAVE, frame::getCurrentLibraryTab, dialogService, preferences, stateManager))));
 
-                leftSpacer,
+        if (!preferences.getWorkspacePreferences().getUseLessSpacingInToolbar()) {
+            getItems().add(leftSpacer);
+        }
 
-                globalSearchBar,
+        getItems().add(globalSearchBar);
 
-                rightSpacer,
+        if (!preferences.getWorkspacePreferences().getUseLessSpacingInToolbar()) {
+            getItems().add(rightSpacer);
+        }
 
+        getItems().addAll(
                 new HBox(
                         factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(frame::getCurrentLibraryTab, StandardEntryType.Article, dialogService, preferences, stateManager)),
                         factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),
@@ -163,6 +168,13 @@ public class MainToolBar extends ToolBar {
         HBox.setHgrow(rightSpacer, Priority.SOMETIMES);
 
         getStyleClass().add("mainToolbar");
+
+        if (preferences.getWorkspacePreferences().getUseLessSpacingInToolbar()) {
+            getItems().stream().filter(node -> node instanceof Separator).map(node -> (Separator) node).forEach(separator -> {
+                separator.setMinWidth(5);
+                separator.setPrefWidth(5);
+            });
+        }
     }
 
     Button createNewEntryFromIdButton() {

--- a/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -116,6 +116,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String SIDE_PANE_WIDTH = "sidePaneWidthFX";
     private static final String SIDE_PANE_COMPONENT_PREFERRED_POSITIONS = "sidePaneComponentPreferredPositions";
     private static final String SIDE_PANE_COMPONENT_NAMES = "sidePaneComponentNames";
+    private static final String USE_LESS_SPACING_IN_TOOLBAR = "useLessSpacingInToolbar";
     // endregion
 
     // region main table, main table columns, save columns
@@ -260,6 +261,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         // region workspace
         defaults.put(MAIN_FONT_SIZE, 9);
+        defaults.put(USE_LESS_SPACING_IN_TOOLBAR, Boolean.FALSE);
         defaults.put(OVERRIDE_DEFAULT_FONT_SIZE, false);
         defaults.put(OPEN_LAST_EDITED, Boolean.TRUE);
         defaults.put(THEME, Theme.BASE_CSS);
@@ -620,6 +622,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getBoolean(OVERRIDE_DEFAULT_FONT_SIZE),
                 getInt(MAIN_FONT_SIZE),
                 (Integer) defaults.get(MAIN_FONT_SIZE),
+                getBoolean(USE_LESS_SPACING_IN_TOOLBAR),
                 new Theme(get(THEME)),
                 getBoolean(THEME_SYNC_OS),
                 getBoolean(OPEN_LAST_EDITED),
@@ -638,6 +641,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         EasyBind.listen(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), (obs, oldValue, newValue) -> putBoolean(OVERRIDE_DEFAULT_FONT_SIZE, newValue));
         EasyBind.listen(workspacePreferences.mainFontSizeProperty(), (obs, oldValue, newValue) -> putInt(MAIN_FONT_SIZE, newValue));
+        EasyBind.listen(workspacePreferences.useLessSpacingInToolbarProperty(), (obs, oldValue, newValue) -> putBoolean(USE_LESS_SPACING_IN_TOOLBAR, newValue));
         EasyBind.listen(workspacePreferences.themeProperty(), (obs, oldValue, newValue) -> put(THEME, newValue.getName()));
         EasyBind.listen(workspacePreferences.themeSyncOsProperty(), (obs, oldValue, newValue) -> putBoolean(THEME_SYNC_OS, newValue));
         EasyBind.listen(workspacePreferences.openLastEditedProperty(), (obs, oldValue, newValue) -> putBoolean(OPEN_LAST_EDITED, newValue));

--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTab.fxml
@@ -60,6 +60,9 @@
             <Label text="%Size"/>
             <Spinner fx:id="fontSize" styleClass="fontsizeSpinner" editable="true"/>
         </HBox>
+
+        <CheckBox fx:id="useLessSpacingInToolbar" text="%Use less spacing in toolbar"
+                  GridPane.rowIndex="5" GridPane.columnIndex="0"/>
     </GridPane>
 
     <Hyperlink fx:id="moreThemes" text = "%Get more themes..." onAction="#openBrowser"/>

--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
@@ -42,6 +42,7 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     @FXML private Button customThemeBrowse;
     @FXML private CheckBox fontOverride;
     @FXML private Spinner<Integer> fontSize;
+    @FXML private CheckBox useLessSpacingInToolbar;
     @FXML private CheckBox openLastStartup;
     @FXML private CheckBox showAdvancedHints;
     @FXML private CheckBox inspectionWarningDuplicate;
@@ -99,6 +100,8 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
         fontSize.setValueFactory(GeneralTabViewModel.fontSizeValueFactory);
         fontSize.getEditor().textProperty().bindBidirectional(viewModel.fontSizeProperty());
         fontSize.getEditor().setTextFormatter(fontSizeFormatter);
+
+        useLessSpacingInToolbar.selectedProperty().bindBidirectional(viewModel.useLessSpacingInToolbarProperty());
 
         new ViewModelListCellFactory<ThemeTypes>()
                 .withText(ThemeTypes::getDisplayName)

--- a/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -72,6 +72,8 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty fontOverrideProperty = new SimpleBooleanProperty();
     private final StringProperty fontSizeProperty = new SimpleStringProperty();
 
+    private final BooleanProperty useLessSpacingInToolbar = new SimpleBooleanProperty();
+
     private final BooleanProperty openLastStartupProperty = new SimpleBooleanProperty();
     private final BooleanProperty showAdvancedHintsProperty = new SimpleBooleanProperty();
     private final BooleanProperty inspectionWarningDuplicateProperty = new SimpleBooleanProperty();
@@ -179,6 +181,8 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
         fontOverrideProperty.setValue(workspacePreferences.shouldOverrideDefaultFontSize());
         fontSizeProperty.setValue(String.valueOf(workspacePreferences.getMainFontSize()));
 
+        useLessSpacingInToolbar.setValue(workspacePreferences.getUseLessSpacingInToolbar());
+
         openLastStartupProperty.setValue(workspacePreferences.shouldOpenLastEdited());
         showAdvancedHintsProperty.setValue(workspacePreferences.shouldShowAdvancedHints());
         inspectionWarningDuplicateProperty.setValue(workspacePreferences.shouldWarnAboutDuplicatesInInspection());
@@ -219,6 +223,12 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
                     workspacePreferences.setTheme(Theme.custom(customPathToThemeProperty.getValue()));
         }
         workspacePreferences.setThemeSyncOs(themeSyncOsProperty.getValue());
+
+        if (workspacePreferences.getUseLessSpacingInToolbar() != useLessSpacingInToolbar.getValue()) {
+            restartWarning.add(Localization.lang("Changed toolbar spacing"));
+        }
+
+        workspacePreferences.setUseLessSpacingInToolbar(useLessSpacingInToolbar.getValue());
 
         workspacePreferences.setOpenLastEdited(openLastStartupProperty.getValue());
         workspacePreferences.setShowAdvancedHints(showAdvancedHintsProperty.getValue());
@@ -353,6 +363,10 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     public StringProperty fontSizeProperty() {
         return fontSizeProperty;
+    }
+
+    public BooleanProperty useLessSpacingInToolbarProperty() {
+        return useLessSpacingInToolbar;
     }
 
     public BooleanProperty openLastStartupProperty() {

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2110,6 +2110,8 @@ Reset\ to\ recommended=Reset to recommended
 Remove\ all=Remove all
 Reset\ All=Reset All
 Linked\ identifiers=Linked identifiers
+Changed\ toolbar\ spacing=Changed toolbar spacing
+Use\ less\ spacing\ in\ toolbar=Use less spacing in toolbar
 
 insert\ entries=insert entries
 


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/561.

What do you think?

New UI:

Toolbar:
![image_2024-09-26_10-51-10](https://github.com/user-attachments/assets/f1f884e7-f5d4-4fb5-9a6d-920d09e40001)

Setting:
![image](https://github.com/user-attachments/assets/90fa51c3-0e5d-490f-a79a-ffc435dcef87)

Old UI:
![image_2024-09-26_10-49-18](https://github.com/user-attachments/assets/320b9ebd-f813-4c6a-a850-0c0db6914cd0)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
