### PR TITLE
Use Markdown in AI Summary tab implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - By double clicking on a local citation in the Citation Relations Tab you can now jump the linked entry. [#11955](https://github.com/JabRef/jabref/pull/11955)
 - We use the menu icon for background tasks as a progress indicator to visualise an import's progress when dragging and dropping several PDF files into the main table. [#12072](https://github.com/JabRef/jabref/pull/12072)
 - The PDF content importer now supports importing title from upto the second page of the PDF. [#12139](https://github.com/JabRef/jabref/issues/12139)
+- We added support of `Markdown` in `AI Summary` tab by using the `CheckBox` next to `Regenerate` button. [#12266](https://github.com/JabRef/jabref/pull/12266)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - By double clicking on a local citation in the Citation Relations Tab you can now jump the linked entry. [#11955](https://github.com/JabRef/jabref/pull/11955)
 - We use the menu icon for background tasks as a progress indicator to visualise an import's progress when dragging and dropping several PDF files into the main table. [#12072](https://github.com/JabRef/jabref/pull/12072)
 - The PDF content importer now supports importing title from upto the second page of the PDF. [#12139](https://github.com/JabRef/jabref/issues/12139)
-- We added support of `Markdown` in `AI Summary` tab by using the `CheckBox` next to `Regenerate` button. [#12266](https://github.com/JabRef/jabref/pull/12266)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.TextFlow?>
+<?import javafx.scene.text.Text?>
 
-<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
+<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
    <children>
-       <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
+       <StackPane fx:id="contentStackPane" VBox.vgrow="ALWAYS" >
+        <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
+       </StackPane>
       <AnchorPane prefHeight="1.0" prefWidth="512.0">
          <children>
              <CheckBox fx:id="markdownCheckbox" layoutX="13.0" mnemonicParsing="false" onAction="#onMarkdownToggle" prefHeight="6.0" prefWidth="81.0" text="Markdown" />

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -18,11 +18,7 @@
                 <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" translateX="-40" />
             </center>
         </BorderPane>
-        <TextFlow textAlignment="CENTER">
-            <children>
-                <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />
-            </children>
-        </TextFlow>
+        <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />
     </children>
     <padding>
         <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
-<?import javafx.scene.web.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.text.TextFlow?>
 
-<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
+<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
    <children>
        <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
-       <WebView fx:id="markdownWebView" visible="false" managed="false" VBox.vgrow="ALWAYS" />
        <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
        <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" />
       <TextFlow textAlignment="CENTER">

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.TextArea?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.text.TextFlow?>
-<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+<?import javafx.scene.web.*?>
+
+<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
    <children>
-      <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
-      <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" />
+       <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
+       <WebView fx:id="markdownWebView" visible="false" managed="false" VBox.vgrow="ALWAYS" />
+       <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
+       <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" />
       <TextFlow textAlignment="CENTER">
          <children>
             <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -1,37 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.text.TextFlow?>
 <?import javafx.scene.text.Text?>
 
-<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
-   <children>
-       <StackPane fx:id="contentStackPane" VBox.vgrow="ALWAYS" >
-                <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
-       </StackPane>
-       <BorderPane prefHeight="30.0" prefWidth="512.0">
-           <left>
-               <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
-           </left>
-           <center>
-               <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" translateX="-40" />
-           </center>
-           <right>
-           </right>
-       </BorderPane>
-      <TextFlow textAlignment="CENTER">
-         <children>
-            <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />
-         </children>
-      </TextFlow>
-   </children>
-   <padding>
-      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-   </padding>
+<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="400.0" minWidth="-Infinity" spacing="8.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
+    <children>
+        <BorderPane minHeight="30.0">
+            <left>
+                <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
+            </left>
+            <center>
+                <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" translateX="-40" />
+            </center>
+        </BorderPane>
+        <TextFlow textAlignment="CENTER">
+            <children>
+                <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />
+            </children>
+        </TextFlow>
+    </children>
+    <padding>
+        <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
+    </padding>
 </fx:root>

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -6,21 +6,25 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.text.TextFlow?>
 <?import javafx.scene.text.Text?>
 
 <fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
    <children>
        <StackPane fx:id="contentStackPane" VBox.vgrow="ALWAYS" >
-        <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
+                <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
        </StackPane>
-      <AnchorPane prefHeight="1.0" prefWidth="512.0">
-         <children>
-             <CheckBox fx:id="markdownCheckbox" layoutX="13.0" mnemonicParsing="false" onAction="#onMarkdownToggle" prefHeight="6.0" prefWidth="81.0" text="Markdown" />
-         </children>
-      </AnchorPane>
-       <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" prefHeight="12.0" prefWidth="91.0" text="%Regenerate" />
+       <BorderPane prefHeight="30.0" prefWidth="512.0">
+           <left>
+               <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
+           </left>
+           <center>
+               <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" translateX="-40" />
+           </center>
+           <right>
+           </right>
+       </BorderPane>
       <TextFlow textAlignment="CENTER">
          <children>
             <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.TextArea?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.text.TextFlow?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
-<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
+<fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" spacing="10.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
    <children>
-       <CheckBox fx:id="markdownCheckbox" mnemonicParsing="false" onAction="#onMarkdownToggle" text="Markdown" />
        <TextArea fx:id="summaryTextArea" editable="false" wrapText="true" VBox.vgrow="ALWAYS" />
-       <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" />
+      <AnchorPane prefHeight="1.0" prefWidth="512.0">
+         <children>
+             <CheckBox fx:id="markdownCheckbox" layoutX="13.0" mnemonicParsing="false" onAction="#onMarkdownToggle" prefHeight="6.0" prefWidth="81.0" text="Markdown" />
+         </children>
+      </AnchorPane>
+       <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" prefHeight="12.0" prefWidth="91.0" text="%Regenerate" />
       <TextFlow textAlignment="CENTER">
          <children>
             <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -12,15 +12,19 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.web.WebView;
 
+import org.jabref.gui.theme.ThemeManager;
 import org.jabref.logic.ai.summarization.Summary;
 import org.jabref.logic.layout.format.MarkdownFormatter;
 import org.jabref.logic.util.WebViewStore;
 
 import com.airhacks.afterburner.views.ViewLoader;
+import jakarta.inject.Inject;
 
 public class SummaryShowingComponent extends VBox {
     @FXML private Text summaryInfoText;
     @FXML private CheckBox markdownCheckbox;
+
+    @Inject private ThemeManager themeManager;
 
     private WebView contentWebView;
     private final Summary summary;
@@ -45,12 +49,10 @@ public class SummaryShowingComponent extends VBox {
 
     private void initializeWebView() {
         contentWebView = WebViewStore.get();
-        contentWebView.setMinHeight(100);
-        contentWebView.setPrefHeight(300);
-
-        // Apply styles directly to the WebView
-
         VBox.setVgrow(contentWebView, Priority.ALWAYS);
+
+        themeManager.installCss(contentWebView.getEngine());
+
         getChildren().addFirst(contentWebView);
     }
 

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -6,24 +6,31 @@ import java.time.format.FormatStyle;
 import java.util.Locale;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
+import javafx.scene.web.WebView;
 
 import org.jabref.logic.ai.summarization.Summary;
+import org.jabref.logic.layout.format.MarkdownFormatter;
 
 import com.airhacks.afterburner.views.ViewLoader;
 
 public class SummaryShowingComponent extends VBox {
     @FXML private TextArea summaryTextArea;
     @FXML private Text summaryInfoText;
+    @FXML private WebView markdownWebView;
+    @FXML private CheckBox markdownCheckbox;
 
     private final Summary summary;
     private final Runnable regenerateCallback;
+    private final MarkdownFormatter markdownFormatter;
 
     public SummaryShowingComponent(Summary summary, Runnable regenerateCallback) {
         this.summary = summary;
         this.regenerateCallback = regenerateCallback;
+        this.markdownFormatter = new MarkdownFormatter();
 
         ViewLoader.view(this)
                   .root(this)
@@ -33,6 +40,8 @@ public class SummaryShowingComponent extends VBox {
     @FXML
     private void initialize() {
         summaryTextArea.setText(summary.content());
+        markdownWebView.setVisible(false);
+        markdownWebView.setManaged(false);
 
         String newInfo = summaryInfoText
                 .getText()
@@ -44,6 +53,29 @@ public class SummaryShowingComponent extends VBox {
 
     private static String formatTimestamp(LocalDateTime timestamp) {
         return timestamp.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withLocale(Locale.getDefault()));
+    }
+
+    @FXML
+    private void onMarkdownToggle() {
+        if (markdownCheckbox.isSelected()) {
+            String htmlContent = markdownFormatter.format(summaryTextArea.getText());
+            markdownWebView.getEngine().loadContent(htmlContent);
+
+            markdownWebView.setPrefHeight(summaryTextArea.getPrefHeight());
+            markdownWebView.setPrefWidth(summaryTextArea.getPrefWidth());
+
+            markdownWebView.setVisible(true);
+            markdownWebView.setManaged(true);
+
+            summaryTextArea.setVisible(false);
+            summaryTextArea.setManaged(false);
+        } else {
+            summaryTextArea.setVisible(true);
+            summaryTextArea.setManaged(true);
+
+            markdownWebView.setVisible(false);
+            markdownWebView.setManaged(false);
+        }
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -49,7 +49,6 @@ public class SummaryShowingComponent extends VBox {
         contentWebView.setPrefHeight(300);
 
         // Apply styles directly to the WebView
-        contentWebView.setStyle("-fx-font-family: Sans;");
 
         VBox.setVgrow(contentWebView, Priority.ALWAYS);
         getChildren().addFirst(contentWebView);
@@ -60,7 +59,12 @@ public class SummaryShowingComponent extends VBox {
         if (isMarkdown) {
             contentWebView.getEngine().loadContent(markdownFormatter.format(content));
         } else {
-            contentWebView.getEngine().loadContent("<pre>" + content + "</pre>");
+            contentWebView.getEngine().loadContent(
+                    "<body style='margin: 0; padding: 0; width: 100vw'>" +
+                            "<div style='white-space: pre-wrap; word-wrap: break-word; width: 100vw'>" +
+                            content +
+                            "</div></body>"
+            );
         }
     }
 

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -21,6 +21,7 @@ import com.airhacks.afterburner.views.ViewLoader;
 import jakarta.inject.Inject;
 
 public class SummaryShowingComponent extends VBox {
+    private static final MarkdownFormatter MARKDOWN_FORMATTER = new MarkdownFormatter();
     @FXML private Text summaryInfoText;
     @FXML private CheckBox markdownCheckbox;
 
@@ -29,7 +30,6 @@ public class SummaryShowingComponent extends VBox {
     private WebView contentWebView;
     private final Summary summary;
     private final Runnable regenerateCallback;
-    private final MarkdownFormatter markdownFormatter = new MarkdownFormatter();
 
     public SummaryShowingComponent(Summary summary, Runnable regenerateCallback) {
         this.summary = summary;
@@ -59,10 +59,10 @@ public class SummaryShowingComponent extends VBox {
     private void updateContent(boolean isMarkdown) {
         String content = summary.content();
         if (isMarkdown) {
-            contentWebView.getEngine().loadContent(markdownFormatter.format(content));
+            contentWebView.getEngine().loadContent(MARKDOWN_FORMATTER.format(content));
         } else {
             contentWebView.getEngine().loadContent(
-                    "<body style='margin: 0; padding: 0; width: 100vw'>" +
+                    "<body style='margin: 0; padding: 5px; width: 100vw'>" +
                             "<div style='white-space: pre-wrap; word-wrap: break-word; width: 100vw'>" +
                             content +
                             "</div></body>"

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -7,26 +7,22 @@ import java.util.Locale;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.TextArea;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.web.WebView;
 
 import org.jabref.logic.ai.summarization.Summary;
 import org.jabref.logic.layout.format.MarkdownFormatter;
+import org.jabref.logic.util.WebViewStore;
 
 import com.airhacks.afterburner.views.ViewLoader;
 
 public class SummaryShowingComponent extends VBox {
-    @FXML private TextArea summaryTextArea;
     @FXML private Text summaryInfoText;
     @FXML private CheckBox markdownCheckbox;
-    @FXML private StackPane contentStackPane;
 
-    private WebView markdownWebView;
-
+    private WebView contentWebView;
     private final Summary summary;
     private final Runnable regenerateCallback;
     private final MarkdownFormatter markdownFormatter = new MarkdownFormatter();
@@ -42,17 +38,37 @@ public class SummaryShowingComponent extends VBox {
 
     @FXML
     private void initialize() {
-        if (!contentStackPane.getChildren().contains(summaryTextArea)) {
-            contentStackPane.getChildren().add(summaryTextArea);
+        initializeWebView();
+        updateContent(false); // Start in plain text mode
+        updateInfoText();
+    }
+
+    private void initializeWebView() {
+        contentWebView = WebViewStore.get();
+        contentWebView.setMinHeight(100);
+        contentWebView.setPrefHeight(300);
+
+        // Apply styles directly to the WebView
+        contentWebView.setStyle("-fx-font-family: Sans;");
+
+        VBox.setVgrow(contentWebView, Priority.ALWAYS);
+        getChildren().addFirst(contentWebView);
+    }
+
+    private void updateContent(boolean isMarkdown) {
+        String content = summary.content();
+        if (isMarkdown) {
+            contentWebView.getEngine().loadContent(markdownFormatter.format(content));
+        } else {
+            contentWebView.getEngine().loadContent("<pre>" + content + "</pre>");
         }
+    }
 
-        summaryTextArea.setText(summary.content());
-
+    private void updateInfoText() {
         String newInfo = summaryInfoText
                 .getText()
                 .replaceAll("%0", formatTimestamp(summary.timestamp()))
                 .replaceAll("%1", summary.aiProvider().getLabel() + " " + summary.model());
-
         summaryInfoText.setText(newInfo);
     }
 
@@ -60,40 +76,9 @@ public class SummaryShowingComponent extends VBox {
         return timestamp.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withLocale(Locale.getDefault()));
     }
 
-    private void initializeMarkdownWebView() {
-        if (markdownWebView == null) {
-            markdownWebView = new WebView();
-            VBox.setVgrow(markdownWebView, Priority.ALWAYS);
-
-            markdownWebView.prefWidthProperty().bind(summaryTextArea.widthProperty());
-            markdownWebView.prefHeightProperty().bind(summaryTextArea.heightProperty());
-
-            markdownWebView.setVisible(false);
-            markdownWebView.setManaged(false);
-            contentStackPane.getChildren().add(markdownWebView);
-        }
-    }
-
     @FXML
     private void onMarkdownToggle() {
-        initializeMarkdownWebView();
-
-        if (markdownCheckbox.isSelected()) {
-            String htmlContent = markdownFormatter.format(summaryTextArea.getText());
-            markdownWebView.getEngine().loadContent(htmlContent);
-
-            markdownWebView.setVisible(true);
-            markdownWebView.setManaged(true);
-
-            summaryTextArea.setVisible(false);
-            summaryTextArea.setManaged(false);
-        } else {
-            summaryTextArea.setVisible(true);
-            summaryTextArea.setManaged(true);
-
-            markdownWebView.setVisible(false);
-            markdownWebView.setManaged(false);
-        }
+        updateContent(markdownCheckbox.isSelected());
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -12,20 +12,16 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.web.WebView;
 
-import org.jabref.gui.theme.ThemeManager;
 import org.jabref.logic.ai.summarization.Summary;
 import org.jabref.logic.layout.format.MarkdownFormatter;
 import org.jabref.logic.util.WebViewStore;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import jakarta.inject.Inject;
 
 public class SummaryShowingComponent extends VBox {
     private static final MarkdownFormatter MARKDOWN_FORMATTER = new MarkdownFormatter();
     @FXML private Text summaryInfoText;
     @FXML private CheckBox markdownCheckbox;
-
-    @Inject private ThemeManager themeManager;
 
     private WebView contentWebView;
     private final Summary summary;
@@ -50,8 +46,6 @@ public class SummaryShowingComponent extends VBox {
     private void initializeWebView() {
         contentWebView = WebViewStore.get();
         VBox.setVgrow(contentWebView, Priority.ALWAYS);
-
-        themeManager.installCss(contentWebView.getEngine());
 
         getChildren().addFirst(contentWebView);
     }

--- a/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextArea;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.web.WebView;
@@ -20,8 +21,9 @@ import com.airhacks.afterburner.views.ViewLoader;
 public class SummaryShowingComponent extends VBox {
     @FXML private TextArea summaryTextArea;
     @FXML private Text summaryInfoText;
-    @FXML private WebView markdownWebView;
     @FXML private CheckBox markdownCheckbox;
+
+    private WebView markdownWebView;
 
     private final Summary summary;
     private final Runnable regenerateCallback;
@@ -39,9 +41,16 @@ public class SummaryShowingComponent extends VBox {
 
     @FXML
     private void initialize() {
-        summaryTextArea.setText(summary.content());
+        markdownWebView = new WebView();
         markdownWebView.setVisible(false);
         markdownWebView.setManaged(false);
+
+        VBox.setVgrow(markdownWebView, Priority.ALWAYS);
+
+        int indexOfTextArea = getChildren().indexOf(summaryTextArea);
+        getChildren().add(indexOfTextArea + 1, markdownWebView);
+
+        summaryTextArea.setText(summary.content());
 
         String newInfo = summaryInfoText
                 .getText()


### PR DESCRIPTION
Closes #12233 

## Description (UPDATED)

As it was pre-requested, I've implemented an option when user is able, using checkbox, to change the formation of the `AI Summary`. If user checks it, `WebView` with formatted into `html` markdown appears, otherwise text stays raw. It is pretty useful new feature that makes `AI Summary` user-friendly for those, who loves to see formatted text, instead of raw `markdown` that besides the text contains "weird", in user's opinion characters.   

## How Code Changed and Why? 

1. In the issue discussion, I asked questions, and maintainers came up with an idea that we need a simple toggle, so I decided to add into `org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml` a `CheckBox` that appears one the left below the `AI Summary`
2. This toggle handled in `org/jabref/gui/ai/components/summary/SummaryShowingComponent.java`file's method `onMarkdownToggle()`. Once user checks the `CheckBox` the `TextArea` disappears, and `WebView` come us.
3. `TextArea` was wrapped in `StackPane` to simplify managing and layering of that component.
4. `WebView` programmatically implemented (lazy initialization) to avoid `findMissingLocalizationKeys` and `findObsoleteLocalizationKeys` tests failure. 
5. To formate raw text into markdown I used `org/jabref/logic/layout/format/MarkdownFormatter.java` that has been already implemented. 

## How to Copy Formatted Content?

Press anywhere in `WebView` component press `ctrl + a`/`cmd + a` then `ctrl + c`/`cmd + c`, and paste it in the desired place ^_^

## Screenshots

- Markdown `CheckBox` checked: 
 
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/e5c677d1-44c1-41de-b4c3-e133eff32a11">

- Markdown `CheckBox` unchecked: 
 
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/0d1d5bc2-42ad-4a6a-bbae-dd3ae408f6f6">




### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
