### PR TITLE
use closeImmediatly()

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/citation/repository/BibEntryRelationRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/citation/repository/BibEntryRelationRepository.java
@@ -23,4 +23,10 @@ public interface BibEntryRelationRepository {
     }
 
     void close();
+
+    /// Close the file and the store, without writing anything (if supported by the implementation).
+    /// This will stop the background thread. This method ignores all errors.
+    default void closeImmediately() {
+        close();
+    }
 }

--- a/jablib/src/main/java/org/jabref/logic/citation/repository/MVStoreBibEntryRelationRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/citation/repository/MVStoreBibEntryRelationRepository.java
@@ -141,4 +141,9 @@ public class MVStoreBibEntryRelationRepository implements BibEntryRelationReposi
     public void close() {
         this.store.close();
     }
+
+    @Override
+    public void closeImmediately() {
+        this.store.closeImmediately();
+    }
 }

--- a/jablib/src/test/java/org/jabref/logic/citation/repository/MVStoreBibEntryRelationRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citation/repository/MVStoreBibEntryRelationRepositoryTest.java
@@ -22,7 +22,6 @@ import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.identifier.DOI;
 import org.jabref.model.entry.types.StandardEntryType;
-import org.jabref.support.DisabledOnCIServer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@DisabledOnCIServer("Strange out of memory exceptions, works with manual testing")
 class MVStoreBibEntryRelationRepositoryTest {
 
     private final static String MV_STORE_NAME = "test-relations.mv";
@@ -63,7 +61,7 @@ class MVStoreBibEntryRelationRepositoryTest {
 
     @AfterEach
     void closeStore() {
-        this.dao.close();
+        this.dao.closeImmediately();
         // On the CI, we sometimes get "OutOfMemoryException"s. This tries to prevent that.
         System.gc();
     }
@@ -234,7 +232,7 @@ class MVStoreBibEntryRelationRepositoryTest {
 
         // WHEN
         daoUnderTest.addRelations(entry, relations);
-        daoUnderTest.close();
+        daoUnderTest.closeImmediately();
         daoUnderTest = new MVStoreBibEntryRelationRepository(file.toAbsolutePath(), MAP_NAME, 7, serializer);
         List<BibEntry> deserializedRelations = daoUnderTest.getRelations(entry);
 


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/11845

Hopefully fixes OutOfMemoryExceptions

Tries to make use of [`closeImmediatly()`](https://javadoc.io/doc/com.h2database/h2/1.4.192/org/h2/mvstore/MVStore.html) of MVStore

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
