### PR TITLE
Try to fix numbering

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-89-run-with-intellij.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-89-run-with-intellij.md
@@ -28,21 +28,19 @@ Due to [IDEA-119280](https://youtrack.jetbrains.com/issue/IDEA-119280), it is a 
     1. Navigate into directory "classes"
     1. Now you have two Explorer windows opened. Copy all files and directories from the first one to the second one.
 11. Locate the class `Launcher` (e.g., by <kbd>ctrl</kbd>+<kbd>N</kbd> and then typing `Launcher`). Press <kbd>Enter</kbd> to jump to that class.
-   <figure>
-     <img src="intellij-search-for-launcher.png" alt="IntelliJ search for class “Launcher”">
-     <figcaption>IntelliJ search for class “Launcher”</figcaption>
-   </figure>
+    <figure>
+      <img src="intellij-search-for-launcher.png" alt="IntelliJ search for class “Launcher”">
+      <figcaption>IntelliJ search for class “Launcher”</figcaption>
+    </figure>
 12. Click on the green play button next to the `main` method to create a Launch configuration. IntelliJ will fail in launching.
-   <figure>
-     <img src="intellij-hover-on-play-button.png" alt="However on green play">
-     <figcaption>However on green play</figcaption>
-   </figure>
-
-   <figure>
-     <img src="intellij-run-jabref-from-launcher.png" alt="Run JabRef via launcher">
-     <figcaption>Run JabRef via launcher</figcaption>
-   </figure>
-
+    <figure>
+      <img src="intellij-hover-on-play-button.png" alt="However on green play">
+      <figcaption>However on green play</figcaption>
+    </figure>
+    <figure>
+      <img src="intellij-run-jabref-from-launcher.png" alt="Run JabRef via launcher">
+      <figcaption>Run JabRef via launcher</figcaption>
+    </figure>
 13. On the top right of the IntelliJ window, next to the newly created launch configuration, click on the drop down
 14. Click on "Edit Configurations..."
 15. On the right, click on "Modify options"
@@ -73,10 +71,10 @@ Due to [IDEA-119280](https://youtrack.jetbrains.com/issue/IDEA-119280), it is a 
    ```
 19. Click "Apply"
 20. Click "Run". You can also click on the debug symbol next to it to enable stopping at breakpoints.
-    <figure>
-      <img src="intellij-run-launcher.png" alt="Launch menu contains “Launcher”">
-      <figcaption>Launch menu contains “Launcher”</figcaption>
-    </figure>
+     <figure>
+       <img src="intellij-run-launcher.png" alt="Launch menu contains “Launcher”">
+       <figcaption>Launch menu contains “Launcher”</figcaption>
+     </figure>
 
 <!-- MD031 is disabled, because otherwise the numbering does not work properly. MD029 and M032 are disabled as a consequence. -->
 <!-- markdownlint-disable-file MD029 MD031 MD032 MD033 -->


### PR DESCRIPTION
At https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-89-run-with-intellij.html the numbering is odd

![image](https://github.com/user-attachments/assets/6d495a29-1c07-4004-8c9e-6557642ad06c)

This PR tries to fix it.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
