### PR TITLE
Enable drag-and-drop of PDFs into groups Fixes #12540

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 [submodule "csl-styles"]
   path = src/main/resources/csl-styles
   url = https://github.com/citation-style-language/styles.git
-  ignore = all
+  # ignore = all
   shallow = true
 [submodule "csl-locales"]
   path = src/main/resources/csl-locales

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 [submodule "csl-styles"]
   path = src/main/resources/csl-styles
   url = https://github.com/citation-style-language/styles.git
-  # ignore = all
+  ignore = all
   shallow = true
 [submodule "csl-locales"]
   path = src/main/resources/csl-locales

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome contributions to JabRef and encourage you to follow the GitHub workfl
 If you are not familiar with this type of workflow, take a look at GitHub's excellent overview on the [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow) and the explanation of [Feature Branch Workflow](https://atlassian.com/git/tutorials/comparing-workflows#feature-branch-workflow) for the idea behind this kind of development.
 
 Before you start, get the JabRef code on your local machine.
-Detailed instructions about this step can be found in our [guidelines for setting up a local workspace](getting-into-the-code/guidelines-for-setting-up-a-local-workspace/).
+Detailed instructions about this step can be found in our [guidelines for setting up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/).
 
 ## Table of Contents
 

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -349,7 +349,8 @@ public class GroupNodeViewModel {
         // TODO: we should also check isNodeDescendant
         boolean canDropOtherGroup = dragboard.hasContent(DragAndDropDataFormats.GROUP);
         boolean canDropEntries = localDragBoard.hasBibEntries() && (groupNode.getGroup() instanceof GroupEntryChanger);
-        return canDropOtherGroup || canDropEntries;
+        boolean canDropFiles = dragboard.hasFiles();
+        return canDropOtherGroup || canDropEntries || canDropFiles;
     }
 
     public void moveTo(GroupNodeViewModel target) {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -54,6 +54,7 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.externalfiles.ImportHandler;
+import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.search.SearchTextField;
 import org.jabref.gui.util.BindingsHelper;
@@ -92,6 +93,7 @@ public class GroupTreeView extends BorderPane {
     private final GuiPreferences preferences;
     private final UndoManager undoManager;
     private final FileUpdateMonitor fileUpdateMonitor;
+    private final KeyBindingRepository keyBindingRepository;
 
 
     private TreeTableView<GroupNodeViewModel> groupTree;
@@ -128,6 +130,7 @@ public class GroupTreeView extends BorderPane {
         this.aiService = aiService;
         this.undoManager = undoManager;
         this.fileUpdateMonitor = fileUpdateMonitor;
+        this.keyBindingRepository = preferences.getKeyBindingRepository();
         createNodes();
         initialize();
     }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -54,6 +54,7 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.actions.StandardActions;
 import org.jabref.gui.externalfiles.ImportHandler;
+import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.search.SearchTextField;
@@ -136,7 +137,7 @@ public class GroupTreeView extends BorderPane {
     }
 
     private void createNodes() {
-        searchField = SearchTextField.create(preferences.getKeyBindingRepository());
+        searchField = SearchTextField.create(keyBindingRepository);
         searchField.setPromptText(Localization.lang("Filter groups..."));
         searchField.setId("groupFilterBar");
         this.setTop(searchField);
@@ -161,6 +162,14 @@ public class GroupTreeView extends BorderPane {
         groupTree.setId("groupTree");
         groupTree.setColumnResizePolicy(TreeTableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         groupTree.getColumns().addAll(List.of(mainColumn, numberColumn, expansionNodeColumn));
+        groupTree.setOnKeyPressed(event -> {
+            if (event.getCode().toString().equals(KeyBinding.GROUP_SUBGROUP_RENAME.getDefaultKeyBinding())) {
+                TreeItem<GroupNodeViewModel> selectedItem = groupTree.getSelectionModel().getSelectedItem();
+                if (selectedItem != null && selectedItem.getParent() != null) {
+                    viewModel.editGroup(selectedItem.getValue());
+                }
+            }
+        });
         this.setCenter(groupTree);
 
         mainColumn.prefWidthProperty().bind(groupTree.widthProperty().subtract(80d).subtract(15d));
@@ -591,6 +600,7 @@ public class GroupTreeView extends BorderPane {
                 removeGroup,
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_ADD, new ContextAction(StandardActions.GROUP_SUBGROUP_ADD, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_RENAME, new ContextAction(StandardActions.GROUP_SUBGROUP_RENAME, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_REMOVE, new ContextAction(StandardActions.GROUP_SUBGROUP_REMOVE, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
@@ -668,7 +678,7 @@ public class GroupTreeView extends BorderPane {
 
             this.executable.bind(BindingsHelper.constantOf(
                     switch (command) {
-                        case GROUP_EDIT ->
+                        case GROUP_EDIT, GROUP_SUBGROUP_RENAME ->
                                 group.isEditable();
                         case GROUP_REMOVE, GROUP_REMOVE_WITH_SUBGROUPS, GROUP_REMOVE_KEEP_SUBGROUPS ->
                                 group.isEditable() && group.canRemove();
@@ -697,7 +707,7 @@ public class GroupTreeView extends BorderPane {
                         viewModel.removeGroupKeepSubgroups(group);
                 case GROUP_REMOVE_WITH_SUBGROUPS ->
                         viewModel.removeGroupAndSubgroups(group);
-                case GROUP_EDIT -> {
+                case GROUP_EDIT, GROUP_SUBGROUP_RENAME -> {
                     viewModel.editGroup(group);
                     groupTree.refresh();
                 }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -391,7 +391,7 @@ public class GroupTreeView extends BorderPane {
             // expand node and all children on drag over
             dragExpansionHandler.expandGroup(row.getTreeItem());
 
-            if (localDragboard.hasBibEntries()) {
+            if (localDragboard.hasBibEntries() || dragboard.hasFiles()) {
                 ControlHelper.setDroppingPseudoClasses(row);
             } else {
                 ControlHelper.setDroppingPseudoClasses(row, event);

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -44,6 +44,7 @@ Add\ entry\ manually=Adicionar entrada manualmente
 Add\ selected\ entries\ to\ this\ group=Adicionar as entradas selecionadas a este grupo
 
 Add\ subgroup=Adicionar subgrupo
+Rename\ subgroup=Renomear subgrupo
 
 Added\ group\ "%0".=O grupo "%0" foi adicionado.
 
@@ -1962,6 +1963,7 @@ No\ full\ text\ document\ found\ for\ entry\ %0.=Nenhum documento encontrado par
 Next\ library=Próxima biblioteca
 Previous\ library=Biblioteca anterior
 Add\ group=Adicionar grupo
+Rename\ group=Renomear grupo
 Entry\ is\ contained\ in\ the\ following\ groups\:=A referência está nos seguintes grupos\:
 Delete\ entries=Remover referências
 Keep\ entries=Manter referências


### PR DESCRIPTION
# Enable drag-and-drop of PDFs into groups Fixes #12540 
Before
![before](https://github.com/user-attachments/assets/c54f92e8-0e19-414c-9864-f75a3b003f71)
After
![after](https://github.com/user-attachments/assets/1cd63ec2-7c1f-4380-be47-c2b949392f07)

 "Closes https://github.com/JabRef/jabref/issues/12540".

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
