### PR TITLE
Add label addition and removal of status: *

### DIFF
--- a/.github/workflows/on-review-submitted.yml
+++ b/.github/workflows/on-review-submitted.yml
@@ -1,0 +1,17 @@
+name: On reviewed PR
+
+on:
+  pull_request_review:
+     types:
+       - submitted
+
+jobs:
+  add-label-changes-required:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh pr edit "$PR_URL" --remove-label "status: ready-for-review"
+          gh pr edit "$PR_URL" --add-label "status: changes required"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}


### PR DESCRIPTION
We have the labels [status: changes required](https://github.com/JabRef/jabref/labels/status%3A%20changes%20required) and [status: ready-for-review](https://github.com/JabRef/jabref/labels/status%3A%20ready-for-review). They can be automatically assigned/removed

- If PR is reviewed: Add `status: changes required` and Remove `status: ready for review`

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
