### PR TITLE
Fix condition

### DIFF
--- a/.github/workflows/on-review-submitted.yml
+++ b/.github/workflows/on-review-submitted.yml
@@ -9,7 +9,7 @@ jobs:
   add-label-changes-required:
     runs-on: ubuntu-latest
     steps:
-      - if: startsWith(github.event.review.state, 'Request')
+      - if: ${{ github.event.review.state == 'changes_requested' }}
         run: |
           gh pr edit "$PR_URL" --remove-label "status: ready-for-review"
           gh pr edit "$PR_URL" --add-label "status: changes required"


### PR DESCRIPTION
The workflow is not triggered. See https://github.com/JabRef/jabref/actions/runs/11425062676/job/31786261409?pr=12038

Trying outher condition.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
