### PR TITLE
Add howto for git modules

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-11-code-into-ide.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-11-code-into-ide.md
@@ -62,4 +62,19 @@ This will make these directories "Unregistered roots:", which is fine.
 ![Directory Mappings having three repositories unregsitered](intellij-directory-mappings-unregistered-roots.png)
 {% endfigure %}
 
+## Ensure that committing with other tools work
+
+Open a "git bash".
+On Windows, navigate to `C:\git-repositories\JabRef`.
+Open the context menu of the file explorer (using the right mouse button), choose "Open Git Bash here".
+
+Execute following command:
+
+```shell
+git update-index --assume-unchanged buildres/abbrv.jabref.org src/main/resources/csl-styles src/main/resources/csl-locales
+```
+
+{: .tip }
+If you do not see the context menu, re-install git following the steps given at [StackOverflow](https://stackoverflow.com/a/50667280/873282).
+
 <!-- markdownlint-disable-file MD033 -->


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref-issue-melting-pot/issues/504

I finally found a "solution" for the git submodule issue (posted at https://stackoverflow.com/questions/66773544/git-submodule-not-ignored-even-with-ignore-all/79176853#79176853). -- Background: I was about to file a bug against `lazygit`, but then I found out that `git add -A` ignores the `ignore = all` setting. After some googling, I found the solution to use `git update-index --assume-unchanged {sub-module-path}`.

This PR adds this to the documetation.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
