### PR TITLE
Add comment for binary-based importers

### DIFF
--- a/src/main/java/org/jabref/logic/importer/Importer.java
+++ b/src/main/java/org/jabref/logic/importer/Importer.java
@@ -77,6 +77,12 @@ public abstract class Importer implements Comparable<Importer> {
      * <p>
      * If importing in a specified format and an empty library is returned, JabRef reports that no entries were found.
      * <p>
+     * If your format is binary-based (PDF, ZIP-based, or others), then you should not solely override this method.
+     * For binary formats do this:
+     * 1. Throw {@link UnsupportedOperationException} in this method.
+     * 2. Override the method {@link Importer#importDatabase(Path)}.
+     * Example of this workaround is in: {@link org.jabref.logic.importer.fileformat.pdf.PdfImporter}.
+     * <p>
      * This method should never return null.
      *
      * @param input the input to read from


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref-issue-melting-pot/issues/764.

Just a small comment explaining how to properly import files that are binary. Also explains a bit why `PdfImport#importDatabase(BufferedReader)` throws an exception.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
~- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)~
~- [ ] Tests created for changes (if applicable)~
- [ ] Manually tested changed features in running JabRef (always required)
~- [ ] Screenshots added in PR description (for UI changes)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
