### PR TITLE
Refine http sever doc

### DIFF
--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -4,7 +4,7 @@ parent: Code Howtos
 # HTTP Server
 
 JabRef has a built-in http server.
-For example, the resource for a library is implemented at [`org.jabref.http.server.LibraryResource`](https://github.com/JabRef/jabref/blob/main/src/main/java/org/jabref/http/server/LibraryResource.java).
+For example, the resource for a library is implemented at [`org.jabref.http.server.LibraryResource`](https://github.com/JabRef/jabref/blob/main/jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java).
 
 ## Start http server
 
@@ -16,26 +16,24 @@ If that list is also empty, the file `src/main/resources/org/jabref/http/server/
 
 ### Starting with gradle
 
-Does not work.
-
-Current try:
-
 ```shell
-./gradlew run -Pcomment=httpserver
+./gradlew run :jabsrv:run
 ```
 
-However, there are with `ForkJoin` (discussion at <https://discuss.gradle.org/t/is-it-ok-to-use-collection-parallelstream-or-other-potentially-multi-threaded-code-within-gradle-plugin-code/28003>)
+The GUI is also started. Just close it.
 
 Gradle output:
 
 ```shell
-> Task :run
-2023-04-22 11:30:59 [main] org.jabref.http.server.Server.main()
-DEBUG: Libraries served: [C:\git-repositories\jabref-all\jabref\src\main\resources\org\jabref\http\server\http-server-demo.bib]
-2023-04-22 11:30:59 [main] org.jabref.http.server.Server.startServer()
-DEBUG: Starting server...
-<============-> 92% EXECUTING [2m 27s]
-> :run
+> Task :jabsrv:run
+2025-05-12 11:52:57 [main] org.glassfish.grizzly.http.server.NetworkListener.start()
+INFO: Started listener bound to [localhost:6050]
+2025-05-12 11:52:57 [main] org.glassfish.grizzly.http.server.HttpServer.start()
+INFO: [HttpServer] Started.
+JabSrv started.
+Stop JabSrv using Ctrl+C
+<============-> 96% EXECUTING [43s]
+> :jabsrv:run
 ```
 
 IntelliJ output, if `org.jabref.http.server.Server#main` is executed:
@@ -52,7 +50,7 @@ DEBUG: Server started.
 
 ## Developing with IntelliJ
 
-IntelliJ Ultimate offers a Markdown-based http-client. One has to open the file `src/test/java/org/jabref/testutils/interactive/http/rest-api.http`.
+IntelliJ Ultimate offers a Markdown-based http-client. One has to open the file `jabsrv/src/test/rest-api.http`.
 Then, there are play buttons appearing for interacting with the server.
 
 ## Get SSL Working


### PR DESCRIPTION
The multi project build not did not update the HTTP server documentation.

This is a small update.

`./gradlew :jabsrv:run` starts all run tasks - see https://github.com/gradle/gradle/issues/20863#issuecomment-2871863540.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
