### PR TITLE
fixed scalling of "preferences" window for 150% more OS scaling

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialog.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
-<DialogPane prefHeight="700.0" prefWidth="1100.0" minHeight="400" minWidth="600"
+<DialogPane prefHeight="600.0" prefWidth="800.0" minHeight="400" minWidth="600"
             xmlns="http://javafx.com/javafx/8.0.212" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="org.jabref.gui.preferences.PreferencesDialogView"
             id="preferencesDialog">

--- a/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesDialogView.java
@@ -52,6 +52,9 @@ public class PreferencesDialogView extends BaseDialog<PreferencesDialogViewModel
                   .load()
                   .setAsDialogPane(this);
 
+        getDialogPane().setPrefWidth(700);
+        getDialogPane().setPrefHeight(500);
+
         ControlHelper.setAction(saveButton, getDialogPane(), event -> savePreferencesAndCloseDialog());
 
         // Stop the default button from firing when the user hits enter within the search box

--- a/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesFilterDialog.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="600.0" prefWidth="950.0"
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="500.0" prefWidth="700.0"
             xmlns="http://javafx.com/javafx/8.0.121" fx:controller="org.jabref.gui.preferences.PreferencesFilterDialog">
 
     <content>


### PR DESCRIPTION
Fixes #12192 

I adjusted the overall size of the "Preferences" dialog by changing its " prefheight " and " prefwidth " in .fxml file 

" show preference " filter in preferences window was still improperly scaling, changes its  " prefheight " and " prefwidth " in preferencesfilterdialog.fxml file 

