### PR TITLE
Endnote XML Exporter: Move factory initialization to constructor

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
@@ -94,7 +94,7 @@ public class EndnoteXmlExporter extends Exporter {
 
     private final DocumentBuilderFactory documentBuilderFactory;
 
-    private record EndNoteType(String name, Integer number) {
+    private record EndNoteType(String name, int number) {
     }
 
     private final BibEntryPreferences bibEntryPreferences;
@@ -261,7 +261,7 @@ public class EndnoteXmlExporter extends Exporter {
         EndNoteType endNoteType = ENTRY_TYPE_MAPPING.getOrDefault(entryType, DEFAULT_TYPE);
         Element refTypeElement = document.createElement("ref-type");
         refTypeElement.setAttribute("name", endNoteType.name());
-        refTypeElement.setTextContent(endNoteType.number().toString());
+        refTypeElement.setTextContent(String.valueOf(endNoteType.number()));
         recordElement.appendChild(refTypeElement);
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/11157

Based on internal discussion, the factory initialization should not be static.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
