### PR TITLE
workflow added for detecting changelog modification (#12783)

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -116,7 +116,7 @@
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
 - jobName: 'CHANGELOG.md needs to be modified'
   message: >
-    You ticked that you modified `CHANGELOG.md`, but there was no change there.
+    You ticked that you modified `CHANGELOG.md`, but a new entry is still missing there.
 
 
     If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -111,7 +111,11 @@
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
-- jobName: 'CHANGELOG.md was modified'
+- jobName: 'CHANGELOG.md needs to be modified'
   message: >
+    You ticked that you modified `CHANGELOG.md`, but there was no change there.
+
+
     If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.
+    If you did not, please replace the cross by a slash to indicate that no `CHANGELOG.md` entry is necessary.
     More details can be found in our [Developer Documentation about the changelog](https://devdocs.jabref.org/decisions/0007-human-readable-changelog.html).

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -116,7 +116,7 @@
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
 - jobName: 'CHANGELOG.md needs to be modified'
   message: >
-    You ticked that you modified `CHANGELOG.md`, but a new entry is still missing there.
+    You ticked that you modified `CHANGELOG.md`, but no new entry was found there.
 
 
     If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -111,3 +111,7 @@
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
+- jobName: 'CHANGELOG.md was modified'
+  message: >
+    If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.
+    More details can be found in our [Developer Documentation about the changelog](https://devdocs.jabref.org/decisions/0007-human-readable-changelog.html).

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -120,5 +120,5 @@
 
 
     If you made changes that are visible to the user, please add a brief description along with the issue number to the `CHANGELOG.md` file.
-    If you did not, please replace the cross by a slash to indicate that no `CHANGELOG.md` entry is necessary.
+    If you did not, please replace the cross (`[x]`) by a slash (`[/]`) to indicate that no `CHANGELOG.md` entry is necessary.
     More details can be found in our [Developer Documentation about the changelog](https://devdocs.jabref.org/decisions/0007-human-readable-changelog.html).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -438,7 +438,7 @@ jobs:
           path: pr_number.txt
 
   changelog_modified:
-    name: CHANGELOG.md was modified
+    name: CHANGELOG.md needs to be modified
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,3 +436,22 @@ jobs:
         with:
           name: pr_number
           path: pr_number.txt
+
+  changelog_modified:
+    name: CHANGELOG.md was modified
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for CHANGELOG.md modifications
+        id: check_changelog_modification
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG\.md$'; then
+            echo "✅ CHANGELOG.md was modified"
+          else
+            echo "❌ CHANGELOG.md was NOT modified"
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,7 +502,7 @@ jobs:
           BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
           echo "Body: $BODY"
 
-          if echo "$BODY" | grep -q 'grep '\- \[x\] Change in `CHANGELOG.md`'; then
+          if echo "$BODY" | grep -q '\- \[x\] Change in `CHANGELOG.md`'; then
             echo "found"
             echo "found=yes" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -496,8 +496,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check PR body for changelog note
+        id: changelog_check
+        run: |
+          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
+          if echo "$BODY" | grep -q '\[x\] Change in CHANGELOG.md described'; then
+            echo "found=yes" >> $GITHUB_OUTPUT
+          else
+            echo "found=no" >> $GITHUB_OUTPUT
+          fi
       - name: Check for CHANGELOG.md modifications
         id: check_changelog_modification
+        if: steps.changelog_check.outputs.found == 'yes'
         run: |
           git fetch origin ${{ github.base_ref }}
           if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG\.md$'; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,7 +502,7 @@ jobs:
           BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
           echo "Body: $BODY"
 
-          if echo "$BODY" | grep -q '[x] Change in CHANGELOG.md described'; then
+          if echo "$BODY" | grep -q '- [x] Change in `CHANGELOG.md` described'; then
             echo "found"
             echo "found=yes" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,7 +502,7 @@ jobs:
           BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
           echo "Body: $BODY"
 
-          if echo "$BODY" | grep -q '- [x] Change in `CHANGELOG.md` described'; then
+          if echo "$BODY" | grep -q '[x] Change in `CHANGELOG.md` described'; then
             echo "found"
             echo "found=yes" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -505,6 +505,8 @@ jobs:
           else
             echo "found=no" >> $GITHUB_OUTPUT
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for CHANGELOG.md modifications
         id: check_changelog_modification
         if: steps.changelog_check.outputs.found == 'yes'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -500,9 +500,13 @@ jobs:
         id: changelog_check
         run: |
           BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
-          if echo "$BODY" | grep -q '\[x\] Change in CHANGELOG.md described'; then
+          echo "Body: $BODY"
+
+          if echo "$BODY" | grep -q '[x] Change in CHANGELOG.md described'; then
+            echo "found"
             echo "found=yes" >> $GITHUB_OUTPUT
           else
+            echo "not found"
             echo "found=no" >> $GITHUB_OUTPUT
           fi
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -502,7 +502,7 @@ jobs:
           BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
           echo "Body: $BODY"
 
-          if echo "$BODY" | grep -q '[x] Change in `CHANGELOG.md` described'; then
+          if echo "$BODY" | grep -q 'grep '\- \[x\] Change in `CHANGELOG.md`'; then
             echo "found"
             echo "found=yes" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12786 / https://github.com/JabRef/jabref/pull/12783

Triggered by https://github.com/JabRef/jabref/pull/12796#issuecomment-2745266922

Check sonly for `[x]` and then for CHANGELOG.md modificatoins - does not check for `[/]` and then if CHANGELOG.md is notg modified

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
