### PR TITLE
Fix tests for BackupManager

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,9 @@ gradlew text eol=lf
 # windows line endings at windows files
 *.bat text eol=crlf
 
-# ensure that line endings of *.bib, *.fxml, *.java, *.properties are normalized to LF
+# ensure that line endings of certain files are normalized to LF
 *.bib text eol=lf
+*.bak text eol=lf
 *.fxml text eol=lf
 *.java text eol=lf
 *.properties text eol=lf


### PR DESCRIPTION
There is a binary file comparison, which fails if .bak is CRLF instead of LF.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
