### PR TITLE
Fix for issue 12549

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where Document Viewer showed technical exceptions when opening entries with non-PDF files. [#13198](https://github.com/JabRef/jabref/issues/13198)
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)
+- Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
+
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
@@ -21,6 +21,7 @@ import org.jabref.logic.importer.IdBasedFetcher;
 import org.jabref.logic.importer.ImportCleanup;
 import org.jabref.logic.importer.WebFetcher;
 import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.importer.fetcher.DoiFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.TaskExecutor;
@@ -107,6 +108,9 @@ public class FetchAndMergeEntry {
         dialog.setTitle(Localization.lang("Merge entry with %0 information", fetcher.getName()));
         dialog.setLeftHeaderText(Localization.lang("Original entry"));
         dialog.setRightHeaderText(Localization.lang("Entry from %0", fetcher.getName()));
+        if (fetcher instanceof DoiFetcher) {
+            dialog.autoSelectBetterFields();
+        }
         Optional<BibEntry> mergedEntry = dialogService.showCustomDialogAndWait(dialog).map(EntriesMergeResult::mergedEntry);
 
         if (mergedEntry.isPresent()) {

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
@@ -64,4 +64,8 @@ public class MergeEntriesDialog extends BaseDialog<EntriesMergeResult> {
     public void configureDiff(ShowDiffConfig diffConfig) {
         threeWayMergeView.showDiff(diffConfig);
     }
+
+    public void autoSelectBetterFields() {
+        threeWayMergeView.autoSelectBetterFields();
+    }
 }

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowView.java
@@ -208,6 +208,10 @@ public class FieldRowView {
         return viewModel.hasEqualLeftAndRightValues();
     }
 
+    public void autoSelectBetterValue() {
+        viewModel.autoSelectBetterValue();
+    }
+
     @Override
     public String toString() {
         return "FieldRowView [shouldShowDiffs=" + shouldShowDiffs.get() + ", fieldNameCell=" + fieldNameCell + ", leftValueCell=" + leftValueCell + ", rightValueCell=" + rightValueCell + ", mergedValueCell=" + mergedValueCell + "]";

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/FieldRowViewModel.java
@@ -16,10 +16,13 @@ import javafx.beans.property.StringProperty;
 
 import org.jabref.gui.mergeentries.newmergedialog.fieldsmerger.FieldMerger;
 import org.jabref.gui.mergeentries.newmergedialog.fieldsmerger.FieldMergerFactory;
+import org.jabref.logic.bibtex.comparator.YearFieldValueValidityComparator;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.EntryTypeFactory;
+import org.jabref.model.entry.types.StandardEntryType;
 import org.jabref.model.strings.StringUtil;
 
 import com.tobiasdiez.easybind.EasyBind;
@@ -118,6 +121,25 @@ public class FieldRowViewModel {
         });
 
         EasyBind.subscribe(hasEqualLeftAndRightBinding(), this::setIsFieldsMerged);
+    }
+
+    public void autoSelectBetterValue() {
+        String leftValue = getLeftFieldValue();
+        String rightValue = getRightFieldValue();
+
+        if (field.equals(StandardField.YEAR)) {
+                YearFieldValueValidityComparator comparator = new YearFieldValueValidityComparator();
+                int comparison = comparator.compare(leftValue, rightValue);
+                if (comparison > 0) {
+                    selectRightValue();
+                } else if (comparison < 0) {
+                    selectLeftValue();
+                }
+        } else if (field.equals(InternalField.TYPE_HEADER)) {
+            if (leftValue.equalsIgnoreCase(StandardEntryType.Misc.getName())) {
+                selectRightValue(); // Select right value if left value is "misc"
+            }
+        }
     }
 
     public void selectNonEmptyValue() {

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/ThreeWayMergeView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/newmergedialog/ThreeWayMergeView.java
@@ -200,4 +200,10 @@ public class ThreeWayMergeView extends VBox {
     public void saveConfiguration() {
         toolbar.saveToolbarConfiguration();
     }
+
+    public void autoSelectBetterFields() {
+        for (FieldRowView row : fieldRows) {
+            row.autoSelectBetterValue();
+        }
+    }
 }

--- a/jabgui/src/test/java/org/jabref/gui/mergeentries/FieldRowViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/mergeentries/FieldRowViewModelTest.java
@@ -214,6 +214,24 @@ public class FieldRowViewModelTest {
         assertEquals(oldRightGroups, groupsField.getRightFieldValue());
     }
 
+    @Test
+    void newYearShouldBeSelectedForYearsWithLargeValueGap(){
+        BibEntry leftEntry = new BibEntry().withField(StandardField.YEAR,"1990");
+        BibEntry rightEntry = new BibEntry().withField(StandardField.YEAR,"2020");
+        FieldRowViewModel yearField = new FieldRowViewModel(StandardField.YEAR,leftEntry,rightEntry,mergedEntry,fieldMergerFactory);
+        yearField.autoSelectBetterValue();
+        assertEquals(FieldRowViewModel.Selection.RIGHT,yearField.getSelection());
+    }
+
+    @Test
+    void yearInRangeShouldBeSelected(){
+        BibEntry leftEntry = new BibEntry().withField(StandardField.YEAR,"1700");
+        BibEntry rightEntry = new BibEntry().withField(StandardField.YEAR,"2000");
+        FieldRowViewModel yearField = new FieldRowViewModel(StandardField.YEAR,leftEntry,rightEntry,mergedEntry,fieldMergerFactory);
+        yearField.autoSelectBetterValue();
+        assertEquals(FieldRowViewModel.Selection.RIGHT,yearField.getSelection());
+    }
+
     public FieldRowViewModel createViewModelForField(Field field) {
         return new FieldRowViewModel(field, leftEntry, rightEntry, mergedEntry, fieldMergerFactory);
     }

--- a/jablib/src/main/java/module-info.java
+++ b/jablib/src/main/java/module-info.java
@@ -249,5 +249,6 @@ open module org.jabref.jablib {
     requires mslinks;
     requires org.antlr.antlr4.runtime;
     requires org.libreoffice.uno;
+    requires org.jetbrains.annotations;
     // endregion
 }

--- a/jablib/src/main/java/org/jabref/logic/bibtex/comparator/FieldValueValidityComparator.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/comparator/FieldValueValidityComparator.java
@@ -1,0 +1,17 @@
+package org.jabref.logic.bibtex.comparator;
+
+import java.util.Comparator;
+
+public class FieldValueValidityComparator implements Comparator<String> {
+    /**
+     * Compares the validity or appropriateness of two field values.
+     *
+     * @param leftValue  value from the fetcher (or candidate)
+     * @param rightValue value from the library (or existing record)
+     * @return 1 if left is better, 0 if undetermined or equal, -1 if left is worse
+     */
+    @Override
+    public int compare(String leftValue, String rightValue) {
+        return 0;
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/bibtex/comparator/YearFieldValueValidityComparator.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/comparator/YearFieldValueValidityComparator.java
@@ -1,0 +1,53 @@
+package org.jabref.logic.bibtex.comparator;
+
+import java.time.Year;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jabref.logic.integrity.YearChecker;
+
+public class YearFieldValueValidityComparator extends FieldValueValidityComparator {
+
+    private static final Pattern YEAR_PATTERN = Pattern.compile("(\\d{4})");
+
+    /**
+     * Compares the validity or appropriateness of two field values.
+     *
+     * @param leftValue  value from the library (or candidate)
+     * @param rightValue value from the fetcher (or existing record)
+     * @return 1 if right is better, 0 if undetermined or equal, -1 if right is worse
+     */
+
+    @Override
+    public int compare(String leftValue, String rightValue) {
+        YearChecker checker = new YearChecker();
+
+        boolean leftValid = checker.checkValue(leftValue).isEmpty();
+
+        if (leftValid) {
+            Optional<Integer> leftYear = extractYear(leftValue);
+            Optional<Integer> rightYear = extractYear(rightValue);
+
+            boolean leftYearInRange = (leftYear.get() >= 1800) && (leftYear.get() <= Year.now().getValue());
+
+            if (leftYearInRange) {
+                int diff = Math.abs(leftYear.get() - rightYear.get());
+                if (diff > 10) {
+                    return Integer.compare(rightYear.get(), leftYear.get());
+                }
+                return 0; // years are close, undetermined
+            }
+            return 1;
+            }
+        return 1;
+    }
+
+    private Optional<Integer> extractYear(String value) {
+        Matcher matcher = YEAR_PATTERN.matcher(value);
+        if (matcher.find()) {
+            return Optional.of(Integer.parseInt(matcher.group(1)));
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION

Closes #12549

![photo_1](https://github.com/user-attachments/assets/ab444d9c-a27d-4bc8-b9ab-aca0a7163dff)
![photo_2](https://github.com/user-attachments/assets/1933b4ef-d979-4742-afef-be7663a6e277)


- Added `YearFieldValueValidityComparator` to prefer DOI year when the local year is unrealistic (e.g., before 1800 or after current year) or differs by more than 10 years  
- Enhanced entry type comparison logic to select the DOI entry type if the local entry is `misc`  
- Applied auto-selection logic in the Merge Entries dialog when merging entries using the DOI fetcher

This PR improves the auto-selection of fields during entry merge from DOI fetch. It ensures that unrealistic or inaccurate local values are automatically replaced by more valid DOI-sourced ones, specifically for the `year` and `entrytype` fields.

### Steps to test

1. Open JabRef and create a new BibTeX entry with a `year` that has a large gap (e.g., `1990`) or entry type set to `@misc`.
2. Use the **"Update with bibliographic data from DOI"** feature with a valid DOI.
3. The Merge Entries dialog should now automatically select the more accurate `year` (if the difference is >10 years or if the local year is unrealistic) and the better `entrytype` (not `misc`).
4. Verify that the correct fields are selected from the right (DOI) side by default.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
