### PR TITLE
Post conflict message as soon as conflict occurrs

### DIFF
--- a/.github/workflows/on-pr-opened.yml
+++ b/.github/workflows/on-pr-opened.yml
@@ -111,7 +111,6 @@ jobs:
         run: gh issue edit ${{ steps.get_issue_number.outputs.ticketNumber }} --add-label "📌 Pinned"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   conflicts_with_target:
     name: Conflicts with target branch
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-synchronize.yml
+++ b/.github/workflows/on-pr-synchronize.yml
@@ -1,0 +1,36 @@
+name: On PR synchronize
+
+on:
+  # _target is required
+  pull_request_target:
+    types:
+      - synchronize
+
+jobs:
+  conflicts_with_target:
+    name: Conflicts with target branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: 'false'
+      - name: Check PR mergeability
+        id: check_mergeable
+        run: |
+          MERGEABLE=$(gh pr view --json mergeable ${{ github.event.number }} --template '{{.mergeable}}')
+          if [ "$MERGEABLE" == "CONFLICTING" ]; then
+            echo "❌ Merge conflicts"
+            exit 1
+          fi
+          echo "✅ No merge conflicts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,7 +7,7 @@ name: Comment on PR
 
 on:
   workflow_run:
-    workflows: ["Tests", "On PR opened"]
+    workflows: ["Tests", "On PR opened", "On PR synchronize"]
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
     types: [completed]
   workflow_dispatch:


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/12747#issuecomment-2760401736

With `synchronize`, a comment should be triggered as soon as there is a modification of `main`

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
