### PR TITLE
Add rename subgroup option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added a feature to rename the subgroup, with the keybinding (F2) for quick access. [#11896](https://github.com/JabRef/jabref/issues/11896)
+- We added a feature to rename the subgroup, with the keybinding (<kbd>F2</kbd>) for quick access. [#11896](https://github.com/JabRef/jabref/issues/11896)
 - We added a new functionality that displays a drop-down list of matching suggestions when typing a citation key pattern. [#12502](https://github.com/JabRef/jabref/issues/12502)
 - We added a new CLI that supports txt, csv, and console-based output for consistency in BibTeX entries. [#11984](https://github.com/JabRef/jabref/issues/11984)
 - We added a new dialog for bibliography consistency check. [#11950](https://github.com/JabRef/jabref/issues/11950)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added an option to rename the subgroup, with the keybinding (F2) for quick access. [#11896](https://github.com/JabRef/jabref/issues/11896)
+- We added a feature to rename the subgroup, with the keybinding (F2) for quick access. [#11896](https://github.com/JabRef/jabref/issues/11896)
 - We added a new functionality that displays a drop-down list of matching suggestions when typing a citation key pattern. [#12502](https://github.com/JabRef/jabref/issues/12502)
 - We added a new CLI that supports txt, csv, and console-based output for consistency in BibTeX entries. [#11984](https://github.com/JabRef/jabref/issues/11984)
 - We added a new dialog for bibliography consistency check. [#11950](https://github.com/JabRef/jabref/issues/11950)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added an option to rename the subgroup, with the keybinding (F2) for quick access. [#11896](https://github.com/JabRef/jabref/issues/11896)
 - We added a new functionality that displays a drop-down list of matching suggestions when typing a citation key pattern. [#12502](https://github.com/JabRef/jabref/issues/12502)
 - We added a new CLI that supports txt, csv, and console-based output for consistency in BibTeX entries. [#11984](https://github.com/JabRef/jabref/issues/11984)
 - We added a new dialog for bibliography consistency check. [#11950](https://github.com/JabRef/jabref/issues/11950)

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -198,13 +198,13 @@ public enum StandardActions implements Action {
     GROUP_GENERATE_SUMMARIES(Localization.lang("Generate summaries for entries in the group")),
     GROUP_GENERATE_EMBEDDINGS(Localization.lang("Generate embeddings for linked files in the group")),
     GROUP_SUBGROUP_ADD(Localization.lang("Add subgroup")),
-    GROUP_SUBGROUP_RENAME(Localization.lang("Rename subgroup"), KeyBinding.GROUP_SUBGROUP_RENAME),
     GROUP_SUBGROUP_REMOVE(Localization.lang("Remove subgroups")),
     GROUP_SUBGROUP_SORT(Localization.lang("Sort subgroups A-Z")),
     GROUP_SUBGROUP_SORT_REVERSE(Localization.lang("Sort subgroups Z-A")),
     GROUP_SUBGROUP_SORT_ENTRIES(Localization.lang("Sort subgroups by # of entries (Descending)")),
     GROUP_SUBGROUP_SORT_ENTRIES_REVERSE(Localization.lang("Sort subgroups by # of entries (Ascending)")),
     GROUP_ENTRIES_ADD(Localization.lang("Add selected entries to this group")),
+    GROUP_SUBGROUP_RENAME(Localization.lang("Rename subgroup"), KeyBinding.GROUP_SUBGROUP_RENAME),
     GROUP_ENTRIES_REMOVE(Localization.lang("Remove selected entries from this group")),
 
     CLEAR_EMBEDDINGS_CACHE(Localization.lang("Clear embeddings cache"));

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -198,6 +198,7 @@ public enum StandardActions implements Action {
     GROUP_GENERATE_SUMMARIES(Localization.lang("Generate summaries for entries in the group")),
     GROUP_GENERATE_EMBEDDINGS(Localization.lang("Generate embeddings for linked files in the group")),
     GROUP_SUBGROUP_ADD(Localization.lang("Add subgroup")),
+    GROUP_SUBGROUP_RENAME(Localization.lang("Rename subgroup"), KeyBinding.GROUP_SUBGROUP_RENAME),
     GROUP_SUBGROUP_REMOVE(Localization.lang("Remove subgroups")),
     GROUP_SUBGROUP_SORT(Localization.lang("Sort subgroups A-Z")),
     GROUP_SUBGROUP_SORT_REVERSE(Localization.lang("Sort subgroups Z-A")),

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -11,6 +11,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.IntegerBinding;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -59,7 +60,7 @@ import io.github.adr.linked.ADR;
 
 public class GroupNodeViewModel {
 
-    private final String displayName;
+    private final SimpleObjectProperty<String> displayName;
     private final boolean isRoot;
     private final ObservableList<GroupNodeViewModel> children;
     private final BibDatabaseContext databaseContext;
@@ -87,7 +88,7 @@ public class GroupNodeViewModel {
         this.localDragBoard = Objects.requireNonNull(localDragBoard);
         this.preferences = preferences;
 
-        displayName = new LatexToUnicodeFormatter().format(groupNode.getName());
+        displayName = new SimpleObjectProperty<>(new LatexToUnicodeFormatter().format(groupNode.getName()));
         isRoot = groupNode.isRoot();
         if (groupNode.getGroup() instanceof AutomaticGroup automaticGroup) {
             children = automaticGroup.createSubgroups(this.databaseContext.getDatabase().getEntries())
@@ -175,7 +176,11 @@ public class GroupNodeViewModel {
     }
 
     public String getDisplayName() {
-        return displayName;
+        return displayName.get();
+    }
+
+    public void setDisplayName(String newName) {
+        displayName.set(newName);
     }
 
     public boolean isRoot() {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -87,6 +87,7 @@ public class GroupTreeView extends BorderPane {
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> mainColumn;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> numberColumn;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> expansionNodeColumn;
+    private TreeTableRow<GroupNodeViewModel> row;
     private CustomTextField searchField;
     private GroupTreeViewModel viewModel;
     private CustomLocalDragboard localDragboard;
@@ -204,6 +205,17 @@ public class GroupTreeView extends BorderPane {
                 .withText(GroupNodeViewModel::getDisplayName)
                 .withIcon(GroupNodeViewModel::getIcon)
                 .withTooltip(GroupNodeViewModel::getDescription)
+                .withOnMouseClickedEvent(group -> event -> {
+                    if (event.getButton() == MouseButton.PRIMARY) {
+                        Node node = (Node) event.getTarget();
+                        while (node != null && !(node instanceof TreeTableRow)) {
+                            node = node.getParent();
+                        }
+                        if (node instanceof TreeTableRow) {
+                            row = (TreeTableRow<GroupNodeViewModel>) node;
+                        }
+                    }
+                })
                 .install(mainColumn);
 
         // Number of hits (only if user wants to see them)
@@ -555,6 +567,7 @@ public class GroupTreeView extends BorderPane {
                 removeGroup,
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_ADD, new ContextAction(StandardActions.GROUP_SUBGROUP_ADD, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_RENAME, new ContextAction(StandardActions.GROUP_SUBGROUP_RENAME, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_REMOVE, new ContextAction(StandardActions.GROUP_SUBGROUP_REMOVE, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
@@ -639,6 +652,8 @@ public class GroupTreeView extends BorderPane {
                         case GROUP_SUBGROUP_ADD ->
                                 group.isEditable() && group.canAddGroupsIn()
                                         || group.isRoot();
+                        case GROUP_SUBGROUP_RENAME ->
+                            group.isEditable();
                         case GROUP_SUBGROUP_REMOVE ->
                                 group.isEditable() && group.hasSubgroups() && group.canRemove()
                                         || group.isRoot();
@@ -685,6 +700,8 @@ public class GroupTreeView extends BorderPane {
                         viewModel.sortReverseEntriesRecursive(group.getGroupNode());
                 case GROUP_ENTRIES_ADD ->
                         viewModel.addSelectedEntries(group);
+                case GROUP_SUBGROUP_RENAME ->
+                        viewModel.renameSubgroups(row);
                 case GROUP_ENTRIES_REMOVE ->
                         viewModel.removeSelectedEntries(group);
             }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -48,6 +48,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.search.SearchTextField;
 import org.jabref.gui.util.BindingsHelper;
@@ -82,6 +83,7 @@ public class GroupTreeView extends BorderPane {
     private final AiService aiService;
     private final TaskExecutor taskExecutor;
     private final GuiPreferences preferences;
+    private final KeyBindingRepository keyBindingRepository;
 
     private TreeTableView<GroupNodeViewModel> groupTree;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> mainColumn;
@@ -112,13 +114,14 @@ public class GroupTreeView extends BorderPane {
         this.preferences = preferences;
         this.dialogService = dialogService;
         this.aiService = aiService;
+        this.keyBindingRepository = preferences.getKeyBindingRepository();
 
         createNodes();
         initialize();
     }
 
     private void createNodes() {
-        searchField = SearchTextField.create(preferences.getKeyBindingRepository());
+        searchField = SearchTextField.create(keyBindingRepository);
         searchField.setPromptText(Localization.lang("Filter groups..."));
         searchField.setId("groupFilterBar");
         this.setTop(searchField);
@@ -645,15 +648,13 @@ public class GroupTreeView extends BorderPane {
 
             this.executable.bind(BindingsHelper.constantOf(
                     switch (command) {
-                        case GROUP_EDIT ->
+                        case GROUP_EDIT, GROUP_SUBGROUP_RENAME ->
                                 group.isEditable();
                         case GROUP_REMOVE, GROUP_REMOVE_WITH_SUBGROUPS, GROUP_REMOVE_KEEP_SUBGROUPS ->
                                 group.isEditable() && group.canRemove();
                         case GROUP_SUBGROUP_ADD ->
                                 group.isEditable() && group.canAddGroupsIn()
                                         || group.isRoot();
-                        case GROUP_SUBGROUP_RENAME ->
-                            group.isEditable();
                         case GROUP_SUBGROUP_REMOVE ->
                                 group.isEditable() && group.hasSubgroups() && group.canRemove()
                                         || group.isRoot();

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -48,6 +48,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.search.SearchTextField;
@@ -89,7 +90,6 @@ public class GroupTreeView extends BorderPane {
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> mainColumn;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> numberColumn;
     private TreeTableColumn<GroupNodeViewModel, GroupNodeViewModel> expansionNodeColumn;
-    private TreeTableRow<GroupNodeViewModel> row;
     private CustomTextField searchField;
     private GroupTreeViewModel viewModel;
     private CustomLocalDragboard localDragboard;
@@ -146,6 +146,14 @@ public class GroupTreeView extends BorderPane {
         groupTree.setId("groupTree");
         groupTree.setColumnResizePolicy(TreeTableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         groupTree.getColumns().addAll(List.of(mainColumn, numberColumn, expansionNodeColumn));
+        groupTree.setOnKeyPressed(event -> {
+            if (event.getCode().toString().equals(KeyBinding.GROUP_SUBGROUP_RENAME.getDefaultKeyBinding())) {
+                TreeItem<GroupNodeViewModel> selectedItem = groupTree.getSelectionModel().getSelectedItem();
+                if (selectedItem != null) {
+                    viewModel.editGroup(groupTree.getRoot().getValue());
+                }
+            }
+        });
         this.setCenter(groupTree);
 
         mainColumn.prefWidthProperty().bind(groupTree.widthProperty().subtract(80d).subtract(15d));
@@ -208,17 +216,6 @@ public class GroupTreeView extends BorderPane {
                 .withText(GroupNodeViewModel::getDisplayName)
                 .withIcon(GroupNodeViewModel::getIcon)
                 .withTooltip(GroupNodeViewModel::getDescription)
-                .withOnMouseClickedEvent(group -> event -> {
-                    if (event.getButton() == MouseButton.PRIMARY) {
-                        Node node = (Node) event.getTarget();
-                        while (node != null && !(node instanceof TreeTableRow)) {
-                            node = node.getParent();
-                        }
-                        if (node instanceof TreeTableRow) {
-                            row = (TreeTableRow<GroupNodeViewModel>) node;
-                        }
-                    }
-                })
                 .install(mainColumn);
 
         // Number of hits (only if user wants to see them)

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -677,7 +677,7 @@ public class GroupTreeView extends BorderPane {
                         viewModel.removeGroupKeepSubgroups(group);
                 case GROUP_REMOVE_WITH_SUBGROUPS ->
                         viewModel.removeGroupAndSubgroups(group);
-                case GROUP_EDIT -> {
+                case GROUP_EDIT, GROUP_SUBGROUP_RENAME -> {
                     viewModel.editGroup(group);
                     groupTree.refresh();
                 }
@@ -701,8 +701,6 @@ public class GroupTreeView extends BorderPane {
                         viewModel.sortReverseEntriesRecursive(group.getGroupNode());
                 case GROUP_ENTRIES_ADD ->
                         viewModel.addSelectedEntries(group);
-                case GROUP_SUBGROUP_RENAME ->
-                        viewModel.renameSubgroups(row);
                 case GROUP_ENTRIES_REMOVE ->
                         viewModel.removeSelectedEntries(group);
             }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -149,8 +149,8 @@ public class GroupTreeView extends BorderPane {
         groupTree.setOnKeyPressed(event -> {
             if (event.getCode().toString().equals(KeyBinding.GROUP_SUBGROUP_RENAME.getDefaultKeyBinding())) {
                 TreeItem<GroupNodeViewModel> selectedItem = groupTree.getSelectionModel().getSelectedItem();
-                if (selectedItem != null) {
-                    viewModel.editGroup(groupTree.getRoot().getValue());
+                if (selectedItem != null && selectedItem.getParent() != null) { 
+                    viewModel.editGroup(selectedItem.getValue());
                 }
             }
         });

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -20,6 +20,9 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.input.KeyCode;
 
 import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
@@ -474,6 +477,35 @@ public class GroupTreeViewModel extends AbstractViewModel {
         );
 
         dialogService.notify(Localization.lang("Summarization started for group \"%0\".", group.getName()));
+    }
+
+    public void renameSubgroups(TreeTableRow<GroupNodeViewModel> row) {
+        GroupNodeViewModel group = row.getItem();
+        if (group == null) {
+            return;
+        }
+
+        TextField textField = new TextField(group.getDisplayName());
+        textField.setMinWidth(row.getWidth());
+
+        textField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.ENTER) {
+                group.setDisplayName(textField.getText());
+                row.setGraphic(null);
+                row.getTreeTableView().refresh();
+            }
+        });
+
+        textField.focusedProperty().addListener((obs, oldVal, newVal) -> {
+            if (!newVal) {
+                group.setDisplayName(textField.getText());
+                row.setGraphic(null);
+                row.getTreeTableView().refresh();
+            }
+        });
+
+        row.setGraphic(textField);
+        textField.requestFocus();
     }
 
     public void removeSubgroups(GroupNodeViewModel group) {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -20,9 +20,6 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.TextField;
-import javafx.scene.control.TreeTableRow;
-import javafx.scene.input.KeyCode;
 
 import org.jabref.gui.AbstractViewModel;
 import org.jabref.gui.DialogService;
@@ -477,35 +474,6 @@ public class GroupTreeViewModel extends AbstractViewModel {
         );
 
         dialogService.notify(Localization.lang("Summarization started for group \"%0\".", group.getName()));
-    }
-
-    public void renameSubgroups(TreeTableRow<GroupNodeViewModel> row) {
-        GroupNodeViewModel group = row.getItem();
-        if (group == null) {
-            return;
-        }
-
-        TextField textField = new TextField(group.getDisplayName());
-        textField.setMinWidth(row.getWidth());
-
-        textField.setOnKeyPressed(event -> {
-            if (event.getCode() == KeyCode.ENTER) {
-                group.setDisplayName(textField.getText());
-                row.setGraphic(null);
-                row.getTreeTableView().refresh();
-            }
-        });
-
-        textField.focusedProperty().addListener((obs, oldVal, newVal) -> {
-            if (!newVal) {
-                group.setDisplayName(textField.getText());
-                row.setGraphic(null);
-                row.getTreeTableView().refresh();
-            }
-        });
-
-        row.setGraphic(textField);
-        textField.requestFocus();
     }
 
     public void removeSubgroups(GroupNodeViewModel group) {

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -121,7 +121,8 @@ public enum KeyBinding {
     CLEAR_SEARCH("Clear search", Localization.lang("Clear search"), "Esc", KeyBindingCategory.SEARCH),
     CLEAR_READ_STATUS("Clear read status", Localization.lang("Clear read status"), "", KeyBindingCategory.EDIT),
     READ("Set read status to read", Localization.lang("Set read status to read"), "", KeyBindingCategory.EDIT),
-    SKIMMED("Set read status to skimmed", Localization.lang("Set read status to skimmed"), "", KeyBindingCategory.EDIT);
+    SKIMMED("Set read status to skimmed", Localization.lang("Set read status to skimmed"), "", KeyBindingCategory.EDIT),
+    GROUP_SUBGROUP_RENAME("Rename group", Localization.lang("Rename group"), "F2", KeyBindingCategory.EDIT);
 
     private final String constant;
     private final String localization;

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -44,6 +44,7 @@ Add\ entry\ manually=Add entry manually
 Add\ selected\ entries\ to\ this\ group=Add selected entries to this group
 
 Add\ subgroup=Add subgroup
+Rename\ subgroup=Rename subgroup
 
 Added\ group\ "%0".=Added group "%0".
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1961,6 +1961,7 @@ No\ full\ text\ document\ found\ for\ entry\ %0.=No full text document found for
 Next\ library=Next library
 Previous\ library=Previous library
 Add\ group=Add group
+Rename\ group=Rename group
 Entry\ is\ contained\ in\ the\ following\ groups\:=Entry is contained in the following groups\:
 Delete\ entries=Delete entries
 Keep\ entries=Keep entries


### PR DESCRIPTION
### Fixes #11896 

This PR adds the functionality to rename a subgroup using the F2 keybinding. 
It converts the text into a text field, allowing the user to change the name, providing a better user experience.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
