### PR TITLE
Keep existing assignees on a PR

### DIFF
--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check assignees
         id: check_assignee
         run: |
-          issue=$(gh issue view 12345 --json assignees)
+          issue=$(gh issue view ${{ steps.get_issue_number.outputs.ticketNumber }} --json assignees)
           count=$(echo "$issue" | jq '.assignees | length')
           if [ "$count" -gt 0 ]; then
             echo "assigned=yes" >> $GITHUB_OUTPUT

--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -84,8 +84,11 @@ jobs:
         with:
           show-progress: 'false'
       - name: Assign PR creator to issue
-        # "gh issue edit" cannot be used - workaround found at https://github.com/cli/cli/issues/9620#issuecomment-2703135049
-        run: gh api -X PATCH /repos/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }} -f assignee=${{ github.event.pull_request.user.login }}
+        run: |
+          # "gh issue edit" cannot be used - workaround found at https://github.com/cli/cli/issues/9620#issuecomment-2703135049
+          ASSIGNEES=$(gh api /repos/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }} --jq '[.assignees[].login] | @json')
+          UPDATED_ASSIGNEES=$(echo $ASSIGNEES | jq --arg new "${{ github.event.pull_request.user.login }}" '. + [$new] | @json')
+          gh api -X PATCH /repos/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }} --input <(echo "{\"assignees\": $UPDATED_ASSIGNEES}")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add label "📌 Pinned"


### PR DESCRIPTION
Note: My PR comment at https://github.com/JabRef/jabref/pull/12775 triggered https://github.com/JabRef/jabref/blob/928b7e55984109ad2ff597777c380be74120893b/.github/workflows/on-pr-opened.yml (https://github.com/JabRef/jabref/actions/runs/13941592810?pr=12775)

Then, it assigned me and pinned numer 12702.

Since also someone else could craft "bad" PR descriptions, I changed the action to just add the current PR worker to the list of assignees instead of replacing it.

(I also fixed a hard-coded issue number)

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
