### PR TITLE
Reword enableFileAnnotationsTab and refactor FileAnnotationsTab::shouldShow

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.java
@@ -1,9 +1,5 @@
 package org.jabref.gui.entryeditor.fileannotationtab;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-
 import javafx.scene.Parent;
 import javafx.scene.control.Tooltip;
 
@@ -15,7 +11,6 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.pdf.FileAnnotationCache;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.pdf.FileAnnotation;
 
 import com.airhacks.afterburner.views.ViewLoader;
 
@@ -37,15 +32,18 @@ public class FileAnnotationTab extends EntryEditorTab {
 
     @Override
     public boolean shouldShow(BibEntry entry) {
-        boolean hasAnnotations = false;
         if (!entryEditorPreferences.shouldShowFileAnnotationsTab()) {
             return entry.getField(StandardField.FILE).isPresent();
         }
-        if (stateManager.activeTabProperty().get().isPresent()) {
-            Map<Path, List<FileAnnotation>> fileAnnotations = stateManager.activeTabProperty().get().get().getAnnotationCache().getFromCache(entry);
-            hasAnnotations = fileAnnotations.values().stream().anyMatch(list -> !list.isEmpty());
-        }
-        return entry.getField(StandardField.FILE).isPresent() && hasAnnotations;
+
+        return entry.getField(StandardField.FILE).isPresent()
+                && stateManager.activeTabProperty().get()
+                .map(tab -> tab.getAnnotationCache()
+                        .getFromCache(entry)
+                        .values()
+                        .stream()
+                        .anyMatch(list -> !list.isEmpty()))
+                .orElse(false);
     }
 
     @Override

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -475,7 +475,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getBoolean(SHOW_AI_SUMMARY),
                 getBoolean(SHOW_AI_CHAT),
                 getBoolean(SHOW_LATEX_CITATIONS),
-                getBoolean(SHOW_FILE_ANNOTATIONS),
+                getBoolean(SMART_FILE_ANNOTATIONS),
                 getBoolean(DEFAULT_SHOW_SOURCE),
                 getBoolean(VALIDATE_IN_ENTRY_EDITOR),
                 getBoolean(ALLOW_INTEGER_EDITION_BIBTEX),
@@ -492,7 +492,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         EasyBind.listen(entryEditorPreferences.shouldShowAiSummaryTabProperty(), (_, _, newValue) -> putBoolean(SHOW_AI_SUMMARY, newValue));
         EasyBind.listen(entryEditorPreferences.shouldShowAiChatTabProperty(), (_, _, newValue) -> putBoolean(SHOW_AI_CHAT, newValue));
         EasyBind.listen(entryEditorPreferences.shouldShowLatexCitationsTabProperty(), (_, _, newValue) -> putBoolean(SHOW_LATEX_CITATIONS, newValue));
-        EasyBind.listen(entryEditorPreferences.shouldShowFileAnnotationsTabProperty(), (_, _, newValue) -> putBoolean(SHOW_FILE_ANNOTATIONS, newValue));
+        EasyBind.listen(entryEditorPreferences.shouldShowFileAnnotationsTabProperty(), (_, _, newValue) -> putBoolean(SMART_FILE_ANNOTATIONS, newValue));
         EasyBind.listen(entryEditorPreferences.showSourceTabByDefaultProperty(), (_, _, newValue) -> putBoolean(DEFAULT_SHOW_SOURCE, newValue));
         EasyBind.listen(entryEditorPreferences.enableValidationProperty(), (_, _, newValue) -> putBoolean(VALIDATE_IN_ENTRY_EDITOR, newValue));
         EasyBind.listen(entryEditorPreferences.allowIntegerEditionBibtexProperty(), (_, _, newValue) -> putBoolean(ALLOW_INTEGER_EDITION_BIBTEX, newValue));

--- a/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTab.java
@@ -24,7 +24,7 @@ public class EntryEditorTab extends AbstractPreferenceTabView<EntryEditorTabView
     @FXML private CheckBox enableAiChatTab;
     @FXML private CheckBox acceptRecommendations;
     @FXML private CheckBox enableLatexCitationsTab;
-    @FXML private CheckBox enableFileAnnotationsTab;
+    @FXML private CheckBox smartFileAnnotationsTab;
     @FXML private CheckBox enableValidation;
     @FXML private CheckBox allowIntegerEdition;
     @FXML private CheckBox journalPopupEnabled;
@@ -56,7 +56,7 @@ public class EntryEditorTab extends AbstractPreferenceTabView<EntryEditorTabView
         enableAiChatTab.selectedProperty().bindBidirectional(viewModel.enableAiChatTabProperty());
         acceptRecommendations.selectedProperty().bindBidirectional(viewModel.acceptRecommendationsProperty());
         enableLatexCitationsTab.selectedProperty().bindBidirectional(viewModel.enableLatexCitationsTabProperty());
-        enableFileAnnotationsTab.selectedProperty().bindBidirectional(viewModel.enableFileAnnotationsTabProperty());
+        smartFileAnnotationsTab.selectedProperty().bindBidirectional(viewModel.smartFileAnnotationsTabProperty());
         enableValidation.selectedProperty().bindBidirectional(viewModel.enableValidationProperty());
         allowIntegerEdition.selectedProperty().bindBidirectional(viewModel.allowIntegerEditionProperty());
         journalPopupEnabled.selectedProperty().bindBidirectional(viewModel.journalPopupProperty());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
@@ -28,7 +28,7 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty enableAiChatTabProperty = new SimpleBooleanProperty();
     private final BooleanProperty acceptRecommendationsProperty = new SimpleBooleanProperty();
     private final BooleanProperty enableLatexCitationsTabProperty = new SimpleBooleanProperty();
-    private final BooleanProperty enableFileAnnotationsTabProperty = new SimpleBooleanProperty();
+    private final BooleanProperty smartFileAnnotationsTabProperty = new SimpleBooleanProperty();
     private final BooleanProperty enableValidationProperty = new SimpleBooleanProperty();
     private final BooleanProperty allowIntegerEditionProperty = new SimpleBooleanProperty();
     private final BooleanProperty journalPopupProperty = new SimpleBooleanProperty();
@@ -63,7 +63,7 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         enableAiChatTabProperty.setValue(entryEditorPreferences.shouldShowAiChatTab());
         acceptRecommendationsProperty.setValue(mrDlibPreferences.shouldAcceptRecommendations());
         enableLatexCitationsTabProperty.setValue(entryEditorPreferences.shouldShowLatexCitationsTab());
-        enableFileAnnotationsTabProperty.setValue(entryEditorPreferences.shouldShowFileAnnotationsTab());
+        smartFileAnnotationsTabProperty.setValue(entryEditorPreferences.shouldShowFileAnnotationsTab());
         enableValidationProperty.setValue(entryEditorPreferences.shouldEnableValidation());
         allowIntegerEditionProperty.setValue(entryEditorPreferences.shouldAllowIntegerEditionBibtex());
         journalPopupProperty.setValue(entryEditorPreferences.shouldEnableJournalPopup() == EntryEditorPreferences.JournalPopupEnabled.ENABLED);
@@ -100,7 +100,7 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         entryEditorPreferences.setShouldShowAiChatTab(enableAiChatTabProperty.getValue());
         mrDlibPreferences.setAcceptRecommendations(acceptRecommendationsProperty.getValue());
         entryEditorPreferences.setShouldShowLatexCitationsTab(enableLatexCitationsTabProperty.getValue());
-        entryEditorPreferences.setShouldShowFileAnnotationsTab(enableFileAnnotationsTabProperty.getValue());
+        entryEditorPreferences.setShouldShowFileAnnotationsTab(smartFileAnnotationsTabProperty.getValue());
         entryEditorPreferences.setShowSourceTabByDefault(defaultSourceProperty.getValue());
         entryEditorPreferences.setEnableValidation(enableValidationProperty.getValue());
         entryEditorPreferences.setAllowIntegerEditionBibtex(allowIntegerEditionProperty.getValue());
@@ -171,8 +171,8 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
         return enableLatexCitationsTabProperty;
     }
 
-    public BooleanProperty enableFileAnnotationsTabProperty() {
-        return enableFileAnnotationsTabProperty;
+    public BooleanProperty smartFileAnnotationsTabProperty() {
+        return smartFileAnnotationsTabProperty;
     }
 
     public BooleanProperty enableValidationProperty() {

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/entryeditor/EntryEditorTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/entryeditor/EntryEditorTab.fxml
@@ -38,7 +38,7 @@
     </CheckBox>
     <CheckBox fx:id="defaultSource" text="%Show BibTeX source by default"/>
     <CheckBox fx:id="enableLatexCitationsTab" text="%Show tab 'LaTeX citations'"/>
-    <CheckBox fx:id="enableFileAnnotationsTab" text="%Show tab 'File annotations' only if it contains highlights or comments"/>
+    <CheckBox fx:id="smartFileAnnotationsTab" text="%Show tab 'File annotations' only if it contains highlights or comments"/>
     <CheckBox fx:id="enableAiSummaryTab" text="%Show tab 'AI Summary'"/>
     <CheckBox fx:id="enableAiChatTab" text="%Show tab 'AI Chat'"/>
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -258,7 +258,7 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String NAME_FORMATER_KEY = "nameFormatterNames";
     public static final String SHOW_RECOMMENDATIONS = "showRecommendations";
     public static final String SHOW_AI_SUMMARY = "showAiSummary";
-    public static final String SHOW_FILE_ANNOTATIONS = "showFileAnnotations";
+    public static final String SMART_FILE_ANNOTATIONS = "smartFileAnnotations";
     public static final String SHOW_AI_CHAT = "showAiChat";
     public static final String ACCEPT_RECOMMENDATIONS = "acceptRecommendations";
     public static final String SHOW_LATEX_CITATIONS = "showLatexCitations";
@@ -553,7 +553,7 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(SHOW_RECOMMENDATIONS, Boolean.TRUE);
         defaults.put(SHOW_AI_CHAT, Boolean.TRUE);
         defaults.put(SHOW_AI_SUMMARY, Boolean.TRUE);
-        defaults.put(SHOW_FILE_ANNOTATIONS, Boolean.TRUE);
+        defaults.put(SMART_FILE_ANNOTATIONS, Boolean.TRUE);
         defaults.put(ACCEPT_RECOMMENDATIONS, Boolean.FALSE);
         defaults.put(SHOW_LATEX_CITATIONS, Boolean.TRUE);
         defaults.put(SHOW_SCITE_TAB, Boolean.TRUE);


### PR DESCRIPTION
Closes N/A;
Refactor "enableFileAnnotationsTab" to "smartFileAnnotationsTab" and rewrote shouldShow() in FileAnnotationTab as requested in #13279

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
