### PR TITLE
merge=union for JabRef_en.properties

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@ gradlew text eol=lf
 *.properties text eol=lf
 
 CHANGELOG.md merge=union
+src/main/resources/l10n/JabRef_en.properties merge=union


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/12678 and https://github.com/JabRef/jabref/pull/12732.

Merge conflicts in `JabRef_en.properties` are mostly because two different new translation strings are added by different branches. When merging using the command line, both are taken - if `merge=union` is active.

This PR enables this.

(Note: It is not supported by GitHub - see https://github.com/isaacs/github/issues/487 for details)

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
