### PR TITLE
Illegal character in query: pipe character in file field #11876

### DIFF
--- a/.github/workflows/on-review-submitted.yml
+++ b/.github/workflows/on-review-submitted.yml
@@ -9,7 +9,7 @@ jobs:
   add-label-changes-required:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - run: echo ${{ github.event.review.state }}
       - if: ${{ github.event.review.state == 'changes_requested' }}

--- a/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -25,7 +25,8 @@ public class FileFieldParser {
         if (value == null) {
             this.value = null;
         } else {
-            this.value = value.replace("$\\backslash$", "\\");
+            String valueFormat = value.replace("|", "%7C");
+            this.value = valueFormat.replace("$\\backslash$", "\\");
         }
     }
 


### PR DESCRIPTION
This pull request implements URL escaping for the pipe character (|) in the FileFieldParser class. This change addresses issue #11876, which caused exceptions in JabRef when processing URLs that contained the pipe character.

Changes Made: Modified the FileFieldParser class to replace the pipe character with its encoded representation (%7C).
Ensured that URLs are properly handled to prevent exceptions.
Benefits: Resolves the recurring exception issue when opening .bib files with problematic URLs.
Related Issue: Closes #11876




