### PR TITLE
Fix wrong detection of issue numbers

### DIFF
--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -42,8 +42,8 @@ jobs:
           titleRegex: '^#(?<ticketNumber>\d+)'
           branchRegex: '^(?<ticketNumber>\d+)'
           # Matches GitHub's closes/fixes/resolves #{number}, but does not match our example `Closes #12345` in PULL_REQUEST_TEMPLATE
-          # Also matches URLs that are wrapped in `<>` and melting pot issues.
-          bodyRegex: '(?<action>fixes|closes|resolves|refs)\s+<?(?:https?:\/\/github\.com\/JabRef\/(?:jabref|jabref-issue-melting-pot)\/issues\/)?#?(?<ticketNumber>(?!12345\b)\d+)>?'
+          # Also matches URLs that are wrapped in `<>`.
+          bodyRegex: '(?<action>fixes|closes|resolves|refs)\s+<?(?:https?:\/\/github\.com\/JabRef\/jabref\/issues\/)?#?(?<ticketNumber>(?!12345\b)\d+)>?'
           bodyRegexFlags: 'i'
           outputOnly: true
       - run: echo "${{ steps.get_issue_number.outputs.ticketNumber }}"


### PR DESCRIPTION
Hotfix for https://github.com/JabRef/jabref/pull/13206

Contributors were assigned wrong issue numbers.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
