### PR TITLE
Increase time-out for work from 30 to 90 days

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -19,7 +19,7 @@ jobs:
         uses: takanome-dev/assign-issue-action@beta
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          days_until_unassign: 30
+          days_until_unassign: 90
           maintainers: koppor, Siedlerchr, ThiloteE, calixtus, HoussemNasri
           assigned_comment: |
             👋 Hey @{{ handle }}, thank you for your interest in this issue! 🎉


### PR DESCRIPTION
We should give students (and us) more time for finishing an issue.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
