### PR TITLE
[OO/CSL] Instantaneous citation insertion and refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We changed the phrase "Cleanup entries" to "Clean up entries". [#12703](https://github.com/JabRef/jabref/issues/12703)
 - A tooltip now appears after 300ms (instead of 2s). [#12649](https://github.com/JabRef/jabref/issues/12649)
 - We improved search in preferences and keybindings. [#12647](https://github.com/JabRef/jabref/issues/12647)
+- We improved the performance of the LibreOffice integration when inserting CSL citations/bibliography. [#12849](https://github.com/JabRef/jabref/pull/12849)
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -598,6 +598,10 @@ public class OOBibBase {
             if (style instanceof CitationStyle citationStyle) {
                 // Handle insertion of CSL Style citations
 
+                // Lock document controllers - disable refresh during the process (avoids document flicker during writing)
+                // MUST always be paired with an unlockControllers() call
+                doc.lockControllers();
+
                 if (citationType == CitationType.AUTHORYEAR_PAR) {
                     // "Cite" button
                     cslCitationOOAdapter.insertCitation(cursor.get(), citationStyle, entries, bibDatabaseContext, bibEntryTypesManager);
@@ -608,6 +612,9 @@ public class OOBibBase {
                     // "Insert empty citation"
                     cslCitationOOAdapter.insertEmptyCitation(cursor.get(), citationStyle, entries);
                 }
+
+                // Release controller lock
+                doc.unlockControllers();
 
                 // If "Automatically sync bibliography when inserting citations" is enabled
                 syncOptions.ifPresent(options -> guiActionUpdateDocument(options.databases, citationStyle));
@@ -935,7 +942,11 @@ public class OOBibBase {
                     BibDatabase bibDatabase = new BibDatabase(citedEntries);
                     BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(bibDatabase);
 
+                    // Lock document controllers - disable refresh during the process (avoids document flicker during writing)
+                    // MUST always be paired with an unlockControllers() call
+                    doc.lockControllers();
                     cslUpdateBibliography.rebuildCSLBibliography(doc, cslCitationOOAdapter, citedEntries, citationStyle, bibDatabaseContext, Injector.instantiateModelOrService(BibEntryTypesManager.class));
+                    doc.unlockControllers();
                 } catch (NoDocumentException
                          | NoSuchElementException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12472 (and prior)

### Change
- Use controller locking to prevent document refresh during citing/re-insertion/bibliography generation/re-generation.
Drastically improves the performance of write operations in the document, making them appear almost instantaneous.


https://github.com/user-attachments/assets/0419a9fa-a854-43bf-9ec9-c8109deb3ed7


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
