### PR TITLE
replacing "Cleanup entries" to "Clean up entries"

### DIFF
--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -1,4 +1,4 @@
-name: Unassign issues
+name: Unassign stale issue assignments
 
 on:
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We removed the obsolete Twitter link and added Mastodon and LinkedIn links in Help -> JabRef resources. [#12660](https://github.com/JabRef/jabref/issues/12660)
 - We improved the Check Integrity dialog entry interaction so that a single click focuses on the corresponding entry and a double-click both focuses on the entry and closes the dialog. [#12245](https://github.com/JabRef/jabref/issues/12245)
 - We improved journal abbreviation lookup with fuzzy matching to handle minor input errors and variations. [#12467](https://github.com/JabRef/jabref/issues/12467)
-- We changed the phrase "Cleanup entries" to "Clean up entries". [#12710](https://github.com/JabRef/jabref/issues/12710)
+- We changed the phrase "Cleanup entries" to "Clean up entries". [#12703](https://github.com/JabRef/jabref/issues/12703)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We removed the obsolete Twitter link and added Mastodon and LinkedIn links in Help -> JabRef resources. [#12660](https://github.com/JabRef/jabref/issues/12660)
 - We improved the Check Integrity dialog entry interaction so that a single click focuses on the corresponding entry and a double-click both focuses on the entry and closes the dialog. [#12245](https://github.com/JabRef/jabref/issues/12245)
 - We improved journal abbreviation lookup with fuzzy matching to handle minor input errors and variations. [#12467](https://github.com/JabRef/jabref/issues/12467)
+- We changed a text JabRef displayed "Cleanup entries" instead of "Clean up entries" [#12710](https://github.com/JabRef/jabref/issues/12710)
 
 ### Fixed
 
@@ -72,7 +73,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where migration of "Search groups" would fail with an exception when the search query is invalid. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where not all linked files from BibDesk in the field `bdsk-file-...` were parsed. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where JabRef displayed an incorrect deletion notification when canceling entry deletion [#12645](https://github.com/JabRef/jabref/issues/12645)
-- We fixed an issue where JabRef displayed "Cleanup entries" instead of "Clean up entries" [#12710](https://github.com/JabRef/jabref/issues/12710)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We removed the obsolete Twitter link and added Mastodon and LinkedIn links in Help -> JabRef resources. [#12660](https://github.com/JabRef/jabref/issues/12660)
 - We improved the Check Integrity dialog entry interaction so that a single click focuses on the corresponding entry and a double-click both focuses on the entry and closes the dialog. [#12245](https://github.com/JabRef/jabref/issues/12245)
 - We improved journal abbreviation lookup with fuzzy matching to handle minor input errors and variations. [#12467](https://github.com/JabRef/jabref/issues/12467)
-- We changed a text JabRef displayed "Cleanup entries" instead of "Clean up entries" [#12710](https://github.com/JabRef/jabref/issues/12710)
+- We changed the phrase "Cleanup entries" to "Clean up entries". [#12710](https://github.com/JabRef/jabref/issues/12710)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where migration of "Search groups" would fail with an exception when the search query is invalid. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where not all linked files from BibDesk in the field `bdsk-file-...` were parsed. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where JabRef displayed an incorrect deletion notification when canceling entry deletion [#12645](https://github.com/JabRef/jabref/issues/12645)
-- We fixed an issue where JabRef displayed "Cleanup entries" instead of "Clean up entries" https://github.com/JabRef/jabref/issues/12703
+- We fixed an issue where JabRef displayed "Cleanup entries" instead of "Clean up entries" [#12710](https://github.com/JabRef/jabref/issues/12710)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where migration of "Search groups" would fail with an exception when the search query is invalid. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where not all linked files from BibDesk in the field `bdsk-file-...` were parsed. [#12555](https://github.com/JabRef/jabref/issues/12555)
 - We fixed an issue where JabRef displayed an incorrect deletion notification when canceling entry deletion [#12645](https://github.com/JabRef/jabref/issues/12645)
+- We fixed an issue where JabRef displayed "Cleanup entries" instead of "Clean up entries" https://github.com/JabRef/jabref/issues/12703
 
 
 ### Removed

--- a/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -150,7 +150,7 @@ public enum StandardActions implements Action {
     GENERATE_CITE_KEY(Localization.lang("Generate citation key"), IconTheme.JabRefIcons.MAKE_KEY, KeyBinding.AUTOGENERATE_CITATION_KEYS),
     GENERATE_CITE_KEYS(Localization.lang("Generate citation keys"), IconTheme.JabRefIcons.MAKE_KEY, KeyBinding.AUTOGENERATE_CITATION_KEYS),
     DOWNLOAD_FULL_TEXT(Localization.lang("Search full text documents online"), IconTheme.JabRefIcons.FILE_SEARCH, KeyBinding.DOWNLOAD_FULL_TEXT),
-    CLEANUP_ENTRIES(Localization.lang("Cleanup entries"), IconTheme.JabRefIcons.CLEANUP_ENTRIES, KeyBinding.CLEANUP),
+    CLEANUP_ENTRIES(Localization.lang("Clean up entries"), IconTheme.JabRefIcons.CLEANUP_ENTRIES, KeyBinding.CLEANUP),
     SET_FILE_LINKS(Localization.lang("Automatically set file links"), KeyBinding.AUTOMATICALLY_LINK_FILES),
 
     EDIT_FILE_LINK(Localization.lang("Edit"), IconTheme.JabRefIcons.EDIT, KeyBinding.OPEN_CLOSE_ENTRY_EDITOR),

--- a/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
@@ -145,7 +145,7 @@ public class CleanupAction extends SimpleCommand {
 
     private void cleanup(BibDatabaseContext databaseContext, CleanupPreferences cleanupPreferences) {
         this.failures.clear();
-        NamedCompound ce = new NamedCompound(Localization.lang("Cleanup entries"));
+        NamedCompound ce = new NamedCompound(Localization.lang("Clean up entries"));
 
         for (BibEntry entry : stateManager.getSelectedEntries()) {
             // undo granularity is on entry level

--- a/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupDialog.java
@@ -11,7 +11,7 @@ import org.jabref.model.database.BibDatabaseContext;
 
 public class CleanupDialog extends BaseDialog<CleanupPreferences> {
     public CleanupDialog(BibDatabaseContext databaseContext, CleanupPreferences initialPreset, FilePreferences filePreferences) {
-        setTitle(Localization.lang("Cleanup entries"));
+        setTitle(Localization.lang("Clean up entries"));
         getDialogPane().setPrefSize(600, 650);
         getDialogPane().getButtonTypes().setAll(ButtonType.OK, ButtonType.CANCEL);
 

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -56,7 +56,7 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
         setText(Localization.lang("Deprecated fields"));
         EasyBind.subscribe(preferences.getWorkspacePreferences().showAdvancedHintsProperty(), advancedHints -> {
             if (advancedHints) {
-                setTooltip(new Tooltip(Localization.lang("Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Cleanup Entries functionality to convert the entry to biblatex.")));
+                setTooltip(new Tooltip(Localization.lang("Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Clean up Entries functionality to convert the entry to biblatex.")));
             } else {
                 setTooltip(new Tooltip(Localization.lang("Shows fields having a successor in biblatex.")));
             }

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -31,7 +31,7 @@ public enum KeyBinding {
     AUTOMATICALLY_LINK_FILES("Automatically link files", Localization.lang("Automatically set file links"), "F7", KeyBindingCategory.QUALITY),
     CHECK_INTEGRITY("Check integrity", Localization.lang("Check integrity"), "ctrl+F8", KeyBindingCategory.QUALITY),
     CHECK_CONSISTENCY("Check consistency", Localization.lang("Check consistency"), "ctrl+F9", KeyBindingCategory.QUALITY),
-    CLEANUP("Cleanup", Localization.lang("Cleanup entries"), "alt+F8", KeyBindingCategory.QUALITY),
+    CLEANUP("Clean up", Localization.lang("Clean up entries"), "alt+F8", KeyBindingCategory.QUALITY),
     CLOSE_DATABASE("Close library", Localization.lang("Close library"), "ctrl+W", KeyBindingCategory.FILE),
     CLOSE("Close dialog", Localization.lang("Close dialog"), "Esc", KeyBindingCategory.VIEW),
     COPY("Copy", Localization.lang("Copy"), "ctrl+C", KeyBindingCategory.EDIT),

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1213,7 +1213,7 @@ Use\ abbreviated\ firstname\ whenever\ possible=Use abbreviated firstname whenev
 Use\ abbreviated\ and\ full\ firstname=Use abbreviated and full firstname
 Name\ format=Name format
 First\ names=First names
-Cleanup\ entries=Cleanup entries
+Clean\ up\ entries=Clean up entries
 Automatically\ assign\ new\ entry\ to\ selected\ groups=Automatically assign new entry to selected groups
 %0\ mode=%0 mode
 Move\ DOIs\ from\ 'note'\ field\ and\ 'URL'\ field\ to\ 'DOI'\ field\ and\ remove\ http\ prefix=Move DOIs from 'note' field and 'URL' field to 'DOI' field and remove http prefix
@@ -1332,7 +1332,7 @@ Convert\ to\ BibTeX\ format\ (e.g.,\ store\ publication\ date\ in\ year\ and\ mo
 Deprecated\ fields=Deprecated fields
 
 Shows\ fields\ having\ a\ successor\ in\ biblatex.=Shows fields having a successor in biblatex.
-Shows\ fields\ having\ a\ successor\ in\ biblatex.\nFor\ instance,\ the\ publication\ month\ should\ be\ part\ of\ the\ date\ field.\nUse\ the\ Cleanup\ Entries\ functionality\ to\ convert\ the\ entry\ to\ biblatex.=Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Cleanup Entries functionality to convert the entry to biblatex.
+Shows\ fields\ having\ a\ successor\ in\ biblatex.\nFor\ instance,\ the\ publication\ month\ should\ be\ part\ of\ the\ date\ field.\nUse\ the\ Cleanup\ Entries\ functionality\ to\ convert\ the\ entry\ to\ biblatex.=Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Clean up Entries functionality to convert the entry to biblatex.
 
 
 No\ read\ status\ information=No read status information

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1332,7 +1332,7 @@ Convert\ to\ BibTeX\ format\ (e.g.,\ store\ publication\ date\ in\ year\ and\ mo
 Deprecated\ fields=Deprecated fields
 
 Shows\ fields\ having\ a\ successor\ in\ biblatex.=Shows fields having a successor in biblatex.
-Shows\ fields\ having\ a\ successor\ in\ biblatex.\nFor\ instance,\ the\ publication\ month\ should\ be\ part\ of\ the\ date\ field.\nUse\ the\ Cleanup\ Entries\ functionality\ to\ convert\ the\ entry\ to\ biblatex.=Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Clean up Entries functionality to convert the entry to biblatex.
+Shows\ fields\ having\ a\ successor\ in\ biblatex.\nFor\ instance,\ the\ publication\ month\ should\ be\ part\ of\ the\ date\ field.\nUse\ the\ Clean\ up\ Entries\ functionality\ to\ convert\ the\ entry\ to\ biblatex.=Shows fields having a successor in biblatex.\nFor instance, the publication month should be part of the date field.\nUse the Clean up Entries functionality to convert the entry to biblatex.
 
 
 No\ read\ status\ information=No read status information


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THIS TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->
Closes https://github.com/JabRef/jabref/issues/12703

This is an simple replace text in few files for changing "Cleanup entries" to "Clean up entries"

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #xyz -->

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.



![Screenshot 1](https://github.com/user-attachments/assets/40a66936-1310-4ae0-ad7c-80b5c514485f)
![Screenshot 2](https://github.com/user-attachments/assets/05d9e8e3-0c4b-41bb-baa8-696d018e27bf)

