### PR TITLE
Fix submodule check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -667,39 +667,23 @@ jobs:
 
   unmodified_submodules:
     name: Submodules not modified
-    if: false && (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request')
+    if: (github.actor != 'dependabot[bot]' && github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # No checkout -> the action uses GitHub's API (which is more reliable for submodule changes due to our submodule settings)
+      - name: Get all submodule changes
+        id: changes
+        uses: tj-actions/changed-files@v46
         with:
-          submodules: true
-          show-progress: 'false'
-      - name: Checkout java-module-packaging
-        uses: actions/checkout@v4
-        with:
-          repository: koppor/java-module-packaging
-          path: build-logic/java-module-packaging
-          ref: fix-params
-      - name: Check for submodule modifications
-        id: check_submodule
+          files: |
+            jablib/src/main/abbrv.jabref.org
+            jablib/src/main/resources/csl-styles
+            jablib/src/main/resources/csl-locales
+      - name: Submodules modified
+        if: steps.changes.outputs.any_changed == 'true'
         run: |
-          git fetch origin ${{ github.base_ref }}
-
-          # enable diffing of submodules
-          sed -i "s/ all/ untracked/" .gitmodules
-
-          if git diff --submodule=log origin/${{ github.base_ref }} HEAD | grep -Eq "^Submodule .* contains modified content$"; then
-            echo "Debug:"
-            echo "Command: git diff --submodule=log origin/${{ github.base_ref }} HEAD"
-            echo "Result:"
-            git diff --submodule=log origin/${{ github.base_ref }} HEAD
-            echo "--end--"
-            echo "Grep result"
-            git diff --submodule=log origin/${{ github.base_ref }} HEAD | grep -E "^Submodule .* contains modified content$"
-            echo "❌ Submodule modifications detected"
-            exit 1
-          fi
-          echo "✅ No submodule modifications"
+          echo "❌ Submodule modifications detected"
+          exit 1
 
   other_than_main:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Since we ignore submodule changes, the check for submodule changes doesn't work (without hacks)

I found an action using GitHub's API for changes - and it works well :)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
