### PR TITLE
Fix for issue #12928

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/help/AboutDialog.fxml
@@ -84,7 +84,7 @@
                 </StackPane>
             </AnchorPane>
             <Label styleClass="sub-heading" text="%Maintainers"/>
-            <Label alignment="CENTER" styleClass="info-sections" text="${controller.viewModel.maintainers}" textAlignment="JUSTIFY" wrapText="true"/>
+            <Label alignment="CENTER" styleClass="info-sections" prefHeight="85.0" text="${controller.viewModel.maintainers}" textAlignment="JUSTIFY" wrapText="true"/>
             <Label styleClass="sub-heading" text="%Contributors"/>
             <HBox alignment="CENTER_LEFT">
                 <Hyperlink styleClass="contrib-section" onAction="#openContributors" text="%JabRef would not have been possible without the help of our contributors." wrapText="true"/>


### PR DESCRIPTION
**Increased Height of maintainers text box to show all maintainers.**

Closes #12928

###In about one to three sentences, describe the changes you have made: what, where, why, ...

I changed the height of the maintainers text area to prefHeight="85.0" (no height declared before) so all the maintainer names are shown under Help > About JabRef. I chose this height so all maintainers are shown while keeping the contributor and version text area the same (without pushing the version text area to scroll)

Screenshot: (https://github.com/user-attachments/assets/8e0eb89f-ffc6-44e3-a40f-c7d4ab3ab7e8)

### Steps to test

Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change.

You can test this issue by running the program with this new code and going to "Help" > "About JabRef" to view the fix. 


### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
