### PR TITLE
Move to other column only if no assignee left

### DIFF
--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -25,42 +25,59 @@ jobs:
           bodyRegex: '#(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/:owner)(\/:repo)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
+      - uses: actions/checkout@v4
+      - name: Remove assignee
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-assignee ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check assignees
+        id: check_assignee
+        run: |
+          issue=$(gh issue view 12345 --json assignees)
+          count=$(echo "$issue" | jq '.assignees | length')
+          if [ "$count" -gt 0 ]; then
+            echo "assigned=yes" >> $GITHUB_OUTPUT
+          else
+            echo "assigned=no" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove assigned label
+        if: steps.check_assignee.outputs.assigned == 'no'
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove pinned label
+        if: steps.check_assignee.outputs.assigned == 'no'
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📌 Pinned"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove FirstTimeCodeContribution label
+        if: steps.check_assignee.outputs.assigned == 'no'
+        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "FirstTimeCodeContribution"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Move issue to "Free to take" in "Good First Issues"
+        if: steps.check_assignee.outputs.assigned == 'no'
         uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/5"
           target-labels: "📍 Assigned"
-          target-column: "Free to take"
+          target-column: "Assigned"
           ignored-columns: ""
           default-column: "Free to take"
           issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           skip-if-not-in-project: true
       - name: Move issue to "Free to take" in "Candidates for University Projects"
+        if: steps.check_assignee.outputs.assigned == 'no'
         uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
           project-url: "https://github.com/orgs/JabRef/projects/3"
           target-labels: "📍 Assigned"
-          target-column: "Free to take"
+          target-column: "Assigned"
           ignored-columns: ""
           default-column: "Free to take"
           issue-number: ${{ steps.get_issue_number.outputs.ticketNumber }}
           skip-if-not-in-project: true
-      - uses: actions/checkout@v4
-      - name: Remove assigned status
-        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-assignee ${{ github.event.pull_request.user.login }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove assigned label
-        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📍 Assigned"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove pinned label
-        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "📌 Pinned"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove FirstTimeCodeContribution label
-        run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --remove-label "FirstTimeCodeContribution"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/12756

When closing a PR, we unassign the contributor and free the issue. However, if someone opens a second PR for the same issue (in the example: https://github.com/JabRef/jabref/issues/12702), the action should not do this work. this PR.

This update of the action fixes it.

The change in `taget-column` should have no effect. With the upstream fix https://github.com/m7kvqbe1/github-action-move-issues/pull/37, the current data of the issue is used (and not stale one)

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
