### PR TITLE
Fix concurrent modification exception

### DIFF
--- a/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
@@ -125,6 +125,8 @@ public class CleanupAction extends SimpleCommand {
         }
 
         failures.addAll(cleaner.getFailures());
+
+        return !changes.isEmpty();
     }
 
     private void showResults() {

--- a/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
+++ b/src/main/java/org/jabref/gui/cleanup/CleanupAction.java
@@ -106,8 +106,10 @@ public class CleanupAction extends SimpleCommand {
 
     /**
      * Runs the cleanup on the entry and records the change.
+     *
+     * @return true iff entry was modified
      */
-    private void doCleanup(BibDatabaseContext databaseContext, CleanupPreferences preset, BibEntry entry, NamedCompound ce) {
+    private boolean doCleanup(BibDatabaseContext databaseContext, CleanupPreferences preset, BibEntry entry, NamedCompound ce) {
         // Create and run cleaner
         CleanupWorker cleaner = new CleanupWorker(
                 databaseContext,
@@ -145,13 +147,12 @@ public class CleanupAction extends SimpleCommand {
 
     private void cleanup(BibDatabaseContext databaseContext, CleanupPreferences cleanupPreferences) {
         this.failures.clear();
+
+        // undo granularity is on set of all entries
         NamedCompound ce = new NamedCompound(Localization.lang("Clean up entries"));
 
-        for (BibEntry entry : stateManager.getSelectedEntries()) {
-            // undo granularity is on entry level
-            doCleanup(databaseContext, cleanupPreferences, entry, ce);
-
-            if (ce.hasEdits()) {
+        for (BibEntry entry : List.copyOf(stateManager.getSelectedEntries())) {
+            if (doCleanup(databaseContext, cleanupPreferences, entry, ce)) {
                 modifiedEntriesCount++;
             }
         }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/836

- Uses copy of list to prevent concurrent modification exception

Additionally:

- Fixed cound of modified entries

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
