### PR TITLE
Fix for issue 11428: auto-completion in search bar now works without tab switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed usage when using running on Snapcraft. [#11465](https://github.com/JabRef/jabref/issues/11465)
 - We fixed detection for `soffice.exe` on Windows. [#11478](https://github.com/JabRef/jabref/pull/11478)
 - We fixed an issue where saving preferences when importing preferences on first run in a snap did not work [forum#4399](https://discourse.jabref.org/t/how-to-report-problems-in-the-distributed-version-5-14-ensuring-that-one-can-no-longer-work-with-jabref/4399/5)
+- We fixed an issue where auto-completion in the search bar was not working until switching tabs. [#11428](https://github.com/JabRef/jabref/issues/11428)
 
 ## [5.14] – 2024-07-08
 

--- a/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -348,6 +348,10 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
             if (selectedTab instanceof LibraryTab libraryTab) {
                 stateManager.setActiveDatabase(libraryTab.getBibDatabaseContext());
                 stateManager.activeTabProperty().set(Optional.of(libraryTab));
+                // Use Platform.runLater to ensure the auto-completer is set in the next event cycle
+                Platform.runLater(() -> {
+                    globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter());
+                });
             } else if (selectedTab == null) {
                 // All databases are closed
                 stateManager.setActiveDatabase(null);
@@ -378,9 +382,6 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
                 stateManager.activeSearchQuery(SearchType.NORMAL_SEARCH).set(libraryTab.searchQueryProperty().get());
             }
             stateManager.searchResultSize(SearchType.NORMAL_SEARCH).bind(libraryTab.resultSizeProperty());
-
-            // Update search autocompleter with information for the correct database:
-            globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter());
 
             libraryTab.getMainTable().requestFocus();
 


### PR DESCRIPTION
### Purpose
see [#11428](https://github.com/JabRef/jabref/issues/11428)
The fix ensures that the auto-completion is set up correctly when a database is initially opened, using `Platform.runLater` to ensure that the completion binder is updated in the next event loop cycle.
closes #11428

### Description
I pulled the latest version 5.15 on Windows 11, and the issue still persists. 
The root cause lies in the [jabref/src/main/java/org/jabref/gui/frame/JabRefFrame.java](https://github.com/JabRef/jabref/blob/8cf8959e9419ce947d8a205d1be754c91353df38/src/main/java/org/jabref/gui/frame/JabRefFrame.java), specifically in the initBindings() method. 
The code responsible for updating the search auto-completion (globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter());) is placed inside a listener that only triggers when the user switches between tabs (Lines 363-383 in 8cf8959). This leads to the bug where the auto-completion is not activated when opening a database for the first time.
![image](https://github.com/user-attachments/assets/a128ec51-6019-4e3c-8dba-e7c799c95123)

### Solution
I noticed that there is another listener in the initBindings() method, responsible for handling the selected tab and executing corresponding operations. By placing the globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter()); inside this listener, the problem can be resolved. Whether the user opens a new database tab or switches to an already open one, this listener gets triggered since both actions select a tab. As a result, this ensures that the search bar auto-completion gets updated appropriately.
![image](https://github.com/user-attachments/assets/e5c3dd52-e1c8-49b9-bc62-2e2e52679832)

### Outcome
Since the JabRefFrame class is part of the UI, it is not suitable for code-based testing. Therefore, I have attached relevant screenshots below for reference.
![image](https://github.com/user-attachments/assets/4823225a-feed-4c16-b71c-17ad4ed1a57c)
Figure 1: Type sm and the auto-complete pop-up window will appear.

![image](https://github.com/user-attachments/assets/314bd87c-9116-4d19-8429-e7bff1a65ac6)
Figure 2: I opened a new database and the autocomplete popup is still active.

![image](https://github.com/user-attachments/assets/5455122a-03ec-4255-a896-a8ce2a60e01b)
Figure 3: I switched to the first database and the auto-completion feature still works.

### Issue to be clarified
There seems to be a problem with the auto-completion logic. I'm not sure if it's because my testing method is wrong (to be honest, I don't really understand the auto-completion logic), or if this problem is related to the current search being restructured.
This problem mainly occurs when I only enter the first letter of the name, and the completion information given is inaccurate, such as Figure 2.

I think it may not be a problem with my code, because I used the  version of the code in main branch (8cf8959) to test, and found that only the first letter of the name is entered, and the same problem as Figure 3 and the following problem will appear.
![image](https://github.com/user-attachments/assets/1422a427-adc2-4635-8a41-e99665c8b53c)

Sometimes when I enter the first two letters of a name, it doesn’t give 100% accurate completion information, such as the screenshot below
![image](https://github.com/user-attachments/assets/a7f49d75-eab1-4ea2-96b9-7b3a6f0c972d)

@LoayGhreeb if possible, could you please take a look into this? I would greatly appreciate your help in identifying the cause. Thank you so much!

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
