### PR TITLE
workflow added for detecting changelog modification

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -111,3 +111,7 @@
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
+- jobName: 'CHANGELOG.md was modified'
+  message: >
+    If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.
+    More details can be found in our [Developer Documentation about the changelog](https://devdocs.jabref.org/decisions/0007-human-readable-changelog.html).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,3 +436,22 @@ jobs:
         with:
           name: pr_number
           path: pr_number.txt
+
+  changelog_modified:
+    name: CHANGELOG.md was modified
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for CHANGELOG.md modifications
+        id: check_changelog_modification
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG\.md$'; then
+            echo "✅ CHANGELOG.md was modified"
+          else
+            echo "❌ CHANGELOG.md was NOT modified"
+            exit 1
+          fi


### PR DESCRIPTION
Added a workflow that detects if no changes were made to CHANGELOG.md and notifies the user to document any changes there.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
