### PR TITLE
Pressing "tab" when last textField of entry editor Tab is in focus will move to the next Tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added a way to navigate through Tabs in Entry Editor by pressing "tab" when the last TextField of a Tab is in focus. [#11937](https://github.com/JabRef/jabref/issues/11937)
 - We added a "view as BibTeX" option before importing an entry from the citation relation tab. [#11826](https://github.com/JabRef/jabref/issues/11826)
 - We added probable search hits instead of exact matches. Sorting by hit score can be done by the new score table column. [#11542](https://github.com/JabRef/jabref/pull/11542)
 - We added support finding LaTeX-encoded special characters based on plain Unicode and vice versa. [#11542](https://github.com/JabRef/jabref/pull/11542)

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -132,8 +132,8 @@ public class EntryEditor extends BorderPane {
         this.redoAction = redoAction;
 
         ViewLoader.view(this)
-                .root(this)
-                .load();
+                       .root(this)
+                       .load();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
         this.fileLinker = new ExternalFilesEntryLinker(preferences.getExternalApplicationsPreferences(), preferences.getFilePreferences(), databaseContext, dialogService);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -132,8 +132,8 @@ public class EntryEditor extends BorderPane {
         this.redoAction = redoAction;
 
         ViewLoader.view(this)
-                    .root(this)
-                    .load();
+                   .root(this)
+                   .load();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
         this.fileLinker = new ExternalFilesEntryLinker(preferences.getExternalApplicationsPreferences(), preferences.getFilePreferences(), databaseContext, dialogService);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -16,12 +16,7 @@ import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
-import javafx.scene.control.Button;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.Label;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
+import javafx.scene.control.*;
 import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;
@@ -36,6 +31,7 @@ import org.jabref.gui.entryeditor.citationrelationtab.CitationRelationsTab;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
 import org.jabref.gui.entryeditor.fileannotationtab.FulltextSearchResultsTab;
 import org.jabref.gui.externalfiles.ExternalFilesEntryLinker;
+import org.jabref.gui.fieldeditors.EditorTextField;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.importer.GrobidOptInDialogHelper;
 import org.jabref.gui.keyboard.KeyBinding;
@@ -100,24 +96,40 @@ public class EntryEditor extends BorderPane {
 
     private SourceTab sourceTab;
 
-    @FXML private TabPane tabbed;
+    @FXML
+    private TabPane tabbed;
 
-    @FXML private Button typeChangeButton;
-    @FXML private Button fetcherButton;
-    @FXML private Label typeLabel;
+    @FXML
+    private Button typeChangeButton;
+    @FXML
+    private Button fetcherButton;
+    @FXML
+    private Label typeLabel;
 
-    @Inject private BuildInfo buildInfo;
-    @Inject private DialogService dialogService;
-    @Inject private TaskExecutor taskExecutor;
-    @Inject private GuiPreferences preferences;
-    @Inject private StateManager stateManager;
-    @Inject private ThemeManager themeManager;
-    @Inject private FileUpdateMonitor fileMonitor;
-    @Inject private CountingUndoManager undoManager;
-    @Inject private BibEntryTypesManager bibEntryTypesManager;
-    @Inject private KeyBindingRepository keyBindingRepository;
-    @Inject private JournalAbbreviationRepository journalAbbreviationRepository;
-    @Inject private AiService aiService;
+    @Inject
+    private BuildInfo buildInfo;
+    @Inject
+    private DialogService dialogService;
+    @Inject
+    private TaskExecutor taskExecutor;
+    @Inject
+    private GuiPreferences preferences;
+    @Inject
+    private StateManager stateManager;
+    @Inject
+    private ThemeManager themeManager;
+    @Inject
+    private FileUpdateMonitor fileMonitor;
+    @Inject
+    private CountingUndoManager undoManager;
+    @Inject
+    private BibEntryTypesManager bibEntryTypesManager;
+    @Inject
+    private KeyBindingRepository keyBindingRepository;
+    @Inject
+    private JournalAbbreviationRepository journalAbbreviationRepository;
+    @Inject
+    private AiService aiService;
 
     private final List<EntryEditorTab> allPossibleTabs;
     private final Collection<OffersPreview> previewTabs;
@@ -130,8 +142,8 @@ public class EntryEditor extends BorderPane {
         this.redoAction = redoAction;
 
         ViewLoader.view(this)
-                  .root(this)
-                  .load();
+                .root(this)
+                .load();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
         this.fileLinker = new ExternalFilesEntryLinker(preferences.getExternalApplicationsPreferences(), preferences.getFilePreferences(), databaseContext, dialogService);
@@ -142,6 +154,7 @@ public class EntryEditor extends BorderPane {
         this.previewTabs = this.allPossibleTabs.stream().filter(OffersPreview.class::isInstance).map(OffersPreview.class::cast).toList();
 
         setupDragAndDrop(libraryTab);
+        EditorTextField.entryContext(tabbed);
 
         EasyBind.subscribe(tabbed.getSelectionModel().selectedItemProperty(), tab -> {
             EntryEditorTab activeTab = (EntryEditorTab) tab;
@@ -471,5 +484,21 @@ public class EntryEditor extends BorderPane {
 
     public void previousPreviewStyle() {
         this.previewTabs.forEach(OffersPreview::previousPreviewStyle);
+    }
+
+    public static boolean checkLastTextField(TabPane tabs, TextField textField) {
+        FieldsEditorTab currentTab = (FieldsEditorTab) tabs.getSelectionModel().getSelectedItem();
+        Collection<Field> shownFields = currentTab.getShownFields();
+        Field lastField = null;
+        for (Field field : shownFields) {
+            lastField = field;
+        }
+            if (textField != null && lastField != null) {
+                if (textField.getId() == null) {
+                    return false;
+                }
+                return lastField.getDisplayName().equalsIgnoreCase(textField.getId());
+            }
+        return false;
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -132,8 +132,8 @@ public class EntryEditor extends BorderPane {
         this.redoAction = redoAction;
 
         ViewLoader.view(this)
-                   .root(this)
-                   .load();
+                  .root(this)
+                  .load();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
         this.fileLinker = new ExternalFilesEntryLinker(preferences.getExternalApplicationsPreferences(), preferences.getFilePreferences(), databaseContext, dialogService);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -132,8 +132,8 @@ public class EntryEditor extends BorderPane {
         this.redoAction = redoAction;
 
         ViewLoader.view(this)
-                       .root(this)
-                       .load();
+                    .root(this)
+                    .load();
 
         this.entryEditorPreferences = preferences.getEntryEditorPreferences();
         this.fileLinker = new ExternalFilesEntryLinker(preferences.getExternalApplicationsPreferences(), preferences.getFilePreferences(), databaseContext, dialogService);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -96,40 +96,24 @@ public class EntryEditor extends BorderPane {
 
     private SourceTab sourceTab;
 
-    @FXML
-    private TabPane tabbed;
+    @FXML private TabPane tabbed;
 
-    @FXML
-    private Button typeChangeButton;
-    @FXML
-    private Button fetcherButton;
-    @FXML
-    private Label typeLabel;
+    @FXML private Button typeChangeButton;
+    @FXML private Button fetcherButton;
+    @FXML private Label typeLabel;
 
-    @Inject
-    private BuildInfo buildInfo;
-    @Inject
-    private DialogService dialogService;
-    @Inject
-    private TaskExecutor taskExecutor;
-    @Inject
-    private GuiPreferences preferences;
-    @Inject
-    private StateManager stateManager;
-    @Inject
-    private ThemeManager themeManager;
-    @Inject
-    private FileUpdateMonitor fileMonitor;
-    @Inject
-    private CountingUndoManager undoManager;
-    @Inject
-    private BibEntryTypesManager bibEntryTypesManager;
-    @Inject
-    private KeyBindingRepository keyBindingRepository;
-    @Inject
-    private JournalAbbreviationRepository journalAbbreviationRepository;
-    @Inject
-    private AiService aiService;
+    @Inject private BuildInfo buildInfo;
+    @Inject private DialogService dialogService;
+    @Inject private TaskExecutor taskExecutor;
+    @Inject private GuiPreferences preferences;
+    @Inject private StateManager stateManager;
+    @Inject private ThemeManager themeManager;
+    @Inject private FileUpdateMonitor fileMonitor;
+    @Inject private CountingUndoManager undoManager;
+    @Inject private BibEntryTypesManager bibEntryTypesManager;
+    @Inject private KeyBindingRepository keyBindingRepository;
+    @Inject private JournalAbbreviationRepository journalAbbreviationRepository;
+    @Inject private AiService aiService;
 
     private final List<EntryEditorTab> allPossibleTabs;
     private final Collection<OffersPreview> previewTabs;
@@ -493,12 +477,12 @@ public class EntryEditor extends BorderPane {
         for (Field field : shownFields) {
             lastField = field;
         }
-            if (textField != null && lastField != null) {
-                if (textField.getId() == null) {
-                    return false;
-                }
-                return lastField.getDisplayName().equalsIgnoreCase(textField.getId());
+        if (textField != null && lastField != null) {
+            if (textField.getId() == null) {
+                return false;
             }
-        return false;
-    }
+            return lastField.getDisplayName().equalsIgnoreCase(textField.getId());
+        }
+    return false;
+}
 }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -16,13 +16,13 @@ import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
+import javafx.scene.control.Button;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
-import javafx.scene.control.ContextMenu;
-import javafx.scene.control.MenuItem;
 import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -16,7 +16,13 @@ import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.geometry.Side;
-import javafx.scene.control.*;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
 import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;

--- a/src/main/java/org/jabref/gui/fieldeditors/CitationKeyEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/CitationKeyEditor.java
@@ -56,6 +56,7 @@ public class CitationKeyEditor extends HBox implements FieldEditorFX {
                 undoManager,
                 dialogService);
 
+        textField.setId(field.getDisplayName());
         establishBinding(textField, viewModel.textProperty(), keyBindingRepository, undoAction, redoAction);
         textField.initContextMenu(Collections::emptyList, keyBindingRepository);
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textField);

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -9,25 +9,35 @@ import java.util.function.Supplier;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
 import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.entryeditor.EntryEditor;
 import org.jabref.gui.fieldeditors.contextmenu.EditorContextAction;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 
 public class EditorTextField extends TextField implements Initializable, ContextMenuAddable {
 
     private final ContextMenu contextMenu = new ContextMenu();
+    public static TabPane tabs;
     private Runnable additionalPasteActionHandler = () -> {
         // No additional paste behavior
     };
 
     public EditorTextField() {
         this("");
+        this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            String keyText = event.getText();
+            if ("\t".equals(keyText) && EntryEditor.checkLastTextField(tabs, this)) {
+                tabs.getSelectionModel().selectNext();
+                event.consume();
+            }
+        });
     }
-
     public EditorTextField(final String text) {
         super(text);
 
@@ -38,6 +48,10 @@ public class EditorTextField extends TextField implements Initializable, Context
         ClipBoardManager.addX11Support(this);
     }
 
+    public static void entryContext(TabPane tab){
+        tabs = tab;
+    }
+
     @Override
     public void initContextMenu(final Supplier<List<MenuItem>> items, KeyBindingRepository keyBindingRepository) {
         setOnContextMenuRequested(event -> {
@@ -46,6 +60,8 @@ public class EditorTextField extends TextField implements Initializable, Context
             contextMenu.show(this, event.getScreenX(), event.getScreenY());
         });
     }
+
+
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -38,6 +38,7 @@ public class EditorTextField extends TextField implements Initializable, Context
             }
         });
     }
+
     public EditorTextField(final String text) {
         super(text);
 
@@ -48,7 +49,7 @@ public class EditorTextField extends TextField implements Initializable, Context
         ClipBoardManager.addX11Support(this);
     }
 
-    public static void entryContext(TabPane tab){
+    public static void entryContext(TabPane tab) {
         tabs = tab;
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -22,8 +22,8 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 
 public class EditorTextField extends TextField implements Initializable, ContextMenuAddable {
 
-    private final ContextMenu contextMenu = new ContextMenu();
     public static TabPane tabs;
+    private final ContextMenu contextMenu = new ContextMenu();
     private Runnable additionalPasteActionHandler = () -> {
         // No additional paste behavior
     };
@@ -60,8 +60,6 @@ public class EditorTextField extends TextField implements Initializable, Context
             contextMenu.show(this, event.getScreenX(), event.getScreenY());
         });
     }
-
-
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {

--- a/src/main/java/org/jabref/gui/fieldeditors/MarkdownEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/MarkdownEditor.java
@@ -22,7 +22,7 @@ public class MarkdownEditor extends SimpleEditor {
     }
 
     @Override
-    protected TextInputControl createTextInputControl() {
+    protected TextInputControl createTextInputControl(Field field) {
         return new EditorTextArea() {
             @Override
             public void paste() {

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -37,15 +37,11 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
         KeyBindingRepository keyBindingRepository = preferences.getKeyBindingRepository();
 
         this.viewModel = new PersonsEditorViewModel(field, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers, undoManager);
-        if (isMultiLine) {
-            EditorTextArea textArea = new EditorTextArea();
-            textArea.setId(field.getName());
-            textInput = textArea;
-        } else {
-            EditorTextField textField = new EditorTextField();
-            textField.setId(field.getName());
-            textInput = textField;
-        }
+        textInput = isMultiLine
+                ? new EditorTextArea()
+                : new EditorTextField();
+
+        textInput.setId(field.getName());
         decoratedStringProperty = new UiThreadStringProperty(viewModel.textProperty());
         establishBinding(textInput, decoratedStringProperty, keyBindingRepository, undoAction, redoAction);
         ((ContextMenuAddable) textInput).initContextMenu(EditorMenus.getNameMenu(textInput), keyBindingRepository);

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -37,7 +37,15 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
         KeyBindingRepository keyBindingRepository = preferences.getKeyBindingRepository();
 
         this.viewModel = new PersonsEditorViewModel(field, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers, undoManager);
-        textInput = isMultiLine ? new EditorTextArea() : new EditorTextField();
+        if (isMultiLine) {
+            EditorTextArea textArea = new EditorTextArea();
+            textArea.setId(field.getName());
+            textInput = textArea;
+        } else {
+            EditorTextField textField = new EditorTextField();
+            textField.setId(field.getName());
+            textInput = textField;
+        }
         decoratedStringProperty = new UiThreadStringProperty(viewModel.textProperty());
         establishBinding(textInput, decoratedStringProperty, keyBindingRepository, undoAction, redoAction);
         ((ContextMenuAddable) textInput).initContextMenu(EditorMenus.getNameMenu(textInput), keyBindingRepository);

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -55,15 +55,9 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
     }
 
     protected TextInputControl createTextInputControl(Field field) {
-        if (isMultiLine) {
-            EditorTextArea textArea = new EditorTextArea();
-            textArea.setId(field.getName());
-            return textArea;
-        } else {
-            EditorTextField textField = new EditorTextField();
-            textField.setId(field.getName());
-            return textField;
-        }
+        TextInputControl inputControl = isMultiLine ? new EditorTextArea() : new EditorTextField();
+        inputControl.setId(field.getName());
+        return inputControl;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -35,7 +35,7 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         this.viewModel = new SimpleEditorViewModel(field, suggestionProvider, fieldCheckers, undoManager);
         this.isMultiLine = isMultiLine;
 
-        textInput = createTextInputControl();
+        textInput = createTextInputControl(field);
         HBox.setHgrow(textInput, Priority.ALWAYS);
 
         establishBinding(textInput, viewModel.textProperty(), preferences.getKeyBindingRepository(), undoAction, redoAction);
@@ -54,8 +54,16 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textInput);
     }
 
-    protected TextInputControl createTextInputControl() {
-        return isMultiLine ? new EditorTextArea() : new EditorTextField();
+    protected TextInputControl createTextInputControl(Field field) {
+        if (isMultiLine) {
+            EditorTextArea textArea = new EditorTextArea();
+            textArea.setId(field.getName());
+            return textArea;
+        } else {
+            EditorTextField textField = new EditorTextField();
+            textField.setId(field.getName());
+            return textField;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Pressing "tab" when the last TextField of the entry editor Tab is in focus will move to the next Tab.

Closes https://github.com/JabRef/jabref/issues/11937

### What I have done

- Changed a method in `EditorTextField`, (`EditorTextField()`), that adds an `EventFilter` to the relative `TextField`, listening for "tab" presses. If "tab" is pressed it checks if the current `TextField` is the last one of its `TabPane` by calling `EntryEditor.checkLastTextField`. This method retrieves the last `Field` of the current `TabPane` and compares its name with the ID of the `TextField`. If true the `TextField` is the last one of its `TabPane` and the next `TabPane` will be selected.

The reason the ID of `TextField` should be equal to the name of its corresponding `Field` is because in classes, `PersonsEditor`, `SimpleEditor` and `CitationKeyEditor` the `TextField` created from the original `Field` has been set an ID of the `Field`'s display name.

### How this changes UI experience

After clicking a `TextField` and bringing it to focus, pressing "tab" will cycle through all the succeeding `TextFields` (the ones below it) until it reaches the last one and then it will switch `TabPane` to the next one toward the right. (see below)
<img width="1440" alt="Screenshot 2024-10-26 at 12 35 54 pm" src="https://github.com/user-attachments/assets/ce23bccb-b6c9-4a68-b1cf-21a0f47d83bf">


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
