### PR TITLE
Markdown Export Formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added a Markdown export functionality [#12220](https://github.com/JabRef/jabref/pull/12220)
 - We added a "view as BibTeX" option before importing an entry from the citation relation tab. [#11826](https://github.com/JabRef/jabref/issues/11826)
 - We added support finding LaTeX-encoded special characters based on plain Unicode and vice versa. [#11542](https://github.com/JabRef/jabref/pull/11542)
 - When a search hits a file, the file icon of that entry is changed accordingly. [#11542](https://github.com/JabRef/jabref/pull/11542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added a Markdown export functionality [#12220](https://github.com/JabRef/jabref/pull/12220)
+- We added a Markdown export layout [#12220](https://github.com/JabRef/jabref/pull/12220)
 - We added a "view as BibTeX" option before importing an entry from the citation relation tab. [#11826](https://github.com/JabRef/jabref/issues/11826)
 - We added support finding LaTeX-encoded special characters based on plain Unicode and vice versa. [#11542](https://github.com/JabRef/jabref/pull/11542)
 - When a search hits a file, the file icon of that entry is changed accordingly. [#11542](https://github.com/JabRef/jabref/pull/11542)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added a Markdown export layout [#12220](https://github.com/JabRef/jabref/pull/12220)
+- We added a Markdown export layout. [#12220](https://github.com/JabRef/jabref/pull/12220)
 - We added a "view as BibTeX" option before importing an entry from the citation relation tab. [#11826](https://github.com/JabRef/jabref/issues/11826)
 - We added support finding LaTeX-encoded special characters based on plain Unicode and vice versa. [#11542](https://github.com/JabRef/jabref/pull/11542)
 - When a search hits a file, the file icon of that entry is changed accordingly. [#11542](https://github.com/JabRef/jabref/pull/11542)

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -13,9 +13,6 @@ import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseMode;
-import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.metadata.SaveOrder;
-import org.jabref.model.metadata.SaveOrder.SortCriterion;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 public class ExporterFactory {

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -47,7 +47,7 @@ public class ExporterFactory {
         exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, saveOrder));
-        exporters.add(new TemplateExporter(Localization.lang("Markdown Titles"), "title-md", "title-md", "title-markdown", StandardFileType.MARKDOWN, layoutPreferences, saveMostRecentFirst));
+        exporters.add(new TemplateExporter(Localization.lang("Markdown titles"), "title-md", "title-md", "title-markdown", StandardFileType.MARKDOWN, layoutPreferences, saveMostRecentFirst));
         exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, saveOrder));

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -30,7 +30,6 @@ public class ExporterFactory {
         List<TemplateExporter> customFormats = preferences.getExportPreferences().getCustomExporters();
         LayoutFormatterPreferences layoutPreferences = preferences.getLayoutFormatterPreferences();
         SelfContainedSaveOrder saveOrder = SelfContainedSaveOrder.of(preferences.getSelfContainedExportConfiguration().getSaveOrder());
-        SelfContainedSaveOrder saveMostRecentFirst = new SelfContainedSaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(new SortCriterion(StandardField.YEAR, true)));
         XmpPreferences xmpPreferences = preferences.getXmpPreferences();
         FieldPreferences fieldPreferences = preferences.getFieldPreferences();
         BibDatabaseMode bibDatabaseMode = preferences.getLibraryPreferences().getDefaultBibDatabaseMode();
@@ -47,7 +46,7 @@ public class ExporterFactory {
         exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, saveOrder));
-        exporters.add(new TemplateExporter(Localization.lang("Markdown titles"), "title-md", "title-md", "title-markdown", StandardFileType.MARKDOWN, layoutPreferences, saveMostRecentFirst));
+        exporters.add(new TemplateExporter(Localization.lang("Markdown titles"), "title-md", "title-md", "title-markdown", StandardFileType.MARKDOWN, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, saveOrder));

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -13,6 +13,9 @@ import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.metadata.SaveOrder;
+import org.jabref.model.metadata.SaveOrder.SortCriterion;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 public class ExporterFactory {
@@ -27,6 +30,7 @@ public class ExporterFactory {
         List<TemplateExporter> customFormats = preferences.getExportPreferences().getCustomExporters();
         LayoutFormatterPreferences layoutPreferences = preferences.getLayoutFormatterPreferences();
         SelfContainedSaveOrder saveOrder = SelfContainedSaveOrder.of(preferences.getSelfContainedExportConfiguration().getSaveOrder());
+        SelfContainedSaveOrder saveMostRecentFirst = new SelfContainedSaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(new SortCriterion(StandardField.YEAR, true)));
         XmpPreferences xmpPreferences = preferences.getXmpPreferences();
         FieldPreferences fieldPreferences = preferences.getFieldPreferences();
         BibDatabaseMode bibDatabaseMode = preferences.getLibraryPreferences().getDefaultBibDatabaseMode();
@@ -43,6 +47,7 @@ public class ExporterFactory {
         exporters.add(new TemplateExporter(Localization.lang("HTML table"), "tablerefs", "tablerefs", "tablerefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML list"), "listrefs", "listrefs", "listrefs", StandardFileType.HTML, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter(Localization.lang("HTML table (with Abstract & BibTeX)"), "tablerefsabsbib", "tablerefsabsbib", "tablerefsabsbib", StandardFileType.HTML, layoutPreferences, saveOrder));
+        exporters.add(new TemplateExporter(Localization.lang("Markdown Titles"), "title-md", "title-md", "title-markdown", StandardFileType.MARKDOWN, layoutPreferences, saveMostRecentFirst));
         exporters.add(new TemplateExporter("Harvard RTF", "harvard", "harvard", "harvard", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690 RTF", "iso690rtf", "iso690RTF", "iso690rtf", StandardFileType.RTF, layoutPreferences, saveOrder));
         exporters.add(new TemplateExporter("ISO 690", "iso690txt", "iso690", "iso690txt", StandardFileType.TXT, layoutPreferences, saveOrder));

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -466,6 +466,8 @@ The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=The marked area does 
 
 HTML\ table=HTML table
 HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML table (with Abstract & BibTeX)
+Markdown\ titles=Markdown titles
+
 Icon=Icon
 
 Ignore=Ignore

--- a/src/main/resources/resource/layout/title-markdown/title-md.article.layout
+++ b/src/main/resources/resource/layout/title-markdown/title-md.article.layout
@@ -1,0 +1,1 @@
+* \format[RemoveLatexCommands,HTMLChars]{\title}. \begin{journal}\format[RemoveLatexCommands,HTMLChars]{\journal}\end{journal}\begin{year} \format{\year}\end{year}

--- a/src/main/resources/resource/layout/title-markdown/title-md.book.layout
+++ b/src/main/resources/resource/layout/title-markdown/title-md.book.layout
@@ -1,0 +1,1 @@
+* \format[RemoveLatexCommands,HTMLChars]{\title}.\begin{publisher} \format[RemoveLatexCommands,HTMLChars]{\publisher}\end{publisher} \format{\year}\end{year}

--- a/src/main/resources/resource/layout/title-markdown/title-md.incollection.layout
+++ b/src/main/resources/resource/layout/title-markdown/title-md.incollection.layout
@@ -1,0 +1,1 @@
+* \format[RemoveLatexCommands,HTMLChars]{\title}. \begin{booktitle}\format[RemoveLatexCommands,HTMLChars]{\booktitle}\end{booktitle}\begin{publisher}, \format[RemoveLatexCommands,HTMLChars]{\publisher}\end{publisher} \format{\year}

--- a/src/main/resources/resource/layout/title-markdown/title-md.inproceedings.layout
+++ b/src/main/resources/resource/layout/title-markdown/title-md.inproceedings.layout
@@ -1,0 +1,1 @@
+* \format[RemoveLatexCommands,HTMLChars]{\title}. \begin{publisher}\format[RemoveLatexCommands,HTMLChars]{\publisher} \end{publisher}\begin{series}\format[RemoveLatexCommands,HTMLChars]{\series}\end{series}\begin{!series}\format[RemoveLatexCommands,HTMLChars]{\booktitle} \format{\year}\end{!series}

--- a/src/main/resources/resource/layout/title-markdown/title-md.layout
+++ b/src/main/resources/resource/layout/title-markdown/title-md.layout
@@ -1,0 +1,1 @@
+* \format[RemoveLatexCommands,HTMLChars]{\title}.\begin{year} \year\end{year}

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -12,6 +12,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.SaveOrder;
+import org.jabref.model.metadata.SelfContainedSaveOrder;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ class MarkdownTitleExporterTest {
 
     private static Exporter htmlWebsiteExporter;
     private static BibDatabaseContext databaseContext;
+    private static final SelfContainedSaveOrder saveMostRecentFirstSaveOrder = new SelfContainedSaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(new SaveOrder.SortCriterion(StandardField.YEAR, true)));
 
     @BeforeAll
     static void setUp() {
@@ -35,7 +37,7 @@ class MarkdownTitleExporterTest {
                 "title-markdown",
                 StandardFileType.MARKDOWN,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                SaveOrder.getDefaultSaveOrder(),
+                saveMostRecentFirstSaveOrder,
                 BlankLineBehaviour.DELETE_BLANKS);
 
         databaseContext = new BibDatabaseContext();

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -44,15 +44,15 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportForNoEntriesWritesNothing(@TempDir Path tempFile) throws Exception {
-        Path file = tempFile.resolve("ThisIsARandomlyNamedFile");
+    final void exportForNoEntriesWritesNothing(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("ThisIsARandomlyNamedFile");
         Files.createFile(file);
-        htmlWebsiteExporter.export(databaseContext, tempFile, Collections.emptyList());
+        htmlWebsiteExporter.export(databaseContext, tempDir, Collections.emptyList());
         assertEquals(Collections.emptyList(), Files.readAllLines(file));
     }
 
     @Test
-    final void exportsCorrectContentArticle(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentArticle(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -61,7 +61,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.PUBLISHER, "THE PRESS")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -72,7 +72,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentInCollection(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentInCollection(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.InCollection)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -81,7 +81,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.PUBLISHER, "PRESS")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -92,7 +92,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentBook(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentBook(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.Book)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -101,7 +101,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.PUBLISHER, "PRESS")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -112,7 +112,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentInProceeedingsPublisher(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentInProceeedingsPublisher(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -122,7 +122,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.SERIES, "CONF'20")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -133,7 +133,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentInProceeedingsNoPublisher(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentInProceeedingsNoPublisher(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -142,7 +142,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.SERIES, "CONF'20")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -153,7 +153,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentInProceeedingsNoSeries(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentInProceeedingsNoSeries(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -161,7 +161,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.BOOKTITLE, "Test Conference")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 
@@ -172,7 +172,7 @@ class MarkdownTitleExporterTest {
     }
 
     @Test
-    final void exportsCorrectContentBracketsInTitle(@TempDir Path tempFile) throws Exception {
+    final void exportsCorrectContentBracketsInTitle(@TempDir Path tempDir) throws Exception {
         BibEntry entry = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("test")
                 .withField(StandardField.AUTHOR, "Test Author")
@@ -180,7 +180,7 @@ class MarkdownTitleExporterTest {
                 .withField(StandardField.JOURNAL, "Journal of this \\& that")
                 .withField(StandardField.YEAR, "2020");
 
-        Path file = tempFile.resolve("RandomFileName");
+        Path file = tempDir.resolve("RandomFileName");
         Files.createFile(file);
         htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
 

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -26,7 +26,7 @@ class MarkdownTitleExporterTest {
 
     private static Exporter htmlWebsiteExporter;
     private static BibDatabaseContext databaseContext;
-    private static final SelfContainedSaveOrder saveMostRecentFirstSaveOrder = new SelfContainedSaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(new SaveOrder.SortCriterion(StandardField.YEAR, true)));
+    private static final SelfContainedSaveOrder SAVE_MOST_RECENT_FIRST_SAVE_ORDER = new SelfContainedSaveOrder(SaveOrder.OrderType.SPECIFIED, List.of(new SaveOrder.SortCriterion(StandardField.YEAR, true)));
 
     @BeforeAll
     static void setUp() {
@@ -37,7 +37,7 @@ class MarkdownTitleExporterTest {
                 "title-markdown",
                 StandardFileType.MARKDOWN,
                 mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
-                saveMostRecentFirstSaveOrder,
+                SAVE_MOST_RECENT_FIRST_SAVE_ORDER,
                 BlankLineBehaviour.DELETE_BLANKS);
 
         databaseContext = new BibDatabaseContext();

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -1,5 +1,10 @@
 package org.jabref.logic.exporter;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseContext;
@@ -12,11 +17,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -7,6 +7,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.metadata.SaveOrder;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -67,7 +68,6 @@ class MarkdownTitleExporterTest {
 
         assertEquals(expected, Files.readAllLines(file));
     }
-
 
     @Test
     final void exportsCorrectContentInCollection(@TempDir Path tempFile) throws Exception {

--- a/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/MarkdownTitleExporterTest.java
@@ -1,0 +1,190 @@
+package org.jabref.logic.exporter;
+
+import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.metadata.SaveOrder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class MarkdownTitleExporterTest {
+
+    private static Exporter htmlWebsiteExporter;
+    private static BibDatabaseContext databaseContext;
+
+    @BeforeAll
+    static void setUp() {
+        htmlWebsiteExporter = new TemplateExporter(
+                "Title-Markdown",
+                "title-md",
+                "title-md",
+                "title-markdown",
+                StandardFileType.MARKDOWN,
+                mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS),
+                SaveOrder.getDefaultSaveOrder(),
+                BlankLineBehaviour.DELETE_BLANKS);
+
+        databaseContext = new BibDatabaseContext();
+    }
+
+    @Test
+    final void exportForNoEntriesWritesNothing(@TempDir Path tempFile) throws Exception {
+        Path file = tempFile.resolve("ThisIsARandomlyNamedFile");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, tempFile, Collections.emptyList());
+        assertEquals(Collections.emptyList(), Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentArticle(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.JOURNAL, "Journal of this \\& that")
+                .withField(StandardField.PUBLISHER, "THE PRESS")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. Journal of this &amp; that 2020");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+
+    @Test
+    final void exportsCorrectContentInCollection(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.InCollection)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.BOOKTITLE, "Test book")
+                .withField(StandardField.PUBLISHER, "PRESS")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. Test book, PRESS 2020");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentBook(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Book)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.BOOKTITLE, "Test book")
+                .withField(StandardField.PUBLISHER, "PRESS")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. PRESS 2020");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentInProceeedingsPublisher(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.BOOKTITLE, "Test Conference")
+                .withField(StandardField.PUBLISHER, "ACM")
+                .withField(StandardField.SERIES, "CONF'20")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. ACM CONF'20");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentInProceeedingsNoPublisher(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.BOOKTITLE, "Test Conference")
+                .withField(StandardField.SERIES, "CONF'20")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. CONF'20");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentInProceeedingsNoSeries(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.InProceedings)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "Test Title")
+                .withField(StandardField.BOOKTITLE, "Test Conference")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* Test Title. Test Conference 2020");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+
+    @Test
+    final void exportsCorrectContentBracketsInTitle(@TempDir Path tempFile) throws Exception {
+        BibEntry entry = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.TITLE, "This is {JabRef}")
+                .withField(StandardField.JOURNAL, "Journal of this \\& that")
+                .withField(StandardField.YEAR, "2020");
+
+        Path file = tempFile.resolve("RandomFileName");
+        Files.createFile(file);
+        htmlWebsiteExporter.export(databaseContext, file, Collections.singletonList(entry));
+
+        List<String> expected = List.of(
+                "* This is JabRef. Journal of this &amp; that 2020");
+
+        assertEquals(expected, Files.readAllLines(file));
+    }
+}


### PR DESCRIPTION
I quickly implemented an export format in a specific (admittedly, opinionated) format to Markdown... I find the format useful to put on websites that uses Markdown as input format [website](https://linusdietz.com/publications).


For anybody who's interested, the command I use to generate the list of the website is: 
```
jabref -n -i literature.bib --exportMatches '(author="dietz"  and (entrytype=="article" or entrytype="inProceedings" or entrytype="inCollection"))',test.md,title-md
```
### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- / Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
