### PR TITLE
Fix removal of all assignees

### DIFF
--- a/.github/workflows/on-issue-unlabeled.yml
+++ b/.github/workflows/on-issue-unlabeled.yml
@@ -6,7 +6,7 @@ on:
        - unlabeled
 
 jobs:
-  ensure_column:
+  handle_Assigned_and_FirstTimeCodeContribution:
     name: "📍 Assigned or FirstTimeCodeContribution"
     if: ${{ (github.event.label.name == '📍 Assigned' || github.event.label.name == 'FirstTimeCodeContribution') && github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
@@ -33,13 +33,6 @@ jobs:
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-  remove_assignees:
-    if: ${{ github.repository_owner == 'JabRef' }}
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
-    steps:
       - uses: actions/checkout@v4
       - name: Remove all assignees
         run: |


### PR DESCRIPTION
I changed the label from "good first issue" to "good second issue" at https://github.com/JabRef/jabref/issues/12556 - and then the Assignee was removed -> https://github.com/JabRef/jabref/actions/runs/14022902800/job/39257172728

Should not happen - only removal if label "Assigned" or "FirstTimeCodeContribution" is removed.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
