### PR TITLE
CSL Styles: Fix parsing of reference marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef icon merges with dark background [#7771](https://github.com/JabRef/jabref/issues/7771)
 - We fixed an issue where an entry's group was no longer highlighted on selection [#12413](https://github.com/JabRef/jabref/issues/12413)
 - We fixed an issue where BibTeX Strings were not included in the backup file [#12462](https://github.com/JabRef/jabref/issues/12462)
+- We fixed an issue where CSL style citations with citation keys having special characters such as hyphens and colons would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef icon merges with dark background [#7771](https://github.com/JabRef/jabref/issues/7771)
 - We fixed an issue where an entry's group was no longer highlighted on selection [#12413](https://github.com/JabRef/jabref/issues/12413)
 - We fixed an issue where BibTeX Strings were not included in the backup file [#12462](https://github.com/JabRef/jabref/issues/12462)
-- We fixed an issue where CSL style citations with citation keys having special characters such as hyphens and colons would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
+- We fixed an issue where CSL style citations with citation keys having special characters (such as hyphens or colons) would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,8 +15,8 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_\\w+ CID_\\d+(?:, JABREF_\\w+ CID_\\d+)*) (\\w+)$");
-    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_(\\w+) CID_(\\w+)");
+    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w-:.]+ CID_\\d+(?:, JABREF_[\\w-:.]+ CID_\\d+)*) (\\w+)$");
+    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:.]+) CID_(\\d+)");
 
     private final String name;
     private List<String> citationKeys;

--- a/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
@@ -43,6 +43,12 @@ class ReferenceMarkTest {
                 Arguments.of(
                         "JABREF_key5 CID_11111, JABREF_key6 CID_22222, JABREF_key7 CID_33333 uniqueId4",
                         List.of("key5", "key6", "key7"), List.of(11111, 22222, 33333), "uniqueId4"
+                ),
+
+                // Non-standard citation key
+                Arguments.of(
+                        "JABREF_willberg-forssman:1997b CID_5 yov3b0su",
+                        List.of("willberg-forssman:1997b"), List.of(5), "yov3b0su"
                 )
         );
     }


### PR DESCRIPTION
Closes https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431

Fixed the regex for parsing of reference marks.
Made the format of valid reference marks more flexible to allow non-standard citation-keys having colons or hyphens, such as `willberg-forssman:1997b`.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
