### PR TITLE
Include PubMed labels in abstract at import (closes #12527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The "automatically sync bibliography when citing" feature of the LibreOffice integration is now disabled by default (can be enabled in settings). [#12472](https://github.com/JabRef/jabref/pull/12472)
 - For the Citation key generator patterns, we reverted how `[authorsAlpha]` would behave to the original pattern and renamed the LNI-based pattern introduced in V6.0-alpha to `[authorsAlphaLNI]`. [#12499](https://github.com/JabRef/jabref/pull/12499)
 - We keep the list of recent files if one files could not be found. [#12517](https://github.com/JabRef/jabref/pull/12517)
+- During the import process, the labels indicating individual paragraphs within an abstract returned by PubMed/Medline XML are preserved. [#12527](https://github.com/JabRef/jabref/issues/12527)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -1033,7 +1033,7 @@ public class MedlineImporter extends Importer implements Parser {
         StringBuilder result = new StringBuilder();
         Optional.ofNullable(reader.getAttributeValue(null, "Label"))
                 .map(String::trim)
-                .filter(label -> !label.isEmpty() && !label.equals("UNLABELLED"))
+                .filter(label -> !label.isEmpty() && !"UNLABELLED".equals(label))
                 .ifPresent(label -> result.append(label).append(": "));
         handleText(reader, textList, startElement, result);
     }
@@ -1117,7 +1117,7 @@ public class MedlineImporter extends Importer implements Parser {
             reader.next();
             if (isStartXMLEvent(reader)) {
                 String elementName = reader.getName().getLocalPart();
-                if (elementName.equals("Author")) {
+                if ("Author".equals(elementName)) {
                     parseAuthor(reader, authorNames);
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -18,7 +18,6 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.events.XMLEvent;
 
 import org.jabref.logic.importer.Importer;
 import org.jabref.logic.importer.ParseException;
@@ -1000,7 +999,6 @@ public class MedlineImporter extends Importer implements Parser {
                         }
                     }
                     case "AbstractText" -> handleAbstractTextElement(reader, abstractTextList, elementName);
-
                 }
             }
 

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MedlineImporterTestNbib.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MedlineImporterTestNbib.bib
@@ -1,5 +1,7 @@
 @article{,
-  abstract = {Just a dummy text. And another dummy},
+  abstract = {BACKGROUND: Just a dummy text.
+
+And another dummy},
   affiliation = {Vanderbilt U, Nashville, TN},
   author = {Gibb, F W and Zamm itt, NaN and Beckett, G and Strachan, M W J},
   chemicals = {Iodine Radioisotopes, Thyroxine},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MedlineImporterTestNbib.xml
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MedlineImporterTestNbib.xml
@@ -261,7 +261,7 @@
         <PublicationType UI="D016454">Review</PublicationType>
         <PublicationType UI="D017065">Practice Guideline</PublicationType>
         <Abstract>
-            <AbstractText>just a dummy.</AbstractText>
+            <AbstractText Label="UNLABELLED">just a dummy.</AbstractText>
             <CopyrightInformation>Copyright from somwhere</CopyrightInformation>
         </Abstract>
         <Sections>


### PR DESCRIPTION
During the import process, the labels indicating individual paragraphs within an abstract returned by PubMed/Medline XML are preserved. Closes #12527. Also complexity of some methodes is reduced.

### Example
![Example](https://github.com/user-attachments/assets/de813b2d-db00-48db-ad62-57bacf60c771)


### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
