### PR TITLE
Change instances of 'Search Selected' to 'Search Pre-configured'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the DOI detection in PDF imports. [#11782](https://github.com/JabRef/jabref/pull/11782)
 - We improved the performance when pasting and importing entries in an existing library. [#11843](https://github.com/JabRef/jabref/pull/11843)
 - When fulltext search is selected but indexing is deactivated, a dialog is now shown asking if the user wants to enable indexing now [#9491](https://github.com/JabRef/jabref/issues/9491)
+- We changed instances of 'Search Selected' to 'Search Pre-configured' in Web Search Preferences UI. [#11871](https://github.com/JabRef/jabref/pull/11871)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
@@ -27,7 +27,7 @@
         <CheckBox fx:id="useCustomDOI" text="%Use custom DOI base URI for article access"/>
         <TextField fx:id="useCustomDOIName" HBox.hgrow="ALWAYS"/>
     </HBox>
-    <Label styleClass="sectionHeader" text="%Catalogues used for 'Search Pre-configured'"/>
+    <Label styleClass="sectionHeader" text="%Catalogues used for 'Search pre-configured'"/>
     <TableView
             fx:id="catalogTable"
             VBox.vgrow="ALWAYS"

--- a/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
@@ -27,7 +27,7 @@
         <CheckBox fx:id="useCustomDOI" text="%Use custom DOI base URI for article access"/>
         <TextField fx:id="useCustomDOIName" HBox.hgrow="ALWAYS"/>
     </HBox>
-    <Label styleClass="sectionHeader" text="%Catalogues used for 'Search Selected'"/>
+    <Label styleClass="sectionHeader" text="%Catalogues used for 'Search Pre-configured'"/>
     <TableView
             fx:id="catalogTable"
             VBox.vgrow="ALWAYS"

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -238,7 +238,7 @@ public class WebFetchers {
 }
 
 /**
- *  Places "Search Selected" to the first of the set
+ *  Places "Search pre-configured" to the first of the set
  */
 class CompositeSearchFirstComparator implements Comparator<SearchBasedFetcher> {
     @Override

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -238,7 +238,7 @@ public class WebFetchers {
 }
 
 /**
- *  Places "Search Selected" to the first of the set
+ *  Places "Search Pre-configured" to the first of the set
  */
 class CompositeSearchFirstComparator implements Comparator<SearchBasedFetcher> {
     @Override

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -238,7 +238,7 @@ public class WebFetchers {
 }
 
 /**
- *  Places "Search pre-configured" to the first of the set
+ *  Places "Search Selected" to the first of the set
  */
 class CompositeSearchFirstComparator implements Comparator<SearchBasedFetcher> {
     @Override

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -238,7 +238,7 @@ public class WebFetchers {
 }
 
 /**
- *  Places "Search Pre-configured" to the first of the set
+ *  Places "Search pre-configured" to the first of the set
  */
 class CompositeSearchFirstComparator implements Comparator<SearchBasedFetcher> {
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
-    public static final String FETCHER_NAME = "Search Selected";
+    public static final String FETCHER_NAME = "Search pre-configured";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSearchBasedFetcher.class);
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
-    public static final String FETCHER_NAME = "Search Pre-configured";
+    public static final String FETCHER_NAME = "Search pre-configured";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSearchBasedFetcher.class);
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
-    public static final String FETCHER_NAME = "Search Selected";
+    public static final String FETCHER_NAME = "Search Pre-configured";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSearchBasedFetcher.class);
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
-    public static final String FETCHER_NAME = "Search pre-configured";
+    public static final String FETCHER_NAME = "Search Selected";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSearchBasedFetcher.class);
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -125,7 +125,7 @@ Case\ sensitive=Case sensitive
 
 change\ assignment\ of\ entries=change assignment of entries
 
-Catalogues\ used\ for\ 'Search\ Pre-configured'=Catalogues used for 'Search Pre-configured'
+Catalogues\ used\ for\ 'Search\ pre-configured'=Catalogues used for 'Search pre-configured'
 
 Change\ case=Change case
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -125,7 +125,7 @@ Case\ sensitive=Case sensitive
 
 change\ assignment\ of\ entries=change assignment of entries
 
-Catalogues\ used\ for\ 'Search\ Selected'=Catalogues used for 'Search Selected'
+Catalogues\ used\ for\ 'Search\ Pre-configured'=Catalogues used for 'Search Pre-configured'
 
 Change\ case=Change case
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Closes #11866 

![image](https://github.com/user-attachments/assets/ee6cd847-8ad7-4ff8-acce-b8fe35899e25)

Instances of 'Search Selected' has been changed to 'Search Pre-configured' in the following files:
- CompositeSearchBasedFetcher.java in line 21
- JabRef_en.properties in line 128
- WebFetchers.java in line 241
- WebSearchTab.fxml in line 30

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
