### PR TITLE
Split assign-workflow in issue-comment and schedule

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -1,11 +1,8 @@
-name: Assign Issue
+name: On isuse comment
 
 on:
-  schedule:
-    - cron: 4 12 * * *
   issue_comment:
     types: [created]
-  workflow_dispatch:
 
 jobs:
   assign:
@@ -39,10 +36,9 @@ jobs:
             It also looks like you skipped reading our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md), which explains exactly how to participate. No worries, it happens to the best of us.
 
             Give it a read, and you’ll discover the ancient wisdom of assigning issues to yourself. Trust me, it’s worth it. 🚀
-      - name: Move Issue to "Assigned" Column in "Candidates for University Projects"
+      - name: Move issue corresponding column in "Candidates for University Projects"
         uses: m7kvqbe1/github-action-move-issues@main
-        # Action currently works for issues only - pre-condition: https://github.com/takanome-dev/assign-issue-action/issues/269 fixed
-        if: github.event_name == 'issue_comment'
+        if: ${{ steps.assign.outputs.assigned == 'yes' || steps.assign.outputs.unassigned == 'yes' }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
@@ -51,9 +47,9 @@ jobs:
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-      - name: Move Issue to "Assigned" Column in "Good First Issues"
+      - name: Move issue corresponding column in "Good First Issues"
         uses: m7kvqbe1/github-action-move-issues@main
-        if: github.event_name == 'issue_comment'
+        if: ${{ steps.assign.outputs.assigned == 'yes' || steps.assign.outputs.unassigned == 'yes' }}
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -1,0 +1,52 @@
+name: Unassign issues
+
+on:
+  schedule:
+    - cron: 4 12 * * *
+  workflow_dispatch:
+
+jobs:
+  unassign_issues:
+    if: github.repository_owner == 'JabRef'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    outputs:
+      unassigned_issues: ${{ steps.unassign.outputs.unassigned_issues }}
+    steps:
+      - name: Unassign stale assignments
+        id: unassign
+        uses: takanome-dev/assign-issue-action@edge
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          days_until_unassign: 45
+  move_unassigned_issues:
+    needs: unassign_issues
+    if: ${{ needs.unassign_issues.outputs.unassigned_issues != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        issue_number: ${{ fromJson(needs.unassign_issues.outputs.unassigned_issues) }}
+    steps:
+      - name: Move issue to "Free to take" in "Good First Issues"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/5"
+          target-labels: "📍 Assigned"
+          target-column: "Free to take"
+          ignored-columns: ""
+          default-column: "Free to take"
+          issue-number: ${{ matrix.issue_number }}
+          skip-if-not-in-project: true
+      - name: Move issue to "Free to take" in "Candidates for University Projects"
+        uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
+        with:
+          github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
+          project-url: "https://github.com/orgs/JabRef/projects/3"
+          target-labels: "📍 Assigned"
+          target-column: "Free to take"
+          ignored-columns: ""
+          default-column: "Free to take"
+          issue-number: ${{ matrix.issue_number }}
+          skip-if-not-in-project: true


### PR DESCRIPTION
This is the final step to really automate the project state moval.

Before: If issues were automatically unassigned, they were still in the "Assigned" Column.

Now: If issues were automatically unassigned, they are moved accordingly.

I cannot really test it, we need to wait until an unassignment happens.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
