### PR TITLE
Update takanome-dev/assign-issue-action to beta

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Assign the user or unassign stale assignments
         id: assign
-        uses: takanome-dev/assign-issue-action@beta
+        uses: takanome-dev/assign-issue-action@refactor-rewrite-action
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           days_until_unassign: 30
@@ -37,19 +37,23 @@ jobs:
             Happy coding! 🚀
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
         if: steps.assign.outputs.assigned == 'yes'
-        uses: m7kvqbe1/github-action-move-issues@v1.1.1
+        uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
           target-labels: "📍 Assigned"
           target-column: "Assigned"
           ignored-columns: ""
+          default-column: "Free to take"
+          skip-if-not-in-project: true
       - name: Move Issue to "Assigned" Column in "Good First Issues"
         if: steps.assign.outputs.assigned == 'yes'
-        uses: m7kvqbe1/github-action-move-issues@v1.1.1
+        uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
           target-labels: "📍 Assigned"
           target-column: "Assigned"
           ignored-columns: ""
+          default-column: "Free to take"
+          skip-if-not-in-project: true

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           days_until_unassign: 30
+          maintainers: koppor, Siedlerchr, ThiloteE, calixtus, HoussemNasri
           assigned_comment: |
             👋 Hey @{{ comment.user.login }},
 

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   assign:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Assign the user or unassign stale assignments
-        uses: takanome-dev/assign-issue-action@v2.1.1
+        id: assign
+        uses: takanome-dev/assign-issue-action@beta
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           days_until_unassign: 30
@@ -32,3 +35,21 @@ jobs:
             🔧 A maintainer can also add the **{{ inputs.pin_label }}** label to prevent it from being unassigned automatically.
 
             Happy coding! 🚀
+      - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
+        if: steps.assign.outputs.assigned == 'yes'
+        uses: m7kvqbe1/github-action-move-issues@v1.1.1
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/3"
+          target-labels: "📍 Assigned"
+          target-column: "Assigned"
+          ignored-columns: ""
+      - name: Move Issue to "Assigned" Column in "Good First Issues"
+        if: steps.assign.outputs.assigned == 'yes'
+        uses: m7kvqbe1/github-action-move-issues@v1.1.1
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/5"
+          target-labels: "📍 Assigned"
+          target-column: "Assigned"
+          ignored-columns: ""

--- a/.github/workflows/on-labeled-issue.yml
+++ b/.github/workflows/on-labeled-issue.yml
@@ -31,21 +31,25 @@ jobs:
 
           Happy coding! 🚀
     - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
+      uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
       with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/3"
-       target-labels: "FirstTimeCodeContribution"
-       target-column: "Assigned"
-       ignored-columns: ""
+        github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+        project-url: "https://github.com/orgs/JabRef/projects/3"
+        target-labels: "📍 Assigned"
+        target-column: "Assigned"
+        ignored-columns: ""
+        default-column: "Free to take"
+        skip-if-not-in-project: true
     - name: Move Issue to "Assigned" Column in "Good First Issues"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
+      uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
       with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/5"
-       target-labels: "FirstTimeCodeContribution"
-       target-column: "Assigned"
-       ignored-columns: ""
+        github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+        project-url: "https://github.com/orgs/JabRef/projects/5"
+        target-labels: "📍 Assigned"
+        target-column: "Assigned"
+        ignored-columns: ""
+        default-column: "Free to take"
+        skip-if-not-in-project: true
   good-first-issue:
     name: "good first issue"
     if: "${{ github.event.label.name == 'good first issue' }}"

--- a/.github/workflows/on-labeled-issue.yml
+++ b/.github/workflows/on-labeled-issue.yml
@@ -46,29 +46,6 @@ jobs:
        target-labels: "FirstTimeCodeContribution"
        target-column: "Assigned"
        ignored-columns: ""
-  Assigned:
-    name: "📍 Assigned"
-    if: ${{ github.event.label.name == '📍 Assigned' }}
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-    - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
-      with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/3"
-       target-labels: "📍 Assigned"
-       target-column: "Assigned"
-       ignored-columns: ""
-    - name: Move Issue to "Assigned" Column in "Good First Issues"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
-      with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/5"
-       target-labels: "📍 Assigned"
-       target-column: "Assigned"
-       ignored-columns: ""
   good-first-issue:
     name: "good first issue"
     if: "${{ github.event.label.name == 'good first issue' }}"

--- a/.github/workflows/on-unlabeled-issue.yml
+++ b/.github/workflows/on-unlabeled-issue.yml
@@ -13,20 +13,22 @@ jobs:
       issues: write
     steps:
     - name: Move Issue to "Free to take" Column in "Candidates for University Projects"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
+      uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
       with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/3"
-       target-labels: "📍 Assigned"
-       target-column: "Assigned"
-       ignored-columns: ""
-       default-column: "Free to take"
+        github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+        project-url: "https://github.com/orgs/JabRef/projects/3"
+        target-labels: "📍 Assigned"
+        target-column: "Assigned"
+        ignored-columns: ""
+        default-column: "Free to take"
+        skip-if-not-in-project: true
     - name: Move Issue to "Free to take" Column in "Good First Issues"
-      uses: m7kvqbe1/github-action-move-issues@v1.1.1
+      uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
       with:
-       github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
-       project-url: "https://github.com/orgs/JabRef/projects/5"
-       target-labels: "📍 Assigned"
-       target-column: "Assigned"
-       ignored-columns: ""
-       default-column: "Free to take"
+        github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+        project-url: "https://github.com/orgs/JabRef/projects/5"
+        target-labels: "📍 Assigned"
+        target-column: "Assigned"
+        ignored-columns: ""
+        default-column: "Free to take"
+        skip-if-not-in-project: true


### PR DESCRIPTION
Now, on assignment via the action, the project is also updated. No more action with the "Assigned" label.

Refs https://github.com/takanome-dev/assign-issue-action/issues/247

Can be merged if https://github.com/takanome-dev/assign-issue-action/pull/245 is merged.

I hope that https://github.com/m7kvqbe1/github-action-move-issues/issues/4 will also be implemented soon 😅

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
