### PR TITLE
Add System.exit

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -505,5 +505,8 @@ public class JabRefGUI extends Application {
         }
 
         LOGGER.trace("Finished stop");
+
+        // Just to be sure that we do not leave any threads running
+        System.exit(0);
     }
 }


### PR DESCRIPTION
My JabRef had the grizzly threads running on exit. I don't have the time to debug now. 

Maybe, in future, there will be other things taking time to properly shut down.

Therfore, I propose to "just" end the JVM so that nothing is left behind by JabRef.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
