### PR TITLE
Try to fix token and condition

### DIFF
--- a/.github/workflows/on-review-submitted.yml
+++ b/.github/workflows/on-review-submitted.yml
@@ -9,9 +9,10 @@ jobs:
   add-label-changes-required:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - if: startsWith(github.event.review.state, 'Request')
+        run: |
           gh pr edit "$PR_URL" --remove-label "status: ready-for-review"
           gh pr edit "$PR_URL" --add-label "status: changes required"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GH_TOKEN_UPDATE_GRADLE_WRAPPER}}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_GH_EDIT_LABELS }}


### PR DESCRIPTION
Tries to fix

```
 gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```

and also that step triggered even on approval

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
