### PR TITLE
Add publishing of JabLib snapshot to maven central

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -185,7 +185,16 @@ jobs:
         with:
           fileName: 'secring.gpg'
           encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
-      - run: ./gradlew -Dsigning.keyId=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -Dsigning.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -Dsigning.secretKeyRingFile=secring.gpg -DmavenCentralUsername=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -DmavenCentralPassword=${{ secrets.KOPPOR_SIGNING_PASSWORD }} :jablib:publishAllPublicationsToMavenCentralRepository
+      - name: store secrets
+        run: |
+          cat >> gradle.properties <<EOF
+          signing.keyId=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          signing.secretKeyRingFile=secring.gpg
+          mavenCentralUsername=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          mavenCentralPassword=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          EOF
+      - run: ./gradlew :jablib:publishAllPublicationsToMavenCentralRepository
 
       - name: Prepare merged jars and modules dir
         # prepareModulesDir is executing a build, which should run through even if no upload to builds.jabref.org is made

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -188,11 +188,11 @@ jobs:
       - name: store secrets
         run: |
           cat >> gradle.properties <<EOF
-          signing.keyId=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
           signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
           signing.secretKeyRingFile=secring.gpg
-          mavenCentralUsername=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
-          mavenCentralPassword=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          mavenCentralUsername=${{ secrets.KOPPOR_MAVENCENTRALUSERNAME }}
+          mavenCentralPassword=${{ secrets.KOPPOR_MAVENCENTRALPASSWORD }}
           EOF
       - run: ./gradlew :jablib:publishAllPublicationsToMavenCentralRepository
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -158,7 +158,7 @@ jobs:
           submodules: 'true'
           show-progress: 'false'
       - name: Install pigz and cache (linux)
-        if: (matrix.os == 'ubuntu-22.04')
+        if: (startsWith(matrix.os, 'ubuntu'))
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: pigz
@@ -330,7 +330,7 @@ jobs:
           get-childitem -Path jabgui/build/distribution/* | rename-item -NewName {$_.name -replace "${{ steps.gitversion.outputs.AssemblySemVer }}","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}${{ matrix.suffix }}"}
           get-childitem -Path jabgui/build/distribution/* | rename-item -NewName {$_.name -replace "portable","${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}${{ matrix.suffix }}-portable"}
       - name: Repack deb file for Debian
-        if: (matrix.os == 'ubuntu-22.04')
+        if: (startsWith(matrix.os, 'ubuntu'))
         shell: bash
         run: |
           cd jabgui/build/distribution

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -49,9 +49,11 @@ jobs:
     outputs:
       upload-to-builds-jabref-org: ${{ steps.binary.outputs.upload-to-builds-jabref-org }}
       secretspresent: ${{ steps.binary.outputs.secretspresent }}
+      tagbuild: ${{ steps.binary.outputs.tagbuild }}
       # requried to avoid obsolete builds in case of labels != "dev: binary"
       should-build: ${{ steps.binary.outputs.should-build }}
       should-notarize: ${{ steps.binary.outputs.should-notarize }}
+
     steps:
       - name: Determine conditions
         id: binary
@@ -90,6 +92,12 @@ jobs:
             echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
             echo "🚫 merge queue – skipping upload"
             exit 0
+          fi
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tagbuild=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tagbuild=false" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]] || [[ "${{ inputs.notarization }}" == "true" ]]; then
@@ -200,7 +208,7 @@ jobs:
           file ${{ steps.secring.outputs.filePath }}
           md5sum ${{ steps.secring.outputs.filePath }}
       - name: publishAllPublicationsToMavenCentralRepository
-        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}"  :jablib:publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ needs.conditions.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository
         if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
       # endregion
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -180,13 +180,14 @@ jobs:
 
       # region Publish JabLib on Maven Central
       - name: Decode secretKeyRingFile
+        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
         id: secring
-        if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
         uses: timheuer/base64-to-file@v1
         with:
           fileName: 'secring.gpg'
           encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
       - name: store secrets
+        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
         run: |
           cat >> gradle.properties <<EOF
           signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
@@ -198,7 +199,10 @@ jobs:
           grep secretKeyRingFile gradle.properties
           file ${{ steps.secring.outputs.filePath }}
           md5sum ${{ steps.secring.outputs.filePath }}
-      - run: ./gradlew :jablib:publishAllPublicationsToMavenCentralRepository
+      - name: publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}"  :jablib:publishAllPublicationsToMavenCentralRepository
+        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
+      # endregion
 
       - name: Prepare merged jars and modules dir
         # prepareModulesDir is executing a build, which should run through even if no upload to builds.jabref.org is made
@@ -354,6 +358,7 @@ jobs:
           set -e
           ${{ matrix.archivePortableJabKit }}
 
+      # region Upload to builds.jabref.org / GitHub artifacts store
       - name: Setup SSH key
         if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true')
         run: |
@@ -372,7 +377,6 @@ jobs:
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
-
       - name: Setup rsync (macOS)
         if: ${{ (steps.diskspace.outputs.available == 'true') && (startsWith(matrix.os, 'macos') && (needs.conditions.outputs.upload-to-builds-jabref-org == 'true')) }}
         run: brew install rsync
@@ -424,6 +428,7 @@ jobs:
             jabgui/build/distribution
             jabkit/build/distribution
           compression-level: 0 # no compression
+      # endregion
 
   comment-on-pr:
     name: Comment on PR

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -190,10 +190,13 @@ jobs:
           cat >> gradle.properties <<EOF
           signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
           signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
-          signing.secretKeyRingFile=secring.gpg
+          signing.secretKeyRingFile=$(pwd)/secring.gpg
           mavenCentralUsername=${{ secrets.KOPPOR_MAVENCENTRALUSERNAME }}
           mavenCentralPassword=${{ secrets.KOPPOR_MAVENCENTRALPASSWORD }}
           EOF
+          grep secretKeyRingFile gradle.properties
+          file secring.gpg
+          md5sum secring.gpg
       - run: ./gradlew :jablib:publishAllPublicationsToMavenCentralRepository
 
       - name: Prepare merged jars and modules dir

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -177,6 +177,16 @@ jobs:
           distribution: 'liberica'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      # region Publish JabLib on Maven Central
+      - name: Decode secretKeyRingFile
+        if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'secring.gpg'
+          encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
+      - run: ./gradlew -Dsigning.keyId=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -Dsigning.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -Dsigning.secretKeyRingFile=secring.gpg -DmavenCentralUsername=${{ secrets.KOPPOR_SIGNING_PASSWORD }} -DmavenCentralPassword=${{ secrets.KOPPOR_SIGNING_PASSWORD }} :jablib:publishAllPublicationsToMavenCentralRepository
+
       - name: Prepare merged jars and modules dir
         # prepareModulesDir is executing a build, which should run through even if no upload to builds.jabref.org is made
         if: (startsWith(matrix.os, 'macos')) || (needs.conditions.outputs.upload-to-builds-jabref-org == 'false')

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -180,6 +180,7 @@ jobs:
 
       # region Publish JabLib on Maven Central
       - name: Decode secretKeyRingFile
+        id: secring
         if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
         uses: timheuer/base64-to-file@v1
         with:
@@ -190,13 +191,13 @@ jobs:
           cat >> gradle.properties <<EOF
           signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
           signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
-          signing.secretKeyRingFile=$(pwd)/secring.gpg
+          signing.secretKeyRingFile=${{ steps.secring.outputs.filePath }}
           mavenCentralUsername=${{ secrets.KOPPOR_MAVENCENTRALUSERNAME }}
           mavenCentralPassword=${{ secrets.KOPPOR_MAVENCENTRALPASSWORD }}
           EOF
           grep secretKeyRingFile gradle.properties
-          file secring.gpg
-          md5sum secring.gpg
+          file ${{ steps.secring.outputs.filePath }}
+          md5sum ${{ steps.secring.outputs.filePath }}
       - run: ./gradlew :jablib:publishAllPublicationsToMavenCentralRepository
 
       - name: Prepare merged jars and modules dir

--- a/.jbang/JabKitLauncher.java
+++ b/.jbang/JabKitLauncher.java
@@ -21,7 +21,7 @@
 
 //REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
 
-//DEPS org.jabref:jablib:0.1.0-SNAPSHOT
+//DEPS org.jabref:jablib:6.+
 //DEPS info.picocli:picocli:4.7.7
 
 import org.jabref.JabKit;

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -5,7 +5,10 @@
         "http://www.checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <suppressions>
+    <suppress checks="[a-zA-Z0-9]*" files="[\\/].jbang[\\/]" />
     <suppress checks="[a-zA-Z0-9]*" files="[\\/]generated[\\/]" />
+    <suppress checks="[a-zA-Z0-9]*" files="[\\/]generated-sources[\\/]" />
+    <suppress checks="[a-zA-Z0-9]*" files="[\\/]generated-src[\\/]" />
     <suppress checks="[a-zA-Z0-9]*" files="[\\/]src-gen[\\/]" />
     <!-- We ignore this file because it's a modification of the original java code https://github.com/openjdk/jfx/blob/jfx15/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TitledPaneSkin.java -->
     <suppress checks="[a-zA-Z0-9]*" files="CustomTitledPaneSkin.java" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ org.gradle.jvmargs=-Xmx6096M
 
 # hint by https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
 org.gradle.caching=true
+
+org.gradle.logging.level=info

--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -26,6 +26,9 @@ val luceneVersion = "10.2.1"
 val jaxbVersion by extra { "4.0.5" }
 
 var version: String = project.findProperty("projVersion")?.toString() ?: "0.1.0"
+if (project.findProperty("tagbuild")?.toString() != "true") {
+    version += "-SNAPSHOT"
+}
 
 dependencies {
     implementation(fileTree(mapOf("dir" to("lib"), "includes" to listOf("*.jar"))))
@@ -502,7 +505,7 @@ mavenPublishing {
 
   signAllPublications()
 
-  coordinates("org.jabref", "jablib", version + "-SNAPSHOT")
+  coordinates("org.jabref", "jablib", version)
 
   pom {
     name.set("jablib")


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13123

Triggered by https://github.com/APIdia-net/apidia.net/issues/2#issuecomment-2888414260

The chosen approach follows https://wiki.debian.org/Subkeys

---

Alternatives:

- import GnuPG key using https://github.com/crazy-max/ghaction-import-gpg

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
