### PR TITLE
Replace new instantiation of BuildInfo with calls to Injector

### DIFF
--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -76,11 +76,17 @@ In `build.gradle`, these variables are filled:
 "springerNatureAPIKey" : System.getenv('SpringerNatureAPIKey')
 ```
 
-The `BuildInfo` class reads from that file and the key needs to be put into the map of default api keys in `JabRefCliPreferences::getDefaultFetcherKeys`
+The `BuildInfo` class reads from that file and the key needs to be put into the map of default api keys in `JabRefCliPreferences::getDefaultFetcherKeys`.
 
 ```java
 keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
 ```
+The fetcher api key can then be obtained by calling the preferences.
+
+```java
+importerPreferences.getApiKey(SpringerFetcher.FETCHER_NAME);
+```
+
 
 When executing `./gradlew run`, gradle executes `processResources` and populates `build/build.properties` accordingly. However, when working directly in the IDE, Eclipse keeps reading `build.properties` from `src/main/resources`. In IntelliJ, the task `JabRef Main` is executing `./gradlew processResources` before running JabRef from the IDE to ensure the `build.properties` is properly populated.
 

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -79,7 +79,7 @@ In `build.gradle`, these variables are filled:
 The `BuildInfo` class reads from that file.
 
 ```java
-new BuildInfo().springerNatureAPIKey
+Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey
 ```
 
 When executing `./gradlew run`, gradle executes `processResources` and populates `build/build.properties` accordingly. However, when working directly in the IDE, Eclipse keeps reading `build.properties` from `src/main/resources`. In IntelliJ, the task `JabRef Main` is executing `./gradlew processResources` before running JabRef from the IDE to ensure the `build.properties` is properly populated.

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -76,10 +76,10 @@ In `build.gradle`, these variables are filled:
 "springerNatureAPIKey" : System.getenv('SpringerNatureAPIKey')
 ```
 
-The `BuildInfo` class reads from that file.
+The `BuildInfo` class reads from that file and the key needs to be put into the map of default api keys in `JabRefCliPreferences::getDefaultFetcherKeys`
 
 ```java
-Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey
+keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
 ```
 
 When executing `./gradlew run`, gradle executes `processResources` and populates `build/build.properties` accordingly. However, when working directly in the IDE, Eclipse keeps reading `build.properties` from `src/main/resources`. In IntelliJ, the task `JabRef Main` is executing `./gradlew processResources` before running JabRef from the IDE to ensure the `build.properties` is properly populated.

--- a/docs/code-howtos/fetchers.md
+++ b/docs/code-howtos/fetchers.md
@@ -76,17 +76,17 @@ In `build.gradle`, these variables are filled:
 "springerNatureAPIKey" : System.getenv('SpringerNatureAPIKey')
 ```
 
-The `BuildInfo` class reads from that file and the key needs to be put into the map of default api keys in `JabRefCliPreferences::getDefaultFetcherKeys`.
+The `BuildInfo` class reads from that file and the key needs to be put into the map of default API keys in `JabRefCliPreferences::getDefaultFetcherKeys`.
 
 ```java
 keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
 ```
+
 The fetcher api key can then be obtained by calling the preferences.
 
 ```java
 importerPreferences.getApiKey(SpringerFetcher.FETCHER_NAME);
 ```
-
 
 When executing `./gradlew run`, gradle executes `processResources` and populates `build/build.properties` accordingly. However, when working directly in the IDE, Eclipse keeps reading `build.properties` from `src/main/resources`. In IntelliJ, the task `JabRef Main` is executing `./gradlew processResources` before running JabRef from the IDE to ensure the `build.properties` is properly populated.
 

--- a/src/main/java/org/jabref/Launcher.java
+++ b/src/main/java/org/jabref/Launcher.java
@@ -33,6 +33,7 @@ import org.jabref.logic.remote.client.RemoteClient;
 import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.Directories;
 import org.jabref.logic.util.HeadlessExecutorService;
+import org.jabref.logic.util.Version;
 import org.jabref.migrations.PreferencesMigrations;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.DirectoryMonitor;
@@ -140,7 +141,8 @@ public class Launcher {
         }
 
         // addLogToDisk
-        Path directory = Directories.getLogDirectory();
+        Version version = Injector.instantiateModelOrService(BuildInfo.class).version;
+        Path directory = Directories.getLogDirectory(version);
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
@@ -12,17 +12,18 @@ import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.google.gson.Gson;
 
 public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyFetcher {
     private static final String SEMANTIC_SCHOLAR_API = "https://api.semanticscholar.org/graph/v1/";
 
-    private static final String API_KEY = new BuildInfo().semanticScholarApiKey;
-
+    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SemanticScholarFetcher(ImporterPreferences importerPreferences) {
         this.importerPreferences = importerPreferences;
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).semanticScholarApiKey;
     }
 
     public String getAPIUrl(String entry_point, BibEntry entry) {
@@ -90,6 +91,6 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
     }
 
     private String getApiKey() {
-        return importerPreferences.getApiKey(getName()).orElse(API_KEY);
+        return importerPreferences.getApiKey(getName()).orElse(apiKey);
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
@@ -16,6 +16,8 @@ import com.airhacks.afterburner.injection.Injector;
 import com.google.gson.Gson;
 
 public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyFetcher {
+    public static final String FETCHER_NAME = "Semantic Scholar Citations Fetcher";
+
     private static final String SEMANTIC_SCHOLAR_API = "https://api.semanticscholar.org/graph/v1/";
 
     private final String apiKey;
@@ -87,7 +89,7 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
 
     @Override
     public String getName() {
-        return "Semantic Scholar Citations Fetcher";
+        return FETCHER_NAME;
     }
 
     private String getApiKey() {

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/semanticscholar/SemanticScholarFetcher.java
@@ -9,10 +9,8 @@ import org.jabref.logic.importer.FetcherException;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.fetcher.CustomizableKeyFetcher;
 import org.jabref.logic.net.URLDownload;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 
-import com.airhacks.afterburner.injection.Injector;
 import com.google.gson.Gson;
 
 public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyFetcher {
@@ -20,12 +18,10 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
 
     private static final String SEMANTIC_SCHOLAR_API = "https://api.semanticscholar.org/graph/v1/";
 
-    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SemanticScholarFetcher(ImporterPreferences importerPreferences) {
         this.importerPreferences = importerPreferences;
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).semanticScholarApiKey;
     }
 
     public String getAPIUrl(String entry_point, BibEntry entry) {
@@ -48,10 +44,8 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
         }
         URLDownload urlDownload = new URLDownload(citationsUrl);
 
-        String apiKey = getApiKey();
-        if (!apiKey.isEmpty()) {
-            urlDownload.addHeader("x-api-key", apiKey);
-        }
+        importerPreferences.getApiKey(getName()).ifPresent(apiKey -> urlDownload.addHeader("x-api-key", apiKey));
+
         CitationsResponse citationsResponse = new Gson()
                 .fromJson(urlDownload.asString(), CitationsResponse.class);
 
@@ -74,10 +68,7 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
         }
 
         URLDownload urlDownload = new URLDownload(referencesUrl);
-        String apiKey = getApiKey();
-        if (!apiKey.isEmpty()) {
-            urlDownload.addHeader("x-api-key", apiKey);
-        }
+        importerPreferences.getApiKey(getName()).ifPresent(apiKey -> urlDownload.addHeader("x-api-key", apiKey));
         ReferencesResponse referencesResponse = new Gson()
                 .fromJson(urlDownload.asString(), ReferencesResponse.class);
 
@@ -90,9 +81,5 @@ public class SemanticScholarFetcher implements CitationFetcher, CustomizableKeyF
     @Override
     public String getName() {
         return FETCHER_NAME;
-    }
-
-    private String getApiKey() {
-        return importerPreferences.getApiKey(getName()).orElse(apiKey);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
+++ b/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -23,6 +24,7 @@ public class ImporterPreferences {
     private final BooleanProperty warnAboutDuplicatesOnImport;
     private final ObjectProperty<Path> importWorkingDirectory;
     private final ObservableSet<FetcherApiKey> apiKeys;
+    private final Map<String, String> defaultApiKeys;
     private final ObservableSet<CustomImporter> customImporters;
     private final BooleanProperty persistCustomKeys;
     private final ObservableList<String> catalogs;
@@ -34,6 +36,7 @@ public class ImporterPreferences {
                                boolean warnAboutDuplicatesOnImport,
                                Set<CustomImporter> customImporters,
                                Set<FetcherApiKey> apiKeys,
+                               Map<String, String> defaultApiKeys,
                                boolean persistCustomKeys,
                                List<String> catalogs,
                                PlainCitationParserChoice defaultPlainCitationParser
@@ -44,6 +47,7 @@ public class ImporterPreferences {
         this.warnAboutDuplicatesOnImport = new SimpleBooleanProperty(warnAboutDuplicatesOnImport);
         this.customImporters = FXCollections.observableSet(customImporters);
         this.apiKeys = FXCollections.observableSet(apiKeys);
+        this.defaultApiKeys = defaultApiKeys;
         this.persistCustomKeys = new SimpleBooleanProperty(persistCustomKeys);
         this.catalogs = FXCollections.observableArrayList(catalogs);
         this.defaultPlainCitationParser = new SimpleObjectProperty<>(defaultPlainCitationParser);
@@ -122,12 +126,17 @@ public class ImporterPreferences {
         this.persistCustomKeys.set(persistCustomKeys);
     }
 
+    /**
+     * @param name of the fetcher
+     * @return either a customized API key if configured or the default key
+     */
     public Optional<String> getApiKey(String name) {
         return apiKeys.stream()
                       .filter(key -> key.getName().equalsIgnoreCase(name))
                       .filter(FetcherApiKey::shouldUse)
                       .findFirst()
-                      .map(FetcherApiKey::getKey);
+                      .map(FetcherApiKey::getKey)
+                      .or(() -> Optional.ofNullable(defaultApiKeys.get(name)));
     }
 
     public void setCatalogs(List<String> catalogs) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -30,14 +30,12 @@ import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.DefaultQueryTransformer;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.net.URLDownload;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.paging.Page;
 import org.jabref.model.strings.StringUtil;
 
-import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
 import kong.unirest.core.json.JSONObject;
@@ -49,17 +47,16 @@ import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
  */
 public class AstrophysicsDataSystem
         implements IdBasedParserFetcher, PagedSearchBasedParserFetcher, EntryBasedParserFetcher, CustomizableKeyFetcher {
+    public static final String FETCHER_NAME = "SAO/NASA ADS";
 
     private static final String API_SEARCH_URL = "https://api.adsabs.harvard.edu/v1/search/query";
     private static final String API_EXPORT_URL = "https://api.adsabs.harvard.edu/v1/export/bibtexabs";
 
-    private final String apiKey;
     private final ImportFormatPreferences preferences;
     private final ImporterPreferences importerPreferences;
 
     public AstrophysicsDataSystem(ImportFormatPreferences preferences, ImporterPreferences importerPreferences) {
         this.preferences = Objects.requireNonNull(preferences);
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).astrophysicsDataSystemAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -81,7 +78,7 @@ public class AstrophysicsDataSystem
 
     @Override
     public String getName() {
-        return "SAO/NASA ADS";
+        return FETCHER_NAME;
     }
 
     /**
@@ -257,7 +254,7 @@ public class AstrophysicsDataSystem
         try {
             String postData = buildPostData(ids);
             URLDownload download = new URLDownload(urLforExport);
-            download.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(apiKey));
+            importerPreferences.getApiKey(getName()).ifPresent(key -> download.addHeader("Authorization", "Bearer " + key));
             download.addHeader("ContentType", "application/json");
             download.setPostData(postData);
             String content = download.asString();
@@ -310,7 +307,7 @@ public class AstrophysicsDataSystem
     @Override
     public URLDownload getUrlDownload(URL url) {
         URLDownload urlDownload = new URLDownload(url);
-        urlDownload.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(apiKey));
+        importerPreferences.getApiKey(getName()).ifPresent(key -> urlDownload.addHeader("Authorization", "Bearer " + key));
         return urlDownload;
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -37,6 +37,7 @@ import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.paging.Page;
 import org.jabref.model.strings.StringUtil;
 
+import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
 import kong.unirest.core.json.JSONObject;
@@ -52,12 +53,13 @@ public class AstrophysicsDataSystem
     private static final String API_SEARCH_URL = "https://api.adsabs.harvard.edu/v1/search/query";
     private static final String API_EXPORT_URL = "https://api.adsabs.harvard.edu/v1/export/bibtexabs";
 
-    private static final String API_KEY = new BuildInfo().astrophysicsDataSystemAPIKey;
+    private final String apiKey;
     private final ImportFormatPreferences preferences;
     private final ImporterPreferences importerPreferences;
 
     public AstrophysicsDataSystem(ImportFormatPreferences preferences, ImporterPreferences importerPreferences) {
         this.preferences = Objects.requireNonNull(preferences);
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).astrophysicsDataSystemAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -255,7 +257,7 @@ public class AstrophysicsDataSystem
         try {
             String postData = buildPostData(ids);
             URLDownload download = new URLDownload(urLforExport);
-            download.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(API_KEY));
+            download.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(apiKey));
             download.addHeader("ContentType", "application/json");
             download.setPostData(postData);
             String content = download.asString();
@@ -308,7 +310,7 @@ public class AstrophysicsDataSystem
     @Override
     public URLDownload getUrlDownload(URL url) {
         URLDownload urlDownload = new URLDownload(url);
-        urlDownload.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(API_KEY));
+        urlDownload.addHeader("Authorization", "Bearer " + importerPreferences.getApiKey(getName()).orElse(apiKey));
         return urlDownload;
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
@@ -23,6 +23,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.google.common.annotations.VisibleForTesting;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
@@ -38,16 +39,17 @@ import org.tinylog.Logger;
  */
 public class BiodiversityLibrary implements SearchBasedParserFetcher, CustomizableKeyFetcher {
 
-    private static final String API_KEY = new BuildInfo().biodiversityHeritageApiKey;
     private static final String BASE_URL = "https://www.biodiversitylibrary.org/api3";
     private static final String RESPONSE_FORMAT = "json";
     private static final String TEST_URL_WITHOUT_API_KEY = "https://www.biodiversitylibrary.org/api3?apikey=";
 
     private static final String FETCHER_NAME = "Biodiversity Heritage";
 
+    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public BiodiversityLibrary(ImporterPreferences importerPreferences) {
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).biodiversityHeritageApiKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -63,7 +65,7 @@ public class BiodiversityLibrary implements SearchBasedParserFetcher, Customizab
 
     public URL getBaseURL() throws URISyntaxException, MalformedURLException {
         URIBuilder baseURI = new URIBuilder(BASE_URL);
-        baseURI.addParameter("apikey", importerPreferences.getApiKey(getName()).orElse(API_KEY));
+        baseURI.addParameter("apikey", importerPreferences.getApiKey(getName()).orElse(apiKey));
         baseURI.addParameter("format", RESPONSE_FORMAT);
 
         return baseURI.build().toURL();

--- a/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BiodiversityLibrary.java
@@ -16,14 +16,12 @@ import org.jabref.logic.importer.SearchBasedParserFetcher;
 import org.jabref.logic.importer.fetcher.transformers.BiodiversityLibraryTransformer;
 import org.jabref.logic.importer.util.JsonReader;
 import org.jabref.logic.net.URLDownload;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.Author;
 import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-import com.airhacks.afterburner.injection.Injector;
 import com.google.common.annotations.VisibleForTesting;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONException;
@@ -38,18 +36,15 @@ import org.tinylog.Logger;
  * @see <a href="https://www.biodiversitylibrary.org/docs/api3.html">API documentation</a>
  */
 public class BiodiversityLibrary implements SearchBasedParserFetcher, CustomizableKeyFetcher {
+    public static final String FETCHER_NAME = "Biodiversity Heritage";
 
     private static final String BASE_URL = "https://www.biodiversitylibrary.org/api3";
     private static final String RESPONSE_FORMAT = "json";
     private static final String TEST_URL_WITHOUT_API_KEY = "https://www.biodiversitylibrary.org/api3?apikey=";
 
-    private static final String FETCHER_NAME = "Biodiversity Heritage";
-
-    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public BiodiversityLibrary(ImporterPreferences importerPreferences) {
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).biodiversityHeritageApiKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -65,7 +60,7 @@ public class BiodiversityLibrary implements SearchBasedParserFetcher, Customizab
 
     public URL getBaseURL() throws URISyntaxException, MalformedURLException {
         URIBuilder baseURI = new URIBuilder(BASE_URL);
-        baseURI.addParameter("apikey", importerPreferences.getApiKey(getName()).orElse(apiKey));
+        importerPreferences.getApiKey(getName()).ifPresent(key -> baseURI.addParameter("apikey", key));
         baseURI.addParameter("format", RESPONSE_FORMAT);
 
         return baseURI.build().toURL();

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -32,6 +32,7 @@ import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.strings.StringUtil;
 
+import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
 import org.apache.hc.core5.net.URIBuilder;
@@ -59,15 +60,16 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
     private static final Pattern PDF_PATTERN = Pattern.compile("\"(https://ieeexplore.ieee.org/ielx[0-9/]+\\.pdf[^\"]+)\"");
     private static final String IEEE_DOI = "10.1109";
     private static final String BASE_URL = "https://ieeexplore.ieee.org";
-    private static final String API_KEY = new BuildInfo().ieeeAPIKey;
     private static final String TEST_URL_WITHOUT_API_KEY = "https://ieeexploreapi.ieee.org/api/v1/search/articles?max_records=0&apikey=";
 
+    private final String apiKey;
     private final ImportFormatPreferences importFormatPreferences;
     private final ImporterPreferences importerPreferences;
 
     private IEEEQueryTransformer transformer;
 
     public IEEE(ImportFormatPreferences importFormatPreferences, ImporterPreferences importerPreferences) {
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).ieeeAPIKey;
         this.importFormatPreferences = Objects.requireNonNull(importFormatPreferences);
         this.importerPreferences = Objects.requireNonNull(importerPreferences);
     }
@@ -265,7 +267,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
     }
 
     private String getApiKey() {
-        return importerPreferences.getApiKey(getName()).orElse(API_KEY);
+        return importerPreferences.getApiKey(getName()).orElse(apiKey);
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -11,12 +11,10 @@ import java.util.stream.Collectors;
 import org.jabref.logic.importer.FulltextFetcher;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.net.URLDownload;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
-import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
@@ -36,16 +34,15 @@ import org.slf4j.LoggerFactory;
  * See <a href="https://dev.elsevier.com/">https://dev.elsevier.com/</a>.
  */
 public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
+    public static final String FETCHER_NAME = "ScienceDirect";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ScienceDirect.class);
 
     private static final String API_URL = "https://api.elsevier.com/content/article/doi/";
-    private static final String FETCHER_NAME = "ScienceDirect";
 
-    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public ScienceDirect(ImporterPreferences importerPreferences) {
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).scienceDirectApiKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -142,7 +139,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
         try {
             String request = API_URL + doi;
             HttpResponse<JsonNode> jsonResponse = Unirest.get(request)
-                                                         .header("X-ELS-APIKey", importerPreferences.getApiKey(getName()).orElse(apiKey))
+                                                         .header("X-ELS-APIKey", importerPreferences.getApiKey(getName()).orElse(""))
                                                          .queryString("httpAccept", "application/json")
                                                          .asJson();
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ScienceDirect.java
@@ -16,6 +16,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
+import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
@@ -38,12 +39,13 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScienceDirect.class);
 
     private static final String API_URL = "https://api.elsevier.com/content/article/doi/";
-    private static final String API_KEY = new BuildInfo().scienceDirectApiKey;
     private static final String FETCHER_NAME = "ScienceDirect";
 
+    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public ScienceDirect(ImporterPreferences importerPreferences) {
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).scienceDirectApiKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -140,7 +142,7 @@ public class ScienceDirect implements FulltextFetcher, CustomizableKeyFetcher {
         try {
             String request = API_URL + doi;
             HttpResponse<JsonNode> jsonResponse = Unirest.get(request)
-                                                         .header("X-ELS-APIKey", importerPreferences.getApiKey(getName()).orElse(API_KEY))
+                                                         .header("X-ELS-APIKey", importerPreferences.getApiKey(getName()).orElse(apiKey))
                                                          .queryString("httpAccept", "application/json")
                                                          .asJson();
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -25,6 +25,7 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.google.common.base.Strings;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
@@ -45,13 +46,14 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringerFetcher.class);
 
     private static final String API_URL = "https://api.springernature.com/meta/v1/json";
-    private static final String API_KEY = new BuildInfo().springerNatureAPIKey;
     // Springer query using the parameter 'q=doi:10.1007/s11276-008-0131-4s=1' will respond faster
     private static final String TEST_URL_WITHOUT_API_KEY = "https://api.springernature.com/meta/v1/json?q=doi:10.1007/s11276-008-0131-4s=1&p=1&api_key=";
 
+    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SpringerFetcher(ImporterPreferences importerPreferences) {
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -188,7 +190,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
     public URL getURLForQuery(QueryNode luceneQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
         uriBuilder.addParameter("q", new SpringerQueryTransformer().transformLuceneQuery(luceneQuery).orElse("")); // Search query
-        uriBuilder.addParameter("api_key", importerPreferences.getApiKey(getName()).orElse(API_KEY)); // API key
+        uriBuilder.addParameter("api_key", importerPreferences.getApiKey(getName()).orElse(apiKey)); // API key
         uriBuilder.addParameter("s", String.valueOf(getPageSize() * pageNumber + 1)); // Start entry, starts indexing at 1
         uriBuilder.addParameter("p", String.valueOf(getPageSize())); // Page size
         return uriBuilder.build().toURL();

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerFetcher.java
@@ -17,7 +17,6 @@ import org.jabref.logic.importer.PagedSearchBasedParserFetcher;
 import org.jabref.logic.importer.Parser;
 import org.jabref.logic.importer.fetcher.transformers.SpringerQueryTransformer;
 import org.jabref.logic.os.OS;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.Month;
@@ -25,7 +24,6 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-import com.airhacks.afterburner.injection.Injector;
 import com.google.common.base.Strings;
 import kong.unirest.core.json.JSONArray;
 import kong.unirest.core.json.JSONObject;
@@ -40,7 +38,6 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://dev.springernature.com/">API documentation</a> for more details
  */
 public class SpringerFetcher implements PagedSearchBasedParserFetcher, CustomizableKeyFetcher {
-
     public static final String FETCHER_NAME = "Springer";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringerFetcher.class);
@@ -49,11 +46,9 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
     // Springer query using the parameter 'q=doi:10.1007/s11276-008-0131-4s=1' will respond faster
     private static final String TEST_URL_WITHOUT_API_KEY = "https://api.springernature.com/meta/v1/json?q=doi:10.1007/s11276-008-0131-4s=1&p=1&api_key=";
 
-    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SpringerFetcher(ImporterPreferences importerPreferences) {
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -190,7 +185,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
     public URL getURLForQuery(QueryNode luceneQuery, int pageNumber) throws URISyntaxException, MalformedURLException {
         URIBuilder uriBuilder = new URIBuilder(API_URL);
         uriBuilder.addParameter("q", new SpringerQueryTransformer().transformLuceneQuery(luceneQuery).orElse("")); // Search query
-        uriBuilder.addParameter("api_key", importerPreferences.getApiKey(getName()).orElse(apiKey)); // API key
+        importerPreferences.getApiKey(getName()).ifPresent(key -> uriBuilder.addParameter("api_key", key)); // API key
         uriBuilder.addParameter("s", String.valueOf(getPageSize() * pageNumber + 1)); // Start entry, starts indexing at 1
         uriBuilder.addParameter("p", String.valueOf(getPageSize())); // Page size
         return uriBuilder.build().toURL();

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
@@ -14,6 +14,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
+import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
@@ -33,12 +34,13 @@ public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(SpringerLink.class);
 
     private static final String API_URL = "https://api.springer.com/meta/v1/json";
-    private static final String API_KEY = new BuildInfo().springerNatureAPIKey;
     private static final String CONTENT_HOST = "link.springer.com";
 
+    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SpringerLink(ImporterPreferences importerPreferences) {
+        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -55,7 +57,7 @@ public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
         // Available in catalog?
         try {
             HttpResponse<JsonNode> jsonResponse = Unirest.get(API_URL)
-                                                         .queryString("api_key", importerPreferences.getApiKey(getName()).orElse(API_KEY))
+                                                         .queryString("api_key", importerPreferences.getApiKey(getName()).orElse(apiKey))
                                                          .queryString("q", "doi:%s".formatted(doi.get().getDOI()))
                                                          .asJson();
             if (jsonResponse.getBody() != null) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/SpringerLink.java
@@ -9,12 +9,10 @@ import java.util.Optional;
 
 import org.jabref.logic.importer.FulltextFetcher;
 import org.jabref.logic.importer.ImporterPreferences;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 
-import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.HttpResponse;
 import kong.unirest.core.JsonNode;
 import kong.unirest.core.Unirest;
@@ -36,11 +34,9 @@ public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
     private static final String API_URL = "https://api.springer.com/meta/v1/json";
     private static final String CONTENT_HOST = "link.springer.com";
 
-    private final String apiKey;
     private final ImporterPreferences importerPreferences;
 
     public SpringerLink(ImporterPreferences importerPreferences) {
-        this.apiKey = Injector.instantiateModelOrService(BuildInfo.class).springerNatureAPIKey;
         this.importerPreferences = importerPreferences;
     }
 
@@ -57,7 +53,7 @@ public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
         // Available in catalog?
         try {
             HttpResponse<JsonNode> jsonResponse = Unirest.get(API_URL)
-                                                         .queryString("api_key", importerPreferences.getApiKey(getName()).orElse(apiKey))
+                                                         .queryString("api_key", importerPreferences.getApiKey(getName()).orElse(""))
                                                          .queryString("q", "doi:%s".formatted(doi.get().getDOI()))
                                                          .asJson();
             if (jsonResponse.getBody() != null) {

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -2092,7 +2092,11 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     private Map<String, String> getDefaultFetcherKeys() {
-        BuildInfo buildInfo = new BuildInfo();
+        BuildInfo buildInfo = Injector.instantiateModelOrService(BuildInfo.class);
+        if (buildInfo == null) {
+            return Collections.emptyMap();
+        }
+
         Map<String, String> keys = new HashMap<>();
         keys.put(SemanticScholarFetcher.FETCHER_NAME, buildInfo.semanticScholarApiKey);
         keys.put(AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey);

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -2104,6 +2104,7 @@ public class JabRefCliPreferences implements CliPreferences {
         keys.put(BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey);
         keys.put(ScienceDirect.FETCHER_NAME, buildInfo.scienceDirectApiKey);
         keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
+        // SpringerLink uses the same key and fetcher name as SpringerFetcher
 
         return keys;
     }

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -2094,6 +2094,7 @@ public class JabRefCliPreferences implements CliPreferences {
     private Map<String, String> getDefaultFetcherKeys() {
         BuildInfo buildInfo = Injector.instantiateModelOrService(BuildInfo.class);
         if (buildInfo == null) {
+            LOGGER.warn("Could not instantiate BuildInfo.");
             return Collections.emptyMap();
         }
 

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -31,6 +31,7 @@ import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.SetChangeListener;
 
+import org.jabref.gui.entryeditor.citationrelationtab.semanticscholar.SemanticScholarFetcher;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.InternalPreferences;
 import org.jabref.logic.JabRefException;
@@ -52,9 +53,12 @@ import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
+import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
+import org.jabref.logic.importer.fetcher.BiodiversityLibrary;
 import org.jabref.logic.importer.fetcher.DBLPFetcher;
 import org.jabref.logic.importer.fetcher.IEEE;
 import org.jabref.logic.importer.fetcher.MrDlibPreferences;
+import org.jabref.logic.importer.fetcher.ScienceDirect;
 import org.jabref.logic.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
@@ -81,6 +85,7 @@ import org.jabref.logic.search.SearchDisplayMode;
 import org.jabref.logic.search.SearchPreferences;
 import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.shared.security.Password;
+import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.Directories;
 import org.jabref.logic.util.Version;
 import org.jabref.logic.util.io.AutoLinkPreferences;
@@ -1998,6 +2003,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION),
                 getCustomImportFormats(),
                 getFetcherKeys(),
+                getDefaultFetcherKeys(),
                 getBoolean(FETCHER_CUSTOM_KEY_PERSIST),
                 getStringList(SEARCH_CATALOGS),
                 PlainCitationParserChoice.valueOf(get(DEFAULT_PLAIN_CITATION_PARSER))
@@ -2081,6 +2087,18 @@ public class JabRefCliPreferences implements CliPreferences {
         } catch (Exception ex) {
             LOGGER.warn("JabRef could not open the key store");
         }
+
+        return keys;
+    }
+
+    private Map<String, String> getDefaultFetcherKeys() {
+        BuildInfo buildInfo = new BuildInfo();
+        Map<String, String> keys = new HashMap<>();
+        keys.put(SemanticScholarFetcher.FETCHER_NAME, buildInfo.semanticScholarApiKey);
+        keys.put(AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey);
+        keys.put(BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey);
+        keys.put(ScienceDirect.FETCHER_NAME, buildInfo.scienceDirectApiKey);
+        keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
 
         return keys;
     }

--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -20,7 +20,6 @@ public final class BuildInfo {
     public final Version version;
     public final String maintainers;
     public final String year;
-    public final String azureInstrumentationKey;
     public final String springerNatureAPIKey;
     public final String astrophysicsDataSystemAPIKey;
     public final String ieeeAPIKey;
@@ -50,7 +49,6 @@ public final class BuildInfo {
         version = Version.parse(properties.getProperty("version"));
         year = properties.getProperty("year", "");
         maintainers = properties.getProperty("maintainers", "");
-        azureInstrumentationKey = BuildInfo.getValue(properties, "azureInstrumentationKey", "");
         springerNatureAPIKey = BuildInfo.getValue(properties, "springerNatureAPIKey", "118d90a519d0fc2a01ee9715400054d4");
         astrophysicsDataSystemAPIKey = BuildInfo.getValue(properties, "astrophysicsDataSystemAPIKey", "tAhPRKADc6cC26mZUnAoBt3MAjCvKbuCZsB4lI3c");
         ieeeAPIKey = BuildInfo.getValue(properties, "ieeeAPIKey", "5jv3wyt4tt2bwcwv7jjk7pc3");

--- a/src/main/java/org/jabref/logic/util/Directories.java
+++ b/src/main/java/org/jabref/logic/util/Directories.java
@@ -25,13 +25,13 @@ public class Directories {
         return Path.of(System.getProperty("user.home"));
     }
 
-    public static Path getLogDirectory() {
+    public static Path getLogDirectory(Version version) {
         return Path.of(AppDirsFactory.getInstance()
                                      .getUserDataDir(
                                              OS.APP_DIR_APP_NAME,
                                              "logs",
                                              OS.APP_DIR_APP_AUTHOR))
-                   .resolve(new BuildInfo().version.toString());
+                   .resolve(version.toString());
     }
 
     public static Path getBackupDirectory() {

--- a/src/test/java/org/jabref/logic/importer/fetcher/BiodiversityLibraryTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/BiodiversityLibraryTest.java
@@ -27,14 +27,14 @@ import static org.mockito.Mockito.when;
 
 @FetcherTest
 class BiodiversityLibraryTest {
-    private final String BASE_URL = "https://www.biodiversitylibrary.org/api3?";
     private final String RESPONSE_FORMAT = "&format=json";
-    private final BuildInfo buildInfo = new BuildInfo();
 
+    private String apiKey;
     private BiodiversityLibrary fetcher;
 
     @BeforeEach
     void setUp() {
+        apiKey = new BuildInfo().biodiversityHeritageApiKey;
         ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
         fetcher = new BiodiversityLibrary(importerPreferences);
@@ -49,15 +49,14 @@ class BiodiversityLibraryTest {
 
     @Test
     void biodiversityHeritageApiKeyIsNotEmpty() {
-        BuildInfo buildInfo = new BuildInfo();
-        assertNotNull(buildInfo.biodiversityHeritageApiKey);
+        assertNotNull(apiKey);
     }
 
     @Test
     void baseURLConstruction() throws MalformedURLException, URISyntaxException {
         String expected = fetcher
                 .getTestUrl()
-                .concat(buildInfo.biodiversityHeritageApiKey)
+                .concat(apiKey)
                 .concat(RESPONSE_FORMAT);
 
         assertEquals(expected, fetcher.getBaseURL().toString());
@@ -68,7 +67,7 @@ class BiodiversityLibraryTest {
     void getPartMetadaUrl(String id) throws MalformedURLException, URISyntaxException {
         String expected = fetcher
                 .getTestUrl()
-                .concat(buildInfo.biodiversityHeritageApiKey)
+                .concat(apiKey)
                 .concat(RESPONSE_FORMAT)
                 .concat("&op=GetPartMetadata&pages=f&names=f")
                 .concat("&id=");
@@ -81,7 +80,7 @@ class BiodiversityLibraryTest {
     void getItemMetadaUrl(String id) throws MalformedURLException, URISyntaxException {
         String expected = fetcher
                 .getTestUrl()
-                .concat(buildInfo.biodiversityHeritageApiKey)
+                .concat(apiKey)
                 .concat(RESPONSE_FORMAT)
                 .concat("&op=GetItemMetadata&pages=f&ocr=f&ocr=f")
                 .concat("&id=");

--- a/src/test/java/org/jabref/logic/util/BuildInfoTest.java
+++ b/src/test/java/org/jabref/logic/util/BuildInfoTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.util;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class BuildInfoTest {
 
@@ -17,11 +16,5 @@ class BuildInfoTest {
     void fileImport() {
         BuildInfo buildInfo = new BuildInfo("/org/jabref/util/build.properties");
         assertEquals("42", buildInfo.version.getFullVersion());
-    }
-
-    @Test
-    void azureInstrumentationKeyIsNotEmpty() {
-        BuildInfo buildInfo = new BuildInfo();
-        assertNotNull(buildInfo.azureInstrumentationKey);
     }
 }


### PR DESCRIPTION
closes https://github.com/JabRef/jabref-issue-melting-pot/issues/604

also removes some telemetry artifacts

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
