### PR TITLE
Consistent wording

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -12,8 +12,7 @@
   message: >
     JUnit tests are failing.
     You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
-    Locate "Tests / Unit tests (pull_request)" and click on it.
-    This brings you to the test output.
+    To see the test output, locate "Tests / Unit tests (pull_request)" and click on it.
 
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
@@ -23,8 +22,7 @@
     Your code currently does not meet [JabRef's code guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
     We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
     You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
-    Locate "Tests / Checkstyle (pull_request)" and click on it.
-    This brings you to the test output.
+    To see the test output, locate "Tests / Checkstyle (pull_request)" and click on it.
 
 
     In case of issues with the import order, double check that you [activated Auto Import](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#enable-proper-import-cleanup).
@@ -38,19 +36,17 @@
     Your code currently does not meet JabRef's code guidelines.
     We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
     You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
-    Locate "Tests / OpenRewrite (pull_request)" and click on it.
-    This brings you to the test output.
+    To see the test output, locate "Tests / OpenRewrite (pull_request)" and click on it.
 
     
     The issues found can be **automatically fixed**.
-    Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
+    Please execute the gradle task *`rewriteRun`* from the [`rewrite` group of the Gradle Tool window](https://devdocs.jabref.org/code-howtos/faq.html#failing-openrewrite-tests) in IntelliJ, then check the results, commit, and push.
 - jobName: Modernizer
   message: >
     Your code currently does not meet JabRef's code guidelines.
     We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
     You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
-    Locate "Tests / Modernizer (pull_request)" and click on it.
-    This brings you to the test output.
+    To see the test output, locate "Tests / Modernizer (pull_request)" and click on it.
 
 
     Please fix the detected errors, commit, and push.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -11,7 +11,8 @@
 - jobName: 'Unit tests'
   message: >
     JUnit tests are failing.
-    In the area "Some checks were not successful", locate "Tests / Unit tests (pull_request)" and click on "Details".
+    You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
+    Locate "Tests / Unit tests (pull_request)" and click on it.
     This brings you to the test output.
 
 
@@ -21,30 +22,38 @@
   message: >
     Your code currently does not meet [JabRef's code guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
     We use [Checkstyle](https://checkstyle.sourceforge.io/) to identify issues.
-    Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
-    Afterwards, please [run checkstyle locally](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#run-checkstyle) and fix the issues.
+    You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
+    Locate "Tests / Checkstyle (pull_request)" and click on it.
+    This brings you to the test output.
 
 
     In case of issues with the import order, double check that you [activated Auto Import](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#enable-proper-import-cleanup).
     You can trigger fixing imports by pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>O</kbd> to trigger [Optimize Imports](https://www.jetbrains.com/guide/tips/optimize-imports/).
+
+
+    Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
+    Afterwards, please [run checkstyle locally](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#run-checkstyle) and fix the issues, commit, and push.
 - jobName: OpenRewrite
   message: >
     Your code currently does not meet JabRef's code guidelines.
     We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
+    You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
+    Locate "Tests / OpenRewrite (pull_request)" and click on it.
+    This brings you to the test output.
+
+    
     The issues found can be **automatically fixed**.
     Please execute the gradle task *`rewriteRun`*, check the results, commit, and push.
-
-
-    You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "OpenRewrite".
 - jobName: Modernizer
   message: >
     Your code currently does not meet JabRef's code guidelines.
     We use [Gradle Modernizer Plugin](https://github.com/andygoossens/gradle-modernizer-plugin#gradle-modernizer-plugin) to ensure "modern" Java coding practices.
+    You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
+    Locate "Tests / Modernizer (pull_request)" and click on it.
+    This brings you to the test output.
+
+
     Please fix the detected errors, commit, and push.
-
-
-    You can check the detailed error output by navigating to your pull request, selecting the tab "Checks", section "Tests" (on the left), subsection "Modernizer".
-
 
 # CHANGELOG.md and *.md
 


### PR DESCRIPTION
Consistent wording for the comments: 

- Always guide users to the test box in a PR - not the tab in the PR.
- Have the action to do as last paragraph of the comment

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
