### PR TITLE
Remove updateEntryEditorIfShowing

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -628,13 +628,6 @@ public class LibraryTab extends Tab {
         }
     }
 
-    public void updateEntryEditorIfShowing() {
-        if (mode == PanelMode.MAIN_TABLE_AND_ENTRY_EDITOR) {
-            BibEntry currentEntry = entryEditor.getCurrentlyEditedEntry();
-            showAndEdit(currentEntry);
-        }
-    }
-
     /**
      * Put an asterisk behind the filename to indicate the database has changed.
      */

--- a/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
@@ -131,7 +131,6 @@ public class CleanupAction extends SimpleCommand {
         }
 
         if (modifiedEntriesCount > 0) {
-            tabSupplier.get().updateEntryEditorIfShowing();
             tabSupplier.get().markBaseChanged();
         }
 

--- a/src/main/java/org/jabref/gui/specialfields/SpecialFieldAction.java
+++ b/src/main/java/org/jabref/gui/specialfields/SpecialFieldAction.java
@@ -82,7 +82,6 @@ public class SpecialFieldAction extends SimpleCommand {
             if (ce.hasEdits()) {
                 undoManager.addEdit(ce);
                 tabSupplier.get().markBaseChanged();
-                tabSupplier.get().updateEntryEditorIfShowing();
                 String outText;
                 if (nullFieldIfValueIsTheSame || value == null) {
                     outText = getTextDone(specialField, Integer.toString(bes.size()));


### PR DESCRIPTION
The method `updateEntryEditorIfShowing` seems to be a left-over of old times.

It was called very rarely.

Since the argument for `showAndEdit` was the currently entry, the only action the thing did was to focus the entry editor. The callers were "Cleanup" and "SpecialFieldAction". I don't think, they need an entry editor focus.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
