### PR TITLE
Add unassignment workflow (and removal of assignees)

### DIFF
--- a/.github/workflows/on-issue-unassigned.yml
+++ b/.github/workflows/on-issue-unassigned.yml
@@ -1,14 +1,13 @@
-name: On issue unlabeled
+name: On issue unassigned
 
 on:
   issues:
      types:
-       - unlabeled
+       - unassigned
 
 jobs:
   ensure_column:
-    name: "📍 Assigned or FirstTimeCodeContribution"
-    if: ${{ (github.event.label.name == '📍 Assigned' || github.event.label.name == 'FirstTimeCodeContribution') && github.repository_owner == 'JabRef' }}
+    if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -18,8 +17,8 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
-          target-labels: "📍 Assigned"
-          target-column: "Assigned"
+          target-labels: ""
+          target-column: "Free to take"
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
@@ -28,12 +27,12 @@ jobs:
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
-          target-labels: "📍 Assigned"
-          target-column: "Assigned"
+          target-labels: ""
+          target-column: "Free to take"
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-  remove_assignees:
+  remove_labels:
     if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
@@ -41,11 +40,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Remove all assignees
-        run: |
-          ASSIGNEES=$(gh issue view ${{ github.event.issue.number }} --json assignees --template '{{range .assignees}}{{.login}} {{end}}')
-          for user in $ASSIGNEES; do
-            gh issue edit ${{ github.event.issue.number }} --remove-assignee "$user"
-          done
+      - name: Remove assigned label
+        run: gh issue edit ${{ github.event.issue.number }} --remove-label "📍 Assigned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove FirstTimeCodeContribution label
+        run: gh issue edit ${{ github.event.issue.number }} --remove-label "FirstTimeCodeContribution"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -49,10 +49,14 @@ jobs:
           skip-if-not-in-project: true
       - uses: actions/checkout@v4
       - name: Remove assigned status
-        run : gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-assignee ${{ github.event.pull_request.user.login }}
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-assignee ${{ github.event.pull_request.user.login }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove assigned label
-        run : gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove FirstTimeCodeContribution label
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "FirstTimeCodeContribution"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At https://github.com/JabRef/jabref/issues/12351, I saw

![image](https://github.com/user-attachments/assets/35455891-00ed-4ee0-acc1-b5df94ae9cf7)

And no workflow was started... still "Assigned". This PR should fix this. ` .github/workflows/on-issue-unassigned.yml` 

Also at unlabled: remove assignees

Also remove "FirstTimeContribution" label.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
