### PR TITLE
Refine condition for testing fetchers

### DIFF
--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -43,6 +43,7 @@ permissions:
 
 jobs:
   fetchertests:
+    if: github.repository == 'JabRef/jabref' || github.event_name != 'schedule'
     name: Fetcher tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I get errors for fetcher tests in the jabref-koppor repo. Contributors probably also see this

![image](https://github.com/user-attachments/assets/5bdda660-5d80-4e05-ad85-05c930d44dbe)

Therefore disabling the scheduled tests on forks.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
