### PR TITLE
Update GitVersion.yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,4 +6,4 @@ branches:
   main:
     regex: ^main
     tag: 'alpha2' # Update this to the tag prefix for the alpha/beta release (e.g., "alpha2") or leave empty
-    pre-release-weight: 32000 # 0 after stable release, 15000 before alpha release, 30000 before beta release, 50000 before stable release
+    pre-release-weight: 30000 # 0 after stable release, 15000 before alpha release, 30000 before beta release, 50000 before stable release

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -6,4 +6,4 @@ branches:
   main:
     regex: ^main
     tag: 'alpha2' # Update this to the tag prefix for the alpha/beta release (e.g., "alpha2") or leave empty
-    pre-release-weight: 16000 # 0 after stable release, 15000 before alpha release, 30000 before beta release, 50000 before stable release
+    pre-release-weight: 32000 # 0 after stable release, 15000 before alpha release, 30000 before beta release, 50000 before stable release


### PR DESCRIPTION
PRs already get a number > 30.000

Therefore, I increase our wight from 16000 to 30000

---

before: main

```json
 {
  "Major": 6,
  "Minor": 0,
  "Patch": 0,
  "PreReleaseTag": "alpha2.113",
  "PreReleaseTagWithDash": "-alpha2.113",
  "PreReleaseLabel": "alpha2",
  "PreReleaseLabelWithDash": "-alpha2",
  "PreReleaseNumber": 113,
  "WeightedPreReleaseNumber": 16113,
  "BuildMetaData": null,
  "BuildMetaDataPadded": "",
  "FullBuildMetaData": "Branch.main.Sha.9e7026a4c9f6822991f57ebb2f4b5d47a1eb9158",
  "MajorMinorPatch": "6.0.0",
  "SemVer": "6.0.0-alpha2.113",
  "LegacySemVer": "6.0.0-alpha2-113",
  "LegacySemVerPadded": "6.0.0-alpha2-0113",
  "AssemblySemVer": "6.0.16113",
  "AssemblySemFileVer": "6.0.0.0",
  "FullSemVer": "6.0.0-alpha2.113",
  "InformationalVersion": "6.0-alpha2.113--2025-05-19--9e7026a",
  "BranchName": "main",
  "EscapedBranchName": "main",
  "Sha": "9e7026a4c9f6822991f57ebb2f4b5d47a1eb9158",
  "ShortSha": "9e7026a",
  "NuGetVersionV2": "6.0.0-alpha2-0113",
  "NuGetVersion": "6.0.0-alpha2-0113",
  "NuGetPreReleaseTagV2": "alpha2-0113",
  "NuGetPreReleaseTag": "alpha2-0113",
  "VersionSourceSha": "6d0d78716893cc09577a957d111d62ba2dfbefd0",
  "CommitsSinceVersionSource": 113,
  "CommitsSinceVersionSourcePadded": "0113",
  "UncommittedChanges": 0,
  "CommitDate": "2025-05-19"
}
```

after - at this pull reuest (no change, because not merged yet)

```json
 {
  "Major": 6,
  "Minor": 0,
  "Patch": 0,
  "PreReleaseTag": "PullRequest13133.115",
  "PreReleaseTagWithDash": "-PullRequest13133.115",
  "PreReleaseLabel": "PullRequest13133",
  "PreReleaseLabelWithDash": "-PullRequest13133",
  "PreReleaseNumber": 115,
  "WeightedPreReleaseNumber": 30115,
  "BuildMetaData": null,
  "BuildMetaDataPadded": "",
  "FullBuildMetaData": "Branch.pull-13133-merge.Sha.d513df25de1775c7e93018a7cc708bdb2e9d94a6",
  "MajorMinorPatch": "6.0.0",
  "SemVer": "6.0.0-PullRequest13133.115",
  "LegacySemVer": "6.0.0-PullRequest13133-115",
  "LegacySemVerPadded": "6.0.0-PullRequest1313-0115",
  "AssemblySemVer": "6.0.30115",
  "AssemblySemFileVer": "6.0.0.0",
  "FullSemVer": "6.0.0-PullRequest13133.115",
  "InformationalVersion": "6.0-PullRequest13133.115--2025-05-19--d513df2",
  "BranchName": "pull/13133/merge",
  "EscapedBranchName": "pull-13133-merge",
  "Sha": "d513df25de1775c7e93018a7cc708bdb2e9d94a6",
  "ShortSha": "d513df2",
  "NuGetVersionV2": "6.0.0-pullrequest1313-0115",
  "NuGetVersion": "6.0.0-pullrequest1313-0115",
  "NuGetPreReleaseTagV2": "pullrequest1313-0115",
  "NuGetPreReleaseTag": "pullrequest1313-0115",
  "VersionSourceSha": "6d0d78716893cc09577a957d111d62ba2dfbefd0",
  "CommitsSinceVersionSource": 115,
  "CommitsSinceVersionSourcePadded": "0115",
  "UncommittedChanges": 0,
  "CommitDate": "2025-05-19"
}
```

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
