### PR TITLE
Improve step names

### DIFF
--- a/.github/workflows/on-labeled.yml
+++ b/.github/workflows/on-labeled.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   FirstTimeCodeContribution:
-    name: Add greeting to issues for first time contributors
     if: ${{ github.event.label.name == 'FirstTimeCodeContribution' }}
     runs-on: ubuntu-latest
     permissions:
@@ -47,7 +46,7 @@ jobs:
        target-column: "Assigned"
        ignored-columns: ""
   Assigned:
-    name: "Update project boards for label '📍 Assigned'"
+    name: "📍 Assigned"
     if: ${{ github.event.label.name == '📍 Assigned' }}
     runs-on: ubuntu-latest
     permissions:
@@ -70,6 +69,7 @@ jobs:
        target-column: "Assigned"
        ignored-columns: ""
   good-first-issue:
+    name: "good first issue"
     if: "${{ github.event.label.name == 'good first issue' }}"
     runs-on: ubuntu-latest
     steps:
@@ -90,6 +90,7 @@ jobs:
           ISSUE_URL=$(jq --raw-output .issue.html_url "$GITHUB_EVENT_PATH")
           gh project item-add 15 --owner JabRef --url $ISSUE_URL
   status-freeze:
+    name: "status: freeze"
     if: "${{ github.event.label.name == 'status: freeze' }}"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When browsing the workflow, GitHub displays only some first characters. Leading to an unreadable output:

![image](https://github.com/user-attachments/assets/674cca96-1288-443d-85f1-3f861a69f985)

This PR fixes it.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
