### PR TITLE
Refine HTTP Server

### DIFF
--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -1,0 +1,61 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DESCRIPTION jabsrv - serve BibTeX files using JabRef
+
+//JAVA 24
+//RUNTIME_OPTIONS --enable-native-access=ALL-UNNAMED
+
+//SOURCES ../jabsrv-cli/src/main/java/org/jabref/http/server/cli/ServerCli.java
+//FILES tinylog.properties=../jabsrv-cli/src/main/resources/tinylog.properties
+
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/BibEntryDTO.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GlobalExceptionMapper.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/GsonFactory.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/JabrefMediaType.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/JabRefResourceLocator.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/CORSFilter.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/LibrariesResource.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/PreferencesFactory.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/RootResource.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/Server.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/server/services/FilesToServe.java
+
+//REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
+
+//DEPS org.jabref:jablib:6.+
+//DEPS info.picocli:picocli:4.7.7
+
+// from jabsrv
+//DEPS org.slf4j:slf4j-api:2.0.17
+//DEPS org.tinylog:slf4j-tinylog:2.7.0
+//DEPS org.tinylog:tinylog-impl:2.7.0
+//DEPS org.slf4j:jul-to-slf4j:2.0.17
+//DEPS org.apache.logging.log4j:log4j-to-slf4j:2.24.3
+//DEPS info.picocli:picocli:4.7.7
+//DEPS org.postgresql:postgresql:42.7.5
+//DEPS org.bouncycastle:bcprov-jdk18on:1.80
+//DEPS com.konghq:unirest-modules-gson:4.4.7
+//DEPS jakarta.ws.rs:jakarta.ws.rs-api:4.0.0
+//DEPS org.glassfish.jersey.core:jersey-server:3.1.10
+//DEPS org.glassfish.jersey.inject:jersey-hk2:3.1.10
+//DEPS org.glassfish.hk2:hk2-api:3.1.1
+//DEPS org.glassfish.hk2:hk2-utils:3.1.1
+//DEPS org.glassfish.hk2:hk2-locator:3.1.1
+//DEPS org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.1.10
+//DEPS org.glassfish.grizzly:grizzly-http-server:4.0.2
+//DEPS org.glassfish.grizzly:grizzly-framework:4.0.2
+//DEPS jakarta.validation:jakarta.validation-api:3.1.1
+//DEPS org.hibernate.validator:hibernate-validator:8.0.2.Final
+//DEPS com.konghq:unirest-modules-gson:4.4.7
+//DEPS com.google.guava:guava:33.4.8-jre
+//DEPS org.jabref:afterburner.fx:2.0.0
+//DEPS net.harawata:appdirs:1.4.0
+//DEPS de.undercouch:citeproc-java:3.3.0
+
+/// This class is required for [jbang](https://www.jbang.dev/)
+public class JabSrvLauncher {
+    public static void main(String[] args) throws Exception {
+        org.jabref.http.server.cli.ServerCli.main(args);
+    }
+}

--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -19,7 +19,7 @@ If that list is also empty, the file `src/main/resources/org/jabref/http/server/
 
 ### Starting with JBang
 
-In case one wants to interact with the http server only and does not want to setup or run IntelliJ, [JBang](https://www.jbang.dev/download/) can be used.
+In case you want to interact only with the http server and do not want to set up or run IntelliJ, [JBang](https://www.jbang.dev/download/) can be used.
 
 In the repository root, run following command:
 

--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -10,19 +10,34 @@ The resource for a library is implemented at [`org.jabref.http.server.LibraryRes
 
 ## Start http server
 
+### Starting with IntelliJ
+
 The class starting the server is located in the project `jabsrv-cli` and is called `org.jabref.http.server.cli.ServerCli`.
 
 Test files to server can be passed as arguments.
-If no files are passed, the last opened files are served.
 If that list is also empty, the file `src/main/resources/org/jabref/http/server/http-server-demo.bib` is served.
+
+### Starting with JBang
+
+In case one wants to interact with the http server only and does not want to setup or run IntelliJ, [JBang](https://www.jbang.dev/download/) can be used.
+
+In the repository root, run following command:
+
+```shell
+jbang .jbang/JabSrvLauncher.java
+```
+
+JBang also offers running without explicit installation, if you have node installed (and WSL available in the case of Windows):
+
+```shell
+npx @jbangdev/jbang .jbang/JabSrvLauncher.java
+```
 
 ### Starting with gradle
 
 ```shell
 ./gradlew run :jabsrv:run
 ```
-
-The GUI is also started. Just close it.
 
 Gradle output:
 
@@ -49,6 +64,12 @@ INFO: [HttpServer] Started.
 2023-04-22 11:44:59 [ForkJoinPool.commonPool-worker-1] org.jabref.http.server.ServerCli.lambda$startServer$4()
 DEBUG: Server started.
 ```
+
+## Served libraries
+
+The last opened libraries are served.
+`demo` serves Chocolate.bib.
+Additional libraries can be served by passing them as arguments.
 
 ## Developing with IntelliJ
 

--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -76,6 +76,8 @@ Additional libraries can be served by passing them as arguments.
 IntelliJ Ultimate offers a Markdown-based http-client. One has to open the file `jabsrv/src/test/rest-api.http`.
 Then, there are play buttons appearing for interacting with the server.
 
+In case you want to debug on Windows, you need to choose "WSL" as the target for the debugger ("Run on") to avoid "command line too long" errors.
+
 ## Get SSL Working
 
 When interacting with the [Microsoft Word AddIn](https://github.com/JabRef/JabRef-Word-Addin), a SSL-based connection is required.

--- a/docs/code-howtos/http-server.md
+++ b/docs/code-howtos/http-server.md
@@ -73,7 +73,7 @@ Additional libraries can be served by passing them as arguments.
 
 ## Developing with IntelliJ
 
-IntelliJ Ultimate offers a Markdown-based http-client. One has to open the file `jabsrv/src/test/rest-api.http`.
+IntelliJ Ultimate offers a Markdown-based http-client. You need to open the file `jabsrv/src/test/rest-api.http`.
 Then, there are play buttons appearing for interacting with the server.
 
 In case you want to debug on Windows, you need to choose "WSL" as the target for the debugger ("Run on") to avoid "command line too long" errors.

--- a/jabsrv/src/main/java/org/jabref/http/server/LibrariesResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/LibrariesResource.java
@@ -1,5 +1,6 @@
 package org.jabref.http.server;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jabref.http.server.services.FilesToServe;
@@ -26,6 +27,8 @@ public class LibrariesResource {
         List<String> fileNamesWithUniqueSuffix = filesToServe.getFilesToServe().stream()
                                                             .map(p -> p.getFileName() + "-" + BackupFileUtil.getUniqueFilePrefix(p))
                                                             .toList();
-        return gson.toJson(fileNamesWithUniqueSuffix);
+        List<String> result = new ArrayList<>(fileNamesWithUniqueSuffix);
+        result.add("demo");
+        return gson.toJson(result);
     }
 }

--- a/jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,8 @@ public class LibraryResource {
         return parserResult;
     }
 
-    private InputStream getChocolateBibAsStream() {
+    /// @return a stream to the Chocolate.bib file in the classpath (is null only if the file was moved or there are issues with the classpath)
+    private @Nullable InputStream getChocolateBibAsStream() {
         return BibDatabase.class.getResourceAsStream("/Chocolate.bib");
     }
 }

--- a/jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/LibraryResource.java
@@ -1,6 +1,10 @@
 package org.jabref.http.server;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Objects;
@@ -13,6 +17,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.BackupFileUtil;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
@@ -27,6 +32,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +51,7 @@ public class LibraryResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getJson(@PathParam("id") String id) {
+    public String getJson(@PathParam("id") String id) throws IOException {
         ParserResult parserResult = getParserResult(id);
         BibEntryTypesManager entryTypesManager = Injector.instantiateModelOrService(BibEntryTypesManager.class);
         List<BibEntryDTO> list = parserResult.getDatabase().getEntries().stream()
@@ -57,28 +63,29 @@ public class LibraryResource {
 
     @GET
     @Produces(JabrefMediaType.JSON_CSL_ITEM)
-    public String getClsItemJson(@PathParam("id") String id) {
+    public String getClsItemJson(@PathParam("id") String id) throws IOException {
         ParserResult parserResult = getParserResult(id);
         JabRefItemDataProvider jabRefItemDataProvider = new JabRefItemDataProvider();
         jabRefItemDataProvider.setData(parserResult.getDatabaseContext(), new BibEntryTypesManager());
         return jabRefItemDataProvider.toJson();
     }
 
-    private ParserResult getParserResult(String id) {
-        java.nio.file.Path library = getLibraryPath(id);
-        ParserResult parserResult;
-        try {
-            parserResult = new BibtexImporter(preferences.getImportFormatPreferences(), new DummyFileUpdateMonitor()).importDatabase(library);
-        } catch (IOException e) {
-            LOGGER.warn("Could not find open library file {}", library, e);
-            throw new InternalServerErrorException("Could not parse library", e);
-        }
-        return parserResult;
-    }
-
     @GET
     @Produces(JabrefMediaType.BIBTEX)
     public Response getBibtex(@PathParam("id") String id) {
+        if ("demo".equals(id)) {
+            StreamingOutput stream = output -> {
+                try (InputStream in = getChocolateBibAsStream()) {
+                    in.transferTo(output);
+                }
+            };
+
+            return Response.ok(stream)
+                           // org.glassfish.jersey.media would be required for a "nice" Java to create ContentDisposition; we avoid this
+                           .header("Content-Disposition", "attachment; filename=\"Chocolate.bib\"")
+                           .build();
+        }
+
         java.nio.file.Path library = getLibraryPath(id);
         String libraryAsString;
         try {
@@ -88,6 +95,7 @@ public class LibraryResource {
             throw new InternalServerErrorException("Could not read library " + library, e);
         }
         return Response.ok()
+                .header("Content-Disposition", "attachment; filename=\"" + library.getFileName() + "\"")
                 .entity(libraryAsString)
                 .build();
     }
@@ -98,5 +106,30 @@ public class LibraryResource {
                           .filter(p -> (p.getFileName() + "-" + BackupFileUtil.getUniqueFilePrefix(p)).equals(id))
                           .findAny()
                           .orElseThrow(NotFoundException::new);
+    }
+
+    private ParserResult getParserResult(String id) throws IOException {
+        BibtexImporter bibtexImporter = new BibtexImporter(preferences.getImportFormatPreferences(), new DummyFileUpdateMonitor());
+
+        if ("demo".equals(id)) {
+            try (InputStream chocolateBibInputStream = getChocolateBibAsStream()) {
+                BufferedReader reader = new BufferedReader(new InputStreamReader(chocolateBibInputStream, StandardCharsets.UTF_8));
+                return bibtexImporter.importDatabase(reader);
+            }
+        }
+
+        java.nio.file.Path library = getLibraryPath(id);
+        ParserResult parserResult;
+        try {
+            parserResult = bibtexImporter.importDatabase(library);
+        } catch (IOException e) {
+            LOGGER.warn("Could not find open library file {}", library, e);
+            throw new InternalServerErrorException("Could not parse library", e);
+        }
+        return parserResult;
+    }
+
+    private InputStream getChocolateBibAsStream() {
+        return BibDatabase.class.getResourceAsStream("/Chocolate.bib");
     }
 }

--- a/jabsrv/src/test/java/org/jabref/http/server/LibrariesResourceTest.java
+++ b/jabsrv/src/test/java/org/jabref/http/server/LibrariesResourceTest.java
@@ -23,8 +23,9 @@ class LibrariesResourceTest extends ServerTest {
     void defaultOneTestLibrary() {
         String expected = """
                 [
+                  "%s",
                   "%s"
-                ]""".formatted(TestBibFile.GENERAL_SERVER_TEST.id);
+                ]""".formatted(TestBibFile.GENERAL_SERVER_TEST.id, "demo");
         assertEquals(expected, target("/libraries").request().get(String.class));
     }
 
@@ -36,8 +37,9 @@ class LibrariesResourceTest extends ServerTest {
         String expected = """
                 [
                   "%s",
+                  "%s",
                   "%s"
-                ]""".formatted(TestBibFile.GENERAL_SERVER_TEST.id, TestBibFile.CHOCOLATE_BIB.id);
+                ]""".formatted(TestBibFile.GENERAL_SERVER_TEST.id, TestBibFile.CHOCOLATE_BIB.id, "demo");
         assertEquals(expected, target("/libraries").request().get(String.class));
     }
 }

--- a/jabsrv/src/test/rest-api.http
+++ b/jabsrv/src/test/rest-api.http
@@ -1,36 +1,70 @@
+# JabRef REST AP
+
 // This file is for IntelliJ's HTTP Client, available in the Ultimate Edition
+
+// One can start an http server using following command:
+//
+// npx @jbangdev/jbang https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java
+//
+// in case JBang is installed (https://www.jbang.dev/download/), following command works, too:
+//
+// jbang https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java
+
+// Alternatively, you can push the green play button in org.jabref.http.server.cli.ServerCli.
+
+### Get a HTML page asking the user to go to /libraries
 
 GET http://localhost:6050
 
-###
+### Get the list of all libraries
 
 GET http://localhost:6050/libraries
 Accept: application/json
 
-###
+## demo cases
 
-GET http://localhost:6050/libraries/notfound
+// JabRef ships with "Chocolate.bib", which is "magically" served when asking for "demo"
 
-###
+### Get JSON of Chocolate.bib
 
-// if you have checkout the JabRef code at c:\git-repositories\jabref, then this
-// will show the contents of your first opened library as BibTeX
+GET http://localhost:6050/libraries/demo
+Accept: application/json
 
-GET http://localhost:6050/libraries/Chocolate.bib-026bd7ec
+### Get plain BibTeX of Chocolate.bib
+
+GET http://localhost:6050/libraries/demo
 Accept: application/x-bibtex
 
-###
+### Get CSL JSON of Chocolate.bib
 
 // if you have checkout the JabRef code at c:\git-repositories\jabref, then this
 // will show the contents of your first opened library using CSL JSON
 
-GET http://localhost:6050/libraries/Chocolate.bib-026bd7ec
+GET http://localhost:6050/libraries/demo
 Accept: application/x-bibtex-library-csl+json
 
-###
+## From here: C:\git-repositories\JabRef\jablib\src\main\resources\Chocolate.bib is required
+
+### Get BibTeX of C:\git-repositories\JabRef\jablib\src\main\resources\Chocolate.bib
+
+GET http://localhost:6050/libraries/Chocolate.bib-6a732609
+Accept: application/x-bibtex
+
+### Get JSON of C:\git-repositories\JabRef\jablib\src\main\resources\Chocolate.bib
+
+GET http://localhost:6050/libraries/Chocolate.bib-6a732609
+Accept: application/json
+
+### Get CSL JSON of C:\git-repositories\JabRef\jablib\src\main\resources\Chocolate.bib
 
 // if you have checkout the JabRef code at c:\git-repositories\jabref, then this
-// will show the contents of your first opened library using json + embedded BibTeX
+// will show the contents of your first opened library using CSL JSON
 
-GET http://localhost:6050/libraries/Chocolate.bib-026bd7ec
-Accept: application/json
+GET http://localhost:6050/libraries/Chocolate.bib-6a732609
+Accept: application/x-bibtex-library-csl+json
+
+## Error cases
+
+### GET not avaialble library
+
+GET http://localhost:6050/libraries/notfound

--- a/jabsrv/src/test/rest-api.http
+++ b/jabsrv/src/test/rest-api.http
@@ -2,7 +2,7 @@
 
 // This file is for IntelliJ's HTTP Client, available in the Ultimate Edition
 
-// One can start an http server using following command:
+// You can start an http server using following command:
 //
 // npx @jbangdev/jbang https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java
 //


### PR DESCRIPTION
- Add "demo" library for http: for test setups, it is useful to have some path working on all instances. <http://localhost:6050/libraries/demo> is now available on all platforms
- On Windows checkout, the "real" Chocolate.bib is now served (it is the same content as served at `/demo`)
- Enable `jbang https://github.com/JabRef/jabref/blob/main/.jbang/JabSrvLauncher.java`
- Restructured `rest-api.http`

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
