### PR TITLE
Add workaround for comment posting / issue move

### DIFF
--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -8,7 +8,9 @@ jobs:
   unassign_issue:
     name: Mark issue as available
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && !github.event.pull_request.merged
+    # dependabot writes PR comments with #{number}. That numbers are referering to issues of other repositories, not of this one.
+    # Therefore, we need to exclude dependabot here.
+    if: github.actor != 'dependabot[bot]' && (github.event.action == 'closed' && !github.event.pull_request.merged)
     permissions:
       contents: read
       issues: write
@@ -86,7 +88,9 @@ jobs:
   comment_on_resolved_issue:
     name: Comment on resolved issue
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && github.event.pull_request.merged
+    # dependabot writes PR comments with #{number}. That numbers are referering to issues of other repositories, not of this one.
+    # Therefore, we need to exclude dependabot here.
+    if: github.actor != 'dependabot[bot]' && (github.event.action == 'closed' && github.event.pull_request.merged)
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -26,7 +26,8 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>\d+)'
+          # Matches GitHub's closes/fixes/resolves #{number}, but does not match our example `Closes #12345` in PULL_REQUEST_TEMPLATE
+          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>(?!12345\b)\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - uses: actions/checkout@v4
@@ -104,7 +105,7 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>\d+)'
+          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>(?!12345\b)\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - name: Comment on issue

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -28,7 +28,7 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
           ticketPrefix: '#'
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
-          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyRegex: '(?i)(fixes|closes|resolves)\s+#(?<ticketNumber>\d+)'
           bodyURLRegex: 'http(s?):\/\/(github.com)(\/JabRef)(\/jabref)(\/issues)\/(?<ticketNumber>\d+)'
           outputOnly: true
       - name: Comment on issue

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -8,9 +8,7 @@ jobs:
   unassign_issue:
     name: Mark issue as available
     runs-on: ubuntu-latest
-    # dependabot writes PR comments with #{number}. That numbers are referering to issues of other repositories, not of this one.
-    # Therefore, we need to exclude dependabot here.
-    if: github.actor != 'dependabot[bot]' && (github.event.action == 'closed' && !github.event.pull_request.merged)
+    if: github.event.action == 'closed' && !github.event.pull_request.merged
     permissions:
       contents: read
       issues: write
@@ -88,9 +86,7 @@ jobs:
   comment_on_resolved_issue:
     name: Comment on resolved issue
     runs-on: ubuntu-latest
-    # dependabot writes PR comments with #{number}. That numbers are referering to issues of other repositories, not of this one.
-    # Therefore, we need to exclude dependabot here.
-    if: github.actor != 'dependabot[bot]' && (github.event.action == 'closed' && github.event.pull_request.merged)
+    if: github.event.action == 'closed' && github.event.pull_request.merged
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Detected at https://github.com/JabRef/jabref/issues/7516#issuecomment-2801983511

Dependabot creates comments with the format `#{number}`. This number is treated as JabRef issue number, but it is not:

![image](https://github.com/user-attachments/assets/bc9c80c7-6de1-4f7e-bc5f-38224c8d51dc)

This is an issue of the RegEx of the used action [ticket-check-action](https://github.com/neofinancial/ticket-check-action). 

I updated the configuration to "listen" to GitHubs keywords `closes` etc.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
