### PR TITLE
Fix inclusion of output string in translation

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -205,7 +205,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
         if (newLanguage != workspacePreferences.getLanguage()) {
             workspacePreferences.setLanguage(newLanguage);
             Localization.setLanguage(newLanguage);
-            restartWarning.add(Localization.lang("Changed language") + ": " + newLanguage.getDisplayName());
+            restartWarning.add(Localization.lang("Changed language: %0", newLanguage.getDisplayName()));
         }
 
         workspacePreferences.setShouldOverrideDefaultFontSize(fontOverrideProperty.getValue());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -205,7 +205,7 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
         if (newLanguage != workspacePreferences.getLanguage()) {
             workspacePreferences.setLanguage(newLanguage);
             Localization.setLanguage(newLanguage);
-            restartWarning.add(Localization.lang("Changed language: %0", newLanguage.getDisplayName()));
+            restartWarning.add(Localization.lang("Changed language to %0", newLanguage.getDisplayName()));
         }
 
         workspacePreferences.setShouldOverrideDefaultFontSize(fontOverrideProperty.getValue());

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -143,7 +143,7 @@ Change\ of\ Grouping\ Method=Change of Grouping Method
 
 change\ preamble=change preamble
 
-Changed\ language=Changed language
+Changed\ language\:\ %0=Changed language: %0
 
 Changed\ preamble=Changed preamble
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -143,7 +143,7 @@ Change\ of\ Grouping\ Method=Change of Grouping Method
 
 change\ preamble=change preamble
 
-Changed\ language\:\ %0=Changed language: %0
+Changed\ language\ to\ %0=Changed language to %0
 
 Changed\ preamble=Changed preamble
 


### PR DESCRIPTION
Fix of translation string

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
