### PR TITLE
Increase file annotation cache from 10 to 1024

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
+++ b/jablib/src/main/java/org/jabref/logic/pdf/FileAnnotationCache.java
@@ -18,16 +18,14 @@ import org.slf4j.LoggerFactory;
 public class FileAnnotationCache {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileAnnotationCache.class);
-    // cache size in entries
-    private final static int CACHE_SIZE = 10;
+
+    private final static int CACHE_SIZE = 1024;
 
     // the inner list holds the annotations per file, the outer collection maps this to a BibEntry.
     private LoadingCache<BibEntry, Map<Path, List<FileAnnotation>>> annotationCache;
 
-    /**
-     * Creates an empty fil annotation cache. Required to allow the annotation cache to be injected into views without
-     * hitting the bug https://github.com/AdamBien/afterburner.fx/issues/71 .
-     */
+    /// Creates an empty fil annotation cache. Required to allow the annotation cache to be injected into views without
+    // hitting the bug <https://github.com/AdamBien/afterburner.fx/issues/71>.
     public FileAnnotationCache() {
     }
 
@@ -47,12 +45,12 @@ public class FileAnnotationCache {
      * @return Map containing a list of annotations in a list for each file
      */
     public Map<Path, List<FileAnnotation>> getFromCache(BibEntry entry) {
-        LOGGER.debug("Loading Bibentry '%s' from cache.".formatted(entry.getCitationKey().orElse(entry.getId())));
+        LOGGER.debug("Loading BibEntry {} from cache.", entry.getCitationKey().orElse(entry.getId()));
         return annotationCache.getUnchecked(entry);
     }
 
     public void remove(BibEntry entry) {
-        LOGGER.debug("Deleted Bibentry '%s' from cache.".formatted(entry.getCitationKey().orElse(entry.getId())));
+        LOGGER.debug("Deleted BibEntry {} from cache.", entry.getCitationKey().orElse(entry.getId()));
         annotationCache.invalidate(entry);
     }
 }


### PR DESCRIPTION
I think, caching only 10 PDF annotations is way too less. I would try with 1k and see how memory consumption goes up.

### Steps to test

1. Open a large library
2. Open 10 entries with files with annotations
3. Check if re-opening of entries: the annotations will load fast
4. Check memory consumption
/### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
