### PR TITLE
Add config for moderne

### DIFF
--- a/.moderne/moderne.yml
+++ b/.moderne/moderne.yml
@@ -1,0 +1,3 @@
+specs: specs.moderne.ai/v1/cli
+java:
+  selectedJdk: '23'

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ java {
     toolchain {
         // If this is updated, also update
         // - build.gradle -> jacoco -> toolVersion (because JaCoCo does not support newest JDK out of the box. Check versions at https://www.jacoco.org/jacoco/trunk/doc/changes.html)
-        // - .gitpod.Dockerfile
         // - .devcontainer/devcontainer.json#L34 and
+        // - .gitpod.Dockerfile
         // - .moderne/moderne.yml
         // - .github/workflows/deployment*.yml
         // - .github/workflows/tests*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -54,13 +54,14 @@ java {
 
     toolchain {
         // If this is updated, also update
+        // - build.gradle -> jacoco -> toolVersion (because JaCoCo does not support newest JDK out of the box. Check versions at https://www.jacoco.org/jacoco/trunk/doc/changes.html)
         // - .gitpod.Dockerfile
         // - .devcontainer/devcontainer.json#L34 and
+        // - .moderne/moderne.yml
         // - .github/workflows/deployment*.yml
         // - .github/workflows/tests*.yml
         // - .github/workflows/update-gradle-wrapper.yml
         // - docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
-        // - build.gradle -> jacoco -> toolVersion (because JaCoCo does not support newest JDK out of the box. Check versions at https://www.jacoco.org/jacoco/trunk/doc/changes.html)
         languageVersion = JavaLanguageVersion.of(23)
         // See https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JvmVendorSpec.html for a full list
         // vendor = JvmVendorSpec.AMAZON


### PR DESCRIPTION
Moderne does not support auto detection of the JDK. Thus, we need an explicit config.

Source: https://rewriteoss.slack.com/archives/C01A843MWG5/p1732576166436149?thread_ts=1732565625.698539&cid=C01A843MWG5

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
