### PR TITLE
convert Inner classes to record classes

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -163,7 +163,6 @@ public class SourceTab extends EntryEditorTab {
 
         @Override
         public void cancelLatestCommittedText() {
-            return;
         }
 
         @Override

--- a/src/main/java/org/jabref/logic/importer/fileformat/MrDLibImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MrDLibImporter.java
@@ -6,6 +6,7 @@ package org.jabref.logic.importer.fileformat;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -91,15 +92,7 @@ public class MrDLibImporter extends Importer {
     /**
      * Small pair-class to ensure the right order of the recommendations.
      */
-    private static class RankedBibEntry {
-
-        public BibEntry entry;
-        public Integer rank;
-
-        public RankedBibEntry(BibEntry entry, Integer rank) {
-            this.rank = rank;
-            this.entry = entry;
-        }
+    private record RankedBibEntry(BibEntry entry, Integer rank) {
     }
 
     /**
@@ -126,8 +119,7 @@ public class MrDLibImporter extends Importer {
         }
 
         // Sort bib entries according to rank
-        rankedBibEntries.sort((RankedBibEntry rankedBibEntry1,
-                               RankedBibEntry rankedBibEntry2) -> rankedBibEntry1.rank.compareTo(rankedBibEntry2.rank));
+        rankedBibEntries.sort(Comparator.comparing((RankedBibEntry rankedBibEntry) -> rankedBibEntry.rank));
         List<BibEntry> bibEntries = rankedBibEntries.stream().map(e -> e.entry).collect(Collectors.toList());
 
         bibDatabase.insertEntries(bibEntries);

--- a/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
@@ -93,21 +93,11 @@ public class EditMerge {
         return madeModifications;
     }
 
-    private static class JoinableGroupData {
-        /**
-         * A list of consecutive citation groups only separated by spaces.
-         */
-        List<CitationGroup> group;
-
-        /**
-         * A cursor covering the XTextRange of each entry in group (and the spaces between them)
-         */
-        XTextCursor groupCursor;
-
-        JoinableGroupData(List<CitationGroup> group, XTextCursor groupCursor) {
-            this.group = group;
-            this.groupCursor = groupCursor;
-        }
+    /**
+     * group : A list of consecutive citation groups only separated by spaces.
+     * groupCursor : A cursor covering the XTextRange of each entry in group (and the spaces between them)
+     */
+    private record JoinableGroupData(List<CitationGroup> group, XTextCursor groupCursor) {
     }
 
     private static class ScanState {

--- a/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
@@ -94,8 +94,8 @@ public class EditMerge {
     }
 
     /**
-     * group : A list of consecutive citation groups only separated by spaces.
-     * groupCursor : A cursor covering the XTextRange of each entry in group (and the spaces between them)
+     * @param group : A list of consecutive citation groups only separated by spaces.
+     * @param groupCursor : A cursor covering the XTextRange of each entry in group (and the spaces between them)
      */
     private record JoinableGroupData(List<CitationGroup> group, XTextCursor groupCursor) {
     }

--- a/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
+++ b/src/main/java/org/jabref/logic/openoffice/action/EditMerge.java
@@ -94,8 +94,8 @@ public class EditMerge {
     }
 
     /**
-     * @param group : A list of consecutive citation groups only separated by spaces.
-     * @param groupCursor : A cursor covering the XTextRange of each entry in group (and the spaces between them)
+     * @param group       A list of consecutive citation groups only separated by spaces.
+     * @param groupCursor A cursor covering the XTextRange of each entry in group (and the spaces between them)
      */
     private record JoinableGroupData(List<CitationGroup> group, XTextCursor groupCursor) {
     }

--- a/src/main/java/org/jabref/model/openoffice/rangesort/RangeSortVisual.java
+++ b/src/main/java/org/jabref/model/openoffice/rangesort/RangeSortVisual.java
@@ -67,7 +67,7 @@ public class RangeSortVisual {
         // collect ordered result
         List<RangeSortable<T>> result = new ArrayList<>(comparableMarks.size());
         for (ComparableMark<RangeSortable<T>> mark : comparableMarks) {
-            result.add(mark.getContent());
+            result.add(mark.content());
         }
 
         if (result.size() != inputSize) {
@@ -111,20 +111,6 @@ public class RangeSortVisual {
      * <p>
      * Used for sorting reference marks by their visual positions.
      */
-    private static class ComparableMark<T> {
-
-        private final Point position;
-        private final int indexInPosition;
-        private final T content;
-
-        public ComparableMark(Point position, int indexInPosition, T content) {
-            this.position = position;
-            this.indexInPosition = indexInPosition;
-            this.content = content;
-        }
-
-        public T getContent() {
-            return content;
-        }
+    private record ComparableMark<T>(Point position, int indexInPosition, T content) {
     }
 }


### PR DESCRIPTION
- refs:#11829
- finish:Inner classes like `ComparableMark` can be converted to record classes.
- most of them can't change it since there are a method in it or changed the record value, which against the purpose of record.

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
