### PR TITLE
changed preferences and keybind search (issue #12647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved journal abbreviation lookup with fuzzy matching to handle minor input errors and variations. [#12467](https://github.com/JabRef/jabref/issues/12467)
 - We changed the phrase "Cleanup entries" to "Clean up entries". [#12703](https://github.com/JabRef/jabref/issues/12703)
 - A tooltip now appears after 300ms (instead of 2s). [#12649](https://github.com/JabRef/jabref/issues/12649)
+- Improved search in preferences and keybindings: You can now find settings by entering values from dropdowns or text fields (like "VScode"), easily locate shortcuts by entering keys (like "ctrl+w"), and matching categories automatically expand—with new "Expand all"/"Collapse all" buttons for quicker navigation. [#12647](https://github.com/JabRef/jabref/issues/12647)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved journal abbreviation lookup with fuzzy matching to handle minor input errors and variations. [#12467](https://github.com/JabRef/jabref/issues/12467)
 - We changed the phrase "Cleanup entries" to "Clean up entries". [#12703](https://github.com/JabRef/jabref/issues/12703)
 - A tooltip now appears after 300ms (instead of 2s). [#12649](https://github.com/JabRef/jabref/issues/12649)
-- Improved search in preferences and keybindings: You can now find settings by entering values from dropdowns or text fields (like "VScode"), easily locate shortcuts by entering keys (like "ctrl+w"), and matching categories automatically expand—with new "Expand all"/"Collapse all" buttons for quicker navigation. [#12647](https://github.com/JabRef/jabref/issues/12647)
+- We improved search in preferences and keybindings. [#12647](https://github.com/JabRef/jabref/issues/12647)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -83,6 +83,13 @@ class PreferencesSearchHandler {
 
     /**
      * Checks if a control contains the given query in its content.
+     * <p>
+     * Matching criteria based on control type:
+     * <ul>
+     *     <li><b>Labeled</b> (e.g., Label, Button): Matches if its text contains the query (case-insensitive).</li>
+     *     <li><b>ComboBox</b>: Matches if any item (converted to string) contains the query (case-insensitive).</li>
+     *     <li><b>TextField</b>: Matches if its content contains the query (case-insensitive).</li>
+     * </ul>
      *
      * @param control The control to check.
      * @param query   The search query.

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -1,17 +1,21 @@
 package org.jabref.gui.preferences;
 
-import com.google.common.collect.ArrayListMultimap;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.control.*;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Control;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.TextField;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
+import com.google.common.collect.ArrayListMultimap;
 
 /**
  * This class is responsible for filtering and searching inside the preferences view based on a search query.
@@ -95,11 +99,9 @@ class PreferencesSearchHandler {
                     .anyMatch(item -> item.toLowerCase(Locale.ROOT).contains(query));
         }
 
-        if(control instanceof TextField textField && textField.getText() != null) {
+        if (control instanceof TextField textField && textField.getText() != null) {
             return textField.getText().toLowerCase(Locale.ROOT).contains(query);
         }
-
-        //add other control elements to check for query match
 
         return false;
     }

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -85,7 +85,7 @@ class PreferencesSearchHandler {
      * @return true if the control contains the query, otherwise false.
      */
     private boolean controlMatchesQuery(Control control, String query) {
-        if (control instanceof Labeled labeled) {
+        if (control instanceof Labeled labeled && labeled.getText() != null) {
             return labeled.getText().toLowerCase(Locale.ROOT).contains(query);
         }
 
@@ -95,7 +95,7 @@ class PreferencesSearchHandler {
                     .anyMatch(item -> item.toLowerCase(Locale.ROOT).contains(query));
         }
 
-        if(control instanceof TextField textField) {
+        if(control instanceof TextField textField && textField.getText() != null) {
             return textField.getText().toLowerCase(Locale.ROOT).contains(query);
         }
 

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -31,7 +31,7 @@ class PreferencesSearchHandler {
      */
     PreferencesSearchHandler(List<PreferencesTab> preferenceTabs) {
         this.preferenceTabs = preferenceTabs;
-        this.preferenceTabsControls = buildPreferenceTabsControlsMap(preferenceTabs);
+        this.preferenceTabsControls = getPreferenceTabsControlsMap(preferenceTabs);
         this.filteredPreferenceTabs = new SimpleListProperty<>(FXCollections.observableArrayList(preferenceTabs));
     }
 
@@ -142,7 +142,7 @@ class PreferencesSearchHandler {
      * @param tabs The list of preferences tabs.
      * @return A map of preferences tabs to their controls.
      */
-    private ArrayListMultimap<PreferencesTab, Control> buildPreferenceTabsControlsMap(List<PreferencesTab> tabs) {
+    private ArrayListMultimap<PreferencesTab, Control> getPreferenceTabsControlsMap(List<PreferencesTab> tabs) {
         ArrayListMultimap<PreferencesTab, Control> controlMap = ArrayListMultimap.create();
         tabs.forEach(tab -> scanControls(tab.getBuilder(), controlMap, tab));
         return controlMap;

--- a/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -1,101 +1,165 @@
 package org.jabref.gui.preferences;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
+import com.google.common.collect.ArrayListMultimap;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.collections.FXCollections;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.control.Labeled;
+import javafx.scene.control.*;
 
-import com.google.common.collect.ArrayListMultimap;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
 
+/**
+ * This class is responsible for filtering and searching inside the preferences view based on a search query.
+ */
 class PreferencesSearchHandler {
 
-    private static PseudoClass labelHighlight = PseudoClass.getPseudoClass("search-highlight");
+    private static final PseudoClass CONTROL_HIGHLIGHT = PseudoClass.getPseudoClass("search-highlight");
+
     private final List<PreferencesTab> preferenceTabs;
     private final ListProperty<PreferencesTab> filteredPreferenceTabs;
-    private final ArrayListMultimap<PreferencesTab, Labeled> preferenceTabsLabelNames;
-    private final ArrayList<Labeled> highlightedLabels = new ArrayList<>();
+    private final ArrayListMultimap<PreferencesTab, Control> preferenceTabsControls;
 
+    /**
+     * Initializes the PreferencesSearchHandler with the given list of preference tabs.
+     *
+     * @param preferenceTabs The list of preference tabs.
+     */
     PreferencesSearchHandler(List<PreferencesTab> preferenceTabs) {
         this.preferenceTabs = preferenceTabs;
-        this.preferenceTabsLabelNames = getPrefsTabLabelMap();
+        this.preferenceTabsControls = buildPreferenceTabsControlsMap(preferenceTabs);
         this.filteredPreferenceTabs = new SimpleListProperty<>(FXCollections.observableArrayList(preferenceTabs));
     }
 
-    public void filterTabs(String text) {
+    /**
+     * Filters the preference tabs based on the provided search query.
+     * Highlights matching controls within tabs.
+     *
+     * @param query The search query to filter tabs.
+     */
+    public void filterTabs(String query) {
         clearHighlights();
-        if (text.isEmpty()) {
-            clearSearch();
+
+        if (query.isBlank()) {
+            resetSearch();
             return;
         }
 
-        filteredPreferenceTabs.clear();
-        for (PreferencesTab tab : preferenceTabsLabelNames.keySet()) {
-            boolean tabContainsLabel = false;
-            for (Labeled labeled : preferenceTabsLabelNames.get(tab)) {
-                if (labelContainsText(labeled, text)) {
-                    tabContainsLabel = true;
-                    highlightLabel(labeled);
-                }
-            }
-            boolean tabNameIsMatchedByQuery = tab.getTabName().toLowerCase(Locale.ROOT).contains(text);
-            if (tabContainsLabel || tabNameIsMatchedByQuery) {
-                filteredPreferenceTabs.add(tab);
-            }
+        String searchQuery = query.toLowerCase(Locale.ROOT);
+
+        List<PreferencesTab> matchedTabs = preferenceTabs.stream()
+                .filter(tab -> tabMatchesQuery(tab, searchQuery))
+                .collect(Collectors.toList());
+
+        filteredPreferenceTabs.setAll(matchedTabs);
+    }
+
+    /**
+     * Checks if a tab matches the given search query either by its name or by its controls.
+     *
+     * @param tab The preferences tab to check.
+     * @param query The search query.
+     * @return True if the tab matches the query.
+     */
+    private boolean tabMatchesQuery(PreferencesTab tab, String query) {
+        boolean tabNameMatches = tab.getTabName().toLowerCase(Locale.ROOT).contains(query);
+
+        boolean controlMatches = preferenceTabsControls.get(tab).stream()
+                .filter(control -> controlMatchesQuery(control, query))
+                .peek(this::highlightControl)
+                .findAny()
+                .isPresent();
+
+        return tabNameMatches || controlMatches;
+    }
+
+    /**
+     * Checks if a control contains the given query in its content.
+     *
+     * @param control The control to check.
+     * @param query   The search query.
+     * @return true if the control contains the query, otherwise false.
+     */
+    private boolean controlMatchesQuery(Control control, String query) {
+        if (control instanceof Labeled labeled) {
+            return labeled.getText().toLowerCase(Locale.ROOT).contains(query);
         }
+
+        if (control instanceof ComboBox<?> comboBox && !comboBox.getItems().isEmpty()) {
+            return comboBox.getItems().stream()
+                    .map(Object::toString)
+                    .anyMatch(item -> item.toLowerCase(Locale.ROOT).contains(query));
+        }
+
+        if(control instanceof TextField textField) {
+            return textField.getText().toLowerCase(Locale.ROOT).contains(query);
+        }
+
+        //add other control elements to check for query match
+
+        return false;
     }
 
-    private boolean labelContainsText(Labeled labeled, String text) {
-        return labeled.getText().toLowerCase(Locale.ROOT).contains(text);
+    /**
+     * Highlights the given control to indicate a match.
+     *
+     * @param control The control to highlight.
+     */
+    private void highlightControl(Control control) {
+        control.pseudoClassStateChanged(CONTROL_HIGHLIGHT, true);
     }
 
-    private void highlightLabel(Labeled labeled) {
-        labeled.pseudoClassStateChanged(labelHighlight, true);
-        highlightedLabels.add(labeled);
-    }
-
+    /**
+     * Clears all highlights from controls.
+     */
     private void clearHighlights() {
-        highlightedLabels.forEach(labeled -> labeled.pseudoClassStateChanged(labelHighlight, false));
+        preferenceTabsControls.values().forEach(control -> control.pseudoClassStateChanged(CONTROL_HIGHLIGHT, false));
     }
 
-    private void clearSearch() {
+    /**
+     * Resets the search, displaying all preference tabs.
+     */
+    private void resetSearch() {
         filteredPreferenceTabs.setAll(preferenceTabs);
     }
 
-    /*
-     * Traverse all nodes of a PreferencesTab and return a
-     * mapping from PreferencesTab to all its Labeled type nodes.
+    /**
+     * Provides the property representing the filtered list of preferences tabs.
+     *
+     * @return The filtered preference tabs as a ListProperty.
      */
-    private ArrayListMultimap<PreferencesTab, Labeled> getPrefsTabLabelMap() {
-        ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap = ArrayListMultimap.create();
-        for (PreferencesTab preferencesTab : preferenceTabs) {
-            Node builder = preferencesTab.getBuilder();
-            if (builder instanceof Parent parentBuilder) {
-                scanLabeledControls(parentBuilder, prefsTabLabelMap, preferencesTab);
-            }
-        }
-        return prefsTabLabelMap;
-    }
-
     protected ListProperty<PreferencesTab> filteredPreferenceTabsProperty() {
         return filteredPreferenceTabs;
     }
 
-    private static void scanLabeledControls(Parent parent, ArrayListMultimap<PreferencesTab, Labeled> prefsTabLabelMap, PreferencesTab preferencesTab) {
-        for (Node child : parent.getChildrenUnmodifiable()) {
-            if (child instanceof Labeled labeled) {
-                if (!labeled.getText().isEmpty()) {
-                    prefsTabLabelMap.put(preferencesTab, labeled);
-                }
-            } else if (child instanceof Parent parentChild) {
-                scanLabeledControls(parentChild, prefsTabLabelMap, preferencesTab);
-            }
+    /**
+     * Builds a map of controls for each preferences tab.
+     *
+     * @param tabs The list of preferences tabs.
+     * @return A map of preferences tabs to their controls.
+     */
+    private ArrayListMultimap<PreferencesTab, Control> buildPreferenceTabsControlsMap(List<PreferencesTab> tabs) {
+        ArrayListMultimap<PreferencesTab, Control> controlMap = ArrayListMultimap.create();
+        tabs.forEach(tab -> scanControls(tab.getBuilder(), controlMap, tab));
+        return controlMap;
+    }
+
+    /**
+     * Recursively scans nodes and collects all controls.
+     *
+     * @param node The current node being scanned.
+     * @param controlMap Map storing tabs and their corresponding controls.
+     * @param tab The PreferencesTab associated with the current node.
+     */
+    private void scanControls(Node node, ArrayListMultimap<PreferencesTab, Control> controlMap, PreferencesTab tab) {
+        if (node instanceof Control control) {
+            controlMap.put(tab, control);
+        } else if (node instanceof Parent parent) {
+            parent.getChildrenUnmodifiable().forEach(child -> scanControls(child, controlMap, tab));
         }
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
@@ -30,7 +30,7 @@
             </columnResizePolicy>
         </TreeTableView>
     </VBox>
-    
+
     <HBox>
         <HBox spacing="10.0" alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
             <Button text="%Expand all" onAction="#expandAll"/>

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import org.controlsfx.control.textfield.CustomTextField?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.TreeTableColumn?>
+<?import javafx.scene.control.TreeTableView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
+<?import org.controlsfx.control.textfield.CustomTextField?>
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.keybindings.KeyBindingsTab">

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.fxml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.MenuButton?>
-<?import javafx.scene.control.TreeTableColumn?>
-<?import javafx.scene.control.TreeTableView?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import org.jabref.gui.icon.JabRefIconView?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
+<?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.keybindings.KeyBindingsTab">
@@ -35,13 +30,19 @@
             </columnResizePolicy>
         </TreeTableView>
     </VBox>
-
-    <HBox spacing="10.0" alignment="CENTER_RIGHT">
-        <MenuButton fx:id="presetsButton" text="%Presets" styleClass="button"/>
-        <Button text="%Reset all" onAction="#resetBindings">
-            <graphic>
-                <JabRefIconView glyph="REFRESH"/>
-            </graphic>
-        </Button>
+    
+    <HBox>
+        <HBox spacing="10.0" alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
+            <Button text="%Expand all" onAction="#expandAll"/>
+            <Button text="%Collapse all" onAction="#collapseAll"/>
+        </HBox>
+        <HBox spacing="10.0" alignment="CENTER_RIGHT" HBox.hgrow="ALWAYS">
+            <MenuButton fx:id="presetsButton" text="%Presets" styleClass="button"/>
+            <Button text="%Reset all" onAction="#resetBindings">
+                <graphic>
+                    <JabRefIconView glyph="REFRESH"/>
+                </graphic>
+            </Button>
+        </HBox>
     </HBox>
 </fx:root>

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -40,13 +40,12 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
     @FXML private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn;
     @FXML private MenuButton presetsButton;
 
-    @Inject
-    private KeyBindingRepository keyBindingRepository;
+    @Inject private KeyBindingRepository keyBindingRepository;
 
     public KeyBindingsTab() {
         ViewLoader.view(this)
-                .root(this)
-                .load();
+                  .root(this)
+                  .load();
     }
 
     @Override
@@ -120,9 +119,6 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
     }
 
     private void setCategoriesExpanded(boolean expanded) {
-        if (keyBindingsTable.getRoot() == null) {
-            return;
-        }
         for (TreeItem<KeyBindingViewModel> child : keyBindingsTable.getRoot().getChildren()) {
             child.setExpanded(expanded);
         }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -1,16 +1,19 @@
 package org.jabref.gui.preferences.keybindings;
 
-import com.airhacks.afterburner.views.ViewLoader;
-import com.tobiasdiez.easybind.EasyBind;
-import jakarta.inject.Inject;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
-import javafx.scene.control.*;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SelectionModel;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
 import javafx.scene.paint.Color;
-import org.controlsfx.control.textfield.CustomTextField;
+
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.JabRefIcon;
 import org.jabref.gui.keyboard.KeyBindingRepository;
@@ -21,6 +24,11 @@ import org.jabref.gui.util.ColorUtil;
 import org.jabref.gui.util.RecursiveTreeItem;
 import org.jabref.gui.util.ViewModelTreeTableCellFactory;
 import org.jabref.logic.l10n.Localization;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import com.tobiasdiez.easybind.EasyBind;
+import jakarta.inject.Inject;
+import org.controlsfx.control.textfield.CustomTextField;
 
 public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabViewModel> implements PreferencesTab {
 
@@ -74,8 +82,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
 
         viewModel.keyBindingPresets().forEach(preset -> presetsButton.getItems().add(createMenuItem(preset)));
 
-        searchBox.textProperty().addListener((observable, previousText, searchTerm) ->
-        {
+        searchBox.textProperty().addListener((observable, previousText, searchTerm) -> {
             viewModel.filterValues(searchTerm);
             setCategoriesExpanded(!searchTerm.isEmpty() || previousText.isEmpty());
         });
@@ -113,7 +120,7 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
     }
 
     private void setCategoriesExpanded(boolean expanded) {
-        if(keyBindingsTable.getRoot() == null) {
+        if (keyBindingsTable.getRoot() == null) {
             return;
         }
         for (TreeItem<KeyBindingViewModel> child : keyBindingsTable.getRoot().getChildren()) {

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -1,19 +1,16 @@
 package org.jabref.gui.preferences.keybindings;
 
+import com.airhacks.afterburner.views.ViewLoader;
+import com.tobiasdiez.easybind.EasyBind;
+import jakarta.inject.Inject;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.SelectionModel;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeTableColumn;
-import javafx.scene.control.TreeTableView;
+import javafx.scene.control.*;
 import javafx.scene.paint.Color;
-
+import org.controlsfx.control.textfield.CustomTextField;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.JabRefIcon;
 import org.jabref.gui.keyboard.KeyBindingRepository;
@@ -25,27 +22,30 @@ import org.jabref.gui.util.RecursiveTreeItem;
 import org.jabref.gui.util.ViewModelTreeTableCellFactory;
 import org.jabref.logic.l10n.Localization;
 
-import com.airhacks.afterburner.views.ViewLoader;
-import com.tobiasdiez.easybind.EasyBind;
-import jakarta.inject.Inject;
-import org.controlsfx.control.textfield.CustomTextField;
-
 public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabViewModel> implements PreferencesTab {
 
-    @FXML private CustomTextField searchBox;
-    @FXML private TreeTableView<KeyBindingViewModel> keyBindingsTable;
-    @FXML private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
-    @FXML private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
-    @FXML private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> resetColumn;
-    @FXML private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn;
-    @FXML private MenuButton presetsButton;
+    @FXML
+    private CustomTextField searchBox;
+    @FXML
+    private TreeTableView<KeyBindingViewModel> keyBindingsTable;
+    @FXML
+    private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
+    @FXML
+    private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
+    @FXML
+    private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> resetColumn;
+    @FXML
+    private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn;
+    @FXML
+    private MenuButton presetsButton;
 
-    @Inject private KeyBindingRepository keyBindingRepository;
+    @Inject
+    private KeyBindingRepository keyBindingRepository;
 
     public KeyBindingsTab() {
         ViewLoader.view(this)
-                  .root(this)
-                  .load();
+                .root(this)
+                .load();
     }
 
     @Override
@@ -82,7 +82,10 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
         viewModel.keyBindingPresets().forEach(preset -> presetsButton.getItems().add(createMenuItem(preset)));
 
         searchBox.textProperty().addListener((observable, previousText, searchTerm) ->
-                viewModel.filterValues(searchTerm));
+        {
+            viewModel.filterValues(searchTerm);
+            setCategoriesExpanded(!searchTerm.isEmpty() || previousText.isEmpty());
+        });
 
         ObjectProperty<Color> flashingColor = new SimpleObjectProperty<>(Color.TRANSPARENT);
         StringProperty flashingColorStringProperty = ColorUtil.createFlashingColorStringProperty(flashingColor);
@@ -104,5 +107,21 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
     @FXML
     private void resetBindings() {
         viewModel.resetToDefault();
+    }
+
+    @FXML
+    private void expandAll() {
+        setCategoriesExpanded(true);
+    }
+
+    @FXML
+    private void collapseAll() {
+        setCategoriesExpanded(false);
+    }
+
+    private void setCategoriesExpanded(boolean expanded) {
+        for (TreeItem<KeyBindingViewModel> child : keyBindingsTable.getRoot().getChildren()) {
+            child.setExpanded(expanded);
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -24,20 +24,13 @@ import org.jabref.logic.l10n.Localization;
 
 public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabViewModel> implements PreferencesTab {
 
-    @FXML
-    private CustomTextField searchBox;
-    @FXML
-    private TreeTableView<KeyBindingViewModel> keyBindingsTable;
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> resetColumn;
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn;
-    @FXML
-    private MenuButton presetsButton;
+    @FXML private CustomTextField searchBox;
+    @FXML private TreeTableView<KeyBindingViewModel> keyBindingsTable;
+    @FXML private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
+    @FXML private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
+    @FXML private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> resetColumn;
+    @FXML private TreeTableColumn<KeyBindingViewModel, KeyBindingViewModel> clearColumn;
+    @FXML private MenuButton presetsButton;
 
     @Inject
     private KeyBindingRepository keyBindingRepository;

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -113,6 +113,9 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
     }
 
     private void setCategoriesExpanded(boolean expanded) {
+        if(keyBindingsTable.getRoot() == null) {
+            return;
+        }
         for (TreeItem<KeyBindingViewModel> child : keyBindingsTable.getRoot().getChildren()) {
             child.setExpanded(expanded);
         }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -65,7 +65,7 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
             KeyBindingViewModel categoryItem = new KeyBindingViewModel(keyBindingRepository, category);
             keyBindingRepository.getKeyBindings().forEach((keyBinding, bind) -> {
                 if (keyBinding.getCategory() != category) return;
-                if (matchesQuery(keyBinding, term.toLowerCase())) {
+                if (matchesSearchTerm(keyBinding, term.toLowerCase())) {
                     KeyBindingViewModel keyBindViewModel = new KeyBindingViewModel(keyBindingRepository, keyBinding, bind);
                     categoryItem.getChildren().add(keyBindViewModel);
                 }
@@ -80,16 +80,16 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
      * Searches for the term in the keybinding's localization, category, or key combination
      *
      * @param keyBinding keybinding to search in
-     * @param term      term to search for
+     * @param searchTerm      term to search for
      * @return true if the term is found in the keybinding
      */
-    private boolean matchesQuery(KeyBinding keyBinding, String term) {
-        if (keyBinding.getLocalization().toLowerCase().contains(term) ||
-                keyBinding.getCategory().getName().toLowerCase().contains(term)) {
+    private boolean matchesSearchTerm(KeyBinding keyBinding, String searchTerm) {
+        if (keyBinding.getLocalization().toLowerCase().contains(searchTerm) ||
+                keyBinding.getCategory().getName().toLowerCase().contains(searchTerm)) {
             return true;
         }
         if (keyBindingRepository.getKeyCombination(keyBinding).isPresent()) {
-            return keyBindingRepository.getKeyCombination(keyBinding).get().toString().toLowerCase().contains(term);
+            return keyBindingRepository.getKeyCombination(keyBinding).get().toString().toLowerCase().contains(searchTerm);
         }
         return false;
     }

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -65,7 +65,9 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
         for (KeyBindingCategory category : KeyBindingCategory.values()) {
             KeyBindingViewModel categoryItem = new KeyBindingViewModel(keyBindingRepository, category);
             keyBindingRepository.getKeyBindings().forEach((keyBinding, bind) -> {
-                if (keyBinding.getCategory() != category) return;
+                if (keyBinding.getCategory() != category) {
+                    return;
+                }
                 if (matchesSearchTerm(keyBinding, term.toLowerCase())) {
                     KeyBindingViewModel keyBindViewModel = new KeyBindingViewModel(keyBindingRepository, keyBinding, bind);
                     categoryItem.getChildren().add(keyBindViewModel);

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -1,5 +1,10 @@
 package org.jabref.gui.preferences.keybindings;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleListProperty;
@@ -9,6 +14,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.input.KeyEvent;
+
 import org.jabref.gui.DialogService;
 import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingCategory;
@@ -20,11 +26,6 @@ import org.jabref.gui.preferences.keybindings.presets.KeyBindingPreset;
 import org.jabref.gui.preferences.keybindings.presets.NewEntryBindingPreset;
 import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.logic.l10n.Localization;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
 

--- a/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTabViewModel.java
@@ -1,10 +1,5 @@
 package org.jabref.gui.preferences.keybindings;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleListProperty;
@@ -14,8 +9,8 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.input.KeyEvent;
-
 import org.jabref.gui.DialogService;
+import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.keyboard.KeyBindingCategory;
 import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.preferences.GuiPreferences;
@@ -25,6 +20,11 @@ import org.jabref.gui.preferences.keybindings.presets.KeyBindingPreset;
 import org.jabref.gui.preferences.keybindings.presets.NewEntryBindingPreset;
 import org.jabref.gui.util.OptionalObjectProperty;
 import org.jabref.logic.l10n.Localization;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
 
@@ -64,9 +64,8 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
         for (KeyBindingCategory category : KeyBindingCategory.values()) {
             KeyBindingViewModel categoryItem = new KeyBindingViewModel(keyBindingRepository, category);
             keyBindingRepository.getKeyBindings().forEach((keyBinding, bind) -> {
-                if (keyBinding.getCategory() == category &&
-                        (keyBinding.getLocalization().toLowerCase().contains(term.toLowerCase()) ||
-                                keyBinding.getCategory().getName().toLowerCase().contains(term.toLowerCase()))) {
+                if (keyBinding.getCategory() != category) return;
+                if (matchesQuery(keyBinding, term.toLowerCase())) {
                     KeyBindingViewModel keyBindViewModel = new KeyBindingViewModel(keyBindingRepository, keyBinding, bind);
                     categoryItem.getChildren().add(keyBindViewModel);
                 }
@@ -75,6 +74,24 @@ public class KeyBindingsTabViewModel implements PreferenceTabViewModel {
                 root.getChildren().add(categoryItem);
             }
         }
+    }
+
+    /**
+     * Searches for the term in the keybinding's localization, category, or key combination
+     *
+     * @param keyBinding keybinding to search in
+     * @param term      term to search for
+     * @return true if the term is found in the keybinding
+     */
+    private boolean matchesQuery(KeyBinding keyBinding, String term) {
+        if (keyBinding.getLocalization().toLowerCase().contains(term) ||
+                keyBinding.getCategory().getName().toLowerCase().contains(term)) {
+            return true;
+        }
+        if (keyBindingRepository.getKeyCombination(keyBinding).isPresent()) {
+            return keyBindingRepository.getKeyCombination(keyBinding).get().toString().toLowerCase().contains(term);
+        }
+        return false;
     }
 
     public void setNewBindingForCurrent(KeyEvent event) {


### PR DESCRIPTION
I've improved the search functionality in the preferences view to include values from comboboxes and text fields, not just labeled controls. Previously, searching for "VScode" returned no results, requiring users to search for "push" instead. Now, comboboxes or textfields containing the searched term can be found directly.

In addition, when searching keybindings, matching categories now expand automatically, which wasn't the case before. I've also added "Expand all" and "Collapse all" buttons at the bottom of the tree table for easier navigation.

It's also now possible to search directly for specific key combinations (e.g., "ctrl+w") to quickly locate the associated actions.


Closes #12647


- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.

![image](https://github.com/user-attachments/assets/8f416874-1f08-4193-b6ca-5bae2653378e)
![image](https://github.com/user-attachments/assets/1ba73de8-3a68-49c0-ad8b-19bd00044c58)
![image](https://github.com/user-attachments/assets/87533956-8489-4943-aed2-407b1f19ed86)
![image](https://github.com/user-attachments/assets/e95663f3-7ac8-40a5-a1ae-89fedaac47b9)
![image](https://github.com/user-attachments/assets/ca188222-20d3-41f7-ad41-ed56147e3f4a)
