### PR TITLE
Link to JabRefs repo

### DIFF
--- a/Dockerfile.jabkit
+++ b/Dockerfile.jabkit
@@ -1,5 +1,3 @@
-LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
-
 FROM gradle:jdk24-noble AS build
 
 WORKDIR /app
@@ -16,6 +14,8 @@ RUN mv jabkit/build/distribution/jabkit /dist
 
 # jpackage needs glibc; alpine does not work
 FROM debian:bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
 
 WORKDIR /work
 

--- a/Dockerfile.jabkit
+++ b/Dockerfile.jabkit
@@ -1,3 +1,5 @@
+LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
+
 FROM gradle:jdk24-noble AS build
 
 WORKDIR /app

--- a/Dockerfile.jabsrv
+++ b/Dockerfile.jabsrv
@@ -1,5 +1,3 @@
-LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
-
 FROM gradle:jdk24-noble AS build
 
 WORKDIR /app
@@ -16,6 +14,8 @@ RUN mv jabsrv-cli/build/distribution/jabsrv /dist
 
 # jpackage needs glibc; alpine does not work
 FROM debian:bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
 
 WORKDIR /work
 

--- a/Dockerfile.jabsrv
+++ b/Dockerfile.jabsrv
@@ -1,3 +1,5 @@
+LABEL org.opencontainers.image.source https://github.com/JabRef/jabref
+
 FROM gradle:jdk24-noble AS build
 
 WORKDIR /app


### PR DESCRIPTION
At https://github.com/orgs/JabRef/packages/container/package/jabsrv, I see

![image](https://github.com/user-attachments/assets/7ef5cfec-63f6-4870-8197-0462c859e02d)

---

This PR does that.

I accept that the names are not consistent:

![image](https://github.com/user-attachments/assets/139aa6f0-44d1-48ff-878f-c66d9bd35188)

I would no open yet another repository for this, because that is more confusing (and the build is more complicated)


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
