### PR TITLE
Output converted exceptions

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -212,6 +212,8 @@ public class UiTaskExecutor implements TaskExecutor {
     }
 
     private static Exception convertToException(Throwable throwable) {
+        // LOGGER.warn here, because the exception silently disappears otherwise
+        LOGGER.warn("Converting throwable to Exception", throwable);
         if (throwable instanceof Exception exception) {
             return exception;
         } else {


### PR DESCRIPTION
When something in a background task fails, there was nothing in the log.

This is a quick fix for a work around.

### Steps to test

Throw an NPE in `org.jabref.model.strings.StringUtil#limitStringLength` or other methods called during startup

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
