### PR TITLE
Fix disable some actions when no libraries are open #19129

### DIFF
--- a/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -2,6 +2,7 @@ package org.jabref.gui.frame;
 
 import java.util.function.Supplier;
 
+import javafx.beans.binding.Bindings;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
@@ -83,6 +84,8 @@ import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.util.FileUpdateMonitor;
+import javafx.beans.binding.Bindings;
+import javafx.scene.control.MenuItem;
 
 public class MainMenu extends MenuBar {
     private final JabRefFrame frame;
@@ -146,13 +149,20 @@ public class MainMenu extends MenuBar {
         Menu tools = new Menu(Localization.lang("Tools"));
         Menu help = new Menu(Localization.lang("Help"));
 
+        MenuItem saveAllMenuItem = factory.createMenuItem(StandardActions.SAVE_ALL, new SaveAllAction(frame::getLibraryTabs, preferences, dialogService));
+        MenuItem newEntryFromPlainTextMenuItem = factory.createMenuItem(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new PlainCitationParserAction(dialogService));
+
+
+        saveAllMenuItem.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
+        newEntryFromPlainTextMenuItem.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
+
         file.getItems().addAll(
                 factory.createMenuItem(StandardActions.NEW_LIBRARY, new NewDatabaseAction(frame, preferences)),
                 factory.createMenuItem(StandardActions.OPEN_LIBRARY, openDatabaseActionSupplier.get()),
                 fileHistoryMenu,
                 factory.createMenuItem(StandardActions.SAVE_LIBRARY, new SaveAction(SaveAction.SaveMethod.SAVE, frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),
                 factory.createMenuItem(StandardActions.SAVE_LIBRARY_AS, new SaveAction(SaveAction.SaveMethod.SAVE_AS, frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),
-                factory.createMenuItem(StandardActions.SAVE_ALL, new SaveAllAction(frame::getLibraryTabs, preferences, dialogService)),
+                saveAllMenuItem, // Use the modified saveAllMenuItem here
                 factory.createMenuItem(StandardActions.CLOSE_LIBRARY, new JabRefFrame.CloseDatabaseAction(frame, stateManager)),
 
                 new SeparatorMenuItem(),
@@ -233,7 +243,7 @@ public class MainMenu extends MenuBar {
 
         library.getItems().addAll(
                 factory.createMenuItem(StandardActions.NEW_ENTRY, new NewEntryAction(frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),
-                factory.createMenuItem(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new PlainCitationParserAction(dialogService)),
+                newEntryFromPlainTextMenuItem,
                 factory.createMenuItem(StandardActions.DELETE_ENTRY, new EditAction(StandardActions.DELETE_ENTRY, frame::getCurrentLibraryTab, stateManager, undoManager)),
 
                 new SeparatorMenuItem(),

--- a/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -84,8 +84,6 @@ import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.util.FileUpdateMonitor;
-import javafx.beans.binding.Bindings;
-import javafx.scene.control.MenuItem;
 
 public class MainMenu extends MenuBar {
     private final JabRefFrame frame;

--- a/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -152,7 +152,6 @@ public class MainMenu extends MenuBar {
         MenuItem saveAllMenuItem = factory.createMenuItem(StandardActions.SAVE_ALL, new SaveAllAction(frame::getLibraryTabs, preferences, dialogService));
         MenuItem newEntryFromPlainTextMenuItem = factory.createMenuItem(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new PlainCitationParserAction(dialogService));
 
-
         saveAllMenuItem.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
         newEntryFromPlainTextMenuItem.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
 

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.frame;
 
+import javafx.beans.binding.Bindings;
 import javafx.concurrent.Task;
 import javafx.geometry.Orientation;
 import javafx.scene.Group;
@@ -105,6 +106,11 @@ public class MainToolBar extends ToolBar {
         final Button pushToApplicationButton = factory.createIconButton(pushToApplicationCommand.getAction(), pushToApplicationCommand);
         pushToApplicationCommand.registerReconfigurable(pushToApplicationButton);
 
+        Button newEntryFromPlainTextButton = factory.createIconButton(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new PlainCitationParserAction(dialogService));
+
+        newEntryFromPlainTextButton.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
+
+
         // Setup Toolbar
 
         getItems().addAll(
@@ -119,11 +125,14 @@ public class MainToolBar extends ToolBar {
 
                 rightSpacer,
 
+
+
+
                 new HBox(
                         factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(frame::getCurrentLibraryTab, StandardEntryType.Article, dialogService, preferences, stateManager)),
                         factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),
                         createNewEntryFromIdButton(),
-                        factory.createIconButton(StandardActions.NEW_ENTRY_FROM_PLAIN_TEXT, new PlainCitationParserAction(dialogService)),
+                        newEntryFromPlainTextButton, // Use the modified button here
                         factory.createIconButton(StandardActions.DELETE_ENTRY, new EditAction(StandardActions.DELETE_ENTRY, frame::getCurrentLibraryTab, stateManager, undoManager))),
 
                 new Separator(Orientation.VERTICAL),
@@ -151,6 +160,8 @@ public class MainToolBar extends ToolBar {
 
                 new HBox(
                         factory.createIconButton(StandardActions.OPEN_GITHUB, new OpenBrowserAction("https://github.com/JabRef/jabref", dialogService, preferences.getExternalApplicationsPreferences()))));
+
+        globalSearchBar.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
 
         leftSpacer.setPrefWidth(50);
         leftSpacer.setMinWidth(Region.USE_PREF_SIZE);

--- a/src/main/java/org/jabref/gui/frame/MainToolBar.java
+++ b/src/main/java/org/jabref/gui/frame/MainToolBar.java
@@ -110,7 +110,6 @@ public class MainToolBar extends ToolBar {
 
         newEntryFromPlainTextButton.disableProperty().bind(Bindings.isEmpty(stateManager.getOpenDatabases()));
 
-
         // Setup Toolbar
 
         getItems().addAll(
@@ -124,10 +123,7 @@ public class MainToolBar extends ToolBar {
                 globalSearchBar,
 
                 rightSpacer,
-
-
-
-
+            
                 new HBox(
                         factory.createIconButton(StandardActions.NEW_ARTICLE, new NewEntryAction(frame::getCurrentLibraryTab, StandardEntryType.Article, dialogService, preferences, stateManager)),
                         factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(frame::getCurrentLibraryTab, dialogService, preferences, stateManager)),


### PR DESCRIPTION
This PR improves the user interface by disabling certain menu items and toolbar buttons when no library is open.
 Specifically:
"Save All" menu item in MainMenu.java is now disabled (greyed out) when there are no open libraries.
"New entry from plain text" menu item in MainMenu.java is now disabled when there are no open libraries.
"Global Search" bar in the main toolbar (MainToolBar.java) is now disabled when there are no open libraries.
"New entry from plain text" button in the main toolbar (MainToolBar.java) is now disabled when there are no open libraries.


## Here's the screenshot:
<img width="1100" alt="1" src="https://github.com/user-attachments/assets/d2ee921a-6951-44f6-a093-ba28e2a5adf1">
<img width="398" alt="2" src="https://github.com/user-attachments/assets/da8a3684-bfad-49cd-9701-230220e5ac8f">
<img width="346" alt="3" src="https://github.com/user-attachments/assets/d6ebe042-7572-4e39-ab54-01b3efbdf7ad">

## Here's the demo video:
https://github.com/user-attachments/assets/9fb688e5-5dbb-4e20-9f16-b0bf33f691d3

Closes #19129

https://github.com/JabRef/jabref/issues/11923

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
