### PR TITLE
Clarify CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,18 +130,22 @@ We reserve the right to reject pull requests that contain little or no genuine a
 ### After submission of a pull request
 
 After you submitted a pull request, automated checks will run.
-You will maybe see "Some checks were not successful".
+You may see "Some checks were not successful".
+You can click on failing checks to see more information about why they failed.
 Then, please look into them and handle accordingly.
 
-Afterwards, you will receive comments on it.
-Maybe, the pull request is approved immediatly, maybe changes are requested.
-In case changes are requested, please implement them.
+Afterwards, you will receive comments on your pull request.
+The pull request may be approved immediatly, or a reviewer may request changes.
+In that case, please implement the requested changes.
 
-After changing your code, commit on the branch and push.
-The pull request will update automatically.
+After implementing changes, commit to the branch your pull request is *from* and push.
+The pull request will automatically be updated with your changes.
+Your commits will also be automatically squashed upon the pull request being accepted.
 
-Never ever close the pull request and open a new one.
-This causes much load on our side and is not the style of the GitHub open source community.
+Please – **Never ever close a pull request and open a new one** -
+This causes unessesary work on our side, and is not in the the style of the GitHub open source community.
+You can push any changes you need to make to the branch your pull request is *from*.
+These changes will be automatically added.
 
 ### Development hints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ Your commits will also be automatically squashed upon the pull request being acc
 Please – **Never ever close a pull request and open a new one** -
 This causes unessesary work on our side, and is not in the the style of the GitHub open source community.
 You can push any changes you need to make to the branch your pull request is *from*.
-These changes will be automatically added.
+These changes will be automatically added to your pull request.
 
 ### Development hints
 


### PR DESCRIPTION
New contributors often unnecessarily close and resubmit pull requests.

This PR updates and clarifies the instructions in section "[After submission of a pull request](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#after-submission-of-a-pull-request)" of CONTRIBUTING.md.

This was suggested in #12015. 
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
