### PR TITLE
Fix remove redundant columns from consistency check table

### DIFF
--- a/.github/workflows/product-map.yml
+++ b/.github/workflows/product-map.yml
@@ -1,0 +1,31 @@
+name: Product Map Generation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  generate-map:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Get changed Java files
+        id: changed-files
+        run: |
+          FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- '*.java' | sed 's|^|\"|' | sed 's|$|\"|' | paste -sd "," -)
+          if [ -z "$FILES" ]; then FILES="\"dummy.java\""; fi
+          echo "expected_files=(${FILES})" >> $GITHUB_ENV
+
+      - name: ProductMap Map Generation
+        uses: product-map/product-map-action@v1.0.15
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          expected_files: ${{ env.expected_files }}
+          user_email: koppdev@gmail.com

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -140,7 +140,6 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
                  default:
                      break;
              }
-            removeColumnWithUniformValue(symbol.getText());
         }
          for (Field field: SpecialField.values()) {
             removeColumnByTitle(field.getDisplayName());

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.consistency;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +25,6 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
 import org.jabref.logic.quality.consistency.ConsistencyMessage;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.SpecialField;
 
 import com.airhacks.afterburner.views.ViewLoader;
@@ -139,9 +139,9 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
             removeColumnWithUniformValue(symbol.getText());
         }
 
-        for (Field field: SpecialField.values()) {
-            removeColumnByTitle(field.getDisplayName());
-        }
+        Arrays.stream(SpecialField.values())
+                      .map(SpecialField::getDisplayName)
+                      .forEach(this::removeColumnByTitle);
     }
 
     private void removeColumnWithUniformValue(String symbol) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -137,12 +137,11 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
         targetSymbols.stream()
             .map(ConsistencySymbol::getText)
-            .forEach(removeColumnWithUniformValue);
-        }
+            .forEach(this::removeColumnWithUniformValue);
 
         Arrays.stream(SpecialField.values())
-                      .map(SpecialField::getDisplayName)
-                      .forEach(this::removeColumnByTitle);
+              .map(SpecialField::getDisplayName)
+              .forEach(this::removeColumnByTitle);
     }
 
     private void removeColumnWithUniformValue(String symbol) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -105,7 +105,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
                 return new ReadOnlyStringWrapper(message.get(columnIndex));
             });
 
-            tableColumn.setCellFactory(column -> new TableCell<ConsistencyMessage, String>() {
+            tableColumn.setCellFactory(_ -> new TableCell<>() {
                 @Override
                 protected void updateItem(String item, boolean empty) {
                     super.updateItem(item, empty);
@@ -118,12 +118,12 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
                     ConsistencySymbol.fromText(item)
                                      .ifPresentOrElse(
-                                              symbol -> setGraphic(symbol.getIcon().getGraphicNode()),
-                                              () -> {
-                                                  setGraphic(null);
-                                                  setText(item);
-                                              }
-                                      );
+                                             symbol -> setGraphic(symbol.getIcon().getGraphicNode()),
+                                             () -> {
+                                                 setGraphic(null);
+                                                 setText(item);
+                                             }
+                                     );
                 }
             });
 
@@ -148,13 +148,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
         List<TableColumn<ConsistencyMessage, ?>> columnToRemove = tableView.getColumns().stream()
                                                                            .filter(column -> {
                                                                                Set<String> values = tableView.getItems().stream()
-                                                                                                             .map(item -> {
-                                                                                                                 Optional<Object> value = Optional.ofNullable(column.getCellObservableValue(item).getValue());
-                                                                                                                 if (value.isPresent()) {
-                                                                                                                     return value.toString();
-                                                                                                                 }
-                                                                                                                 return "";
-                                                                                                             })
+                                                                                                             .map(item -> Optional.ofNullable(column.getCellObservableValue(item).getValue()).map(Object::toString).orElse(""))
                                                                                                              .collect(Collectors.toSet());
                                                                                return values.size() == 1 && values.contains(symbol);
                                                                            })

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.consistency;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -129,19 +130,16 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
             tableView.getColumns().add(tableColumn);
         }
 
-          for (ConsistencySymbol symbol: ConsistencySymbol.values()) {
-             switch (symbol) {
-                 case ConsistencySymbol.OPTIONAL_FIELD_AT_ENTRY_TYPE_CELL_ENTRY:
-                     removeColumnWithUniformValue(ConsistencySymbol.OPTIONAL_FIELD_AT_ENTRY_TYPE_CELL_ENTRY.getText());
-                     break;
-                 case ConsistencySymbol.REQUIRED_FIELD_AT_ENTRY_TYPE_CELL_ENTRY:
-                     removeColumnWithUniformValue(ConsistencySymbol.REQUIRED_FIELD_AT_ENTRY_TYPE_CELL_ENTRY.getText());
-                     break;
-                 default:
-                     break;
-             }
+        EnumSet<ConsistencySymbol> targetSymbols = EnumSet.of(
+                ConsistencySymbol.OPTIONAL_FIELD_AT_ENTRY_TYPE_CELL_ENTRY,
+                ConsistencySymbol.REQUIRED_FIELD_AT_ENTRY_TYPE_CELL_ENTRY
+        );
+
+        for (ConsistencySymbol symbol : targetSymbols) {
+            removeColumnWithUniformValue(symbol.getText());
         }
-         for (Field field: SpecialField.values()) {
+
+        for (Field field: SpecialField.values()) {
             removeColumnByTitle(field.getDisplayName());
         }
     }


### PR DESCRIPTION
### Follow-up for #12433 

This PR ensures that columns for JabRef specific fields like ranking, read status, and more are not included in the table. Additionally, it removes redundant columns where the entire column represents there is an optional or required field is present

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

![Screenshot (113)](https://github.com/user-attachments/assets/0ddd36d8-c7d8-4bd4-ac7b-711a3f8ec7d9)

Removed
![Screenshot (112)](https://github.com/user-attachments/assets/87c0f548-c607-40a8-8f0c-d18da2253c84)
