### PR TITLE
Tiny CSL architectural cleanup

### DIFF
--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -73,6 +73,7 @@ public class OOBibBase {
     private final OOBibBaseConnect connection;
 
     private CSLCitationOOAdapter cslCitationOOAdapter;
+    private CSLUpdateBibliography cslUpdateBibliography;
 
     private OpenOfficePreferences openOfficePreferences;
 
@@ -92,6 +93,7 @@ public class OOBibBase {
             Supplier<List<BibDatabaseContext>> databasesSupplier = stateManager::getOpenDatabases;
             OOStyle initialStyle = openOfficePreferences.getCurrentStyle(); // may be a jstyle, can still be used for detecting subsequent style changes in context of CSL
             cslCitationOOAdapter = new CSLCitationOOAdapter(doc, databasesSupplier, initialStyle);
+            cslUpdateBibliography = new CSLUpdateBibliography();
         }
     }
 
@@ -889,8 +891,6 @@ public class OOBibBase {
             }
         } else if (style instanceof CitationStyle citationStyle) {
             try {
-
-                CSLUpdateBibliography cslUpdateBibliography = new CSLUpdateBibliography();
 
                 OOResult<XTextDocument, OOError> odoc = getXTextDocument();
                 if (testDialog(errorTitle, odoc.asVoidResult())) {

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -90,7 +90,8 @@ public class OOBibBase {
         if (cslCitationOOAdapter == null) {
             StateManager stateManager = Injector.instantiateModelOrService(StateManager.class);
             Supplier<List<BibDatabaseContext>> databasesSupplier = stateManager::getOpenDatabases;
-            cslCitationOOAdapter = new CSLCitationOOAdapter(doc, databasesSupplier, openOfficePreferences);
+            OOStyle initialStyle = openOfficePreferences.getCurrentStyle(); // may be a jstyle, can still be used for detecting subsequent style changes in context of CSL
+            cslCitationOOAdapter = new CSLCitationOOAdapter(doc, databasesSupplier, initialStyle);
         }
     }
 

--- a/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStyleGenerator;
-import org.jabref.logic.openoffice.OpenOfficePreferences;
+import org.jabref.logic.openoffice.style.OOStyle;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -49,12 +49,12 @@ public class CSLCitationOOAdapter {
     private CitationStyle currentStyle;
     private boolean styleChanged;
 
-    public CSLCitationOOAdapter(XTextDocument doc, Supplier<List<BibDatabaseContext>> databasesSupplier, OpenOfficePreferences openOfficePreferences) throws WrappedTargetException, NoSuchElementException {
+    public CSLCitationOOAdapter(XTextDocument doc, Supplier<List<BibDatabaseContext>> databasesSupplier, OOStyle initialStyle) throws WrappedTargetException, NoSuchElementException {
         this.document = doc;
         this.markManager = new CSLReferenceMarkManager(doc);
         this.databasesSupplier = databasesSupplier;
-        if (openOfficePreferences.getCurrentStyle() instanceof CitationStyle citationStyle) {
-            this.currentStyle = citationStyle;
+        if (initialStyle instanceof CitationStyle citationStyle) {
+            this.currentStyle = citationStyle; // else the currentStyle purposely stays null, still causing a difference with the subsequent style if CSL (valid comparison)
         }
 
         markManager.readAndUpdateExistingMarks();


### PR DESCRIPTION
Some quick architectural cleanups triggered by discussion at https://github.com/JabRef/jabref/pull/12784#discussion_r2014742700.

- Free `CSLCitationOOAdapter` completely of preferences.
- Some related comments explaining usage of the initial style of generic style type to detect changes in styles in the adapter
- Only one instance of `CSLUpdateBibliography` needed - some more breathing space for the garbage collector.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
