### PR TITLE
Fix submodule repo name

### DIFF
--- a/docs/code-howtos/faq.md
+++ b/docs/code-howtos/faq.md
@@ -124,7 +124,7 @@ For `csl-styles`, `csl-locales`, and `abbrev.jabref.org`:
 git merge origin/main
 git checkout main -- jablib/src/main/resources/csl-styles
 git checkout main -- jablib/src/main/resources/csl-locales
-git checkout main -- jablib/src/main/abbrev.jabref.org
+git checkout main -- jablib/src/main/abbrv.jabref.org
 git commit -m "Fix submodules"
 git push
 ```


### PR DESCRIPTION
abbrv instad of abbrev

Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
