### PR TITLE
Add test for conflicts

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -81,3 +81,10 @@
     - ✅ `Fixes https://github.com/JabRef/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
     - ✅ `Fixes https://github.com/Koppor/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
     - ❌ `Fixes [#xyz](https://github.com/JabRef/jabref/issues/xyz)` links pull-request to issue. Merging the PR will **NOT** close the issue.
+- jobName: 'Conflicts with target branch'
+  message: >
+    Your pull request conflicts with the target branch.
+
+    Please merge `upstream/main` with your code.
+    Preferrably, do this using `git` in your machine.
+    Conflicts in `CHANGELOG.md`` will be handled by a union of changes.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -379,16 +379,10 @@ jobs:
         run: |
           MERGEABLE=$(gh pr view --json mergeable 12574 --template '{{.mergeable}}')
           if [ "$MERGEABLE" == "CONFLICTING" ]; then
-            echo "conflicting=yes" >> $GITHUB_OUTPUT
-          else
-            echo "conflicting==no" >> $GITHUB_OUTPUT
+            echo "❌ Merge conflicts"
+            exit 1
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: React if conflicting
-        if: steps.check_mergeable.outputs.conflicting == 'yes'
-        run: |
-          gh pr comment ${{ github.event.number }} --body "⚠️ PR has merge conflicts. Please resolve."
+          echo "✅ No merge conflicts"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -366,14 +366,40 @@ jobs:
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.0
 
+  conflicts_with_target:
+    if: github.event_name == 'pull_request'
+    name: Conflicts with target branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
+      - name: Check PR mergeability
+        id: check_mergeable
+        run: |
+          MERGEABLE=$(gh pr view --json mergeable 12574 --template '{{.mergeable}}')
+          if [ "$MERGEABLE" == "CONFLICTING" ]; then
+            echo "conflicting=yes" >> $GITHUB_OUTPUT
+          else
+            echo "conflicting==no" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: React if conflicting
+        if: steps.check_mergeable.outputs.conflicting == 'yes'
+        run: |
+          gh pr comment ${{ github.event.number }} --body "⚠️ PR has merge conflicts. Please resolve."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   no-force-push:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Check force push
         id: force_push_check
         run: |
@@ -390,6 +416,7 @@ jobs:
           fi
 
   other_than_main:
+    if: github.event_name == 'pull_request'
     name: Source branch is other than "main"
     runs-on: ubuntu-latest
     steps:
@@ -400,6 +427,7 @@ jobs:
               core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read [the CONTRIBUTING guide](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing) carefully again. 👈')
 
   upload-pr-number:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Create pr_number.txt


### PR DESCRIPTION
Sometimes PRs have conflicts and contributors do not react. Think, we should comment.

note to self `gh pr comment` cannot be used due to rights restrictions: https://github.com/thollander/actions-comment-pull-request?tab=readme-ov-file#permissions

~~I am also checking `gh pr comment` here (https://cli.github.com/manual/gh_pr_comment). Not sure if this works.. But I want to try (if yes, I can deprecate https://github.com/koppor/ghprcomment/)~~

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
