### PR TITLE
Fix version check for alpha3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where bibliography entries generated from CSL styles had leading spaces. [#13074](https://github.com/JabRef/jabref/pull/13074)
 - We fixed an issue where the preview area in the "Select Style" dialog of the LibreOffice integration was too small to display full content. [#13051](https://github.com/JabRef/jabref/issues/13051)
 - We fixed an issue where the tab showing the fulltext search results was not displayed. [#12865](https://github.com/JabRef/jabref/issues/12865)
-- We fixed an issue where the Version checker did not correctly recognize the newer alpha version
+- We fixed an issue where the Version checker did not correctly recognize the newer alpha versions, [#13242](https://github.com/JabRef/jabref/pull/13242)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where bibliography entries generated from CSL styles had leading spaces. [#13074](https://github.com/JabRef/jabref/pull/13074)
 - We fixed an issue where the preview area in the "Select Style" dialog of the LibreOffice integration was too small to display full content. [#13051](https://github.com/JabRef/jabref/issues/13051)
 - We fixed an issue where the tab showing the fulltext search results was not displayed. [#12865](https://github.com/JabRef/jabref/issues/12865)
+- We fixed an issue where the Version checker did not correctly recognize the newer alpha version
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where bibliography entries generated from CSL styles had leading spaces. [#13074](https://github.com/JabRef/jabref/pull/13074)
 - We fixed an issue where the preview area in the "Select Style" dialog of the LibreOffice integration was too small to display full content. [#13051](https://github.com/JabRef/jabref/issues/13051)
 - We fixed an issue where the tab showing the fulltext search results was not displayed. [#12865](https://github.com/JabRef/jabref/issues/12865)
-- We fixed an issue where the Version checker did not correctly recognize the newer alpha versions, [#13242](https://github.com/JabRef/jabref/pull/13242)
+- We fixed an issue where the Version checker did not correctly recognize the newer alpha versions. [#13242](https://github.com/JabRef/jabref/pull/13242)
 
 ### Removed
 

--- a/jablib/src/main/java/org/jabref/logic/util/Version.java
+++ b/jablib/src/main/java/org/jabref/logic/util/Version.java
@@ -25,7 +25,7 @@ public class Version {
 
     private static final Version UNKNOWN_VERSION = new Version();
 
-    private final static Pattern VERSION_PATTERN = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(?<stage>-alpha|-beta)?(?<num>\\d+)?(?<dev>-?dev)?.*");
+    private final static Pattern VERSION_PATTERN = Pattern.compile("(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?(?<stage>-alpha|-beta)?(\\.|)(?<num>\\d+)?(?<dev>-?dev)?.*");
     private final static Pattern CI_SUFFIX_PATTERN = Pattern.compile("-ci\\.\\d+");
 
     private static final String JABREF_GITHUB_RELEASES = "https://api.github.com/repos/JabRef/JabRef/releases";

--- a/jablib/src/test/java/org/jabref/logic/util/VersionTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/VersionTest.java
@@ -307,6 +307,13 @@ class VersionTest {
     }
 
     @Test
+    void alpha3IsNewerThanAlpha2WithoutDot() {
+        Version alphaNewer = Version.parse("6.0-alpha.3-2025-04-27--c52dc44");
+        Version alphaNotNewer = Version.parse("6.0-alpha2");
+        assertTrue(alphaNewer.isNewerThan(alphaNotNewer));
+    }
+
+    @Test
     void alphaShouldBeUpdatedToStables() {
         Version alpha = Version.parse("2.8-alpha");
         Version stable = Version.parse("2.8");


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/877

We have dot and a version without a dot between the version number.




### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
