### PR TITLE
Issue#12585: When merging groups or keywords, remove duplicates

### DIFF
--- a/src/main/java/org/jabref/gui/mergeentries/newmergedialog/fieldsmerger/GroupMerger.java
+++ b/src/main/java/org/jabref/gui/mergeentries/newmergedialog/fieldsmerger/GroupMerger.java
@@ -12,7 +12,7 @@ import org.jabref.model.strings.StringUtil;
  * */
 public class GroupMerger implements FieldMerger {
     public static final String GROUPS_SEPARATOR = ", ";
-    public static final Pattern GROUPS_SEPARATOR_REGEX = Pattern.compile("\s*,\s*");
+    public static final Pattern GROUPS_SEPARATOR_REGEX = Pattern.compile("[;,]\\s*");
 
     @Override
     public String merge(String groupsA, String groupsB) {
@@ -23,9 +23,13 @@ public class GroupMerger implements FieldMerger {
         } else if (StringUtil.isBlank(groupsB)) {
             return groupsA;
         } else {
+            groupsA = groupsA.trim();
+            groupsB = groupsB.trim();
+
             return Arrays.stream(GROUPS_SEPARATOR_REGEX.split(groupsA + GROUPS_SEPARATOR + groupsB))
-                         .distinct()
-                         .collect(Collectors.joining(GROUPS_SEPARATOR));
+                    .map(String::trim)
+                    .distinct()
+                    .collect(Collectors.joining(GROUPS_SEPARATOR));
         }
     }
 }

--- a/src/main/java/org/jabref/gui/mergeentries/newmergedialog/fieldsmerger/KeywordMerger.java
+++ b/src/main/java/org/jabref/gui/mergeentries/newmergedialog/fieldsmerger/KeywordMerger.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.mergeentries.newmergedialog.fieldsmerger;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import org.jabref.model.entry.BibEntryPreferences;
@@ -19,7 +21,32 @@ public class KeywordMerger implements FieldMerger {
 
     @Override
     public String merge(String keywordsA, String keywordsB) {
+        Character keywordSeparatorA = detectSeparator(keywordsA);
+        Character keywordSeparatorB = detectSeparator(keywordsB);
+
+        if (keywordSeparatorA != null && keywordSeparatorB != null && keywordSeparatorA != keywordSeparatorB) {
+            throw new IllegalArgumentException("Multiple different separators detected in keywords");
+        }
+
+        this.bibEntryPreferences.setKeywordSeparator(keywordSeparatorA);
         Character delimiter = bibEntryPreferences.getKeywordSeparator();
         return KeywordList.merge(keywordsA, keywordsB, delimiter).getAsString(delimiter);
+    }
+
+    private Character detectSeparator(String keywords) {
+        Map<Character, Integer> separatorCount = new HashMap<>();
+
+        for (char c : keywords.toCharArray()) {
+            if (!Character.isLetterOrDigit(c) && !Character.isWhitespace(c)) {
+                separatorCount.put(c, separatorCount.getOrDefault(c, 0) + 1);
+            }
+        }
+
+        if (separatorCount.size() > 1) {
+            throw new IllegalArgumentException("Multiple different separators detected in keywords: " + keywords);
+        }
+
+        return separatorCount.keySet().stream().findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No valid separator found in keywords: " + keywords));
     }
 }


### PR DESCRIPTION
Issue#12585: When merging groups or keywords, remove duplicates. now can merge keywords and groups enven the delimeter is not comma. but still want to know if it is the expected result?

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x ] Screenshots added in PR description (for UI changes)
<img width="1737" alt="Screenshot 2025-03-07 at 4 57 03 PM" src="https://github.com/user-attachments/assets/91e0c49b-6b7f-40f2-b845-cc42106e6dd3" />
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

