### PR TITLE
Fix Citationkey pattern dropdown UI issue

### DIFF
--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
@@ -98,7 +98,7 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
         }
 
         private void populatePopup(List<String> searchResult) {
-            int heightOfMenuItem = 30; // Height of menu item
+            int heightOfMenuItem = 30; 
             List<CustomMenuItem> menuItems = new ArrayList<>();
 
             double space = getAvailableSpaceBelow(this);

--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javafx.geometry.Bounds;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.CustomMenuItem;
 import javafx.scene.control.Label;
@@ -12,6 +13,7 @@ import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
 import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.stage.Window;
 
 import org.jabref.logic.citationkeypattern.CitationKeyPattern;
 import org.jabref.logic.l10n.Localization;
@@ -57,9 +59,6 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
     }
 
     static class CitationKeyPatternSuggestionTextField extends TextField {
-        // Maximum number of entries that can be displayed in the popup menu.
-        private static final int MAX_ENTRIES = 7;
-
         private final List<String> citationKeyPatterns;
         private final ContextMenu suggestionsList;
 
@@ -99,8 +98,13 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
         }
 
         private void populatePopup(List<String> searchResult) {
+            int heightOfMenuItem = 30; // Height of menu item
             List<CustomMenuItem> menuItems = new ArrayList<>();
-            int count = Math.min(searchResult.size(), MAX_ENTRIES);
+
+            double space = getAvailableSpaceBelow(this);
+            int maxItems = (int) (space / heightOfMenuItem) - 1;
+
+            int count = Math.min(searchResult.size(), maxItems);
 
             for (int i = 0; i < count; i++) {
                 final String result = searchResult.get(i);
@@ -126,6 +130,23 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
             if (!menuItems.isEmpty()) {
                 menuItems.getFirst().getContent().requestFocus();
             }
+        }
+
+        public static double getAvailableSpaceBelow(TextField textField) {
+            if (textField.getScene() == null || textField.getScene().getWindow() == null) {
+                return 0;
+            }
+
+            Window window = textField.getScene().getWindow();
+            if (window == null) {
+                return 0;
+            }
+
+            Bounds bounds = textField.localToScreen(textField.getBoundsInLocal());
+            double screenHeight = window.getHeight();
+            double textFieldBottom = bounds.getMinY() + textField.getHeight();
+
+            return screenHeight - (textFieldBottom - window.getY());
         }
 
         private Menu createPatternsSubMenu() {

--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
@@ -126,7 +126,7 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
             }
 
             if (!menuItems.isEmpty()) {
-                Platform.runLater(() -> heightOfMenuItem = (int) menuItems.get(0).getContent().getBoundsInLocal().getHeight());
+                Platform.runLater(() -> heightOfMenuItem = (int) menuItems.getFirst().getContent().getBoundsInLocal().getHeight());
             }
 
             suggestionsList.getItems().clear();

--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javafx.application.Platform;
 import javafx.geometry.Bounds;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.CustomMenuItem;
@@ -61,10 +62,12 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
     static class CitationKeyPatternSuggestionTextField extends TextField {
         private final List<String> citationKeyPatterns;
         private final ContextMenu suggestionsList;
+        private int heightOfMenuItem;
 
         public CitationKeyPatternSuggestionTextField(List<String> citationKeyPatterns) {
             this.citationKeyPatterns = new ArrayList<>(citationKeyPatterns);
             this.suggestionsList = new ContextMenu();
+            this.heightOfMenuItem = 30;
 
             setListener();
         }
@@ -98,7 +101,6 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
         }
 
         private void populatePopup(List<String> searchResult) {
-            int heightOfMenuItem = 30; 
             List<CustomMenuItem> menuItems = new ArrayList<>();
 
             double space = getAvailableSpaceBelow(this);
@@ -121,6 +123,10 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
                     positionCaret(result.length());
                     suggestionsList.hide();
                 });
+            }
+
+            if (!menuItems.isEmpty()) {
+                Platform.runLater(() -> heightOfMenuItem = (int) menuItems.get(0).getContent().getBoundsInLocal().getHeight());
             }
 
             suggestionsList.getItems().clear();

--- a/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
+++ b/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternSuggestionCell.java
@@ -67,6 +67,7 @@ public class CitationKeyPatternSuggestionCell extends TextFieldTableCell<Citatio
         public CitationKeyPatternSuggestionTextField(List<String> citationKeyPatterns) {
             this.citationKeyPatterns = new ArrayList<>(citationKeyPatterns);
             this.suggestionsList = new ContextMenu();
+            // Initial reasonable estimate before the menu items are populated. We overwrite this dynamically
             this.heightOfMenuItem = 30;
 
             setListener();


### PR DESCRIPTION
### Follow up for #12516

Issue: The added dropdown has an issue, it shifts upwards when it reaches the bottom of the screen due to the default behavior of Context Menu in JavaFX.

This PR ensures that the dropdown is properly positioned and dynamically adjusts its height based on the available space. 

Additionally, the "All patterns" submenu is always shown when displaying the suggestions list is not possible, ensuring that the  UX is not compromised.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

### Before 
![Screenshot (132)](https://github.com/user-attachments/assets/47716f97-c219-419c-b168-8ada246a7f5b)

### After 
![Screenshot (134)](https://github.com/user-attachments/assets/8e45b078-21f8-4787-8e4d-6f0cd6e12bfd)
![Screenshot (135)](https://github.com/user-attachments/assets/110006ff-b47e-45b6-be10-37cc3d992feb)


