### PR TITLE
Force focus on current tab

### DIFF
--- a/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -638,15 +638,22 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
             this(tabContainer, null, stateManager);
         }
 
+        public TabPane getTabbedPane() {
+            return tabbedPane;
+        }
+
         @Override
         public void execute() {
             Platform.runLater(() -> {
+                tabContainer.getTabbedPane().requestFocus();
+
                 if (libraryTab == null) {
-                    if (tabContainer.getCurrentLibraryTab() == null) {
+                    LibraryTab current = tabContainer.getCurrentLibraryTab();
+                    if (current == null) {
                         LOGGER.error("No library tab to close");
                         return;
                     }
-                    tabContainer.closeTab(tabContainer.getCurrentLibraryTab());
+                    tabContainer.closeTab(current);
                 } else {
                     tabContainer.closeTab(libraryTab);
                 }


### PR DESCRIPTION
<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

Closes https://github.com/JabRef/jabref/issues/12931 

JabRef sometimes closed the last-opened tab, not the currently visible (selected) tab.
Fixed by force focusing on the current tab when Ctrl+W is pressed

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
