### PR TITLE
Fix: Usage of "Copy to" option preference

### DIFF
--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -59,7 +59,7 @@ public class CopyTo extends SimpleCommand {
             }
         }
 
-        if (includeCrossReferences) {
+        if (copyToPreferences.getShouldIncludeCrossReferences()) {
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
         } else {
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -49,7 +49,7 @@ public class CopyTo extends SimpleCommand {
         // we need to operate on a copy otherwise we might get ConcurrentModification issues
         List<BibEntry> selectedEntries = stateManager.getSelectedEntries().stream().toList();
 
-        boolean includeCrossReferences = false;
+        boolean includeCrossReferences = copyToPreferences.getShouldIncludeCrossReferences();
         boolean showDialogBox = copyToPreferences.getShouldAskForIncludingCrossReferences();
 
         for (BibEntry bibEntry : selectedEntries) {
@@ -59,7 +59,7 @@ public class CopyTo extends SimpleCommand {
             }
         }
 
-        if (copyToPreferences.getShouldIncludeCrossReferences()) {
+        if (includeCrossReferences) {
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
         } else {
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -56,6 +56,7 @@ public class CopyTo extends SimpleCommand {
             if (bibEntry.hasField(StandardField.CROSSREF) && showDialogBox) {
                 includeCrossReferences = askForCrossReferencedEntries();
                 copyToPreferences.setShouldIncludeCrossReferences(includeCrossReferences);
+                break;
             }
         }
 


### PR DESCRIPTION
### Fixes #12500

This fix ensures that the "Copy to" option follows the chosen preference correctly.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.


https://github.com/user-attachments/assets/93a6dde8-776a-4b80-94df-4f779d10843c