### PR TITLE
Readd `@deprecated` annotation

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -395,9 +395,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     }
 
     /**
-     * Never ever add a call to this method. There should be only one caller.
-     * All other usages should get the preferences passed (or injected).
+     * @deprecated Never ever add a call to this method. There should be only one caller.
+     *             All other usages should get the preferences passed (or injected).
+     *             The JabRef team leaves the <code>@deprecated</code> annotation to have IntelliJ listing this method with a strike-through.
      */
+    @Deprecated
     public static JabRefGuiPreferences getInstance() {
         if (JabRefGuiPreferences.singleton == null) {
             JabRefGuiPreferences.singleton = new JabRefGuiPreferences();

--- a/src/main/java/org/jabref/logic/bibtex/InvalidFieldValueException.java
+++ b/src/main/java/org/jabref/logic/bibtex/InvalidFieldValueException.java
@@ -1,10 +1,11 @@
 package org.jabref.logic.bibtex;
 
 /**
- * Use only if you know what you are doing.
- *
- * Otherwise, you should implement your functionality as {@link org.jabref.logic.integrity.IntegrityCheck} instead.
+ * @deprecated Use only if you know what you are doing.
+ *             Otherwise, you should implement your functionality as {@link org.jabref.logic.integrity.IntegrityCheck} instead.
+ *             The JabRef team leaves the <code>@deprecated</code> annotation to have IntelliJ listing this method with a strike-through.
  */
+@Deprecated
 public class InvalidFieldValueException extends Exception {
 
     public InvalidFieldValueException(String message) {

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -665,9 +665,11 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     /**
-     * Never ever add a call to this method. There should be only one caller.
-     * All other usages should get the preferences passed (or injected).
+     * @Deprecated Never ever add a call to this method. There should be only one caller.
+     *             All other usages should get the preferences passed (or injected).
+     *             The JabRef team leaves the <code>@deprecated</code> annotation to have IntelliJ listing this method with a strike-through.
      */
+    @Deprecated
     public static JabRefCliPreferences getInstance() {
         if (JabRefCliPreferences.singleton == null) {
             JabRefCliPreferences.singleton = new JabRefCliPreferences();

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -665,7 +665,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     /**
-     * @Deprecated Never ever add a call to this method. There should be only one caller.
+     * @deprecated Never ever add a call to this method. There should be only one caller.
      *             All other usages should get the preferences passed (or injected).
      *             The JabRef team leaves the <code>@deprecated</code> annotation to have IntelliJ listing this method with a strike-through.
      */


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12055.

Closes https://github.com/JabRef/jabref/issues/11674

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
