### PR TITLE
Use "library" for .bib file

### DIFF
--- a/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
@@ -23,7 +23,7 @@ import static picocli.CommandLine.Mixin;
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.ParentCommand;
 
-@Command(name = "check-consistency", description = "Check consistency of the database.")
+@Command(name = "check-consistency", description = "Check consistency of the library.")
 class CheckConsistency implements Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckConsistency.class);
 


### PR DESCRIPTION
We use "library" for .bib file and "database" for SQL-database.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
