### PR TITLE
Add link to JabRef guru

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -24,7 +24,7 @@ jobs:
 
             We're excited to have you on board. Start by exploring our [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) guidelines, and don't forget to check out our [workspace setup guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) to get started smoothly.
 
-            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref).
+            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref) or our gitter chat.
 
             In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
 

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -24,6 +24,8 @@ jobs:
 
             We're excited to have you on board. Start by exploring our [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) guidelines, and don't forget to check out our [workspace setup guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) to get started smoothly.
 
+            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref).
+
             In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
 
             Having any questions or issues? Feel free to ask here on GitHub. Need help setting up your local workspace? Join the conversation on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref). And don't hesitate to open a (draft) pull request early on to show the direction it is heading towards. This way, you will receive valuable feedback.

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -24,7 +24,7 @@ jobs:
 
             We're excited to have you on board. Start by exploring our [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) guidelines, and don't forget to check out our [workspace setup guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) to get started smoothly.
 
-            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref) or ask on our gitter chat.
+            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref) or ask on our Gitter chat.
 
             In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
 

--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -24,7 +24,7 @@ jobs:
 
             We're excited to have you on board. Start by exploring our [Contributing](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md) guidelines, and don't forget to check out our [workspace setup guidelines](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace) to get started smoothly.
 
-            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref) or our gitter chat.
+            For questions on JabRef functionality and the code base, you can consult the [JabRef Guru](https://gurubase.io/g/jabref) or ask on our gitter chat.
 
             In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
 

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -27,6 +27,8 @@ jobs:
               > [!WARNING]
               > This issue will be **automatically unassigned** in **{{ days_remaining }} days** if there's no activity.
 
+              Remember that you can ask the [JabRef Guru](https://gurubase.io/g/jabref) about anything regarding JabRef. Additionally, our contributing guide has [hints on creating a pull request](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#pull-request-process) and a link to our Gitter chat.
+
               <details open>
               <summary>How to keep your assignment</summary>
 


### PR DESCRIPTION
Since our gitter chat is not that frequently used, but students seem to be stuck, we add links to the JabRef Guru: https://gurubase.io/g/jabref on issue assignment and reminders.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
