### PR TITLE
Implement early exit

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -916,22 +916,22 @@ public class LibraryTab extends Tab {
     }
 
     private int doCopyEntry(List<BibEntry> selectedEntries) {
-        if (!selectedEntries.isEmpty()) {
-            List<BibtexString> stringConstants = bibDatabaseContext.getDatabase().getUsedStrings(selectedEntries);
-            try {
-                if (stringConstants.isEmpty()) {
-                    clipBoardManager.setContent(selectedEntries, entryTypesManager);
-                } else {
-                    clipBoardManager.setContent(selectedEntries, entryTypesManager, stringConstants);
-                }
-                return selectedEntries.size();
-            } catch (IOException e) {
-                LOGGER.error("Error while copying selected entries to clipboard.", e);
-                return -1;
-            }
+        if (selectedEntries.isEmpty()) {
+            return 0;
         }
 
-        return 0;
+        List<BibtexString> stringConstants = bibDatabaseContext.getDatabase().getUsedStrings(selectedEntries);
+        try {
+            if (stringConstants.isEmpty()) {
+                clipBoardManager.setContent(selectedEntries, entryTypesManager);
+            } else {
+                clipBoardManager.setContent(selectedEntries, entryTypesManager, stringConstants);
+            }
+            return selectedEntries.size();
+        } catch (IOException e) {
+            LOGGER.error("Error while copying selected entries to clipboard.", e);
+            return -1;
+        }
     }
 
     public void pasteEntry() {


### PR DESCRIPTION
Implement "early exit" pattern for org.jabref.gui.LibraryTab#doCopyEntry

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
