### PR TITLE
Fix link

### DIFF
--- a/docs/code-howtos/javafx.md
+++ b/docs/code-howtos/javafx.md
@@ -212,7 +212,7 @@ DialogService dialogService = Injector.instantiateModelOrService(DialogService.c
 ## Properties and Bindings
 
 JabRef makes heavy use of Properties and Bindings. These are wrappers around Observables. A good explanation on the concept can be found here:
-[JavaFX Bindings and Properties](https://edencoding.com/javafx-properties-and-binding-a-complete-guide/)
+[JavaFX Bindings and Properties](https://web.archive.org/web/20240921154452/https://edencoding.com/javafx-properties-and-binding-a-complete-guide/)
 
 ## Features missing in JavaFX
 


### PR DESCRIPTION
The page `https://edencoding.com/javafx-properties-and-binding-a-complete-guide/`  is currently an online casino:

![image](https://github.com/user-attachments/assets/2c228415-dc52-401f-bd85-f733192f21c6)

Therefore replaced by archive.org link

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [ ] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
