### PR TITLE
Try other template format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
-Describe the changes you have made here: what, why, ... Link the issue that will be closed, e.g., "Closes #333". If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47". "Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
+Describe the changes you have made here: what, why, ...
+Link the issue that will be closed, e.g., "Closes #333". If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
 
 ### Mandatory checks
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,4 @@
-<!-- 
-Describe the changes you have made here: what, why, ... 
-Link the issue that will be closed, e.g., "Closes #333".
-If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47".
-"Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
-Don't reference an issue in the PR title because GitHub does not support auto-linking there.
--->
+Describe the changes you have made here: what, why, ... Link the issue that will be closed, e.g., "Closes #333". If your PR closes a koppor issue, link it using its URL, e.g., "Closes https://github.com/koppor/jabref/issues/47". "Closes" is a keyword GitHub uses to link PRs with issues; do not change it.
 
 ### Mandatory checks
 


### PR DESCRIPTION
Studients do not delete the HTML comment markers (e.g., https://github.com/JabRef/jabref/pull/12009), thus, the link does not work. I shortened the howto to a two-liner.

They always link the issue in the title - thus I removed that recommendation; as long as they link in the text, we are fine.

I removed the explanation text for "Closes". They can google background information.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
