### PR TITLE
Speed up gradle update

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -3,6 +3,9 @@ name: Update Gradle Wrapper
 on:
   schedule:
     - cron: "0 5 * * 1"
+  pull_request:
+    paths:
+      - .github/workflows/update-gradle-wrapper.yml
   workflow_dispatch:
 
 jobs:
@@ -11,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '24'
-          distribution: 'liberica'
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2
         with:


### PR DESCRIPTION
According to https://github.com/gradle-update/update-gradle-wrapper-action, one does not need a JDK.

![image](https://github.com/user-attachments/assets/b5fdc5c3-752f-41fb-afcc-1658156e8952)

Follow-up to https://github.com/JabRef/jabref/pull/13282

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
