### PR TITLE
Improve matching of DOIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a highlighted diff regarding changes to the Group Tree Structure of a bib file, made outside JabRef. [#11221](https://github.com/JabRef/jabref/issues/11221)
 - We added a new setting in the 'Entry Editor' preferences to hide the 'File Annotations' tab when no annotations are available. [#13143](https://github.com/JabRef/jabref/issues/13143)
 - We added support for multi-file import across different formats. [#13269](https://github.com/JabRef/jabref/issues/13269)
+- We improved the detection of DOIs on the first page of a PDF.
 - We added support for dark title bar on Windows. [#11457](https://github.com/JabRef/jabref/issues/11457)
-
-### Changed
-
 - We moved some functionality from the graphical application `jabref` with new command verbs `generate-citation-keys`, `check-consistency`, `fetch`, `search`, `convert`, `generate-bib-from-aux`, `preferences` and `pdf` to the new toolkit. [#13012](https://github.com/JabRef/jabref/pull/13012) [#110](https://github.com/JabRef/jabref/issues/110)
 - We merged the 'New Entry', 'Import by ID', and 'New Entry from Plain Text' tools into a single 'Create New Entry' tool. [#8808](https://github.com/JabRef/jabref/issues/8808)
 - We renamed the "Body Text" CSL bibliography header format name to "Text body" as per internal LibreOffice conventions. [#13074](https://github.com/JabRef/jabref/pull/13074)

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/pdf/PdfContentImporter.java
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.pdfbox.text.TextPosition;
+import org.jspecify.annotations.Nullable;
 
 import static org.jabref.model.strings.StringUtil.isNullOrEmpty;
 
@@ -576,18 +577,12 @@ public class PdfContentImporter extends PdfImporter {
         return Optional.of(entry);
     }
 
-    private String getDoi(String doi) {
+    private @Nullable String getDoi(@Nullable String currentDoi) {
         int pos;
-        if (doi == null) {
-            pos = curString.indexOf("DOI");
-            if (pos < 0) {
-                pos = curString.indexOf(StandardField.DOI.getName());
-            }
-            if (pos >= 0) {
-                return DOI.findInText(curString).map(DOI::asString).orElse(null);
-            }
+        if (currentDoi == null) {
+            return DOI.findInText(curString).map(DOI::asString).orElse(null);
         }
-        return doi;
+        return currentDoi;
     }
 
     private String getArXivId(String arXivId) {


### PR DESCRIPTION
Follow-up to #11782

The paper https://ieeexplore.ieee.org/document/9706284 has a DOI, but JabRef could not read it. Fixed.

    Digital Object Identifier no. 10.1109/TPDS.2022.3148985

Before PR: Only search for "DOI", not for "Digital Object Identifier". Since we have a very good DOI pattern, we don't need to search for letters "DOI", but can directly search for the DOI pattern.

![image](https://github.com/user-attachments/assets/e4963c90-8296-4d9e-b7e1-1075e2a16774)

Test-cases have a high effort, therefore not added one.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
