### PR TITLE
Move module tweaking of merged module to launcher

### DIFF
--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -169,17 +169,6 @@ application {
         "-XX:+UseZGC", "-XX:+ZUncommit",
         "-XX:+UseStringDeduplication",
 
-        // Fix for https://github.com/JabRef/jabref/issues/11188
-        "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",
-        "--add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",
-
-        // Fix for https://github.com/JabRef/jabref/issues/11198
-        "--add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module",
-        "--add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module",
-        "--add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",
-        // fix for https://github.com/JabRef/jabref/issues/11426
-        "--add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module",
-
         // Fix for https://github.com/JabRef/jabref/issues/11225 on linux
         "--add-opens=javafx.controls/javafx.scene.control=org.jabref",
         "--add-exports=javafx.base/com.sun.javafx.event=org.jabref",
@@ -244,8 +233,19 @@ jlink {
     )
 
     launcher {
-        name =
-            "JabRef"
+        name = "JabRef"
+        jvmArgs = listOf(
+            // Fix for https://github.com/JabRef/jabref/issues/11188
+            "--add-exports=javafx.base/com.sun.javafx.event=org.jabref.merged.module",
+            "--add-exports=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",
+
+            // Fix for https://github.com/JabRef/jabref/issues/11198
+            "--add-opens=javafx.graphics/javafx.scene=org.jabref.merged.module",
+            "--add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module",
+            "--add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",
+            // fix for https://github.com/JabRef/jabref/issues/11426
+            "--add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module"
+        )
     }
 
     // TODO: Remove as soon as dependencies are fixed (upstream)

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -180,7 +180,7 @@ application {
         "--add-opens=javafx.base/javafx.collections=org.jabref",
         "--add-opens=javafx.base/javafx.collections.transformation=org.jabref",
 
-        "--enable-native-access=org.jabref.merged.module,ai.djl.tokenizers,ai.djl.pytorch_engine,com.sun.jna,javafx.graphics,javafx.media,javafx.web,org.apache.lucene.core"
+        "--enable-native-access=ai.djl.tokenizers,ai.djl.pytorch_engine,com.sun.jna,javafx.graphics,javafx.media,javafx.web,org.apache.lucene.core"
     )
 }
 
@@ -244,7 +244,9 @@ jlink {
             "--add-opens=javafx.controls/javafx.scene.control=org.jabref.merged.module",
             "--add-opens=javafx.controls/com.sun.javafx.scene.control=org.jabref.merged.module",
             // fix for https://github.com/JabRef/jabref/issues/11426
-            "--add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module"
+            "--add-opens=javafx.controls/javafx.scene.control.skin=org.jabref.merged.module",
+
+            "--enable-native-access=org.jabref.merged.module"
         )
     }
 


### PR DESCRIPTION
When executing in the IDE, I get

```
WARNING: Unknown module: org.jabref.merged.module specified to --add-exports
WARNING: Unknown module: org.jabref.merged.module specified to --add-exports
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --add-opens
WARNING: Unknown module: org.jabref.merged.module specified to --enable-native-access
```

This is correct as the merged module is created by the jlink plugin, not before.

I fixed by moving these arguments to jlink.

I am not sure if `--enable-native-access` can be called multiple times. Therefore, a separate commit to be able to revert if this does not work.

### Steps to test

1. Download binary
2. Run
3. See if https://github.com/JabRef/jabref/issues/11198 occurs
4. See if https://github.com/JabRef/jabref/issues/11188 occurs
5. See if console / log shows something about native access warnings

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] not done 
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
