### PR TITLE
Fix for issue 12269 Show username while hovering over user-specific file directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added new modifiers `camel_case`, `camel_case_n`, `short_title`, and `very_short_title` for the [citation key generator](https://docs.jabref.org/setup/citationkeypatterns). [#11367](https://github.com/JabRef/jabref/issues/11367)
 - By double clicking on a local citation in the Citation Relations Tab you can now jump the linked entry. [#11955](https://github.com/JabRef/jabref/pull/11955)
 - We use the menu icon for background tasks as a progress indicator to visualise an import's progress when dragging and dropping several PDF files into the main table. [#12072](https://github.com/JabRef/jabref/pull/12072)
+- We added a hover on user-specific file directory label. If the mouse is on hover, JabRef displays: user: {username}, host: {hostname}.
 - The PDF content importer now supports importing title from upto the second page of the PDF. [#12139](https://github.com/JabRef/jabref/issues/12139)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added new modifiers `camel_case`, `camel_case_n`, `short_title`, and `very_short_title` for the [citation key generator](https://docs.jabref.org/setup/citationkeypatterns). [#11367](https://github.com/JabRef/jabref/issues/11367)
 - By double clicking on a local citation in the Citation Relations Tab you can now jump the linked entry. [#11955](https://github.com/JabRef/jabref/pull/11955)
 - We use the menu icon for background tasks as a progress indicator to visualise an import's progress when dragging and dropping several PDF files into the main table. [#12072](https://github.com/JabRef/jabref/pull/12072)
-- We added a hover on user-specific file directory label. If the mouse is on hover, JabRef displays: user: {username}, host: {hostname}.
+- We added a hover on user-specific file directory label. If the mouse is on hover, JabRef displays: user: {username}, host: {hostname}[#12269](https://github.com/JabRef/jabref/issues/12269)
 - The PDF content importer now supports importing title from upto the second page of the PDF. [#12139](https://github.com/JabRef/jabref/issues/12139)
 
 ### Changed

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralProperties.fxml
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralProperties.fxml
@@ -47,9 +47,19 @@
         </Button>
 
         <Label text="%User-specific file directory"
-               GridPane.columnIndex="0" GridPane.rowIndex="2"/>
+               fx:id="userSpecificFileLabel"
+               GridPane.columnIndex="0" GridPane.rowIndex="2">
+            <tooltip>
+                <Tooltip fx:id="userSpecificFileTooltip"/>
+            </tooltip>
+        </Label>
+
         <TextField fx:id="userSpecificFileDirectory"
-                   GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+                   GridPane.columnIndex="1" GridPane.rowIndex="2"
+        />
+
+
+
         <Button onAction="#browseUserSpecificFileDirectory"
                 styleClass="icon-button,narrow" prefHeight="20.0" prefWidth="20.0"
                 GridPane.columnIndex="2" GridPane.rowIndex="2">
@@ -86,6 +96,5 @@
                GridPane.columnIndex="0" GridPane.rowIndex="6"/>
         <ComboBox fx:id="encoding" prefWidth="150.0"
                   GridPane.columnIndex="1" GridPane.hgrow="ALWAYS" GridPane.rowIndex="6"/>
-
     </GridPane>
 </fx:root>

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
@@ -71,7 +71,6 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
         }
 
         userSpecificFileTooltip.setText("User: " + username + " | Host: " + hostname);
-       // userSpecificFileTooltip.textProperty().bind(viewModel.userSpecificFileDirectoryTooltipProperty().get().textProperty());
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
@@ -18,6 +18,8 @@ import org.jabref.model.database.BibDatabaseMode;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import jakarta.inject.Inject;
+import org.mariadb.jdbc.internal.logging.Logger;
+import org.mariadb.jdbc.internal.logging.LoggerFactory;
 
 public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralPropertiesViewModel> {
     @FXML private ComboBox<Charset> encoding;
@@ -28,7 +30,6 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
     @FXML private Tooltip userSpecificFileTooltip;
 
     @Inject private CliPreferences preferences;
-
     public GeneralPropertiesView(BibDatabaseContext databaseContext) {
         this.databaseContext = databaseContext;
 
@@ -64,10 +65,11 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
         String username = System.getProperty("user.name"); // Get system username
         // Get hostname
         String hostname = "Unknown Host"; // Default value in case of error
+        Logger logger = LoggerFactory.getLogger(GeneralPropertiesView.class);
         try {
             hostname = InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
-            e.printStackTrace(); // Print error if hostname retrieval fails
+            logger.error("Failed to retrieve the hostname", e); // Use the logger instead of printStackTrace
         }
 
         userSpecificFileTooltip.setText("User: " + username + " | Host: " + hostname);

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesView.java
@@ -1,10 +1,13 @@
 package org.jabref.gui.libraryproperties.general;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.libraryproperties.AbstractPropertiesTabView;
 import org.jabref.gui.util.ViewModelListCellFactory;
@@ -22,6 +25,7 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
     @FXML private TextField librarySpecificFileDirectory;
     @FXML private TextField userSpecificFileDirectory;
     @FXML private TextField laTexFileDirectory;
+    @FXML private Tooltip userSpecificFileTooltip;
 
     @Inject private CliPreferences preferences;
 
@@ -57,6 +61,17 @@ public class GeneralPropertiesView extends AbstractPropertiesTabView<GeneralProp
         librarySpecificFileDirectory.textProperty().bindBidirectional(viewModel.librarySpecificDirectoryPropertyProperty());
         userSpecificFileDirectory.textProperty().bindBidirectional(viewModel.userSpecificFileDirectoryProperty());
         laTexFileDirectory.textProperty().bindBidirectional(viewModel.laTexFileDirectoryProperty());
+        String username = System.getProperty("user.name"); // Get system username
+        // Get hostname
+        String hostname = "Unknown Host"; // Default value in case of error
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            e.printStackTrace(); // Print error if hostname retrieval fails
+        }
+
+        userSpecificFileTooltip.setText("User: " + username + " | Host: " + hostname);
+       // userSpecificFileTooltip.textProperty().bind(viewModel.userSpecificFileDirectoryTooltipProperty().get().textProperty());
     }
 
     @FXML

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
@@ -15,6 +15,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
+import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.libraryproperties.PropertiesTabViewModel;
@@ -44,11 +45,16 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
     private final BibDatabaseContext databaseContext;
     private final MetaData metaData;
 
+    private final ObjectProperty<Tooltip> userSpecificFileDirectoryTooltip = new SimpleObjectProperty<>(new Tooltip());
     GeneralPropertiesViewModel(BibDatabaseContext databaseContext, DialogService dialogService, CliPreferences preferences) {
         this.dialogService = dialogService;
         this.preferences = preferences;
         this.databaseContext = databaseContext;
         this.metaData = databaseContext.getMetaData();
+    }
+
+    public ObjectProperty<Tooltip> userSpecificFileDirectoryTooltipProperty() {
+        return this.userSpecificFileDirectoryTooltip;
     }
 
     @Override
@@ -61,6 +67,9 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
         librarySpecificDirectoryProperty.setValue(metaData.getLibrarySpecificFileDirectory().orElse("").trim());
         userSpecificFileDirectoryProperty.setValue(metaData.getUserFileDirectory(preferences.getFilePreferences().getUserAndHost()).orElse("").trim());
         laTexFileDirectoryProperty.setValue(metaData.getLatexFileDirectory(preferences.getFilePreferences().getUserAndHost()).map(Path::toString).orElse(""));
+        Tooltip tooltip = new Tooltip();
+        tooltip.setStyle("-fx-font-size: 12px;"); // Optional styling
+        userSpecificFileDirectoryTooltip.set(tooltip);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
+++ b/src/main/java/org/jabref/gui/libraryproperties/general/GeneralPropertiesViewModel.java
@@ -15,7 +15,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
-import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.libraryproperties.PropertiesTabViewModel;
@@ -45,16 +44,11 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
     private final BibDatabaseContext databaseContext;
     private final MetaData metaData;
 
-    private final ObjectProperty<Tooltip> userSpecificFileDirectoryTooltip = new SimpleObjectProperty<>(new Tooltip());
     GeneralPropertiesViewModel(BibDatabaseContext databaseContext, DialogService dialogService, CliPreferences preferences) {
         this.dialogService = dialogService;
         this.preferences = preferences;
         this.databaseContext = databaseContext;
         this.metaData = databaseContext.getMetaData();
-    }
-
-    public ObjectProperty<Tooltip> userSpecificFileDirectoryTooltipProperty() {
-        return this.userSpecificFileDirectoryTooltip;
     }
 
     @Override
@@ -67,9 +61,6 @@ public class GeneralPropertiesViewModel implements PropertiesTabViewModel {
         librarySpecificDirectoryProperty.setValue(metaData.getLibrarySpecificFileDirectory().orElse("").trim());
         userSpecificFileDirectoryProperty.setValue(metaData.getUserFileDirectory(preferences.getFilePreferences().getUserAndHost()).orElse("").trim());
         laTexFileDirectoryProperty.setValue(metaData.getLatexFileDirectory(preferences.getFilePreferences().getUserAndHost()).map(Path::toString).orElse(""));
-        Tooltip tooltip = new Tooltip();
-        tooltip.setStyle("-fx-font-size: 12px;"); // Optional styling
-        userSpecificFileDirectoryTooltip.set(tooltip);
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12269

Added a tooltip that displays the current username and host upon hovering on user-specific directory label
would kindly ask the issue maintainers to please specify what should the Latex file directory tooltip show on hovering so that I can add it within this PR.

![image](https://github.com/user-attachments/assets/ceb92c28-1ff7-492d-9f3e-e6fd3b29bcc2)


### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
