### PR TITLE
fix: allow Unicode characters in citation keys for LibreOffice integr…

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,8 +15,9 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$");
-    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:./]+) CID_(\\d+)");
+   private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\p{L}\\p{N}_\\-.]+ CID_\\d+(?:, JABREF_[\\p{L}\\p{N}_\\-.]+ CID_\\d+)*) (\\p{L}.*)$");
+   private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\p{L}\\p{N}_\\-.]+) CID_(\\d+)");
+
 
     private final String name;
     private List<String> citationKeys;


### PR DESCRIPTION
Closes #13301

This pull request updates the regex patterns in ReferenceMark.java to support Unicode characters in citation keys (e.g., Ты2025, Я2025). Previously, JabRef failed to recognize non-Latin keys during LibreOffice bibliography syncing. The new pattern replaces \w with [\\p{L}\\p{N}_\\-.]+ to allow letters and digits from any language, along with underscore, hyphen, and dot characters commonly used in citation keys.

🔍 Steps to test
Open JabRef and create a new .bib library

Add an entry with a non-Latin citation key, such as:

bibtex
@Article{Ты2025,
  author = {Ты},
  title  = {You},
  year   = {2025}
}
Connect LibreOffice (if available) and insert this citation

Click Make/Sync Bibliography

💡 Expected result: No errors or regex mismatches; the citation key is correctly parsed and bibliography is generated.

✅ Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (entry added under "Fixed")
- [x] Manually tested changed features in running JabRef
- [/] Tests created for changes (not applicable: visual LibreOffice citation bug, regex-only)
- [/] Screenshots added in PR description (not visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): not affected
- [x] [Checked user documentation](https://docs.jabref.org/): no update needed for this fix
