### PR TITLE
Improve performance with duplicate check on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
 - We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)
-- We improved the performance when pasting entries []
+- We improved the performance when pasting entries in an existing library. [#11843](https://github.com/JabRef/jabref/pull/11843)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
 - We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)
-- We improved the performance when pasting entries in an existing library. [#11843](https://github.com/JabRef/jabref/pull/11843)
+- We improved the performance when pasting and importing entries in an existing library. [#11843](https://github.com/JabRef/jabref/pull/11843)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
 - We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)
+- We improved the performance when pasting entries []
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -106,7 +106,7 @@ public class DuplicateCheck {
 
     private static boolean isFarFromThreshold(double value) {
         if (value < 0.0) {
-            LOGGER.debug("Value {} is below zero. Should not happen", value);
+            LOGGER.trace("Value {} is below zero. Should not happen", value);
         }
         return value - DuplicateCheck.DUPLICATE_THRESHOLD > DuplicateCheck.DOUBT_RANGE;
     }
@@ -309,7 +309,7 @@ public class DuplicateCheck {
         }
         final double distanceIgnoredCase = new StringSimilarity().editDistanceIgnoreCase(longer, shorter);
         final double similarity = (longerLength - distanceIgnoredCase) / longerLength;
-        LOGGER.debug("Longer string: {} Shorter string: {} Similarity: {}", longer, shorter, similarity);
+        LOGGER.trace("Longer string: {} Shorter string: {} Similarity: {}", longer, shorter, similarity);
         return similarity;
     }
 


### PR DESCRIPTION
Run duplicate check on background thread

In 90% cases better performance, except if you have plenty of duplicates (UI dialog is shown then)

Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/574

Side effect, UI might freeze if you copy a large number of entries because of respawning the duplicate entry dialog. Not happy about it, 
 
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
