### PR TITLE
Change coordinates of plugin fix to get it working (again)

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -18,7 +18,8 @@ plugins {
 
     // id("dev.jbang") version "0.2.0"
     // Workaround for https://github.com/jbangdev/jbang-gradle-plugin/issues/7
-    id("com.github.koppor.jbang-gradle-plugin") version "fix-7-SNAPSHOT"
+    // Build state at https://jitpack.io/#koppor/jbang-gradle-plugin/fix-7-SNAPSHOT
+    id("com.github.koppor.jbang-gradle-plugin") version "8a85836163"
 }
 
 var version: String = project.findProperty("projVersion")?.toString() ?: "0.1.0"


### PR DESCRIPTION
Should fix following issue - hopefully

```
Plugin [id: 'com.github.koppor.jbang-gradle-plugin', version: 'fix-7-SNAPSHOT', artifact: 'com.github.koppor:jbang-gradle-plugin:fix-7-SNAPSHOT'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Included Builds (None of the included builds contain this plugin)
- Plugin Repositories (could not resolve plugin artifact 'com.github.koppor:jbang-gradle-plugin:fix-7-SNAPSHOT')
  Searched in the following repositories:
    Gradle Central Plugin Repository
    maven(https://jitpack.io)

```