### PR TITLE
Hide tab bar

### DIFF
--- a/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/src/main/java/org/jabref/gui/LibraryTab.java
@@ -345,6 +345,24 @@ public class LibraryTab extends Tab {
 
     private void setDatabaseContext(BibDatabaseContext bibDatabaseContext) {
         TabPane tabPane = this.getTabPane();
+
+         stateManager.getOpenDatabases().addListener((ListChangeListener<BibDatabaseContext>) change -> {
+            int numberOfOpenDatabases = stateManager.getOpenDatabases().size();
+            if (numberOfOpenDatabases == 1) {
+                tabPane.setStyle("-fx-tab-max-height: 0;");
+                tabPane.lookup(".tab-header-area").setStyle("-fx-pref-height: 0; visibility: hidden");
+                tabPane.lookupAll(".tab-pane > .tab-header-area > .headers-region > .tab").forEach(node -> {
+                    node.setStyle("-fx-padding: 0; -fx-border-width: 0; -fx-pref-height: 0;");
+                });
+            } else {
+                tabPane.setStyle("");
+                tabPane.lookup(".tab-header-area").setStyle("");
+                tabPane.lookupAll(".tab-pane > .tab-header-area > .headers-region > .tab").forEach(node -> {
+                    node.setStyle("");
+                });
+            }
+        });
+
         if (tabPane == null) {
             LOGGER.debug("User interrupted loading. Not showing any library.");
             return;

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -123,6 +123,15 @@ public class ActionFactory {
         return checkMenuItem;
     }
 
+    public CheckMenuItem createCustomCheckMenuItem(Action action, Command command, boolean selected, String text) {
+        CheckMenuItem checkMenuItem = ActionUtils.createCheckMenuItem(new JabRefAction(action, command, keyBindingRepository));
+        checkMenuItem.textProperty().unbind();
+        checkMenuItem.setText(text);
+        checkMenuItem.setSelected(selected);
+
+        return checkMenuItem;
+    }
+
     public Menu createMenu(Action action) {
         Menu menu = ActionUtils.createMenu(new JabRefAction(action, keyBindingRepository));
 

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -10,6 +10,7 @@ import org.jabref.logic.l10n.Localization;
 
 public enum StandardActions implements Action {
 
+    COPY_TO(Localization.lang("Copy to")),
     COPY_MORE(Localization.lang("Copy") + "..."),
     COPY_TITLE(Localization.lang("Copy title"), KeyBinding.COPY_TITLE),
     COPY_KEY(Localization.lang("Copy citation key"), KeyBinding.COPY_CITATION_KEY),

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -1,0 +1,95 @@
+package org.jabref.gui.edit;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jabref.gui.ClipBoardManager;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.ActionHelper;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.actions.StandardActions;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.logic.journals.JournalAbbreviationRepository;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CopyTo extends SimpleCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CopyTo.class);
+    private final StandardActions action;
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private final ClipBoardManager clipBoardManager;
+    private final GuiPreferences preferences;
+    private final JournalAbbreviationRepository abbreviationRepository;
+    private final List<String> checkedPaths;
+    private final String path;
+
+    public CopyTo(StandardActions action,
+                  DialogService dialogService,
+                  StateManager stateManager,
+                  ClipBoardManager clipBoardManager,
+                  GuiPreferences preferences,
+                  JournalAbbreviationRepository abbreviationRepository,
+                  List<String> checkedPaths,
+                  String path) {
+        this.action = action;
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.clipBoardManager = clipBoardManager;
+        this.preferences = preferences;
+        this.abbreviationRepository = abbreviationRepository;
+        this.checkedPaths = checkedPaths;
+        this.path = path;
+        this.executable.bind(ActionHelper.needsEntriesSelected(stateManager));
+    }
+
+    @Override
+    public void execute() {
+        Logger logger = LoggerFactory.getLogger(CopyTo.class);
+
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+
+        List<BibEntry> selectedEntries = stateManager.getSelectedEntries();
+        List<String> titles = selectedEntries.stream()
+                .filter(entry -> entry.getTitle().isPresent())
+                .map(entry -> entry.getTitle().get())
+                .collect(Collectors.toList());
+
+        for(String title: titles) {
+            logger.info("Selected Entreis: " + title);
+        }
+        for(String checkedPath: checkedPaths) {
+            logger.info("Selected Libraries to copy: " + checkedPath);
+        }
+
+        boolean includeCrossReferences = askForCrossReferencedEntries();
+        preferences.getCopyToPreferences().setShouldIncludeCrossReferences(includeCrossReferences);
+
+        if(preferences.getCopyToPreferences().getShouldIncludeCrossReferences()) {
+            logger.info("Include Cross References");
+        } else {
+            logger.info("Exclude Cross References");
+        }
+    }
+
+    private boolean askForCrossReferencedEntries() {
+        if(preferences.getCopyToPreferences().getShouldAskForIncludingCrossReferences()) {
+            return dialogService.showConfirmationDialogWithOptOutAndWait(
+                    Localization.lang("Include or exclude cross-referenced entries"),
+                    Localization.lang("Would you like to include cross-reference entries in the current operation?"),
+                    Localization.lang("Include"),
+                    Localization.lang("Exclude"),
+                    Localization.lang("Do not ask again"),
+                    optOut -> preferences.getCopyToPreferences().setShouldAskForIncludingCrossReferences(!optOut)
+            );
+        } else {
+            return preferences.getCopyToPreferences().getShouldIncludeCrossReferences();
+        }
+    }
+}

--- a/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
+++ b/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
@@ -1,0 +1,35 @@
+package org.jabref.gui.edit;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CopyToPreferences {
+    private final Logger logger = LoggerFactory.getLogger(CopyToPreferences.class);
+
+    private final BooleanProperty shouldIncludeCrossReferences = new SimpleBooleanProperty();
+    private final BooleanProperty shouldAskForIncludingCrossReferences = new SimpleBooleanProperty();
+
+    public CopyToPreferences(boolean shouldAskForIncludingCrossReferences,
+                             boolean shouldIncludeCrossReferences
+                             ) {
+        this.shouldIncludeCrossReferences.set(shouldIncludeCrossReferences);
+        this.shouldAskForIncludingCrossReferences.set(shouldAskForIncludingCrossReferences);
+    }
+
+    public boolean getShouldIncludeCrossReferences() {
+        return shouldIncludeCrossReferences.get();
+    }
+    public void setShouldIncludeCrossReferences(boolean decision) {
+        this.shouldIncludeCrossReferences.set(decision);
+    }
+
+    public boolean getShouldAskForIncludingCrossReferences() {
+        return shouldAskForIncludingCrossReferences.get();
+    }
+    public void setShouldAskForIncludingCrossReferences(boolean decision) {
+        this.shouldAskForIncludingCrossReferences.set(decision);
+    }
+}

--- a/src/main/java/org/jabref/gui/preferences/GuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/GuiPreferences.java
@@ -17,8 +17,11 @@ import org.jabref.gui.preview.PreviewPreferences;
 import org.jabref.gui.push.PushToApplicationPreferences;
 import org.jabref.gui.specialfields.SpecialFieldsPreferences;
 import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.gui.edit.CopyToPreferences;
 
 public interface GuiPreferences extends CliPreferences {
+    CopyToPreferences getCopyToPreferences();
+
     EntryEditorPreferences getEntryEditorPreferences();
 
     MergeDialogPreferences getMergeDialogPreferences();

--- a/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -45,6 +45,7 @@ import org.jabref.gui.push.PushToApplications;
 import org.jabref.gui.sidepane.SidePaneType;
 import org.jabref.gui.specialfields.SpecialFieldsPreferences;
 import org.jabref.gui.theme.Theme;
+import org.jabref.gui.edit.CopyToPreferences;
 import org.jabref.logic.bst.BstPreviewLayout;
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStylePreviewLayout;
@@ -213,6 +214,11 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String UNLINKED_FILES_SELECTED_DATE_RANGE = "unlinkedFilesSelectedDateRange";
     private static final String UNLINKED_FILES_SELECTED_SORT = "unlinkedFilesSelectedSort";
 
+    // Add a constant key for the preference
+    // private static String REMEMBER_CROSS_REFERENCE_DECISION = "rememberCrossReferenceDecision";
+    private static String INCLUDE_CROSS_REFERENCES = "includeCrossReferences";
+    private static String ASK_FOR_INCLUDING_CROSS_REFERENCES = "askForIncludingCrossReferences";
+
     private static JabRefGuiPreferences singleton;
 
     private EntryEditorPreferences entryEditorPreferences;
@@ -232,6 +238,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private ColumnPreferences mainTableColumnPreferences;
     private ColumnPreferences searchDialogColumnPreferences;
     private KeyBindingRepository keyBindingRepository;
+    private CopyToPreferences copyToPreferences;
 
     private JabRefGuiPreferences() {
         super();
@@ -394,6 +401,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         // By default disable "Fit table horizontally on the screen"
         defaults.put(AUTO_RESIZE_MODE, Boolean.FALSE);
         // endregion
+
+        defaults.put(ASK_FOR_INCLUDING_CROSS_REFERENCES, Boolean.TRUE);
+        defaults.put(INCLUDE_CROSS_REFERENCES, Boolean.FALSE);
     }
 
     /**
@@ -407,6 +417,17 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             JabRefGuiPreferences.singleton = new JabRefGuiPreferences();
         }
         return JabRefGuiPreferences.singleton;
+    }
+
+    public CopyToPreferences getCopyToPreferences() {
+        if(copyToPreferences != null) {
+            return copyToPreferences;
+        }
+        copyToPreferences = new CopyToPreferences(
+                getBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES),
+                getBoolean(INCLUDE_CROSS_REFERENCES)
+        );
+        return copyToPreferences;
     }
 
     // region EntryEditorPreferences


### PR DESCRIPTION
### Fixes #9971

This PR introduces a feature to hide the tab bar when only a single library is open in JabRef, enhancing the user interface for  devices with low screen space.

### THE CHANGES MADE
- When a single library is open, the tab bar is hidden.
- Ensured that the tab bar is restored when more than one library is open, maintaining expected functionality.

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

![c](https://github.com/user-attachments/assets/b2b8cbe7-bef9-4112-b34d-a43b704c3f19)