### PR TITLE
Update java-module-packaging

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -179,12 +179,6 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
           show-progress: 'false'
-      - name: Fetch preview of java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Install pigz and cache (linux)
         if: (startsWith(matrix.os, 'ubuntu'))
         uses: awalsh128/cache-apt-pkgs-action@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,12 +39,6 @@ jobs:
           fetch-depth: 0
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.2.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -65,12 +59,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -91,12 +79,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -119,12 +101,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: markdownlint-cli2-action
         uses: DavidAnson/markdownlint-cli2-action@v20
         with:
@@ -141,12 +117,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Generate JBang cache key
         id: cache-key
         shell: bash
@@ -187,12 +157,6 @@ jobs:
           submodules: 'false'
           show-progress: 'false'
           fetch-depth: 0
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Cache clparse jar
         id: cache-clparse
         uses: actions/cache@v4
@@ -219,12 +183,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -246,12 +204,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -301,12 +253,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -342,12 +288,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -372,12 +312,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -398,12 +332,6 @@ jobs:
             jbang-
       - name: Setup JBang
         uses: jbangdev/setup-jbang@main
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - run: jbang build .jbang/CheckoutPR.java
       - run: jbang build .jbang/CloneJabRef.java
       - run: jbang build --fresh .jbang/JabKitLauncher.java
@@ -445,12 +373,6 @@ jobs:
         with:
           submodules: 'true'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         if: github.ref == 'refs/heads/main'
         uses: actions/setup-java@v4
@@ -483,12 +405,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -509,12 +425,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - uses: gradle/actions/wrapper-validation@v4
 
   mandatory-checks-section-exists:
@@ -536,12 +446,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
 
       - name: Check for existence of Mandatory Checks section
         id: check_mandatory_section
@@ -578,12 +482,6 @@ jobs:
         with:
           submodules: 'false'
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Check for PR checklist
         id: check_changelog_modification
         run: |
@@ -627,12 +525,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Merge Conflict finder
         uses: olivernybroe/action-conflict-finder@v4.1
 
@@ -644,12 +536,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Check force push
         id: force_push_check
         run: |
@@ -674,12 +560,6 @@ jobs:
         with:
           submodules: true
           show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Check for submodule modifications
         id: check_submodule
         run: |
@@ -730,12 +610,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
       - name: Check PR body for changelog note
         id: changelog_check
         run: |

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation("com.github.andygoossens:gradle-modernizer-plugin:1.11.0")
     implementation("org.gradlex:extra-java-module-info:1.12")
     implementation("org.gradlex:java-module-dependencies:1.9.1")
-    implementation("org.gradlex:java-module-packaging:1.0.1") // required for platform-specific packaging of JavaFX dependencies
+    implementation("org.gradlex:java-module-packaging:1.1") // required for platform-specific packaging of JavaFX dependencies
     implementation("org.gradlex:java-module-testing:1.7")
     implementation("org.gradlex:jvm-dependency-conflict-resolution:2.4")
     implementation("org.gradle.toolchains:foojay-resolver:1.0.0")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,6 +1,1 @@
 rootProject.name = "build-logic"
-
-// If this is not found:
-// - clone https://github.com/gradlex-org/java-module-packaging next to this file
-// - switch to branch 'preview' and pull
-includeBuild("java-module-packaging")

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,5 @@
 jdk:
   - openjdk24
-before_install:
-  - cd build-logic
-  - git clone https://github.com/koppor/java-module-packaging.git
-  - cd ..
 install:
   - ./gradlew :versions:publishToMavenLocal
   - ./gradlew :jablib:publishToMavenLocal


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13401

v1.1 of java-module-packaging was released: https://github.com/gradlex-org/java-module-packaging/releases/tag/v1.1

We don't need our custom build of it any more. 🎉

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
