### PR TITLE
Add alias for importToOpen with a single dash to be backwards comptaible

### DIFF
--- a/jabgui/buildres/windows/JabRefHost.ps1
+++ b/jabgui/buildres/windows/JabRefHost.ps1
@@ -36,7 +36,7 @@ try {
     # WriteAllLines should write the file as UTF-8 without BOM
     # unlike Out-File which writes UTF-16 with BOM in ps5.1
     [IO.File]::WriteAllLines($tempfile, $messageText)
-    $output = & $jabRefExe -importToOpen $tempfile *>&1
+    $output = & $jabRefExe --importToOpen $tempfile *>&1
     Remove-Item $tempfile *>$null
     # For debugging: uncomment the following lines to get the output of JabRef be displayed as a popup 
     #$wshell = New-Object -ComObject Wscript.Shell

--- a/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
+++ b/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
@@ -23,7 +23,7 @@ public class GuiCommandLine {
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"--importToOpen"}, description = "Same as --import, but will be imported to the opened tab")
+    @Option(names = {"-importToOpen","--importToOpen"}, description = "Same as --import, but will be imported to the opened tab")
     public String importToOpen;
 
     @Option(names = {"--reset"}, description = "Reset all preferences to default values.")


### PR DESCRIPTION
adjust ps1 script as well

<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes _____
Describe the changes you have made here: what, where, why, ...
If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ...

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
