### PR TITLE
Add .jbang/README.md

### DIFF
--- a/.jbang/README.md
+++ b/.jbang/README.md
@@ -1,0 +1,30 @@
+# JBang scripts for JabRef
+
+This directory contains [JBang](https://www.jbang.dev/) scripts for JabRef.
+
+Three use cases:
+
+- Try out any pull request with minimal installation. See [our blog entry](https://blog.jabref.org/2025/05/31/run-pr/) for details.
+- Run `JabKit`
+- Run `JabSrv`
+
+## Running `JabKit`
+
+`JabKit` is the CLI tool of JabRef.
+
+If you have JBang installed, just run `jbang jabkit@jabref --help`
+
+IF not, download [`gg.cmd`](https://github.com/eirikb/gg/tree/main?tab=readme-ov-file#ggcmd), please it in the current directory or on your `PATH` and execute
+
+    gg.cmd jbang jabkit@jabref --help
+
+## Running `JabSrv`
+
+`JabSrv` is the http server of JabRef.
+
+If you have JBang installed, just run `jbang jabsrv@jabref --help`
+
+WIth `gg.cmd`:
+
+    gg.cmd jbang jabsrv@jabref --help
+

--- a/.jbang/README.md
+++ b/.jbang/README.md
@@ -5,26 +5,22 @@ This directory contains [JBang](https://www.jbang.dev/) scripts for JabRef.
 Three use cases:
 
 - Try out any pull request with minimal installation. See [our blog entry](https://blog.jabref.org/2025/05/31/run-pr/) for details.
-- Run `JabKit`
-- Run `JabSrv`
+- Run `JabKit` - JabRef's CLI tool.
+- Run `JabSrv` - JabRef's HTTP server.
 
 ## Running `JabKit`
 
-`JabKit` is the CLI tool of JabRef.
-
 If you have JBang installed, just run `jbang jabkit@jabref --help`
 
-IF not, download [`gg.cmd`](https://github.com/eirikb/gg/tree/main?tab=readme-ov-file#ggcmd), please it in the current directory or on your `PATH` and execute
+If not, download [`gg.cmd`](https://github.com/eirikb/gg/tree/main?tab=readme-ov-file#ggcmd), place it in the current directory (or on your `PATH`) and execute:
 
     gg.cmd jbang jabkit@jabref --help
 
 ## Running `JabSrv`
 
-`JabSrv` is the http server of JabRef.
-
 If you have JBang installed, just run `jbang jabsrv@jabref --help`
 
-WIth `gg.cmd`:
+With `gg.cmd`:
 
     gg.cmd jbang jabsrv@jabref --help
 


### PR DESCRIPTION
I think, it would be good to have a README.md for our JBang scripts.

Here an initial proposal.

`jbang jabsrv@jabref` fails here, but I think, this is just a hickup, because https://github.com/JabRef/jbang-catalog/blob/main/jbang-catalog.json contains `jabsrv`.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
