### PR TITLE
Add "reminder_comment"

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -28,8 +28,6 @@ jobs:
             Having any questions or issues? Feel free to ask here on GitHub. Need help setting up your local workspace? Join the conversation on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref). And don't hesitate to open a (draft) pull request early on to show the direction it is heading towards. This way, you will receive valuable feedback.
 
             Happy coding! 🚀
-
-            ⏳ Please note, you will be automatically unassigned if there is not a (draft) pull request within **{{ total_days }} days** (by **{{ unassigned_date }}**).
           assignment_suggestion_comment: >
             👋 Hey @{{ handle }}, looks like you’re eager to work on this issue—great! 🎉
             It also looks like you skipped reading our [CONTRIBUTING.md](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md), which explains exactly how to participate. No worries, it happens to the best of us.

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -19,13 +19,32 @@ jobs:
         uses: takanome-dev/assign-issue-action@edge
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
-          days_until_unassign: 14
+          reminder_comment: |
+              ### ⏰ Assignment Reminder
+
+              Hi @{{ handle }}, this is a friendly reminder about your assignment to this issue.
+
+              > [!WARNING]
+              > This issue will be **automatically unassigned** in **{{ days_remaining }} days** if there's no activity.
+
+              <details open>
+              <summary>How to keep your assignment</summary>
+
+              \
+              You can prevent automatic unassignment by:
+
+              - Making progress on the issue by submitting a draft PR
+              - Asking for the **{{{ pin_label }}}** label if you need more time
+              </details>
+
+              We appreciate your contribution and are here to help if needed!
+          days_until_unassign: 21
           unassigned_comment: |
             ### 📋 Assignment Update
 
             Hi @{{ handle }}, due to inactivity, you have been unassigned from this issue.
 
-            <details open>
+            <details>
             <summary>Next steps</summary>
 
             \

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -31,9 +31,9 @@ jobs:
               <summary>How to keep your assignment</summary>
 
               \
-              You can prevent automatic unassignment by:
+              If you are working on it, you can prevent automatic unassignment by:
 
-              - Making progress on the issue by submitting a draft PR
+              - Submitting a draft PR with your progress
               - Asking for the **{{{ pin_label }}}** label if you need more time
               </details>
 


### PR DESCRIPTION
Ports https://github.com/takanome-dev/assign-issue-action/pull/320 to here.

- Changed "final" unassignment deadline to 21 days
- Sends a reminder after 11 days

Options: turn back to 14 days (and reminder after 7 days); but I think, this could be too pushy for student groups. 10 /11days is a good meassure IMHO

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
