### PR TITLE
11802: add new KeyBinding for bibliographic data shortcut

### DIFF
--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -113,7 +113,7 @@ public enum StandardActions implements Action {
     ABBREVIATE_DOTLESS(Localization.lang("dotless"), Localization.lang("Abbreviate journal names of the selected entries (DOTLESS abbreviation)")),
     ABBREVIATE_SHORTEST_UNIQUE(Localization.lang("shortest unique"), Localization.lang("Abbreviate journal names of the selected entries (SHORTEST UNIQUE abbreviation)")),
     UNABBREVIATE(Localization.lang("Unabbreviate journal names"), Localization.lang("Unabbreviate journal names of the selected entries"), KeyBinding.UNABBREVIATE),
-
+    GET_BIBLIOGRAPHIC_DATA(Localization.lang("Get bibliographic data"), IconTheme.JabRefIcons.SEARCH,KeyBinding.GET_BIBLIOGRAPHIC_DATA),
     MANAGE_CUSTOM_EXPORTS(Localization.lang("Manage custom exports")),
     MANAGE_CUSTOM_IMPORTS(Localization.lang("Manage custom imports")),
     CUSTOMIZE_ENTRY_TYPES(Localization.lang("Customize entry types")),

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -8,6 +8,7 @@ import org.jabref.logic.l10n.Localization;
 public enum KeyBinding {
     EDITOR_DELETE("Delete", Localization.lang("Delete text"), "", KeyBindingCategory.EDITOR),
     // DELETE BACKWARDS = Rubout
+    GET_BIBLIOGRAPHIC_DATA("Get bibliographic data", Localization.lang("Get bibliographic data"), "ctrl+shift+alt+B", KeyBindingCategory.EDITOR),
     EDITOR_BACKWARD("Move caret left", Localization.lang("Move caret left"), "", KeyBindingCategory.EDITOR),
     EDITOR_FORWARD("Move caret right", Localization.lang("Move caret right"), "", KeyBindingCategory.EDITOR),
     EDITOR_WORD_BACKWARD("Move caret to previous word", Localization.lang("Move caret to previous word"), "", KeyBindingCategory.EDITOR),


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/11802
Resolves https://discourse.jabref.org/t/shortcuts-for-get-bibliographic-data-from-doi-and-look-up-doi/4468
Resolves https://discourse.jabref.org/t/how-to-assign-a-keyboard-shortcut-to-search-document-identifier-online-doi/5244

<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
