### PR TITLE
Improve readme for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Check out the ways you can contribute, below:
 - Please have a look at our [guidelines for contributing](CONTRIBUTING.md).
 - Make sure to follow our [step-by-step guide on how to set-up your workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
 - Quick overview on the architecture needed? Look at our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation).
-- Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or improve the user documentation. Learn how to help at [contribute.jabref.org](https://contribute.jabref.org).
 - You are welcome to fix bugs, contribute new features or add documentation. To get your contribution included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
 - To work on existing JabRef issues, check out our [issue tracker](https://github.com/JabRef/jabref/issues). New to open source contributing? Look for issues with the ["good first issue"](https://github.com/JabRef/jabref/labels/good%20first%20issue) label to get started.
+- Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or improve the user documentation. Learn how to help at [contribute.jabref.org](https://contribute.jabref.org).
+
 
 We use [GitHub Actions](https://github.com/JabRef/jabref/actions) for executing the tests after each commit.
 For developing, it is sufficient to only run the associated test locally (see example [here](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html)) for the classes you changed.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Check out the ways you can contribute, below:
 - You are welcome to fix bugs, contribute new features or add documentation. To get your contribution included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
 - To work on existing JabRef issues, check out our [issue tracker](https://github.com/JabRef/jabref/issues). New to open source contributing? Look for issues with the ["good first issue"](https://github.com/JabRef/jabref/labels/good%20first%20issue) label to get started.
 - Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or improve the user documentation. Learn how to help at [contribute.jabref.org](https://contribute.jabref.org).
-
+- To report an issue, request a feature or suggest enhancements, please open an issue at our [issues page](https://github.com/JabRef/jabref/issues).
 
 We use [GitHub Actions](https://github.com/JabRef/jabref/actions) for executing the tests after each commit.
 For developing, it is sufficient to only run the associated test locally (see example [here](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html)) for the classes you changed.

--- a/README.md
+++ b/README.md
@@ -74,20 +74,19 @@ An explanation of donation possibilities and usage of donations is available at 
 [![Test Status](https://github.com/JabRef/jabref/workflows/Tests/badge.svg)](https://github.com/JabRef/jabref/actions?query=workflow%3ATests)
 [![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=main)
 
-Want to be part of a free and open-source project that tens of thousands of scientists use every day?
+Want to be part of a free and open-source project that tens of thousands of researchers use every day?
 Check out the ways you can contribute, below:
 
-- Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or learn how to help at [contribute.jabref.org](https://contribute.jabref.org)
-- Quick overview on the architecture needed? Look at our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation)
-- For details on how to contribute, have a look at our [guidelines for contributing](CONTRIBUTING.md).
-- You are welcome to contribute new features. To get your code included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and create a [pull request](https://help.github.com/en/articles/about-pull-requests).
+- Please have a look at our [guidelines for contributing](CONTRIBUTING.md).
+- Make sure to follow our [step-by-step guide on how to set-up your workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
+- Quick overview on the architecture needed? Look at our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation).
+- Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or improve the user documentation. Learn how to help at [contribute.jabref.org](https://contribute.jabref.org).
+- You are welcome to fix bugs, contribute new features or add documentation. To get your contribution included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
 - To work on existing JabRef issues, check out our [issue tracker](https://github.com/JabRef/jabref/issues). New to open source contributing? Look for issues with the ["good first issue"](https://github.com/JabRef/jabref/labels/good%20first%20issue) label to get started.
 
-Please follow our [step-by-step guide on how to set-up your workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
-
 We use [GitHub Actions](https://github.com/JabRef/jabref/actions) for executing the tests after each commit.
-For developing, it is sufficient to locally only run the associated test for the classes you changed.
-GitHub will report any other failure.
+For developing, it is sufficient to only run the associated test locally (see example [here](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html)) for the classes you changed.
+GitHub will report any other failure. To find solutions to the most common errors that lead to such failures, check our [FAQ page](https://devdocs.jabref.org/code-howtos/faq).
 
 We view pull requests as a collaborative process.
 Submit a pull request early to get feedback from the team on work in progress.


### PR DESCRIPTION
Follow-up to my commit https://github.com/JabRef/jabref/commit/2edf46ef60c778b2c987b7e348c89c6b9040b675.
Majorly - rearranged "contribution" pointers in readme in the order of their importance - taking into consideration that programmers are the most frequent contributors to JabRef.

Changes (or the assumptions on which the changes are based):
1. JabRef is not just used by scientists.
2. The first reference to direct people to should be `CONTRIBUTING.md` - as it is the bible.
3. Second most important pointer is the local development setup (rearranged).
4. Non-programmers can improve user-docs as well - added text.
5. Bug fixes are generally what people start with, not feature additions. Programmers can also improve documentation.
6. Added link to an example on running test locally.
7. Added pointer to FAQs for common failing tests.
8. Added note on opening issues.

### Mandatory checks

<!--
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
