### PR TITLE
Feat #11221: Rich diff for Metadata Group Tree External changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added support for import of a Refer/BibIX file format. [#13069](https://github.com/JabRef/jabref/issues/13069)
 - We added a new `jabkit` command `pseudonymize` to pseudonymize the library. [#13109](https://github.com/JabRef/jabref/issues/13109)
 - We added functionality to focus running instance when trying to start a second instance. [#13129](https://github.com/JabRef/jabref/issues/13129)
+- We added a highlighted diff regarding changes to the Group Tree Structure of a bib file, made outside JabRef. [#11221](https://github.com/JabRef/jabref/issues/11221)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/metedatachange/MetadataChangeDetailsView.java
@@ -1,13 +1,21 @@
 package org.jabref.gui.collab.metedatachange;
 
+import javafx.geometry.Orientation;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.control.SplitPane;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.collab.DatabaseChangeDetailsView;
+import org.jabref.gui.mergeentries.newmergedialog.diffhighlighter.DiffHighlighter;
+import org.jabref.gui.mergeentries.newmergedialog.diffhighlighter.SplitDiffHighlighter;
 import org.jabref.logic.bibtex.comparator.MetaDataDiff;
 import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.metadata.MetaData;
+
+import org.fxmisc.richtext.StyleClassedTextArea;
 
 public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
 
@@ -18,15 +26,172 @@ public final class MetadataChangeDetailsView extends DatabaseChangeDetailsView {
         header.getStyleClass().add("sectionHeader");
         container.getChildren().add(header);
 
+        // Add views for each detected difference
         for (MetaDataDiff.Difference diff : metadataChange.getMetaDataDiff().getDifferences(globalCitationKeyPatterns)) {
-            container.getChildren().add(new Label(getDifferenceString(diff.differenceType())));
-            container.getChildren().add(new Label(diff.originalObject().toString()));
-            container.getChildren().add(new Label(diff.newObject().toString()));
+            addDifferenceView(container, diff, metadataChange);
         }
 
-        ScrollPane scrollPane = new ScrollPane(container);
+        this.setAllAnchorsAndAttachChild(container);
+    }
 
-        this.setAllAnchorsAndAttachChild(scrollPane);
+    /**
+     * Adds a view for a specific metadata difference to the container.
+     * Default view if not a group diff.
+     *
+     * @param container The parent container to add the difference view to
+     * @param diff The metadata difference to display
+     * @param metadataChange The metadata change object containing all changes
+     */
+    private void addDifferenceView(VBox container, MetaDataDiff.Difference diff, MetadataChange metadataChange) {
+        Label typeLabel = new Label(getDifferenceString(diff.differenceType()));
+        typeLabel.getStyleClass().add("diff-type-label");
+        container.getChildren().add(typeLabel);
+
+        // Show appropriate view based on difference type
+        if (diff.differenceType() == MetaDataDiff.DifferenceType.GROUPS) {
+            container.getChildren().add(createGroupDiffSplitPane(metadataChange));
+        } else {
+            container.getChildren().add(createDefaultDiffScrollPane(diff));
+        }
+    }
+
+    /**
+     * Creates a scroll pane showing simple text differences.
+     *
+     * @param diff The difference to display
+     * @return Configured ScrollPane showing the difference
+     */
+    private ScrollPane createDefaultDiffScrollPane(MetaDataDiff.Difference diff) {
+        VBox diffContainer = new VBox(15);
+
+        // Show both original and new values
+        diffContainer.getChildren().add(new Label(diff.originalObject().toString()));
+        diffContainer.getChildren().add(new Label(diff.newObject().toString()));
+
+        ScrollPane scrollPane = new ScrollPane(diffContainer);
+        scrollPane.setFitToWidth(true);
+        return scrollPane;
+    }
+
+    /**
+     * Creates a split pane showing differences in groups tree structure.
+     *
+     * @param metadataChange The metadata change containing groups differences
+     * @return Configured SplitPane showing groups differences
+     */
+    private SplitPane createGroupDiffSplitPane(MetadataChange metadataChange) {
+        // Create text areas for both sides
+        StyleClassedTextArea jabrefTextArea = createConfiguredTextArea();
+        StyleClassedTextArea diskTextArea = createConfiguredTextArea();
+
+        // Populate content from both versions
+        String jabRefContent = getMetadataGroupsContent(metadataChange.getMetaDataDiff().getOriginalMetaData());
+        String diskContent = getMetadataGroupsContent(metadataChange.getMetaDataDiff().getNewMetaData());
+
+        jabrefTextArea.replaceText(jabRefContent);
+        diskTextArea.replaceText(diskContent);
+
+        // Highlight differences between the two versions
+        SplitDiffHighlighter highlighter = new SplitDiffHighlighter(
+                jabrefTextArea,
+                diskTextArea,
+                DiffHighlighter.BasicDiffMethod.CHARS
+        );
+        highlighter.highlight();
+
+        ScrollPane leftScrollPane = createScrollPane(jabrefTextArea);
+        ScrollPane rightScrollPane = createScrollPane(diskTextArea);
+
+        Label inJabRef = new Label(Localization.lang("In JabRef"));
+        inJabRef.getStyleClass().add("lib-change-header");
+        Label onDisk = new Label(Localization.lang("On disk"));
+        onDisk.getStyleClass().add("lib-change-header");
+
+        VBox leftContainer = new VBox(5, inJabRef, leftScrollPane);
+        VBox rightContainer = new VBox(5, onDisk, rightScrollPane);
+
+        // Create and configure split pane
+        SplitPane splitPane = new SplitPane(leftContainer, rightContainer);
+        splitPane.setOrientation(Orientation.HORIZONTAL);
+        splitPane.setDividerPositions(0.5);
+
+        Label legendLabel = new Label(Localization.lang("Red: Removed   Blue: Changed   Green: Added"));
+        legendLabel.getStyleClass().add("lib-change-legend");
+
+        VBox resultContainer = new VBox(splitPane, legendLabel);
+        resultContainer.setSpacing(5);
+
+        return new SplitPane(resultContainer);
+    }
+
+    /**
+     * Creates a configured scroll pane for a text area.
+     *
+     * @param textArea The text area to wrap in a scroll pane
+     * @return Configured ScrollPane
+     */
+    private ScrollPane createScrollPane(StyleClassedTextArea textArea) {
+        ScrollPane scrollPane = new ScrollPane(textArea);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setFitToHeight(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        setAllAnchorsAndAttachChild(scrollPane);
+        return scrollPane;
+    }
+
+    /**
+     * Creates a configured text area for displaying diff content.
+     *
+     * @return Configured StyleClassedTextArea
+     */
+    private StyleClassedTextArea createConfiguredTextArea() {
+        StyleClassedTextArea textArea = new StyleClassedTextArea();
+        textArea.setEditable(false);
+        textArea.setWrapText(false);
+        textArea.setAutoHeight(true);
+        return textArea;
+    }
+
+    /**
+     * Extracts the groups tree content from metadata as a string.
+     *
+     * @param metadata The metadata containing groups
+     * @return String representation of groups tree, or empty string if no groups
+     */
+    private String getMetadataGroupsContent(MetaData metadata) {
+        return metadata.getGroups()
+                       .map(this::convertGroupTreeToString)
+                       .orElse("");
+    }
+
+    /**
+     * Converts a group tree to a string representation with indentation.
+     *
+     * @param node The root node of the group tree
+     * @return String representation of the group tree
+     */
+    private String convertGroupTreeToString(GroupTreeNode node) {
+        StringBuilder builder = new StringBuilder();
+        appendGroupTreeNode(node, builder, 0);
+        return builder.toString();
+    }
+
+    /**
+     * Recursively appends a group tree node to the string builder.
+     *
+     * @param node The current node to append
+     * @param builder The string builder to append to
+     * @param level The current depth level in the tree (for indentation)
+     */
+    private void appendGroupTreeNode(GroupTreeNode node, StringBuilder builder, int level) {
+        builder.append("|  ".repeat(level))
+          .append(node.getName())
+          .append("\n");
+
+        for (GroupTreeNode child : node.getChildren()) {
+            appendGroupTreeNode(child, builder, level + 1);
+        }
     }
 
     private String getDifferenceString(MetaDataDiff.DifferenceType changeType) {

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -736,6 +736,12 @@ TextFlow > .tooltip-text-monospaced {
     -fx-padding: 0.2em 0em 0.2em 0.2em;
 }
 
+.lib-change-legend {
+    -fx-font-size: 11px;
+    -fx-text-fill: #555;
+    -fx-padding: 4 0 0 5;
+}
+
 .table-view .groupColumnBackground {
     -fx-stroke: -jr-gray-2;
 }

--- a/jablib/src/main/java/org/jabref/logic/bibtex/comparator/MetaDataDiff.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/comparator/MetaDataDiff.java
@@ -123,6 +123,10 @@ public class MetaDataDiff {
         return newMetaData;
     }
 
+    public MetaData getOriginalMetaData() {
+        return originalMetaData;
+    }
+
     /**
      * Currently, the groups diff is contained here - and as entry in {@link #getDifferences(GlobalCitationKeyPatterns)}
      */


### PR DESCRIPTION
Regarding #11221.

We have introduced a dedicated view for visualizing external changes in the Metadata Group Tree, made directly in .bib files.

Previously, users had no visibility or info about which groups were added, removed, or modified when external changes occurred. This made it very difficult to understand the changes.

With this update, the Group Tree is now displayed directly in the External Changes Resolver dialog. Visual highlights, using `org.jabref.gui.mergeentries.DiffHighlighting`, indicate differences between the old and new versions. This makes it possible to understand what has changed so that they can decide to accept or reject the changes.

Furthermore, to support large or deeply nested group trees, the old and new one are now scrollable independently. This ensures users can explore the full structure on both sides without losing context.


https://github.com/user-attachments/assets/1cd285b4-128e-41a1-9b0f-3a1192f97c93

Regarding the merging aspect, we spent some time discussing possible approaches, but it turned out to be more complex than we initially expected. Because of that, we decided to focus on delivering a clear and useful visual diff.

While this doesn’t fully address all the points raised in the issue, we believe it represents solid progress. Previously, users had no meaningful insight into what had changed, so this already brings significant value to the external changes workflow.

Tests were not created since this is a visual diff for the user.


### Steps to test

The instructions to test are displayed in the video.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
