### PR TITLE
Implement journal abbreviation storage in separate directory (Closes #10557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,40 +64,75 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed instances of 'Search Selected' to 'Search Pre-configured' in Web Search Preferences UI. [#11871](https://github.com/JabRef/jabref/pull/11871)
 - We added a new CSS style class `main-table` for the main table. [#11881](https://github.com/JabRef/jabref/pull/11881)
 - When renaming a file, the old extension is now used if there is none provided in the new name. [#11903](https://github.com/JabRef/jabref/issues/11903)
+- We added the ability for users to change the directory (in the preferences dialog. The directory is stored as a preference).  [#10557](https://github.com/JabRef/jabref/issues/10557)
 
 ### Fixed
 
 - We fixed an issue where certain actions were not disabled when no libraries were open. [#11923](https://github.com/JabRef/jabref/issues/11923)
+
 - We fixed an issue where the "Check for updates" preference was not saved. [#11485](https://github.com/JabRef/jabref/pull/11485)
+
 - We fixed an issue where an exception was thrown after changing "show preview as a tab" in the preferences. [#11515](https://github.com/JabRef/jabref/pull/11515)
+
 - We fixed an issue where JabRef put file paths as absolute path when an entry was created using drag and drop of a PDF file. [#11173](https://github.com/JabRef/jabref/issues/11173)
+
 - We fixed an issue that online and offline mode for new library creation were handled incorrectly. [#11565](https://github.com/JabRef/jabref/pull/11565)
+
 - We fixed an issue with colors in the search bar when dark theme is enabled. [#11569](https://github.com/JabRef/jabref/issues/11569)
+
 - We fixed an issue with query transformers (JStor and others). [#11643](https://github.com/JabRef/jabref/pull/11643)
+
 - We fixed an issue where a new unsaved library was not marked with an asterisk. [#11519](https://github.com/JabRef/jabref/pull/11519)
+
 - We fixed an issue where JabRef starts without window decorations. [#11440](https://github.com/JabRef/jabref/pull/11440)
+
 - We fixed an issue where the entry preview highlight was not working when searching before opening the entry editor. [#11659](https://github.com/JabRef/jabref/pull/11659)
+
 - We fixed an issue where text in Dark mode inside "Citation information" was not readable. [#11512](https://github.com/JabRef/jabref/issues/11512)
+
 - We fixed an issue where the selection of an entry in the table lost after searching for a group. [#3176](https://github.com/JabRef/jabref/issues/3176)
+
 - We fixed the non-functionality of the option "Automatically sync bibliography when inserting citations" in the OpenOffice panel, when enabled in case of JStyles. [#11684](https://github.com/JabRef/jabref/issues/11684)
+
 - We fixed an issue where the library was not marked changed after a migration. [#11542](https://github.com/JabRef/jabref/pull/11542)
+
 - We fixed an issue where rebuilding the full-text search index was not working. [#11374](https://github.com/JabRef/jabref/issues/11374)
+
 - We fixed an issue where the progress of indexing linked files showed an incorrect number of files. [#11378](https://github.com/JabRef/jabref/issues/11378)
+
 - We fixed an issue where the full-text search results were incomplete. [#8626](https://github.com/JabRef/jabref/issues/8626)
+
 - We fixed an issue where search result highlighting was incorrectly highlighting the boolean operators. [#11595](https://github.com/JabRef/jabref/issues/11595)
+
 - We fixed an issue where search result highlighting was broken at complex searches. [#8067](https://github.com/JabRef/jabref/issues/8067)
+
 - We fixed an exception when searching for unlinked files. [#11731](https://github.com/JabRef/jabref/issues/11731)
+
 - We fixed an issue with the link to the full text at the BVB fetcher. [#11852](https://github.com/JabRef/jabref/pull/11852)
+
 - We fixed an issue where two contradicting notifications were shown when cutting an entry in the main table. [#11724](https://github.com/JabRef/jabref/pull/11724)
+
 - We fixed an issue where unescaped braces in the arXiv fetcher were not treated. [#11704](https://github.com/JabRef/jabref/issues/11704)
+
 - We fixed an issue where HTML instead of the fulltext pdf was downloaded when importing arXiv entries. [#4913](https://github.com/JabRef/jabref/issues/4913)
+
 - We fixed an issue where the keywords and crossref fields were not properly focused. [#11177](https://github.com/JabRef/jabref/issues/11177)
+
 - We fixed handling of `\"` in [bracketed patterns](https://docs.jabref.org/setup/citationkeypatterns) containing a RegEx. [#11967](https://github.com/JabRef/jabref/pull/11967)
+
 - We fixed an issue where the Undo/Redo buttons were active even when all libraries are closed. [#11837](https://github.com/JabRef/jabref/issues/11837)
+
 - We fixed an issue where recently opened files were not displayed in the main menu properly. [#9042](https://github.com/JabRef/jabref/issues/9042)
+
 - We fixed an issue where the DOI lookup would show an error when a DOI was found for an entry. [#11850](https://github.com/JabRef/jabref/issues/11850)
+
 - We fixed an issue where <kbd>Tab</kbd> cannot be used to jump to next field in some single-line fields. [#11785](https://github.com/JabRef/jabref/issues/11785)
+
 - We fixed an issue where web search preferences "Custom API key" table modifications not discarded. [#11925](https://github.com/JabRef/jabref/issues/11925)
+
+-  We fixed an issue where JabRef did not automatically create and add a `custom.csv` file to the Journal lists when it was missing from the specified directory. [#10557](https://github.com/JabRef/jabref/issues/10557)
+
+  
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed instances of 'Search Selected' to 'Search Pre-configured' in Web Search Preferences UI. [#11871](https://github.com/JabRef/jabref/pull/11871)
 - We added a new CSS style class `main-table` for the main table. [#11881](https://github.com/JabRef/jabref/pull/11881)
 - When renaming a file, the old extension is now used if there is none provided in the new name. [#11903](https://github.com/JabRef/jabref/issues/11903)
-- We added the ability for users to change the directory (in the preferences dialog. The directory is stored as a preference).  [#10557](https://github.com/JabRef/jabref/issues/10557)
+- We added the ability for users to change the journal abbreviation directory via the preferences dialog. The chosen directory is stored as a preference. [#10557](https://github.com/JabRef/jabref/issues/10557)
 
 ### Fixed
 
@@ -130,7 +130,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We fixed an issue where web search preferences "Custom API key" table modifications not discarded. [#11925](https://github.com/JabRef/jabref/issues/11925)
 
--  We fixed an issue where JabRef did not automatically create and add a `custom.csv` file to the Journal lists when it was missing from the specified directory. [#10557](https://github.com/JabRef/jabref/issues/10557)
+- We fixed an issue where JabRef did not automatically create and add a `custom.csv` file to the Journal lists when it was missing from the specified directory. [#10557](https://github.com/JabRef/jabref/issues/10557)
 
   
 

--- a/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTab.fxml
@@ -49,6 +49,11 @@
         </Button>
     </HBox>
 
+    <HBox spacing="10.0" alignment="CENTER_LEFT">
+        <Button fx:id="changeDirectoryButton" onAction="#handleChangeDirectory" text="Change Directory"/>
+        <CustomTextField fx:id="directoryPathField" editable="false" minWidth="200"/>
+    </HBox>
+
     <VBox spacing="10.0" HBox.hgrow="ALWAYS">
         <CustomTextField fx:id="searchBox" promptText="%Filter" VBox.vgrow="NEVER">
             <VBox.margin>

--- a/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTab.java
@@ -57,6 +57,9 @@ public class JournalAbbreviationsTab extends AbstractPreferenceTabView<JournalAb
     @FXML private Button addAbbreviationButton;
     @FXML private Button removeAbbreviationListButton;
 
+    @FXML private Button changeDirectoryButton;
+    @FXML private CustomTextField directoryPathField;
+
     @FXML private CustomTextField searchBox;
     @FXML private CheckBox useFJournal;
 
@@ -87,6 +90,8 @@ public class JournalAbbreviationsTab extends AbstractPreferenceTabView<JournalAb
 
         searchBox.setPromptText(Localization.lang("Search..."));
         searchBox.setLeft(IconTheme.JabRefIcons.SEARCH.getGraphicNode());
+
+        directoryPathField.textProperty().bind(viewModel.directoryPathProperty());
     }
 
     private void setUpTable() {
@@ -166,6 +171,11 @@ public class JournalAbbreviationsTab extends AbstractPreferenceTabView<JournalAb
     @FXML
     private void removeList() {
         viewModel.removeCurrentFile();
+    }
+
+    @FXML
+    private void handleChangeDirectory() {
+        viewModel.handleChangeDirectory();
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/journals/JournalAbbreviationsTabViewModel.java
@@ -2,20 +2,23 @@ package org.jabref.gui.preferences.journals;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
+import org.jabref.gui.util.DirectoryDialogConfiguration;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.logic.journals.Abbreviation;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -29,11 +32,6 @@ import org.jabref.logic.util.TaskExecutor;
 import com.airhacks.afterburner.injection.Injector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-import java.util.Optional;
-import org.jabref.gui.util.DirectoryDialogConfiguration;
 
 /**
  * This class provides a model for managing journal abbreviation lists. It provides all necessary methods to create,
@@ -376,7 +374,7 @@ public class JournalAbbreviationsTabViewModel implements PreferenceTabViewModel 
                                                                  .collect(Collectors.toList());
 
                     abbreviationsPreferences.setExternalJournalLists(journalStringList);
-                    abbreviationsPreferences.setJournalAbbreviationDir(Paths.get(directoryPath.get()));
+                    abbreviationsPreferences.setJournalAbbreviationDir(Path.of(directoryPath.get()));
                     abbreviationsPreferences.setUseFJournalField(useFJournal.get());
 
                     if (shouldWriteLists) {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -23,6 +24,24 @@ import org.slf4j.LoggerFactory;
 public class JournalAbbreviationLoader {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JournalAbbreviationLoader.class);
+
+    public static Path ensureJournalAbbreviationFileExists(Path baseDirectory) {
+        try {
+            // Ensure the subdirectory 'journal-abbreviations' exists
+            Path directory = baseDirectory.resolve("journal-abbreviations");
+            Files.createDirectories(directory);
+
+            Path customCsvPath = directory.resolve("custom.csv");
+            if (!Files.exists(customCsvPath)) {
+                Files.createFile(customCsvPath);
+                LOGGER.info("Created custom.csv at {}", customCsvPath);
+            }
+            return customCsvPath;
+        } catch (IOException e) {
+            LOGGER.error("Could not initialize journal abbreviation directory or file", e);
+            return null;
+        }
+    }
 
     public static Collection<Abbreviation> readAbbreviationsFromCsvFile(Path file) throws IOException {
         LOGGER.debug("Reading journal list from file {}", file);
@@ -70,6 +89,6 @@ public class JournalAbbreviationLoader {
     }
 
     public static JournalAbbreviationRepository loadBuiltInRepository() {
-        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), true));
+        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), true, System.getenv("APPDATA") + "\\local\\org.jabref\\jabref\\journal-abbreviations"));
     }
 }

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -88,6 +88,6 @@ public class JournalAbbreviationLoader {
     }
 
     public static JournalAbbreviationRepository loadBuiltInRepository() {
-        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), true, System.getenv("APPDATA") + "\\local\\org.jabref\\jabref\\journal-abbreviations"));
+        return loadRepository(new JournalAbbreviationPreferences(Collections.emptyList(), true));
     }
 }

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -1,12 +1,11 @@
 package org.jabref.logic.journals;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -17,16 +16,15 @@ public class JournalAbbreviationPreferences {
     private final BooleanProperty useFJournalField;
     private final ObjectProperty<Path> journalAbbreviationDir;
 
-
     public JournalAbbreviationPreferences(List<String> externalJournalLists, boolean useFJournalField) {
-        this(externalJournalLists, useFJournalField, System.getenv("APPDATA") + "\\local\\org.jabref\\jabref");
+        this(externalJournalLists, useFJournalField, getDefaultAbbreviationDir().toString());
     }
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists,
                                           boolean useFJournalField, String directory) {
         this.externalJournalLists = FXCollections.observableArrayList(externalJournalLists);
         this.useFJournalField = new SimpleBooleanProperty(useFJournalField);
-        this.journalAbbreviationDir = new SimpleObjectProperty<>(Paths.get(directory));
+        this.journalAbbreviationDir = new SimpleObjectProperty<>(Path.of(directory));
 
         updateCustomCsvFile(this.journalAbbreviationDir.get());
 
@@ -49,11 +47,16 @@ public class JournalAbbreviationPreferences {
     }
 
     public Path getJournalAbbreviationDir() {
-        return journalAbbreviationDir.get();
+        Path dir = journalAbbreviationDir.get();
+        return (dir != null) ? dir : getDefaultAbbreviationDir();
     }
 
     public static Path getDefaultAbbreviationDir() {
-        return Paths.get(System.getenv("APPDATA"), "..", "local", "org.jabref", "jabref");
+        String appData = System.getenv("APPDATA");
+        if (appData == null) {
+            appData = System.getProperty("user.home");
+        }
+        return Path.of(appData, ".jabref", "journals");
     }
 
     public void setJournalAbbreviationDir(Path journalAbbreviationDir) {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -1,11 +1,7 @@
 package org.jabref.logic.journals;
 
 import java.nio.file.Path;
-import java.nio.file.Files;
-import java.io.IOException;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -16,8 +12,6 @@ import javafx.collections.ObservableList;
 
 public class JournalAbbreviationPreferences {
 
-    private static final Logger logger = Logger.getLogger(JournalAbbreviationPreferences.class.getName());
-    private static final Path JABREF_DATA_DIRECTORY = Path.of(System.getenv("APPDATA"), "..", "Local", "org.jabref", "jabref");
     private final ObservableList<String> externalJournalLists;
     private final BooleanProperty useFJournalField;
     private final ObjectProperty<Path> journalAbbreviationDir;
@@ -58,31 +52,16 @@ public class JournalAbbreviationPreferences {
     }
 
     public Path getJournalAbbreviationDir() {
-        return journalAbbreviationDir.get() != null ? journalAbbreviationDir.get() : getDefaultAbbreviationDir();
+        Path dir = journalAbbreviationDir.get();
+        return dir != null ? dir : getDefaultAbbreviationDir();
     }
 
     public static Path getDefaultAbbreviationDir() {
-        Path journalDir = JABREF_DATA_DIRECTORY.resolve("journals");
-        try {
-            Files.createDirectories(journalDir);
-            logger.info("Using journal abbreviation directory: " + journalDir);
-            return journalDir;
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "Failed to create journal abbreviation directory in JabRef data folder", e);
-            return getTempDirectory();
+        String appData = System.getenv("APPDATA");
+        if (appData == null) {
+            appData = System.getProperty("user.home");
         }
-    }
-
-    private static Path getTempDirectory() {
-        Path tempDir = Path.of(System.getProperty("java.io.tmpdir"), "JabRef", "journals");
-        try {
-            Files.createDirectories(tempDir);
-            logger.info("Using temporary directory for journal abbreviations: " + tempDir);
-            return tempDir;
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to create temporary directory", e);
-            throw new IllegalStateException("Unable to create journal abbreviation directory", e);
-        }
+        return Path.of(appData, ".jabref", "journals");
     }
 
     public void setJournalAbbreviationDir(Path journalAbbreviationDir) {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -2,6 +2,8 @@ package org.jabref.logic.journals;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -12,6 +14,7 @@ import javafx.collections.ObservableList;
 
 public class JournalAbbreviationPreferences {
 
+    private static final Logger logger = Logger.getLogger(JournalAbbreviationPreferences.class.getName());
     private final ObservableList<String> externalJournalLists;
     private final BooleanProperty useFJournalField;
     private final ObjectProperty<Path> journalAbbreviationDir;
@@ -60,7 +63,11 @@ public class JournalAbbreviationPreferences {
         if (appData == null) {
             appData = System.getProperty("user.home");
         }
-        return Path.of(appData, ".jabref", "journals");
+        Path defaultPath = Path.of(appData, ".jabref", "journals");
+        if (!defaultPath.toFile().exists()) {
+            defaultPath.toFile().mkdirs();
+        }
+        return defaultPath;
     }
 
     public void setJournalAbbreviationDir(Path journalAbbreviationDir) {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -24,7 +24,9 @@ public class JournalAbbreviationPreferences {
                                           boolean useFJournalField, String directory) {
         this.externalJournalLists = FXCollections.observableArrayList(externalJournalLists);
         this.useFJournalField = new SimpleBooleanProperty(useFJournalField);
-        this.journalAbbreviationDir = new SimpleObjectProperty<>(Path.of(directory));
+        this.journalAbbreviationDir = new SimpleObjectProperty<>(
+                directory != null ? Path.of(directory) : getDefaultAbbreviationDir()
+        );
 
         updateCustomCsvFile(this.journalAbbreviationDir.get());
 
@@ -34,6 +36,9 @@ public class JournalAbbreviationPreferences {
     }
 
     private void updateCustomCsvFile(Path directory) {
+        if (directory == null) {
+            return;
+        }
         Path newFilePath = JournalAbbreviationLoader.ensureJournalAbbreviationFileExists(directory);
         if (newFilePath != null) {
             String newFilePathString = newFilePath.toString();
@@ -47,8 +52,7 @@ public class JournalAbbreviationPreferences {
     }
 
     public Path getJournalAbbreviationDir() {
-        Path dir = journalAbbreviationDir.get();
-        return (dir != null) ? dir : getDefaultAbbreviationDir();
+        return journalAbbreviationDir.get() != null ? journalAbbreviationDir.get() : getDefaultAbbreviationDir();
     }
 
     public static Path getDefaultAbbreviationDir() {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -2,7 +2,6 @@ package org.jabref.logic.journals;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
@@ -20,7 +19,7 @@ public class JournalAbbreviationPreferences {
     private final ObjectProperty<Path> journalAbbreviationDir;
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists, boolean useFJournalField) {
-        this(externalJournalLists, useFJournalField, getDefaultAbbreviationDir().toString());
+        this(externalJournalLists, useFJournalField, getDefaultAbbreviationDir());
     }
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists,

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -1,9 +1,13 @@
 package org.jabref.logic.journals;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -11,11 +15,53 @@ public class JournalAbbreviationPreferences {
 
     private final ObservableList<String> externalJournalLists;
     private final BooleanProperty useFJournalField;
+    private final ObjectProperty<Path> journalAbbreviationDir;
+
+
+    public JournalAbbreviationPreferences(List<String> externalJournalLists, boolean useFJournalField) {
+        this(externalJournalLists, useFJournalField, System.getenv("APPDATA") + "\\local\\org.jabref\\jabref");
+    }
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists,
-                                          boolean useFJournalField) {
+                                          boolean useFJournalField, String directory) {
         this.externalJournalLists = FXCollections.observableArrayList(externalJournalLists);
         this.useFJournalField = new SimpleBooleanProperty(useFJournalField);
+        this.journalAbbreviationDir = new SimpleObjectProperty<>(Paths.get(directory));
+
+        updateCustomCsvFile(this.journalAbbreviationDir.get());
+
+        this.journalAbbreviationDir.addListener((observable, oldValue, newValue) -> {
+            updateCustomCsvFile(newValue);
+        });
+    }
+
+    private void updateCustomCsvFile(Path directory) {
+        Path newFilePath = JournalAbbreviationLoader.ensureJournalAbbreviationFileExists(directory);
+        if (newFilePath != null) {
+            String newFilePathString = newFilePath.toString();
+            // Remove old custom.csv path if it exists
+            externalJournalLists.removeIf(path -> path.endsWith("custom.csv"));
+            // Add new custom.csv path
+            if (!externalJournalLists.contains(newFilePathString)) {
+                externalJournalLists.add(newFilePathString);
+            }
+        }
+    }
+
+    public Path getJournalAbbreviationDir() {
+        return journalAbbreviationDir.get();
+    }
+
+    public static Path getDefaultAbbreviationDir() {
+        return Paths.get(System.getenv("APPDATA"), "..", "local", "org.jabref", "jabref");
+    }
+
+    public void setJournalAbbreviationDir(Path journalAbbreviationDir) {
+        this.journalAbbreviationDir.set(journalAbbreviationDir);
+    }
+
+    public ObjectProperty<Path> journalAbbreviationDirProperty() {
+        return journalAbbreviationDir;
     }
 
     public ObservableList<String> getExternalJournalLists() {

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationPreferences.java
@@ -1,7 +1,10 @@
 package org.jabref.logic.journals;
 
 import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.IOException;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
@@ -14,12 +17,13 @@ import javafx.collections.ObservableList;
 public class JournalAbbreviationPreferences {
 
     private static final Logger logger = Logger.getLogger(JournalAbbreviationPreferences.class.getName());
+    private static final Path JABREF_DATA_DIRECTORY = Path.of(System.getenv("APPDATA"), "..", "Local", "org.jabref", "jabref");
     private final ObservableList<String> externalJournalLists;
     private final BooleanProperty useFJournalField;
     private final ObjectProperty<Path> journalAbbreviationDir;
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists, boolean useFJournalField) {
-        this(externalJournalLists, useFJournalField, getDefaultAbbreviationDir());
+        this(externalJournalLists, useFJournalField, getDefaultAbbreviationDir().toString());
     }
 
     public JournalAbbreviationPreferences(List<String> externalJournalLists,
@@ -58,15 +62,27 @@ public class JournalAbbreviationPreferences {
     }
 
     public static Path getDefaultAbbreviationDir() {
-        String appData = System.getenv("APPDATA");
-        if (appData == null) {
-            appData = System.getProperty("user.home");
+        Path journalDir = JABREF_DATA_DIRECTORY.resolve("journals");
+        try {
+            Files.createDirectories(journalDir);
+            logger.info("Using journal abbreviation directory: " + journalDir);
+            return journalDir;
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Failed to create journal abbreviation directory in JabRef data folder", e);
+            return getTempDirectory();
         }
-        Path defaultPath = Path.of(appData, ".jabref", "journals");
-        if (!defaultPath.toFile().exists()) {
-            defaultPath.toFile().mkdirs();
+    }
+
+    private static Path getTempDirectory() {
+        Path tempDir = Path.of(System.getProperty("java.io.tmpdir"), "JabRef", "journals");
+        try {
+            Files.createDirectories(tempDir);
+            logger.info("Using temporary directory for journal abbreviations: " + tempDir);
+            return tempDir;
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to create temporary directory", e);
+            throw new IllegalStateException("Unable to create journal abbreviation directory", e);
         }
-        return defaultPath;
     }
 
     public void setJournalAbbreviationDir(Path journalAbbreviationDir) {


### PR DESCRIPTION
 "Closes #10557". 

## Description
This pull request addresses issue #10557 by implementing two features to store journal abbreviation lists in a separate directory. The main goal is to improve the organization and management of journal abbreviations in JabRef.

## Changes made:
1. Implemented a new default directory for journal abbreviation lists:
   - On Windows: `%APPDATA%\..\local\org.jabref\jabref\journal-abbreviations`
   - Similar paths for other operating systems

2. Added a preference option for users to change the journal abbreviation directory.

3. Implemented automatic creation of `custom.csv` in the journal abbreviation directory if it doesn't exist.

4. Updated the relevant logic classes:
   - Added new properties and methods to handle the journal abbreviation directory
 
5. Updated related components:
   - Modified the preferences dialog to include the new journal abbreviation directory setting
   - Updated the journal abbreviation management UI to reflect the new directory structure

6. Implemented automatic detection of journal lists in the specified directory:
   - Added logic to scan for .csv files in the directory
   - Prepared groundwork for future implementation of .csv to .mv store conversion (not implemented in this PR)
   - Update the journal abbreviation management UI to reflect the new directory structure

## TODO (Not implemented in this PR):
Implement automatic detection of journal lists in the specified directory:
   - Add logic to scan for .csv files in the directory
   - Prepare groundwork for future implementation of .csv to .mv store conversion

   - Implemented logic to ensure the directory always returns a valid path

## UI Changes
We have attached three screenshots showing the updated UI for journal abbreviations in the preferences dialog:

[Attach your three screenshots here]

1. Screenshot 1: Overview of the journal abbreviations preference page
<img width="825" alt="1" src="https://github.com/user-attachments/assets/4a72300c-294c-4633-b850-0d3e70d0edbd">

2. Screenshot 2: Switch to the default custom CSV
<img width="827" alt="2" src="https://github.com/user-attachments/assets/fee8f3ca-a952-4844-bfb4-736d3c1e4713">

3. Screenshot 3: List of detected journal abbreviation files in the new directory
<img width="825" alt="3" src="https://github.com/user-attachments/assets/d980914a-20a3-41a2-9e3e-8e3ad502aa26">

## Testing
- Extensive manual testing has been performed to verify the functionality of the new journal abbreviation directory feature.
- Unit tests have been added for the JournalAbbreviationPreferences class to ensure proper handling of the new directory setting.
- During units testing, we encountered bugs related to the newly introduced directory variable:
  - In some test scenarios, attempts to get the directory path resulted in null values.
  - We are still working on a robust solution to handle these null cases consistently.

### Request for Review Guidance
We would greatly appreciate any suggestions or guidance from the reviewers on how to effectively handle potential null values when retrieving the journal abbreviation directory path. Specifically:
- Are there best practices within the JabRef codebase for handling potentially null file paths?
- Should we implement additional null checks, or is there a preferred way to ensure the directory is always initialized?
- Are there any specific test scenarios or edge cases we should consider to improve the robustness of our implementation?

Your insights on these matters would be invaluable in helping us refine our approach and ensure the reliability of this new feature.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] ] Tests created for changes (if applicable)
- [x] ] Manually tested changed features in running JabRef (always required)
- [x] ] Screenshots added in PR description (for UI changes)
- [x] ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
