### PR TITLE
Add assign-me-action

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -1,0 +1,34 @@
+name: Assign Issue
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: takanome-dev/assign-issue-action@v2.1.1
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          days_until_unassign: 30
+          assigned_comment: |
+            👋 Hey @{{ comment.user.login }},
+
+            Thanks for your interest in this issue! 🎉
+
+            Newcomers, we're excited to have you on board. Start by exploring our [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) guidelines, and don't forget to check out our [workspace setup guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) to get started smoothly.
+
+            In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
+
+            Having any questions or issues? Feel free to ask here on GitHub. Need help setting up your local workspace? Join the conversation on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref). And don't hesitate to open a (draft) pull request early on to show the direction it is heading towards. This way, you will receive valuable feedback.
+
+            ⚠ Note that this issue will become unassigned if it isn't closed within **{{ totalDays }} days**.
+
+            🔧 A maintainer can also add the **{{ inputs.pin_label }}** label to prevent it from being unassigned automatically.
+
+            Happy coding! 🚀

--- a/.github/workflows/react-on-issue-labels.yml
+++ b/.github/workflows/react-on-issue-labels.yml
@@ -46,3 +46,26 @@ jobs:
        target-labels: "FirstTimeCodeContribution"
        target-column: "Assigned"
        ignored-columns: ""
+  Assigned:
+    name: "Update project boards for label '📍 Assigned'"
+    if: ${{ github.event.label.name == '📍 Assigned' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
+      uses: m7kvqbe1/github-action-move-issues@v1.0.0
+      with:
+       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+       project-url: "https://github.com/orgs/JabRef/projects/3"
+       target-labels: "📍 Assigned"
+       target-column: "Assigned"
+       ignored-columns: ""
+    - name: Move Issue to "Assigned" Column in "Good First Issues"
+      uses: m7kvqbe1/github-action-move-issues@v1.0.0
+      with:
+       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+       project-url: "https://github.com/orgs/JabRef/projects/5"
+       target-labels: "📍 Assigned"
+       target-column: "Assigned"
+       ignored-columns: ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,14 @@ If you are not familiar with this type of workflow, take a look at GitHub's exce
 Before you start, get the JabRef code on your local machine.
 Detailed instructions about this step can be found in our [guidelines for setting up a local workspace](getting-into-the-code/guidelines-for-setting-up-a-local-workspace/).
 
+## Table of Contents
+
+- [Choosing a task](#choosing-a-task-join-the-chat-at-httpsgitterimjabrefjabref)
+- [Getting a task assigned](#getting-a-task-assigned)
+- [Pull Request Process](#pull-request-process)
+  - [Requirements on the pull request and code](#requirements-on-the-pull-request-and-code)
+  - [Development hints](#development-hints)
+
 ## Choosing a task [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
 
 In general, we offer small issues perfect for aspiring developers.
@@ -47,6 +55,11 @@ For improving developer's documentation, go on at the [docs/ subdirectory of Jab
 GitHub offers a good guide at [Editing files in another user's repository](https://help.github.com/en/github/managing-files-in-a-repository/editing-files-in-another-users-repository).
 
 One can also add [callouts](https://just-the-docs.github.io/just-the-docs-tests/components/callouts/).
+
+## Getting a task assigned
+
+Comment on the issue you want to work at with `/assign-me`.
+GitHub will then automatically assign you.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ We collect good issues to start with at our [list of good first issues](https://
 
 ### I am a student and I want to choose from a curated list of university projects
 
-Have a look at [JabRefs candidates for university projects](https://github.com/orgs/JabRef/projects/3). There, a list of possible projects to work on during a teaching period is offered.
+Take a look at [JabRef's candidates for university projects](https://github.com/orgs/JabRef/projects/3). There, a list of possible projects to work on during a teaching period is offered.
 
 ### I am a lecturer
 
@@ -43,7 +43,7 @@ Look at the discussions in our forum about [new features](https://discourse.jabr
 Find an interesting topic, discuss it and start contributing.
 Alternatively, you can check out [JabRef's projects page at GitHub](https://github.com/JabRef/jabref/projects?query=is%3Aopen).
 Although, of course, you can choose to work on ANY issue, choosing from the projects page has the advantage that these issues have already been categorized, sorted and screened by JabRef maintainers.
-A typical sub classifications scheme is "priority" (high, normal and low). Fixing high priority issues is preferred.
+A typical subclassifications scheme is "priority" (high, normal and low). Fixing high priority issues is preferred.
 
 ### I want to know how to contribute code and set up my workspace
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ Detailed instructions about this step can be found in our [guidelines for settin
 
 ## Table of Contents
 
-- [Choosing a task](#choosing-a-task-join-the-chat-at-httpsgitterimjabrefjabref)
-- [Getting a task assigned](#getting-a-task-assigned)
-- [Pull Request Process](#pull-request-process)
-  - [Requirements on the pull request and code](#requirements-on-the-pull-request-and-code)
-  - [Development hints](#development-hints)
+* [Choosing a task](#choosing-a-task-)
+* [Getting a task assigned](#getting-a-task-assigned)
+* [Pull Request Process](#pull-request-process)
+  * [Requirements on the pull request and code](#requirements-on-the-pull-request-and-code)
+  * [Development hints](#development-hints)
 
 ## Choosing a task [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref)
 


### PR DESCRIPTION
We constantly get contributors wanting to have an issue assigned. To reduce the load, I propose the [assign-issue-action](https://github.com/takanome-dev/assign-issue-action). Contributors can then issue `/assign-me` and then they get assigned. Nice feature: After 30 days of inactivity, they get unassigned. (We can configure this time frame)

I also included text of our [newcomer text](https://github.com/JabRef/jabref/blob/main/.github/workflows/add-greeting-to-issue.yml).

Drawback: Our project boards are not updated accordingly. Filed as feature-wish to the action -> https://github.com/takanome-dev/assign-issue-action/issues/239

Alternative [`.take`](https://github.com/bdougie/take-action). Seems to have the same capabilities as the chosen action. Found via https://github.com/community/maintainers/discussions/447#discussioncomment-10756193.

Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/570

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
