### PR TITLE
Enable "automerge" label handling on a PR.

### DIFF
--- a/.github/workflows/on-labeled-issue.yml
+++ b/.github/workflows/on-labeled-issue.yml
@@ -1,11 +1,8 @@
-name: On labeled
+name: On labeled issue
 
 on:
   issues:
      types:
-       - labeled
-  pull_request_target:
-    types:
        - labeled
 
 jobs:

--- a/.github/workflows/on-labeled-pr.yml
+++ b/.github/workflows/on-labeled-pr.yml
@@ -1,0 +1,23 @@
+name: On labeled PR
+
+on:
+  pull_request:
+     types:
+       - labeled
+
+jobs:
+  automerge:
+    name: Auto Merge
+    if: "${{ github.event.label.name == 'automerge' }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE}}
+      - name: Merge PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}

--- a/.github/workflows/on-unlabeled-issue.yml
+++ b/.github/workflows/on-unlabeled-issue.yml
@@ -1,11 +1,8 @@
-name: On unlabeled
+name: On unlabeled issue
 
 on:
   issues:
      types:
-       - unlabeled
-  pull_request_target:
-    types:
        - unlabeled
 
 jobs:


### PR DESCRIPTION
We have support for automerge (see https://github.com/JabRef/jabref/blob/main/.github/workflows/automerge.yml for details). It ensures a) updates come in quickly and b) are checked by the CI.

Sometimes, we need things to go in quickly without a review (e.g., hot fixes). They should go in after a successful CI check.

Idea: Use "automerge" label. If that label is present, the CI will try to merge this PR after a successful check.

This PR also renames the workflows and fixes triggers.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
