### PR TITLE
Add "📌 Pinned" for WIP workflows

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -29,7 +29,7 @@ jobs:
 
             Happy coding! 🚀
 
-            ⏳ Please note, you will be automatically unassigned if the issue isn't closed within **{{ total_days }} days** (by **{{ unassigned_date }}**). A maintainer can also add the "**{{ pin_label }}**" label to prevent automatic unassignment.
+            ⏳ Please note, you will be automatically unassigned if there is not a (draft) pull request within **{{ total_days }} days** (by **{{ unassigned_date }}**).
           assignment_suggestion_comment: >
             👋 Hey @{{ handle }}, looks like you’re eager to work on this issue—great! 🎉
             It also looks like you skipped reading our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md), which explains exactly how to participate. No worries, it happens to the best of us.

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -16,7 +16,7 @@ jobs:
         uses: takanome-dev/assign-issue-action@edge
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          days_until_unassign: 45
+          days_until_unassign: 14
           maintainers: 'koppor,Siedlerchr,ThiloteE,calixtus,HoussemNasri,subhramit,LinusDietz'
           assigned_comment: |
             👋 Hey @{{ handle }}, thank you for your interest in this issue! 🎉

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -56,6 +56,10 @@ jobs:
         run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove pinned label
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📌 Pinned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove FirstTimeCodeContribution label
         run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "FirstTimeCodeContribution"
         env:

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -52,6 +52,10 @@ jobs:
         run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-assignee ${{ github.event.pull_request.user.login }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add label "📌 Pinned"
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-label "📌 Pinned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   conflicts_with_target:
     name: Conflicts with target branch
     runs-on: ubuntu-latest

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -19,7 +19,7 @@ jobs:
         uses: takanome-dev/assign-issue-action@edge
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          days_until_unassign: 45
+          days_until_unassign: 14
   move_unassigned_issues:
     needs: unassign_issues
     if: ${{ needs.unassign_issues.outputs.unassigned_issues != '[]' }}


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/issues/12434#issuecomment-2727112445

The action itself suggests 7 days as default for unassignment (https://github.com/takanome-dev/assign-issue-action?tab=readme-ov-file#inputs). This was too short for us, we opted for `45` days. Often, nothing happens and the issue ist just unassigned.

We are interested that a PR is there which is worked on.

IMHO, two weeks should be enough to open a draft PR - or discuss on the issue itself something to get a draft PR ready.

Therefore: If PR is opened, `📌 Pinned` label is added. With this, label, the issue is not unassigned after 14 days. In case the PR is closed without merging, the `📌 Pinned` label is removed.

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
