### PR TITLE
Enable product-map for contributions

### DIFF
--- a/.github/workflows/product-map.yml
+++ b/.github/workflows/product-map.yml
@@ -22,11 +22,10 @@ jobs:
           FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- '*.java' | sed 's|^|\"|' | sed 's|$|\"|' | paste -sd "," -)
           if [ -z "$FILES" ]; then FILES="\"dummy.java\""; fi
           echo "expected_files=(${FILES})" >> $GITHUB_ENV
+          echo "Files: ${FILES}"
 
       - name: ProductMap Map Generation
         uses: product-map/product-map-action@main
-        # disabled because of https://github.com/product-map/product-map-action/issues/7
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           expected_files: ${{ env.expected_files }}


### PR DESCRIPTION
Since https://github.com/product-map/product-map-action/issues/7 is fixed, we can try out product map.

Follow-up to https://github.com/JabRef/jabref/pull/12644

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
