### PR TITLE
Remove java9 property from BuildInfo

### DIFF
--- a/src/main/java/org/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/org/jabref/logic/util/BuildInfo.java
@@ -20,14 +20,13 @@ public final class BuildInfo {
     public final Version version;
     public final String maintainers;
     public final String year;
-    public final String springerNatureAPIKey;
+
     public final String astrophysicsDataSystemAPIKey;
+    public final String biodiversityHeritageApiKey;
     public final String ieeeAPIKey;
     public final String scienceDirectApiKey;
-    public final String minRequiredJavaVersion;
-    public final boolean allowJava9;
-    public final String biodiversityHeritageApiKey;
     public final String semanticScholarApiKey;
+    public final String springerNatureAPIKey;
 
     public BuildInfo() {
         this("/build.properties");
@@ -43,20 +42,19 @@ public final class BuildInfo {
                 }
             }
         } catch (IOException ignored) {
-            // nothing to do -> default already set
+            // nothing to do -> default will be set
         }
 
         version = Version.parse(properties.getProperty("version"));
         year = properties.getProperty("year", "");
         maintainers = properties.getProperty("maintainers", "");
-        springerNatureAPIKey = BuildInfo.getValue(properties, "springerNatureAPIKey", "118d90a519d0fc2a01ee9715400054d4");
+
         astrophysicsDataSystemAPIKey = BuildInfo.getValue(properties, "astrophysicsDataSystemAPIKey", "tAhPRKADc6cC26mZUnAoBt3MAjCvKbuCZsB4lI3c");
+        biodiversityHeritageApiKey = BuildInfo.getValue(properties, "biodiversityHeritageApiKey", "36b910b6-2eb3-46f2-b64c-9abc149925ba");
         ieeeAPIKey = BuildInfo.getValue(properties, "ieeeAPIKey", "5jv3wyt4tt2bwcwv7jjk7pc3");
         scienceDirectApiKey = BuildInfo.getValue(properties, "scienceDirectApiKey", "fb82f2e692b3c72dafe5f4f1fa0ac00b");
-        minRequiredJavaVersion = properties.getProperty("minRequiredJavaVersion", "1.8");
-        allowJava9 = "true".equals(properties.getProperty("allowJava9", "true"));
-        biodiversityHeritageApiKey = BuildInfo.getValue(properties, "biodiversityHeritageApiKey", "36b910b6-2eb3-46f2-b64c-9abc149925ba");
         semanticScholarApiKey = BuildInfo.getValue(properties, "semanticScholarApiKey", "");
+        springerNatureAPIKey = BuildInfo.getValue(properties, "springerNatureAPIKey", "118d90a519d0fc2a01ee9715400054d4");
     }
 
     private static String getValue(Properties properties, String key, String defaultValue) {


### PR DESCRIPTION
Our `BuildInfo` class contained non-used properties from a very long time ago. I removed that.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
