### PR TITLE
feat: select correct tab for creation of new entry (#13087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the provision to choose different CSL bibliography body formats (e.g. First Line Indent, Hanging Indent, Bibliography 1, etc.) in the LibreOffice integration. [#13049](https://github.com/JabRef/jabref/issues/13049)
 - We added "Bibliography Heading" to the available CSL bibliography header formats in the LibreOffice integration. [#13049](https://github.com/JabRef/jabref/issues/13049)
 - We added a new button to toggle the file path between an absolute and relative formats in context of library properties. [#13031](https://github.com/JabRef/jabref/issues/13031)
+- We added automatic selection of the “Enter Identifier” tab with pre-filled clipboard content if the clipboard contains a valid identifier when opening the “Create New Entry” dialog. [#13087](https://github.com/JabRef/jabref/issues/13087)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -45,6 +45,8 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.model.entry.types.BiblatexAPAEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexSoftwareEntryTypeDefinitions;
@@ -143,7 +145,22 @@ public class NewEntryView extends BaseDialog<BibEntry> {
     private void finalizeTabs() {
         NewEntryDialogTab approach = initialApproach;
         if (approach == null) {
-            approach = preferences.getLatestApproach();
+            final String clipboardText = ClipBoardManager.getContents().trim();
+            if (!StringUtil.isBlank(clipboardText)) {
+                BibEntry tempEntry = new BibEntry();
+                tempEntry.setField(StandardField.DOI, clipboardText);
+                IdentifierParser parser = new IdentifierParser(tempEntry);
+        
+                if (parser.parse(StandardField.DOI).isPresent()) {
+                    approach = NewEntryDialogTab.ENTER_IDENTIFIER;
+                    interpretText.setText(clipboardText);
+                    interpretText.selectAll();
+                } else {
+                    approach = preferences.getLatestApproach();
+                }
+            } else {
+                approach = preferences.getLatestApproach();
+            }
         }
 
         switch (approach) {

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -35,18 +35,18 @@ import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.gui.util.UiTaskExecutor;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.ai.AiService;
+import org.jabref.logic.importer.CompositeIdFetcher;
 import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.WebFetcher;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
-import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.Identifier;
 import org.jabref.model.entry.types.BiblatexAPAEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexSoftwareEntryTypeDefinitions;
@@ -147,10 +147,8 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         if (approach == null) {
             final String clipboardText = ClipBoardManager.getContents().trim();
             if (!StringUtil.isBlank(clipboardText)) {
-                BibEntry tempEntry = new BibEntry().withField(StandardField.DOI, clipboardText);
-                IdentifierParser parser = new IdentifierParser(tempEntry);
-        
-                if (parser.parse(StandardField.DOI).isPresent()) {
+                Optional<Identifier> identifier = CompositeIdFetcher.getIdentifier(clipboardText);
+                if (identifier.isPresent()) {
                     approach = NewEntryDialogTab.ENTER_IDENTIFIER;
                     interpretText.setText(clipboardText);
                     interpretText.selectAll();

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryView.java
@@ -39,6 +39,7 @@ import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.WebFetcher;
 import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
+import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseMode;
@@ -46,7 +47,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.logic.importer.util.IdentifierParser;
 import org.jabref.model.entry.types.BiblatexAPAEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
 import org.jabref.model.entry.types.BiblatexSoftwareEntryTypeDefinitions;
@@ -147,8 +147,7 @@ public class NewEntryView extends BaseDialog<BibEntry> {
         if (approach == null) {
             final String clipboardText = ClipBoardManager.getContents().trim();
             if (!StringUtil.isBlank(clipboardText)) {
-                BibEntry tempEntry = new BibEntry();
-                tempEntry.setField(StandardField.DOI, clipboardText);
+                BibEntry tempEntry = new BibEntry().withField(StandardField.DOI, clipboardText);
                 IdentifierParser parser = new IdentifierParser(tempEntry);
         
                 if (parser.parse(StandardField.DOI).isPresent()) {

--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -271,6 +271,7 @@ public class NewEntryViewModel {
                     Localization.lang(
                         "An unknown error has occurred.\n" +
                         "This entry may need to be added manually."));
+                executing.set(false);
                 return;
             }
 
@@ -285,6 +286,7 @@ public class NewEntryViewModel {
             handler.importEntryWithDuplicateCheck(libraryTab.getBibDatabaseContext(), result.get());
 
             executedSuccessfully.set(true);
+            executing.set(false);
         });
 
         taskExecutor.execute(idLookupWorker);
@@ -362,6 +364,7 @@ public class NewEntryViewModel {
                         "An unknown error has occurred.\n" +
                         "Entries may need to be added manually."));
                 LOGGER.error("An invalid result was returned when parsing citations.");
+                executing.set(false);
                 return;
             }
 
@@ -376,6 +379,7 @@ public class NewEntryViewModel {
             handler.importEntriesWithDuplicateCheck(libraryTab.getBibDatabaseContext(), result.get());
 
             executedSuccessfully.set(true);
+            executing.set(false);
         });
 
         taskExecutor.execute(interpretWorker);
@@ -445,6 +449,7 @@ public class NewEntryViewModel {
                         "An unknown error has occurred.\n" +
                         "Entries may need to be added manually."));
                 LOGGER.error("An invalid result was returned when parsing Bib(La)Tex entries.");
+                executing.set(false);
                 return;
             }
 
@@ -459,6 +464,7 @@ public class NewEntryViewModel {
             handler.importEntriesWithDuplicateCheck(libraryTab.getBibDatabaseContext(), result.get());
 
             executedSuccessfully.set(true);
+            executing.set(false);
         });
 
         taskExecutor.execute(bibtexWorker);


### PR DESCRIPTION
Select correct tab for creation of new entry (#13087)
Closes #13087

### Summary of changes
This PR improves the user experience when creating new entries. If the clipboard contains a valid identifier (like a DOI), the 'Enter Identifier' tab will now be automatically selected, and the identifier will be pre-filled.  

Changes made:
- Automatically select "Enter identifier" tab when clipboard contains valid identifier 
- Automatically populate the input field with clipboard content 
- If no valid identifier is found, the dialog falls back to the previously used approach from preferences.

### Screenshots
Before:  
![Before](https://github.com/user-attachments/assets/2b1590c9-8386-42d8-88a0-198840c0d69a)

After:  
![After](https://github.com/user-attachments/assets/afe38bb7-14ad-41cd-bcde-b52ee2ffdcc9)
![Screen Recording 2025-05-09 at 6 18 38 PM](https://github.com/user-attachments/assets/8866dee2-78ff-4ce8-b9e1-435cee79f55b)

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (not applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): No update needed
- [x] [Checked documentation](https://docs.jabref.org/): No update needed

### Collaborators
[@lydia-yan](https://github.com/lydia-yan) [@yoasaaa](https://github.com/yoasaaa) [@brandon-lau0](https://github.com/brandon-lau0) [@FlyJoanne](https://github.com/FlyJoanne)
