### PR TITLE
Fix import of DOI with < and > characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
 - We fixed a bug where LaTeX commands were not removed from filenames generated using the `[bibtexkey] - [fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
 - We fixed an issue where JabRef interface would not properly refresh after a group removal. [#11487](https://github.com/JabRef/jabref/issues/11487)
+- We fixed an issue where valid DOI couldn't be imported if they had special characters like < or >. [#12434](https://github.com/JabRef/jabref/issues/12434)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef would not open if an invalid external journal abbreviation path was encountered. [#12776](https://github.com/JabRef/jabref/issues/12776)
 - We fixed a bug where LaTeX commands were not removed from filenames generated using the `[bibtexkey] - [fulltitle]` pattern. [#12188](https://github.com/JabRef/jabref/issues/12188)
 - We fixed an issue where JabRef interface would not properly refresh after a group removal. [#11487](https://github.com/JabRef/jabref/issues/11487)
-- We fixed an issue where valid DOI couldn't be imported if they had special characters like < or >. [#12434](https://github.com/JabRef/jabref/issues/12434)
+- We fixed an issue where valid DOI could not be imported if it had special characters like `<` or `>`. [#12434](https://github.com/JabRef/jabref/issues/12434)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -5,6 +5,8 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -219,7 +221,8 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
     public Optional<String> getAgency(DOI doi) throws FetcherException, MalformedURLException {
         Optional<String> agency = Optional.empty();
         try {
-            URLDownload download = getUrlDownload(URLUtil.create(DOI.AGENCY_RESOLVER + "/" + doi.asString()));
+            URLDownload download = getUrlDownload(URLUtil.create(DOI.AGENCY_RESOLVER + "/" + URLEncoder.encode(doi.asString(),
+                    StandardCharsets.UTF_8)));
             JSONObject response = new JSONArray(download.asString()).getJSONObject(0);
             if (response != null) {
                 agency = Optional.ofNullable(response.optString("RA"));

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
@@ -70,6 +70,19 @@ class DoiFetcherTest {
             .withField(StandardField.PUBLISHER, "American Physical Society (APS)")
             .withField(StandardField.PAGES, "023315")
             .withField(StandardField.NUMBER, "2");
+    private final BibEntry bibBenedetto2000 = new BibEntry(StandardEntryType.Article)
+            .withCitationKey("Benedetto_2000")
+            .withField(StandardField.AUTHOR, "Benedetto, D. and Caglioti, E. and Marchioro, C.")
+            .withField(StandardField.JOURNAL, "Mathematical Methods in the Applied Sciences")
+            .withField(StandardField.TITLE, "On the motion of a vortex ring with a sharply concentrated vorticity")
+            .withField(StandardField.YEAR, "2000")
+            .withField(StandardField.MONTH, "#jan#")
+            .withField(StandardField.VOLUME, "23")
+            .withField(StandardField.DOI, "10.1002/(sici)1099-1476(20000125)23:2<147::aid-mma108>3.0.co;2-j")
+            .withField(StandardField.ISSN, "1099-1476")
+            .withField(StandardField.PUBLISHER, "Wiley")
+            .withField(StandardField.PAGES, "147--168")
+            .withField(StandardField.NUMBER, "2");
 
     @Test
     void getName() {
@@ -124,5 +137,11 @@ class DoiFetcherTest {
     void aPSJournalCopiesArticleIdToPageField() throws FetcherException {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1103/physreva.102.023315");
         assertEquals(Optional.of(bibEntryStenzel2020), fetchedEntry);
+    }
+
+    @Test
+    void performSearchDOIWithUnencodedCharacters() throws FetcherException {
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1002/(SICI)1099-1476(20000125)23:2<147::AID-MMA108>3.0.CO;2-J");
+        assertEquals(Optional.of(bibBenedetto2000), fetchedEntry);
     }
 }


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes #12434

This fixes an issue where valid DOI couldn't be imported if they had some special characters like _<_ or _>_.

### Describe the changes you have made here: what, where, why, ...

These characters have to be URL encoded which was usually done with DOI#getURIAsASCIIString but this returns the whole URL and DoiFetcher#getAgency used a different domain, so it created the URL manually with DOI#asString which is not URL encoded. I added the URL encoding in DoiFetcher#getAgency.

The image below shows that the DOI mentioned in the issue was imported successfully after the fix.

![image](https://github.com/user-attachments/assets/411f3c41-5f0c-4898-9f60-18f0456767eb)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
