### PR TITLE
Fix tooltip display for multiple linked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an exception would occur when running abbreviate journals for multiple entries. [#12634](https://github.com/JabRef/jabref/issues/12634)
 - We fixed an issue where JabRef displayed dropdown triangle in wrong place in "Search for unlinked local files" dialog [#12713](https://github.com/JabRef/jabref/issues/12713)
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
+- We fixed an issue where the tooltip only displayed the first linked file when hovering. [#12470](https://github.com/JabRef/jabref/issues/12470)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef displayed dropdown triangle in wrong place in "Search for unlinked local files" dialog [#12713](https://github.com/JabRef/jabref/issues/12713)
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
 - We fixed a bug where LaTeX commands were not removed from filenames generated using the `[bibtexkey] - [fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
-- We fixed an issue where the tooltip only displayed the first linked file when hovering. [#12470](https://github.com/JabRef/jabref/issues/12470
+- We fixed an issue where the tooltip only displayed the first linked file when hovering. [#12470](https://github.com/JabRef/jabref/issues/12470)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -138,10 +138,18 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
     }
 
     private String createFileTooltip(List<LinkedFile> linkedFiles) {
-        if (!linkedFiles.isEmpty()) {
-            return Localization.lang("Open file %0", linkedFiles.getFirst().getLink());
+        if (linkedFiles.isEmpty()) {
+            return null;
         }
-        return null;
+
+        StringBuilder sb = new StringBuilder();
+
+        for (LinkedFile linkedFile : linkedFiles) {
+            sb.append(linkedFile.getLink()).append("\n");
+        }
+
+        String fileLabel = linkedFiles.size() == 1 ? "file" : "files...";
+        return Localization.lang("Open " + fileLabel) + "\n" + sb.toString();
     }
 
     private ContextMenu createFileMenu(BibEntryTableViewModel entry, List<LinkedFile> linkedFiles) {

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -2,6 +2,7 @@ package org.jabref.gui.maintable.columns;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import javafx.scene.Node;
@@ -142,16 +143,16 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
             return null;
         }
 
-        StringBuilder sb = new StringBuilder();
+        StringJoiner joiner = new StringJoiner("\n");
 
         for (LinkedFile linkedFile : linkedFiles) {
-            sb.append("\n").append(linkedFile.getLink());
+            joiner.add(linkedFile.getLink());
         }
 
         if (linkedFiles.size() == 1) {
-            return Localization.lang("Open file %0", sb.toString());
+            return Localization.lang("Open file %0", joiner.toString());
         }
-        return Localization.lang("Open files...") + sb.toString();
+        return Localization.lang("Open files...") + "\n\n" + joiner.toString();
     }
 
     private ContextMenu createFileMenu(BibEntryTableViewModel entry, List<LinkedFile> linkedFiles) {

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -2,7 +2,6 @@ package org.jabref.gui.maintable.columns;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import javafx.scene.Node;

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -143,16 +143,14 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
             return null;
         }
 
-        StringJoiner joiner = new StringJoiner("\n");
-
-        for (LinkedFile linkedFile : linkedFiles) {
-            joiner.add(linkedFile.getLink());
-        }
+        String filePaths = linkedFiles.stream()
+                                      .map(LinkedFile::getLink)
+                                      .collect(Collectors.joining("\n"));
 
         if (linkedFiles.size() == 1) {
-            return Localization.lang("Open file %0", joiner.toString());
+            return Localization.lang("Open file %0", filePaths);
         }
-        return Localization.lang("Open files...") + "\n\n" + joiner.toString();
+        return filePaths;
     }
 
     private ContextMenu createFileMenu(BibEntryTableViewModel entry, List<LinkedFile> linkedFiles) {

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -148,8 +148,10 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
             sb.append(linkedFile.getLink()).append("\n");
         }
 
-        String fileLabel = linkedFiles.size() == 1 ? "file" : "files...";
-        return Localization.lang("Open " + fileLabel) + "\n" + sb.toString();
+        if (sb.length() == 1) {
+            return Localization.lang("Open file %0", sb.toString());
+        }
+        return Localization.lang("Open files...") + "\n" + sb.toString();
     }
 
     private ContextMenu createFileMenu(BibEntryTableViewModel entry, List<LinkedFile> linkedFiles) {

--- a/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
+++ b/src/main/java/org/jabref/gui/maintable/columns/FileColumn.java
@@ -145,13 +145,13 @@ public class FileColumn extends MainTableColumn<List<LinkedFile>> {
         StringBuilder sb = new StringBuilder();
 
         for (LinkedFile linkedFile : linkedFiles) {
-            sb.append(linkedFile.getLink()).append("\n");
+            sb.append("\n").append(linkedFile.getLink());
         }
 
-        if (sb.length() == 1) {
+        if (linkedFiles.size() == 1) {
             return Localization.lang("Open file %0", sb.toString());
         }
-        return Localization.lang("Open files...") + "\n" + sb.toString();
+        return Localization.lang("Open files...") + sb.toString();
     }
 
     private ContextMenu createFileMenu(BibEntryTableViewModel entry, List<LinkedFile> linkedFiles) {


### PR DESCRIPTION
Ensures that when hovering over the "Linked Files" tab, the tooltip displays all linked files instead of just the first one. This fix resolves the issue where only the first linked file was shown.

The logic in createFileTooltip was updated to generate a single string containing the paths of all linked files.

An early return was added at the beginning to handle cases where no files are linked, improving efficiency. The text for the "Open file" action was also adjusted: it now displays "Open file" when there is only one linked file and "Open files..." when there are multiple. The phrase "Open files..." was chosen because it was the only plural form available in the translation files, as neither "Open files" nor "Open files %0" were present. This ensures consistency across different languages without requiring changes to existing translations.

The images below illustrate the updated behavior of the "Open file" action.

#### Case: Single linked file

![single_file](https://github.com/user-attachments/assets/8ca5a39c-d655-4ecd-bf5c-d6f30574992f)

#### Case: Multiple linked files  

![multiple_files](https://github.com/user-attachments/assets/0d4e6b72-b720-46f2-bba9-d13d7e88f822)

<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Fixes #12470

### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
