### PR TITLE
Add fetcher test info to developer documentation

### DIFF
--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -67,9 +67,8 @@ This test is triggered when any kind of documentation is touched (be it the JabR
 
 ### Failing <b>Fetcher</b> tests
 
-Check first if you have changed any fetcher logic.
-If you have, check if the changes you have made are correct. You can look for more details on running fetcher tests in [here](https://devdocs.jabref.org/code-howtos/testing.html#fetchers-in-tests).
-Otherwise, these errors can be caused by the network or an external server. For more information, you can look in [here](https://devdocs.jabref.org/code-howtos/fetchers.html#committing-and-pushing-changes-to-fetcher-files).
+Fetcher tests are run when any file in the `.../fetcher` directory has been touched. If you have changed any fetcher logic, check if the changes are correct. You can look for more details on how to locally run fetcher tests [here](https://devdocs.jabref.org/code-howtos/testing.html#fetchers-in-tests).
+Otherwise, since these tests depend on remote services, their failure can also be caused by the network or an external server, and thus can be ignored in the context of your contribution. For more information, you can look [here](https://devdocs.jabref.org/code-howtos/fetchers.html#committing-and-pushing-changes-to-fetcher-files).
 
 ## Gradle outputs
 

--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -65,6 +65,12 @@ More information on the architecture can be found at [../getting-into-the-code/h
 
 This test is triggered when any kind of documentation is touched (be it the JabRef docs, or JavaDoc in code). If you changed something in the documentation, and particularly added/changed any links (to external files or websites), check if the links are correct and working. If you didn't change/add any link, or added correct links, the test is most probably failing due to any of the existing links being broken, and thus can be ignored (in the context of your contribution).
 
+### Failing <b>Fetcher</b> tests
+
+Check first if you have changed any fetcher logic.
+If you have, check if the changes you have made are correct. You can look for more details on running fetcher tests in [here](https://devdocs.jabref.org/code-howtos/testing.html#fetchers-in-tests).
+Otherwise, these errors can be caused by the network or an external server. For more information, you can look in [here](https://devdocs.jabref.org/code-howtos/fetchers.html#committing-and-pushing-changes-to-fetcher-files).
+
 ## Gradle outputs
 
 ### `ANTLR Tool version 4.12.0 used for code generation does not match the current runtime version 4.13.1`

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -87,6 +87,6 @@ When executing `./gradlew run`, gradle executes `processResources` and populates
 ## Committing and pushing changes to fetcher files
 
 Fetcher tests are run when pushing changes from any file in the `src/main/java/org/jabref/logic/importer/fetcher/` directory.
-Since these tests rely on remote services, some tests may fail due to the network or the external server.
+Since these tests rely on remote services, some of them may fail due to the network or the external server.
 
 To learn more about doing fetcher tests locally, see Fetchers in tests in [Testing](https://devdocs.jabref.org/code-howtos/testing.html).

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -83,3 +83,10 @@ new BuildInfo().springerNatureAPIKey
 ```
 
 When executing `./gradlew run`, gradle executes `processResources` and populates `build/build.properties` accordingly. However, when working directly in the IDE, Eclipse keeps reading `build.properties` from `src/main/resources`. In IntelliJ, the task `JabRef Main` is executing `./gradlew processResources` before running JabRef from the IDE to ensure the `build.properties` is properly populated.
+
+## Committing and pushing changes to fetcher files
+
+Fetcher tests are run when pushing changes from any file in the `src/main/java/org/jabref/logic/importer/fetcher/` directory.
+Since these tests rely on remote services, some tests may fail due to the network or the external server.
+
+To learn more about doing fetcher tests locally, see Fetchers in tests in [Testing](https://devdocs.jabref.org/code-howtos/testing.html).

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -86,7 +86,7 @@ When executing `./gradlew run`, gradle executes `processResources` and populates
 
 ## Committing and pushing changes to fetcher files
 
-Fetcher tests are run when pushing changes from any file in the `src/main/java/org/jabref/logic/importer/fetcher/` directory.
+Fetcher tests are run when a PR contains changes touching any file in the `src/main/java/org/jabref/logic/importer/fetcher/` directory.
 Since these tests rely on remote services, some of them may fail due to the network or the external server.
 
 To learn more about doing fetcher tests locally, see Fetchers in tests in [Testing](https://devdocs.jabref.org/code-howtos/testing.html).

--- a/docs/code-howtos/testing.md
+++ b/docs/code-howtos/testing.md
@@ -148,7 +148,7 @@ Fetcher tests can be run locally by executing the Gradle task `fetcherTest`. Thi
 ./gradlew fetcherTest
 ```
 
-Or, if one is using IntelliJ, by double-clicking `fetcherTest` in the Gradle sidebar; this could be found through the following path: `JabRef > Tasks > other`.
+Alternatively, if one is using IntelliJ, this can also be done by double-clicking the `fetcherTest` task under the `other` group in the Gradle Tool window (`JabRef > Tasks > other > fetcherTest`).
 
 ## Advanced testing and further reading
 

--- a/docs/code-howtos/testing.md
+++ b/docs/code-howtos/testing.md
@@ -142,7 +142,7 @@ Set the environment variable `DBMS` to `mysql`.
 
 ## Fetchers in tests
 
-Fetcher tests could be done by executing the Gradle task `fetcherTest`. This could be done by typing the following in the command line:
+Fetcher tests can be run locally by executing the Gradle task `fetcherTest`. This can be done by running the following command in the command line:
 
 ```shell
 ./gradlew fetcherTest

--- a/docs/code-howtos/testing.md
+++ b/docs/code-howtos/testing.md
@@ -140,6 +140,15 @@ docker run -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=jabref -p 3800:3307 mys
 
 Set the environment variable `DBMS` to `mysql`.
 
+## Fetchers in tests
+
+Fetcher tests could be done by executing the Gradle task `fetcherTest`. This could be done by typing the following in the command line:
+```shell
+./gradlew fetcherTest
+```
+Or, if one is using IntelliJ, by double-clicking `fetcherTest` in the Gradle sidebar; this could be found through the following path: `JabRef > Tasks > other`.
+
+
 ## Advanced testing and further reading
 
 On top of basic unit testing, there are more ways to test a software:

--- a/docs/code-howtos/testing.md
+++ b/docs/code-howtos/testing.md
@@ -143,11 +143,12 @@ Set the environment variable `DBMS` to `mysql`.
 ## Fetchers in tests
 
 Fetcher tests could be done by executing the Gradle task `fetcherTest`. This could be done by typing the following in the command line:
+
 ```shell
 ./gradlew fetcherTest
 ```
-Or, if one is using IntelliJ, by double-clicking `fetcherTest` in the Gradle sidebar; this could be found through the following path: `JabRef > Tasks > other`.
 
+Or, if one is using IntelliJ, by double-clicking `fetcherTest` in the Gradle sidebar; this could be found through the following path: `JabRef > Tasks > other`.
 
 ## Advanced testing and further reading
 


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link the issue that will be closed, e.g., "Closes #333".
If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
Don't reference an issue in the PR title because GitHub does not support auto-linking there.
-->

Information pertaining to (automatic) fetcher tests are added to fetchers.md. Information pertaining to how fetcher tests could be done locally are also added to testing.md.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
