### PR TITLE
Rearrange some CSL methods, add more tests

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -49,7 +49,6 @@ import org.jabref.gui.theme.Theme;
 import org.jabref.logic.bst.BstPreviewLayout;
 import org.jabref.logic.citationstyle.CSLStyleLoader;
 import org.jabref.logic.citationstyle.CSLStyleUtils;
-import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.citationstyle.CitationStylePreviewLayout;
 import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
@@ -905,7 +904,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         return cycle.stream()
                     .map(layout -> {
-                        if (CitationStyle.isCitationStyleFile(layout)) {
+                        if (CSLStyleUtils.isCitationStyleFile(layout)) {
                             BibEntryTypesManager entryTypesManager = Injector.instantiateModelOrService(BibEntryTypesManager.class);
                             return CSLStyleUtils.createCitationStyleFromFile(layout)
                                                 .map(file -> (PreviewLayout) new CitationStylePreviewLayout(file, entryTypesManager))

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 import java.util.Objects;
 
 import org.jabref.logic.openoffice.style.OOStyle;
-import org.jabref.logic.util.StandardFileType;
 
 /**
  * Representation of a CitationStyle. Stores its name, the file path and the style itself.
@@ -34,13 +33,6 @@ public class CitationStyle implements OOStyle {
      */
     public CitationStyle(String filePath, String title, boolean isNumericStyle, String source) {
         this(filePath, title, isNumericStyle, source, !Path.of(filePath).isAbsolute());
-    }
-
-    /**
-     * Checks if the given style file is a CitationStyle based on its extension
-     */
-    public static boolean isCitationStyleFile(String styleFile) {
-        return StandardFileType.CITATION_STYLE.getExtensions().stream().anyMatch(styleFile::endsWith);
     }
 
     public String getTitle() {

--- a/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -45,7 +45,6 @@ import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.citationstyle.CSLStyleLoader;
 import org.jabref.logic.citationstyle.CSLStyleUtils;
-import org.jabref.logic.citationstyle.CitationStyle;
 import org.jabref.logic.cleanup.CleanupPreferences;
 import org.jabref.logic.cleanup.FieldFormatterCleanups;
 import org.jabref.logic.exporter.BibDatabaseWriter;
@@ -1124,7 +1123,7 @@ public class JabRefCliPreferences implements CliPreferences {
         OOStyle currentStyle = CSLStyleLoader.getDefaultStyle(); // Defaults to IEEE CSL Style
 
         // Reassign currentStyle based on actual last used CSL style or JStyle
-        if (CitationStyle.isCitationStyleFile(currentStylePath)) {
+        if (CSLStyleUtils.isCitationStyleFile(currentStylePath)) {
             currentStyle = CSLStyleUtils.createCitationStyleFromFile(currentStylePath)
                                         .orElse(CSLStyleLoader.getDefaultStyle());
         } else {

--- a/src/test/java/org/jabref/logic/citationstyle/CSLStyleUtilsTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CSLStyleUtilsTest.java
@@ -44,7 +44,7 @@ class CSLStyleUtilsTest {
             "vancouver",
             "nature.",
             "",
-            "chicago.CSL" // testing case sensitivity
+            "chicago.CSL" // case sensitivity - should reject
     })
     void rejectsNonCslExtension(String filename) {
         assertFalse(CSLStyleUtils.isCitationStyleFile(filename));

--- a/src/test/java/org/jabref/logic/citationstyle/CSLStyleUtilsTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CSLStyleUtilsTest.java
@@ -6,9 +6,11 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -20,6 +22,39 @@ class CSLStyleUtilsTest {
     private static final String MODIFIED_IEEE = "ieee-bold-author.csl";
     private static final String MODIFIED_APA = "modified-apa.csl";
     private static final String LITERATURA = "literatura.csl";
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ieee.csl",
+            "apa.csl",
+            "harvard.csl",
+            "vancouver.csl",
+            "/path/to/style/nature.csl",
+            "C:\\Users\\username\\Documents\\styles\\chicago.csl"
+    })
+    void acceptsCslExtension(String filename) {
+        assertTrue(CSLStyleUtils.isCitationStyleFile(filename));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ieee.txt",
+            "apa.xml",
+            "harvard.css",
+            "vancouver",
+            "nature.",
+            "",
+            "chicago.CSL" // testing case sensitivity
+    })
+    void rejectsNonCslExtension(String filename) {
+        assertFalse(CSLStyleUtils.isCitationStyleFile(filename));
+    }
+
+    @Test
+    void acceptsFilenameWithMultipleDots() {
+        assertTrue(CSLStyleUtils.isCitationStyleFile("ieee.modified.csl"));
+        assertTrue(CSLStyleUtils.isCitationStyleFile("apa.v7.csl"));
+    }
 
     @ParameterizedTest
     @MethodSource("styleTestData")


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12951
- `isCitationStyleFile(...)` is a static file-based utility used across many classes, and does not depend on a Citation Style model instance. A model instance should already _assume_ that it's a valid Citation Style file. Moved it to `CSLStyleUtils`.
- Rearranged methods in `CSLStyleUtils` for better readability.
- Added tests for `isCitationStyleFile(...)`

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
