### PR TITLE
Enable JEP-450 and ZGC

### DIFF
--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -363,6 +363,7 @@ jobs:
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
           --java-options -XX:+UseZGC \
+          --java-options -XX:+ZUncommit \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -362,8 +362,8 @@ jobs:
           --jlink-options --bind-services \
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
-          --java-options -XX:+UseZGC \
-          --java-options -XX:+ZUncommit \
+          --java-options -XX:+UseZGC --java-options -XX:+ZUncommit \
+          --java-options -XX:+UseStringDeduplication \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -360,6 +360,8 @@ jobs:
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services \
+          --java-options -XX:+UnlockExperimentalVMOptions \
+          --java-options -XX:+UseCompactObjectHeaders \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -362,6 +362,7 @@ jobs:
           --jlink-options --bind-services \
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
+          --java-options -XX:+UseZGC \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -261,8 +261,8 @@ jobs:
           --jlink-options --bind-services \
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
-          --java-options -XX:+UseZGC \
-          --java-options -XX:+ZUncommit \
+          --java-options -XX:+UseZGC --java-options -XX:+ZUncommit \
+          --java-options -XX:+UseStringDeduplication \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -262,6 +262,7 @@ jobs:
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
           --java-options -XX:+UseZGC \
+          --java-options -XX:+ZUncommit \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -259,6 +259,8 @@ jobs:
           --resource-dir buildres/mac \
           --file-associations buildres/mac/bibtexAssociations.properties \
           --jlink-options --bind-services \
+          --java-options -XX:+UnlockExperimentalVMOptions \
+          --java-options -XX:+UseCompactObjectHeaders \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -261,6 +261,7 @@ jobs:
           --jlink-options --bind-services \
           --java-options -XX:+UnlockExperimentalVMOptions \
           --java-options -XX:+UseCompactObjectHeaders \
+          --java-options -XX:+UseZGC \
           --java-options --add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module \
           --java-options --add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module \
           --java-options --add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module \

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -151,7 +151,7 @@ application {
 
         // Note that the arguments are cleared for the "run" task to avoid messages like "WARNING: Unknown module: org.jabref.merged.module specified to --add-exports"
 
-        // Enable JEP 519: Compact Object Headers
+        // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
         // Fix for https://github.com/JabRef/jabref/issues/11188

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -154,7 +154,7 @@ application {
         // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
-        "-XX:+UseZGC",
+        "-XX:+UseZGC", "-XX:+ZUncommit",
 
         // Fix for https://github.com/JabRef/jabref/issues/11188
         "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -154,6 +154,8 @@ application {
         // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
+        "-XX:+UseZGC",
+
         // Fix for https://github.com/JabRef/jabref/issues/11188
         "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",
         "--add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -147,10 +147,12 @@ application {
     applicationDefaultJvmArgs = listOf(
         // On a change here, also adapt
         //   1. "run > moduleOptions"
-        //   2. "deployment.yml" (macOS part)
-        //   3. "deployment-arm64.yml"
+        //   2. "binaries.yml" (macOS part)
 
         // Note that the arguments are cleared for the "run" task to avoid messages like "WARNING: Unknown module: org.jabref.merged.module specified to --add-exports"
+
+        // Enable JEP 519: Compact Object Headers
+        "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
         // Fix for https://github.com/JabRef/jabref/issues/11188
         "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -155,6 +155,7 @@ application {
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
         "-XX:+UseZGC", "-XX:+ZUncommit",
+        "-XX:+UseStringDeduplication",
 
         // Fix for https://github.com/JabRef/jabref/issues/11188
         "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",

--- a/jabkit/build.gradle.kts
+++ b/jabkit/build.gradle.kts
@@ -78,7 +78,7 @@ application {
 
     // Also passed to launcher (https://badass-jlink-plugin.beryx.org/releases/latest/#launcher)
     applicationDefaultJvmArgs = listOf(
-        // Enable JEP 519: Compact Object Headers
+        // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
         "--enable-native-access=com.sun.jna,javafx.graphics,org.apache.lucene.core"
     )

--- a/jabkit/build.gradle.kts
+++ b/jabkit/build.gradle.kts
@@ -80,6 +80,10 @@ application {
     applicationDefaultJvmArgs = listOf(
         // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
+
+        // Default garbage collector is sufficient for CLI APP
+        // "-XX:+UseZGC",
+
         "--enable-native-access=com.sun.jna,javafx.graphics,org.apache.lucene.core"
     )
 }

--- a/jabkit/build.gradle.kts
+++ b/jabkit/build.gradle.kts
@@ -83,6 +83,7 @@ application {
 
         // Default garbage collector is sufficient for CLI APP
         // "-XX:+UseZGC", "-XX:+ZUncommit",
+        // "-XX:+UseStringDeduplication",
 
         "--enable-native-access=com.sun.jna,javafx.graphics,org.apache.lucene.core"
     )

--- a/jabkit/build.gradle.kts
+++ b/jabkit/build.gradle.kts
@@ -78,6 +78,8 @@ application {
 
     // Also passed to launcher (https://badass-jlink-plugin.beryx.org/releases/latest/#launcher)
     applicationDefaultJvmArgs = listOf(
+        // Enable JEP 519: Compact Object Headers
+        "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
         "--enable-native-access=com.sun.jna,javafx.graphics,org.apache.lucene.core"
     )
 }

--- a/jabkit/build.gradle.kts
+++ b/jabkit/build.gradle.kts
@@ -82,7 +82,7 @@ application {
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
         // Default garbage collector is sufficient for CLI APP
-        // "-XX:+UseZGC",
+        // "-XX:+UseZGC", "-XX:+ZUncommit",
 
         "--enable-native-access=com.sun.jna,javafx.graphics,org.apache.lucene.core"
     )

--- a/jabsrv-cli/build.gradle.kts
+++ b/jabsrv-cli/build.gradle.kts
@@ -21,6 +21,7 @@ application{
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
         "-XX:+UseZGC", "-XX:+ZUncommit",
+        "-XX:+UseStringDeduplication",
 
         "--enable-native-access=com.sun.jna,org.apache.lucene.core"
     )

--- a/jabsrv-cli/build.gradle.kts
+++ b/jabsrv-cli/build.gradle.kts
@@ -17,7 +17,12 @@ application{
     mainModule.set("org.jabref.jabsrv.cli")
 
     applicationDefaultJvmArgs = listOf(
-        "--enable-native-access=com.sun.jna"
+        // Enable JEP 450: Compact Object Headers
+        "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
+
+        "-XX:+UseZGC",
+
+        "--enable-native-access=com.sun.jna,org.apache.lucene.core"
     )
 }
 

--- a/jabsrv-cli/build.gradle.kts
+++ b/jabsrv-cli/build.gradle.kts
@@ -119,15 +119,6 @@ tasks.named<JavaExec>("run") {
     }
 }
 
-tasks.named<JavaExec>("run") {
-    doFirst {
-        application.applicationDefaultJvmArgs =
-            listOf(
-                "--enable-native-access=com.sun.jna"
-            )
-    }
-}
-
 // This is more or less a clone of jabgui/build.gradle.kts -> jlink
 jlink {
     // https://github.com/beryx/badass-jlink-plugin/issues/61#issuecomment-504640018

--- a/jabsrv-cli/build.gradle.kts
+++ b/jabsrv-cli/build.gradle.kts
@@ -20,7 +20,7 @@ application{
         // Enable JEP 450: Compact Object Headers
         "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCompactObjectHeaders",
 
-        "-XX:+UseZGC",
+        "-XX:+UseZGC", "-XX:+ZUncommit",
 
         "--enable-native-access=com.sun.jna,org.apache.lucene.core"
     )


### PR DESCRIPTION
This enables [JEP 450: Compact Object Headers (Experimental)](https://openjdk.org/jeps/450).

They are considered stable: [JEP 519: Compact Object Headers](https://openjdk.org/jeps/519)

> In one setting, the SPECjbb2015 benchmark uses [22% less heap space and 8% less CPU time](https://github.com/rkennke/talks/blob/master/Lilliput-FOSDEM-2025.pdf).
>
> In another setting, the number of garbage collections done by SPECjbb2015 is [reduced by 15%](https://bugs.openjdk.org/browse/JDK-8350457?focusedId=14766358&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14766358), with both the G1 and Parallel collectors.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
