### PR TITLE
Add ADR-0042 and fix ADR-0036

### DIFF
--- a/docs/decisions/0036-use-textarea-for-chat-content.md
+++ b/docs/decisions/0036-use-textarea-for-chat-content.md
@@ -3,7 +3,7 @@ nav_order: 0036
 parent: Decision Records
 ---
 
-# Use TextArea for Chat Message Content
+# Use `TextArea` for Chat Message Content
 
 ## Context and Problem Statement
 
@@ -41,7 +41,7 @@ which for now we value more than Markdown rendering.
 
 ### Use a third-party package
 
-There seems to be only one package for JavaFX that provides a ready-to-use UI node for Markdown rendering.
+There seems to be [only one package](https://github.com/JPro-one/markdown-javafx-renderer) for JavaFX that provides a ready-to-use UI node for Markdown rendering.
 
 * Good, because it is easy to implement
 * Good, because it renders Markdown
@@ -81,4 +81,4 @@ Actually we used an `ExpandingTextArea` from `GemsFX` package so the content can
 as much space as it needs in the `ScrollPane`.
 
 About the selection and copying, this goes down to fundamental issue from JavaFX.
-`Text` and `Label` cannot be selected by any means.
+`Text` and `Label` as a whole or a part [cannot be selected and/or copied](https://bugs.openjdk.org/browse/JDK-8091644).

--- a/docs/decisions/0036-use-textarea-for-chat-content.md
+++ b/docs/decisions/0036-use-textarea-for-chat-content.md
@@ -77,6 +77,8 @@ There seems to be [only one package](https://github.com/JPro-one/markdown-javafx
 
 ## More Information
 
+This ADR is highly linked to [ADR-0042](./0042-use-webview-for-summarization-content.md).
+
 Actually we used an `ExpandingTextArea` from `GemsFX` package so the content can occupy
 as much space as it needs in the `ScrollPane`.
 

--- a/docs/decisions/0042-use-webview-for-summarization-content.md
+++ b/docs/decisions/0042-use-webview-for-summarization-content.md
@@ -1,0 +1,38 @@
+---
+nav_order: 0042
+parent: Decision Records
+---
+
+# Use `WebView` for Chat Message Content
+
+## Context and Problem Statement
+
+This decision record concerns the UI component that is used for rendering the content of AI summaries.
+
+## Decision Drivers
+
+Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+
+## Considered Options
+
+Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+
+## Decision Outcome
+
+Chosen option: "Use `WebView`".
+
+Some of the options does not support selecting and copying of text. Some options do not render Markdown.
+
+However, in contrary to [ADR-0036](./0036-use-textarea-for-chat-content.md), we chose here a `WebView`, instead of `TextArea`, because there is only one summary content in UI (when user switches entries, no new components are added, rather old ones are *rebinding* to new entry). It would hurt the performance if we used `WebView` for messages, as there could be a lot of messages in one chat.
+
+## Pros and Cons of the Options
+
+Same as in [ADR-0036](./0036-use-textarea-for-chat-content.md).
+
+## More Information
+
+This ADR is highly linked to [ADR-0036](./0036-use-textarea-for-chat-content.md).
+
+About the selection and copying, this goes down to fundamental issue from JavaFX.
+`Text` and `Label` as a whole or a part [cannot be selected and/or copied](https://bugs.openjdk.org/browse/JDK-8091644).
+

--- a/docs/decisions/0042-use-webview-for-summarization-content.md
+++ b/docs/decisions/0042-use-webview-for-summarization-content.md
@@ -35,4 +35,3 @@ This ADR is highly linked to [ADR-0036](./0036-use-textarea-for-chat-content.md)
 
 About the selection and copying, this goes down to fundamental issue from JavaFX.
 `Text` and `Label` as a whole or a part [cannot be selected and/or copied](https://bugs.openjdk.org/browse/JDK-8091644).
-


### PR DESCRIPTION
- Added a link to JavaFX Markdown UI component, that is the only one existing (for current moment).
- Wrote `ADR-0042`.
- Fixed some wording and style.

I don't know, but can I replace whole sections in one ADR by linking to whole sections in other ADR?

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)~
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
