### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
-<!-- YOU HAVE TO MODIFY THE TEXT BELOW TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->
+Closes #_____
 
-<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD -->
-<!-- Example: Closes (link) OR Closes #12345 -->
+Describe the changes you have made here: what, where, why, ... in a short and crisp way.
 
-Closes _____
-Describe the changes you have made here: what, where, why, ...
 If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ...
+
+<!-- YOU HAVE TO MODIFY THE TEXT ABOVE TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->
+<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes (link) OR Closes #12345 -->
 
 ### Mandatory checks
 


### PR DESCRIPTION
GitHub app on the mobile phone always displsays `<!-- YOU HAVE TO ...` as preview text. I think, I cannot convince GitHub to update their app to "correctly" render the PR text.

I think, adding "PLEASE DELETE THIS TEXT" is not a good instruction.

Thus, I propose to re-order the text in the PR template.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
