### PR TITLE
Fix label removal on unassigment

### DIFF
--- a/.github/workflows/on-issue-unassigned.yml
+++ b/.github/workflows/on-issue-unassigned.yml
@@ -6,13 +6,27 @@ on:
        - unassigned
 
 jobs:
-  ensure_column:
+  columns_and_labels:
     if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      contents: read
     steps:
+      - name: Check assignees
+        id: check_assignee
+        run: |
+          issue=$(gh issue view ${{ github.event.issue.number }} --json assignees)
+          count=$(echo "$issue" | jq '.assignees | length')
+          if [ "$count" -gt 0 ]; then
+            echo "assigned=yes" >> $GITHUB_OUTPUT
+          else
+            echo "assigned=no" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Move Issue to "Free to take" Column in "Candidates for University Projects"
+        if: steps.check_assignee.outputs.assigned == 'no'
         uses: m7kvqbe1/github-action-move-issues@main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
@@ -23,6 +37,7 @@ jobs:
           default-column: "Free to take"
           skip-if-not-in-project: true
       - name: Move Issue to "Free to take" Column in "Good First Issues"
+        if: steps.check_assignee.outputs.assigned == 'no'
         uses: m7kvqbe1/github-action-move-issues@main
         with:
           github-token: ${{ secrets.GH_TOKEN_ACTION_MOVE_ISSUE }}
@@ -32,19 +47,16 @@ jobs:
           ignored-columns: ""
           default-column: "Free to take"
           skip-if-not-in-project: true
-  remove_labels:
-    if: ${{ github.repository_owner == 'JabRef' }}
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
-    steps:
       - uses: actions/checkout@v4
-      - name: Remove assigned label
-        run: gh issue edit ${{ github.event.issue.number }} --remove-label "📍 Assigned"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove FirstTimeCodeContribution label
-        run: gh issue edit ${{ github.event.issue.number }} --remove-label "FirstTimeCodeContribution"
+        if: steps.check_assignee.outputs.assigned == 'no'
+      - name: Remove labels assigned, reminder-sent, pinned, and "FirstTimeCodeContribution"
+        if: steps.check_assignee.outputs.assigned == 'no'
+        run: |
+          set -e
+
+          gh issue edit ${{ github.event.issue.number }} --remove-label "📍 Assigned"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "🔔 reminder-sent"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "📌 Pinned"
+          gh issue edit ${{ github.event.issue.number }} --remove-label "FirstTimeCodeContribution"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -86,14 +86,6 @@ jobs:
           gh issue edit ${{ needs.determine_issue_number.outputs.issue_number }} --remove-label "FirstTimeCodeContribution"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove label pinned (to enable automated pinging and unassignment with a message)
-        if: steps.check_assignee.outputs.assigned == 'yes'
-        run: |
-          set -e
-
-          gh issue edit ${{ needs.determine_issue_number.outputs.issue_number }} --remove-label "📌 Pinned"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Move issue to "Free to take" in "Good First Issues"
         if: steps.check_assignee.outputs.assigned == 'no'
         uses: m7kvqbe1/github-action-move-issues/@add-issue-parameter


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/issues/13013 - the action removed the assigned and pinned label; even though I was assigned.

This PR fixes this

Also removes some more labels on PR closing

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
