### PR TITLE
fixed issue #12856

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -336,7 +336,7 @@ public class EntryEditor extends BorderPane implements PreviewControls, AdaptVis
                 stateManager);
         tabs.add(sourceTab);
         tabs.add(new LatexCitationsTab(preferences, dialogService, stateManager, directoryMonitor));
-        tabs.add(new FulltextSearchResultsTab(stateManager, preferences, dialogService, taskExecutor));
+        tabs.add(new FulltextSearchResultsTab(stateManager, preferences, dialogService, taskExecutor,this));
         tabs.add(new AiSummaryTab(aiService, dialogService, stateManager, this, preferences));
         tabs.add(new AiChatTab(aiService, dialogService, preferences, stateManager, this, taskExecutor));
 

--- a/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -347,7 +347,7 @@ public class MainMenu extends MenuBar {
                 factory.createMenuItem(StandardActions.SHOW_PDF_VIEWER, new ShowDocumentViewerAction(stateManager, preferences)),
                 factory.createMenuItem(StandardActions.EDIT_ENTRY, new OpenEntryEditorAction(frame::getCurrentLibraryTab, stateManager)),
                 factory.createMenuItem(StandardActions.OPEN_CONSOLE, new OpenConsoleAction(stateManager, preferences, dialogService))
-        );
+                );
 
         help.getItems().addAll(
                 factory.createMenuItem(StandardActions.HELP, new HelpAction(HelpFile.CONTENTS, dialogService, preferences.getExternalApplicationsPreferences())),


### PR DESCRIPTION


<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
<!-- Example: Closes (link) OR Closes #12345 -->

Closes [#12856](https://github.com/JabRef/jabref/issues/12865)
Implemented handleFocus() in FulltextSearchResultsTab , now search results tab shows correctly after a fulltext search, and disappear after the fulltextsearch flag is disabled; fixed also an issue where sometimes the search results tab would be empty after a successful search.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
