### PR TITLE
Limit some workflows to main repository

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   assign:
+    if: github.repository_owner == 'JabRef'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   lychee:
+    if: github.repository_owner == 'JabRef'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -7,27 +7,14 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'JabRef'
     steps:
       - name: Cancel deployment run
         uses: styfle/cancel-workflow-action@0.12.1
         with:
           ignore_sha: true
           workflow_id: 9813 # workflow "Deployment"
-      - name: Check secrets presence
-        id: checksecrets
-        shell: bash
-        run: |
-          if [ "$BUILDJABREFPRIVATEKEY" == "" ]; then
-            echo "secretspresent=NO" >> $GITHUB_OUTPUT
-            echo "❌ Secret BUILDJABREFPRIVATEKEY not present"
-          else
-            echo "secretspresent=YES" >> $GITHUB_OUTPUT
-            echo "✔️ Secret BUILDJABREFPRIVATEKEY present"
-          fi
-        env:
-          BUILDJABREFPRIVATEKEY: ${{ secrets.buildJabRefPrivateKey }}
       - name: Delete folder on builds.jabref.org
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: appleboy/ssh-action@v1.1.0
         with:
           script: rm -rf /var/www/builds.jabref.org/www/pull/${{ github.event.pull_request.number }} || true
@@ -36,7 +23,6 @@ jobs:
           username: jrrsync
           key: ${{ secrets.buildJabRefPrivateKey }}
       - name: Update PR comment
-        if: steps.checksecrets.outputs.secretspresent == 'YES'
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: download-link

--- a/.github/workflows/deployment-arm64.yml
+++ b/.github/workflows/deployment-arm64.yml
@@ -34,6 +34,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == 'JabRef'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deployment-jdk-ea.yml
+++ b/.github/workflows/deployment-jdk-ea.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository_owner == 'JabRef'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   action:
+    if: github.repository_owner == 'JabRef'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'

--- a/.github/workflows/on-labeled-issue.yml
+++ b/.github/workflows/on-labeled-issue.yml
@@ -9,7 +9,7 @@ jobs:
   Assigned:
     # Triggered when manually assigned the label "📍 Assigned" to trigger the automatic unassignment after 30 days
     name: "📍 Assigned"
-    if: ${{ github.event.label.name == '📍 Assigned' }}
+    if: ${{ github.event.label.name == '📍 Assigned' && github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -35,7 +35,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
   FirstTimeCodeContribution:
-    if: ${{ github.event.label.name == 'FirstTimeCodeContribution' }}
+    if: ${{ github.event.label.name == 'FirstTimeCodeContribution' && github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -80,7 +80,7 @@ jobs:
         skip-if-not-in-project: true
   good-first-issue:
     name: "good first issue"
-    if: "${{ github.event.label.name == 'good first issue' }}"
+    if: "${{ github.event.label.name == 'good first issue' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-latest
     steps:
       - name: "good first issue"
@@ -90,7 +90,7 @@ jobs:
           ISSUE_URL=$(jq --raw-output .issue.html_url "$GITHUB_EVENT_PATH")
           gh project item-add 5 --owner JabRef --url $ISSUE_URL
   needs-refinement:
-    if: github.event.label.name == 'needs-refinement'
+    if: github.event.label.name == 'needs-refinement' && github.repository_owner == 'JabRef'
     runs-on: ubuntu-latest
     steps:
       - name: needs-refinement
@@ -101,7 +101,7 @@ jobs:
           gh project item-add 15 --owner JabRef --url $ISSUE_URL
   status-freeze:
     name: "status: freeze"
-    if: "${{ github.event.label.name == 'status: freeze' }}"
+    if: "${{ github.event.label.name == 'status: freeze' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-latest
     steps:
       - name: "status: freeze"
@@ -111,7 +111,7 @@ jobs:
           ISSUE_URL=$(jq --raw-output .issue.html_url "$GITHUB_EVENT_PATH")
           gh project item-add 9 --owner JabRef --url $ISSUE_URL
   ui:
-    if: "${{ github.event.label.name == 'ui' }}"
+    if: "${{ github.event.label.name == 'ui' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-latest
     steps:
       - name: ui

--- a/.github/workflows/on-labeled-pr.yml
+++ b/.github/workflows/on-labeled-pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   automerge:
     name: Auto Merge
-    if: "${{ github.event.label.name == 'automerge' }}"
+    if: "${{ github.event.label.name == 'automerge' && github.repository_owner == 'JabRef' }}"
     runs-on: ubuntu-latest
     steps:
       - name: Approve PR

--- a/.github/workflows/on-unlabeled-issue.yml
+++ b/.github/workflows/on-unlabeled-issue.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   FirstTimeCodeContribution_or_Assigned:
-    if: ${{ (github.event.label.name == 'FirstTimeCodeContribution') || (github.event.label.name == '📍 Assigned') }}
+    if: ${{ ((github.event.label.name == 'FirstTimeCodeContribution') || (github.event.label.name == '📍 Assigned')) && github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   comment:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && (github.repository_owner == 'JabRef') }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-gradle-wrapper:
+    if: github.repository_owner == 'JabRef'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Some checks (e.g., external links) and updates (gradle wrapper) should only be done in our main repo.

Needs to be "tested" in "production"

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
