### PR TITLE
Fix trigger of fetcher tests

### DIFF
--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'src/main/java/org/jabref/logic/importer/fetcher/**'
       - 'src/test/java/org/jabref/logic/importer/fetcher/**'
+      - 'src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java'
+      - 'src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java'
       - 'src/main/java/org/jabref/logic/crawler/**'
       - 'src/test/java/org/jabref/logic/crawler/**'
       - '.github/workflows/tests-fetchers.yml'
@@ -15,6 +17,10 @@ on:
     paths:
       - 'src/main/java/org/jabref/logic/importer/fetcher/**'
       - 'src/test/java/org/jabref/logic/importer/fetcher/**'
+      - 'src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java'
+      - 'src/test/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporterTest.java'
+      - 'src/main/java/org/jabref/logic/crawler/**'
+      - 'src/test/java/org/jabref/logic/crawler/**'
       - '.github/workflows/tests-fetchers.yml'
       - 'build.gradle'
   schedule:


### PR DESCRIPTION
Follow-up to #8258 -> `org.jabref.logic.importer.fileformat.pdf.PdfMergeMetadataImporterTest` is marked as fetcher test. Thus, fetcher tests should run if a change in this file occurs.

Whole thing triggered by https://github.com/JabRef/jabref/pull/12088 rendering a test not working, but did not show up, because no fetcher tests ran.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
