### PR TITLE
Revert "workflow added for detecting changelog modification"

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -111,7 +111,3 @@
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
-- jobName: 'CHANGELOG.md was modified'
-  message: >
-    If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.
-    More details can be found in our [Developer Documentation about the changelog](https://devdocs.jabref.org/decisions/0007-human-readable-changelog.html).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,22 +436,3 @@ jobs:
         with:
           name: pr_number
           path: pr_number.txt
-
-  changelog_modified:
-    name: CHANGELOG.md was modified
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check for CHANGELOG.md modifications
-        id: check_changelog_modification
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG\.md$'; then
-            echo "✅ CHANGELOG.md was modified"
-          else
-            echo "❌ CHANGELOG.md was NOT modified"
-            exit 1
-          fi


### PR DESCRIPTION
Reverts JabRef/jabref#12783

This check raised discussion among the maintainers (smilar discussions I had before)

I was convinced that this workflow is too much  - and would also require (`/no-changelog-entry-needed` bot reaction).

A possible follow-up is to add a check for the "checklist" part in the PR description.

@palukku sorry for the effort spend!