### PR TITLE
Switch Badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing
-<!-- markdownlint-disable MD001 -->
+
+<!-- markdownlint-disable-next-line MD001 -->
 ### For programmers
 
 A detailed guide on contributing for programmers is available at <https://devdocs.jabref.org>.
@@ -15,7 +16,7 @@ As one consequence, for non-basic issues, you will have to work on the requireme
 ### For non-programmers
 
 For non-programmers, a general overview on contributing is available at <https://docs.jabref.org/contributing>.
-<!-- markdownlint-enable MD001 -->
+
 ## Table of Contents
 
 * [Choosing a task](#choosing-a-task-)
@@ -101,15 +102,26 @@ Simply navigate to <https://github.com/jabref/jabref/> and click on the Star but
 1. Follow the steps at [Pre Condition 3: Code on the local machine](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.html) to a) create a fork and b) have the fork checked out on your local machine
 2. Ensure that you followed the [steps to set up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/) to have the code running properly in IntelliJ.
 3. **Create a new branch** (such as `fix-for-issue-121`). Be sure to create a **separate branch** for each improvement you implement.
-4. Work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/code-howtos) if you have questions about your implementation.
-5. Create a [pull request to JabRef main repository](https://github.com/JabRef/jabref/pulls).
+4. Read our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation).
+5. Work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/code-howtos) if you have questions about your implementation.
+6. Create a [pull request to JabRef main repository](https://github.com/JabRef/jabref/pulls).
    For an overview on the concept of pull requests, take a look at GitHub's [pull request help documentation](https://help.github.com/articles/about-pull-requests/).
    1. Ensure that you followed the requirements listed below. They are not too hard, they merely support the maintainers to focus on supportive feedback than just stating the obvious.
    2. For text inspirations, consider [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request).
    3. In case your pull request is not yet complete or not yet ready for review, create a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.
-6. Wait for feedback of the developers
-7. Address the feedback of the developers
-8. After two developers gave their green flag, the pull request will be merged.
+7. Wait for automatic checks to run and bots commenting.
+8. Address the feedback of the automated checks. To find solutions to the most common errors that lead to such failures, check our [FAQ page](https://devdocs.jabref.org/code-howtos/faq).
+9. Wait for feedback of one of the developers.
+10. Address the feedback of the developer.
+11. Wait for feedback of a second developer.
+12. Address the feedback of the second developer.
+13. After two developers gave their green flag, the pull request will be merged.
+
+We view pull requests as a collaborative process.
+Submit a pull request early to enable feedback from the team while you continue working.
+Please also remember to discuss bigger changes early with the core developers to ensure properly spend time and work.
+Some fundamental design decisions can be found within our list of [Architectural Decision Records](https://devdocs.jabref.org/decisions/).
+After a pull request is ready for review, we will discuss improvements with you and agree to merge them once the [developers](https://github.com/JabRef/jabref/blob/main/MAINTAINERS) approve.
 
 In case you have any questions, please
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ The pull request may be approved immediatly, or a reviewer may request changes a
 In that case, you are expected to answer any questions and implement the requested changes.
 
 Please – **never ever close a pull request and open a new one** -
-This causes unessesary work on our side, and is not in the the style of the GitHub Open Source community.
+This causes unnecessary work on our side, and is not in the style of the GitHub Open Source community.
 You can push any changes you need to make to the branch your pull request is *from*.
 These changes will be automatically reflected in your pull request.
 

--- a/README.md
+++ b/README.md
@@ -64,15 +64,7 @@ You can use our [GitHub issue tracker](https://github.com/JabRef/jabref/issues) 
 
 An explanation of donation possibilities and usage of donations is available at our [donations page](https://donations.jabref.org).
 
-## Contributing
-
-[![dev-docs](https://img.shields.io/badge/dev-docs-blue)](https://devdocs.jabref.org/)
-[![Help Contribute to Open Source](https://www.codetriage.com/jabref/jabref/badges/users.svg)](https://www.codetriage.com/jabref/jabref)
-[![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![OpenHub](https://www.openhub.net/p/jabref/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jabref)
-[![Deployment Status](https://github.com/JabRef/jabref/workflows/Deployment/badge.svg)](https://github.com/JabRef/jabref/actions?query=workflow%3ADeployment)
-[![Test Status](https://github.com/JabRef/jabref/workflows/Tests/badge.svg)](https://github.com/JabRef/jabref/actions?query=workflow%3ATests)
-[![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=main)
+## Contributing [![APIdia](https://apidia.net/java/JabRef/badge.svg)](https://apidia.net/java/JabRef)
 
 Want to be part of a free and open-source project that tens of thousands of researchers use every day?
 Check out the ways you can contribute, below:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JabRef Bibliography Management
+# JabRef Bibliography Management [![APIdia](https://apidia.net/java/JabRef/badge.svg)](https://apidia.net/java/JabRef)
 
 JabRef is an open-source, cross-platform citation and reference management tool.
 
@@ -64,28 +64,10 @@ You can use our [GitHub issue tracker](https://github.com/JabRef/jabref/issues) 
 
 An explanation of donation possibilities and usage of donations is available at our [donations page](https://donations.jabref.org).
 
-## Contributing [![APIdia](https://apidia.net/java/JabRef/badge.svg)](https://apidia.net/java/JabRef)
+## Contributing
 
 Want to be part of a free and open-source project that tens of thousands of researchers use every day?
-Check out the ways you can contribute, below:
-
-- Please have a look at our [guidelines for contributing](CONTRIBUTING.md).
-- Make sure to follow our [step-by-step guide on how to set-up your workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace).
-- For a quick overview of the architecture, check out our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation).
-- You are welcome to fix bugs, contribute new features or add documentation. To get your contribution included into JabRef, just [fork](https://help.github.com/en/articles/fork-a-repo) the JabRef repository, make your changes, and submit a [pull request](https://help.github.com/en/articles/about-pull-requests).
-- To work on existing JabRef issues, check out our [issue tracker](https://github.com/JabRef/jabref/issues). New to open source contributing? Look for issues with the ["good first issue"](https://github.com/JabRef/jabref/labels/good%20first%20issue) label to get started.
-- Not a programmer? Help translating JabRef at [Crowdin](https://crowdin.com/project/jabref) or improve the user documentation. Learn how to help at [contribute.jabref.org](https://contribute.jabref.org).
-- To report an issue, request a feature or suggest enhancements, please open an issue at our [issues page](https://github.com/JabRef/jabref/issues).
-
-We use [GitHub Actions](https://github.com/JabRef/jabref/actions) for executing the tests after each commit.
-For developing, it is sufficient to only run the associated test locally (see example [here](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html)) for the classes you changed.
-GitHub will report any other failure. To find solutions to the most common errors that lead to such failures, check our [FAQ page](https://devdocs.jabref.org/code-howtos/faq).
-
-We view pull requests as a collaborative process.
-Submit a pull request early to get feedback from the team on work in progress.
-We will discuss improvements with you and agree to merge them once the [developers](https://github.com/JabRef/jabref/blob/main/MAINTAINERS) approve.
-Please also remember to discuss bigger changes early with the core developers to ensure properly spend time and work.
-Some fundamental design decisions can be found within our list of [Architectural Decision Records](https://devdocs.jabref.org/decisions/).
+Please have a look at our [guidelines for contributing](CONTRIBUTING.md).
 
 ## Research and Education
 

--- a/docs/code-howtos/code-quality.md
+++ b/docs/code-howtos/code-quality.md
@@ -33,6 +33,11 @@ We use [GitHub's dependabot](https://docs.github.com/en/code-security/getting-st
 Moreover, we try to test JabRef with the latest Java Development Kit (JDK) builds.
 Our results can be seen at the [Quality Outreach page](https://wiki.openjdk.org/display/quality/Quality+Outreach).
 
+## Statistics
+
+* [![Test Status](https://github.com/JabRef/jabref/workflows/Tests/badge.svg)](https://github.com/JabRef/jabref/actions?query=workflow%3ATests)
+* [![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=main)
+
 ## Background literature
 
 We strongly recommend reading following two books on code quality:

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.md
@@ -15,6 +15,8 @@ This section explains how you get the JabRef code onto your machine in a form al
 3. Create a fork by clicking at fork button on the right top corner
 4. A fork repository will be created under your account `https://github.com/YOUR_USERNAME/jabref`.
 
+A longer explanation is available at <https://help.github.com/en/articles/fork-a-repo>.
+
 ## Clone your forked repository on your local machine
 
 In a command line, navigate to the folder where you want to place the source code (parent folder of `jabref`).


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/29b77d13-517e-47e2-945f-3668f98fea46)

After:

![image](https://github.com/user-attachments/assets/bd8ce7af-605b-459d-be33-4991f98f9f9d)

I know, I liked these badges some years ago. With our target group, I think, they are not useful at all - APIdia is :)

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
