### PR TITLE
Add information on unassignment

### DIFF
--- a/.github/workflows/on-labeled-issue.yml
+++ b/.github/workflows/on-labeled-issue.yml
@@ -25,6 +25,10 @@ jobs:
 
           Having any questions or issues? Feel free to ask here on GitHub. Need help setting up your local workspace? Join the conversation on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref). And don't hesitate to open a (draft) pull request early on to show the direction it is heading towards. This way, you will receive valuable feedback.
 
+          ⚠ Note that this issue will become unassigned if it isn't closed within **30 days**.
+
+          🔧 A maintainer can also add the **`Pinned`** label to prevent it from being unassigned automatically.
+
           Happy coding! 🚀
     - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
       uses: m7kvqbe1/github-action-move-issues@v1.1.1


### PR DESCRIPTION
Until https://github.com/takanome-dev/assign-issue-action/issues/244 is implemented, we should make the unassignment procedure transparent.

I just copied over the text from the reaction on `/assign-me`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
