### PR TITLE
Searching for entries with empty field

### DIFF
--- a/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
+++ b/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
@@ -209,10 +209,12 @@ public class SearchToSqlVisitor extends SearchBaseVisitor<SqlQueryNode> {
 
         // field = "" -> should find entries where the field is empty
         // field != "" -> should find entries where the field is not empty
-        if (term.isEmpty() && searchFlags.contains(NEGATION)) {
-            searchFlags.remove(NEGATION);
-        } else if (term.isEmpty()) {
-            searchFlags.add(NEGATION);
+        if (term.isEmpty()) {
+            if (searchFlags.contains(NEGATION)) {
+                searchFlags.remove(NEGATION);
+            } else {
+                searchFlags.add(NEGATION);
+            }
         }
 
         return getFieldQueryNode(field.toLowerCase(Locale.ROOT), term, searchFlags);

--- a/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
+++ b/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
@@ -207,6 +207,14 @@ public class SearchToSqlVisitor extends SearchBaseVisitor<SqlQueryNode> {
             setFlags(searchFlags, REGULAR_EXPRESSION, true, true);
         }
 
+        // field = "" -> should find entries where the field is empty
+        // field != "" -> should find entries where the field is not empty
+        if (term.isEmpty() && searchFlags.contains(NEGATION)) {
+            searchFlags.remove(NEGATION);
+        } else if (term.isEmpty()) {
+            searchFlags.add(NEGATION);
+        }
+
         return getFieldQueryNode(field.toLowerCase(Locale.ROOT), term, searchFlags);
     }
 

--- a/src/test/java/org/jabref/logic/search/query/SearchQuerySQLConversionTest.java
+++ b/src/test/java/org/jabref/logic/search/query/SearchQuerySQLConversionTest.java
@@ -695,6 +695,38 @@ class SearchQuerySQLConversionTest {
                             )
                         )
                         SELECT * FROM cte0 GROUP BY entryid"""
+                ),
+
+                Arguments.of(
+                        "file = \"\"",
+                        """
+                        WITH
+                        cte0 AS (
+                            SELECT main_table.entryid
+                            FROM bib_fields."tableName" AS main_table
+                            WHERE main_table.entryid NOT IN (
+                                SELECT inner_table.entryid
+                                FROM bib_fields."tableName" AS inner_table
+                                WHERE (
+                                    (inner_table.field_name = 'file') AND ((inner_table.field_value_literal ILIKE ('%%')) OR (inner_table.field_value_transformed ILIKE ('%%')))
+                                )
+                            )
+                        )
+                        SELECT * FROM cte0 GROUP BY entryid"""
+                ),
+
+                Arguments.of(
+                        "file != \"\"",
+                        """
+                        WITH
+                        cte0 AS (
+                            SELECT main_table.entryid
+                            FROM bib_fields."tableName" AS main_table
+                            WHERE (
+                                (main_table.field_name = 'file') AND ((main_table.field_value_literal ILIKE ('%%')) OR (main_table.field_value_transformed ILIKE ('%%')))
+                            )
+                        )
+                        SELECT * FROM cte0 GROUP BY entryid"""
                 )
         );
     }


### PR DESCRIPTION
Follow-up to #11803.

Reverse searching with empty fields: Searching with `file = ""` will now return entries where the file field is empty, while searching with `file != ""` will return entries that contain files.

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/667 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
