### PR TITLE
Always select entry in main table when showing entry editor

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -482,7 +482,6 @@ public class LibraryTab extends Tab {
         Platform.runLater(() -> {
             // Focus field and entry in main table (async to give entry editor time to load)
             entryEditor.setFocusToField(field);
-            clearAndSelect(entry);
         });
     }
 
@@ -567,11 +566,15 @@ public class LibraryTab extends Tab {
     }
 
     /**
-     * Sets the entry editor as the bottom component in the split pane. If an entry editor already was shown, makes sure that the divider doesn't move. Updates the mode to SHOWING_EDITOR. Then shows the given entry.
+     * Sets the entry editor as the bottom component in the split pane. If an entry editor already was shown, makes sure that the divider doesn't move. Updates the mode to {@link PanelMode#MAIN_TABLE_AND_ENTRY_EDITOR}.
+     * Then shows the given entry.
+     *
+     * Additionally, selects the entry in the main table - so that the selected entry in the main table always corresponds to the edited entry.
      *
      * @param entry The entry to edit.
      */
     public void showAndEdit(BibEntry entry) {
+        this.clearAndSelect(entry);
         if (!splitPane.getItems().contains(entryEditor)) {
             splitPane.getItems().addLast(entryEditor);
             mode = PanelMode.MAIN_TABLE_AND_ENTRY_EDITOR;
@@ -889,16 +892,16 @@ public class LibraryTab extends Tab {
     }
 
     public void insertEntries(final List<BibEntry> entries) {
-        if (!entries.isEmpty()) {
-            importHandler.importCleanedEntries(entries);
+        if (entries.isEmpty()) {
+            return;
+        }
 
-            // Create an UndoableInsertEntries object.
-            getUndoManager().addEdit(new UndoableInsertEntries(bibDatabaseContext.getDatabase(), entries));
-
-            markBaseChanged();
-            if (preferences.getEntryEditorPreferences().shouldOpenOnNewEntry()) {
-                showAndEdit(entries.getFirst());
-            }
+        importHandler.importCleanedEntries(entries);
+        getUndoManager().addEdit(new UndoableInsertEntries(bibDatabaseContext.getDatabase(), entries));
+        markBaseChanged();
+        if (preferences.getEntryEditorPreferences().shouldOpenOnNewEntry()) {
+            showAndEdit(entries.getFirst());
+        } else {
             clearAndSelect(entries.getFirst());
         }
     }

--- a/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -317,7 +317,6 @@ public class CitationRelationsTab extends EntryEditorTab {
         citingTask.cancel();
         citedByTask.cancel();
         libraryTab.showAndEdit(entry.localEntry());
-        libraryTab.clearAndSelect(entry.localEntry());
     }
 
     /**


### PR DESCRIPTION
In some code patghways, the entry editor was shown, but the main table selection was not updated.

IMHO if the entry editor is shown - there should be a single (!) entry in the main table focused: The entry currently edited.

(This PR contains some code cleanup from https://github.com/JabRef/jabref/pull/12124/ - the important change is the removal of explicit `clearAndSelect` calls and include them into `showAndEdit`)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
