### PR TITLE
Move issues on PR activity

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -49,3 +49,35 @@
     Commits will be lost, comments on commits will loose their context.
     This makes it harder to review.
     In the end, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) either way before being merged into the `main`` branch.
+- jobName: move_issue
+  message: |
+    Your pull request needs to link an issue.
+
+    To ease organizational workflows, please link this pull-request to the issue with syntax as described in <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>:
+
+    > <h2 id="linking-a-pull-request-to-an-issue-using-a-keyword">Linking a pull request to an issue using a keyword</h2>
+    > <p>You can link a pull request to an issue by using a supported keyword
+    > in the pull request's description or in a commit message. The pull
+    > request <strong>must be</strong> on the default branch.</p>
+    > <ul>
+    > <li>close</li>
+    > <li>closes</li>
+    > <li>closed</li>
+    > <li>fix</li>
+    > <li>fixes</li>
+    > <li>fixed</li>
+    > <li>resolve</li>
+    > <li>resolves</li>
+    > <li>resolved</li>
+    > </ul>
+    > <p>If you use a keyword to reference a pull request comment in another
+    > pull request, the pull requests will be linked. Merging the referencing
+    > pull request also closes the referenced pull request.</p>
+    > <p>The syntax for closing keywords depends on whether the issue is in the same repository as the pull request.</p>
+
+    ### Examples
+
+    - ✅ `Fixes #xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ✅ `Fixes https://github.com/JabRef/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ✅ `Fixes https://github.com/Koppor/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ❌ `Fixes [#xyz](https://github.com/JabRef/jabref/issues/xyz)` links pull-request to issue. Merging the PR will **NOT** close the issue.

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -1,0 +1,57 @@
+name: Mark issue as available
+
+on:
+  pull_request_target:
+    types: [ closed ]
+
+jobs:
+  unassign_issue:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'closed' && !github.event.pull_request.merged
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Determine issue number
+        id: get_issue_number
+        uses: koppor/ticket-check-action@add-output
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
+          ticketPrefix: '#'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          branchRegex: '^(?<ticketNumber>\d+)'
+          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/(?<ticketNumber>\d+)'
+          outputOnly: true
+      - name: Move issue to "Free to take" in "Good First Issues"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/5"
+          target-labels: "📍 Assigned"
+          target-column: "Free to take"
+          ignored-columns: ""
+          default-column: "Free to take"
+          issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
+          skip-if-not-in-project: true
+      - name: Move issue to "Free to take" in "Candidates for University Projects"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/3"
+          target-labels: "📍 Assigned"
+          target-column: "Free to take"
+          ignored-columns: ""
+          default-column: "Free to take"
+          issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
+          skip-if-not-in-project: true
+      - uses: actions/checkout@v4
+      - name: Remove assigned status
+        run : gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-assignee ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove assigned label
+        run : gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -1,0 +1,55 @@
+name: Mark issue as in progress
+
+on:
+  # _target is required
+  pull_request_target:
+
+jobs:
+  move_issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine issue number
+        id: get_issue_number
+        uses: koppor/ticket-check-action@add-output
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
+          ticketPrefix: '#'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          branchRegex: '^(?<ticketNumber>\d+)'
+          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/(?<ticketNumber>\d+)'
+          outputOnly: true
+      - name: Move issue to "In Progress" in "Good First Issues"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/5"
+          target-labels: "📍 Assigned"
+          target-column: "In Progress"
+          ignored-columns: ""
+          default-column: "In Progress"
+          issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
+          skip-if-not-in-project: true
+      - name: Move issue to "In Progress" in "Candidates for University Projects"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/7"
+          target-labels: "📍 Assigned"
+          target-column: "In Progress"
+          ignored-columns: ""
+          default-column: "In Progress"
+          issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
+          skip-if-not-in-project: true
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,7 +7,7 @@ name: Comment on PR
 
 on:
   workflow_run:
-    workflows: ["Tests"]
+    workflows: ["Tests", "Mark issue as in progress"]
     types:
       - completed
 


### PR DESCRIPTION
- When a contributor opens a PR, we needed to manually update the state in the project.
- When we closed a PR without merging, we needed to manually update the state in the project (and also manually unassign the user)

With this PR, we get this in an automated fassion.

Following PRs need to be monitored and these files updated as soon as the PRs are merged:

- https://github.com/neofinancial/ticket-check-action/pull/58
- https://github.com/m7kvqbe1/github-action-move-issues/pull/38

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
