### PR TITLE
refactor: simplify getAuthorTitleYear logic 

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -740,15 +740,19 @@ public class BibEntry implements Cloneable {
      * Author1, Author2: Title (Year)
      */
     public String getAuthorTitleYear(int maxCharacters) {
-        String[] s = new String[]{getField(StandardField.AUTHOR).orElse("N/A"), getField(StandardField.TITLE).orElse("N/A"),
-                getField(StandardField.YEAR).orElse("N/A")};
+        String author = getField(StandardField.AUTHOR).orElse("N/A");
+        String title = getField(StandardField.TITLE).orElse("N/A");
+        String year = getField(StandardField.YEAR).orElse("N/A");
 
-        String text = s[0] + ": \"" + s[1] + "\" (" + s[2] + ')';
-        if ((maxCharacters <= 0) || (text.length() <= maxCharacters)) {
-            return text;
+        String formatted = author + ": \"" + title + "\" (" + year + ")";
+
+        if (maxCharacters > 0 && formatted.length() > maxCharacters) {
+            return formatted.substring(0, maxCharacters + 1) + "...";
         }
-        return text.substring(0, maxCharacters + 1) + "...";
+
+        return formatted;
     }
+
 
     /**
      * Returns the title of the given BibTeX entry as an Optional.


### PR DESCRIPTION
 What does this PR do?

Refactors the method `getAuthorTitleYear(int maxCharacters)` in `BibEntry.java` to simplify logic and improve readability, without changing its behavior.

 Changes made

- Replaced string manipulation code with a clearer, cleaner version.
- Preserved output format and truncation behavior.
- Verified functionality via quick local testing.

Fixes https://github.com/JabRef/jabref/issues/13426


