### PR TITLE
Fix the displayed name of an untitled database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the name of the untitled database was shown as a blank space in the right-click context menu's "Copy to" option. [#12459](https://github.com/JabRef/jabref/pull/12459)
 - We fixed an issue where the F3 shortcut key did not work without opening the right-click context menu. [#12417](https://github.com/JabRef/jabref/pull/12417)
 - We fixed an issue where a bib file with UFF-8 charset was wrongly loaded with a different charset [forum#5369](https://discourse.jabref.org/t/jabref-5-15-opens-bib-files-with-shift-jis-encoding-instead-of-utf-8/5369/)
 - We fixed an issue where new entries were inserted in the middle of the table instead of at the end. [#12371](https://github.com/JabRef/jabref/pull/12371)

--- a/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
+++ b/src/main/java/org/jabref/gui/maintable/RightClickMenu.java
@@ -133,18 +133,18 @@ public class RightClickMenu {
 
         if (!openDatabases.isEmpty()) {
             openDatabases.forEach(bibDatabaseContext -> {
-                Optional<Path> destinationPath = Optional.empty();
+                Optional<String> destinationPath = Optional.empty();
                 String destinationDatabaseName = "";
 
                 if (bibDatabaseContext.getDatabasePath().isPresent()) {
-                    destinationPath = bibDatabaseContext.getDatabasePath();
-                    String uniquePathName = FileUtil.getUniquePathFragment(stateManager.collectAllDatabasePaths(), destinationPath.get()).get();
-                    if (uniquePathName.equals(sourceDatabaseName)) {
+                    destinationDatabaseName = FileUtil.getUniquePathFragment(stateManager.collectAllDatabasePaths(), bibDatabaseContext.getDatabasePath().get()).get();
+                    if (destinationDatabaseName.equals(sourceDatabaseName)) {
                         return;
                     }
-                    destinationDatabaseName = uniquePathName;
                 } else if (bibDatabaseContext.getLocation() == DatabaseLocation.SHARED) {
                     destinationDatabaseName = bibDatabaseContext.getDBMSSynchronizer().getDBName() + " [" + Localization.lang("shared") + "]";
+                } else {
+                    destinationDatabaseName = destinationPath.orElse(Localization.lang("untitled"));
                 }
 
                 copyToMenu.getItems().addAll(


### PR DESCRIPTION
### Fixes

The fix ensures that if the database is untitled, the "Copy to" option in the right-click context menu displays "untitled" instead of a blank space.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

![Screenshot (40)](https://github.com/user-attachments/assets/dc668e46-925d-4167-9a8a-9bffe9f6446f)