### PR TITLE
test: add boundary case tests for search history retrieval

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/search/GetLastSearchHistoryTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/search/GetLastSearchHistoryTest.java
@@ -60,4 +60,25 @@ class GetLastSearchHistoryTest {
         expected = List.of();
         assertEquals(expected, lastSearchHistory);
     }
+
+    @Test
+    void getMoreThanAvailableHistory() {
+        StateManager stateManager = new StateManager();
+        stateManager.addSearchHistory("test1");
+        stateManager.addSearchHistory("test2");
+        List<String> lastSearchHistory = stateManager.getLastSearchHistory(5);
+        List<String> expected = List.of("test1", "test2");
+
+        assertEquals(expected, lastSearchHistory);
+    }
+
+    @Test
+    void getHistoryWhenEmpty() {
+        StateManager stateManager = new StateManager();
+        List<String> history = stateManager.getLastSearchHistory(3);
+        assertEquals(List.of(), history);
+
+        history = stateManager.getWholeSearchHistory();
+        assertEquals(List.of(), history);
+    }
 }


### PR DESCRIPTION
No linked issue (test coverage enhancement)

### Summary of changes
This PR adds two small but meaningful test cases to `GetLastSearchHistoryTest.java`:

- `getMoreThanAvailableHistory`: ensures that requesting more entries than the list contains returns all available entries
- `getHistoryWhenEmpty`: verifies that an empty `StateManager` returns an empty list for both full and partial retrieval methods

These tests improve robustness against boundary cases in search history logic.

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): No update needed
- [x] [Checked documentation](https://docs.jabref.org/): No update needed

### Collaborators
[@lydia-yan](https://github.com/lydia-yan) [@yoasaaa](https://github.com/yoasaaa) [@brandon-lau0](https://github.com/brandon-lau0) [@FlyJoanne](https://github.com/FlyJoanne)
