### PR TITLE
Refine hint on pasting keys.

### DIFF
--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -133,8 +133,10 @@ class LocalizationConsistencyTest {
                            .collect(Collectors.joining("\n",
                                    """
 
-                                           DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE
-                                           PASTE THESE INTO THE ENGLISH LANGUAGE FILE "JabRef_en.properties"
+                                           DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE.
+                                           PASTE THESE INTO THE ENGLISH LANGUAGE FILE "JabRef_en.properties".
+                                           Search for a proper place; typically related keys are grouped together.
+                                           Maybe you find a similar key - then adapt your langauge instead of adding load to translators by adding a new key.
 
                                            """,
                                    "\n\n")));
@@ -148,8 +150,8 @@ class LocalizationConsistencyTest {
                         "Obsolete keys found in language properties file: \n\n",
                         """
 
-                                1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE
-                                2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE "JabRef_en.properties"
+                                1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE.
+                                2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE "JabRef_en.properties".
 
                                 """))
         );

--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -136,7 +136,7 @@ class LocalizationConsistencyTest {
                                            DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE.
                                            PASTE THESE INTO THE ENGLISH LANGUAGE FILE "JabRef_en.properties".
                                            Search for a proper place; typically related keys are grouped together.
-                                           Maybe you find a similar key - then adapt your langauge instead of adding load to translators by adding a new key.
+                                           If a similar key is already present, please adapt your language instead of adding load to translators by adding a new key.
 
                                            """,
                                    "\n\n")));


### PR DESCRIPTION
People tend to blindly add localization keys into `JabRef_en.properties`. 

With the proposed text, they maybe think more?

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
