### PR TITLE
Update user agent and log URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - ⚠️ Renamed command line parameters `embeddBibfileInPdf` to `embedBibFileInPdf`, `writeMetadatatoPdf` to `writeMetadataToPdf`, and `writeXMPtoPdf` to `writeXmpToPdf`. [#11575](https://github.com/JabRef/jabref/pull/11575)
 - The browse button for a Custom theme now opens in the directory of the current used CSS file. [#11597](https://github.com/JabRef/jabref/pull/11597)
 - The browse button for a Custom exporter now opens in the directory of the current used exporter file. [#11717](https://github.com/JabRef/jabref/pull/11717)
+- JabRef now uses TLS 1.2 for all HTTPS connections. [#11852](https://github.com/JabRef/jabref/pull/11852)
 - We improved the display of long messages in the integrity check dialog. [#11619](https://github.com/JabRef/jabref/pull/11619)
 - We improved the undo/redo buttons in the main toolbar and main menu to be disabled when there is nothing to undo/redo. [#8807](https://github.com/JabRef/jabref/issues/8807)
 - We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where search result highlighting was incorrectly highlighting the boolean operators. [#11595](https://github.com/JabRef/jabref/issues/11595)
 - We fixed an issue where search result highlighting was broken at complex searches. [#8067](https://github.com/JabRef/jabref/issues/8067)
 - We fixed an exception when searching for unlinked files. [#11731](https://github.com/JabRef/jabref/issues/11731)
+- We fixed an issue with the link to the full text at the BVB fetcher. [#11852](https://github.com/JabRef/jabref/pull/11852)
 - We fixed an issue where two contradicting notifications were shown when cutting an entry in the main table. [#11724](https://github.com/JabRef/jabref/pull/11724)
 - We fixed an issue where unescaped braces in the arXiv fetcher were not treated. [#11704](https://github.com/JabRef/jabref/issues/11704)
 - We fixed an issue where HTML instead of the fulltext pdf was downloaded when importing arXiv entries. [#4913](https://github.com/JabRef/jabref/issues/4913)

--- a/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DownloadLinkedFileAction.java
@@ -10,10 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocketFactory;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleProperty;
@@ -243,8 +240,6 @@ public class DownloadLinkedFileAction extends SimpleCommand {
     }
 
     private BackgroundTask<Path> prepareDownloadTask(Path targetDirectory, URLDownload urlDownload) {
-        SSLSocketFactory defaultSSLSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
-        HostnameVerifier defaultHostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier();
         return BackgroundTask
                 .wrap(() -> {
                     String suggestedName;
@@ -263,7 +258,6 @@ public class DownloadLinkedFileAction extends SimpleCommand {
                 .then(destination -> new FileDownloadTask(urlDownload.getSource(), destination))
                 .onFailure(ex -> LOGGER.error("Error in download", ex))
                 .onFinished(() -> {
-                    URLDownload.setSSLVerification(defaultSSLSocketFactory, defaultHostnameVerifier);
                     downloadProgress.unbind();
                     downloadProgress.set(1);
                 });

--- a/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTabViewModel.java
@@ -5,10 +5,6 @@ import java.net.HttpURLConnection;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
@@ -217,15 +213,10 @@ public class WebSearchTabViewModel implements PreferenceTabViewModel {
         if (!apiKey.isEmpty()) {
             URLDownload urlDownload;
             try {
-                SSLSocketFactory defaultSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
-                HostnameVerifier defaultHostnameVerifier = HttpsURLConnection.getDefaultHostnameVerifier();
-
                 urlDownload = new URLDownload(testUrlWithoutApiKey + apiKey);
                 // The HEAD request cannot be used because its response is not 200 (maybe 404 or 596...).
                 int statusCode = ((HttpURLConnection) urlDownload.getSource().openConnection()).getResponseCode();
                 keyValid = (statusCode >= 200) && (statusCode < 300);
-
-                URLDownload.setSSLVerification(defaultSslSocketFactory, defaultHostnameVerifier);
             } catch (IOException | UnirestException e) {
                 keyValid = false;
             }

--- a/src/main/java/org/jabref/logic/importer/FetcherException.java
+++ b/src/main/java/org/jabref/logic/importer/FetcherException.java
@@ -89,6 +89,10 @@ public class FetcherException extends JabRefException {
         return API_KEY_PATTERN.matcher(url).replaceAll(REDACTED_STRING);
     }
 
+    public static Object getRedactedUrl(URL source) {
+        return API_KEY_PATTERN.matcher(source.toString()).replaceAll(REDACTED_STRING);
+    }
+
     private String getPrefix() {
         String superLocalizedMessage = super.getLocalizedMessage();
         if (!StringUtil.isBlank(superLocalizedMessage)) {

--- a/src/main/java/org/jabref/logic/importer/FetcherException.java
+++ b/src/main/java/org/jabref/logic/importer/FetcherException.java
@@ -14,10 +14,8 @@ import org.slf4j.LoggerFactory;
 
 public class FetcherException extends JabRefException {
     private static final Logger LOGGER = LoggerFactory.getLogger(FetcherException.class);
-
-    Pattern API_KEY_PATTERN = Pattern.compile("(?i)(api|key|api[-_]?key)=[^&]*");
-
-    String REDACTED_STRING = "[REDACTED]";
+    private static final Pattern API_KEY_PATTERN = Pattern.compile("(?i)(api|key|api[-_]?key)=[^&]*");
+    private static String REDACTED_STRING = "[REDACTED]";
 
     private final String url;
     private final SimpleHttpResponse httpResponse;

--- a/src/main/java/org/jabref/logic/importer/fetcher/BvbFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BvbFetcher.java
@@ -14,6 +14,9 @@ import org.jabref.logic.importer.fileformat.MarcXmlParser;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 
+/**
+ * Fetcher for <a href="Bibliotheksverbund Bayern (BVB)">https://www.bib-bvb.de/</a>.
+ */
 public class BvbFetcher implements SearchBasedParserFetcher {
 
     private static final String URL_PATTERN = "http://bvbr.bib-bvb.de:5661/bvb01sru?";

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -30,6 +30,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.strings.StringUtil;
 
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
@@ -118,10 +119,9 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         entry.setField(StandardField.ISBN, jsonEntry.optString("isbn"));
         entry.setField(StandardField.ISSN, jsonEntry.optString("issn"));
         entry.setField(StandardField.ISSUE, jsonEntry.optString("issue"));
-        try {
-            entry.addFile(new LinkedFile(URI.create(jsonEntry.optString("pdf_url")).toURL(), "PDF"));
-        } catch (MalformedURLException e) {
-            LOGGER.error("Fetched PDF URL String is malformed.");
+        String pdfUrl = jsonEntry.optString("pdf_url");
+        if (!StringUtil.isBlank(pdfUrl)) {
+            entry.addFile(new LinkedFile("", pdfUrl, "PDF"));
         }
         entry.setField(StandardField.JOURNALTITLE, jsonEntry.optString("publication_title"));
         entry.setField(StandardField.DATE, jsonEntry.optString("publication_date"));

--- a/src/main/java/org/jabref/logic/importer/fetcher/ResearchGate.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ResearchGate.java
@@ -69,7 +69,7 @@ public class ResearchGate implements FulltextFetcher, EntryBasedFetcher, SearchB
         try {
             html = getHTML(entry);
         } catch (FetcherException | NullPointerException e) {
-            LOGGER.debug("ResearchGate server is not available");
+            LOGGER.debug("ResearchGate server is not available", e);
             return Optional.empty();
         }
         Elements eLink = html.getElementsByTag("section");

--- a/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -18,6 +18,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.jabref.logic.importer.AuthorListParser;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.Date;
@@ -405,8 +406,8 @@ public class MarcXmlParser implements Parser {
 
             if ("Volltext".equals(fulltext) && StringUtil.isNotBlank(resource)) {
                 try {
-                    LinkedFile linkedFile = new LinkedFile(URI.create(resource).toURL(), "PDF");
-                    bibEntry.setField(StandardField.FILE, linkedFile.toString());
+                    LinkedFile linkedFile = new LinkedFile("", URI.create(resource).toURL(), StandardFileType.PDF.getName());
+                    bibEntry.setFiles(List.of(linkedFile));
                 } catch (MalformedURLException | IllegalArgumentException e) {
                     LOGGER.info("Malformed URL: {}", resource);
                 }

--- a/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -407,7 +407,7 @@ public class MarcXmlParser implements Parser {
                 try {
                     LinkedFile linkedFile = new LinkedFile(URI.create(resource).toURL(), "PDF");
                     bibEntry.setField(StandardField.FILE, linkedFile.toString());
-                } catch (MalformedURLException e) {
+                } catch (MalformedURLException | IllegalArgumentException e) {
                     LOGGER.info("Malformed URL: {}", resource);
                 }
             } else {

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -382,7 +382,7 @@ public class URLDownload {
             } else if (status >= 400) {
                 // in case of an error, propagate the error message
                 SimpleHttpResponse httpResponse = new SimpleHttpResponse(httpURLConnection);
-                LOGGER.info("{}: {}", this.source, httpResponse);
+                LOGGER.info("{}: {}", FetcherException.getRedactedUrl(this.source), httpResponse);
                 if (status < 500) {
                     throw new FetcherClientException(this.source, httpResponse);
                 } else {

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -382,6 +382,10 @@ public class URLDownload {
 
     private URLConnection getUrlConnection() throws IOException {
         URLConnection connection = this.source.openConnection();
+
+        if (connection instanceof HttpURLConnection httpConnection) {
+            httpConnection.setInstanceFollowRedirects(true);
+        }
         connection.setConnectTimeout((int) connectTimeout.toMillis());
         for (Entry<String, String> entry : this.parameters.entrySet()) {
             connection.setRequestProperty(entry.getKey(), entry.getValue());

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -32,9 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
 
 import org.jabref.http.dto.SimpleHttpResponse;
 import org.jabref.logic.importer.FetcherClientException;
@@ -96,19 +94,6 @@ public class URLDownload {
     public URLDownload(URL source) {
         this.source = source;
         this.addHeader("User-Agent", URLDownload.USER_AGENT);
-    }
-
-    /**
-     * @param socketFactory trust manager
-     * @param verifier      host verifier
-     */
-    public static void setSSLVerification(SSLSocketFactory socketFactory, HostnameVerifier verifier) {
-        try {
-            HttpsURLConnection.setDefaultSSLSocketFactory(socketFactory);
-            HttpsURLConnection.setDefaultHostnameVerifier(verifier);
-        } catch (Exception e) {
-            LOGGER.error("A problem occurred when reset SSL verification", e);
-        }
     }
 
     public URL getSource() {

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  */
 public class URLDownload {
 
-    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36";
+    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0";
     private static final Logger LOGGER = LoggerFactory.getLogger(URLDownload.class);
     private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(30);
     private static final int MAX_RETRIES = 3;
@@ -384,7 +384,7 @@ public class URLDownload {
             } else if (status >= 400) {
                 // in case of an error, propagate the error message
                 SimpleHttpResponse httpResponse = new SimpleHttpResponse(httpURLConnection);
-                LOGGER.info("{}", httpResponse);
+                LOGGER.info("{}: {}", this.source, httpResponse);
                 if (status < 500) {
                     throw new FetcherClientException(this.source, httpResponse);
                 } else {

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -103,6 +103,7 @@ public class URLDownload {
         try {
             sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(null, null, new SecureRandom());
+            // Note: SSL certificates are installed at {@link TrustStoreManager#configureTrustStore(Path)}
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             LOGGER.error("Could not initialize SSL context", e);
             sslContext = null;

--- a/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
+++ b/src/main/java/org/jabref/logic/net/ssl/TrustStoreManager.java
@@ -27,6 +27,9 @@ import javax.net.ssl.X509TrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @implNote SSL certificates are installed at {@link TrustStoreManager#configureTrustStore(Path)}
+ */
 public class TrustStoreManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TrustStoreManager.class);
@@ -163,7 +166,9 @@ public class TrustStoreManager {
         }
     }
 
-    // based on https://stackoverflow.com/a/62586564/3450689
+    /**
+     * @implNote based on https://stackoverflow.com/a/62586564/3450689
+     */
     private static void configureTrustStore(Path myStorePath) throws NoSuchAlgorithmException, KeyManagementException, KeyStoreException,
         CertificateException, IOException {
         X509TrustManager jreTrustManager = getJreTrustManager();

--- a/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
@@ -80,7 +80,7 @@ class BvbFetcherTest {
     @Test
     void performSearchMatchingMultipleEntries() throws FetcherException {
         List<BibEntry> searchResult = fetcher.performSearch("effective java bloch");
-        assertEquals(List.of(bibEntryISBN9783960886402, bibEntryISBN0134685997), searchResult.subList(0, 1));
+        assertEquals(List.of(bibEntryISBN9783960886402, bibEntryISBN0134685997), searchResult.subList(0, 2));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
@@ -5,7 +5,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
@@ -29,7 +31,7 @@ class BvbFetcherTest {
             .withField(StandardField.AUTHOR, "Bloch, Joshua")
             .withField(StandardField.TITLEADDON, "Joshua Bloch")
             .withField(StandardField.EDITION, "3. Auflage, Übersetzung der englischsprachigen 3. Originalausgabe 2018")
-            .withField(StandardField.FILE, "ParsedFileField{description='', link='http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353', fileType='PDF'}")
+            .withFiles(List.of(new LinkedFile("", "http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353", StandardFileType.PDF)))
             .withField(StandardField.ISBN, "9783960886402")
             .withField(StandardField.KEYWORDS, "Klassen, Interfaces, Generics, Enums, Annotationen, Lambdas, Streams, Module, parallel, Parallele Programmierung, Serialisierung, funktional, funktionale Programmierung, Java EE, Jakarta EE")
             .withField(StandardField.ADDRESS, "Heidelberg")
@@ -78,8 +80,7 @@ class BvbFetcherTest {
     @Test
     void performSearchMatchingMultipleEntries() throws FetcherException {
         List<BibEntry> searchResult = fetcher.performSearch("effective java bloch");
-        assertEquals(bibEntryISBN9783960886402, searchResult.getFirst());
-        assertEquals(bibEntryISBN0134685997, searchResult.get(1));
+        assertEquals(List.of(bibEntryISBN9783960886402, bibEntryISBN0134685997), searchResult.subList(0, 1));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
@@ -12,7 +12,6 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.apache.lucene.queryparser.flexible.standard.parser.StandardSyntaxParser;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.jabref.logic.importer.fetcher.transformers.AbstractQueryTransformer.NO_EXPLICIT_FIELD;
@@ -23,8 +22,30 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class BvbFetcherTest {
 
     BvbFetcher fetcher = new BvbFetcher();
-    BibEntry bibEntryISBN0134685997;
-    BibEntry bibEntryISBN9783960886402;
+    BibEntry bibEntryISBN9783960886402 = new BibEntry(StandardEntryType.Misc)
+            .withField(StandardField.TITLE, "Effective Java")
+            .withField(StandardField.YEAR, "2018")
+            .withField(StandardField.SUBTITLE, "best practices für die Java-Plattform")
+            .withField(StandardField.AUTHOR, "Bloch, Joshua")
+            .withField(StandardField.TITLEADDON, "Joshua Bloch")
+            .withField(StandardField.EDITION, "3. Auflage, Übersetzung der englischsprachigen 3. Originalausgabe 2018")
+            .withField(StandardField.FILE, "ParsedFileField{description='', link='http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353', fileType='PDF'}")
+            .withField(StandardField.ISBN, "9783960886402")
+            .withField(StandardField.KEYWORDS, "Klassen, Interfaces, Generics, Enums, Annotationen, Lambdas, Streams, Module, parallel, Parallele Programmierung, Serialisierung, funktional, funktionale Programmierung, Java EE, Jakarta EE")
+            .withField(StandardField.ADDRESS, "Heidelberg")
+            .withField(StandardField.PAGETOTAL, "396")
+            .withField(StandardField.PUBLISHER, "{dpunkt.verlag} and {Dpunkt. Verlag (Heidelberg)}");
+
+    BibEntry bibEntryISBN0134685997 = new BibEntry(StandardEntryType.Misc)
+            .withField(StandardField.TITLE, "Effective Java")
+            .withField(StandardField.YEAR, "2018")
+            .withField(StandardField.AUTHOR, "Bloch, Joshua")
+            .withField(StandardField.TITLEADDON, "Joshua Bloch")
+            .withField(StandardField.EDITION, "Third edition")
+            .withField(StandardField.ISBN, "0134685997")
+            .withField(StandardField.PAGETOTAL, "392")
+            .withField(StandardField.ADDRESS, "Boston")
+            .withField(StandardField.PUBLISHER, "{Addison-Wesley}");
 
     @Test
     void performTest() throws Exception {
@@ -36,41 +57,6 @@ class BvbFetcherTest {
 //        System.out.println(fetcher.getURLForQuery(new StandardSyntaxParser().parse(searchquery, NO_EXPLICIT_FIELD)));
 //        System.out.println("Test result:\n");
 //        result.forEach(entry -> System.out.println(entry.toString()));
-    }
-
-    @BeforeEach
-    void setUp() {
-        fetcher = new BvbFetcher();
-
-        bibEntryISBN9783960886402 = new BibEntry(StandardEntryType.Misc)
-                .withField(StandardField.TITLE, "Effective Java")
-                .withField(StandardField.YEAR, "2018")
-                .withField(StandardField.SUBTITLE, "best practices für die Java-Plattform")
-                .withField(StandardField.AUTHOR, "Bloch, Joshua")
-                .withField(StandardField.TITLEADDON, "Joshua Bloch")
-                .withField(StandardField.EDITION, "3. Auflage, Übersetzung der englischsprachigen 3. Originalausgabe 2018")
-                .withField(StandardField.FILE, "ParsedFileField{description='', link='http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353', fileType='PDF'}")
-                .withField(StandardField.ISBN, "9783960886402")
-                .withField(StandardField.KEYWORDS, "Klassen, Interfaces, Generics, Enums, Annotationen, Lambdas, Streams, Module, parallel, Parallele Programmierung, Serialisierung, funktional, funktionale Programmierung, Java EE, Jakarta EE")
-                .withField(StandardField.ADDRESS, "Heidelberg")
-                .withField(StandardField.PAGETOTAL, "396")
-                .withField(StandardField.PUBLISHER, "{dpunkt.verlag} and {Dpunkt. Verlag (Heidelberg)}");
-
-        bibEntryISBN0134685997 = new BibEntry(StandardEntryType.Misc)
-                .withField(StandardField.TITLE, "Effective Java")
-                .withField(StandardField.YEAR, "2018")
-                .withField(StandardField.AUTHOR, "Bloch, Joshua")
-                .withField(StandardField.TITLEADDON, "Joshua Bloch")
-                .withField(StandardField.EDITION, "Third edition")
-                .withField(StandardField.ISBN, "0134685997")
-                .withField(StandardField.PAGETOTAL, "392")
-                .withField(StandardField.ADDRESS, "Boston")
-                .withField(StandardField.PUBLISHER, "{Addison-Wesley}");
-    }
-
-    @Test
-    void getName() {
-        assertEquals("Bibliotheksverbund Bayern (Experimental)", fetcher.getName());
     }
 
     @Test


### PR DESCRIPTION
This updates the user agent to the latest one by FireFox (source: https://www.whatismybrowser.com/guides/the-latest-user-agent/firefox)

This also logs the URL used for an error HTTP response.

Example:

```
INFO: https://www.researchgate.net/search.Search.html?type=publication&query=Paranoid%3A%20a%20global%20secure%20file%20access%20control%20system: SimpleHttpResponse{statusCode=403, response
```

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
