### PR TITLE
Add requirement Id to ui-recommendations.md

### DIFF
--- a/docs/code-howtos/ui-recommendations.md
+++ b/docs/code-howtos/ui-recommendations.md
@@ -8,19 +8,27 @@ parent: Code Howtos
   * For a usual form, place the label above the text field
   * If the user uses the form often to edit fields, then it might make sense to switch to left-aligned labels
 
-## Designing GUI Confirmation dialogs
+## Designing GUI Confirmation Dialogs
 
 1. Avoid asking questions
 2. Be as concise as possible
 3. Identify the item at risk
 4. Name your buttons for the actions
 
-More information: [http://ux.stackexchange.com/a/768](http://ux.stackexchange.com/a/768)
+More information:
+
+- [StackOverflow: What are some alternatives to the phrase "Are you sure you want to XYZ" in confirmation dialogs?](https://ux.stackexchange.com/q/756/93436).
+- JabRef issue discussing Yes/No/Cancel: [koppor#149](https://github.com/koppor/jabref/issues/149).
+
+### Name your buttons for the actions
+`req~ui.dialogs.confirmation.naming~1`
 
 ## Form validation
 
 * Only validate input after leaving the field (or after the user stopped typing for some time)
 * The user shouldn't be able to submit the form if there are errors
 * However, disabling the submit button in case there are errors is also not optimal. Instead, clicking the submit button should highlight the errors.
-* Empty required files shouldn't be marked as invalid until the user a) tries to submit the form or b) focused the field, deleted it contents and then left the field (see [Example](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_required)
-* Ideally, the error message should be shown below the text field and not as a tooltip (so that users quickly understand what's the problem). For example as here [in Boostrap](https://mdbootstrap.com/docs/jquery/forms/validation/?#custom-styles)
+* Empty required files shouldn't be marked as invalid until the user a) tries to submit the form or b) focused the field, deleted it contents and then left the field (see [Example](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_required)()
+* Ideally, the error message should be shown below the text field and not as a tooltip (so that users quickly understand what's the problem). For example as [in Boostrap](https://mdbootstrap.com/docs/jquery/forms/validation/?#custom-styles).
+
+<!-- markdownlint-disable-file MD022 -->


### PR DESCRIPTION
I am trying to give Ids to our important requirements. Background: https://devdocs.jabref.org/requirements/

This is for preparing to make https://github.com/JabRef/jabref-issue-melting-pot/issues/465 public.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
