### PR TITLE
Fix: Increase preview area in style selection dialog to show full citation preview (#13051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where directory check for relative path was not handled properly under library properties. [#13017](https://github.com/JabRef/jabref/issues/13017)
 - We fixed an issue where the option for which method to use when parsing plaintext citations was unavailable in the 'Create New Entry' tool. [#8808](https://github.com/JabRef/jabref/issues/8808)
 - We fixed an issue where the "Make/Sync bibliography" button in the OpenOffice/LibreOffice sidebar was not enabled when a jstyle was selected. [#13055](https://github.com/JabRef/jabref/pull/13055)
+- We fixed an issue where the preview area in the "Select Style" dialog (CSL/JStyle) was too small to display full content on macOS. [#13051](https://github.com/JabRef/jabref/issues/13051)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where directory check for relative path was not handled properly under library properties. [#13017](https://github.com/JabRef/jabref/issues/13017)
 - We fixed an issue where the option for which method to use when parsing plaintext citations was unavailable in the 'Create New Entry' tool. [#8808](https://github.com/JabRef/jabref/issues/8808)
 - We fixed an issue where the "Make/Sync bibliography" button in the OpenOffice/LibreOffice sidebar was not enabled when a jstyle was selected. [#13055](https://github.com/JabRef/jabref/pull/13055)
-- We fixed an issue where the preview area in the "Select Style" dialog (CSL/JStyle) was too small to display full content on macOS. [#13051](https://github.com/JabRef/jabref/issues/13051)
+- We fixed an issue where the preview area in the "Select Style" dialog of the LibreOffice integration was too small to display full content. [#13051](https://github.com/JabRef/jabref/issues/13051)
 
 ### Removed
 

--- a/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/openoffice/StyleSelectDialog.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import org.controlsfx.control.textfield.CustomTextField?>
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" minHeight="-Infinity" minWidth="-Infinity" prefHeight="580.0"
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" minHeight="-Infinity" minWidth="-Infinity" prefHeight="680.0"
             prefWidth="800.0" xmlns="http://javafx.com/javafx/8.0.171"
             fx:controller="org.jabref.gui.openoffice.StyleSelectDialogView"
             id="styleSelectDialog">
@@ -71,7 +71,7 @@
                         </TableView>
                         <VBox spacing="4.0">
                             <Label text="%Preview" styleClass="sectionHeader"/>
-                            <VBox fx:id="jStylePreviewBox" prefHeight="84.0" prefWidth="665.0"/>
+                            <VBox fx:id="jStylePreviewBox" prefHeight="200.0" prefWidth="665.0"/>
                         </VBox>
                     </VBox>
                 </Tab>


### PR DESCRIPTION
Fix: Increase preview area in style selection dialog to show full citation preview (#13051)

Closes #13051

### Summary of changes

This PR fixes a UI issue where the preview of citation styles (both Jstyle and CSL) in the OpenOffice style selection dialog was too small, especially on macOS. The preview box height has been increased to ensure full visibility of citation content without requiring vertical scrolling or cutting off lines.

Changes made:
- Increased the height (`prefHeight`) of the `VBox` containing the preview (`cslPreviewBox` and `jStylePreviewBox`) in `StyleSelectDialog.fxml`.
- Verified visually that the updated layout does not impact the overall dialog size or distort other elements.

### Screenshots

Before (macOS):  
![image](https://github.com/user-attachments/assets/364d32f0-991f-41ef-9c61-cc307e47be24)

After (macOS):  
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/9eb6f8ff-39ac-45b5-9937-dd9841fb0532" />
<img width="1004" alt="image" src="https://github.com/user-attachments/assets/05263e81-6849-48ec-8607-c344695d37ff" />

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (not applicable - UI layout only)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): No update needed
- [x] [Checked documentation](https://docs.jabref.org/): No update needed

### Collaborators
@lydia-yan @yoasaaa  @flyjoanne @brandon-lau0