### PR TITLE
Tag-Based Selection for Entry fields in Preferences

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextField?>
 <?import com.dlsc.gemsfx.TagsField?>
-<?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.entry.EntryTab">

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
@@ -29,9 +29,6 @@
                 <Insets top="-4.0"/>
             </HBox.margin>
         </TagsField>
-        <padding>
-            <Insets left="20.0"/>
-        </padding>
     </HBox>
 
     <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import com.dlsc.gemsfx.TagsField?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.Tooltip?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import com.dlsc.gemsfx.TagsField?>
+
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.entry.EntryTab">
@@ -49,6 +55,5 @@
 
     <Label styleClass="sectionHeader" text="%Time stamp"/>
     <CheckBox fx:id="addCreationDate" text="%Add timestamp to new entries (field &quot;creationdate&quot;)"/>
-    <CheckBox fx:id="addModificationDate"
-              text="%Add timestamp to modified entries (field &quot;modificationdate&quot;)"/>
+    <CheckBox fx:id="addModificationDate" text="%Add timestamp to modified entries (field &quot;modificationdate&quot;)"/>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.fxml
@@ -5,6 +5,7 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
+<?import com.dlsc.gemsfx.TagsField?>
 <?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
@@ -22,21 +23,24 @@
 
     <CheckBox fx:id="resolveStrings" text="%Resolve BibTeX strings"/>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label text="%Affected fields"/>
-        <TextField fx:id="resolveStringsForFields" HBox.hgrow="ALWAYS"
-                   disable="${!resolveStrings.selected}">
+        <Label text="%Affected fields" minWidth="150" maxWidth="200"/>
+        <TagsField fx:id="resolveStringsForFields" HBox.hgrow="ALWAYS" disable="${!resolveStrings.selected}">
             <HBox.margin>
                 <Insets top="-4.0"/>
             </HBox.margin>
-        </TextField>
+        </TagsField>
         <padding>
             <Insets left="20.0"/>
         </padding>
     </HBox>
 
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <Label text="%Do not wrap when saving"/>
-        <TextField fx:id="nonWrappableFields" HBox.hgrow="ALWAYS"/>
+        <Label text="%Do not wrap when saving" minWidth="150" maxWidth="200"/>
+        <TagsField fx:id="nonWrappableFields" HBox.hgrow="ALWAYS">
+            <HBox.margin>
+                <Insets top="-4.0"/>
+            </HBox.margin>
+        </TagsField>
     </HBox>
 
     <Label styleClass="sectionHeader" text="%Entry owner"/>
@@ -53,5 +57,6 @@
 
     <Label styleClass="sectionHeader" text="%Time stamp"/>
     <CheckBox fx:id="addCreationDate" text="%Add timestamp to new entries (field &quot;creationdate&quot;)"/>
-    <CheckBox fx:id="addModificationDate" text="%Add timestamp to modified entries (field &quot;modificationdate&quot;)"/>
+    <CheckBox fx:id="addModificationDate"
+              text="%Add timestamp to modified entries (field &quot;modificationdate&quot;)"/>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
@@ -1,13 +1,11 @@
 package org.jabref.gui.preferences.entry;
 
-import java.util.function.UnaryOperator;
-
+import com.airhacks.afterburner.views.ViewLoader;
 import com.dlsc.gemsfx.TagsField;
 import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.*;
-
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
@@ -17,30 +15,41 @@ import org.jabref.gui.preferences.PreferencesTab;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
-
-import com.airhacks.afterburner.views.ViewLoader;
 import org.jabref.model.entry.field.Field;
+
+import java.util.function.UnaryOperator;
+
 
 public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> implements PreferencesTab {
     private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
 
-    @FXML private TextField keywordSeparator;
+    @FXML
+    private TextField keywordSeparator;
 
-    @FXML private CheckBox resolveStrings;
-    @FXML private TagsField<Field> resolveStringsForFields;
-    @FXML private TagsField<Field> nonWrappableFields;
-    @FXML private CheckBox markOwner;
-    @FXML private TextField markOwnerName;
-    @FXML private CheckBox markOwnerOverwrite;
-    @FXML private Button markOwnerHelp;
+    @FXML
+    private CheckBox resolveStrings;
+    @FXML
+    private TagsField<Field> resolveStringsForFields;
+    @FXML
+    private TagsField<Field> nonWrappableFields;
+    @FXML
+    private CheckBox markOwner;
+    @FXML
+    private TextField markOwnerName;
+    @FXML
+    private CheckBox markOwnerOverwrite;
+    @FXML
+    private Button markOwnerHelp;
 
-    @FXML private CheckBox addCreationDate;
-    @FXML private CheckBox addModificationDate;
+    @FXML
+    private CheckBox addCreationDate;
+    @FXML
+    private CheckBox addModificationDate;
 
     public EntryTab() {
         ViewLoader.view(this)
-                  .root(this)
-                  .load();
+                .root(this)
+                .load();
     }
 
     public void initialize() {
@@ -56,7 +65,6 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         };
         TextFormatter<String> formatter = new TextFormatter<>(singleCharacterFilter);
         keywordSeparator.setTextFormatter(formatter);
-
 
         setupTagsWraps();
         setupTagsField();
@@ -74,6 +82,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         ActionFactory actionFactory = new ActionFactory();
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.OWNER, dialogService, preferences.getExternalApplicationsPreferences()), markOwnerHelp);
     }
+
     private void setupTagsField() {
         resolveStringsForFields.setCellFactory(new ViewModelListCellFactory<Field>().withText(Field::getDisplayName));
         resolveStringsForFields.tagsProperty().bindBidirectional(viewModel.resolveStringsForFieldsProperty());
@@ -84,6 +93,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         resolveStringsForFields.getEditor().getStyleClass().clear();
         resolveStringsForFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> resolveStringsForFields.pseudoClassStateChanged(FOCUSED, newValue));
     }
+
     private void setupTagsWraps() {
         nonWrappableFields.setCellFactory(new ViewModelListCellFactory<Field>().withText(Field::getDisplayName));
         nonWrappableFields.tagsProperty().bindBidirectional(viewModel.nonWrappableFieldsProperty());
@@ -103,6 +113,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         tagLabel.setContentDisplay(ContentDisplay.RIGHT);
         return tagLabel;
     }
+
     private Node createWrapTag(Field field) {
         Label tagLabel = new Label();
         tagLabel.setText(field.getDisplayName());

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
@@ -2,32 +2,33 @@ package org.jabref.gui.preferences.entry;
 
 import java.util.function.UnaryOperator;
 
+import com.dlsc.gemsfx.TagsField;
+import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.TextField;
-import javafx.scene.control.TextFormatter;
+import javafx.scene.Node;
+import javafx.scene.control.*;
 
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
+import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
+import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 
 import com.airhacks.afterburner.views.ViewLoader;
+import org.jabref.model.entry.field.Field;
 
 public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> implements PreferencesTab {
-
-
+    private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
 
     @FXML private TextField keywordSeparator;
 
     @FXML private CheckBox resolveStrings;
-    @FXML private TextField resolveStringsForFields;
-    @FXML private TextField nonWrappableFields;
-
+    @FXML private TagsField<Field> resolveStringsForFields;
+    @FXML private TagsField<Field> nonWrappableFields;
     @FXML private CheckBox markOwner;
     @FXML private TextField markOwnerName;
     @FXML private CheckBox markOwnerOverwrite;
@@ -44,7 +45,6 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
 
     public void initialize() {
         this.viewModel = new EntryTabViewModel(preferences);
-
         keywordSeparator.textProperty().bindBidirectional(viewModel.keywordSeparatorProperty());
 
         // Use TextFormatter to limit the length of the Input of keywordSeparator to 1 character only.
@@ -55,13 +55,13 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
             return null; // null means the change is rejected
         };
         TextFormatter<String> formatter = new TextFormatter<>(singleCharacterFilter);
-
         keywordSeparator.setTextFormatter(formatter);
 
-        resolveStrings.selectedProperty().bindBidirectional(viewModel.resolveStringsProperty());
-        resolveStringsForFields.textProperty().bindBidirectional(viewModel.resolveStringsForFieldsProperty());
-        nonWrappableFields.textProperty().bindBidirectional(viewModel.nonWrappableFieldsProperty());
 
+        setupTagsWraps();
+        setupTagsField();
+
+        resolveStrings.selectedProperty().bindBidirectional(viewModel.resolveStringsProperty());
         markOwner.selectedProperty().bindBidirectional(viewModel.markOwnerProperty());
         markOwnerName.textProperty().bindBidirectional(viewModel.markOwnerNameProperty());
         markOwnerName.disableProperty().bind(markOwner.selectedProperty().not());
@@ -73,6 +73,43 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
 
         ActionFactory actionFactory = new ActionFactory();
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.OWNER, dialogService, preferences.getExternalApplicationsPreferences()), markOwnerHelp);
+    }
+    private void setupTagsField() {
+        resolveStringsForFields.setCellFactory(new ViewModelListCellFactory<Field>().withText(Field::getDisplayName));
+        resolveStringsForFields.tagsProperty().bindBidirectional(viewModel.resolveStringsForFieldsProperty());
+        resolveStringsForFields.setConverter(viewModel.getFieldStringConverter());
+        resolveStringsForFields.setTagViewFactory(this::createTag);
+        resolveStringsForFields.setShowSearchIcon(false);
+        resolveStringsForFields.setOnMouseClicked(event -> resolveStringsForFields.getEditor().requestFocus());
+        resolveStringsForFields.getEditor().getStyleClass().clear();
+        resolveStringsForFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> resolveStringsForFields.pseudoClassStateChanged(FOCUSED, newValue));
+    }
+    private void setupTagsWraps() {
+        nonWrappableFields.setCellFactory(new ViewModelListCellFactory<Field>().withText(Field::getDisplayName));
+        nonWrappableFields.tagsProperty().bindBidirectional(viewModel.nonWrappableFieldsProperty());
+        nonWrappableFields.setConverter(viewModel.getFieldStringConverter());
+        nonWrappableFields.setTagViewFactory(this::createWrapTag);
+        nonWrappableFields.setShowSearchIcon(false);
+        nonWrappableFields.setOnMouseClicked(event -> nonWrappableFields.getEditor().requestFocus());
+        nonWrappableFields.getEditor().getStyleClass().clear();
+        nonWrappableFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> nonWrappableFields.pseudoClassStateChanged(FOCUSED, newValue));
+    }
+
+    private Node createTag(Field field) {
+        Label tagLabel = new Label();
+        tagLabel.setText(field.getDisplayName());
+        tagLabel.setGraphic(IconTheme.JabRefIcons.REMOVE_TAGS.getGraphicNode());
+        tagLabel.getGraphic().setOnMouseClicked(event -> resolveStringsForFields.removeTags(field));
+        tagLabel.setContentDisplay(ContentDisplay.RIGHT);
+        return tagLabel;
+    }
+    private Node createWrapTag(Field field) {
+        Label tagLabel = new Label();
+        tagLabel.setText(field.getDisplayName());
+        tagLabel.setGraphic(IconTheme.JabRefIcons.REMOVE_TAGS.getGraphicNode());
+        tagLabel.getGraphic().setOnMouseClicked(event -> nonWrappableFields.removeTags(field));
+        tagLabel.setContentDisplay(ContentDisplay.RIGHT);
+        return tagLabel;
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
@@ -27,27 +27,22 @@ import com.airhacks.afterburner.views.ViewLoader;
 import com.dlsc.gemsfx.TagsField;
 
 public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> implements PreferencesTab {
+
     private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
-    @FXML
-    private TextField keywordSeparator;
-    @FXML
-    private CheckBox resolveStrings;
-    @FXML
-    private TagsField<Field> resolveStringsForFields;
-    @FXML
-    private TagsField<Field> nonWrappableFields;
-    @FXML
-    private CheckBox markOwner;
-    @FXML
-    private TextField markOwnerName;
-    @FXML
-    private CheckBox markOwnerOverwrite;
-    @FXML
-    private Button markOwnerHelp;
-    @FXML
-    private CheckBox addCreationDate;
-    @FXML
-    private CheckBox addModificationDate;
+
+    @FXML private TextField keywordSeparator;
+
+    @FXML private CheckBox resolveStrings;
+    @FXML private TagsField<Field> resolveStringsForFields;
+    @FXML private TagsField<Field> nonWrappableFields;
+
+    @FXML private CheckBox markOwner;
+    @FXML private TextField markOwnerName;
+    @FXML private CheckBox markOwnerOverwrite;
+    @FXML private Button markOwnerHelp;
+
+    @FXML private CheckBox addCreationDate;
+    @FXML private CheckBox addModificationDate;
 
     public EntryTab() {
         ViewLoader.view(this)
@@ -57,6 +52,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
 
     public void initialize() {
         this.viewModel = new EntryTabViewModel(preferences);
+
         keywordSeparator.textProperty().bindBidirectional(viewModel.keywordSeparatorProperty());
 
         // Use TextFormatter to limit the length of the Input of keywordSeparator to 1 character only.
@@ -67,17 +63,23 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
             return null; // null means the change is rejected
         };
         TextFormatter<String> formatter = new TextFormatter<>(singleCharacterFilter);
+
         keywordSeparator.setTextFormatter(formatter);
+
         setupTagsWraps();
         setupTagsField();
+
         resolveStrings.selectedProperty().bindBidirectional(viewModel.resolveStringsProperty());
+
         markOwner.selectedProperty().bindBidirectional(viewModel.markOwnerProperty());
         markOwnerName.textProperty().bindBidirectional(viewModel.markOwnerNameProperty());
         markOwnerName.disableProperty().bind(markOwner.selectedProperty().not());
         markOwnerOverwrite.selectedProperty().bindBidirectional(viewModel.markOwnerOverwriteProperty());
         markOwnerOverwrite.disableProperty().bind(markOwner.selectedProperty().not());
+
         addCreationDate.selectedProperty().bindBidirectional(viewModel.addCreationDateProperty());
         addModificationDate.selectedProperty().bindBidirectional(viewModel.addModificationDateProperty());
+
         ActionFactory actionFactory = new ActionFactory();
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.OWNER, dialogService, preferences.getExternalApplicationsPreferences()), markOwnerHelp);
     }
@@ -90,7 +92,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         resolveStringsForFields.setShowSearchIcon(false);
         resolveStringsForFields.setOnMouseClicked(event -> resolveStringsForFields.getEditor().requestFocus());
         resolveStringsForFields.getEditor().getStyleClass().clear();
-        resolveStringsForFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> resolveStringsForFields.pseudoClassStateChanged(FOCUSED, newValue));
+        resolveStringsForFields.getEditor().focusedProperty().addListener((_, _, newValue) -> resolveStringsForFields.pseudoClassStateChanged(FOCUSED, newValue));
     }
 
     private void setupTagsWraps() {
@@ -101,7 +103,7 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         nonWrappableFields.setShowSearchIcon(false);
         nonWrappableFields.setOnMouseClicked(event -> nonWrappableFields.getEditor().requestFocus());
         nonWrappableFields.getEditor().getStyleClass().clear();
-        nonWrappableFields.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> nonWrappableFields.pseudoClassStateChanged(FOCUSED, newValue));
+        nonWrappableFields.getEditor().focusedProperty().addListener((_, _, newValue) -> nonWrappableFields.pseudoClassStateChanged(FOCUSED, newValue));
     }
 
     private Node createTag(Field field) {

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
@@ -1,11 +1,17 @@
 package org.jabref.gui.preferences.entry;
 
-import com.airhacks.afterburner.views.ViewLoader;
-import com.dlsc.gemsfx.TagsField;
+import java.util.function.UnaryOperator;
+
 import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
+
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.help.HelpAction;
@@ -17,7 +23,8 @@ import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.field.Field;
 
-import java.util.function.UnaryOperator;
+import com.airhacks.afterburner.views.ViewLoader;
+import com.dlsc.gemsfx.TagsField;
 
 
 public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> implements PreferencesTab {

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTab.java
@@ -26,13 +26,10 @@ import org.jabref.model.entry.field.Field;
 import com.airhacks.afterburner.views.ViewLoader;
 import com.dlsc.gemsfx.TagsField;
 
-
 public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> implements PreferencesTab {
     private static final PseudoClass FOCUSED = PseudoClass.getPseudoClass("focused");
-
     @FXML
     private TextField keywordSeparator;
-
     @FXML
     private CheckBox resolveStrings;
     @FXML
@@ -47,7 +44,6 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
     private CheckBox markOwnerOverwrite;
     @FXML
     private Button markOwnerHelp;
-
     @FXML
     private CheckBox addCreationDate;
     @FXML
@@ -72,20 +68,16 @@ public class EntryTab extends AbstractPreferenceTabView<EntryTabViewModel> imple
         };
         TextFormatter<String> formatter = new TextFormatter<>(singleCharacterFilter);
         keywordSeparator.setTextFormatter(formatter);
-
         setupTagsWraps();
         setupTagsField();
-
         resolveStrings.selectedProperty().bindBidirectional(viewModel.resolveStringsProperty());
         markOwner.selectedProperty().bindBidirectional(viewModel.markOwnerProperty());
         markOwnerName.textProperty().bindBidirectional(viewModel.markOwnerNameProperty());
         markOwnerName.disableProperty().bind(markOwner.selectedProperty().not());
         markOwnerOverwrite.selectedProperty().bindBidirectional(viewModel.markOwnerOverwriteProperty());
         markOwnerOverwrite.disableProperty().bind(markOwner.selectedProperty().not());
-
         addCreationDate.selectedProperty().bindBidirectional(viewModel.addCreationDateProperty());
         addModificationDate.selectedProperty().bindBidirectional(viewModel.addModificationDateProperty());
-
         ActionFactory actionFactory = new ActionFactory();
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.OWNER, dialogService, preferences.getExternalApplicationsPreferences()), markOwnerHelp);
     }

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTabViewModel.java
@@ -1,8 +1,14 @@
 package org.jabref.gui.preferences.entry;
 
-import javafx.beans.property.*;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.util.StringConverter;
+
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.logic.bibtex.FieldPreferences;
 import org.jabref.logic.preferences.CliPreferences;

--- a/src/main/java/org/jabref/gui/preferences/entry/EntryTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/entry/EntryTabViewModel.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.preferences.entry;
 
 import javafx.beans.property.*;
-
 import javafx.collections.FXCollections;
 import javafx.util.StringConverter;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
@@ -12,9 +11,6 @@ import org.jabref.logic.preferences.TimestampPreferences;
 import org.jabref.model.entry.BibEntryPreferences;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class EntryTabViewModel implements PreferenceTabViewModel {
 
@@ -60,19 +56,16 @@ public class EntryTabViewModel implements PreferenceTabViewModel {
     @Override
     public void storeSettings() {
         bibEntryPreferences.keywordSeparatorProperty().setValue(keywordSeparatorProperty.getValue().charAt(0));
-
         fieldPreferences.setResolveStrings(resolveStringsProperty.getValue());
         ownerPreferences.setUseOwner(markOwnerProperty.getValue());
         ownerPreferences.setDefaultOwner(markOwnerNameProperty.getValue());
         ownerPreferences.setOverwriteOwner(markOwnerOverwriteProperty.getValue());
-
         timestampPreferences.setAddCreationDate(addCreationDateProperty.getValue());
         timestampPreferences.setAddModificationDate(addModificationDateProperty.getValue());
         fieldPreferences.getResolvableFields().clear();
         fieldPreferences.getResolvableFields().addAll(resolveStringsForFieldsProperty.getValue());
         fieldPreferences.getNonWrappableFields().clear();
         fieldPreferences.getNonWrappableFields().addAll(nonWrappableFieldsProperty.getValue());
-
     }
 
     public StringProperty keywordSeparatorProperty() {


### PR DESCRIPTION
This PR Fixes #12550

This PR replaces the existing text-based field selection with a tag-based selection format, similar to the implementation in the Autocompletion settings.

### Changes Made

- Converted text-based text input to TagsField components, allowing users to select fields dynamically instead of relying on static text labels.
- Improved layout alignment to ensure text and tags are displayed correctly.
- Adjusted spacing and padding in HBox to prevent label truncation or misalignment.
- Ensured that the new TagsField selection method works consistently with other settings sections.

### Screenshots after Fix Applied
![new](https://github.com/user-attachments/assets/d62ee062-013f-4247-8be6-a6c459c037c6)


### Mandatory checks
- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
