### PR TITLE
Improve `MainTable#findEntry`

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -259,7 +259,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         } else {
             // select new entry
             getSelectionModel().clearSelection();
-            model.getViewModelByIndex(database.getDatabase().indexOf(bibEntry)).ifPresent(entry -> {
+            findEntry(bibEntry).ifPresent(entry -> {
                 getSelectionModel().select(entry);
                 scrollTo(entry);
             });
@@ -487,6 +487,10 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                 .stream()
                 .map(BibEntryTableViewModel::getEntry)
                 .collect(Collectors.toList());
+    }
+
+    private Optional<BibEntryTableViewModel> findEntry(BibEntry entry) {
+        return model.getViewModelByIndex(database.getDatabase().indexOf(entry));
     }
 
     public void setCitationMergeMode(boolean citationMerge) {

--- a/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -259,7 +259,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
         } else {
             // select new entry
             getSelectionModel().clearSelection();
-            findEntry(bibEntry).ifPresent(entry -> {
+            model.getViewModelByIndex(database.getDatabase().indexOf(bibEntry)).ifPresent(entry -> {
                 getSelectionModel().select(entry);
                 scrollTo(entry);
             });
@@ -487,13 +487,6 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                 .stream()
                 .map(BibEntryTableViewModel::getEntry)
                 .collect(Collectors.toList());
-    }
-
-    private Optional<BibEntryTableViewModel> findEntry(BibEntry entry) {
-        return model.getEntriesFilteredAndSorted()
-                    .stream()
-                    .filter(viewModel -> viewModel.getEntry().equals(entry))
-                    .findFirst();
     }
 
     public void setCitationMergeMode(boolean citationMerge) {

--- a/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -195,6 +195,13 @@ public class MainTableDataModel {
         return entriesFilteredAndSorted;
     }
 
+    public Optional<BibEntryTableViewModel> getViewModelByIndex(int index) {
+        if (index < 0 || index >= entriesViewModel.size()) {
+            return Optional.empty();
+        }
+        return Optional.of(entriesViewModel.get(index));
+    }
+
     public void resetFieldFormatter() {
         this.fieldValueFormatter.setValue(new MainTableFieldValueFormatter(nameDisplayPreferences, bibDatabaseContext));
     }

--- a/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -38,10 +38,13 @@ import com.google.common.eventbus.Subscribe;
 import com.tobiasdiez.easybind.EasyBind;
 import com.tobiasdiez.easybind.Subscription;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.jabref.model.search.PostgreConstants.ENTRY_ID;
 
 public class MainTableDataModel {
+    private final Logger LOGGER = LoggerFactory.getLogger(MainTableDataModel.class);
 
     private final ObservableList<BibEntryTableViewModel> entriesViewModel;
     private final FilteredList<BibEntryTableViewModel> entriesFiltered;
@@ -197,6 +200,7 @@ public class MainTableDataModel {
 
     public Optional<BibEntryTableViewModel> getViewModelByIndex(int index) {
         if (index < 0 || index >= entriesViewModel.size()) {
+            LOGGER.warn("Tried to access out of bounds index {} in entriesViewModel", index);
             return Optional.empty();
         }
         return Optional.of(entriesViewModel.get(index));

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -637,7 +637,11 @@ public class BibDatabase {
      */
     public int indexOf(BibEntry bibEntry) {
         int index = Collections.binarySearch(entries, bibEntry, Comparator.comparing(BibEntry::getId));
-        return index >= 0 ? index : -1;
+        if (index >= 0) {
+            return index;
+        }
+        LOGGER.warn("Could not find entry with ID {} in the database", bibEntry.getId());
+        return -1;
     }
 
     public BibEntry getEntryById(String id) {


### PR DESCRIPTION
Instead of the sequential scan to find the entry view model, retrieve the index of the entry from the database. This is faster because it uses a binary search based on the entry id.

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/660

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
