### PR TITLE
Fix application not saved in external file type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where identifier paste couldn't work with Unicode REPLACEMENT CHARACTER. [#11986](https://github.com/JabRef/jabref/issues/11986)
 - We fixed an issue when click on entry at "Check Integrity" wasn't properly focusing the entry and field. [#11997](https://github.com/JabRef/jabref/issues/11997)
 - We fixed an issue with the ui not scaling when changing the font size [#11219](https://github.com/JabRef/jabref/issues/11219)
+- We fixed an issue where a custom application for external file types would not be saved [#112311](https://github.com/JabRef/jabref/issues/12311)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
@@ -82,7 +82,12 @@ public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
         ExternalFileTypeItemViewModel typeToModify = new ExternalFileTypeItemViewModel(type.toExternalFileType());
         showEditDialog(typeToModify, Localization.lang("Edit file type"));
 
-        if (!isValidExternalFileType(typeToModify)) {
+        if (type.extensionProperty().get().equals(typeToModify.extensionProperty().get())) {
+            if (withEmptyValue(typeToModify)) {
+                LOGGER.warn("One of the fields is empty or invalid. Not saving.");
+                return false;
+            }
+        } else if (!isValidExternalFileType(typeToModify)) {
             return false;
         }
 
@@ -97,12 +102,12 @@ public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
 
     public boolean isValidExternalFileType(ExternalFileTypeItemViewModel item) {
         if (withEmptyValue(item)) {
-            LOGGER.debug("One of the fields is empty or invalid.");
+            LOGGER.warn("One of the fields is empty or invalid. Not saving.");
             return false;
         }
 
         if (!isUniqueExtension(item)) {
-            LOGGER.debug("File Extension exists already.");
+            LOGGER.warn("File Extension already exists. Not saving.");
             return false;
         }
 


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/12311

File extension uniqueness checks does not make sense oneedit when ext didn't change 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
