### PR TITLE
Auto rename files feature fix for #11316

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -21,13 +21,7 @@
         <ToggleGroup fx:id="autolinkToggleGroup"/>
         <ToggleGroup fx:id="fileDirectoryToggleGroup"/>
     </fx:define>
-    <Label styleClass="titleHeader" text="%Linked files"/>
     <Label styleClass="sectionHeader" text="%File directory"/>
-    <CheckBox fx:id="autoRenameFilesOnChange" text="%Auto rename files if entry changes">
-        <tooltip>
-            <Tooltip text="%Automatically rename attached files when the entry changes"/>
-        </tooltip>
-    </CheckBox>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <RadioButton fx:id="useMainFileDirectory" text="%Main file directory" toggleGroup="$fileDirectoryToggleGroup"></RadioButton>
         <TextField fx:id="mainFileDirectory" HBox.hgrow="ALWAYS"/>
@@ -64,6 +58,11 @@
     <CheckBox fx:id="fulltextIndex" text="%Automatically index all linked files for fulltext search"/>
 
     <Label styleClass="sectionHeader" text="%Linked file name conventions"/>
+    <CheckBox fx:id="autoRenameFilesOnChange" text="%Auto rename files if entry changes">
+        <tooltip>
+            <Tooltip text="%Automatically rename attached files when the entry changes"/>
+        </tooltip>
+    </CheckBox>
     <GridPane hgap="4.0" vgap="4.0">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" percentWidth="30.0"/>

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -23,6 +23,11 @@
     </fx:define>
     <Label styleClass="titleHeader" text="%Linked files"/>
     <Label styleClass="sectionHeader" text="%File directory"/>
+    <CheckBox fx:id="autoRenameFilesOnChange" text="%Auto rename files if entry changes">
+        <tooltip>
+            <Tooltip text="%Automatically rename attached files when the entry changes"/>
+        </tooltip>
+    </CheckBox>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
         <RadioButton fx:id="useMainFileDirectory" text="%Main file directory" toggleGroup="$fileDirectoryToggleGroup"></RadioButton>
         <TextField fx:id="mainFileDirectory" HBox.hgrow="ALWAYS"/>

--- a/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -35,12 +35,14 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty autolinkUseRegexProperty = new SimpleBooleanProperty();
     private final StringProperty autolinkRegexKeyProperty = new SimpleStringProperty("");
     private final ListProperty<String> defaultFileNamePatternsProperty =
-            new SimpleListProperty<>(FXCollections.observableArrayList(FilePreferences.DEFAULT_FILENAME_PATTERNS));
+    new SimpleListProperty<>(FXCollections.observableArrayList(FilePreferences.DEFAULT_FILENAME_PATTERNS));
     private final BooleanProperty fulltextIndex = new SimpleBooleanProperty();
     private final StringProperty fileNamePatternProperty = new SimpleStringProperty();
     private final StringProperty fileDirectoryPatternProperty = new SimpleStringProperty();
     private final BooleanProperty confirmLinkedFileDeleteProperty = new SimpleBooleanProperty();
     private final BooleanProperty moveToTrashProperty = new SimpleBooleanProperty();
+    private final BooleanProperty autoRenameFilesOnChangeProperty = new SimpleBooleanProperty(false);
+
 
     private final Validator mainFileDirValidator;
 
@@ -84,6 +86,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         fileDirectoryPatternProperty.setValue(filePreferences.getFileDirectoryPattern());
         confirmLinkedFileDeleteProperty.setValue(filePreferences.confirmDeleteLinkedFile());
         moveToTrashProperty.setValue(filePreferences.moveToTrash());
+        autoRenameFilesOnChangeProperty.setValue(filePreferences.isAutoRenameFilesOnChange());
 
         // Autolink preferences
         switch (autoLinkPreferences.getCitationKeyDependency()) {
@@ -116,6 +119,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
         autoLinkPreferences.setRegularExpression(autolinkRegexKeyProperty.getValue());
         filePreferences.confirmDeleteLinkedFile(confirmLinkedFileDeleteProperty.getValue());
         filePreferences.moveToTrash(moveToTrashProperty.getValue());
+        filePreferences.setAutoRenameFilesOnChange(autoRenameFilesOnChangeProperty.getValue());
     }
 
     ValidationStatus mainFileDirValidationStatus() {
@@ -191,6 +195,10 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty moveToTrashProperty() {
         return this.moveToTrashProperty;
+    }
+
+    public BooleanProperty autoRenameFilesOnChangeProperty() {
+        return this.autoRenameFilesOnChangeProperty;
     }
 }
 

--- a/src/main/java/org/jabref/logic/FilePreferences.java
+++ b/src/main/java/org/jabref/logic/FilePreferences.java
@@ -32,6 +32,7 @@ public class FilePreferences {
     private final BooleanProperty confirmDeleteLinkedFile = new SimpleBooleanProperty();
     private final BooleanProperty moveToTrash = new SimpleBooleanProperty();
     private final BooleanProperty shouldKeepDownloadUrl = new SimpleBooleanProperty();
+    private final BooleanProperty autoRenameFilesOnChange = new SimpleBooleanProperty(false);
 
     public FilePreferences(String userAndHost,
                            String mainFileDirectory,
@@ -45,7 +46,8 @@ public class FilePreferences {
                            Path backupDirectory,
                            boolean confirmDeleteLinkedFile,
                            boolean moveToTrash,
-                           boolean shouldKeepDownloadUrl) {
+                           boolean shouldKeepDownloadUrl,
+                           boolean autoRenameFilesOnChange) {
         this.userAndHost.setValue(userAndHost);
         this.mainFileDirectory.setValue(mainFileDirectory);
         this.storeFilesRelativeToBibFile.setValue(storeFilesRelativeToBibFile);
@@ -59,6 +61,7 @@ public class FilePreferences {
         this.confirmDeleteLinkedFile.setValue(confirmDeleteLinkedFile);
         this.moveToTrash.setValue(moveToTrash);
         this.shouldKeepDownloadUrl.setValue(shouldKeepDownloadUrl);
+        this.autoRenameFilesOnChange.setValue(autoRenameFilesOnChange);
     }
 
     public String getUserAndHost() {
@@ -211,6 +214,18 @@ public class FilePreferences {
 
     public BooleanProperty shouldKeepDownloadUrlProperty() {
         return shouldKeepDownloadUrl;
+    }
+
+    public boolean isAutoRenameFilesOnChange() {
+        return autoRenameFilesOnChange.get();
+    }
+
+    public void setAutoRenameFilesOnChange(boolean autoRenameFilesOnChange) {
+        this.autoRenameFilesOnChange.set(autoRenameFilesOnChange);
+    }
+
+    public BooleanProperty autoRenameFilesOnChangeProperty() {
+        return autoRenameFilesOnChange;
     }
 
     public void setKeepDownloadUrl(boolean shouldKeepDownloadUrl) {

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -339,6 +339,7 @@ public class JabRefCliPreferences implements CliPreferences {
     private static final String DOWNLOAD_LINKED_FILES = "downloadLinkedFiles";
     private static final String FULLTEXT_INDEX_LINKED_FILES = "fulltextIndexLinkedFiles";
     private static final String KEEP_DOWNLOAD_URL = "keepDownloadUrl";
+    private static final String AUTO_RENAME_FILES_ON_CHANGE = "autoRenameFilesOnChange";
 
     // Indexes for Strings within stored custom export entries
     private static final int EXPORTER_NAME_INDEX = 0;
@@ -1554,7 +1555,8 @@ public class JabRefCliPreferences implements CliPreferences {
                 getBoolean(CONFIRM_LINKED_FILE_DELETE),
                 // We make use of the fallback, because we need AWT being initialized, which is not the case at the constructor JabRefPreferences()
                 getBoolean(TRASH_INSTEAD_OF_DELETE, moveToTrashSupported()),
-                getBoolean(KEEP_DOWNLOAD_URL));
+                getBoolean(KEEP_DOWNLOAD_URL),
+                getBoolean(AUTO_RENAME_FILES_ON_CHANGE, false));
 
         EasyBind.listen(getInternalPreferences().getUserAndHostProperty(), (obs, oldValue, newValue) -> filePreferences.getUserAndHostProperty().setValue(newValue));
         EasyBind.listen(filePreferences.mainFileDirectoryProperty(), (obs, oldValue, newValue) -> put(MAIN_FILE_DIRECTORY, newValue));
@@ -1569,6 +1571,7 @@ public class JabRefCliPreferences implements CliPreferences {
         EasyBind.listen(filePreferences.confirmDeleteLinkedFileProperty(), (obs, oldValue, newValue) -> putBoolean(CONFIRM_LINKED_FILE_DELETE, newValue));
         EasyBind.listen(filePreferences.moveToTrashProperty(), (obs, oldValue, newValue) -> putBoolean(TRASH_INSTEAD_OF_DELETE, newValue));
         EasyBind.listen(filePreferences.shouldKeepDownloadUrlProperty(), (obs, oldValue, newValue) -> putBoolean(KEEP_DOWNLOAD_URL, newValue));
+        EasyBind.listen(filePreferences.autoRenameFilesOnChangeProperty(), (obs, oldValue, newValue) -> putBoolean(AUTO_RENAME_FILES_ON_CHANGE, newValue));
 
         return filePreferences;
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2731,6 +2731,10 @@ Cannot\ delete\ file\ '%0'=Cannot delete file '%0'
 This\ operation\ requires\ selected\ linked\ files.=This operation requires selected linked files.
 Move\ deleted\ files\ to\ trash\ (instead\ of\ deleting\ them)=Move deleted files to trash (instead of deleting them)
 
+# Linked files preferences
+Auto\ rename\ files\ if\ entry\ changes=Auto rename files if entry changes
+Automatically\ rename\ attached\ files\ when\ the\ entry\ changes=Automatically rename attached files when the entry changes
+
 File\ permission\ error=File permission error
 JabRef\ does\ not\ have\ permission\ to\ access\ %s=JabRef does not have permission to access %s
 


### PR DESCRIPTION
Added a new option [ ] Auto rename files if entry changes under Preferences -> Linked files -> Linked file name conventions, with the default value set to false. When this option is enabled, JabRef will automatically rename files if the filename matches the defined naming pattern.

Users requested that JabRef automatically rename files when entry data is changed, provided the filename matches the defined naming pattern. This feature improves file management automation and reduces the need for manual intervention.

refs #11316

<img width="1710" alt="Screenshot 2025-02-02 at 11 18 28" src="https://github.com/user-attachments/assets/9891cb34-54c0-4669-a2ba-c4fc5a236e66" />

### Mandatory checks
<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
