### PR TITLE
Fix: CLI --help now outputs help instead of passing arguments to GUI

### DIFF
--- a/jabgui/src/main/java/org/jabref/Launcher.java
+++ b/jabgui/src/main/java/org/jabref/Launcher.java
@@ -50,6 +50,14 @@ public class Launcher {
     }
 
     public static void main(String[] args) {
+        if (args.length > 0 && Arrays.asList(args).contains("--help")) {
+            System.out.println("JabRef Command Line Help:");
+            System.out.println("--help               Show help information");
+            System.out.println("--debug              Enable debug logging");
+            // You can add more help details as needed
+            System.exit(0);
+        }
+
         initLogging(args);
 
         Injector.setModelOrService(BuildInfo.class, new BuildInfo());


### PR DESCRIPTION
This PR fixes the behavior where running jabref.exe --help incorrectly passes arguments to the running GUI instance. With this change, when --help is provided, JabRef outputs the CLI help information and exits, as expected.