### PR TITLE
Reduce workflow runs for forks

### DIFF
--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -4,8 +4,6 @@
 name: Binaries (JDK and JavaFX early access builds)
 
 on:
-  schedule:
-    - cron: "0 18 * * *"
   pull_request:
     types:
       - opened

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -462,15 +462,6 @@ jobs:
             jabgui/build/distribution
             jabkit/build/distribution
           compression-level: 0 # no compression
-      - name: Upload to GitHub workflow artifacts store
-        if: ${{ (needs.conditions.outputs.upload-to-builds-jabref-org == 'false') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: JabRef-${{ matrix.os }}
-          path: |
-            jabgui/build/distribution
-            jabkit/build/distribution
-          compression-level: 0 # no compression
       # endregion
 
   comment-on-pr:

--- a/.github/workflows/delete-old-runs-automatically.yml
+++ b/.github/workflows/delete-old-runs-automatically.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 1 * *'
 jobs:
   del_runs:
+    if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'JabRef' }}
     strategy:
       matrix:
         component: [jabkit, jabsrv]
@@ -39,7 +40,7 @@ jobs:
             type=ref,event=pr
       - name: Login to GitHub Container Registry
         if: >
-          (github.event_name == 'push' && github.repository == 'JabRef/jabref') || 
+          (github.event_name == 'push' && github.repository == 'JabRef/jabref') ||
           (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
         uses: docker/login-action@v3
         with:
@@ -54,8 +55,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: >
-            ${{ 
-              (github.event_name == 'push' && github.repository == 'JabRef/jabref') || 
+            ${{
+              (github.event_name == 'push' && github.repository == 'JabRef/jabref') ||
               (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
             }}
           platforms: linux/amd64

--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   cache:
+    if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.repository_owner == 'JabRef' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,7 +227,7 @@ jobs:
 
   tests-windows:
     name: "Unit tests (Windows) – ${{ matrix.module }}"
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.repository_owner == 'JabRef')
     runs-on: windows-latest
     strategy:
       matrix:
@@ -251,6 +251,7 @@ jobs:
           CI: "true"
 
   databasetests:
+    if: (github.repository_owner == 'JabRef')
     name: Database tests
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
Tries to disable workflows for forks (to save money for them)

Quick adressing of https://github.com/JabRef/jabref-issue-melting-pot/issues/964, but needs more work as follow-up.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
