### PR TITLE
Allow - in citaton keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When importing a file using "Find Unlinked Files", when one or more file directories are available, the file path will be relativized where possible [koppor#549](https://github.com/koppor/jabref/issues/549)
 - We added minimum window sizing for windows dedicated to creating new entries [#11944](https://github.com/JabRef/jabref/issues/11944)
 - We changed the name of the library-based file directory from 'General File Directory' to 'Library-specific File Directory' per issue. [#571](https://github.com/koppor/jabref/issues/571)
-- We allow a dash (`-`) being part in a citation key.
+- We allow a dash (`-`) being part in a citation key. [#12144](https://github.com/JabRef/jabref/pull/12144)
 - The CitationKey column is now a default shown column for the entry table. [#10510](https://github.com/JabRef/jabref/issues/10510)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When importing a file using "Find Unlinked Files", when one or more file directories are available, the file path will be relativized where possible [koppor#549](https://github.com/koppor/jabref/issues/549)
 - We added minimum window sizing for windows dedicated to creating new entries [#11944](https://github.com/JabRef/jabref/issues/11944)
 - We changed the name of the library-based file directory from 'General File Directory' to 'Library-specific File Directory' per issue. [#571](https://github.com/koppor/jabref/issues/571)
+- We allow a dash (`-`) being part in a citation key.
 - The CitationKey column is now a default shown column for the entry table. [#10510](https://github.com/JabRef/jabref/issues/10510)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When importing a file using "Find Unlinked Files", when one or more file directories are available, the file path will be relativized where possible [koppor#549](https://github.com/koppor/jabref/issues/549)
 - We added minimum window sizing for windows dedicated to creating new entries [#11944](https://github.com/JabRef/jabref/issues/11944)
 - We changed the name of the library-based file directory from 'General File Directory' to 'Library-specific File Directory' per issue. [#571](https://github.com/koppor/jabref/issues/571)
-- We allow a dash (`-`) being part in a citation key. [#12144](https://github.com/JabRef/jabref/pull/12144)
+- We changed the defualt [unwanted charachters](https://docs.jabref.org/setup/citationkeypatterns#removing-unwanted-characters) in the citation key generator and allow a dash (`-`) and colon (`:`) being part of a citation key. [#12144](https://github.com/JabRef/jabref/pull/12144)
 - The CitationKey column is now a default shown column for the entry table. [#10510](https://github.com/JabRef/jabref/issues/10510)
 
 ### Fixed

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
  * This is the utility class of the LabelPattern package.
  */
 public class CitationKeyGenerator extends BracketedPattern {
+
     /**
      * All single characters that we can use for extending a key to make it unique.
      */
@@ -30,13 +31,14 @@ public class CitationKeyGenerator extends BracketedPattern {
     /// Note that `+` is a wanted character to indicate "et al." in authorsAlpha.
     /// Example: `ABC+`. See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
     ///
-    /// Source: <https://tex.stackexchange.com/questions/408530/what-characters-are-allowed-to-use-as-delimiters-for-bibtex-keys
+    /// See also #DISALLOWED_CHARACTERS
     public static final String DEFAULT_UNWANTED_CHARACTERS = "`ʹ:!;?^";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
-
-    // Source of disallowed characters : https://tex.stackexchange.com/a/408548/9075
+    /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
+    /// These characters are disallowed in BibTeX keys.
     private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
 
     private final AbstractCitationKeyPatterns citeKeyPattern;
     private final BibDatabase database;

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -26,12 +26,12 @@ public class CitationKeyGenerator extends BracketedPattern {
      */
     public static final String APPENDIX_CHARACTERS = "abcdefghijklmnopqrstuvwxyz";
 
-    /**
-     * List of unwanted characters. These will be removed at the end.
-     * Note that <code>+</code> is a wanted character to indicate "et al." in authorsAlpha.
-     * Example: "ABC+". See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
-     */
-    public static final String DEFAULT_UNWANTED_CHARACTERS = "-`ʹ:!;?^";
+    /// List of unwanted characters. These will be removed at the end.
+    /// Note that `+` is a wanted character to indicate "et al." in authorsAlpha.
+    /// Example: `ABC+`. See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
+    ///
+    /// Source: <https://tex.stackexchange.com/questions/408530/what-characters-are-allowed-to-use-as-delimiters-for-bibtex-keys
+    public static final String DEFAULT_UNWANTED_CHARACTERS = "`ʹ:!;?^";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
 

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -32,7 +32,7 @@ public class CitationKeyGenerator extends BracketedPattern {
     /// Example: `ABC+`. See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
     ///
     /// See also #DISALLOWED_CHARACTERS
-    public static final String DEFAULT_UNWANTED_CHARACTERS = "`ʹ!;?^";
+    public static final String DEFAULT_UNWANTED_CHARACTERS = "?!;^`ʹ";
 
     /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
     /// These characters are disallowed in BibTeX keys.

--- a/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -32,7 +32,7 @@ public class CitationKeyGenerator extends BracketedPattern {
     /// Example: `ABC+`. See {@link org.jabref.logic.citationkeypattern.BracketedPatternTest#authorsAlpha()} for examples.
     ///
     /// See also #DISALLOWED_CHARACTERS
-    public static final String DEFAULT_UNWANTED_CHARACTERS = "`ʹ:!;?^";
+    public static final String DEFAULT_UNWANTED_CHARACTERS = "`ʹ!;?^";
 
     /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
     /// These characters are disallowed in BibTeX keys.

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -66,7 +66,6 @@ class CitationKeyGeneratorTest {
     private static final String AUTHNOFMTH = "[auth%d_%d]";
     private static final String AUTHFOREINI = "[authForeIni]";
     private static final String AUTHFIRSTFULL = "[authFirstFull]";
-    private static final String AUTHORS = "[authors]";
     private static final String AUTHORSALPHA = "[authorsAlpha]";
     private static final String AUTHORLAST = "[authorLast]";
     private static final String AUTHORLASTFOREINI = "[authorLastForeIni]";
@@ -493,14 +492,19 @@ class CitationKeyGeneratorTest {
         assertEquals("Newton", generateKey(AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_2, AUTHFIRSTFULL));
     }
 
-    /**
-     * Tests [authors]
-     */
-    @Test
-    void allAuthors() {
-        assertEquals("Newton", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORS));
-        assertEquals("NewtonMaxwell", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORS));
-        assertEquals("NewtonMaxwellEinstein", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORS));
+    @ParameterizedTest
+    @MethodSource
+    void authors(String expectedKey, BibEntry entry, String pattern) {
+        assertEquals(expectedKey, generateKey(entry, pattern));
+    }
+
+    static Stream<Arguments> authors() {
+        return Stream.of(
+                Arguments.of("Newton", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, "[authors]"),
+                Arguments.of("NewtonMaxwell", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, "[authors]"),
+                Arguments.of("NewtonMaxwellEinstein", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, "[authors]"),
+                Arguments.of("Newton-Maxwell-Einstein", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, "[authors:regex(\"(.)([A-Z])\",\"$1-$2\")]")
+        );
     }
 
     static Stream<Arguments> authorsAlpha() {

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -191,14 +191,15 @@ class CitationKeyGeneratorTest {
             "@ARTICLE{kohn, author={Andreas Ùöning}, year={2000}}", "Uoe",
 
             # Special cases
-            "@ARTICLE{kohn, author={Oraib Al-Ketan}, year={2000}}", "AlK",
+            # We keep "-" in citation keys, thus Al-Ketan with three letters is "Al-"
+            "@ARTICLE{kohn, author={Oraib Al-Ketan}, year={2000}}", "Al-",
             "@ARTICLE{kohn, author={Andrés D'Alessandro}, year={2000}}", "DAl",
             "@ARTICLE{kohn, author={Andrés Aʹrnold}, year={2000}}", "Arn"
             """
     )
     void makeLabelAndCheckLegalKeys(String bibtexString, String expectedResult) throws ParseException {
-        Optional<BibEntry> bibEntry = BibtexParser.singleFromString(bibtexString, importFormatPreferences);
-        String citationKey = generateKey(bibEntry.orElse(null), "[auth3]", new BibDatabase());
+        BibEntry bibEntry = BibtexParser.singleFromString(bibtexString, importFormatPreferences).get();
+        String citationKey = generateKey(bibEntry, "[auth3]", new BibDatabase());
 
         String cleanedKey = CitationKeyGenerator.cleanKey(citationKey, DEFAULT_UNWANTED_CHARACTERS);
 
@@ -975,7 +976,7 @@ class CitationKeyGeneratorTest {
                 .withField(StandardField.AUTHOR, AUTHOR_STRING_FIRSTNAME_FULL_LASTNAME_FULL_COUNT_1)
                 .withField(StandardField.YEAR, "2019");
 
-        assertEquals("Newton2019", generateKey(entry, "[auth]-[year]"));
+        assertEquals("Newton-2019", generateKey(entry, "[auth]-[year]"));
     }
 
     @Test
@@ -983,7 +984,7 @@ class CitationKeyGeneratorTest {
         BibEntry entry = new BibEntry().withField(StandardField.AUTHOR, "Newton, Isaac")
                                        .withField(StandardField.YEAR, "2019");
 
-        assertEquals("newt2019", generateKey(entry, "[auth4:lower]-[year]"));
+        assertEquals("newt-2019", generateKey(entry, "[auth4:lower]-[year]"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -899,7 +899,7 @@ class CitationKeyGeneratorTest {
     @Test
     void generateKeyStripsColonFromTitle() {
         BibEntry entry = new BibEntry().withField(StandardField.TITLE, "Green Scheduling of: Whatever");
-        assertEquals("GreenSchedulingOfWhatever", generateKey(entry, "[title]"));
+        assertEquals("GreenSchedulingOf:Whatever", generateKey(entry, "[title]"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
@@ -270,7 +270,7 @@ class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[author:(Problem:No Author Provided)]");
         entry.clearField(StandardField.AUTHOR);
         new CitationKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("ProblemNoAuthorProvided"), entry.getCitationKey());
+        assertEquals(Optional.of("Problem:NoAuthorProvided"), entry.getCitationKey());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -85,4 +85,10 @@ class RegexFormatterTest {
         formatter = new RegexFormatter("(\"(\\w+).*\", \"$1\")");
         assertEquals("First", formatter.format("First Second Third"));
     }
+
+    @Test
+    void addDash() {
+        formatter = new RegexFormatter("(\"(.)([A-Z])\", \"$1-$2\")");
+        assertEquals("First-Second-Third", formatter.format("FirstSecondThird"));
+    }
 }


### PR DESCRIPTION
Doesn't fully work, needs some more polishing.

Follow-up to https://github.com/JabRef/jabref/pull/9703

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
