### PR TITLE
fix location of properties files for crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,6 @@
 files:
-  - source: /src/main/resources/l10n/JabRef_en.properties
-    translation: /src/main/resources/l10n/JabRef_%two_letters_code%.properties
+  - source: jablib/src/main/resources/l10n/JabRef_en.properties
+    translation: jablib/src/main/resources/l10n/JabRef_%two_letters_code%.properties
     languages_mapping:
       two_letters_code:
         pt-BR: pt_BR


### PR DESCRIPTION
Fix properties location

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
