### PR TITLE
Fix maven url

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.repositories.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.repositories.gradle.kts
@@ -8,5 +8,5 @@ repositories {
     // Required for one.jpro.jproutils:tree-showing
     maven { url = uri("https://sandec.jfrog.io/artifactory/repo") }
 
-    maven { url = uri("file:${rootDir.absolutePath}/jablib/lib")}
+    maven { url = rootDir.resolve("jablib/lib").toURI() }
 }


### PR DESCRIPTION
With Gradle 9.0. RC 1 I get

```
> Failed to apply plugin 'org.jabref.gradle.base.repositories'.
   > Cannot convert URI 'file:C:\git-repositories\JabRef/jablib/lib' to a file.
```

This PR fixes this.

Follow-up to https://github.com/JabRef/jabref/pull/13319

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
