### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,5 @@ org.gradle.jvmargs=-Xmx6096M
 # hint by https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
 org.gradle.caching=true
 
-org.gradle.logging.level=info
+# Activate this if you work on the build itself
+# org.gradle.logging.level=info


### PR DESCRIPTION
Removes info output

It seems that checkstyle also used the `info` level maybe: https://github.com/JabRef/jabref/actions/runs/15122637206/job/42508299242?pr=13146

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
