### PR TITLE
Enable move back to column "Free to take"

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -34,7 +34,6 @@ jobs:
 
             ⏳ Please note, you will be automatically unassigned if the issue isn't closed within **{{ total_days }} days** (by **{{ unassigned_date }}**). A maintainer can also add the "**{{ pin_label }}**"" label to prevent automatic unassignment.
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
-        if: steps.assign.outputs.assigned == 'yes'
         uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
@@ -45,7 +44,6 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move Issue to "Assigned" Column in "Good First Issues"
-        if: steps.assign.outputs.assigned == 'yes'
         uses: m7kvqbe1/github-action-move-issues@feat/skip-if-not-in-project-flag
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}


### PR DESCRIPTION
After reading https://github.com/m7kvqbe1/github-action-move-issues/pull/28/files, I think, the configuration with `default-column` works fine.

- If label "Assigned" is put: The issue is put to column "Assigned"
- If label "Assigned" is removed (AKA not existing): The issue is put to column "Free to take"

We still have to use a WIP version, because we do not want to track all issues in these boards, but only the issues we manually put there. (https://github.com/m7kvqbe1/github-action-move-issues/pull/28/)

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
