### PR TITLE
Bring back `authorsAlpha` citation key pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the user comments field visibility so that it remains displayed if it contains text. Additionally, users can now easily toggle the field on or off via buttons unless disabled in preferences. [#11021](https://github.com/JabRef/jabref/issues/11021)
 - The LibreOffice integration for CSL styles is now more performant. [#12472](https://github.com/JabRef/jabref/pull/12472)
 - The "automatically sync bibliography when citing" feature of the LibreOffice integration is now disabled by default (can be enabled in settings). [#12472](https://github.com/JabRef/jabref/pull/12472)
-- For the Citation key generator patterns, we reverted how `[authorsAlpha]` would behave to the original pattern and renamed the LNI-based pattern to `[authorsAlphaLNI]`. [#12499](https://github.com/JabRef/jabref/pull/12499)
+- For the Citation key generator patterns, we reverted how `[authorsAlpha]` would behave to the original pattern and renamed the LNI-based pattern introduced in V6.0-alpha to `[authorsAlphaLNI]`. [#12499](https://github.com/JabRef/jabref/pull/12499)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the user comments field visibility so that it remains displayed if it contains text. Additionally, users can now easily toggle the field on or off via buttons unless disabled in preferences. [#11021](https://github.com/JabRef/jabref/issues/11021)
 - The LibreOffice integration for CSL styles is now more performant. [#12472](https://github.com/JabRef/jabref/pull/12472)
 - The "automatically sync bibliography when citing" feature of the LibreOffice integration is now disabled by default (can be enabled in settings). [#12472](https://github.com/JabRef/jabref/pull/12472)
+- For the Citation key generator patterns, we reverted how `[authorsAlpha]` would behave to the original pattern and renamed the LNI-based pattern to `[authorsAlphaLNI]`. [#12499](https://github.com/JabRef/jabref/pull/12499)
 
 ### Fixed
 
@@ -39,6 +40,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where mixing JStyle and CSL style citations in LibreOffice caused two separate bibliography sections to be generated. [#12262](https://github.com/JabRef/jabref/issues/12262)
 - We fixed an issue in the LibreOffice integration where the formatting of text (e.g. superscript) was lost when using certain numeric CSL styles. [melting-pot#772](https://github.com/JabRef/jabref-issue-melting-pot/issues/772)
 - We fixed an issue where CSL style citations with citation keys having special characters (such as hyphens or colons) would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
+- We fixed an issue where the `[authorsAlpha]` pattern in Citation key generator would not behave as per the user documentation. [#12312](https://github.com/JabRef/jabref/issues/12312)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -359,6 +359,8 @@ public class BracketedPattern {
                         return allAuthors(authorList);
                     case "authorsAlpha":
                         return authorsAlpha(authorList);
+                    case "authorsAlphaV2":
+                        return authorsAlphaV2(authorList);
                     case "authorLast":
                         return lastAuthor(authorList);
                     case "authorLastForeIni":
@@ -849,6 +851,61 @@ public class BracketedPattern {
      * @return the initials of all authors' names
      */
     public static String authorsAlpha(AuthorList authorList) {
+        StringBuilder alphaStyle = new StringBuilder();
+        int maxAuthors;
+        final boolean maxAuthorsExceeded;
+        if (authorList.getNumberOfAuthors() <= MAX_ALPHA_AUTHORS) {
+            maxAuthors = authorList.getNumberOfAuthors();
+            maxAuthorsExceeded = false;
+        } else {
+            maxAuthors = MAX_ALPHA_AUTHORS - 1;
+            maxAuthorsExceeded = true;
+        }
+
+        if (authorList.getNumberOfAuthors() == 1) {
+            String[] firstAuthor = authorList.getAuthor(0).getNamePrefixAndFamilyName()
+                                             .replaceAll("\\s+", " ").trim().split(" ");
+            // take first letter of any "prefixes" (e.g. van der Aalst -> vd)
+            for (int j = 0; j < (firstAuthor.length - 1); j++) {
+                alphaStyle.append(firstAuthor[j], 0, 1);
+            }
+            // append last part of last name completely
+            alphaStyle.append(firstAuthor[firstAuthor.length - 1], 0,
+                    Math.min(3, firstAuthor[firstAuthor.length - 1].length()));
+        } else {
+            boolean andOthersPresent = authorList.getAuthor(maxAuthors - 1).equals(Author.OTHERS);
+            if (andOthersPresent) {
+                maxAuthors--;
+            }
+            List<String> vonAndLastNames = authorList.getAuthors().stream()
+                                                     .limit(maxAuthors)
+                                                     .map(Author::getNamePrefixAndFamilyName)
+                                                     .toList();
+            for (String vonAndLast : vonAndLastNames) {
+                // replace all whitespaces by " "
+                // split the lastname at " "
+                String[] nameParts = vonAndLast.replaceAll("\\s+", " ").trim().split(" ");
+                for (String part : nameParts) {
+                    // use first character of each part of lastname
+                    alphaStyle.append(part, 0, 1);
+                }
+            }
+            if (andOthersPresent || maxAuthorsExceeded) {
+                alphaStyle.append("+");
+            }
+        }
+        return alphaStyle.toString();
+    }
+
+    /**
+     * Returns the authors according to the <a href="https://github.com/michel-kraemer/citeproc-java">BibTeX LNI template</a>
+     * Examples: <a href="https://github.com/gi-ev/biblatex-lni/blob/main/basic-test-en.tex">Examples from the tmplate</a>
+     * Also see discussion at the <a href="https://github.com/JabRef/jabref/pull/11614">pull request that introduced this</a>.
+     *
+     * @param authorList an {@link AuthorList}
+     * @return the initials of all authors' names
+     */
+    public static String authorsAlphaV2(AuthorList authorList) {
         StringBuilder alphaStyle = new StringBuilder();
         int numberOfAuthors = authorList.getNumberOfAuthors();
         boolean andOthersPresent = numberOfAuthors > 1 &&

--- a/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -359,8 +359,8 @@ public class BracketedPattern {
                         return allAuthors(authorList);
                     case "authorsAlpha":
                         return authorsAlpha(authorList);
-                    case "authorsAlphaV2":
-                        return authorsAlphaV2(authorList);
+                    case "authorsAlphaLNI":
+                        return authorsAlphaLNI(authorList);
                     case "authorLast":
                         return lastAuthor(authorList);
                     case "authorLastForeIni":
@@ -905,7 +905,7 @@ public class BracketedPattern {
      * @param authorList an {@link AuthorList}
      * @return the initials of all authors' names
      */
-    public static String authorsAlphaV2(AuthorList authorList) {
+    public static String authorsAlphaLNI(AuthorList authorList) {
         StringBuilder alphaStyle = new StringBuilder();
         int numberOfAuthors = authorList.getNumberOfAuthors();
         boolean andOthersPresent = numberOfAuthors > 1 &&

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -100,7 +100,7 @@ public class CSLFormatUtils {
 
             if (author.isPresent() && year.isPresent()) {
                 AuthorList authorList = AuthorList.parse(author.get());
-                String alphaKey = BracketedPattern.authorsAlphaV2(authorList);
+                String alphaKey = BracketedPattern.authorsAlphaLNI(authorList);
 
                 // Extract last two digits of the year
                 String shortYear = year.get().length() >= 2 ?

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLFormatUtils.java
@@ -100,7 +100,7 @@ public class CSLFormatUtils {
 
             if (author.isPresent() && year.isPresent()) {
                 AuthorList authorList = AuthorList.parse(author.get());
-                String alphaKey = BracketedPattern.authorsAlpha(authorList);
+                String alphaKey = BracketedPattern.authorsAlphaV2(authorList);
 
                 // Extract last two digits of the year
                 String shortYear = year.get().length() >= 2 ?

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -95,7 +95,7 @@ class BracketedPatternTest {
         assertEquals(expected, BracketedPattern.authorsAlpha(list));
     }
 
-    static Stream<Arguments> authorsAlphaV2() {
+    static Stream<Arguments> authorsAlphaLNI() {
         return Stream.of(
                 Arguments.of("Ar", "Alexander Artemenko and others"),
                 Arguments.of("Aa", "Aachen and others"),
@@ -122,8 +122,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authorsAlphaV2(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authorsAlphaV2(list));
+    void authorsAlphaLNI(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authorsAlphaLNI(list));
     }
 
     /**
@@ -340,7 +340,7 @@ class BracketedPatternTest {
             "'New', '[auth3_1]', 'Isaac Newton'",
             "'Newton', '[authshort]', 'Isaac Newton'",
             "'New', '[authorsAlpha]', 'Isaac Newton'",
-            "'Ne', '[authorsAlphaV2]', 'Isaac Newton'",
+            "'Ne', '[authorsAlphaLNI]', 'Isaac Newton'",
             "'Newton', '[authorLast]', 'Isaac Newton'",
             "'I', '[authorLastForeIni]', 'Isaac Newton'",
 

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -68,7 +68,8 @@ class BracketedPatternTest {
                 Arguments.of("AachenBerlinChemnitzDüsseldorf", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("AachenBerlinChemnitzDüsseldorfEtAl", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("AachenBerlinChemnitzDüsseldorfEssen", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("AachenBerlinChemnitzDüsseldorfEssenEtAl", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("AachenBerlinChemnitzDüsseldorfEssenEtAl", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -86,7 +87,8 @@ class BracketedPatternTest {
                 Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -146,7 +148,8 @@ class BracketedPatternTest {
                 Arguments.of("AacheBCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("AacheBCD+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("AacheBCDE", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("AacheBCDE+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("AacheBCDE+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -170,7 +173,8 @@ class BracketedPatternTest {
                 Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -194,7 +198,8 @@ class BracketedPatternTest {
                 Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("A", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -219,7 +224,8 @@ class BracketedPatternTest {
                 Arguments.of("AB", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("AB", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("AB", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("AB", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("AB", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -244,7 +250,8 @@ class BracketedPatternTest {
                 Arguments.of("ABC", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("ABC", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("ABC", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("ABC", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("ABC", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -268,7 +275,8 @@ class BracketedPatternTest {
                 Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -292,7 +300,8 @@ class BracketedPatternTest {
                 Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("Aachen.etal", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest
@@ -316,7 +325,8 @@ class BracketedPatternTest {
                 Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf"),
                 Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
                 Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
-                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+                Arguments.of("Aachen.Berlin.ea", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others")
+        );
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -79,6 +79,24 @@ class BracketedPatternTest {
 
     static Stream<Arguments> authorsAlpha() {
         return Stream.of(
+                Arguments.of("A+", "Alexander Artemenko and others"),
+                Arguments.of("A+", "Aachen and others"),
+                Arguments.of("AB+", "Aachen and Berlin and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and others"),
+                Arguments.of("ABCD", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and others"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("ABC+", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen and others"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authorsAlpha(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authorsAlpha(list));
+    }
+
+    static Stream<Arguments> authorsAlphaV2() {
+        return Stream.of(
                 Arguments.of("Ar", "Alexander Artemenko and others"),
                 Arguments.of("Aa", "Aachen and others"),
                 Arguments.of("Aa", "Aachen and Berlin and others"),
@@ -104,8 +122,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authorsAlpha(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authorsAlpha(list));
+    void authorsAlphaV2(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authorsAlphaV2(list));
     }
 
     /**
@@ -321,7 +339,8 @@ class BracketedPatternTest {
             "'New', '[auth3]', 'Isaac Newton'",
             "'New', '[auth3_1]', 'Isaac Newton'",
             "'Newton', '[authshort]', 'Isaac Newton'",
-            "'Ne', '[authorsAlpha]', 'Isaac Newton'",
+            "'New', '[authorsAlpha]', 'Isaac Newton'",
+            "'Ne', '[authorsAlphaV2]', 'Isaac Newton'",
             "'Newton', '[authorLast]', 'Isaac Newton'",
             "'I', '[authorLastForeIni]', 'Isaac Newton'",
 

--- a/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -67,6 +67,7 @@ class CitationKeyGeneratorTest {
     private static final String AUTHFOREINI = "[authForeIni]";
     private static final String AUTHFIRSTFULL = "[authFirstFull]";
     private static final String AUTHORSALPHA = "[authorsAlpha]";
+    private static final String AUTHORSALPHALNI = "[authorsAlphaLNI]";
     private static final String AUTHORLAST = "[authorLast]";
     private static final String AUTHORLASTFOREINI = "[authorLastForeIni]";
     private static final String AUTHORINI = "[authorIni]";
@@ -510,14 +511,33 @@ class CitationKeyGeneratorTest {
 
     static Stream<Arguments> authorsAlpha() {
         return Stream.of(
-                Arguments.of("Ne", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORSALPHA),
+                Arguments.of("New", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORSALPHA),
                 Arguments.of("NM", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORSALPHA),
                 Arguments.of("NME", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORSALPHA),
                 Arguments.of("NMEB", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHORSALPHA),
-                Arguments.of("NMEB", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORSALPHA),
-                Arguments.of("Aa", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORSALPHA),
-                Arguments.of("AL", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORSALPHA),
-                Arguments.of("Ne", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3, AUTHORSALPHA)
+                Arguments.of("NME+", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORSALPHA),
+                Arguments.of("vdAal", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORSALPHA),
+                Arguments.of("vdAvL", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORSALPHA),
+                Arguments.of("NM+", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3, AUTHORSALPHA)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authorsAlphaLNI(String expected, BibEntry entry, String pattern) {
+        assertEquals(expected, generateKey(entry, pattern));
+    }
+
+    static Stream<Arguments> authorsAlphaLNI() {
+        return Stream.of(
+                Arguments.of("Ne", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORSALPHALNI),
+                Arguments.of("NM", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORSALPHALNI),
+                Arguments.of("NME", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORSALPHALNI),
+                Arguments.of("NMEB", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHORSALPHALNI),
+                Arguments.of("NMEB", AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORSALPHALNI),
+                Arguments.of("Aa", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORSALPHALNI),
+                Arguments.of("AL", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORSALPHALNI),
+                Arguments.of("Ne", AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_AND_OTHERS_COUNT_3, AUTHORSALPHALNI)
         );
     }
 


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12312

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
