### PR TITLE
Update assign-issue.yml

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -33,6 +33,12 @@ jobs:
             Happy coding! 🚀
 
             ⏳ Please note, you will be automatically unassigned if the issue isn't closed within **{{ total_days }} days** (by **{{ unassigned_date }}**). A maintainer can also add the "**{{ pin_label }}**"" label to prevent automatic unassignment.
+          assignment_suggestion_comment: >
+            👋 Hey @{{ handle }}, it looks like you're interested in working on this issue! 🎉
+            
+            It also looks like that you did not find our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing).
+            Please read on there.
+            Then, you will also learn how to assign an issue to yourself.
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
         uses: m7kvqbe1/github-action-move-issues@main
         # Action currently works for issues only - pre-condition: https://github.com/takanome-dev/assign-issue-action/issues/269 fixed

--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -34,11 +34,11 @@ jobs:
 
             ⏳ Please note, you will be automatically unassigned if the issue isn't closed within **{{ total_days }} days** (by **{{ unassigned_date }}**). A maintainer can also add the "**{{ pin_label }}**"" label to prevent automatic unassignment.
           assignment_suggestion_comment: >
-            👋 Hey @{{ handle }}, it looks like you're interested in working on this issue! 🎉
-            
-            It also looks like that you did not find our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing).
-            Please read on there.
-            Then, you will also learn how to assign an issue to yourself.
+            👋 Hey @{{ handle }}, looks like you’re eager to work on this issue—great! 🎉
+
+            It also looks like you skipped reading our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md), which explains exactly how to participate. No worries, it happens to the best of us.
+
+            Give it a read, and you’ll discover the ancient wisdom of assigning issues to yourself. Trust me, it’s worth it. 🚀
       - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
         uses: m7kvqbe1/github-action-move-issues@main
         # Action currently works for issues only - pre-condition: https://github.com/takanome-dev/assign-issue-action/issues/269 fixed


### PR DESCRIPTION
I am really fed up that contributors do not read CONTRIBUTNG.md. I think, we should really point them to that (and not help them not reading it)

We have a good table of contents:

![image](https://github.com/user-attachments/assets/2972f6fa-d5af-45d2-a414-cf8f3ae12780)

Thus, I suggest to remove the direct hint to `/assign-me` and add a link to the contributing.md file

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
