### PR TITLE
Add SSRN urls to CompositeIdFetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a different background color to the search bar to indicate when the search syntax is wrong. [#11658](https://github.com/JabRef/jabref/pull/11658)
 - We added a setting which always adds the literal "Cited on pages" text before each JStyle citation. [#11691](https://github.com/JabRef/jabref/pull/11732)
 - We added a new plain citation parser that uses LLMs. [#11825](https://github.com/JabRef/jabref/issues/11825)
+- We added an importer for ssrn URLs. [#12021](https://github.com/JabRef/jabref/pull/12021)
 - We added a compare button to the duplicates in the citation relations tab to open the "Possible duplicate entries" window. [#11192](https://github.com/JabRef/jabref/issues/11192)
 - We added automatic browser extension install on Windows for Chrome and Edge. [#6076](https://github.com/JabRef/jabref/issues/6076)
 - We added a search bar for filtering keyboard shortcuts. [#11686](https://github.com/JabRef/jabref/issues/11686)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a different background color to the search bar to indicate when the search syntax is wrong. [#11658](https://github.com/JabRef/jabref/pull/11658)
 - We added a setting which always adds the literal "Cited on pages" text before each JStyle citation. [#11691](https://github.com/JabRef/jabref/pull/11732)
 - We added a new plain citation parser that uses LLMs. [#11825](https://github.com/JabRef/jabref/issues/11825)
-- We added an importer for ssrn URLs. [#12021](https://github.com/JabRef/jabref/pull/12021)
+- We added an importer for SSRN URLs. [#12021](https://github.com/JabRef/jabref/pull/12021)
 - We added a compare button to the duplicates in the citation relations tab to open the "Possible duplicate entries" window. [#11192](https://github.com/JabRef/jabref/issues/11192)
 - We added automatic browser extension install on Windows for Chrome and Edge. [#6076](https://github.com/JabRef/jabref/issues/6076)
 - We added a search bar for filtering keyboard shortcuts. [#11686](https://github.com/JabRef/jabref/issues/11686)

--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -32,9 +32,6 @@ import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.ImportFormatReader;
 import org.jabref.logic.importer.ImportFormatReader.UnknownFormatImport;
 import org.jabref.logic.importer.ParseException;
-import org.jabref.logic.importer.fetcher.ArXivFetcher;
-import org.jabref.logic.importer.fetcher.DoiFetcher;
-import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
 import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackgroundTask;
@@ -49,9 +46,6 @@ import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.BibtexString;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.entry.identifier.ArXivIdentifier;
-import org.jabref.model.entry.identifier.DOI;
-import org.jabref.model.entry.identifier.ISBN;
 import org.jabref.model.groups.GroupEntryChanger;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.util.FileUpdateMonitor;
@@ -383,24 +377,6 @@ public class ImportHandler {
             dialogService.showErrorDialogAndWait(Localization.lang("Import error"), ex);
             return Collections.emptyList();
         }
-    }
-
-    private List<BibEntry> fetchByDOI(DOI doi) throws FetcherException {
-        LOGGER.info("Found DOI identifier in clipboard");
-        Optional<BibEntry> entry = new DoiFetcher(preferences.getImportFormatPreferences()).performSearchById(doi.getDOI());
-        return OptionalUtil.toList(entry);
-    }
-
-    private List<BibEntry> fetchByArXiv(ArXivIdentifier arXivIdentifier) throws FetcherException {
-        LOGGER.info("Found arxiv identifier in clipboard");
-        Optional<BibEntry> entry = new ArXivFetcher(preferences.getImportFormatPreferences()).performSearchById(arXivIdentifier.getNormalizedWithoutVersion());
-        return OptionalUtil.toList(entry);
-    }
-
-    private List<BibEntry> fetchByISBN(ISBN isbn) throws FetcherException {
-        LOGGER.info("Found ISBN identifier in clipboard");
-        Optional<BibEntry> entry = new IsbnFetcher(preferences.getImportFormatPreferences()).performSearchById(isbn.getNormalized());
-        return OptionalUtil.toList(entry);
     }
 
     public void importEntriesWithDuplicateCheck(BibDatabaseContext database, List<BibEntry> entriesToAdd) {

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -10,6 +10,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.identifier.ArXivIdentifier;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.identifier.ISBN;
+import org.jabref.model.entry.identifier.SSRN;
 
 public class CompositeIdFetcher {
 
@@ -41,6 +42,11 @@ public class CompositeIdFetcher {
             return new IacrEprintFetcher(importFormatPreferences).performSearchById(iacrEprint.get().getNormalized());
         }*/
 
+        Optional<SSRN> ssrn = SSRN.parse(identifier);
+        if (ssrn.isPresent()) {
+            return new DoiFetcher(importFormatPreferences).performSearchById(ssrn.get().intoDoi().getNormalized());
+        }
+
         return Optional.empty();
     }
 
@@ -52,7 +58,8 @@ public class CompositeIdFetcher {
         Optional<DOI> doi = DOI.findInText(identifier);
         Optional<ArXivIdentifier> arXivIdentifier = ArXivIdentifier.parse(identifier);
         Optional<ISBN> isbn = ISBN.parse(identifier);
+        Optional<SSRN> ssrn = SSRN.parse(identifier);
 
-        return Stream.of(doi, arXivIdentifier, isbn).anyMatch(Optional::isPresent);
+        return Stream.of(doi, arXivIdentifier, isbn, ssrn).anyMatch(Optional::isPresent);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/CompositeIdFetcher.java
@@ -44,7 +44,7 @@ public class CompositeIdFetcher {
 
         Optional<SSRN> ssrn = SSRN.parse(identifier);
         if (ssrn.isPresent()) {
-            return new DoiFetcher(importFormatPreferences).performSearchById(ssrn.get().intoDoi().getNormalized());
+            return new DoiFetcher(importFormatPreferences).performSearchById(ssrn.get().toDoi().getNormalized());
         }
 
         return Optional.empty();

--- a/src/main/java/org/jabref/model/entry/identifier/SSRN.java
+++ b/src/main/java/org/jabref/model/entry/identifier/SSRN.java
@@ -15,7 +15,7 @@ public class SSRN extends EprintIdentifier {
     private static final Pattern SSRN_URL_FULL_MATCH = Pattern.compile("^" + SSRN_URL_REGEX + "$", Pattern.CASE_INSENSITIVE);
     private static final Pattern SSRN_URL_MATCH = Pattern.compile(SSRN_URL_REGEX, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
-    private final int abstractId;
+    private final Integer abstractId;
 
     /**
      * Tries to parse an SSRN identifier
@@ -42,7 +42,7 @@ public class SSRN extends EprintIdentifier {
         throw new IllegalArgumentException(string + " is not a valid SSRN identifier");
     }
 
-    public SSRN(int abstractId) {
+    public SSRN(Integer abstractId) {
         this.abstractId = abstractId;
     }
 
@@ -68,11 +68,11 @@ public class SSRN extends EprintIdentifier {
     }
 
     /**
-     * Generate the DOI of the article
+     * Generate the DOI based on the SSRN
      *
-     * @return a short doi formatted as "10.2139/ssrn.[article]"
+     * @return a doi formatted as <code>10.2139/ssrn.[article]</code>
      */
-    public DOI intoDoi() {
+    public DOI toDoi() {
         return new DOI("10.2139/ssrn." + abstractId);
     }
 }

--- a/src/main/java/org/jabref/model/entry/identifier/SSRN.java
+++ b/src/main/java/org/jabref/model/entry/identifier/SSRN.java
@@ -1,0 +1,77 @@
+package org.jabref.model.entry.identifier;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents an SSRN article, identified by its abstract ID.
+ */
+public class SSRN extends EprintIdentifier {
+
+    private static final String SSRN_URL_REGEX = "(https?://)?(papers\\.)?ssrn\\.com/(sol3/papers.cfm\\?)?abstract(_id)?=(?<id>\\d+)";
+    private static final Pattern SSRN_URL_FULL_MATCH = Pattern.compile("^" + SSRN_URL_REGEX + "$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SSRN_URL_MATCH = Pattern.compile(SSRN_URL_REGEX, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+
+    private final int abstractId;
+
+    /**
+     * Tries to parse an SSRN identifier
+     *
+     * @param string Either a number or a SSRN url that has the abstract ID in it
+     * @throws NullPointerException If you pass a null to the constructor
+     * @throws IllegalArgumentException Invalid string passed to the constructor
+     */
+    public SSRN(String string) {
+        Objects.requireNonNull(string);
+        string = string.trim();
+
+        if (string.chars().allMatch(Character::isDigit)) {
+            abstractId = Integer.parseInt(string);
+            return;
+        }
+
+        Matcher matcher = SSRN_URL_FULL_MATCH.matcher(string);
+        if (matcher.find()) {
+            abstractId = Integer.parseInt(matcher.group("id"));
+            return;
+        }
+
+        throw new IllegalArgumentException(string + " is not a valid SSRN identifier");
+    }
+
+    public SSRN(int abstractId) {
+        this.abstractId = abstractId;
+    }
+
+    public static Optional<SSRN> parse(String data) {
+        Matcher matcher = SSRN_URL_MATCH.matcher(data);
+        if (matcher.find()) {
+            int abstractId = Integer.parseInt(matcher.group("id"));
+            return Optional.of(new SSRN(abstractId));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public String getNormalized() {
+        return String.valueOf(abstractId);
+    }
+
+    @Override
+    public Optional<URI> getExternalURI() {
+        URI uri = URI.create("https://ssrn.com/abstract=" + abstractId);
+        return Optional.of(uri);
+    }
+
+    /**
+     * Generate the DOI of the article
+     * @return a short doi formatted as "10.2139/ssrn.[article]"
+     */
+    public DOI intoDoi() {
+        return new DOI("10.2139/ssrn." + abstractId);
+    }
+}

--- a/src/main/java/org/jabref/model/entry/identifier/SSRN.java
+++ b/src/main/java/org/jabref/model/entry/identifier/SSRN.java
@@ -70,7 +70,7 @@ public class SSRN extends EprintIdentifier {
     /**
      * Generate the DOI based on the SSRN
      *
-     * @return a doi formatted as <code>10.2139/ssrn.[article]</code>
+     * @return a DOI formatted as <code>10.2139/ssrn.[article]</code>
      */
     public DOI toDoi() {
         return new DOI("10.2139/ssrn." + abstractId);

--- a/src/main/java/org/jabref/model/entry/identifier/SSRN.java
+++ b/src/main/java/org/jabref/model/entry/identifier/SSRN.java
@@ -69,6 +69,7 @@ public class SSRN extends EprintIdentifier {
 
     /**
      * Generate the DOI of the article
+     *
      * @return a short doi formatted as "10.2139/ssrn.[article]"
      */
     public DOI intoDoi() {

--- a/src/test/java/org/jabref/model/entry/identifier/SSRNTest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/SSRNTest.java
@@ -1,13 +1,13 @@
 package org.jabref.model.entry.identifier;
 
+import java.net.URI;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.net.URI;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,11 +20,11 @@ public class SSRNTest {
                 Arguments.of(false, "  4904445   "),
 
                 // URLs
-                Arguments.of( true, "https://ssrn.com/abstract=4904445"),
-                Arguments.of( true, "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445"),
-                Arguments.of( true, "  https://ssrn.com/abstract=4904445    "),
-                Arguments.of( true, "  https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445     "),
-                Arguments.of( true, "http://ssrn.com/abstract=4904445")
+                Arguments.of(true, "https://ssrn.com/abstract=4904445"),
+                Arguments.of(true, "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445"),
+                Arguments.of(true, "  https://ssrn.com/abstract=4904445    "),
+                Arguments.of(true, "  https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445     "),
+                Arguments.of(true, "http://ssrn.com/abstract=4904445")
         );
     }
 
@@ -47,19 +47,19 @@ public class SSRNTest {
     }
 
     @Test
-    public void testFindInText() {
+    public void findInText() {
         Optional<SSRN> parsed = SSRN.parse("The example paper (https://ssrn.com/abstract=4904445) should be found within this text");
         assertTrue(parsed.isPresent());
         assertEquals("4904445", parsed.get().getNormalized());
     }
 
     @Test
-    public void testIdentifierNormalisation() {
+    public void identifierNormalisation() {
         assertEquals("123456", new SSRN(123456).getNormalized());
     }
 
     @Test
-    public void testIdentifierExternalUrl() {
+    public void identifierExternalUrl() {
         SSRN ssrnIdentifier = new SSRN(123456);
         URI uri = URI.create("https://ssrn.com/abstract=123456");
         assertEquals(Optional.of(uri), ssrnIdentifier.getExternalURI());

--- a/src/test/java/org/jabref/model/entry/identifier/SSRNTest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/SSRNTest.java
@@ -1,0 +1,67 @@
+package org.jabref.model.entry.identifier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SSRNTest {
+    private static Stream<Arguments> provideTestData() {
+        return Stream.of(
+                // Basic string
+                Arguments.of(false, "4904445"),
+                Arguments.of(false, "  4904445   "),
+
+                // URLs
+                Arguments.of( true, "https://ssrn.com/abstract=4904445"),
+                Arguments.of( true, "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445"),
+                Arguments.of( true, "  https://ssrn.com/abstract=4904445    "),
+                Arguments.of( true, "  https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4904445     "),
+                Arguments.of( true, "http://ssrn.com/abstract=4904445")
+        );
+    }
+
+    /**
+     * @param findInText if the input should be found when passing through "find in text"
+     * @param input the input to be checked
+     */
+    @ParameterizedTest
+    @MethodSource("provideTestData")
+    public void acceptCorrectSSRNAbstracts(boolean findInText, String input) {
+        assertEquals("4904445", new SSRN(input).getNormalized());
+        Optional<SSRN> parsed = SSRN.parse(input);
+
+        if (findInText) {
+            assertTrue(parsed.isPresent());
+            assertEquals("4904445", parsed.get().getNormalized());
+        } else {
+            assertTrue(parsed.isEmpty());
+        }
+    }
+
+    @Test
+    public void testFindInText() {
+        Optional<SSRN> parsed = SSRN.parse("The example paper (https://ssrn.com/abstract=4904445) should be found within this text");
+        assertTrue(parsed.isPresent());
+        assertEquals("4904445", parsed.get().getNormalized());
+    }
+
+    @Test
+    public void testIdentifierNormalisation() {
+        assertEquals("123456", new SSRN(123456).getNormalized());
+    }
+
+    @Test
+    public void testIdentifierExternalUrl() {
+        SSRN ssrnIdentifier = new SSRN(123456);
+        URI uri = URI.create("https://ssrn.com/abstract=123456");
+        assertEquals(Optional.of(uri), ssrnIdentifier.getExternalURI());
+    }
+}


### PR DESCRIPTION
Allows importing (e.g. via pasting) of both short and long SSRN URLs via their associated DOI.

This also removes some dead code that was not cleaned up in #12009.
Closes #11687 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
