### PR TITLE
Fix: Refresh groupTree after removing group (fixes #11487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where an exception would occur when running abbreviate journals for multiple entries. [#12634](https://github.com/JabRef/jabref/issues/12634)
 - We fixed an issue where JabRef displayed dropdown triangle in wrong place in "Search for unlinked local files" dialog [#12713](https://github.com/JabRef/jabref/issues/12713)
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
+- We fixed an issue where JabRef interface would not properly refresh after a group removal. [#11487](https://github.com/JabRef/jabref/issues/11487)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -713,12 +713,18 @@ public class GroupTreeView extends BorderPane {
         @Override
         public void execute() {
             switch (command) {
-                case GROUP_REMOVE ->
+                case GROUP_REMOVE -> {
                         viewModel.removeGroupNoSubgroups(group);
-                case GROUP_REMOVE_KEEP_SUBGROUPS ->
+                        groupTree.refresh();
+                }
+                case GROUP_REMOVE_KEEP_SUBGROUPS -> {
                         viewModel.removeGroupKeepSubgroups(group);
-                case GROUP_REMOVE_WITH_SUBGROUPS ->
+                        groupTree.refresh();
+                }
+                case GROUP_REMOVE_WITH_SUBGROUPS -> {
                         viewModel.removeGroupAndSubgroups(group);
+                        groupTree.refresh();
+                }
                 case GROUP_EDIT, GROUP_SUBGROUP_RENAME -> {
                     viewModel.editGroup(group);
                     groupTree.refresh();

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -713,28 +713,20 @@ public class GroupTreeView extends BorderPane {
         @Override
         public void execute() {
             switch (command) {
-                case GROUP_REMOVE -> {
+                case GROUP_REMOVE ->
                         viewModel.removeGroupNoSubgroups(group);
-                        groupTree.refresh();
-                }
-                case GROUP_REMOVE_KEEP_SUBGROUPS -> {
+                case GROUP_REMOVE_KEEP_SUBGROUPS ->
                         viewModel.removeGroupKeepSubgroups(group);
-                        groupTree.refresh();
-                }
-                case GROUP_REMOVE_WITH_SUBGROUPS -> {
+                case GROUP_REMOVE_WITH_SUBGROUPS ->
                         viewModel.removeGroupAndSubgroups(group);
-                        groupTree.refresh();
-                }
-                case GROUP_EDIT, GROUP_SUBGROUP_RENAME -> {
-                    viewModel.editGroup(group);
-                    groupTree.refresh();
-                }
+                case GROUP_EDIT, GROUP_SUBGROUP_RENAME ->
+                        viewModel.editGroup(group);
                 case GROUP_GENERATE_EMBEDDINGS ->
                         viewModel.generateEmbeddings(group);
                 case GROUP_GENERATE_SUMMARIES ->
                         viewModel.generateSummaries(group);
                 case GROUP_CHAT ->
-                    viewModel.chatWithGroup(group);
+                        viewModel.chatWithGroup(group);
                 case GROUP_SUBGROUP_ADD ->
                         viewModel.addNewSubgroup(group, GroupDialogHeader.SUBGROUP);
                 case GROUP_SUBGROUP_REMOVE ->
@@ -752,6 +744,7 @@ public class GroupTreeView extends BorderPane {
                 case GROUP_ENTRIES_REMOVE ->
                         viewModel.removeSelectedEntries(group);
             }
+            groupTree.refresh();
         }
     }
 


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes https://github.com/JabRef/jabref/issues/11487

Problem:
Previously, when a group was removed, it would still appear on hover, and users could interact with it via the right-click context menu. Additionally, for groups without a description, the description of the previously removed group could incorrectly appear due to this bug. This was caused by the UI not refreshing immediately after the group was deleted. (before_changes.mp4)

https://github.com/user-attachments/assets/68c2cea4-7cab-4989-a43d-4a6508599238


Solution:
Added groupTree.refresh(); after group removal to ensure the interface updates correctly, preventing ghost groups from lingering in the UI and avoiding incorrect description display for newly created groups. (after_changes.mp4)

https://github.com/user-attachments/assets/2e7ea605-8721-48ec-bdf6-434372903f21



### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
