### PR TITLE
Fix BibTexStrings not included in backup file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where removing the sort from the table did not restore the original order. [#12371](https://github.com/JabRef/jabref/pull/12371)
 - We fixed an issue where JabRef icon merges with dark background [#7771](https://github.com/JabRef/jabref/issues/7771)
 - We fixed an issue where an entry's group was no longer highlighted on selection [#12413](https://github.com/JabRef/jabref/issues/12413)
+- We fixed an issue where BibTeX Strings were not included in the backup file [#12462](https://github.com/JabRef/jabref/issues/12462)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
@@ -60,7 +60,7 @@ public class BackupManager {
 
     private static final int DELAY_BETWEEN_BACKUP_ATTEMPTS_IN_SECONDS = 19;
 
-    private static final Set<BackupManager> runningInstances = new HashSet<>();
+    private static final Set<BackupManager> RUNNING_INSTANCES = new HashSet<>();
 
     private final BibDatabaseContext bibDatabaseContext;
     private final CliPreferences preferences;
@@ -110,7 +110,7 @@ public class BackupManager {
     public static BackupManager start(LibraryTab libraryTab, BibDatabaseContext bibDatabaseContext, BibEntryTypesManager entryTypesManager, CliPreferences preferences) {
         BackupManager backupManager = new BackupManager(libraryTab, bibDatabaseContext, entryTypesManager, preferences);
         backupManager.startBackupTask(preferences.getFilePreferences().getBackupDirectory());
-        runningInstances.add(backupManager);
+        RUNNING_INSTANCES.add(backupManager);
         return backupManager;
     }
 
@@ -120,7 +120,7 @@ public class BackupManager {
      * @param bibDatabaseContext Associated {@link BibDatabaseContext}
      */
     public static void discardBackup(BibDatabaseContext bibDatabaseContext, Path backupDir) {
-        runningInstances.stream().filter(instance -> instance.bibDatabaseContext == bibDatabaseContext).forEach(backupManager -> backupManager.discardBackup(backupDir));
+        RUNNING_INSTANCES.stream().filter(instance -> instance.bibDatabaseContext == bibDatabaseContext).forEach(backupManager -> backupManager.discardBackup(backupDir));
     }
 
     /**
@@ -131,8 +131,8 @@ public class BackupManager {
      * @param backupDir The path to the backup directory
      */
     public static void shutdown(BibDatabaseContext bibDatabaseContext, Path backupDir, boolean createBackup) {
-        runningInstances.stream().filter(instance -> instance.bibDatabaseContext == bibDatabaseContext).forEach(backupManager -> backupManager.shutdown(backupDir, createBackup));
-        runningInstances.removeIf(instance -> instance.bibDatabaseContext == bibDatabaseContext);
+        RUNNING_INSTANCES.stream().filter(instance -> instance.bibDatabaseContext == bibDatabaseContext).forEach(backupManager -> backupManager.shutdown(backupDir, createBackup));
+        RUNNING_INSTANCES.removeIf(instance -> instance.bibDatabaseContext == bibDatabaseContext);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/gui/autosaveandbackup/BackupManager.java
@@ -38,6 +38,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.event.BibDatabaseContextChangedEvent;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.BibtexString;
 import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.metadata.SelfContainedSaveOrder;
 
@@ -59,7 +60,7 @@ public class BackupManager {
 
     private static final int DELAY_BETWEEN_BACKUP_ATTEMPTS_IN_SECONDS = 19;
 
-    private static Set<BackupManager> runningInstances = new HashSet<>();
+    private static final Set<BackupManager> runningInstances = new HashSet<>();
 
     private final BibDatabaseContext bibDatabaseContext;
     private final CliPreferences preferences;
@@ -268,6 +269,9 @@ public class BackupManager {
                                                 .map(BibEntry.class::cast)
                                                 .toList();
         BibDatabase bibDatabaseClone = new BibDatabase(list);
+        bibDatabaseContext.getDatabase().getStringValues().stream().map(BibtexString::clone)
+                          .map(BibtexString.class::cast)
+                          .forEach(bibDatabaseClone::addString);
         BibDatabaseContext bibDatabaseContextClone = new BibDatabaseContext(bibDatabaseClone, bibDatabaseContext.getMetaData());
 
         Charset encoding = bibDatabaseContext.getMetaData().getEncoding().orElse(StandardCharsets.UTF_8);


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/12462

![grafik](https://github.com/user-attachments/assets/03b2a652-72db-4764-8fee-8f09b987e720)



### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
