### PR TITLE
feat(focus): Add functionality to focus on running instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added an "Open example library" button to Welcome Tab. [#13014](https://github.com/JabRef/jabref/issues/13014)
 - We added automatic detection and selection of the identifier type (e.g., DOI, ISBN, arXiv) based on clipboard content when opening the "New Entry" dialog [#13111](https://github.com/JabRef/jabref/pull/13111)
 - We added support for import of a Refer/BibIX file format. [#13069](https://github.com/JabRef/jabref/issues/13069)
+- We added functionality to focus running instance when trying to start a second instance. [#13129](https://github.com/JabRef/jabref/issues/13129)
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added support for import of a Refer/BibIX file format. [#13069](https://github.com/JabRef/jabref/issues/13069)
 - We added functionality to focus running instance when trying to start a second instance. [#13129](https://github.com/JabRef/jabref/issues/13129)
 
-
 ### Changed
 
 - We moved some functionality from the graphical application `jabref` with new command verbs `generate-citation-keys`, `check-consistency`, `fetch`, `search`, `convert`, `generate-bib-from-aux`, `preferences` and `pdf` to the new toolkit. [#13012](https://github.com/JabRef/jabref/pull/13012) [#110](https://github.com/JabRef/jabref/issues/110)

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -645,7 +645,6 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     public void handleUiCommands(List<UiCommand> uiCommands) {
         if (uiCommands.stream().anyMatch(UiCommand.Focus.class::isInstance)) {
             mainStage.toFront();
-            mainStage.requestFocus();
             return;
         }
         viewModel.handleUiCommands(uiCommands);

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -643,6 +643,11 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
     @Override
     public void handleUiCommands(List<UiCommand> uiCommands) {
+        if (uiCommands.stream().anyMatch(UiCommand.Focus.class::isInstance)) {
+            mainStage.toFront();
+            mainStage.requestFocus();
+            return;
+        }
         viewModel.handleUiCommands(uiCommands);
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/remote/CLIMessageHandler.java
+++ b/jabgui/src/main/java/org/jabref/gui/remote/CLIMessageHandler.java
@@ -36,4 +36,9 @@ public class CLIMessageHandler implements RemoteMessageHandler {
         List<UiCommand> uiCommands = argumentProcessor.processArguments();
         Platform.runLater(() -> uiMessageHandler.handleUiCommands(uiCommands));
     }
+
+    @Override
+    public void handleFocus() {
+        Platform.runLater(() -> uiMessageHandler.handleUiCommands(List.of(new UiCommand.Focus())));
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/UiCommand.java
+++ b/jablib/src/main/java/org/jabref/logic/UiCommand.java
@@ -12,6 +12,8 @@ public sealed interface UiCommand {
 
     record AppendToCurrentLibrary(List<Path> toAppend) implements UiCommand { }
 
+    record Focus() implements UiCommand { }
+
     /// @deprecated used by the browser extension only
     @Deprecated
     record AppendBibTeXToCurrentLibrary(String bibtex) implements UiCommand { }

--- a/jablib/src/main/java/org/jabref/logic/remote/RemoteMessage.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/RemoteMessage.java
@@ -16,5 +16,9 @@ public enum RemoteMessage {
     /**
      * Request server to identify itself. No message content.
      */
-    PING
+    PING,
+    /**
+     * Request the running instance to focus its window. No message content.
+     */
+    FOCUS
 }

--- a/jablib/src/main/java/org/jabref/logic/remote/RemoteMessage.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/RemoteMessage.java
@@ -18,7 +18,7 @@ public enum RemoteMessage {
      */
     PING,
     /**
-     * Request the running instance to focus its window. No message content.
+     * Request the running instance to focus its window when a second instance tries to execute. No message content.
      */
     FOCUS
 }

--- a/jablib/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
@@ -63,6 +63,22 @@ public class RemoteClient {
         }
     }
 
+    /**
+     * Attempt to send a focus command to already running JabRef instance.
+     *
+     * @return true if successful, false otherwise.
+     */
+    public boolean sendFocus() {
+        try (Protocol protocol = openNewConnection()) {
+            protocol.sendMessage(RemoteMessage.FOCUS);
+            javafx.util.Pair<RemoteMessage, Object> response = protocol.receiveMessage();
+            return response.getKey() == RemoteMessage.OK;
+        } catch (IOException e) {
+            LOGGER.debug("Could not send focus command to the server at port {}", port, e);
+            return false;
+        }
+    }
+
     private Protocol openNewConnection() throws IOException {
         Socket socket = new Socket();
         socket.setSoTimeout(TIMEOUT);

--- a/jablib/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/client/RemoteClient.java
@@ -71,7 +71,7 @@ public class RemoteClient {
     public boolean sendFocus() {
         try (Protocol protocol = openNewConnection()) {
             protocol.sendMessage(RemoteMessage.FOCUS);
-            javafx.util.Pair<RemoteMessage, Object> response = protocol.receiveMessage();
+            Pair<RemoteMessage, Object> response = protocol.receiveMessage();
             return response.getKey() == RemoteMessage.OK;
         } catch (IOException e) {
             LOGGER.debug("Could not send focus command to the server at port {}", port, e);

--- a/jablib/src/main/java/org/jabref/logic/remote/server/RemoteListenerServer.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/server/RemoteListenerServer.java
@@ -63,6 +63,10 @@ public class RemoteListenerServer implements Runnable {
                     throw new IOException("Argument for 'SEND_COMMAND_LINE_ARGUMENTS' is not of type String[]. Got " + argument);
                 }
                 break;
+            case FOCUS:
+                messageHandler.handleFocus();
+                protocol.sendMessage(RemoteMessage.OK);
+                break;
             default:
                 throw new IOException("Unhandled message to server " + type);
         }

--- a/jablib/src/main/java/org/jabref/logic/remote/server/RemoteMessageHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/server/RemoteMessageHandler.java
@@ -4,5 +4,5 @@ package org.jabref.logic.remote.server;
 public interface RemoteMessageHandler {
     void handleCommandLineArguments(String[] message);
 
-    default void handleFocus() {}
+    default void handleFocus() { }
 }

--- a/jablib/src/main/java/org/jabref/logic/remote/server/RemoteMessageHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/server/RemoteMessageHandler.java
@@ -3,4 +3,6 @@ package org.jabref.logic.remote.server;
 @FunctionalInterface
 public interface RemoteMessageHandler {
     void handleCommandLineArguments(String[] message);
+
+    default void handleFocus() {}
 }


### PR DESCRIPTION
Closes #13129 
This issue consisted on focusing a running instance of Jabref when the user tried to open another instance of the program. To do so, the first step was to modify the handleMultipleAppInstances function, to return an option from an enum containing CONTINUE, SHUTDOWN, FOCUS to determine what to do next. If there is no instance, CONTINUE is selected and one boots up, if an instance is running, FOCUS is returned. Focus is a function created inside UiCommands. In the launcher if FOCUS is returned it triggers RemoteClient's sendFocus function, which sends the message FOCUS and its outlined inside RemoteMessage. Then the RemoteListenerServer picks up this FOCUS message inside of a case within a switch, which calls a function from the RemoteMessageHandler called handlerFocus() and being overridden inside CLIMessageHandler, and sends the platform a list of  UiCommands, consisting of one UiCommand.Focus (This because JabRefFrame expects a list of UiCommands not just one UiCommand). This UiCommand is then picked up in JabRefFrame, which then calls the toFront() and requestFocus() functions to show the running instance. 
This makes the user see the already running instance, and at the same time handles all the functions needed to send Focus from the Launcher to the JabRefFrame. 


## Running JabRef Instance from IntelliJ 
<img width="1680" alt="Screenshot 2025-05-30 at 12 50 51 p m" src="https://github.com/user-attachments/assets/49f628bc-a1ae-4a85-bbbe-ab90aadb0be5" />

## Message when running ./gradlew jabgui:run in Terminal with running instance
<img width="559" alt="Screenshot 2025-05-30 at 12 55 32 p m" src="https://github.com/user-attachments/assets/9fe4f702-5f28-4336-b5a5-4fd363521899" />



### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
