### PR TITLE
Add change of state on assignment

### DIFF
--- a/.github/workflows/react-on-issue-labels.yml
+++ b/.github/workflows/react-on-issue-labels.yml
@@ -1,4 +1,4 @@
-name: Add greeting to issues for first time contributors
+name: React on issue labels
 
 on:
   issues:
@@ -9,7 +9,8 @@ on:
        - labeled
 
 jobs:
-  GreetingFirstTimeCodeContribution:
+  FirstTimeCodeContribution:
+    name: Add greeting to issues for first time contributors
     if: ${{ github.event.label.name == 'FirstTimeCodeContribution' }}
     runs-on: ubuntu-latest
     permissions:
@@ -29,3 +30,19 @@ jobs:
           Having any questions or issues? Feel free to ask here on GitHub. Need help setting up your local workspace? Join the conversation on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref). And don't hesitate to open a (draft) pull request early on to show the direction it is heading towards. This way, you will receive valuable feedback.
 
           Happy coding! 🚀
+    - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
+      uses: m7kvqbe1/github-action-move-issues@v1.0.0
+      with:
+       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+       project-url: "https://github.com/orgs/JabRef/projects/3"
+       target-labels: "FirstTimeCodeContribution"
+       target-column: "Assigned"
+       ignored-columns: ""
+    - name: Move Issue to "Assigned" Column in "Good First Issues"
+      uses: m7kvqbe1/github-action-move-issues@v1.0.0
+      with:
+       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+       project-url: "https://github.com/orgs/JabRef/projects/5"
+       target-labels: "FirstTimeCodeContribution"
+       target-column: "Assigned"
+       ignored-columns: ""


### PR DESCRIPTION
After we assign a `FirstTimeContribution` label, change the state in the project.

This relates to https://github.com/JabRef/jabref/pull/11945.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
