### PR TITLE
Fix "Copy to" preferences

### DIFF
--- a/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
+++ b/src/main/java/org/jabref/gui/edit/CopyToPreferences.java
@@ -20,11 +20,19 @@ public class CopyToPreferences {
         this.shouldIncludeCrossReferences.set(decision);
     }
 
+    public BooleanProperty shouldIncludeCrossReferencesProperty() {
+        return shouldIncludeCrossReferences;
+    }
+
     public boolean getShouldAskForIncludingCrossReferences() {
         return shouldAskForIncludingCrossReferences.get();
     }
 
     public void setShouldAskForIncludingCrossReferences(boolean decision) {
         this.shouldAskForIncludingCrossReferences.set(decision);
+    }
+
+    public BooleanProperty shouldAskForIncludingCrossReferencesProperty() {
+        return shouldAskForIncludingCrossReferences;
     }
 }

--- a/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -427,6 +427,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES),
                 getBoolean(INCLUDE_CROSS_REFERENCES)
         );
+
+        EasyBind.listen(copyToPreferences.shouldAskForIncludingCrossReferencesProperty(), (obs, oldValue, newValue) -> putBoolean(ASK_FOR_INCLUDING_CROSS_REFERENCES, newValue));
+        EasyBind.listen(copyToPreferences.shouldIncludeCrossReferencesProperty(), (obs, oldValue, newValue) -> putBoolean(INCLUDE_CROSS_REFERENCES, newValue));
+
         return copyToPreferences;
     }
 


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes #12843 

This pull request addresses an issue where the dialog prompting users about including cross-references reappears even after the user has selected the "Do not ask again" option. Additionally, it resolves the problem of the updated state of preferences not being saved correctly, ensuring that the last saved state persists across sessions.

* Use EasyBind.listen() in `getCopyToPreferences` to observe any change in these properties to save the preferences.
* Implemented property binding in  `CopyToPreferences` class.

_Screen Recordings:_ 

https://github.com/user-attachments/assets/79ee2755-3576-42ad-8284-516a07f7c04e

https://github.com/user-attachments/assets/88e5359e-c797-462d-926d-7722d642b9d4

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
