### PR TITLE
Fix for issue 13234

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved JabRef's internal document viewer. It now allows text section, searching and highlighting of search terms and page rotation [#13193](https://github.com/JabRef/jabref/pull/13193).
 - When importing a PDF, there is no empty entry column shown in the multi merge dialog. [#13132](https://github.com/JabRef/jabref/issues/13132)
 - We added a progress dialog to the "Check consistency" action and progress output to the corresponding cli command. [#12487](https://github.com/JabRef/jabref/issues/12487)
+- We added Enhanced "Citation Relations" feature: "Look up a DOI and try again." is now a clickable hyperlink that triggers a DOI lookup. The link shows result states ("Looking up DOI...", "No DOI found", "List of citations") as appropriate.
 
 ### Fixed
 
@@ -1568,6 +1569,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added the ability to use negation in export filter layouts. [#5138](https://github.com/JabRef/jabref/pull/5138)
 - Focus on Name Area instead of 'OK' button whenever user presses 'Add subgroup'. [#6307](https://github.com/JabRef/jabref/issues/6307)
 - We changed the behavior of merging that the entry which has "smaller" bibkey will be selected. [#7395](https://github.com/JabRef/jabref/issues/7395)
+- we added a new 
 
 ### Fixed
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -403,10 +403,12 @@ public class CitationRelationsTab extends EntryEditorTab {
                 CrossRef doiFetcher = new CrossRef();
                 BackgroundTask.wrap(() -> doiFetcher.findIdentifier(entry))
                               .onRunning(() -> listView.setPlaceholder(new Label("Looking up DOI...")))
-                              .onFinished(() -> listView.setPlaceholder(placeHolder))
-                              .onSuccess(identifier -> {
-                                  if (identifier.isPresent()) {
-                                      System.out.println(identifier.get());
+                              .onSuccess(doiIdentifier -> {
+                                  if (doiIdentifier.isPresent()) {
+                                      System.out.println(doiIdentifier.get());
+                                      entry.setField(StandardField.DOI, doiIdentifier.get().asString());
+                                      searchForRelations(entry, listView, abortButton, refreshButton, searchType, importButton, progress, shouldRefresh);
+//                                      searchForRelations(entry, listView, abortButton, refreshButton, CitationFetcher.SearchType.CITED_BY, importButton, progress, shouldRefresh);
                                   } else {
                                       dialogService.notify("No DOI found");
                                   }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -405,10 +405,8 @@ public class CitationRelationsTab extends EntryEditorTab {
                               .onRunning(() -> listView.setPlaceholder(new Label("Looking up DOI...")))
                               .onSuccess(doiIdentifier -> {
                                   if (doiIdentifier.isPresent()) {
-                                      System.out.println(doiIdentifier.get());
                                       entry.setField(StandardField.DOI, doiIdentifier.get().asString());
                                       searchForRelations(entry, listView, abortButton, refreshButton, searchType, importButton, progress, shouldRefresh);
-//                                      searchForRelations(entry, listView, abortButton, refreshButton, CitationFetcher.SearchType.CITED_BY, importButton, progress, shouldRefresh);
                                   } else {
                                       dialogService.notify("No DOI found");
                                   }


### PR DESCRIPTION
Closes #13234 

This PR enhances the "Citation relations" feature by making the "Look up a DOI and try again." text a clickable hyperlink. On clicking, the text changes to "Looking up DOI...". Based on the lookup result:

If a DOI is found, it is used for citation relations.

If no DOI is found, a notification "No DOI found" is shown and the link resets to its original state.


### Steps to test

- Add a paper in jabRef entry editor. 
- Go to citation relations. You will see hyperlink. Click on that hyperlink.

<img width="1231" alt="Screenshot 2025-06-09 at 5 05 12 PM" src="https://github.com/user-attachments/assets/2e8f469f-e3d2-4151-9b4b-f2aefee9f3b9" />

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
