### PR TITLE
[OO] Allow slashes in citation keys for reference marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where BibTeX Strings were not included in the backup file [#12462](https://github.com/JabRef/jabref/issues/12462)
 - We fixed an issue where mixing JStyle and CSL style citations in LibreOffice caused two separate bibliography sections to be generated. [#12262](https://github.com/JabRef/jabref/issues/12262)
 - We fixed an issue in the LibreOffice integration where the formatting of text (e.g. superscript) was lost when using certain numeric CSL styles. [melting-pot#772](https://github.com/JabRef/jabref-issue-melting-pot/issues/772)
-- We fixed an issue where CSL style citations with citation keys having special characters (such as hyphens or colons) would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
+- We fixed an issue where CSL style citations with citation keys having special characters (such as hyphens, colons or slashes) would not be recognized as valid by JabRef. [forum#5431](https://discourse.jabref.org/t/error-when-connecting-to-libreoffice/5431)
 - We fixed an issue where the `[authorsAlpha]` pattern in Citation key generator would not behave as per the user documentation. [#12312](https://github.com/JabRef/jabref/issues/12312)
 - We fixed an issue where import at "Search for unlinked local files" would re-add already imported files. [#12274](https://github.com/JabRef/jabref/issues/12274)
 - We fixed an issue where month values 21–24 (ISO 8601-2019 season codes) in Biblatex date fields were not recognized as seasons during parsing. [#12437](https://github.com/JabRef/jabref/issues/12437)

--- a/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,8 +15,8 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w-:.]+ CID_\\d+(?:, JABREF_[\\w-:.]+ CID_\\d+)*) (\\w+)$");
-    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:.]+) CID_(\\d+)");
+    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w\\-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$");
+    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:./]+) CID_(\\d+)");
 
     private final String name;
     private List<String> citationKeys;

--- a/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,7 +15,7 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w\\-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$");
+    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$");
     private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:./]+) CID_(\\d+)");
 
     private final String name;

--- a/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
@@ -49,6 +49,11 @@ class ReferenceMarkTest {
                 Arguments.of(
                         "JABREF_willberg-forssman:1997b CID_5 yov3b0su",
                         List.of("willberg-forssman:1997b"), List.of(5), "yov3b0su"
+                ),
+
+                Arguments.of(
+                        "JABREF_PGF/TikZTeam2023 CID_8 kyu75a4s",
+                        List.of("PGF/TikZTeam2023"), List.of(8), "kyu75a4s"
                 )
         );
     }

--- a/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
+++ b/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
@@ -50,7 +50,6 @@ class ReferenceMarkTest {
                         "JABREF_willberg-forssman:1997b CID_5 yov3b0su",
                         List.of("willberg-forssman:1997b"), List.of(5), "yov3b0su"
                 ),
-
                 Arguments.of(
                         "JABREF_PGF/TikZTeam2023 CID_8 kyu75a4s",
                         List.of("PGF/TikZTeam2023"), List.of(8), "kyu75a4s"


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12474

To accommodate the following auto-generated default citation key from the bibtex entry mentioned in https://github.com/JabRef/jabref/issues/12930#issue-2991246751:
```
@Online{,
  author = {{The PGF/TikZ Team}},
  date   = {2023-01-16},
  title  = {pgf – Create PostScript and PDF graphics in TeX},
  url    = {https://ctan.org/pkg/pgf},
}
```
![image](https://github.com/user-attachments/assets/71a0d52e-9df1-4934-98aa-faee32251c0b)
[contains forward slashes("`/`")]

Earlier behavior: The key would not be parsed properly as it was not flexible enough to allow slashes. After citation, on trying to generate bibliography, following dialog was observed:

![image](https://github.com/user-attachments/assets/061da000-53d4-402a-b521-847be3e09292)
And then the exception:
![image](https://github.com/user-attachments/assets/ec33a0a0-5d55-4b14-ae5b-1d48dca7c999)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
