### PR TITLE
Add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+set windows-shell := ["powershell"]
+
+[unix]
+gui:
+    sh ./gg.cmd gradle :jabgui:run
+
+[unix]
+checkout-pr pr-id:
+    sh ./gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
+
+[windows]
+gui:
+    .\gg.cmd gradle :jabgui:run
+
+[windows]
+checkout-pr pr-id:
+    .\gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
+
+run-pr pr-id:
+    just checkout-pr {{pr-id}}
+    just gui


### PR DESCRIPTION
This adds a `justfile` to enable `.\gg.cmd gh/casey/just run-pr 13182`.

A justfile is read by [`just`](https://just.systems/). 

Alternative could be [mise tasks](https://mise.jdx.dev/tasks/), but they are not that easily to get running on different platforms with the same 

Future

    .\gg.cmd just run-pr 13182

(blocked by https://github.com/eirikb/gg/issues/112)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
