### PR TITLE
Add confirmation for 'Copy to' with cross-reference status

### DIFF
--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -61,10 +61,10 @@ public class CopyTo extends SimpleCommand {
 
         if (includeCrossReferences) {
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
-            dialogService.notify(Localization.lang("Entry copied successfully, including cross-reference."));
+            dialogService.notify(Localization.lang("Entries copied successfully, including cross-references."));
         } else {
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);
-            dialogService.notify(Localization.lang("Entry copied successfully, no cross-reference included."));
+            dialogService.notify(Localization.lang("Entries copied successfully, without cross-references."));
         }
     }
 

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -61,8 +61,10 @@ public class CopyTo extends SimpleCommand {
 
         if (includeCrossReferences) {
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
+            dialogService.notify(Localization.lang("Entry copied successfully, including cross-reference."));
         } else {
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);
+            dialogService.notify(Localization.lang("Entry copied successfully, no cross-reference included."));
         }
     }
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2828,7 +2828,6 @@ File\ Move\ Errors=File Move Errors
 Could\ not\ move\ file\ %0.\ Please\ close\ this\ file\ and\ retry.=Could not move file %0. Please close this file and retry.
 
 Copy\ to=Copy to
-
 Include=Include
 Exclude=Exclude
 Include\ or\ exclude\ cross-referenced\ entries=Include or exclude cross-referenced entries

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2833,5 +2833,5 @@ Include=Include
 Exclude=Exclude
 Include\ or\ exclude\ cross-referenced\ entries=Include or exclude cross-referenced entries
 Would\ you\ like\ to\ include\ cross-reference\ entries\ in\ the\ current\ operation?=Would you like to include cross-reference entries in the current operation?
-Entry\ copied\ successfully,\ including\ cross-reference.=Entry copied successfully, including cross-reference.
-Entry\ copied\ successfully,\ no\ cross-reference\ included.=Entry copied successfully, no cross-reference included.
+Entries\ copied\ successfully,\ including\ cross-references.=Entries copied successfully, including cross-references.
+Entries\ copied\ successfully,\ without\ cross-references.=Entries copied successfully, without cross-references.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2828,7 +2828,10 @@ File\ Move\ Errors=File Move Errors
 Could\ not\ move\ file\ %0.\ Please\ close\ this\ file\ and\ retry.=Could not move file %0. Please close this file and retry.
 
 Copy\ to=Copy to
+
 Include=Include
 Exclude=Exclude
 Include\ or\ exclude\ cross-referenced\ entries=Include or exclude cross-referenced entries
 Would\ you\ like\ to\ include\ cross-reference\ entries\ in\ the\ current\ operation?=Would you like to include cross-reference entries in the current operation?
+Entry\ copied\ successfully,\ including\ cross-reference.=Entry copied successfully, including cross-reference.
+Entry\ copied\ successfully,\ no\ cross-reference\ included.=Entry copied successfully, no cross-reference included.


### PR DESCRIPTION
fixes #12486 

Add confirmation message after using "Copy to" option, also show whether the cross-reference entry was copied or not.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

Copy to with cross-reference included
![bandicam 2025-02-12 15-19-03-300 - frame at 0m18s](https://github.com/user-attachments/assets/4294e696-9281-4a12-beb8-1bebb4268cc2)
Copy to with cross-reference excluded 
![bandicam 2025-02-12 15-19-03-300 - frame at 0m8s](https://github.com/user-attachments/assets/5bd3a3a4-65a6-4883-9a57-f12d3120bd60)

