### PR TITLE
Remove second "Citation key" column from the Consistency check results table.

### DIFF
--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -105,9 +105,8 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
                 List<String> message = row.getValue().message();
                 if (currentIndex < message.size()) {
                     return new ReadOnlyStringWrapper(message.get(currentIndex));
-                } else {
-                    return new ReadOnlyStringWrapper("");
                 }
+                return new ReadOnlyStringWrapper("");
             });
             columnIndex++;
 

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -25,6 +25,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
 import org.jabref.logic.quality.consistency.ConsistencyMessage;
 import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.SpecialField;
 
 import com.airhacks.afterburner.views.ViewLoader;

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -25,7 +25,6 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
 import org.jabref.logic.quality.consistency.ConsistencyMessage;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.SpecialField;
 
 import com.airhacks.afterburner.views.ViewLoader;
@@ -104,7 +103,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
             tableColumn.setCellValueFactory(row -> {
                 List<String> message = row.getValue().message();
-                if (currentIndex<message.size()) {
+                if (currentIndex < message.size()) {
                     return new ReadOnlyStringWrapper(message.get(currentIndex));
                 } else {
                     return new ReadOnlyStringWrapper("");

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -99,7 +99,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
         int columnIndex = 0;
         for (String columnName : viewModel.getColumnNames()) {
-           final int currentIndex = columnIndex;
+            final int currentIndex = columnIndex;
             TableColumn<ConsistencyMessage, String> tableColumn = new TableColumn<>(columnName);
 
             tableColumn.setCellValueFactory(row -> {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -106,7 +106,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
                 List<String> message = row.getValue().message();
                 if (currentIndex<message.size()){
                     return new ReadOnlyStringWrapper(message.get(currentIndex));
-                } else{
+                } else {
                     return new ReadOnlyStringWrapper("");
                 }
             });

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -104,7 +104,7 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
             tableColumn.setCellValueFactory(row -> {
                 List<String> message = row.getValue().message();
-                if (currentIndex<message.size()){
+                if (currentIndex<message.size()) {
                     return new ReadOnlyStringWrapper(message.get(currentIndex));
                 } else {
                     return new ReadOnlyStringWrapper("");

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -97,14 +97,20 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
 
         tableView.setItems(filteredData);
 
-        for (int i = 0; i < viewModel.getColumnNames().size(); i++) {
-            int columnIndex = i;
-            TableColumn<ConsistencyMessage, String> tableColumn = new TableColumn<>(viewModel.getColumnNames().get(i));
+        int columnIndex = 0;
+        for (String columnName : viewModel.getColumnNames()) {
+           final int currentIndex = columnIndex;
+            TableColumn<ConsistencyMessage, String> tableColumn = new TableColumn<>(columnName);
 
             tableColumn.setCellValueFactory(row -> {
                 List<String> message = row.getValue().message();
-                return new ReadOnlyStringWrapper(message.get(columnIndex));
+                if (currentIndex<message.size()){
+                    return new ReadOnlyStringWrapper(message.get(currentIndex));
+                } else{
+                    return new ReadOnlyStringWrapper("");
+                }
             });
+            columnIndex++;
 
             tableColumn.setCellFactory(_ -> new TableCell<>() {
                 @Override

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -149,8 +149,6 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
         Arrays.stream(SpecialField.values())
               .map(SpecialField::getDisplayName)
               .forEach(this::removeColumnByTitle);
-
-        removeColumnByTitle(InternalField.KEY_FIELD.getName());
     }
 
     private void removeColumnWithUniformValue(String symbol) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialog.java
@@ -142,6 +142,8 @@ public class ConsistencyCheckDialog extends BaseDialog<Void> {
         Arrays.stream(SpecialField.values())
               .map(SpecialField::getDisplayName)
               .forEach(this::removeColumnByTitle);
+
+        removeColumnByTitle(InternalField.KEY_FIELD.getName());
     }
 
     private void removeColumnWithUniformValue(String symbol) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.consistency;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -10,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,12 +97,12 @@ public class ConsistencyCheckDialogViewModel extends AbstractViewModel {
         return tableData;
     }
 
-    public List<String> getColumnNames() {
+    public Set<String> getColumnNames() {
         Set<String> result = new LinkedHashSet<>(columnCount + EXTRA_COLUMNS_COUNT);
         result.add("Entry Type");
         result.add("Citation Key");
         allReportedFields.forEach(field-> result.add(field.getDisplayName().trim()));
-        return new ArrayList<>(result);
+        return result;
     }
 
     private void writeMapEntry(Map.Entry<EntryType, BibliographyConsistencyCheck.EntryTypeResult> mapEntry) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.consistency;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -54,6 +56,7 @@ public class ConsistencyCheckDialogViewModel extends AbstractViewModel {
     private final List<Field> allReportedFields;
     private final int columnCount;
     private final int EXTRA_COLUMNS_COUNT = 2;
+    private int CITATION_KEY_COLUMN_INDEX = -1;
     private final ObservableList<ConsistencyMessage> tableData = FXCollections.observableArrayList();
     private final StringProperty selectedEntryType = new SimpleStringProperty();
 
@@ -95,13 +98,11 @@ public class ConsistencyCheckDialogViewModel extends AbstractViewModel {
     }
 
     public List<String> getColumnNames() {
-        List<String> result = new ArrayList<>(columnCount + EXTRA_COLUMNS_COUNT);
+        Set<String> result = new LinkedHashSet<>(columnCount + EXTRA_COLUMNS_COUNT);
         result.add("Entry Type");
         result.add("Citation Key");
-        allReportedFields.forEach(field -> {
-            result.add(field.getDisplayName());
-        });
-        return result;
+        allReportedFields.forEach(field-> result.add(field.getDisplayName().trim()));
+        return new ArrayList<>(result);
     }
 
     private void writeMapEntry(Map.Entry<EntryType, BibliographyConsistencyCheck.EntryTypeResult> mapEntry) {

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
@@ -98,7 +98,7 @@ public class ConsistencyCheckDialogViewModel extends AbstractViewModel {
     public Set<String> getColumnNames() {
         Set<String> result = new LinkedHashSet<>(columnCount + EXTRA_COLUMNS_COUNT);
         result.add("Entry Type");
-        result.add("Citation Key");
+        result.add("CitationKey");
         allReportedFields.forEach(field-> result.add(field.getDisplayName().trim()));
         return result;
     }

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
@@ -56,7 +56,6 @@ public class ConsistencyCheckDialogViewModel extends AbstractViewModel {
     private final List<Field> allReportedFields;
     private final int columnCount;
     private final int EXTRA_COLUMNS_COUNT = 2;
-    private int CITATION_KEY_COLUMN_INDEX = -1;
     private final ObservableList<ConsistencyMessage> tableData = FXCollections.observableArrayList();
     private final StringProperty selectedEntryType = new SimpleStringProperty();
 

--- a/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/consistency/ConsistencyCheckDialogViewModel.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.consistency;
 
-import java.util.Set;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12697

This PR remove the second "Citation key" column from the Consistency check results table.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
