### PR TITLE
Fix some bugs with PDF imports

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -147,7 +147,7 @@ public class ImportHandler {
                                     entry.clearField(StandardField.FILE);
                                     // Modifiers do not work on macOS: https://bugs.openjdk.org/browse/JDK-8264172
                                     // Similar code as org.jabref.gui.preview.PreviewPanel.PreviewPanel
-                                    DragDrop.handleDropOfFiles(files, transferMode, fileLinker, entry);
+                                    DragDrop.handleDropOfFiles(List.of(file), transferMode, fileLinker, entry);
                                     entriesToAdd.addAll(pdfEntriesInFile);
                                     addResultToList(file, true, Localization.lang("File was successfully imported as a new entry"));
                                 });

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -149,7 +149,6 @@ public class UnlinkedFilesDialogViewModel {
         List<Path> fileList = checkedFileListProperty.stream()
                                                      .map(item -> item.getValue().getPath())
                                                      .filter(path -> path.toFile().isFile())
-                                                     .map(path -> directory.relativize(path))
                                                      .collect(Collectors.toList());
         if (fileList.isEmpty()) {
             LOGGER.warn("There are no valid files checked");

--- a/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesDialogViewModel.java
@@ -10,7 +10,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
 
@@ -145,29 +144,32 @@ public class UnlinkedFilesDialogViewModel {
     }
 
     public void startImport() {
-        Path directory = this.getSearchDirectory();
-        List<Path> fileList = checkedFileListProperty.stream()
-                                                     .map(item -> item.getValue().getPath())
-                                                     .filter(path -> path.toFile().isFile())
-                                                     .collect(Collectors.toList());
+        List<Path> fileList = checkedFileListProperty
+                .stream()
+                .map(TreeItem::getValue)
+                .map(FileNodeViewModel::getPath)
+                .filter(Files::isRegularFile)
+                .toList();
+
         if (fileList.isEmpty()) {
-            LOGGER.warn("There are no valid files checked");
+            LOGGER.warn("There are no valid files checked for import");
             return;
         }
         resultList.clear();
 
-        importFilesBackgroundTask = importHandler.importFilesInBackground(fileList, bibDatabase, preferences.getFilePreferences(), TransferMode.LINK)
-                                                 .onRunning(() -> {
-                                                     progressValueProperty.bind(importFilesBackgroundTask.workDonePercentageProperty());
-                                                     progressTextProperty.bind(importFilesBackgroundTask.messageProperty());
-                                                     taskActiveProperty.setValue(true);
-                                                 })
-                                                 .onFinished(() -> {
-                                                     progressValueProperty.unbind();
-                                                     progressTextProperty.unbind();
-                                                     taskActiveProperty.setValue(false);
-                                                 })
-                                                 .onSuccess(resultList::addAll);
+        importFilesBackgroundTask = importHandler
+                .importFilesInBackground(fileList, bibDatabase, preferences.getFilePreferences(), TransferMode.LINK)
+                .onRunning(() -> {
+                    progressValueProperty.bind(importFilesBackgroundTask.workDonePercentageProperty());
+                    progressTextProperty.bind(importFilesBackgroundTask.messageProperty());
+                    taskActiveProperty.setValue(true);
+                })
+                .onFinished(() -> {
+                    progressValueProperty.unbind();
+                    progressTextProperty.unbind();
+                    taskActiveProperty.setValue(false);
+                })
+                .onSuccess(resultList::addAll);
         importFilesBackgroundTask.executeWith(taskExecutor);
     }
 
@@ -175,12 +177,13 @@ public class UnlinkedFilesDialogViewModel {
      * This starts the export of all files of all selected nodes in the file tree view.
      */
     public void startExport() {
-        List<Path> fileList = checkedFileListProperty.stream()
-                                                     .map(item -> item.getValue().getPath())
-                                                     .filter(path -> path.toFile().isFile())
-                                                     .toList();
+        List<Path> fileList = checkedFileListProperty
+                .stream()
+                .map(item -> item.getValue().getPath())
+                .filter(Files::isRegularFile)
+                .toList();
         if (fileList.isEmpty()) {
-            LOGGER.warn("There are no valid files checked");
+            LOGGER.warn("There are no valid files checked for export");
             return;
         }
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -15,6 +15,8 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.swing.text.html.Option;
+
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.os.OS;
@@ -203,7 +205,7 @@ public class PdfContentImporter extends PdfImporter {
         List<BibEntry> result = new ArrayList<>(1);
         try (PDDocument document = new XmpUtilReader().loadWithAutomaticDecryption(filePath)) {
             String firstPageContents = getFirstPageContents(document);
-            String titleByFontSize = extractTitleFromDocument(document);
+            Optional<String> titleByFontSize = extractTitleFromDocument(document);
             Optional<BibEntry> entry = getEntryFromPDFContent(firstPageContents, OS.NEWLINE, titleByFontSize);
             entry.ifPresent(result::add);
         } catch (EncryptedPdfsNotSupportedException e) {
@@ -216,7 +218,7 @@ public class PdfContentImporter extends PdfImporter {
         return new ParserResult(result);
     }
 
-    private static String extractTitleFromDocument(PDDocument document) throws IOException {
+    private static Optional<String> extractTitleFromDocument(PDDocument document) throws IOException {
         TitleExtractorByFontSize stripper = new TitleExtractorByFontSize();
         return stripper.getTitle(document);
     }
@@ -230,7 +232,7 @@ public class PdfContentImporter extends PdfImporter {
             this.textPositionsList = new ArrayList<>();
         }
 
-        public String getTitle(PDDocument document) throws IOException {
+        public Optional<String> getTitle(PDDocument document) throws IOException {
             this.setStartPage(1);
             this.setEndPage(2);
             this.writeText(document, new StringWriter());
@@ -266,7 +268,7 @@ public class PdfContentImporter extends PdfImporter {
             return isFarAway(previousTextPosition, textPosition);
         }
 
-        private String findLargestFontText(List<TextPosition> textPositions) {
+        private Optional<String> findLargestFontText(List<TextPosition> textPositions) {
             Map<Float, StringBuilder> fontSizeTextMap = new TreeMap<>(Collections.reverseOrder());
             TextPosition previousTextPosition = null;
             for (TextPosition textPosition : textPositions) {
@@ -285,10 +287,10 @@ public class PdfContentImporter extends PdfImporter {
             for (Map.Entry<Float, StringBuilder> entry : fontSizeTextMap.entrySet()) {
                 String candidateText = entry.getValue().toString().trim();
                 if (isLegalTitle(candidateText)) {
-                    return candidateText;
+                    return Optional.of(candidateText);
                 }
             }
-            return fontSizeTextMap.values().iterator().next().toString().trim();
+            return fontSizeTextMap.values().stream().findFirst().map(StringBuilder::toString).map(String::trim);
         }
 
         private boolean isLegalTitle(String candidateText) {
@@ -334,7 +336,7 @@ public class PdfContentImporter extends PdfImporter {
      *         is successful. Otherwise, an empty {@link Optional}.
      */
     @VisibleForTesting
-    Optional<BibEntry> getEntryFromPDFContent(String firstpageContents, String lineSeparator, String titleByFontSize) {
+    Optional<BibEntry> getEntryFromPDFContent(String firstpageContents, String lineSeparator, Optional<String> titleByFontSize) {
         String firstpageContentsUnifiedLineBreaks = StringUtil.unifyLineBreaks(firstpageContents, lineSeparator);
 
         lines = firstpageContentsUnifiedLineBreaks.split(lineSeparator);
@@ -393,8 +395,8 @@ public class PdfContentImporter extends PdfImporter {
         title = streamlineTitle(curString);
         // i points to the next non-empty line
         curString = "";
-        if (!isNullOrEmpty(titleByFontSize)) {
-            title = titleByFontSize;
+        if (titleByFontSize.isPresent() && !isNullOrEmpty(titleByFontSize.get())) {
+            title = titleByFontSize.get();
         }
 
         // after title: authors

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -15,8 +15,6 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.swing.text.html.Option;
-
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.os.OS;

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -136,21 +136,9 @@ public class PdfMergeMetadataImporter extends PdfImporter {
         return new ParserResult(List.of(entry));
     }
 
-    /**
-     * A modified version of {@link PdfMergeMetadataImporter#importDatabase(Path)}, but it
-     * relativizes the {@code filePath} if there are working directories before parsing it
-     * into {@link PdfMergeMetadataImporter#importDatabase(Path)}
-     * (Otherwise no path modification happens).
-     *
-     * @param filePath    The unrelativized {@code filePath}.
-     */
     public ParserResult importDatabase(Path filePath, BibDatabaseContext context, FilePreferences filePreferences) throws IOException {
         Objects.requireNonNull(context);
         Objects.requireNonNull(filePreferences);
-
-        List<Path> directories = context.getFileDirectories(filePreferences);
-
-        // filePath = FileUtil.relativize(filePath, directories);
 
         return importDatabase(filePath);
     }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -150,7 +150,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
 
         List<Path> directories = context.getFileDirectories(filePreferences);
 
-        filePath = FileUtil.relativize(filePath, directories);
+        // filePath = FileUtil.relativize(filePath, directories);
 
         return importDatabase(filePath);
     }

--- a/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/PdfContentImporterTest.java
@@ -70,7 +70,7 @@ class PdfContentImporterTest {
                 Corpus linguistics investigates human language by starting out from large
                 """;
 
-        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n", ""));
+        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n", Optional.empty()));
     }
 
     @Test
@@ -93,7 +93,7 @@ class PdfContentImporterTest {
                 UNSPECIFIED
                 Master of Research (MRes) thesis, University of Kent,.""";
 
-        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n", ""));
+        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContents, "\n", Optional.empty()));
     }
 
     @Test
@@ -126,7 +126,7 @@ class PdfContentImporterTest {
                 British Journal of Nutrition
                 https://doi.org/10.1017/S0007114507795296 Published online by Cambridge University Press""";
 
-        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n", ""));
+        assertEquals(Optional.of(entry), importer.getEntryFromPDFContent(firstPageContent, "\n", Optional.empty()));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Some bugs:

- Several steps of PDF import didn't work because of relativization. I removed it, but IDK if it's okay to do this. After that, all steps worked.
- When searching for unlinked files, PDF import didn't work at all.
- There was some bug when importing specific PDF files, when algorithm can't find title of the book. I replaced `String` to `Optional<String>` and import worked correctly.
- NEW: replaced `files` to `List.of(file)` in `ImportHandler`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [?] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
~- [ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
