### PR TITLE
Disablew non-working tets (with issue links)

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ApsFetcherTest.java
@@ -8,11 +8,13 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @FetcherTest
+@Disabled("See https://github.com/JabRef/jabref/issues/12864")
 class ApsFetcherTest {
 
     private ApsFetcher finder;

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -15,6 +15,7 @@ import org.jabref.model.paging.Page;
 import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
+@Disabled("https://github.com/JabRef/jabref-issue-melting-pot/issues/843")
 public class AstrophysicsDataSystemTest implements PagedSearchFetcherTest {
 
     private AstrophysicsDataSystem fetcher;

--- a/src/test/java/org/jabref/logic/importer/fetcher/BiodiversityLibraryTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/BiodiversityLibraryTest.java
@@ -15,6 +15,7 @@ import org.jabref.testutils.category.FetcherTest;
 
 import kong.unirest.core.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
+@Disabled("https://github.com/JabRef/jabref-issue-melting-pot/issues/844")
 class BiodiversityLibraryTest {
     private final String RESPONSE_FORMAT = "&format=json";
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IEEETest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
+@Disabled("https://github.com/JabRef/jabref-issue-melting-pot/issues/846")
 class IEEETest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTest {
 
     private static ImportFormatPreferences importFormatPreferences;

--- a/src/test/java/org/jabref/logic/importer/fetcher/LOBIDFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/LOBIDFetcherTest.java
@@ -93,6 +93,12 @@ class LOBIDFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchF
     public void supportsYearSearch() {
     }
 
+    @Test
+    @Override
+    @Disabled("Results returned contain a few incorrect years. The majority are accurate")
+    public void supportsYearRangeSearch() {
+    }
+
     @Override
     public PagedSearchBasedFetcher getPagedFetcher() {
         return fetcher;

--- a/src/test/java/org/jabref/logic/importer/fetcher/SearchBasedFetcherCapabilityTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SearchBasedFetcherCapabilityTest.java
@@ -80,6 +80,8 @@ interface SearchBasedFetcherCapabilityTest {
         List<String> yearsInYearRange = List.of("2018", "2019", "2020");
 
         List<BibEntry> result = getFetcher().performSearch("year-range:2018-2020");
+        assertFalse(result.isEmpty());
+
         FieldPreferences fieldPreferences = mock(FieldPreferences.class);
         when(fieldPreferences.getNonWrappableFields()).thenReturn(FXCollections.observableArrayList());
         ImportCleanup.targeting(BibDatabaseMode.BIBTEX, fieldPreferences).doPostCleanup(result);
@@ -88,8 +90,8 @@ interface SearchBasedFetcherCapabilityTest {
                                                     .filter(Optional::isPresent)
                                                     .map(Optional::get)
                                                     .distinct()
-                                                    .collect(Collectors.toList());
-        assertFalse(result.isEmpty());
+                                                    .toList();
+
         assertTrue(yearsInYearRange.containsAll(differentYearsInResult));
     }
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/ACMPortalParserTest.java
@@ -18,12 +18,14 @@ import org.jabref.testutils.category.FetcherTest;
 
 import org.apache.hc.core5.net.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @FetcherTest
+@Disabled("https://github.com/jabref/jabref/issues/10257")
 class ACMPortalParserTest {
 
     ACMPortalParser parser;


### PR DESCRIPTION
Our fetcher tests fail since several dev calls. This PR disables them to put our focus to other things.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
