### PR TITLE
Fixed tests for springer fetcher

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerFetcherTest.java
@@ -9,11 +9,13 @@ import javafx.collections.FXCollections;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.PagedSearchBasedFetcher;
 import org.jabref.logic.importer.SearchBasedFetcher;
+import org.jabref.logic.util.BuildInfo;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.testutils.category.FetcherTest;
 
+import com.airhacks.afterburner.injection.Injector;
 import kong.unirest.core.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -32,8 +34,10 @@ class SpringerFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSear
 
     @BeforeEach
     void setUp() {
-        when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
+        BuildInfo buildInfo = Injector.instantiateModelOrService(BuildInfo.class);
         fetcher = new SpringerFetcher(importerPreferences);
+        when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
+        when(importerPreferences.getApiKey(fetcher.getName())).thenReturn(Optional.of(buildInfo.springerNatureAPIKey));
     }
 
     @Test


### PR DESCRIPTION
Added  default api key support for springer fetcher tests. Fixes #12610 

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
