### PR TITLE
Update JavaDoc for CSL citation generation

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -63,7 +63,7 @@ public class CSLAdapter {
      *
      * @param newStyle  journal style of the output
      * @param newFormat usually HTML or RTF.
-     * @throws IOException An error occurred in the underlying JavaScript framework
+     * @throws IOException An error occurred in the underlying framework
      */
     private void initialize(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
         final boolean newCslInstanceNeedsToBeCreated = (cslInstance == null) || !Objects.equals(newStyle, style);

--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CitationStyleGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CitationStyleGenerator.java
@@ -29,7 +29,7 @@ public class CitationStyleGenerator {
     /**
      * Generates a citation based on a given list of entries, .csl style source content and output format with a given {@link BibDatabaseContext}.
      *
-     * @implNote the citation is generated using JavaScript which may take some time, better call it from outside the main Thread
+     * @implNote The citation is generated using an external library which may take some time, debatable if it is better to call it from outside the main Thread.
      */
     public static String generateCitation(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) {
         try {
@@ -43,7 +43,7 @@ public class CitationStyleGenerator {
     /**
      * Generates a bibliography list in HTML format based on a given list of entries and .csl style source content with a default {@link BibDatabaseContext}.
      *
-     * @implNote the bibliography is generated using JavaScript which may take some time, better call it from outside the main Thread
+     * @implNote The bibliography is generated using an external library which may take some time, debatable if it is better to call it from outside the main Thread.
      */
     protected static String generateBibliography(List<BibEntry> bibEntries, String style, BibEntryTypesManager entryTypesManager) {
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(bibEntries));
@@ -54,7 +54,7 @@ public class CitationStyleGenerator {
     /**
      * Generates a bibliography list based on a given list of entries, .csl style source content and output format with a given {@link BibDatabaseContext}.
      *
-     * @implNote The bibliographies are generated using JavaScript which may take some time, better call it from outside the main thread.
+     * @implNote The bibliographies are generated using an external library which may take some time, debatable if it is better to call it from outside the main Thread.
      */
     public static List<String> generateBibliography(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) {
         try {


### PR DESCRIPTION
Support for Citation Styles in JabRef was introduced in 2016 in https://github.com/JabRef/jabref/pull/1928, which had included a warning comment regarding citation generation time due to citeproc-java using JavaScript. Also refs. https://github.com/JabRef/jabref/pull/3533 where this comment put as an implNote.

As of [release 3.0.0](https://github.com/michel-kraemer/citeproc-java/releases/tag/3.0.0) of citeproc-java (March 2024), the library is implemented in pure Java, so the comments needed some refinement.

Suggestions welcome, as I was hesitant to remove the "takes time" part from the comments.
### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
