### PR TITLE
Suppress sun.util.log for warnings

### DIFF
--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -7,13 +7,6 @@ writerConsole.format = {date} [{thread}] {class}.{method}()\n{level}: {message}\
 # More shrunk exception logs. See https://tinylog.org/v2/configuration/#strip-stack-trace-elements for details
 exception = strip: jdk.internal
 
-level@org.apache.pdfbox.pdmodel.font = error
-level@org.apache.pdfbox.pdmodel.PDSimpleFont = error
-level@org.apache.fontbox.util.autodetect.FontFileFinder = warn
-level@org.apache.fontbox.ttf = warn
-level@ai.djl = info
-level@io.zonky.test.db.postgres.embedded = warn
-
 #level@org.jabref.gui.JabRefGUI = debug
 
 # AI debugging
@@ -26,3 +19,14 @@ level@io.zonky.test.db.postgres.embedded = warn
 #level@org.jabref.logic.ai.FileEmbeddingsManager = trace
 #level@org.jabref.logic.ai.impl.embeddings.LowLevelIngestor = trace
 #level@org.jabref.logic.ai.chat.AiChatLogic = trace
+
+level@ai.djl = info
+
+level@io.zonky.test.db.postgres.embedded = warn
+
+level@org.apache.fontbox.util.autodetect.FontFileFinder = warn
+level@org.apache.fontbox.ttf = warn
+level@org.apache.pdfbox.pdmodel.font = error
+level@org.apache.pdfbox.pdmodel.PDSimpleFont = error
+
+level@sun.util.logging.internal.LoggingProviderImpl = error


### PR DESCRIPTION
Fixes  https://github.com/JabRef/jabref/issues/12494 by adding a workaround

    level@sun.util.logging.internal.LoggingProviderImpl = error

I also reordered the log level config so that the jabref appear first

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
