### PR TITLE
Use setup-jbang action (instead of custom call of .sh script)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -283,9 +283,7 @@ jobs:
           submodules: 'false'
           show-progress: 'false'
       - name: Install JBang
-        run: |
-          curl -Ls https://sh.jbang.dev | bash -s - app setup
-          echo "$HOME/.jbang/bin" >> $GITHUB_PATH
+        uses: jbangdev/setup-jbang@main
       - run: jbang build .jbang/CheckoutPR.java
       - run: jbang build .jbang/CloneJabRef.java
       - run: jbang build .jbang/JabKitLauncher.java

--- a/.jbang/CheckoutPR.java
+++ b/.jbang/CheckoutPR.java
@@ -75,6 +75,8 @@ public class CheckoutPR {
             pr = repo.getPullRequest(prNumber);
         }
 
+        System.out.println("Determined PR URL is " + pr.getUrl());
+
         if (pr.isMerged()) {
             System.out.println("Pull request is already merged - checking out main branch...");
             checkoutUpstreamMain();

--- a/.jbang/CheckoutPR.java
+++ b/.jbang/CheckoutPR.java
@@ -147,6 +147,7 @@ public class CheckoutPR {
         }
 
         System.out.println("Checked out PR #" + pr.getNumber() + " (" + pr.getTitle() + ") to branch '" + localBranchName + "'.");
+        System.out.println("Checked out commit " + pr.getHead().getSha() + "'.");
     }
 
     private static void checkoutUpstreamMain() throws Exception {

--- a/.jbang/CheckoutPR.java
+++ b/.jbang/CheckoutPR.java
@@ -146,8 +146,8 @@ public class CheckoutPR {
                .call();
         }
 
-        System.out.println("Checked out PR #" + pr.getNumber() + " (" + pr.getTitle() + ") to branch '" + localBranchName + "'.");
-        System.out.println("Checked out commit " + pr.getHead().getSha() + "'.");
+        System.out.println("Checked out PR #" + pr.getNumber() + " (" + pr.getTitle() + ") to branch " + localBranchName + ".");
+        System.out.println("Checked out commit " + pr.getHead().getSha() + ".");
     }
 
     private static void checkoutUpstreamMain() throws Exception {

--- a/justfile
+++ b/justfile
@@ -46,7 +46,8 @@ run-jabkit *FLAGS:
 run-jabsrv *FLAGS:
     .\gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
 
-run-main: run main
+run-main:
+    just run main
 
 run-pr pr-id:
     just checkout-pr {{pr-id}}

--- a/justfile
+++ b/justfile
@@ -46,6 +46,8 @@ run-jabkit *FLAGS:
 run-jabsrv *FLAGS:
     .\gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
 
+run-main: run main
+
 run-pr pr-id:
     just checkout-pr {{pr-id}}
     just run-gui


### PR DESCRIPTION
Refines `CheckoutPR.java` to show more information

![image](https://github.com/user-attachments/assets/d1691151-bb38-4e0a-b20d-84128eee6086)

I wanted to show the current HEAD commit SHA, but this was not easily possible. Thus, I left "as is".

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
