### PR TITLE
Maven publish on a separate workflow

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -212,32 +212,6 @@ jobs:
       - name: Setup JBang
         uses: jbangdev/setup-jbang@main
 
-      # region Publish JabLib on Maven Central
-      - name: Decode secretKeyRingFile
-        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
-        id: secring
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'secring.gpg'
-          encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
-      - name: store secrets
-        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (startsWith(matrix.os, 'ubuntu'))
-        run: |
-          cat >> gradle.properties <<EOF
-          signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
-          signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
-          signing.secretKeyRingFile=${{ steps.secring.outputs.filePath }}
-          mavenCentralUsername=${{ secrets.KOPPOR_MAVENCENTRALUSERNAME }}
-          mavenCentralPassword=${{ secrets.KOPPOR_MAVENCENTRALPASSWORD }}
-          EOF
-          grep secretKeyRingFile gradle.properties
-          file ${{ steps.secring.outputs.filePath }}
-          md5sum ${{ steps.secring.outputs.filePath }}
-      - name: publishAllPublicationsToMavenCentralRepository
-        if: (needs.conditions.outputs.upload-to-builds-jabref-org == 'true') && (matrix.os == 'ubuntu-22.04')
-        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ needs.conditions.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository || true # prevent failing publish to stop the workflow
-      # endregion
-
       - name: Basic build (assemble)
         run: ./gradlew -i -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" assemble
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,100 @@
+name: Publish to maven central
+
+on:
+  pull_request:
+    paths:
+     - .github\workflows\publish.yml
+  push:
+    paths:
+     - .github\workflows\publish.yml
+    tags:
+      - '*'
+  schedule:
+    # run on each Monday
+    - cron: '2 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+env:
+  GRADLE_OPTS: -Xmx4g -Dorg.gradle.vfs.watch=false
+  JAVA_OPTS: -Xmx4g
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ github.event_name }}"
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: jablib
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fetch all history for all tags and branches
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+          show-progress: 'false'
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3.2.1
+        with:
+          versionSpec: "5.x"
+      - name: Run GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3.2.1
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'corretto'
+          java-package: 'jdk'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Generate JBang cache key
+        id: cache-key
+        shell: bash
+        run: |
+          echo "cache_key=jbang-$(date +%F)" >> $GITHUB_OUTPUT
+      - name: Use cache
+        uses: actions/cache@v4
+        with:
+          lookup-only: true
+          path: ~/.jbang
+          key: ${{ steps.cache-key.outputs.cache_key }}
+          restore-keys:
+            jbang-
+      - name: Setup JBang
+        uses: jbangdev/setup-jbang@main
+
+      # region Publish JabLib on Maven Central
+      - id: istagbuild
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tagbuild=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tagbuild=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Decode secretKeyRingFile
+        id: secring
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'secring.gpg'
+          encodedString: ${{ secrets.KOPPOR_SIGNING_SECRETKEYRINGFILE_BASE64 }}
+      - name: store secrets
+        run: |
+          cat >> gradle.properties <<EOF
+          signing.keyId=${{ secrets.KOPPOR_SIGNING_KEYID }}
+          signing.password=${{ secrets.KOPPOR_SIGNING_PASSWORD }}
+          signing.secretKeyRingFile=${{ steps.secring.outputs.filePath }}
+          mavenCentralUsername=${{ secrets.KOPPOR_MAVENCENTRALUSERNAME }}
+          mavenCentralPassword=${{ secrets.KOPPOR_MAVENCENTRALPASSWORD }}
+          EOF
+          grep secretKeyRingFile gradle.properties
+          file ${{ steps.secring.outputs.filePath }}
+          md5sum ${{ steps.secring.outputs.filePath }}
+      - name: publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ steps.istagbuild.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository
+      # endregion

--- a/.github/workflows/tests-fetchers.yml
+++ b/.github/workflows/tests-fetchers.yml
@@ -24,8 +24,8 @@ on:
       - '.github/workflows/tests-fetchers.yml'
       - 'build.gradle'
   schedule:
-    # run on each Wednesday
-    - cron: '2 3 * * 3'
+    # run on each Monday
+    - cron: '2 3 * * 1'
   workflow_dispatch:
 
 env:

--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -9,6 +9,7 @@ java {
         // - .devcontainer/devcontainer.json#L34 and
         // - .moderne/moderne.yml
         // - .github/workflows/binaries*.yml
+        // - .github/workflows/publish.yml
         // - .github/workflows/tests*.yml
         // - .github/workflows/update-gradle-wrapper.yml
         // - docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md


### PR DESCRIPTION
Follow-up to #13368 

Now that maven central is up and running again, we should check the publishing of our library.

It is available at https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/jabref/jablib/

It was the first step on publishing, because we experimented with using it using JBang.

I think, we don't change it that often, therefore I switched to weekly publishing plus manual trigger.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
