### PR TITLE
Update JaCoCo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,7 @@ javafx {
 }
 
 jacoco {
-    toolVersion = "0.8.13.202411081104"
+    toolVersion = "0.8.13-SNAPSHOT"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ java {
         // - .github/workflows/tests*.yml
         // - .github/workflows/update-gradle-wrapper.yml
         // - docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
+        // - build.gradle -> jacoco -> toolVersion (because JaCoCo does not support newest JDK out of the box. Check versions at https://www.jacoco.org/jacoco/trunk/doc/changes.html)
         languageVersion = JavaLanguageVersion.of(23)
         // See https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JvmVendorSpec.html for a full list
         // vendor = JvmVendorSpec.AMAZON

--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ javafx {
 }
 
 jacoco {
-    toolVersion = "0.8.10"
+    toolVersion = "0.8.13.202411081104"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,7 @@ sourceSets {
 repositories {
     mavenCentral()
     maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url 'https://jitpack.io' }
     maven { url 'https://oss.sonatype.org/content/groups/public' }
 


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12166

JaCoCo needs to be updated to support JDK23. (Refs https://github.com/jacoco/jacoco/pull/1757)

Changes: https://www.jacoco.org/jacoco/trunk/doc/changes.html

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
