### PR TITLE
Try to fix `FileNotFoundException` on selecting default JStyles

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyle.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyle.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -277,19 +276,19 @@ public class JStyle implements Comparable<JStyle>, OOStyle {
      */
     private void reload() throws IOException {
         if (styleFile != null) {
-            Path resourcePath = styleFile;
             if (fromResource) {
-                try {
-                    URL resUrl = JStyle.class.getResource(path);
-                    if (resUrl != null) {
-                        resourcePath = Path.of(resUrl.toURI());
+                URL resUrl = JStyle.class.getResource(path);
+                if (resUrl != null) {
+                    try (InputStream stream = resUrl.openStream()) {
+                        initialize(stream);
+                        this.styleFileModificationTime = System.currentTimeMillis();
+                        return;
                     }
-                } catch (URISyntaxException ex) {
-                    LOGGER.error("Couldn't resolve resource path for style  {}", path, ex);
                 }
             }
-            this.styleFileModificationTime = Files.getLastModifiedTime(resourcePath).toMillis();
-            try (InputStream stream = Files.newInputStream(resourcePath)) {
+
+            this.styleFileModificationTime = Files.getLastModifiedTime(styleFile).toMillis();
+            try (InputStream stream = Files.newInputStream(styleFile)) {
                 initialize(stream);
             }
         }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13073
This is an internal PR to observe any side-effects.
The issue occurs only when running via gradle, and not on installing via dmg/msi.
Description of fix based on [artifact](https://claude.ai/public/artifacts/f6f424c6-034c-4c70-b4f4-511f70f481d6).

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
