### PR TITLE
Remove usage of Injector in `StyleSelectDialogViewModel`

### DIFF
--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialogViewModel.java
@@ -36,8 +36,6 @@ import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import com.airhacks.afterburner.injection.Injector;
-
 public class StyleSelectDialogViewModel {
 
     private final DialogService dialogService;
@@ -48,6 +46,8 @@ public class StyleSelectDialogViewModel {
     private final ExternalApplicationsPreferences externalApplicationsPreferences;
     private final FilePreferences filePreferences;
     private final OpenOfficePreferences openOfficePreferences;
+
+    private final BibEntryTypesManager bibEntryTypesManager;
 
     private final ObjectProperty<Tab> selectedTab = new SimpleObjectProperty<>();
 
@@ -72,6 +72,8 @@ public class StyleSelectDialogViewModel {
         this.externalApplicationsPreferences = preferences.getExternalApplicationsPreferences();
         this.filePreferences = preferences.getFilePreferences();
         this.openOfficePreferences = preferences.getOpenOfficePreferences();
+
+        this.bibEntryTypesManager = bibEntryTypesManager;
 
         jStyles.addAll(loadJStyles());
 
@@ -198,7 +200,7 @@ public class StyleSelectDialogViewModel {
 
                 List<CitationStyle> allStyles = CSLStyleLoader.getStyles();
                 List<CitationStylePreviewLayout> updatedLayouts = allStyles.stream()
-                                                                           .map(style -> new CitationStylePreviewLayout(style, Injector.instantiateModelOrService(BibEntryTypesManager.class)))
+                                                                           .map(style -> new CitationStylePreviewLayout(style, bibEntryTypesManager))
                                                                            .toList();
 
                 availableCslLayouts.setAll(updatedLayouts);


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12951.

Use `BibEntryTypesManager` from constructor instead of redundantly using injector in `StyleSelectDialogViewModel`.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
