### PR TITLE
Fix `OpenAITokenizer` constructor deprecation

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/chatting/AiChatLogic.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/chatting/AiChatLogic.java
@@ -27,6 +27,7 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.TokenWindowChatMemory;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiChatModelName;
 import dev.langchain4j.model.openai.OpenAiTokenizer;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
@@ -98,7 +99,7 @@ public class AiChatLogic {
     private void rebuildChatMemory(List<ChatMessage> chatMessages) {
         this.chatMemory = TokenWindowChatMemory
                 .builder()
-                .maxTokens(aiPreferences.getContextWindowSize(), new OpenAiTokenizer())
+                .maxTokens(aiPreferences.getContextWindowSize(), new OpenAiTokenizer(OpenAiChatModelName.GPT_4_O_MINI))
                 .build();
 
         chatMessages.stream().filter(chatMessage -> !(chatMessage instanceof ErrorMessage)).forEach(chatMemory::add);

--- a/jablib/src/main/java/org/jabref/logic/ai/chatting/AiChatLogic.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/chatting/AiChatLogic.java
@@ -97,6 +97,15 @@ public class AiChatLogic {
     }
 
     private void rebuildChatMemory(List<ChatMessage> chatMessages) {
+        // Because we can't get a tokenizer for each model, {@link AiChatLogic} assumes that
+        // every text is tokenized like it's tokenized for OpenAI's GPT-4o-mini model.
+        // 
+        // Reasons why we can't get tokenizer for each model:
+        // - Some tokenizers might not be available in langchain4j.
+        // - User may use a custom model, but there is no way to supply a custom tokenizer.
+        // - OpenAI API (and compatible ones) doesn't have an endpoint for tokenizing text.
+        //
+        // This is another dark workaround of AI integration. But it works "good-enough" for now.
         this.chatMemory = TokenWindowChatMemory
                 .builder()
                 .maxTokens(aiPreferences.getContextWindowSize(), new OpenAiTokenizer(OpenAiChatModelName.GPT_4_O_MINI))


### PR DESCRIPTION
Just a small fix.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
