### PR TITLE
Let consistency checker yield a return code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved JabRef's internal document viewer. It now allows text section, searching and highlighting of search terms and page rotation [#13193](https://github.com/JabRef/jabref/pull/13193).
 - When importing a PDF, there is no empty entry column shown in the multi merge dialog. [#13132](https://github.com/JabRef/jabref/issues/13132)
 - We added a progress dialog to the "Check consistency" action and progress output to the corresponding cli command. [#12487](https://github.com/JabRef/jabref/issues/12487)
+- We made the `check-consistency` command of the toolkit always return an exit code; 0 means no issues found, a non-zero exit code reflects any issues, which allows CI to fail in these cases [#13328](https://github.com/JabRef/jabref/issues/13328).
 
 ### Fixed
 

--- a/jabkit/src/main/java/org/jabref/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/JabKit.java
@@ -85,7 +85,8 @@ public class JabKit {
                     ArgumentProcessor.getAvailableImportFormats(preferences),
                     ArgumentProcessor.getAvailableExportFormats(preferences),
                     WebFetchers.getSearchBasedFetchers(preferences.getImportFormatPreferences(), preferences.getImporterPreferences()));
-            commandLine.execute(args);
+            int result = commandLine.execute(args);
+            System.exit(result);
         } catch (Exception ex) {
             LOGGER.error("Unexpected exception", ex);
         }

--- a/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
@@ -40,9 +40,6 @@ class CheckConsistency implements Callable<Integer> {
     @Option(names = {"--output-format"}, description = "Output format: txt or csv", defaultValue = "txt")
     private String outputFormat;
 
-    @Option(names = {"--fail-on-error"}, description = "Return a non-zero exit code in case of error")
-    private boolean failOnError;
-
     @Override
     public Integer call() {
         Optional<ParserResult> parserResult = ArgumentProcessor.importFile(
@@ -52,7 +49,7 @@ class CheckConsistency implements Callable<Integer> {
                 sharedOptions.porcelain);
         if (parserResult.isEmpty()) {
             System.out.println(Localization.lang("Unable to open file '%0'.", inputFile));
-            return 1;
+            return 2;
         }
 
         if (parserResult.get().isInvalid()) {
@@ -99,11 +96,11 @@ class CheckConsistency implements Callable<Integer> {
             writer.flush();
         } catch (IOException e) {
             LOGGER.error("Error writing results", e);
-            return 3;
+            return 2;
         }
 
-        if (failOnError && !result.entryTypeToResultMap().isEmpty()) {
-            return -1;
+        if (!result.entryTypeToResultMap().isEmpty()) {
+            return 1;
         }
 
         if (!sharedOptions.porcelain) {

--- a/jabkit/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
+++ b/jabkit/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
@@ -143,11 +143,12 @@ class ArgumentProcessorTest {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent, true));
 
-        commandLine.execute(args.toArray(String[]::new));
+        int executionResult = commandLine.execute(args.toArray(String[]::new));
 
         String output = outContent.toString();
         assertTrue(output.contains("Checking consistency for entry type 1 of 1\n"));
         assertTrue(output.contains("Consistency check completed"));
+        assertEquals(0, executionResult);
 
         System.setOut(System.out);
     }
@@ -163,10 +164,11 @@ class ArgumentProcessorTest {
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));
 
-        commandLine.execute(args.toArray(String[]::new));
+        int executionResult = commandLine.execute(args.toArray(String[]::new));
 
         String output = outContent.toString();
         assertEquals("", output);
+        assertEquals(0, executionResult);
 
         System.setOut(System.out);
     }


### PR DESCRIPTION
Closes #13328

A rough sketch of my idea how the consistency checker could yield a return code in cases where it did not find some inconsistencies.  This can be especially useful, when the checker is used in scripts or CI, where it could mark the stage as failing due to the non-zero return code.

@Siedlerchr @koppor This is a probably very hacky way of doing it, to sketch the idea.  I'd like to know your feedback about it, though.

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

Run the jabkit CLI with argument `check-consistency --input /path/to/erronueous.bib`

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes (link) OR Closes #12345 -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [X] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
