### PR TITLE
Improve copy to dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a feature for enabling drag-and-drop of files into groups  [#12540](https://github.com/JabRef/jabref/issues/12540)
 - We added support for reordering keywords via drag and drop, automatic alphabetical ordering, and improved pasting and editing functionalities in the keyword editor. [#10984](https://github.com/JabRef/jabref/issues/10984)
 - We added a new functionality where author names having multiple spaces in-between will be considered as separate user block as it does for " and ". [#12701](https://github.com/JabRef/jabref/issues/12701)
+- We Improved the "Copy to" feature by showing a success dialog when entries (and cross-references) are copied. [#12486](https://github.com/JabRef/jabref/issues/12486)
 
 ### Changed
 

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -61,11 +61,27 @@ public class CopyTo extends SimpleCommand {
         }
 
         if (includeCrossReferences) {
+            int before = targetDatabaseContext.getEntries().size();
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
-            dialogService.notify(Localization.lang("Entries copied successfully, including cross-references."));
+            int after = targetDatabaseContext.getEntries().size();
+            if (after > before) {
+                String targetLibraryName = targetDatabaseContext.getDatabasePath()
+                        .map(path -> path.getFileName().toString())
+                        .orElse("target library");
+
+                dialogService.notify(Localization.lang("Entries copied successfully to %0, including cross-references.", targetLibraryName));
+            }
         } else {
+            int before = targetDatabaseContext.getEntries().size();
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);
-            dialogService.notify(Localization.lang("Entries copied successfully, without cross-references."));
+            int after = targetDatabaseContext.getEntries().size();
+            if (after > before) {
+                String targetLibraryName = targetDatabaseContext.getDatabasePath()
+                        .map(path -> path.getFileName().toString())
+                        .orElse("target library");
+
+                dialogService.notify(Localization.lang("Entries copied successfully to %0, without cross-references.", targetLibraryName));
+            }
         }
     }
 

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -66,9 +66,9 @@ public class CopyTo extends SimpleCommand {
         if (includeCrossReferences) {
             int before = targetDatabaseContext.getEntries().size();
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
-            dialogService.notify(Localization.lang("Entries copied successfully, including cross-references."))
+            dialogService.notify(Localization.lang("Entries copied successfully, including cross-references."));
             int after = targetDatabaseContext.getEntries().size();
-            if (after > before) {
+            if (after == before) {
                 dialogService.notify(Localization.lang("No new entries were added to the target library."));
                 return;
             }
@@ -106,8 +106,12 @@ public class CopyTo extends SimpleCommand {
     }
 
     public Optional<BibEntry> getCrossRefEntry(BibEntry bibEntryToCheck, BibDatabaseContext sourceDatabaseContext) {
-        return sourceDatabaseContext.getEntries().stream().filter(entry -> bibEntryToCheck.getField(StandardField.CROSSREF).equals(entry.getCitationKey())).findFirst();
+        return bibEntryToCheck.getField(StandardField.CROSSREF)
+                .flatMap(crossRefKey -> sourceDatabaseContext.getEntries().stream()
+                        .filter(entry -> entry.getCitationKey().isPresent() && entry.getCitationKey().get().equals(crossRefKey))
+                        .findFirst());
     }
+
 
     private boolean askForCrossReferencedEntries() {
         if (copyToPreferences.getShouldAskForIncludingCrossReferences()) {

--- a/src/main/java/org/jabref/gui/edit/CopyTo.java
+++ b/src/main/java/org/jabref/gui/edit/CopyTo.java
@@ -28,6 +28,9 @@ public class CopyTo extends SimpleCommand {
     private final BibDatabaseContext sourceDatabaseContext;
     private final BibDatabaseContext targetDatabaseContext;
 
+    private static final String DEFAULT_TARGET_LIBRARY_NAME = "target library";
+
+
     public CopyTo(DialogService dialogService,
                   StateManager stateManager,
                   CopyToPreferences copyToPreferences,
@@ -63,14 +66,18 @@ public class CopyTo extends SimpleCommand {
         if (includeCrossReferences) {
             int before = targetDatabaseContext.getEntries().size();
             copyEntriesWithCrossRef(selectedEntries, targetDatabaseContext);
+            dialogService.notify(Localization.lang("Entries copied successfully, including cross-references."))
             int after = targetDatabaseContext.getEntries().size();
             if (after > before) {
-                String targetLibraryName = targetDatabaseContext.getDatabasePath()
-                        .map(path -> path.getFileName().toString())
-                        .orElse("target library");
-
-                dialogService.notify(Localization.lang("Entries copied successfully to %0, including cross-references.", targetLibraryName));
+                dialogService.notify(Localization.lang("No new entries were added to the target library."));
+                return;
             }
+
+            String targetLibraryName = targetDatabaseContext.getDatabasePath()
+                    .map(path -> path.getFileName().toString())
+                    .orElse(DEFAULT_TARGET_LIBRARY_NAME);
+
+            dialogService.notify(Localization.lang("Copied %0 entries to '%1'", String.valueOf(after - before), targetLibraryName));
         } else {
             int before = targetDatabaseContext.getEntries().size();
             copyEntriesWithoutCrossRef(selectedEntries, targetDatabaseContext);

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2865,8 +2865,8 @@ Exclude=Exclude
 Include\ or\ exclude\ cross-referenced\ entries=Include or exclude cross-referenced entries
 Would\ you\ like\ to\ include\ cross-reference\ entries\ in\ the\ current\ operation?=Would you like to include cross-reference entries in the current operation?
 
-Entries\ copied\ successfully,\ including\ cross-references.=Entries copied successfully, including cross-references.
-Entries\ copied\ successfully,\ without\ cross-references.=Entries copied successfully, without cross-references.
+Entries\ copied\ successfully,\ including\ cross-references.=Entries copied successfully to %0, including cross-references.=Entries copied successfully to %0, including cross-references.
+Entries\ copied\ successfully,\ without\ cross-references.=Entries copied successfully to %0, without cross-references.=Entries copied successfully to %0, without cross-references.
 Ask\ whether\ to\ include\ cross-references\ when\ copying\ to\ another\ library=Ask whether to include cross-references when copying to another library
 
 All\ patterns=All patterns

--- a/src/test/java/org/jabref/gui/edit/CopyToTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyToTest.java
@@ -147,7 +147,6 @@ public class CopyToTest {
         verify(dialogService).notify(Localization.lang("Entries and cross-references successfully copied to target library"));
     }
 
-
     @Test
     void executeWithCrossRefAndUserExcludes() {
         selectedEntries.add(entryWithCrossRef);
@@ -168,5 +167,4 @@ public class CopyToTest {
         verify(importHandler).importEntriesWithDuplicateCheck(targetDatabaseContext, selectedEntries);
         verify(dialogService).notify(Localization.lang("Entries successfully copied to target library"));
     }
-
 }

--- a/src/test/java/org/jabref/gui/edit/CopyToTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyToTest.java
@@ -144,7 +144,7 @@ public class CopyToTest {
         expectedEntries.add(referencedEntry);
 
         verify(importHandler).importEntriesWithDuplicateCheck(targetDatabaseContext, expectedEntries);
-        verify(dialogService).notify("Entries and cross-references successfully copied to target library");
+        verify(dialogService).notify(Localization.lang("Entries and cross-references successfully copied to target library"));
     }
 
 
@@ -166,7 +166,7 @@ public class CopyToTest {
         copyTo.execute();
 
         verify(importHandler).importEntriesWithDuplicateCheck(targetDatabaseContext, selectedEntries);
-        verify(dialogService).notify("Entries successfully copied to target library");
+        verify(dialogService).notify(Localization.lang("Entries successfully copied to target library"));
     }
 
 }

--- a/src/test/java/org/jabref/gui/edit/CopyToTest.java
+++ b/src/test/java/org/jabref/gui/edit/CopyToTest.java
@@ -131,13 +131,22 @@ public class CopyToTest {
         when(dialogService.showConfirmationDialogWithOptOutAndWait(anyString(), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(true);
 
         copyTo = new CopyTo(dialogService, stateManager, preferences.getCopyToPreferences(), importHandler, sourceDatabaseContext, targetDatabaseContext);
+
+        // Simulate entries added
+        when(targetDatabaseContext.getEntries()).thenReturn(
+                new BibDatabase(new ArrayList<>()).getEntries(),                             // before
+                new BibDatabase(List.of(entryWithCrossRef, referencedEntry)).getEntries()   // after
+        );
+
         copyTo.execute();
 
         List<BibEntry> expectedEntries = new ArrayList<>(selectedEntries);
         expectedEntries.add(referencedEntry);
 
         verify(importHandler).importEntriesWithDuplicateCheck(targetDatabaseContext, expectedEntries);
+        verify(dialogService).notify("Entries and cross-references successfully copied to target library");
     }
+
 
     @Test
     void executeWithCrossRefAndUserExcludes() {
@@ -147,8 +156,17 @@ public class CopyToTest {
         when(dialogService.showConfirmationDialogWithOptOutAndWait(anyString(), anyString(), anyString(), anyString(), anyString(), any())).thenReturn(false);
 
         copyTo = new CopyTo(dialogService, stateManager, preferences.getCopyToPreferences(), importHandler, sourceDatabaseContext, targetDatabaseContext);
+
+        // Simulate an entry was added
+        when(targetDatabaseContext.getEntries()).thenReturn(
+                new BibDatabase(new ArrayList<>()).getEntries(), // before
+                new BibDatabase(List.of(entryWithCrossRef)).getEntries() // after
+        );
+
         copyTo.execute();
 
         verify(importHandler).importEntriesWithDuplicateCheck(targetDatabaseContext, selectedEntries);
+        verify(dialogService).notify("Entries successfully copied to target library");
     }
+
 }


### PR DESCRIPTION
Closes #12486

## Description

This PR improves the UX for the "Copy to" option in JabRef.

### ✅ What's Changed

- Added clear dialogService notifications after entries are copied.
- Notifies users if cross-referenced entries were included.
- Gives feedback when no new entries were added to the target library.
- Improves clarity and user confidence during copy operations.

## Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/)
- [ ] [Checked documentation](https://docs.jabref.org/)

---

Please let me know if any further improvements are needed. Happy to adjust!
