### PR TITLE
Unassign after 45 days of inactivity

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -19,7 +19,7 @@ jobs:
         uses: takanome-dev/assign-issue-action@fix-rate-limit-err
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          days_until_unassign: 90
+          days_until_unassign: 45
           maintainers: 'koppor,Siedlerchr,ThiloteE,calixtus,HoussemNasri,subhramit,LinusDietz'
           assigned_comment: |
             👋 Hey @{{ handle }}, thank you for your interest in this issue! 🎉


### PR DESCRIPTION
After reading through https://github.com/JabRef/jabref/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3A%22%F0%9F%93%8D%20Assigned%22, I think, there are issues without any activity. Since we run out of "good first issues", we should enable others to take part.

We can still add "[📌 Pinned](https://github.com/JabRef/jabref/labels/%F0%9F%93%8C%20Pinned)" if a contributor needs longer to work on things.

I am aware that the metrics are still not that good - currently, all activity on an issue counts - not only the one of a contributor (https://github.com/takanome-dev/assign-issue-action/issues/268) or pull request activity (https://github.com/takanome-dev/assign-issue-action/issues/267). 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
