### PR TITLE
Fix postgres unique constraint exception

### DIFF
--- a/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
+++ b/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
@@ -285,8 +285,10 @@ public class BibFieldsIndexer {
     }
 
     public void updateEntry(BibEntry entry, Field field) {
-        removeField(entry, field);
-        insertField(entry, field);
+        synchronized (entry.getId()) {
+            removeField(entry, field);
+            insertField(entry, field);
+        }
     }
 
     private void insertField(BibEntry entry, Field field) {


### PR DESCRIPTION
Attempt to fix #12167.

I cannot reproduce the issue on my machine, but I guess it may be related to background threads and quickly updating the entry.
One possible scenario is that the user is updating the field quickly, and updating the field is a critical section that should be completed as an atomic operation without interruptions.

```
updateEntry(BibEntry entry, Field field) {
	removeField(entry, field);
	insertField(entry, field);
}
```
The issue might occur if the first thread removes the field, but before it inserts the field again, another thread updates the same entry and also removes the field. This could result in both threads attempting to insert the same field into the table twice, violating the primary key constraint (`entryId`, `fieldName`), which must be unique.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
