### PR TITLE
[OO] Major performance improvements & fixes

### DIFF
--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -69,7 +69,6 @@ public class CSLCitationOOAdapter {
 
         OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
         insertReferences(cursor, entries, ooText, selectedStyle.isNumericStyle());
-        cursor.collapseToEnd();
     }
 
     /**
@@ -119,7 +118,6 @@ public class CSLCitationOOAdapter {
             }
             OOText ooText = OOFormat.setLocaleNone(OOText.fromString(finalText));
             insertReferences(cursor, List.of(currentEntry), ooText, selectedStyle.isNumericStyle());
-            cursor.collapseToEnd();
         }
     }
 
@@ -131,9 +129,6 @@ public class CSLCitationOOAdapter {
             throws CreationException, Exception {
         OOText emptyOOText = OOFormat.setLocaleNone(OOText.fromString(""));
         insertReferences(cursor, entries, emptyOOText, selectedStyle.isNumericStyle());
-
-        // Move the cursor to the end of the inserted text - although no need as we don't insert any text, but a good practice
-        cursor.collapseToEnd();
     }
 
     /**
@@ -165,11 +160,6 @@ public class CSLCitationOOAdapter {
                 OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
 
                 OOTextIntoOO.write(document, cursor, ooText);
-                    // Select the paragraph break
-                    cursor.goLeft((short) 1, true);
-
-                    // Delete the selected content (paragraph break)
-                    cursor.setString("");
             }
         } else {
             // Ordering will be according to citeproc item data provider (default)
@@ -180,7 +170,6 @@ public class CSLCitationOOAdapter {
                 OOText ooText = OOFormat.setLocaleNone(OOText.fromString(formattedCitation));
                 OOTextIntoOO.write(document, cursor, ooText);
             }
-            cursor.collapseToEnd();
         }
     }
 
@@ -208,12 +197,8 @@ public class CSLCitationOOAdapter {
         CSLReferenceMark mark = markManager.createReferenceMark(entries);
         mark.insertReferenceIntoOO(document, cursor, ooText, !preceedingSpaceExists, false);
 
-        // Move the cursor to the end of the inserted text
-        cursor.collapseToEnd();
-
         markManager.setUpdateRequired(isNumericStyle);
         readAndUpdateExistingMarks();
-        cursor.collapseToEnd();
     }
 
     /**

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -75,7 +75,7 @@ public class CSLFormatUtils {
         // Convert line breaks to paragraph breaks
         html = html.replaceAll("[\n\r]+", "<p></p>");
 
-        // Remove leading paragraph tags (including any whitespace after them)
+        // Remove leading paragraph tags (preserving any whitespaces after them for indentation)
         html = html.replaceAll("^\\s*<p>\\s*</p>", "");
 
         // Remove extra trailing paragraph tags when there are multiple (keeping one)

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -72,6 +72,18 @@ public class CSLFormatUtils {
         // Clean up any remaining span tags
         html = html.replaceAll("</?span[^>]*>", "");
 
+        // Convert line breaks to paragraph breaks
+        html = html.replaceAll("[\n\r]+", "<p></p>");
+
+        // First ensure only single paragraph tags
+        html = html.replaceAll("(<p>\\s*</p>)+", "<p></p>");
+
+        // Remove leading paragraph tags (including any whitespace after them)
+        html = html.replaceAll("^\\s*<p>\\s*</p>", "");
+
+        // Remove extra paragraph tag when there are two at the end (keeping one)
+        html = html.replaceAll("<p>\\s*</p>\\s*<p>\\s*</p>$", "<p></p>");
+
         return html;
     }
 
@@ -113,9 +125,9 @@ public class CSLFormatUtils {
 
     /**
      * Method to update citation number of a bibliographic entry (to be inserted in the list of references).
-     * By default, citeproc-java ({@link org.jabref.logic.citationstyle.CitationStyleGenerator#generateBibliography(List, String, CitationStyleOutputFormat, BibDatabaseContext, BibEntryTypesManager) generateBibliography} always start the numbering of a list of citations with "1".
-     * If a citation doesn't correspond to the first cited entry, the number should be changed to the relevant current citation number.
-     * If an entries has been cited before, the colder number should be reused.
+     * By default, citeproc-java ({@link org.jabref.logic.citationstyle.CitationStyleGenerator#generateBibliography(List, String, CitationStyleOutputFormat, BibDatabaseContext, BibEntryTypesManager) generateBibliography} always starts the numbering of a list of citations with "1".
+     * If a citation doesn't correspond to the first cited entry, the number should be changed to the appropriate current citation number.
+     * The numbers should be globally unique. If an entry has been cited before, the older citation number corresponding to it should be reused.
      * The number can be enclosed in different formats, such as "1", "1.", "1)", "(1)" or "[1]".
      * <p>
      * <b>Precondition:</b> Use ONLY with numeric citation styles.</p>

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -75,14 +75,11 @@ public class CSLFormatUtils {
         // Convert line breaks to paragraph breaks
         html = html.replaceAll("[\n\r]+", "<p></p>");
 
-        // First ensure only single paragraph tags
-        html = html.replaceAll("(<p>\\s*</p>)+", "<p></p>");
-
         // Remove leading paragraph tags (including any whitespace after them)
         html = html.replaceAll("^\\s*<p>\\s*</p>", "");
 
-        // Remove extra paragraph tag when there are two at the end (keeping one)
-        html = html.replaceAll("<p>\\s*</p>\\s*<p>\\s*</p>$", "<p></p>");
+        // Remove extra trailing paragraph tags when there are multiple (keeping one)
+        html = html.replaceAll("(?:<p>\\s*</p>\\s*){2,}$", "<p></p>");
 
         return html;
     }

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLUpdateBibliography.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLUpdateBibliography.java
@@ -101,9 +101,7 @@ public class CSLUpdateBibliography {
 
         // Use CSLCitationOOAdapter to insert the bibliography
         cslAdapter.insertBibliography(cursor, citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
-        LOGGER.debug("Bibliography inserted using CSLCitationOOAdapter");
 
-        cursor.collapseToEnd();
         LOGGER.debug("CSL bibliography section population completed");
     }
 }

--- a/src/test/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtilsTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtilsTest.java
@@ -535,7 +535,7 @@ class CSLFormatUtilsTest {
                         STYLE_LIST.stream().filter(e -> "The Journal of Veterinary Medical Science".equals(e.getTitle())).findAny().get()
                 ),
 
-                // Type:"<BOLD>1."
+                // Type: "<BOLD>1."
                 Arguments.of(
                         "  \n" +
                                 "    <b>3</b>. <b>Smith  B, Jones  B, Williams  J</b>. Title of the test entry. <i>BibTeX Journal</i> 2016 ; 34 : 45–67.\n" +

--- a/src/test/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtilsTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtilsTest.java
@@ -159,114 +159,94 @@ class CSLFormatUtilsTest {
 
                 // Non-numeric, parentheses, commas, full stops, slashes, hyphens, colons, italics
                 Arguments.of(
-                        "  Smith, B., Jones, B., & Williams, J. (2016). Title of the test entry. <i>BibTeX Journal</i>, <i>34</i>(3), 45–67. https://doi.org/10.1001/bla.blubb\n",
+                        "  Smith, B., Jones, B., & Williams, J. (2016). Title of the test entry. <i>BibTeX Journal</i>, <i>34</i>(3), 45–67. https://doi.org/10.1001/bla.blubb<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Psychological Association 7th edition".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric type "[1]", brackets, newlines
                 Arguments.of(
-                        "  \n" +
-                                "    [1] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” <i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016, doi: 10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    [1] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” <i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016, doi: 10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "IEEE".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric type "1."
                 Arguments.of(
-                        "  \n" +
-                                "    1. Smith, B., Jones, B., Williams, J.: Title of the test entry. BibTeX Journal. 34, 45–67 (2016). https://doi.org/10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    1. Smith, B., Jones, B., Williams, J.: Title of the test entry. BibTeX Journal. 34, 45–67 (2016). https://doi.org/10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Springer - Lecture Notes in Computer Science".equals(e.getTitle())).findAny().get()
                 ),
 
                 Arguments.of(
-                        "  Smith, Bill, Bob Jones, and Jeff Williams. 2016. “Title of the Test Entry.” Edited by Phil Taylor. <i>BibTeX Journal</i> 34 (3): 45–67. https://doi.org/10.1001/bla.blubb.\n",
+                        "  Smith, Bill, Bob Jones, and Jeff Williams. 2016. “Title of the Test Entry.” Edited by Phil Taylor. <i>BibTeX Journal</i> 34 (3): 45–67. https://doi.org/10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Chicago Manual of Style 17th edition (author-date)".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Semicolons
                 Arguments.of(
-                        "  \n" +
-                                "    1. Smith B, Jones B, Williams J. Title of the test entry. Taylor P, editor. BibTeX Journal [Internet]. 2016 Jul;34(3):45–67. Available from: https://github.com/JabRef\n" +
-                                "  \n",
+                        "    1. Smith B, Jones B, Williams J. Title of the test entry. Taylor P, editor. BibTeX Journal [Internet]. 2016 Jul;34(3):45–67. Available from: https://github.com/JabRef<p></p>",
                         STYLE_LIST.stream().filter(e -> "Vancouver".equals(e.getTitle())).findAny().get()
                 ),
 
                 Arguments.of(
-                        "  \n" +
-                                "    1. Smith, B., Jones, B. & Williams, J. Title of the test entry. <i>BibTeX Journal</i> <b>34</b>, 45–67 (2016).\n" +
-                                "  \n",
+                        "    1. Smith, B., Jones, B. & Williams, J. Title of the test entry. <i>BibTeX Journal</i> <b>34</b>, 45–67 (2016).<p></p>",
                         STYLE_LIST.stream().filter(e -> "Nature".equals(e.getTitle())).findAny().get()
                 ),
 
                 Arguments.of(
-                        "  \n" +
-                                "    1. Smith B, Jones B, Williams J. Title of the test entry. Taylor P, ed. <i>BibTeX Journal</i>. 2016;34(3):45-67. doi:10.1001/bla.blubb\n" +
-                                "  \n",
+                        "    1. Smith B, Jones B, Williams J. Title of the test entry. Taylor P, ed. <i>BibTeX Journal</i>. 2016;34(3):45-67. doi:10.1001/bla.blubb<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Medical Association 11th edition".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Small-caps
                 Arguments.of(
-                        "  <smallcaps>Smith</smallcaps>, <smallcaps>B.</smallcaps>, <smallcaps>Jones</smallcaps>, <smallcaps>B.</smallcaps>, <smallcaps>Williams</smallcaps>, <smallcaps>J.</smallcaps> (2016) Title of the test entry <smallcaps>Taylor</smallcaps>, <smallcaps>P.</smallcaps> (ed.). <i>BibTeX Journal</i>, 34(3), pp. 45–67.\n",
+                        "  <smallcaps>Smith</smallcaps>, <smallcaps>B.</smallcaps>, <smallcaps>Jones</smallcaps>, <smallcaps>B.</smallcaps>, <smallcaps>Williams</smallcaps>, <smallcaps>J.</smallcaps> (2016) Title of the test entry <smallcaps>Taylor</smallcaps>, <smallcaps>P.</smallcaps> (ed.). <i>BibTeX Journal</i>, 34(3), pp. 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "De Montfort University - Harvard".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Underlines
                 Arguments.of(
-                        "  Smith, Bill, Bob Jones, and Jeff Williams. “Title of the test entry.” Ed. Phil Taylor. <u>BibTeX Journal</u> 34.3 (2016): 45–67. <https://github.com/JabRef>.\n",
+                        "  Smith, Bill, Bob Jones, and Jeff Williams. “Title of the test entry.” Ed. Phil Taylor. <u>BibTeX Journal</u> 34.3 (2016): 45–67. <https://github.com/JabRef>.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Modern Language Association 7th edition (underline)".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Non-breaking spaces
                 Arguments.of(
-                        "  Smith, Bill, Bob Jones, & Jeff Williams, “Title of the test entry,” <i>BibTeX Journal</i>, 2016, vol. 34, no. 3, pp. 45–67.\n",
+                        "  Smith, Bill, Bob Jones, & Jeff Williams, “Title of the test entry,” <i>BibTeX Journal</i>, 2016, vol. 34, no. 3, pp. 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Histoire & Mesure (Français)".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric with a full stop - "1."
                 Arguments.of(
-                        "  \n" +
-                                "    1. Smith, B., Jones, B. and Williams, J. 2016. Title of the test entry. <i>BibTeX Journal</i>. <b>34</b>: 45–67.\n" +
-                                "  \n",
+                        "    1. Smith, B., Jones, B. and Williams, J. 2016. Title of the test entry. <i>BibTeX Journal</i>. <b>34</b>: 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "The Journal of Veterinary Medical Science".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Bold text, bold numeric with a full stop - "<BOLD>1."
                 Arguments.of(
-                        "  \n" +
-                                "    <b>1</b>. <b>Smith  B, Jones  B, Williams  J</b>. Title of the test entry. <i>BibTeX Journal</i> 2016 ; 34 : 45–67.\n" +
-                                "  \n",
+                        "    <b>1</b>. <b>Smith  B, Jones  B, Williams  J</b>. Title of the test entry. <i>BibTeX Journal</i> 2016 ; 34 : 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Acta Orthopædica Belgica".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Naked numeric - "1"
                 Arguments.of(
-                        "  \n" +
-                                "    1 Smith Bill, Jones Bob, Williams Jeff. Title of the test entry. <i>BibTeX Journal</i> 2016;<b>34</b>(3):45–67. Doi: 10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    1 Smith Bill, Jones Bob, Williams Jeff. Title of the test entry. <i>BibTeX Journal</i> 2016;<b>34</b>(3):45–67. Doi: 10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Acta Anaesthesiologica Taiwanica".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric in parentheses - "(1)"
                 Arguments.of(
-                        "  \n" +
-                                "    (1) Smith, B.; Jones, B.; Williams, J. Title of the Test Entry. <i>BibTeX Journal</i> <b>2016</b>, <i>34</i> (3), 45–67. https://doi.org/10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    (1) Smith, B.; Jones, B.; Williams, J. Title of the Test Entry. <i>BibTeX Journal</i> <b>2016</b>, <i>34</i> (3), 45–67. https://doi.org/10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Chemical Society".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric with right parenthesis - "1)"
                 Arguments.of(
-                        "  \n" +
-                                "    1) Smith B., Jones B., Williams J., <i>BibTeX Journal</i>, <b>34</b>, 45–67 (2016).\n" +
-                                "  \n",
+                        "    1) Smith B., Jones B., Williams J., <i>BibTeX Journal</i>, <b>34</b>, 45–67 (2016).<p></p>",
                         STYLE_LIST.stream().filter(e -> "Chemical and Pharmaceutical Bulletin".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Numeric in superscript - "<SUPERSCRIPT>1"
                 Arguments.of(
-                        "  <sup>1</sup> B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal <b>34</b>(3), 45–67 (2016).\n",
+                        "  <sup>1</sup> B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal <b>34</b>(3), 45–67 (2016).<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Institute of Physics 4th edition".equals(e.getTitle())).findAny().get()
                 )
         );
@@ -521,55 +501,43 @@ class CSLFormatUtilsTest {
 
                 // Type: "[1]"
                 Arguments.of(
-                        "  \n" +
-                                "    [3] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” <i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016, doi: 10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    [3] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” <i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016, doi: 10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "IEEE".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "1."
                 Arguments.of(
-                        "  \n" +
-                                "    3. Smith, B., Jones, B. and Williams, J. 2016. Title of the test entry. <i>BibTeX Journal</i>. <b>34</b>: 45–67.\n" +
-                                "  \n",
+                        "    3. Smith, B., Jones, B. and Williams, J. 2016. Title of the test entry. <i>BibTeX Journal</i>. <b>34</b>: 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "The Journal of Veterinary Medical Science".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "<BOLD>1."
                 Arguments.of(
-                        "  \n" +
-                                "    <b>3</b>. <b>Smith  B, Jones  B, Williams  J</b>. Title of the test entry. <i>BibTeX Journal</i> 2016 ; 34 : 45–67.\n" +
-                                "  \n",
+                        "    <b>3</b>. <b>Smith  B, Jones  B, Williams  J</b>. Title of the test entry. <i>BibTeX Journal</i> 2016 ; 34 : 45–67.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Acta Orthopædica Belgica".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "1"
                 Arguments.of(
-                        "  \n" +
-                                "    3 Smith Bill, Jones Bob, Williams Jeff. Title of the test entry. <i>BibTeX Journal</i> 2016;<b>34</b>(3):45–67. Doi: 10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    3 Smith Bill, Jones Bob, Williams Jeff. Title of the test entry. <i>BibTeX Journal</i> 2016;<b>34</b>(3):45–67. Doi: 10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "Acta Anaesthesiologica Taiwanica".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "(1)"
                 Arguments.of(
-                        "  \n" +
-                                "    (3) Smith, B.; Jones, B.; Williams, J. Title of the Test Entry. <i>BibTeX Journal</i> <b>2016</b>, <i>34</i> (3), 45–67. https://doi.org/10.1001/bla.blubb.\n" +
-                                "  \n",
+                        "    (3) Smith, B.; Jones, B.; Williams, J. Title of the Test Entry. <i>BibTeX Journal</i> <b>2016</b>, <i>34</i> (3), 45–67. https://doi.org/10.1001/bla.blubb.<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Chemical Society".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "1)"
                 Arguments.of(
-                        "  \n" +
-                                "    3) Smith B., Jones B., Williams J., <i>BibTeX Journal</i>, <b>34</b>, 45–67 (2016).\n" +
-                                "  \n",
+                        "    3) Smith B., Jones B., Williams J., <i>BibTeX Journal</i>, <b>34</b>, 45–67 (2016).<p></p>",
                         STYLE_LIST.stream().filter(e -> "Chemical and Pharmaceutical Bulletin".equals(e.getTitle())).findAny().get()
                 ),
 
                 // Type: "<SUPERSCRIPT>1"
                 Arguments.of(
-                        "  <sup>3</sup> B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal <b>34</b>(3), 45–67 (2016).\n",
+                        "  <sup>3</sup> B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal <b>34</b>(3), 45–67 (2016).<p></p>",
                         STYLE_LIST.stream().filter(e -> "American Institute of Physics 4th edition".equals(e.getTitle())).findAny().get()
                 )
         );


### PR DESCRIPTION
# CSL4LibreOffice - Performance improvements and fixes

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/697
- Reduces the number of UNO API calls - 
a) The `OOTextIntoOO#write()` method by default shifts the cursor to the end of the text after operations are done, so calling `cursor.collapseToEnd()` everywhere is needless.  
b) Explicit deletion of extra newlines/paragraph breaks using `cursor.setString()` is no longer needed in case of numeric styles as RegEx in `transformHTML` is now adapted to handle it, which is way faster.
- Changes newlines in bibliography to paragraph breaks, improving performance of documents with a large number of bibliographic entries drastically, as per information from https://bugs.documentfoundation.org/show_bug.cgi?id=163984
Old:
![image](https://github.com/user-attachments/assets/3777e339-97f2-40bd-b0ed-fffa6e8e6e27)
New: 
![image](https://github.com/user-attachments/assets/6c2bd601-43ba-4fb2-a1d7-dddf4e03a75a)

- Fixes extra newlines before each numeric bibliographic entry, which also used to cause one to be placed after the title (see comparison above)
- Some miscellaneous documentation enhancements

Credits to @ThiloteE for investigating and the @LibreOffice community for prompt support!


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] ~Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)~ [Changes in unreleased]
- [ ] ~Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
