### PR TITLE
EntryEditor now also shows on empty entries

### DIFF
--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -1,0 +1,15 @@
+---
+parent: Requirements
+---
+# Entry Editor
+
+### Entry Editor should show the last entry
+`req~entry-editor.keep-showing~1`
+
+The Entry Editor should "always" show a valid entry.
+
+When users search or select a group not containing the entry shown in the Entry Editor, the Entry Editor should keep showing until user select a new entry explicitly.
+
+Needs: impl
+
+<!-- markdownlint-disable-file MD022 -->

--- a/docs/requirements/entry-editor.md
+++ b/docs/requirements/entry-editor.md
@@ -3,7 +3,7 @@ parent: Requirements
 ---
 # Entry Editor
 
-### Entry Editor should show the last entry
+## Entry Editor should show the last entry
 `req~entry-editor.keep-showing~1`
 
 The Entry Editor should "always" show a valid entry.

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -425,14 +425,12 @@ public class EntryEditor extends BorderPane implements PreviewControls {
             typeSubscription.unsubscribe();
         }
 
-        if (!currentlyEditedEntry.isEmpty()) {
-            typeSubscription = EasyBind.subscribe(this.currentlyEditedEntry.typeProperty(), _ -> {
-                typeLabel.setText(new TypedBibEntry(currentlyEditedEntry, tabSupplier.get().getBibDatabaseContext().getMode()).getTypeForDisplay());
-                adaptVisibleTabs();
-                setupToolBar();
-                getSelectedTab().notifyAboutFocus(currentlyEditedEntry);
-            });
-        }
+        typeSubscription = EasyBind.subscribe(this.currentlyEditedEntry.typeProperty(), _ -> {
+            typeLabel.setText(new TypedBibEntry(currentlyEditedEntry, tabSupplier.get().getBibDatabaseContext().getMode()).getTypeForDisplay());
+            adaptVisibleTabs();
+            setupToolBar();
+            getSelectedTab().notifyAboutFocus(currentlyEditedEntry);
+        });
 
         if (preferences.getEntryEditorPreferences().showSourceTabByDefault()) {
             tabbed.getSelectionModel().select(sourceTab);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -169,9 +169,11 @@ public class EntryEditor extends BorderPane implements PreviewControls {
             }
         });
 
-        stateManager.getSelectedEntries().addListener((InvalidationListener) c -> {
+        stateManager.getSelectedEntries().addListener((InvalidationListener) _ -> {
                     if (stateManager.getSelectedEntries().isEmpty()) {
-                        setCurrentlyEditedEntry(new BibEntry());
+                        // [impl->req~entry-editor.keep-showing~1]
+                        // No change in the entry editor
+                        // We allow users to edit the "old" entry
                     } else {
                         setCurrentlyEditedEntry(stateManager.getSelectedEntries().getFirst());
                     }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -181,7 +181,7 @@ public class EntryEditor extends BorderPane implements PreviewControls {
         );
 
         EasyBind.listen(preferences.getPreviewPreferences().showPreviewAsExtraTabProperty(),
-                (obs, oldValue, newValue) -> {
+                (_, _, newValue) -> {
                     if (currentlyEditedEntry != null) {
                         adaptVisibleTabs();
                         Tab tab = tabbed.getSelectionModel().selectedItemProperty().get();


### PR DESCRIPTION
Follow-up to #12210

Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/861

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
