### PR TITLE
These are initial changes for a task regarding issue #13463

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
@@ -58,7 +58,9 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     @FXML private CheckBox remoteServer;
     @FXML private TextField remotePort;
     @FXML private CheckBox enableHttpServer;
+    @FXML private TextField enableHttpPort;
     @FXML private Button remoteHelp;
+    @FXML private Button enableHttpHelp;
     @Inject private FileUpdateMonitor fileUpdateMonitor;
     @Inject private BibEntryTypesManager entryTypesManager;
 
@@ -136,6 +138,7 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
         ActionFactory actionFactory = new ActionFactory();
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.AUTOSAVE, dialogService, preferences.getExternalApplicationsPreferences()), autosaveLocalLibrariesHelp);
         actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.REMOTE, dialogService, preferences.getExternalApplicationsPreferences()), remoteHelp);
+        actionFactory.configureIconButton(StandardActions.HELP, new HelpAction(HelpFile.REMOTE, dialogService, preferences.getExternalApplicationsPreferences()), enableHttpHelp);
 
         createBackup.selectedProperty().bindBidirectional(viewModel.createBackupProperty());
         backupDirectory.textProperty().bindBidirectional(viewModel.backupDirectoryProperty());
@@ -143,6 +146,7 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
 
         Platform.runLater(() -> {
             validationVisualizer.initVisualization(viewModel.remotePortValidationStatus(), remotePort);
+            validationVisualizer.initVisualization(viewModel.enableHttpPortValidationStatus(), enableHttpPort);
             validationVisualizer.initVisualization(viewModel.fontSizeValidationStatus(), fontSize);
             validationVisualizer.initVisualization(viewModel.customPathToThemeValidationStatus(), customThemePath);
         });
@@ -152,6 +156,8 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
         remotePort.disableProperty().bind(remoteServer.selectedProperty().not());
 
         enableHttpServer.selectedProperty().bindBidirectional(viewModel.enableHttpServerProperty());
+        enableHttpPort.textProperty().bindBidirectional(viewModel.enableHttpPortProperty());
+        enableHttpPort.disableProperty().bind(enableHttpServer.selectedProperty().not());
     }
 
     @FXML

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
@@ -83,7 +83,11 @@
     </HBox>
 
     <Label styleClass="sectionHeader" text="%HTTP Server" />
-    <CheckBox fx:id="enableHttpServer" text="%Enable HTTP Server (e.g., for JabMap)" />
+    <HBox alignment="CENTER_LEFT" spacing="10.0">
+        <CheckBox fx:id="enableHttpServer" text="%Enable HTTP Server (e.g., for JabMap)" />
+        <TextField fx:id="enableHttpPort" maxWidth="100.0" HBox.hgrow="ALWAYS" />
+        <Button fx:id="enableHttpHelp" prefWidth="20.0" />
+    </HBox>
 
     <Label styleClass="sectionHeader" text="%Libraries"/>
     <GridPane hgap="10.0" vgap="4.0">

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -365,6 +365,7 @@ public class JabRefCliPreferences implements CliPreferences {
     // Remote
     private static final String USE_REMOTE_SERVER = "useRemoteServer";
     private static final String REMOTE_SERVER_PORT = "remoteServerPort";
+    private static final String ENABLE_HTTP_SERVER_PORT = "enableHttpServerPort";
     private static final String ENABLE_HTTP_SERVER = "enableHttpServer";
 
     private static final String AI_ENABLED = "aiEnabled";
@@ -639,6 +640,7 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(USE_REMOTE_SERVER, Boolean.TRUE);
         defaults.put(REMOTE_SERVER_PORT, 6050);
         defaults.put(ENABLE_HTTP_SERVER, Boolean.FALSE);
+        defaults.put(ENABLE_HTTP_SERVER_PORT, 23119);
 
         defaults.put(EXTERNAL_JOURNAL_LISTS, "");
         defaults.put(USE_AMS_FJOURNAL, true);
@@ -1250,10 +1252,12 @@ public class JabRefCliPreferences implements CliPreferences {
         remotePreferences = new RemotePreferences(
                 getInt(REMOTE_SERVER_PORT),
                 getBoolean(USE_REMOTE_SERVER),
+                getInt(ENABLE_HTTP_SERVER_PORT),
                 getBoolean(ENABLE_HTTP_SERVER));
 
         EasyBind.listen(remotePreferences.portProperty(), (_, _, newValue) -> putInt(REMOTE_SERVER_PORT, newValue));
         EasyBind.listen(remotePreferences.useRemoteServerProperty(), (_, _, newValue) -> putBoolean(USE_REMOTE_SERVER, newValue));
+        EasyBind.listen(remotePreferences.httpPortProperty(), (_, _, newValue) -> putInt(ENABLE_HTTP_SERVER_PORT, newValue));
         EasyBind.listen(remotePreferences.enableHttpServerProperty(), (_, _, newValue) -> putBoolean(ENABLE_HTTP_SERVER, newValue));
 
         return remotePreferences;

--- a/jablib/src/main/java/org/jabref/logic/remote/RemotePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/remote/RemotePreferences.java
@@ -24,11 +24,13 @@ public class RemotePreferences {
     private final IntegerProperty port;
     private final BooleanProperty useRemoteServer;
 
+    private final IntegerProperty httpPort;
     private final BooleanProperty enableHttpServer;
 
-    public RemotePreferences(int port, boolean useRemoteServer, boolean enableHttpServer) {
+    public RemotePreferences(int port, boolean useRemoteServer, int httpPort, boolean enableHttpServer) {
         this.port = new SimpleIntegerProperty(port);
         this.useRemoteServer = new SimpleBooleanProperty(useRemoteServer);
+        this.httpPort = new SimpleIntegerProperty(httpPort);
         this.enableHttpServer = new SimpleBooleanProperty(enableHttpServer);
     }
 
@@ -58,6 +60,22 @@ public class RemotePreferences {
 
     public void setUseRemoteServer(boolean useRemoteServer) {
         this.useRemoteServer.setValue(useRemoteServer);
+    }
+
+    public int getHttpPort() {
+        return httpPort.getValue();
+    }
+
+    public IntegerProperty httpPortProperty() {
+        return httpPort;
+    }
+
+    public void setHttpPort(int httpPort) {
+        this.httpPort.setValue(httpPort);
+    }
+
+    public boolean isDifferentHttpPort(int otherHttpPort) {
+        return getHttpPort() != otherHttpPort;
     }
 
     public boolean enableHttpServer() {

--- a/jablib/src/test/java/org/jabref/logic/remote/RemotePreferencesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/remote/RemotePreferencesTest.java
@@ -13,7 +13,7 @@ class RemotePreferencesTest {
 
     @BeforeEach
     void setUp() {
-        preferences = new RemotePreferences(1000, true, false);
+        preferences = new RemotePreferences(1000, true, 3000, false);
     }
 
     @Test
@@ -22,9 +22,20 @@ class RemotePreferencesTest {
     }
 
     @Test
+    void getHttpPort() {
+        assertEquals(3000, preferences.getHttpPort());
+    }
+
+    @Test
     void setPort() {
         preferences.setPort(2000);
         assertEquals(2000, preferences.getPort());
+    }
+
+    @Test
+    void setHttpPort() {
+        preferences.setHttpPort(4000);
+        assertEquals(4000, preferences.getHttpPort());
     }
 
     @Test
@@ -44,7 +55,17 @@ class RemotePreferencesTest {
     }
 
     @Test
+    void isDifferentHttpPortTrue() {
+        assertTrue(preferences.isDifferentHttpPort(4000));
+    }
+
+    @Test
     void isDifferentPortFalse() {
         assertFalse(preferences.isDifferentPort(1000));
+    }
+
+    @Test
+    void isDifferentHttpPortFalse() {
+        assertFalse(preferences.isDifferentHttpPort(3000));
     }
 }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13463

I attempted to make changes to add an option to change the HTTP port under general preferences. However, the TextField I created named "enableHttpPort" does not have the default port number 23119 - despite changes. I tried to match the changes for "remotePort", but became confused and would like help.

My intended steps is to update all classes and configuration files to match the changes for JabRef "remotePort" for HTTP port. I would like feedback to accomplish this which includes removing or adding lines of code.

### Steps to test

You can test this task by building the application per JabRef contributor instructions and going to to JabRef preferences -> general and running the test on line 10 in the RemotePreferencesTest class.

![Screenshot 2025-07-05 121445](https://github.com/user-attachments/assets/05d913a7-97fe-40aa-b8ac-c01638c8d646)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
