### PR TITLE
Fix usage of non-EA JDK

### DIFF
--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -283,9 +283,9 @@ jobs:
           cd jabgui
 
           # see https://github.com/jdx/mise/discussions/4973
-          eval $(mise hook-env -f | grep 'export JAVA_HOME')
-          eval $(mise hook-env -f | grep 'export PATH')
-          echo $JAVA_HOME
+          # eval $(mise hook-env -f | grep 'export JAVA_HOME')
+          # eval $(mise hook-env -f | grep 'export PATH')
+          # echo $JAVA_HOME
 
           jpackage \
           --module org.jabref/org.jabref.Launcher \
@@ -335,9 +335,9 @@ jobs:
           cd jabgui
 
           # see https://github.com/jdx/mise/discussions/4973
-          eval $(mise hook-env -f | grep 'export JAVA_HOME')
-          eval $(mise hook-env -f | grep 'export PATH')
-          echo $JAVA_HOME
+          # eval $(mise hook-env -f | grep 'export JAVA_HOME')
+          # eval $(mise hook-env -f | grep 'export PATH')
+          # echo $JAVA_HOME
 
           jpackage \
           --module org.jabref/org.jabref.Launcher \

--- a/.github/workflows/binaries-ea.yml
+++ b/.github/workflows/binaries-ea.yml
@@ -224,10 +224,17 @@ jobs:
         shell: bash
         run: mv ~/AppData/Local/mise ~/.asdf
       - name: Setup JDK for gradle itself
+        if: false
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+      - name: Setup JDK ${{ env.jdk_version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: '${{ env.jdk_version }}'
+          distribution: 'corretto'
+          java-package: 'jdk'
       # endregion
 
       # region JavaFX


### PR DESCRIPTION
We cannot use JDK-25-ea due to https://github.com/gradle/gradle/issues/33310. We therefore disabled the whole EA thing in the workflows. We forgot to update the sepate steps for macOS. 

Fixed by this PR.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
