### PR TITLE
Fix startup in case of files

### DIFF
--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -189,6 +189,9 @@ jacoco {
 */
 
 tasks.named<JavaExec>("run") {
+    // "assert" statements in the code should activated when running using gradle
+    enableAssertions = true
+
     doFirst {
         // Clear the default JVM arguments to avoid warnings
         // application.applicationDefaultJvmArgs = emptyList()

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -138,6 +138,7 @@ public class JabRefGUI extends Application {
         WebViewStore.init();
 
         DefaultFileUpdateMonitor fileUpdateMonitor = new DefaultFileUpdateMonitor();
+        this.fileUpdateMonitor = fileUpdateMonitor;
         HeadlessExecutorService.INSTANCE.executeInterruptableTask(fileUpdateMonitor, "FileUpdateMonitor");
         Injector.setModelOrService(FileUpdateMonitor.class, fileUpdateMonitor);
 

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -175,7 +175,7 @@ public class LibraryTab extends Tab {
         this.dialogService = dialogService;
         this.preferences = Objects.requireNonNull(preferences);
         this.stateManager = Objects.requireNonNull(stateManager);
-        assert !bibDatabaseContext.getDatabasePath().isPresent() || fileUpdateMonitor != null;
+        assert bibDatabaseContext.getDatabasePath().isEmpty() || fileUpdateMonitor != null;
         this.fileUpdateMonitor = fileUpdateMonitor;
         this.entryTypesManager = entryTypesManager;
         this.clipBoardManager = clipBoardManager;
@@ -752,7 +752,7 @@ public class LibraryTab extends Tab {
 
     public void resetChangeMonitor() {
         changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
-        assert !bibDatabaseContext.getDatabasePath().isPresent() || fileUpdateMonitor != null;
+        assert bibDatabaseContext.getDatabasePath().isEmpty() || fileUpdateMonitor != null;
         changeMonitor = Optional.of(new DatabaseChangeMonitor(bibDatabaseContext,
                 fileUpdateMonitor,
                 taskExecutor,

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -175,6 +175,7 @@ public class LibraryTab extends Tab {
         this.dialogService = dialogService;
         this.preferences = Objects.requireNonNull(preferences);
         this.stateManager = Objects.requireNonNull(stateManager);
+        assert !bibDatabaseContext.getDatabasePath().isPresent() || fileUpdateMonitor != null;
         this.fileUpdateMonitor = fileUpdateMonitor;
         this.entryTypesManager = entryTypesManager;
         this.clipBoardManager = clipBoardManager;
@@ -751,6 +752,7 @@ public class LibraryTab extends Tab {
 
     public void resetChangeMonitor() {
         changeMonitor.ifPresent(DatabaseChangeMonitor::unregister);
+        assert !bibDatabaseContext.getDatabasePath().isPresent() || fileUpdateMonitor != null;
         changeMonitor = Optional.of(new DatabaseChangeMonitor(bibDatabaseContext,
                 fileUpdateMonitor,
                 taskExecutor,

--- a/jabgui/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -197,6 +197,7 @@ public class OpenDatabaseAction extends SimpleCommand {
         // Run the actual open in a thread to prevent the program
         // locking until the file is loaded.
         if (!filesToOpen.isEmpty()) {
+            assert fileUpdateMonitor != null;
             FileHistory fileHistory = preferences.getLastFilesOpenedPreferences().getFileHistory();
             filesToOpen.forEach(theFile -> {
                 // This method will execute the concrete file opening and loading in a background thread
@@ -223,6 +224,8 @@ public class OpenDatabaseAction extends SimpleCommand {
         if (!Files.exists(file)) {
             return;
         }
+
+        assert fileUpdateMonitor != null;
 
         BackgroundTask<ParserResult> backgroundTask = BackgroundTask.wrap(() -> loadDatabase(file));
         // The backgroundTask is executed within the method createLibraryTab


### PR DESCRIPTION
Follow-up to #13012

`fileUpdateMonitor` was not initalized properly.

Additionally, this PR enables `assert` statements to be evaluted.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
