### PR TITLE
Add PR creator as issue assignee when a PR is opened

### DIFF
--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -45,6 +45,13 @@ jobs:
           default-column: "In Progress"
           issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           skip-if-not-in-project: true
+      - uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
+      - name: Assign PR creator to issue
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-assignee ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   conflicts_with_target:
     name: Conflicts with target branch
     runs-on: ubuntu-latest


### PR DESCRIPTION
Triggered by  https://github.com/JabRef/jabref/pull/12745 -> https://github.com/JabRef/jabref/pull/12747

Currently, issues are unassigned when a PR is closed. If a contributor submits a new PR, the issue is marked as "in-progress", but the assignee is not updated.

With this PR the assignees of an issue are "enrichted" by the PR submitter.

I am aware that an issue have then multiple persons assigned. I think, this helps rather then it hurts.

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
