### PR TITLE
Change the message in the Integrity check progress dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
+- We changed the message displayed in the Integrity Check Progress dialog to "Waiting for the check to finish...". [#12694](https://github.com/JabRef/jabref/issues/12694)
 - We moved the "Generate a new key for imported entries" option from the "Web search" tab to the "Citation key generator" tab in preferences. [#12436](https://github.com/JabRef/jabref/pull/12436)
 - We improved the offline parsing of BibTeX data from PDF-documents. [#12278](https://github.com/JabRef/jabref/issues/12278)
 - The tab bar is now hidden when only one library is open. [#9971](https://github.com/JabRef/jabref/issues/9971)

--- a/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
+++ b/src/main/java/org/jabref/gui/integrity/IntegrityCheckAction.java
@@ -85,7 +85,7 @@ public class IntegrityCheckAction extends SimpleCommand {
 
         dialogService.showProgressDialog(
                 Localization.lang("Checking integrity..."),
-                Localization.lang("Checking integrity..."),
+                Localization.lang("Waiting for the check to finish..."),
                 task);
         taskExecutor.execute(task);
     }

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1029,6 +1029,7 @@ Line\ %0\:\ Found\ corrupted\ citation\ key\ %1\ (comma\ missing).=Line %0: Foun
 
 Check\ integrity=Check integrity
 Checking\ integrity...=Checking integrity...
+Waiting\ for\ the\ check\ to\ finish...=Waiting for the check to finish...
 
 Field\ Presence\ Consistency\ Check\ Result=Field Presence Consistency Check Result
 required\ field\ is\ present=required field is present


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12694

This PR changes the text "Checking integrity..." to "Waiting for the check to finish..." in integrity check progress dialog.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
