### PR TITLE
Fix for issue: Sanitization of generated filenames (remove LaTeX commands) #12188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an exception would occur when running abbreviate journals for multiple entries. [#12634](https://github.com/JabRef/jabref/issues/12634)
 - We fixed an issue where JabRef displayed dropdown triangle in wrong place in "Search for unlinked local files" dialog [#12713](https://github.com/JabRef/jabref/issues/12713)
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
+- We fixed a bug where LaTeX commands (e.g., \mkbibquote{}) were not removed from filenames generated using the `[fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an exception would occur when running abbreviate journals for multiple entries. [#12634](https://github.com/JabRef/jabref/issues/12634)
 - We fixed an issue where JabRef displayed dropdown triangle in wrong place in "Search for unlinked local files" dialog [#12713](https://github.com/JabRef/jabref/issues/12713)
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
-- We fixed a bug where LaTeX commands (e.g., \mkbibquote{}) were not removed from filenames generated using the `[fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
+- We fixed a bug where LaTeX commands were not removed from filenames generated using the `[bibtexkey] - [fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
 - We fixed a bug where LaTeX commands were not removed from filenames generated using the `[bibtexkey] - [fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
 
-
 ### Removed
 
 - "Web of Science" [journal abbreviation list](https://docs.jabref.org/advanced/journalabbreviations) was removed. [abbrv.jabref.org#176](https://github.com/JabRef/abbrv.jabref.org/issues/176)

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.citationkeypattern.BracketedPattern;
+import org.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -329,9 +330,12 @@ public class FileUtil {
         if (targetName.isEmpty()) {
             targetName = entry.getCitationKey().orElse("default");
         }
-
+        // Remove LaTeX commands (e.g., \mkbibquote{}) from expanded fields before cleaning filename
+        // See: https://github.com/JabRef/jabref/issues/12188
+        targetName = new RemoveLatexCommandsFormatter().format(targetName);
         // Removes illegal characters from filename
         targetName = FileNameCleaner.cleanFileName(targetName);
+
         return targetName;
     }
 

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -48,6 +48,7 @@ public class FileUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileUtil.class);
     private static final String ELLIPSIS = "...";
     private static final int ELLIPSIS_LENGTH = ELLIPSIS.length();
+    private static final RemoveLatexCommandsFormatter REMOVE_LATEX_COMMANDS_FORMATTER = new RemoveLatexCommandsFormatter();
 
     /**
      * MUST ALWAYS BE A SORTED ARRAY because it is used in a binary search
@@ -330,9 +331,10 @@ public class FileUtil {
         if (targetName.isEmpty()) {
             targetName = entry.getCitationKey().orElse("default");
         }
+
         // Remove LaTeX commands (e.g., \mkbibquote{}) from expanded fields before cleaning filename
         // See: https://github.com/JabRef/jabref/issues/12188
-        targetName = new RemoveLatexCommandsFormatter().format(targetName);
+        targetName = REMOVE_LATEX_COMMANDS_FORMATTER.format(targetName);
         // Removes illegal characters from filename
         targetName = FileNameCleaner.cleanFileName(targetName);
 

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -153,6 +153,17 @@ class FileUtilTest {
     }
 
     @Test
+    void getLinkedFileNameRemovesLatexCommands() {
+        String pattern = "[citationkey] - [fulltitle]";
+        BibEntry entry = new BibEntry();
+        entry.setCitationKey("BrayBuildingCommunity");
+        entry.setField(StandardField.TITLE, "Building \\mkbibquote{Community}");
+
+        String result = FileUtil.createFileNameFromPattern(null, entry, pattern);
+        assertEquals("BrayBuildingCommunity - Building Community", result);
+    }
+
+    @Test
     void getFileExtensionSimpleFile() {
         assertEquals("pdf", FileUtil.getFileExtension(Path.of("test.pdf")).get());
     }

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -158,9 +158,9 @@ class FileUtilTest {
         BibEntry entry = new BibEntry();
         entry.setCitationKey("BrayBuildingCommunity");
         entry.setField(StandardField.TITLE, "Building \\mkbibquote{Community}");
-
+        String expected = "BrayBuildingCommunity - Building Community";
         String result = FileUtil.createFileNameFromPattern(null, entry, pattern);
-        assertEquals("BrayBuildingCommunity - Building Community", result);
+        assertEquals(expected, result);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -155,9 +155,9 @@ class FileUtilTest {
     @Test
     void getLinkedFileNameRemovesLatexCommands() {
         String pattern = "[citationkey] - [fulltitle]";
-        BibEntry entry = new BibEntry();
-        entry.setCitationKey("BrayBuildingCommunity");
-        entry.setField(StandardField.TITLE, "Building \\mkbibquote{Community}");
+        BibEntry entry = new BibEntry()
+                .withCitationKey("BrayBuildingCommunity")
+                .withField(StandardField.TITLE, "Building \\mkbibquote{Community}");
         String expected = "BrayBuildingCommunity - Building Community";
         String result = FileUtil.createFileNameFromPattern(null, entry, pattern);
         assertEquals(expected, result);


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes #12188

This fixes an issue where LaTeX commands (e.g., \mkbibquote{...}) were retained in generated filenames using the [fulltitle] pattern.

### Describe the changes you have made here: what, where, why, ...
- When the filename pattern is set to `[bibtexkey] - [fulltitle]`, and linked files are renamed automatically (e.g., during PDF import or when using "Rename file to pattern"), the class `LinkedFileHandler` calls `FileUtil.createFileNameFromPattern()` to generate the new filename.

- Previously, this method only applied `FileNameCleaner.cleanFileName(targetName)`, which removes illegal characters, but does not strip LaTeX commands such as `\mkbibquote{}`. This led to filenames like: `BrayBuildingCommunity - Building _mkbibquote_Community_.pdf`

- To fix this, I added a call to `RemoveLatexCommandsFormatter.format()` before cleaning the filename. This ensures LaTeX commands are properly stripped, while keeping their inner content.

**Example:**
- Input title: Building \mkbibquote{Community}
- File pattern: [bibtexkey] - [fulltitle]
- Old output: BrayBuildingCommunity - Building _mkbibquote_Community_.pdf
- New output: BrayBuildingCommunity - Building Community.pdf


### Mandatory checks

<!--
Go throgh the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
