### PR TITLE
Add best-title picking logic in mergeCandidates method

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -208,7 +208,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
         }
 
         //if the title ends in .ccc or .cccc where c is any alphabetic char, minus 10 points
-        int endsinExtension = Title.matches(".*\\.[a-zA-Z]{3,4}") ? -10 : 0;
+        int endsInExtension= title.matches(".*\\.[a-zA-Z]{3,4}") ? -10 : 0;
 
         int endsWithFileExtension = 0;
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -202,7 +202,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
 
     private static int calculateTitleScore(String title) {
         //for every word in the title, plus one point
-        int wordcount = Title.trim().split("\\s+").length;
+        int wordCount = title.trim().split("\\s+").length;
         if(wordcount > 35){
             wordcount = -2; //super long titles are less favourable
         }

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -200,7 +200,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
         return entry;
     }
 
-    private static int calculateTitleScore(String Title) {
+    private static int calculateTitleScore(String title) {
         //for every word in the title, plus one point
         int wordcount = Title.trim().split("\\s+").length;
         if(wordcount > 35){

--- a/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -212,7 +212,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
 
         int endsWithFileExtension = 0;
 
-        if (Title.matches("(?i).*(\\.(pdf|docx?|txt|jpg|png))$")){
+        if (title.matches("(?i).*(\\.(pdf|docx?|txt|jpg|png))$")){
             //Check for some common file extensions, remove points if contains these common filepath endings.
             endsWithFileExtension = -10; // subtract ten more points for file extension ending, very undesirable.
         }


### PR DESCRIPTION
Closes #11999 

I modified the mergeCanditates method to merge the "best" title candidate. This consisted of also adding a helper method to this process, calculateTitleScore. This method scores titles based on a variety of heuristics, such as file path endings, ending with .(chars), and the number of words contained with a title. 

mergeCanditates method effectively merges all candidates, and then overrides the previously merged title with the chosen best title.

Rationale: This reintroduces the ability to pick the best title from multiple candidates, addressing the regression where titles were simply overwritten in a last-wins manner. Now the best title according to the heuristics is selected.


### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
