### PR TITLE
Fix issue 12889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Added
 
-- We added automatic PDF downloads for arXiv entries when the "Download referenced files" option is enabled in Web Search preferences [#12889](https://github.com/JabRef/jabref/issues/12889)
-
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#NUM`.
@@ -33,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We enhanced support for parsing XMP metadata from PDF files. [#12829](https://github.com/JabRef/jabref/issues/12829)
 - We added a "Preview" header in the JStyles tab in the "Select style" dialog, to make it consistent with the CSL styles tab. [#12838](https://github.com/JabRef/jabref/pull/12838)
 - We added path validation to file directories in library properties dialog. [#11840](https://github.com/JabRef/jabref/issues/11840)
+- We added automatic PDF downloads for arXiv entries when the "Download referenced files" option is enabled in Web Search preferences [#12889](https://github.com/JabRef/jabref/issues/12889)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Added
+
+- We added automatic PDF downloads for arXiv entries when the "Download referenced files" option is enabled in Web Search preferences [#581](https://github.com/JabRef/jabref/issues/581)
+
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#NUM`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- We added automatic PDF downloads for arXiv entries when the "Download referenced files" option is enabled in Web Search preferences [#581](https://github.com/JabRef/jabref/issues/581)
+- We added automatic PDF downloads for arXiv entries when the "Download referenced files" option is enabled in Web Search preferences [#12889](https://github.com/JabRef/jabref/issues/12889)
 
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
+++ b/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
@@ -46,8 +46,12 @@ public class IconValidationDecorator extends GraphicValidationDecoration {
         label.setGraphic(graphic);
         label.setTooltip(createTooltip(message));
         label.setAlignment(position);
+<<<<<<< HEAD
         // Prevent label from stretching
         label.setMaxHeight(Control.USE_PREF_SIZE); 
+=======
+        label.setMaxHeight(Control.USE_PREF_SIZE); // Prevent label from stretching
+>>>>>>> 24326a6bd7 (Final fix to issue #12884)
         return label;
     }
 

--- a/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
+++ b/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
@@ -46,12 +46,8 @@ public class IconValidationDecorator extends GraphicValidationDecoration {
         label.setGraphic(graphic);
         label.setTooltip(createTooltip(message));
         label.setAlignment(position);
-<<<<<<< HEAD
         // Prevent label from stretching
         label.setMaxHeight(Control.USE_PREF_SIZE); 
-=======
-        label.setMaxHeight(Control.USE_PREF_SIZE); // Prevent label from stretching
->>>>>>> 24326a6bd7 (Final fix to issue #12884)
         return label;
     }
 

--- a/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
+++ b/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
@@ -9,13 +9,13 @@ import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 
-import org.jabref.gui.icon.IconTheme;
-
 import org.controlsfx.control.decoration.Decoration;
 import org.controlsfx.control.decoration.GraphicDecoration;
 import org.controlsfx.validation.Severity;
 import org.controlsfx.validation.ValidationMessage;
 import org.controlsfx.validation.decoration.GraphicValidationDecoration;
+
+import org.jabref.gui.icon.IconTheme;
 
 /**
  * This class is similar to {@link GraphicValidationDecoration} but with a different style and font-based icon.

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -150,6 +150,18 @@ public class CitationStyle implements OOStyle {
             return Optional.empty();
         }
 
+        // First try to load as external file
+        Path externalPath = Path.of(styleFile);
+        if (Files.exists(externalPath)) {
+            try (InputStream inputStream = Files.newInputStream(externalPath)) {
+                return createCitationStyleFromSource(inputStream, styleFile);
+            } catch (IOException e) {
+                LOGGER.error("Error reading external file", e);
+                return Optional.empty();
+            }
+        }
+
+        // If not found as external file, try as internal resource
         String internalFile = STYLES_ROOT + (styleFile.startsWith("/") ? "" : "/") + styleFile;
         Path internalFilePath = Path.of(internalFile);
         boolean isExternalFile = Files.exists(internalFilePath);
@@ -159,12 +171,10 @@ public class CitationStyle implements OOStyle {
                 return Optional.empty();
             }
             return createCitationStyleFromSource(inputStream, styleFile);
-        } catch (NoSuchFileException e) {
-            LOGGER.error("Could not find file: {}", styleFile, e);
         } catch (IOException e) {
             LOGGER.error("Error reading source file", e);
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 
     /**

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -781,7 +781,14 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                 getDate().ifPresent(date -> bibEntry.setField(StandardField.DATE, date));
                 primaryCategory.ifPresent(category -> bibEntry.setField(StandardField.EPRINTCLASS, category));
                 journalReferenceText.ifPresent(journal -> bibEntry.setField(StandardField.JOURNAL, journal));
-                getPdfUrl().ifPresent(url -> bibEntry.setFiles(Collections.singletonList(new LinkedFile(url, "PDF"))));
+                
+                // Set up LinkedFile for automatic PDF download
+                getPdfUrl().ifPresent(url -> {
+                    LinkedFile pdfFile = new LinkedFile(url, "PDF");
+                    pdfFile.setDownloadAutomatically(true);
+                    bibEntry.setFiles(Collections.singletonList(pdfFile));
+                });
+                
                 return bibEntry;
             }
         }

--- a/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -23,6 +23,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.hc.core5.net.URIBuilder;
+import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.jabref.logic.cleanup.EprintCleanup;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.FetcherException;
@@ -48,9 +50,6 @@ import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.paging.Page;
 import org.jabref.model.strings.StringUtil;
 import org.jabref.model.util.OptionalUtil;
-
-import org.apache.hc.core5.net.URIBuilder;
-import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -781,14 +780,6 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                 getDate().ifPresent(date -> bibEntry.setField(StandardField.DATE, date));
                 primaryCategory.ifPresent(category -> bibEntry.setField(StandardField.EPRINTCLASS, category));
                 journalReferenceText.ifPresent(journal -> bibEntry.setField(StandardField.JOURNAL, journal));
-                
-                // Set up LinkedFile for automatic PDF download
-                getPdfUrl().ifPresent(url -> {
-                    LinkedFile pdfFile = new LinkedFile(url, "PDF");
-                    pdfFile.setDownloadAutomatically(true);
-                    bibEntry.setFiles(Collections.singletonList(pdfFile));
-                });
-                
                 return bibEntry;
             }
         }

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import javafx.beans.Observable;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
@@ -47,6 +49,7 @@ public class LinkedFile implements Serializable {
     // be a URI, where a file type might not be present.
     private transient StringProperty fileType = new SimpleStringProperty();
     private transient StringProperty sourceURL = new SimpleStringProperty();
+    private transient BooleanProperty downloadAutomatically = new SimpleBooleanProperty(false);
 
     public LinkedFile(String description, Path link, String fileType) {
         this(Objects.requireNonNull(description), Objects.requireNonNull(link).toString(), Objects.requireNonNull(fileType));
@@ -150,7 +153,7 @@ public class LinkedFile implements Serializable {
     }
 
     public Observable[] getObservables() {
-        return new Observable[] {this.link, this.description, this.fileType, this.sourceURL};
+        return new Observable[] {this.link, this.description, this.fileType, this.sourceURL, this.downloadAutomatically};
     }
 
     @Override
@@ -162,7 +165,8 @@ public class LinkedFile implements Serializable {
             return Objects.equals(description.get(), that.description.get())
                     && Objects.equals(link.get(), that.link.get())
                     && Objects.equals(fileType.get(), that.fileType.get())
-                    && Objects.equals(sourceURL.get(), that.sourceURL.get());
+                    && Objects.equals(sourceURL.get(), that.sourceURL.get())
+                    && Objects.equals(downloadAutomatically.get(), that.downloadAutomatically.get());
         }
         return false;
     }
@@ -175,6 +179,7 @@ public class LinkedFile implements Serializable {
         out.writeUTF(getLink());
         out.writeUTF(getDescription());
         out.writeUTF(getSourceUrl());
+        out.writeBoolean(shouldDownloadAutomatically());
         out.flush();
     }
 
@@ -186,6 +191,7 @@ public class LinkedFile implements Serializable {
         link = new SimpleStringProperty(in.readUTF());
         description = new SimpleStringProperty(in.readUTF());
         sourceURL = new SimpleStringProperty(in.readUTF());
+        downloadAutomatically = new SimpleBooleanProperty(in.readBoolean());
     }
 
     /**
@@ -201,7 +207,7 @@ public class LinkedFile implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(description.get(), link.get(), fileType.get(), sourceURL.get());
+        return Objects.hash(description.get(), link.get(), fileType.get(), sourceURL.get(), downloadAutomatically.get());
     }
 
     @Override
@@ -211,6 +217,7 @@ public class LinkedFile implements Serializable {
                 ", link='" + link.get() + '\'' +
                 ", fileType='" + fileType.get() + '\'' +
                 (StringUtil.isNullOrEmpty(sourceURL.get()) ? "" : (", sourceUrl='" + sourceURL.get() + '\'')) +
+                ", downloadAutomatically=" + downloadAutomatically.get() +
                 '}';
     }
 
@@ -220,6 +227,18 @@ public class LinkedFile implements Serializable {
 
     public boolean isOnlineLink() {
         return isOnlineLink(link.get());
+    }
+
+    public boolean shouldDownloadAutomatically() {
+        return downloadAutomatically.get();
+    }
+
+    public void setDownloadAutomatically(boolean shouldDownload) {
+        this.downloadAutomatically.set(shouldDownload);
+    }
+
+    public BooleanProperty downloadAutomaticallyProperty() {
+        return downloadAutomatically;
     }
 
     public Optional<Path> findIn(BibDatabaseContext databaseContext, FilePreferences filePreferences) {


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes #12889 

changes :

I made enhancements to the <b>Entry Editor</b>, specifically in the <b>General section</b>. Now, when a field (such as a URL) contains an HTTP/HTTPS link and the user double-clicks on it, the link is automatically takes it to dowload PDF through browser. This improves the workflow for users who often deal with direct document links by making it easier and faster to download referenced PDFs.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
