### PR TITLE
Fix environement variable name for gh cli

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,9 +26,9 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE}}
+          GH_TOKEN: ${{secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE}}
       - name: Merge PR
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}
+          GH_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     # Run only if PR is inside JabRef's main repository and created by dependabot or by an update workflow
     if: >
-      (github.repository == 'JabRef/jabref') && 
+      (github.repository == 'JabRef/jabref') &&
       (github.event.pull_request.head.repo.full_name == 'JabRef/jabref') &&
       (
         (github.actor == 'dependabot[bot]') ||
         (
-          startsWith(github.event.pull_request.title, '[Bot] ') || 
-          startsWith(github.event.pull_request.title, 'Bump ') || 
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
           startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
           startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
         )

--- a/.github/workflows/on-review-submitted.yml
+++ b/.github/workflows/on-review-submitted.yml
@@ -14,4 +14,4 @@ jobs:
           gh pr edit "$PR_URL" --add-label "status: changes required"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}
+          GH_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}


### PR DESCRIPTION
On https://github.com/JabRef/jabref/actions/runs/11416917936/job/31768654513, I got

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

Not sure why it works for the auto merge. This PR makes all environment variable names consistent.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
