### PR TITLE
--porcelain does not output any info or warn errors on the console

### DIFF
--- a/jabkit/src/main/java/org/jabref/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/JabKit.java
@@ -133,8 +133,9 @@ public class JabKit {
         SLF4JBridgeHandler.install();
 
         // We must configure logging as soon as possible, which is why we cannot wait for the usual
-        // argument parsing workflow to parse logging options e.g. --debug
+        // argument parsing workflow to parse logging options: i.e. --debug or --porcelain
         boolean isDebugEnabled = Arrays.stream(args).anyMatch(arg -> "--debug".equalsIgnoreCase(arg));
+        boolean isPorcelainEnabled = Arrays.stream(args).anyMatch(arg -> "--porcelain".equalsIgnoreCase(arg));
 
         // addLogToDisk
         // We cannot use `Injector.instantiateModelOrService(BuildInfo.class).version` here, because this initializes logging
@@ -147,10 +148,19 @@ public class JabKit {
             return;
         }
 
+        String level;
+        if (isDebugEnabled) {
+            level = "debug";
+        } else if (isPorcelainEnabled) {
+            level = "error";
+        } else {
+            level = "info";
+        }
+
         // The "Shared File Writer" is explained at
         // https://tinylog.org/v2/configuration/#shared-file-writer
         Map<String, String> configuration = Map.of(
-                "level", isDebugEnabled ? "debug" : "info",
+                "level", level,
                 "writerFile", "rolling file",
                 "writerFile.level", isDebugEnabled ? "debug" : "info",
                 // We need to manually join the path, because ".resolve" does not work on Windows, because ":" is not allowed in file names on Windows


### PR DESCRIPTION
```bash
koppor@DESKTOP-KAK953S MINGW64 /c/git-repositories/jabref (refine-consistency-output)
$ jbang .jbang/JabKitLauncher.java
2025-07-05 11:41:15 [main] org.jabref.logic.journals.JournalAbbreviationLoader.loadRepository()
INFO: Loaded journal abbreviations from C:\Users\koppor\AppData\Local\Temp\jabref-journal14768976930855100370\journal-list.mv

   &&&    &&&&&    &&&&&&&&   &&&&&&&&   &&&&&&&&& &&&&&&&&&
   &&&    &&&&&    &&&   &&&  &&&   &&&  &&&       &&&
   &&&   &&& &&&   &&&   &&&  &&&   &&&  &&&       &&&
   &&&   &&   &&   &&&&&&&    &&&&&&&&   &&&&&&&&  &&&&&&&
   &&&  &&&&&&&&&  &&&   &&&  &&&   &&&  &&&       &&&
   &&&  &&&   &&&  &&&   &&&  &&&   &&&  &&&       &&&
&&&&&   &&&   &&&  &&&&&&&&   &&&   &&&  &&&&&&&&& &&&

Version: 100.0.0

Staying on top of your literature since 2003 - https://www.jabref.org/

Please report issues at https://github.com/JabRef/jabref/issues


koppor@DESKTOP-KAK953S MINGW64 /c/git-repositories/jabref (refine-consistency-output)
$ jbang .jbang/JabKitLauncher.java  --porcelain

   &&&    &&&&&    &&&&&&&&   &&&&&&&&   &&&&&&&&& &&&&&&&&&
   &&&    &&&&&    &&&   &&&  &&&   &&&  &&&       &&&
   &&&   &&& &&&   &&&   &&&  &&&   &&&  &&&       &&&
   &&&   &&   &&   &&&&&&&    &&&&&&&&   &&&&&&&&  &&&&&&&
   &&&  &&&&&&&&&  &&&   &&&  &&&   &&&  &&&       &&&
   &&&  &&&   &&&  &&&   &&&  &&&   &&&  &&&       &&&
&&&&&   &&&   &&&  &&&&&&&&   &&&   &&&  &&&&&&&&& &&&

Version: 100.0.0

Staying on top of your literature since 2003 - https://www.jabref.org/

Please report issues at https://github.com/JabRef/jabref/issues
```

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
