### PR TITLE
Add JBang tests and renovate support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,6 +273,24 @@ jobs:
           CI: "true"
           DBMS: "postgresql"
 
+  jbang:
+    name: JBang.md
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+      - name: Install JBang
+        run: |
+          curl -Ls https://sh.jbang.dev | bash -s - app setup
+          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+      - run: jbang build .jbang/CheckoutPR.java
+      - run: jbang build .jbang/CloneJabRef.java
+      - run: jbang build .jbang/JabKitLauncher.java
+      - run: jbang build .jbang/JabSrvLauncher.java
+
   codecoverage:
     if: false
     name: Code coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,7 +274,7 @@ jobs:
           DBMS: "postgresql"
 
   jbang:
-    name: JBang.md
+    name: JBang
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "regexManagers": [
+    {
+      "managerFilePatterns": ".jbang/*.java",
+      "matchStrings": [
+        "//DEPS (?<depName>\\S+):(\\${\\S+:(?<currentValue>[^ }]+)})",
+        "//DEPS ((?<depName>\\S+:\\S+):(?<currentValue>[^$]\\S+))(\\@\\w+)?"
+      ],
+      "datasourceTemplate": "maven"
+    }
+  ]
+}


### PR DESCRIPTION
We have four JBang scripts: https://github.com/JabRef/jabref/tree/main/.jbang - they specify dependencies inside the files and do not re-use the depdencies in `build.gradle.kts`.

I think, with [Forking Renovate GitHub App](https://github.com/apps/forking-renovate) and rough JBang tests, we could have automatic updates, similar to `dependabot`.

Alternative: Write a script updating the version numbers in the JBang scripts `//DEP` statements based on the information in `build.gradle.kts` files. Would be another JBang script :p. Maybe 50 lines, but IDK if its worth.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
