### PR TITLE
Click on non-existing PDF should raises dialog box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where moved or renamed linked files in the file directory were not automatically relinked by the “search for unlinked files” feature. [#13264](https://github.com/JabRef/jabref/issues/13264)
 - We fixed an issue where the tab showing the fulltext search results was not displayed. [#12865](https://github.com/JabRef/jabref/issues/12865)
 - We fixed an issue showing an empty tooltip in maintable. [#11681](https://github.com/JabRef/jabref/issues/11681)
-- We fixed an issue displaying a warning if a file to open is not found.
+- We fixed an issue displaying a warning if a file to open is not found. [#13430](https://github.com/JabRef/jabref/pull/13430)
 - We fixed an issue where Document Viewer showed technical exceptions when opening entries with non-PDF files. [#13198](https://github.com/JabRef/jabref/issues/13198)
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where moved or renamed linked files in the file directory were not automatically relinked by the “search for unlinked files” feature. [#13264](https://github.com/JabRef/jabref/issues/13264)
 - We fixed an issue where the tab showing the fulltext search results was not displayed. [#12865](https://github.com/JabRef/jabref/issues/12865)
 - We fixed an issue showing an empty tooltip in maintable. [#11681](https://github.com/JabRef/jabref/issues/11681)
+- We fixed an issue displaying a warning if a file to open is not found.
 - We fixed an issue where Document Viewer showed technical exceptions when opening entries with non-PDF files. [#13198](https://github.com/JabRef/jabref/issues/13198)
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -184,15 +184,12 @@ public abstract class NativeDesktop {
             return true;
         }
         Optional<Path> file = FileUtil.find(databaseContext, link, filePreferences);
-        if (file.isPresent()) {
-            // Open the file:
-            String filePath = file.get().toString();
-            openExternalFilePlatformIndependent(type, filePath, externalApplicationsPreferences);
-            return true;
+        if (file.isEmpty()) {
+            return false;
         }
 
-        // No file matched the name, try to open it directly using the given app
-        openExternalFilePlatformIndependent(type, link, externalApplicationsPreferences);
+        String filePath = file.get().toString();
+        openExternalFilePlatformIndependent(type, filePath, externalApplicationsPreferences);
         return true;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
+++ b/jabgui/src/main/java/org/jabref/gui/desktop/os/NativeDesktop.java
@@ -184,7 +184,7 @@ public abstract class NativeDesktop {
             return true;
         }
         Optional<Path> file = FileUtil.find(databaseContext, link, filePreferences);
-        if (file.isPresent() && Files.exists(file.get())) {
+        if (file.isPresent()) {
             // Open the file:
             String filePath = file.get().toString();
             openExternalFilePlatformIndependent(type, filePath, externalApplicationsPreferences);

--- a/jabgui/src/main/java/org/jabref/gui/externalfiletype/ExternalFileType.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiletype/ExternalFileType.java
@@ -19,7 +19,7 @@ public interface ExternalFileType {
     JabRefIcon getIcon();
 
     /**
-     * Get the bibtex field name used for this file type. Currently we assume that field name equals filename extension.
+     * Get the bibtex field name used for this file type. Currently, we assume that field name equals filename extension.
      *
      * @return The field name.
      */


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/968

In the case of a NON-online link (AKA a file) and a NON existing file, following code was executed

    // No file matched the name, try to open it directly using the given app
    openExternalFilePlatformIndependent(type, link, externalApplicationsPreferences);

IDK why. Is in since more than one year. Strange.

I removed it.

### Steps to test

1. Rename an attached file
2. Try to open with JabRef
3. See error dialog

![image](https://github.com/user-attachments/assets/8804bd7a-1a1a-4ffd-9f71-aca9024789b2)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
