### PR TITLE
[OO] Localize string, add preview header

### DIFF
--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.fxml
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.fxml
@@ -57,7 +57,13 @@
                                     text="%Add style file" BorderPane.alignment="CENTER"/>
                         </right>
                         <bottom>
-                            <VBox fx:id="jstylePreviewBox" prefHeight="84.0" prefWidth="665.0" BorderPane.alignment="CENTER"/>
+                            <VBox spacing="4.0">
+                                <padding>
+                                    <Insets top="10.0" right="10.0" bottom="10.0" left="10.0"/>
+                                </padding>
+                                <Label text="%Preview" styleClass="sectionHeader"/>
+                                <VBox fx:id="jstylePreviewBox" prefHeight="84.0" prefWidth="665.0" BorderPane.alignment="CENTER"/>
+                            </VBox>
                         </bottom>
                     </BorderPane>
                 </Tab>
@@ -66,7 +72,7 @@
                 <padding>
                     <Insets left="10.0" right="10.0" bottom="10.0"/>
                 </padding>
-                <Label text="Currently set style:" styleClass="currentStyleLabel"/>
+                <Label text="%Currently set style:" styleClass="currentStyleLabel"/>
                 <Label fx:id="currentStyleNameLabel" styleClass="currentStyleNameLabel"/>
             </HBox>
         </VBox>

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2848,8 +2848,9 @@ Warning\:\ The\ selected\ directory\ is\ not\ empty.=Warning: The selected direc
 Warning\:\ Failed\ to\ check\ if\ the\ directory\ is\ empty.=Warning: Failed to check if the directory is empty.
 Warning\:\ The\ selected\ directory\ is\ not\ a\ valid\ directory.=Warning: The selected directory is not a valid directory.
 
-Currently\ selected\ JStyle\:\ '%0' = Currently selected JStyle: '%0'
-Currently\ selected\ CSL\ Style\:\ '%0' = Currently selected CSL Style: '%0'
+Currently\ set\ style\:=Currently set style:
+Currently\ selected\ JStyle\:\ '%0'=Currently selected JStyle: '%0'
+Currently\ selected\ CSL\ Style\:\ '%0'=Currently selected CSL Style: '%0'
 Store\ url\ for\ downloaded\ file=Store url for downloaded file
 
 Compare\ with\ existing\ entry=Compare with existing entry


### PR DESCRIPTION
Chsnges:
- There was a string ("Currently set style:") in select style fxml which was not localized - fixed
- Fixed spaces around the "=" in two other entries related to OO in the localization file
- Added the "Preview" header for the JStyles tab, to make it consistent with CSL:
  
  ![image](https://github.com/user-attachments/assets/67f83b2c-188d-44e9-b193-af0a727011f3)


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
