### PR TITLE
Add run-jabkit and run-jabsrv to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,21 +1,37 @@
 set windows-shell := ["powershell"]
 
 [unix]
-gui:
-    sh ./gg.cmd gradle :jabgui:run
-
-[unix]
 checkout-pr pr-id:
     sh ./gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
 
-[windows]
-gui:
-    .\gg.cmd gradle :jabgui:run
+[unix]
+run-gui:
+    sh ./gg.cmd gradle :jabgui:run
+
+[unix]
+run-jabkit *FLAGS:
+    sh ./gg.cmd gradle :jabkit:run --args="{{FLAGS}}"
+
+[unix]
+run-jabsrv *FLAGS:
+    sh ./gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
 
 [windows]
 checkout-pr pr-id:
     .\gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
 
+[windows]
+run-gui:
+    .\gg.cmd gradle :jabgui:run
+
+[windows]
+run-jabkit *FLAGS:
+    .\gg.cmd gradle :jabkit:run --args="{{FLAGS}}"
+
+[windows]
+run-jabsrv *FLAGS:
+    .\gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
+
 run-pr pr-id:
     just checkout-pr {{pr-id}}
-    just gui
+    just run-gui


### PR DESCRIPTION
This refines the `justfile` to enable

    .\gg.cmd just run-jabkit --help

and

    .\gg.cmd just run-jabsrv C:\temp\test.bib

This is for users and developrs not wanting to install a JDK or input more complicated gradle commands.

Moreover, `gui` run name was replaced by `run-gui`.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
