### PR TITLE
Make PR text comments always appearing

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -1,42 +1,3 @@
-# PR text
-
-- jobName: 'PR checklist OK'
-  message: >
-    Note that your PR will not be accepted/reviewed until you have gone through the mandatory checks in the description and mark them as one of `[x] done`, `[ ] not done (yet)`, `[/] not applicable`.
-- jobName: 'Determine issue number'
-  message: |
-    Your pull request needs to link an issue.
-
-    To ease organizational workflows, please link this pull-request to the issue with syntax as described in <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>:
-
-    > <h2 id="linking-a-pull-request-to-an-issue-using-a-keyword">Linking a pull request to an issue using a keyword</h2>
-    > <p>You can link a pull request to an issue by using a supported keyword
-    > in the pull request's description or in a commit message. The pull
-    > request <strong>must be</strong> on the default branch.</p>
-    > <ul>
-    > <li>close</li>
-    > <li>closes</li>
-    > <li>closed</li>
-    > <li>fix</li>
-    > <li>fixes</li>
-    > <li>fixed</li>
-    > <li>resolve</li>
-    > <li>resolves</li>
-    > <li>resolved</li>
-    > </ul>
-    > <p>If you use a keyword to reference a pull request comment in another
-    > pull request, the pull requests will be linked. Merging the referencing
-    > pull request also closes the referenced pull request.</p>
-    > <p>The syntax for closing keywords depends on whether the issue is in the same repository as the pull request.</p>
-
-    ### Examples
-
-    - ✅ `Fixes #xyz` links pull-request to issue. Merging the PR will close the issue.
-    - ✅ `Fixes https://github.com/JabRef/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
-    - ✅ `Fixes https://github.com/Koppor/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
-    - ❌ `Fixes [#xyz](https://github.com/JabRef/jabref/issues/xyz)` links pull-request to issue. Merging the PR will **NOT** close the issue.
-
-
 # Compilation, tests, and code style
 
 - jobName: windows installer and portable version
@@ -141,3 +102,44 @@
     For this pull request, this is OK.
     For subsequent pull requests, please start with a different branch with a proper branch name.
     See [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#pull-request-process) for more details.
+
+
+# PR text
+
+- jobName: 'PR checklist OK'
+  always: true
+  message: >
+    Note that your PR will not be accepted/reviewed until you have gone through the mandatory checks in the description and mark them as one of `[x] done`, `[ ] not done (yet)`, `[/] not applicable`.
+- jobName: 'Determine issue number'
+  always: true
+  message: |
+    Your pull request needs to link an issue.
+
+    To ease organizational workflows, please link this pull-request to the issue with syntax as described in <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>:
+
+    > <h2 id="linking-a-pull-request-to-an-issue-using-a-keyword">Linking a pull request to an issue using a keyword</h2>
+    > <p>You can link a pull request to an issue by using a supported keyword
+    > in the pull request's description or in a commit message. The pull
+    > request <strong>must be</strong> on the default branch.</p>
+    > <ul>
+    > <li>close</li>
+    > <li>closes</li>
+    > <li>closed</li>
+    > <li>fix</li>
+    > <li>fixes</li>
+    > <li>fixed</li>
+    > <li>resolve</li>
+    > <li>resolves</li>
+    > <li>resolved</li>
+    > </ul>
+    > <p>If you use a keyword to reference a pull request comment in another
+    > pull request, the pull requests will be linked. Merging the referencing
+    > pull request also closes the referenced pull request.</p>
+    > <p>The syntax for closing keywords depends on whether the issue is in the same repository as the pull request.</p>
+
+    ### Examples
+
+    - ✅ `Fixes #xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ✅ `Fixes https://github.com/JabRef/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ✅ `Fixes https://github.com/Koppor/jabref/issues/xyz` links pull-request to issue. Merging the PR will close the issue.
+    - ❌ `Fixes [#xyz](https://github.com/JabRef/jabref/issues/xyz)` links pull-request to issue. Merging the PR will **NOT** close the issue.


### PR DESCRIPTION
Context: https://github.com/JabRef/jabref/pull/12817

Students want to geht their code out and seem not to care about the checks of code. Thus, waiting for a PR checklist being fixed before any code comments appear leads to NOOP on their side.

With this update of `ghprcomments.yml`, students get:

- Comments on failing code - first hit only
- Always comments on wrong PR format (both issue link and checklist)

This is a HOT FIX, therefore merging immediatly.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
