### PR TITLE
Fix method name

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/externalfiletypes/ExternalFileTypesTabViewModel.java
@@ -83,7 +83,7 @@ public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
         showEditDialog(typeToModify, Localization.lang("Edit file type"));
 
         if (type.extensionProperty().get().equals(typeToModify.extensionProperty().get())) {
-            if (withEmptyValue(typeToModify)) {
+            if (hasEmptyValue(typeToModify)) {
                 LOGGER.warn("One of the fields is empty or invalid. Not saving.");
                 return false;
             }
@@ -101,7 +101,7 @@ public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
     }
 
     public boolean isValidExternalFileType(ExternalFileTypeItemViewModel item) {
-        if (withEmptyValue(item)) {
+        if (hasEmptyValue(item)) {
             LOGGER.warn("One of the fields is empty or invalid. Not saving.");
             return false;
         }
@@ -114,7 +114,7 @@ public class ExternalFileTypesTabViewModel implements PreferenceTabViewModel {
         return true;
     }
 
-    private boolean withEmptyValue(ExternalFileTypeItemViewModel item) {
+    private boolean hasEmptyValue(ExternalFileTypeItemViewModel item) {
         return item.getName().isEmpty() || item.extensionProperty().get().isEmpty() || item.mimetypeProperty().get().isEmpty();
     }
 


### PR DESCRIPTION
Follow-up to #10496.

The method name was not consistent to other Java code.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
