### PR TITLE
Clean build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,10 +227,7 @@ dependencies {
         exclude module: 'oraclepki'
     }
 
-    implementation ('com.google.guava:guava:33.1.0-jre') {
-        // TODO: Remove this as soon as https://github.com/google/guava/issues/2960 is fixed
-        exclude module: "jsr305"
-    }
+    implementation 'com.google.guava:guava:33.1.0-jre'
 
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
@@ -565,18 +562,7 @@ tasks.register('generateCitationStyleCatalog', JavaExec) {
 }
 
 jar.dependsOn('generateCitationStyleCatalog')
-
-// catalog from above task needs to be copied to build output for tests
-tasks.register('copyCitationStyleCatalog', Copy) {
-    from 'src/main/resources/citation-style-catalog.json'
-    into 'build/resources/main'
-    mustRunAfter 'checkstyleMain'
-    dependsOn 'generateCitationStyleCatalog'
-}
-
-compileTestJava.dependsOn('copyCitationStyleCatalog')
-generateJournalListMV.dependsOn('copyCitationStyleCatalog')
-generateLtwaListMV.dependsOn('copyCitationStyleCatalog')
+compileTestJava.dependsOn("generateCitationStyleCatalog")
 
 tasks.register('generateCitaviSource', XjcTask) {
     group = 'JabRef'

--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ dependencies {
         exclude module: 'oraclepki'
     }
 
-    implementation 'com.google.guava:guava:33.1.0-jre'
+    implementation 'com.google.guava:guava:33.4.8-jre'
 
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     implementation 'jakarta.inject:jakarta.inject-api:2.0.1'

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyleCatalogGenerator.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyleCatalogGenerator.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 @AllowedToUseClassGetResource("Required for loading internal CSL styles")
 public class CitationStyleCatalogGenerator {
     private static final String STYLES_ROOT = "/csl-styles";
-    private static final String CATALOG_PATH = "src/main/resources/citation-style-catalog.json";
+    private static final String CATALOG_PATH = "build/resources/main/citation-style-catalog.json";
     private static final String DEFAULT_STYLE = "ieee.csl";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationStyleCatalogGenerator.class);


### PR DESCRIPTION
Some cleanups/optimizations in build process of JabRef:
- Do not export the generated CSL catalog into `src/main/resources/` and then copy it to `build/resources/main`. 
Instead, export it directly to `build/resources/main` and let both JabRef application as well as tests use it from there. The catalog is an artifact generated during build process, not an "src" resource like the actual csl style files. (Trigger: https://github.com/JabRef/jabref/pull/12960#discussion_r2051556121)
- Remove `exclude module: "jsr305"` from guava dependency as https://github.com/google/guava/issues/2960 is fixed.
### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
