### PR TITLE
Disable meta data elements in adr-template

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - '.github/workflows/pages.yml'
   push:
+    branches:
+      main
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7' # Not needed with a .ruby-version file
+          ruby-version: '3.3' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 1 # Increment this number if you need to re-download cached gems
+          cache-version: 0 # Increment this number if you need to re-download cached gems
           working-directory: docs/
       - name: Setup Pages
         id: pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,9 +19,8 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
 concurrency:
-  group: "pages"
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
 
 jobs:

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.3" # installed by `gem jekyll`
+gem "jekyll", "~> 4.3.4" # installed by `gem jekyll`
 
 # Homepage: https://github.com/paulrobertlloyd/jekyll-figure#jekyll-figure
 gem 'jekyll-figure'
 
-gem "just-the-docs", "0.5.0"
+gem "just-the-docs", "0.10.0"
 
 gem "jekyll-remote-theme"
 

--- a/docs/decisions/adr-template.md
+++ b/docs/decisions/adr-template.md
@@ -10,11 +10,11 @@ nav_order: 100
 parent: Decision Records
 
 # These are optional metadata elements. Feel free to remove any of them.
-status: "{proposed | rejected | accepted | deprecated | … | superseded by ADR-0123"
-date: {YYYY-MM-DD when the decision was last updated}
-decision-makers: {list everyone involved in the decision}
-consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
-informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+# status: "{proposed | rejected | accepted | deprecated | … | superseded by ADR-0123"
+# date: {YYYY-MM-DD when the decision was last updated}
+# decision-makers: {list everyone involved in the decision}
+# consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+# informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 <!-- we need to disable MD025, because we use the different heading "ADR Template" in the homepage (see above) than it is foreseen in the template -->
 <!-- markdownlint-disable-next-line MD025 -->


### PR DESCRIPTION
Jekyll build fails. This should fix it

Udpates just-the-docs from 0.5.0 to 0.10.0 - see https://github.com/just-the-docs/just-the-docs/blob/main/MIGRATION.md#migrating-and-upgrading for a guide (not thoroughly followed)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
