### PR TITLE
Rename JabRefCli to JabKit

### DIFF
--- a/src/main/java/org/jabref/Launcher.java
+++ b/src/main/java/org/jabref/Launcher.java
@@ -2,7 +2,7 @@ package org.jabref;
 
 import java.util.List;
 
-import org.jabref.cli.JabRefCli;
+import org.jabref.cli.JabKit;
 import org.jabref.gui.JabRefGUI;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.preferences.JabRefGuiPreferences;
@@ -23,7 +23,7 @@ import com.airhacks.afterburner.injection.Injector;
 public class Launcher {
 
     public static void main(String[] args) {
-        JabRefCli.initLogging(args);
+        JabKit.initLogging(args);
 
         // Initialize preferences
         final JabRefGuiPreferences preferences = JabRefGuiPreferences.getInstance();
@@ -33,7 +33,7 @@ public class Launcher {
         DefaultFileUpdateMonitor fileUpdateMonitor = new DefaultFileUpdateMonitor();
         HeadlessExecutorService.INSTANCE.executeInterruptableTask(fileUpdateMonitor, "FileUpdateMonitor");
 
-        List<UiCommand> uiCommands = JabRefCli.processArguments(args, preferences, fileUpdateMonitor);
+        List<UiCommand> uiCommands = JabKit.processArguments(args, preferences, fileUpdateMonitor);
         // The method `processArguments` quites the whole JVM if no GUI is needed.
 
         PreferencesMigrations.runMigrations(preferences);

--- a/src/main/java/org/jabref/cli/JabKit.java
+++ b/src/main/java/org/jabref/cli/JabKit.java
@@ -37,12 +37,16 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.tinylog.configuration.Configuration;
 
-/**
- * Entrypoint for a command-line only version of JabRef.
- *
- * Does not do any preference migrations
- */
-public class JabRefCli {
+/// Entrypoint for a command-line only version of JabRef.
+/// It does not open any dialogs, just parses the command line arguments and outputs text and creates/modifies files.
+///
+/// See [Command Line Interface Guidelines](https://clig.dev/) for general guidelines how to design a good CLI interface.
+///
+/// It does not open any GUI.
+/// For the GUI application see {@link org.jabref.Launcher}.
+///
+/// Does not do any preference migrations.
+public class JabKit {
     private static Logger LOGGER;
 
     public static void main(String[] args) {
@@ -144,7 +148,7 @@ public class JabRefCli {
         try {
             Files.createDirectories(directory);
         } catch (IOException e) {
-            LOGGER = LoggerFactory.getLogger(JabRefCli.class);
+            LOGGER = LoggerFactory.getLogger(JabKit.class);
             LOGGER.error("Could not create log directory {}", directory, e);
             return;
         }
@@ -162,7 +166,7 @@ public class JabRefCli {
                 "writerFile.backups", "30");
         configuration.forEach(Configuration::set);
 
-        LOGGER = LoggerFactory.getLogger(JabRefCli.class);
+        LOGGER = LoggerFactory.getLogger(JabKit.class);
     }
 
     /**


### PR DESCRIPTION
On [JabCon2024](https://blog.jabref.org/2024/09/18/JabCon24/), we discussed about naming. Current state:

- `JabKit` for the command-line-only version
- `JabLib` for a library published by [Maven Central](https://central.sonatype.com/)

This PR implements this naming.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
