### PR TITLE
Fix issue #11938: Tab in empty text area field should focus the next field

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -28,7 +28,7 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
     };
 
     public EditorTextArea() {
-        // Call the constructor with an empty string
+        // Call the constructor with an empty string.
         this("");
 
         // Add an event filter to handle key press events

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -28,17 +28,10 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
     };
 
     public EditorTextArea() {
-        // Call the constructor with an empty string.
         this("");
-
-        // Add an event filter to handle key press events
         this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            // If the TAB key is pressed and the TextArea is empty
             if (event.getCode() == KeyCode.TAB && this.getText().isEmpty()) {
-                // Move the focus to the next parent element (likely the next form field)
                 this.getParent().requestFocus();
-
-                // Consume the event to prevent further processing of the TAB key
                 event.consume();
             }
         });

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -30,7 +30,7 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
     public EditorTextArea() {
         this("");
         this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            if (event.getCode() == KeyCode.TAB && this.getText().isEmpty()) {
+            if (event.getCode() == KeyCode.TAB && this.getText() != null && this.getText().isEmpty()) {
                 this.getParent().requestFocus();
                 event.consume();
             }

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -28,14 +28,22 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
     };
 
     public EditorTextArea() {
+        // Call the constructor with an empty string
         this("");
+
+        // Add an event filter to handle key press events
         this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            // If the TAB key is pressed and the TextArea is empty
             if (event.getCode() == KeyCode.TAB && this.getText().isEmpty()) {
+                // Move the focus to the next parent element (likely the next form field)
                 this.getParent().requestFocus();
+
+                // Consume the event to prevent further processing of the TAB key
                 event.consume();
             }
         });
     }
+
 
     public EditorTextArea(final String text) {
         super(text);

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -44,7 +44,6 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
         });
     }
 
-
     public EditorTextArea(final String text) {
         super(text);
 

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -10,6 +10,8 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.fieldeditors.contextmenu.EditorContextAction;
@@ -27,6 +29,12 @@ public class EditorTextArea extends TextArea implements Initializable, ContextMe
 
     public EditorTextArea() {
         this("");
+        this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == KeyCode.TAB && this.getText().isEmpty()) {
+                this.getParent().requestFocus();
+                event.consume();
+            }
+        });
     }
 
     public EditorTextArea(final String text) {


### PR DESCRIPTION
This PR addresses the issue where pressing the Tab key in an empty text area should focus the next field, but it wasn't behaving as expected. The code change ensures that when the TextArea is empty, pressing the Tab key moves the focus to the next form field.

Closes https://github.com/JabRef/jabref/issues/11938

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
