### PR TITLE
Relax constraint on valid checklist states

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -411,7 +411,7 @@ jobs:
           echo "Found boxes: $BOXES"
 
           while IFS= read -r line; do
-              if ! printf '%s\n' "$line" | grep -Eq "^- \[(x|/| )\] "; then
+              if ! printf '%s\n' "$line" | grep -Eq "^- \[(x|/| |)\] "; then
                   echo "❌ Found improperly formatted checkbox: '$line'"
                   exit 1
               fi


### PR DESCRIPTION
Trigger: https://github.com/JabRef/jabref/pull/12815#issuecomment-2750902040
It can be a common error to use `[]` instead of `[ ]` by just removing the dot and not adding a space.
It conveys the same information, as the contributor has read the checklist and removed the dot.
We relax the constraint for the "valid states" format a bit.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
