### PR TITLE
drag'n'drop now works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the drag'n'drop functionality in entryeditor did not work [12561](https://github.com/JabRef/jabref/issues/12561)
 - We fixed an issue where the F4 shortcut key did not work without opening the right-click context menu. [#6101](https://github.com/JabRef/jabref/pull/6101)
 - We fixed an issue where the file renaming dialog was not resizable and its size was too small for long file names. [#12518](https://github.com/JabRef/jabref/pull/12518)
 - We fixed an issue where the name of the untitled database was shown as a blank space in the right-click context menu's "Copy to" option. [#12459](https://github.com/JabRef/jabref/pull/12459)

--- a/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelListCellFactory.java
@@ -192,7 +192,10 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
                         setOnDragDetected(event -> toOnDragDetected.accept(viewModel, event));
                     }
                     if (toOnDragDropped != null) {
-                        setOnDragDropped(event -> toOnDragDropped.accept(viewModel, event));
+                        setOnDragDropped(event -> {
+                            event.consume(); // Prevent cells from acting as drop targets
+                            getParent().fireEvent(event); // The action performed was not look at the parent, the drop box
+                        });
                     }
                     if (toOnDragEntered != null) {
                         setOnDragEntered(event -> toOnDragEntered.accept(viewModel, event));
@@ -201,7 +204,10 @@ public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCe
                         setOnDragExited(event -> toOnDragExited.accept(viewModel, event));
                     }
                     if (toOnDragOver != null) {
-                        setOnDragOver(event -> toOnDragOver.accept(viewModel, event));
+                        setOnDragOver(event -> {
+                            event.consume(); // Prevent cells from acting as drop targets
+                            getParent().fireEvent(event); // The action performed was not look at the parent, the drop box
+                        });
                     }
                     for (Map.Entry<PseudoClass, Callback<T, ObservableValue<Boolean>>> pseudoClassWithCondition : pseudoClasses.entrySet()) {
                         ObservableValue<Boolean> condition = pseudoClassWithCondition.getValue().call(viewModel);


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12561

ViewModelListCellFactory.java contained the calls to the OnDrag() properties like onDragOver() and onDragDrop(), which were necessary for the drag and drop functionality. We added an event.consume() call and a call to the parent to restart the indicator for the drag and drop file indicator. This allowed us to repeatedly drag and drop files in the correct cell.

![image](https://github.com/user-attachments/assets/c5a057af-46ce-4af1-9845-f11e9e9ede12)
Now works

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
