### PR TITLE
Hotfix for CAYW in GUI

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
@@ -21,6 +21,7 @@ import org.jabref.architecture.AllowedToUseAwt;
 import org.jabref.http.server.cayw.format.FormatterService;
 import org.jabref.http.server.cayw.gui.CAYWEntry;
 import org.jabref.http.server.cayw.gui.SearchDialog;
+import org.jabref.http.server.services.ContextsToServe;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.model.database.BibDatabase;
@@ -29,7 +30,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
-import com.google.gson.Gson;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
@@ -52,10 +52,10 @@ public class CAYWResource {
     private CliPreferences preferences;
 
     @Inject
-    private Gson gson;
+    private FormatterService formatterService;
 
     @Inject
-    private FormatterService formatterService;
+    private ContextsToServe contextsToServe;
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
@@ -166,6 +166,12 @@ public class CAYWResource {
     private synchronized void initializeGUI() {
         // TODO: Implement a better way to handle the window popup since this is a bit hacky.
         if (!initialized) {
+            if (!contextsToServe.getContextsToServe().isEmpty()) {
+                LOGGER.debug("Running inside JabRef UI, no need to initialize JavaFX for CAYW resource.");
+                initialized = true;
+                return;
+            }
+            LOGGER.debug("Initializing JavaFX for CAYW resource.");
             CountDownLatch latch = new CountDownLatch(1);
             Platform.startup(() -> {
                 Platform.setImplicitExit(false);


### PR DESCRIPTION
CAYW initialized JavaFX Toolkit - and double initialization is not allowed 😅

### Steps to test

1. Start JabRef
2. Enable HTTP
3. Call cyaw

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
