### PR TITLE
Do not use Injector while initializing logging

### DIFF
--- a/src/main/java/org/jabref/cli/JabRefCli.java
+++ b/src/main/java/org/jabref/cli/JabRefCli.java
@@ -26,7 +26,6 @@ import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.client.RemoteClient;
 import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.Directories;
-import org.jabref.logic.util.Version;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -140,8 +139,8 @@ public class JabRefCli {
         }
 
         // addLogToDisk
-        Version version = Injector.instantiateModelOrService(BuildInfo.class).version;
-        Path directory = Directories.getLogDirectory(version);
+        // We cannot use `Injector.instantiateModelOrService(BuildInfo.class).version` here, because this initializes logging
+        Path directory = Directories.getLogDirectory(new BuildInfo().version);
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {


### PR DESCRIPTION
Current main:

```
> Task :run
WARNING: Using incubator modules: jdk.incubator.vector
Messages are not initialized before accessing key: Display help on command line options
Exception in thread "main" java.lang.UnsupportedOperationException: Configuration cannot be changed after applying to tinylog
        at org.tinylog.api@2.7.0/org.tinylog.configuration.Configuration.set(Configuration.java:288)
        at java.base/java.util.Map.forEach(Map.java:733)
        at org.jabref@100.0.0/org.jabref.cli.JabRefCli.initLogging(JabRefCli.java:164)
        at org.jabref@100.0.0/org.jabref.Launcher.main(Launcher.java:26)
```

This is because of the use of injector (introduced in https://github.com/JabRef/jabref/pull/11954 - and merged into https://github.com/JabRef/jabref/pull/11921).

This PR fixes it.

---

Hotfix, therefore I will merge immediatly.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
