### PR TITLE
Use wiremock deps only in test

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -238,16 +238,14 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest-library:3.0")
 
     testImplementation("org.wiremock:wiremock:3.13.0")
-    // Required by Wiremock - and our patching of Wiremock
-    implementation("com.github.jknack:handlebars:4.3.1") {
+    testImplementation("com.github.jknack:handlebars:4.3.1") {
         exclude(group = "org.mozilla", module = "rhino")
     }
-    implementation("com.github.jknack:handlebars-helpers:4.3.1") {
+    testImplementation("com.github.jknack:handlebars-helpers:4.3.1") {
         exclude(group = "org.mozilla", module = "rhino")
         exclude(group = "org.apache.commons", module = "commons-lang3")
     }
-    // no "test", because of https://github.com/gradlex-org/extra-java-module-info/issues/134#issuecomment-2956556651
-    implementation("com.github.koppor:wiremock-slf4j-shim:main-SNAPSHOT")
+    testImplementation("com.github.koppor:wiremock-slf4j-shim:main-SNAPSHOT")
     testImplementation("com.github.koppor:wiremock-slf4j-spi-shim:main-SNAPSHOT")
 
     // Required for LocalizationConsistencyTest


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13299

Let's hope that this works.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
