### PR TITLE
fixed the first underscore which was ignored

### DIFF
--- a/src/main/java/org/jabref/gui/util/ControlHelper.java
+++ b/src/main/java/org/jabref/gui/util/ControlHelper.java
@@ -119,6 +119,7 @@ public class ControlHelper {
         if (ellipsisString == null) {
             ellipsisString = "";
         }
+        text = text.replace("_", "__");
 
         if (maxCharacters == -1) {
             maxCharacters = 75; // default


### PR DESCRIPTION
Fixes #12215 

When multiple files were attached the tooltip and context menu in the "Linked File" tab removed the first underscore (_) from file names.

the file paths were correct internally and opened the right files.

javaFX treats _ as a  shortcut key indicator

I updated **ControlHelper.truncateString()** to replace single underscores (_) with double underscores (__) before displaying text in the UI.

attached the SS of the fix

![Screenshot 2025-02-03 224324](https://github.com/user-attachments/assets/7754b7e2-e1e2-45d7-a4b5-bde16a1ad697)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [ ] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
