### PR TITLE
Closes #13275 : export footer only for commands that support --output

### DIFF
--- a/jabkit/src/main/java/org/jabref/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/JabKit.java
@@ -106,7 +106,7 @@ public class JabKit {
             boolean hasInputOption = subCommand.getCommandSpec().options().stream()
                                                .anyMatch(opt -> Arrays.asList(opt.names()).contains("--input-format"));
             boolean hasOutputOption = subCommand.getCommandSpec().options().stream()
-                                                .anyMatch(opt -> Arrays.asList(opt.names()).contains("--output-format"));
+                                                .anyMatch(opt -> Arrays.asList(opt.names()).contains("--output"));
 
             String footerText = "";
             footerText += hasInputOption ? inputFooter : "";


### PR DESCRIPTION
Closes #13275 
the ``--output`` option is more indicative of export behavior than ``--output-format`` while checking among the option names.

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

#### Commands that export
``./gradlew :jabkit:run --args="convert --help"``
``./gradlew :jabkit:run --args="generate-bib-from-aux --help"``
``./gradlew :jabkit:run --args="generate-citation-keys --help"``
``./gradlew :jabkit:run --args="pseudonymize --help"``
``./gradlew :jabkit:run --args="search --help"``

#### Commands that don't
``./gradlew :jabkit:run --args="check-consistency --help"``
``./gradlew :jabkit:run --args="pdf --help"``
``./gradlew :jabkit:run --args="preferences --help"``



<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes (link) OR Closes #12345 -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
