### PR TITLE
Speed up build by making assumptions

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -232,6 +232,7 @@ var taskGenerateJournalListMV = tasks.register<JBangTask>("generateJournalListMV
 
     inputs.dir(abbrvJabRefOrgDir)
     outputs.file(generatedJournalFile)
+    onlyIf {!generatedJournalFile.get().asFile.exists()}
 }
 
 var taskGenerateCitationStyleCatalog = tasks.register<JBangTask>("generateCitationStyleCatalog") {
@@ -240,9 +241,10 @@ var taskGenerateCitationStyleCatalog = tasks.register<JBangTask>("generateCitati
 
     script = rootProject.layout.projectDirectory.file("build-support/src/main/java/CitationStyleCatalogGenerator.java").asFile.absolutePath
 
-
     inputs.dir(layout.projectDirectory.dir("src/main/resources/csl-styles"))
-    outputs.file(layout.buildDirectory.file("generated/resources/citation-style-catalog.json"))
+    val cslCatalogJson = layout.buildDirectory.file("generated/resources/citation-style-catalog.json")
+    outputs.file(cslCatalogJson)
+    onlyIf {!cslCatalogJson.get().asFile.exists()}
 }
 
 var ltwaCsvFile = layout.buildDirectory.file("tmp/ltwa_20210702.csv")
@@ -283,7 +285,9 @@ var taskGenerateLtwaListMV = tasks.register<JBangTask>("generateLtwaListMV") {
     script = rootProject.layout.projectDirectory.file("build-support/src/main/java/LtwaListMvGenerator.java").asFile.absolutePath
 
     inputs.file(ltwaCsvFile)
-    outputs.file(layout.buildDirectory.file("generated/resources/journals/ltwa-list.mv"))
+    val ltwaListMv = layout.buildDirectory.file("generated/resources/journals/ltwa-list.mv");
+    outputs.file(ltwaListMv)
+    onlyIf {!ltwaListMv.get().asFile.exists()}
 }
 
 // Adds ltwa, journal-list.mv, and citation-style-catalog.json to the resources directory


### PR DESCRIPTION
We generate *.mv and `citation-style-catalog.json`.

Gradle runs these tasks even if the input directory does not change.

The input directory do not change that often; ignoring these speeds up the build significantly.

Assumptions:

- GitHub CI starts on blank build directory
- Developers seldomly work on parts of jabref requiring fresh abbreviation lists and new/other citation styles
- If developers work in the area of mv files, they will refresh these files on their own.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
