### PR TITLE
Just Delete link from entry if the file is no longer accesible on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue when click on entry at "Check Integrity" wasn't properly focusing the entry and field. [#11997](https://github.com/JabRef/jabref/issues/11997)
 - We fixed an issue with the ui not scaling when changing the font size [#11219](https://github.com/JabRef/jabref/issues/11219)
 - We fixed an issue where a custom application for external file types would not be saved [#112311](https://github.com/JabRef/jabref/issues/12311)
-- We fixed an issue where a no longer existing file cannot be deleted from an entry using keyboard shortcut [#9731](https://github.com/JabRef/jabref/issues/9731)
+- We fixed an issue where a file that no longer exists could not be deleted from an entry using keyboard shortcut [#9731](https://github.com/JabRef/jabref/issues/9731)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue when click on entry at "Check Integrity" wasn't properly focusing the entry and field. [#11997](https://github.com/JabRef/jabref/issues/11997)
 - We fixed an issue with the ui not scaling when changing the font size [#11219](https://github.com/JabRef/jabref/issues/11219)
 - We fixed an issue where a custom application for external file types would not be saved [#112311](https://github.com/JabRef/jabref/issues/12311)
+- We fixed an issue where a no longer existing file cannot be deleted from an entry using keyboard shortcut [#9731](https://github.com/JabRef/jabref/issues/9731)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
+++ b/src/main/java/org/jabref/gui/linkedfile/DeleteFileAction.java
@@ -99,6 +99,7 @@ public class DeleteFileAction extends SimpleCommand {
                 dialogTitle = Localization.lang("Delete '%0'", path.getFileName().toString());
             } else {
                 dialogService.notify(Localization.lang("Error accessing file '%0'.", linkedFile.getLink()));
+                deleteFiles(false);
                 // Deleting a non-existing file is a success
                 success = true;
                 return;


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/9731


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
