### PR TITLE
Fix for missing localization strings in SciteTab and Preferences dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where JabRef interface would not properly refresh after a group removal. [#11487](https://github.com/JabRef/jabref/issues/11487)
 - We fixed an issue where valid DOI could not be imported if it had special characters like `<` or `>`. [#12434](https://github.com/JabRef/jabref/issues/12434)
 - We fixed an issue where the tooltip only displayed the first linked file when hovering. [#12470](https://github.com/JabRef/jabref/issues/12470)
+- We fixed an issue where some texts in the "Citation Information" tab and the "Preferences" dialog could not be translated. [#12883](https://github.com/JabRef/jabref/pull/12883)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
@@ -1,9 +1,5 @@
 package org.jabref.gui.entryeditor;
 
-import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import javafx.geometry.HPos;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
@@ -22,6 +18,9 @@ import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.entry.BibEntry;
 
 import com.tobiasdiez.easybind.EasyBind;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.controlsfx.control.HyperlinkLabel;
 
 /**
@@ -44,7 +43,7 @@ public class SciteTab extends EntryEditorTab {
         this.dialogService = dialogService;
         this.sciteResultsPane = new GridPane();
         this.progressIndicator = new ProgressIndicator();
-        setText(NAME);
+        setText(Localization.lang("Citation information"));
         setTooltip(new Tooltip(Localization.lang("Search scite.ai for Smart Citations")));
         setSciteResultsPane();
     }
@@ -96,7 +95,8 @@ public class SciteTab extends EntryEditorTab {
     private VBox getTalliesPane(SciteTallyModel tallModel) {
         Label titleLabel = new Label(Localization.lang("Tallies for %0", tallModel.doi()));
         titleLabel.getStyleClass().add("scite-tallies-label");
-        Text message = new Text("Total Citations: %d\nSupporting: %d\nContradicting: %d\nMentioning: %d\nUnclassified: %d\nCiting Publications: %d".formatted(
+        Text message = new Text(Localization.lang(
+                "Total Citations: %0\nSupporting: %1\nContradicting: %2\nMentioning: %3\nUnclassified: %4\nCiting Publications: %5",
                 tallModel.total(),
                 tallModel.supporting(),
                 tallModel.contradicting(),

--- a/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
@@ -1,5 +1,9 @@
 package org.jabref.gui.entryeditor;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import javafx.geometry.HPos;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
@@ -18,9 +22,6 @@ import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.entry.BibEntry;
 
 import com.tobiasdiez.easybind.EasyBind;
-import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import org.controlsfx.control.HyperlinkLabel;
 
 /**

--- a/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
@@ -97,14 +97,7 @@ public class SciteTab extends EntryEditorTab {
         Label titleLabel = new Label(Localization.lang("Tallies for %0", tallModel.doi()));
         titleLabel.getStyleClass().add("scite-tallies-label");
         Text message = new Text(Localization.lang(
-                """
-                Total Citations: %0
-                Supporting: %1
-                Contradicting: %2
-                Mentioning: %3
-                Unclassified: %4
-                Citing Publications: %5
-                """,
+                "Total Citations: %0\nSupporting: %1\nContradicting: %2\nMentioning: %3\nUnclassified: %4\nCiting Publications: %5",
                 tallModel.total(),
                 tallModel.supporting(),
                 tallModel.contradicting(),

--- a/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SciteTab.java
@@ -97,7 +97,14 @@ public class SciteTab extends EntryEditorTab {
         Label titleLabel = new Label(Localization.lang("Tallies for %0", tallModel.doi()));
         titleLabel.getStyleClass().add("scite-tallies-label");
         Text message = new Text(Localization.lang(
-                "Total Citations: %0\nSupporting: %1\nContradicting: %2\nMentioning: %3\nUnclassified: %4\nCiting Publications: %5",
+                """
+                Total Citations: %0
+                Supporting: %1
+                Contradicting: %2
+                Mentioning: %3
+                Unclassified: %4
+                Citing Publications: %5
+                """,
                 tallModel.total(),
                 tallModel.supporting(),
                 tallModel.contradicting(),

--- a/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/ai/AiTab.fxml
@@ -248,13 +248,13 @@
             <Tab text="%System message for chatting" closable="false">
                 <TextArea fx:id="systemMessageTextArea"/>
             </Tab>
-            <Tab text="User message for chatting" closable="false">
+            <Tab text="%User message for chatting" closable="false">
                 <TextArea fx:id="userMessageTextArea"/>
             </Tab>
-            <Tab text="Completion text for summarization of a chunk" closable="false">
+            <Tab text="%Completion text for summarization of a chunk" closable="false">
                 <TextArea fx:id="summarizationChunkTextArea"/>
             </Tab>
-            <Tab text="Completion text for summarization of several chunks" closable="false">
+            <Tab text="%Completion text for summarization of several chunks" closable="false">
                 <TextArea fx:id="summarizationCombineTextArea"/>
             </Tab>
         </TabPane>

--- a/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.fxml
+++ b/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.fxml
@@ -20,7 +20,7 @@
          fx:controller="org.jabref.gui.preferences.preview.PreviewTab">
     <Label text="%Current Preview" styleClass="titleHeader"/>
     <CheckBox fx:id="showAsTabCheckBox" text="%Show preview as a tab in entry editor"/>
-    <CheckBox fx:id="showPreviewTooltipCheckBox" text="Show preview in entry table tooltip"/>
+    <CheckBox fx:id="showPreviewTooltipCheckBox" text="%Show preview in entry table tooltip"/>
     <Button fx:id="bstFileButton" text="%Add BST file" onAction="#selectBstFile" />
     <HBox spacing="4.0">
         <VBox spacing="4.0" HBox.hgrow="ALWAYS">

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2895,3 +2895,6 @@ Current\ JabRef\ version\:\ %0=Current JabRef version: %0
 Download\ development\ version=Download development version
 CHANGELOG=CHANGELOG
 Show\ preview\ in\ entry\ table\ tooltip=Show preview in entry table tooltip
+Citation\ information=Citation information
+Total\ Citations\:\ %0\nSupporting\:\ %1\nContradicting\:\ %2\nMentioning\:\ %3\nUnclassified\:\ %4\nCiting\ Publications\:\ %5=Total Citations: %0\nSupporting: %1\nContradicting: %2\nMentioning: %3\nUnclassified: %4\nCiting Publications: %5
+

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2894,3 +2894,4 @@ Open\ welcome\ tab=Open welcome tab
 Current\ JabRef\ version\:\ %0=Current JabRef version: %0
 Download\ development\ version=Download development version
 CHANGELOG=CHANGELOG
+Show\ preview\ in\ entry\ table\ tooltip=Show preview in entry table tooltip


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

### Description

After translating Chinese (Simplified), I found that some texts could not be translated:
- "User message for chatting", "Completion text for summarization of a chunk", "Completion text for summarization of several chunks" are in the localization dictionary but missing the prefix `%` in `AiTab.fxml`.
- "Show preview in entry table tooltip" in the `PreviewTab.fxml` also needs a prefix `%` to get translated.
- The tab title of "Citation Information" could not be translated and the content of the tab could not be translated as well.

### Solution

To solve this, I made some fixes as follows:
- I directly added the prefix `%` for the first two spots, and added the localization strings in `JabRef_en.properties` according to [Localization | Developer Documentation](https://devdocs.jabref.org/code-howtos/localization.html).
- Following the common action by other `EntryEditorTab`s (e.g. [`LatexCitationsTab`](https://github.com/JabRef/jabref/blob/1a15f4da1d2ee35fb6e373a40da8a3c27a1a2d69/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java#L51), [`CommentsTab`](https://github.com/JabRef/jabref/blob/1a15f4da1d2ee35fb6e373a40da8a3c27a1a2d69/src/main/java/org/jabref/gui/entryeditor/CommentsTab.java#L63)), I ignored the String `NAME` and added the localization string for `setText` directly. This may bring a new question about whether this constant `NAME` is necessary for `EntryEditorTab` since it will not be referenced later in the tab and some tabs (e.g. [`AiChatTab`](https://github.com/JabRef/jabref/blob/1a15f4da1d2ee35fb6e373a40da8a3c27a1a2d69/src/main/java/org/jabref/gui/entryeditor/AiChatTab.java#L61)) don't have such a constant which indicates that it is not a necessary constant for `EntryEditorTab` class at least for now (maybe it is necessary before).
- As for the body of `SciteTab`, I replaced the original `.formatted()` method to `Localization.lang()` method directly.

### Tests

This PR passed the [`LocalizationConsistencyTest`](https://github.com/JabRef/jabref/blob/main/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java) and [`SciteTabTest`](https://github.com/JabRef/jabref/blob/main/src/test/java/org/jabref/gui/entryeditor/SciteTabTest.java) on my machine.

### Screenshots

Here is some screeshots, some spots only have screenshots before this PR since they could not be translated yet:

#### Before

<img width="1068" alt="AiTab" src="https://github.com/user-attachments/assets/4d882a4c-6a26-46e2-b820-f6bea458eba1" />
<img width="721" alt="PreviewTab" src="https://github.com/user-attachments/assets/b5e32569-4727-4eff-899a-f5c20f6e2496" />
<img width="593" alt="SciteTab" src="https://github.com/user-attachments/assets/2c7cf087-c01c-4240-be37-df887d8a8329" />

#### After
<img width="980" alt="AiTab after" src="https://github.com/user-attachments/assets/5e33ee36-0d3e-4a8a-9f04-156588c7bc20" />

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
