### PR TITLE
Add explicit error on missing number

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Keep ALL the items. Mark them as follows:
 [/] not applicable
 -->
 
-- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
+- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
 - [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
 - [ ] Tests created for changes (if applicable)
 - [ ] Manually tested changed features in running JabRef (always required)

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -9,8 +9,8 @@
   message: >
     Your code does not compile.
     Please ensure your changes compile successfully before pushing changes.
-   
-    
+
+
     To verify compilation locally, run `./gradlew build` or try running JabRef.
 - jobName: 'Conflicts with target branch'
   message: >
@@ -64,7 +64,7 @@
     Force pushing is a very bad practice when working together on a project (mainly because it is [not supported well by GitHub itself](https://github.com/orgs/community/discussions/3478)).
     Commits are lost and comments on commits lose their context, thus making it harder to review changes.
     At the end, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway before being merged into the `main` branch.
-- jobName: 'Mark issue as in progress'
+- jobName: 'Determine issue number'
   message: |
     Your pull request needs to link an issue.
 

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -62,18 +62,6 @@ jobs:
           default-column: "In Progress"
           issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           skip-if-not-in-project: true
-      - uses: actions/checkout@v4
-        with:
-          show-progress: 'false'
-      - name: Assign PR creator to issue
-        # "gh issue edit" cannot be used - workaround found at https://github.com/cli/cli/issues/9620#issuecomment-2703135049
-        run: gh api -X PATCH /repos/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }} -f assignee=${{ github.event.pull_request.user.login }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add label "📌 Pinned"
-        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-label "📌 Pinned"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ensure_assignment:
     name: Ensure that contributor is assigned (fails if not commented on issue)
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -5,6 +5,23 @@ on:
   pull_request_target:
 
 jobs:
+  determine_issue_number:
+    name: Determine issue number
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine issue number
+        uses: koppor/ticket-check-action@add-output
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
+          ticketPrefix: '#'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          branchRegex: '^(?<ticketNumber>\d+)'
+          bodyRegex: '#(?!12345\b)(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
+          outputOnly: true
   move_issue:
     name: Mark issue as in progress
     runs-on: ubuntu-latest
@@ -20,7 +37,7 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyRegex: '#(?!12345\b)(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - name: Move issue to "In Progress" in "Good First Issues"
@@ -57,6 +74,37 @@ jobs:
         run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-label "📌 Pinned"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ensure_assignment:
+    name: Ensure that contributor is assigned (fails if not commented on issue)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Determine issue number
+        id: get_issue_number
+        uses: koppor/ticket-check-action@add-output
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/:owner/:repo/issues/%ticketNumber%'
+          ticketPrefix: '#'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          branchRegex: '^(?<ticketNumber>\d+)'
+          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
+          outputOnly: true
+      - uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
+      - name: Assign PR creator to issue
+        # "gh issue edit" cannot be used - workaround found at https://github.com/cli/cli/issues/9620#issuecomment-2703135049
+        run: gh api -X PATCH /repos/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }} -f assignee=${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add label "📌 Pinned"
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-label "📌 Pinned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   conflicts_with_target:
     name: Conflicts with target branch
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -77,7 +77,7 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyRegex: '#(?!12345\b)(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - uses: actions/checkout@v4


### PR DESCRIPTION
Risen by https://github.com/JabRef/jabref/pull/12761

Our RegEx matched the wrong issue number:

![image](https://github.com/user-attachments/assets/e87abc50-31e2-490c-af01-ec85404425ad)

Therefore, the contributor could not be assigned to the issue:

![image](https://github.com/user-attachments/assets/fb0c31ac-0318-4aa8-977f-7bd6820667ee)

Separated check into "Ensure that contributor is assigned (fails if not commented on issue)" to really make explicit when assignment does not work -- will not raise any comment

Also fixed a typo

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
