### PR TITLE
always set maximized  to false on exit for mac

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -30,6 +30,7 @@ import org.jabref.logic.UiCommand;
 import org.jabref.logic.ai.AiService;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.ProxyRegisterer;
+import org.jabref.logic.os.OS;
 import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.remote.server.RemoteListenerServerManager;
 import org.jabref.logic.search.PostgreServer;
@@ -287,13 +288,19 @@ public class JabRefGUI extends Application {
 
     private void saveWindowState() {
         CoreGuiPreferences preferences = JabRefGUI.preferences.getGuiPreferences();
-        if (!mainStage.isMaximized()) {
+        // workaround for mac, maximize will always report true
+        if (!mainStage.isMaximized() || OS.OS_X) {
             preferences.setPositionX(mainStage.getX());
             preferences.setPositionY(mainStage.getY());
             preferences.setSizeX(mainStage.getWidth());
             preferences.setSizeY(mainStage.getHeight());
         }
-        preferences.setWindowMaximised(mainStage.isMaximized());
+        // maximize does not correctly work on OSX, reports true, although the window was resized!
+        if (OS.OS_X) {
+            preferences.setWindowMaximised(false);
+        } else {
+            preferences.setWindowMaximised(mainStage.isMaximized());
+        }
         debugLogWindowState(mainStage);
     }
 


### PR DESCRIPTION
I reset my prefs, jabref was opening in maximized mode, I resized Jabref but the stage still reported maximized

Refs https://github.com/JabRef/jabref/issues/11530

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
