### PR TITLE
Fix #11799: Made file renaming dialog resizable and increased its size

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -178,6 +178,8 @@ public class JabRefDialogService implements DialogService {
         inputDialog.setHeaderText(title);
         inputDialog.setContentText(content);
         inputDialog.initOwner(mainWindow);
+        inputDialog.getDialogPane().setPrefSize(500, 200); // Set preferred size
+        inputDialog.setResizable(true);
         return inputDialog.showAndWait();
     }
 


### PR DESCRIPTION
This pull request resolves #11799 by:

- Setting a preferred size for the file renaming dialog (500x200) to accommodate long file names and improve usability.
- Adding setResizable(true) to allow users to resize the dialog, providing greater flexibility across different screen sizes and resolutions.