### PR TITLE
Hotfix for non-shutdown of http server

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/manager/HttpServerManager.java
+++ b/jabsrv/src/main/java/org/jabref/http/manager/HttpServerManager.java
@@ -25,6 +25,12 @@ public class HttpServerManager implements AutoCloseable {
         if (!isStarted()) {
             httpServerThread = new HttpServerThread(contextsToServe, uri);
             httpServerThread.start();
+            if (httpServerThread.started()) {
+                LOGGER.debug("HTTP server manager started successfully.");
+            } else {
+                LOGGER.error("Failed to start HTTP server manager.");
+                httpServerThread = null;
+            }
         }
     }
 


### PR DESCRIPTION
When another server was started, JabRef could not shut down.

There migth be other issues - e.g., when working with preferences and another port (https://github.com/JabRef/jabref/pull/13479), but that can be handled then ^^

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
