### PR TITLE
fix(jabgui): focus to link field whe open dialog

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
+import javafx.application.Platform;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
@@ -86,6 +87,8 @@ public class LinkedFileEditDialog extends BaseDialog<LinkedFile> {
         link.textProperty().bindBidirectional(viewModel.linkProperty());
         fileType.valueProperty().bindBidirectional(viewModel.selectedExternalFileTypeProperty());
         sourceUrl.textProperty().bindBidirectional(viewModel.sourceUrlProperty());
+
+        Platform.runLater(() -> link.requestFocus());
     }
 
     @FXML


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13486

focus to link field when open LinkedFileEditDialog

![2025-07-07_14-04](https://github.com/user-attachments/assets/a83c692e-995b-49e6-8b60-3d7ba2abaf56)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
