### PR TITLE
Revert module name changes for remaining 'unnamed' Jars

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -4,9 +4,12 @@ plugins {
     id("org.gradlex.java-module-dependencies") // only for mappings at the moment
 }
 
-// TODO remove to translate 'requires' from 'module-info.java' to Gradle dependencies
-//      and remove 'dependencies {}' block from build.gradle files
-javaModuleDependencies { analyseOnly = true }
+javaModuleDependencies {
+    // TODO remove to translate 'requires' from 'module-info.java' to Gradle dependencies
+    //      and remove 'dependencies {}' block from build.gradle files
+    analyseOnly = true
+    moduleNameToGA.put("jul.to.slf4j", "org.slf4j:jul-to-slf4j")
+}
 
 jvmDependencyConflicts {
     consistentResolution {
@@ -107,7 +110,7 @@ extraJavaModuleInfo {
         uses("ai.djl.repository.zoo.ZooProvider")
         uses("ai.djl.repository.RepositoryFactory")
     }
-    module("at.favre.lib:hkdf", "at.favre.lib.hkdf")
+    module("at.favre.lib:hkdf", "hkdf")
     module("com.github.javakeyring:java-keyring", "java.keyring")
 
     module("com.github.tomtung:latex2unicode_2.13", "com.github.tomtung.latex2unicode") {
@@ -115,16 +118,19 @@ extraJavaModuleInfo {
         requireAllDefinedDependencies()
     }
     module("com.lihaoyi:fastparse_2.13", "fastparse") {
+        overrideModuleName() // fastparse_2.13 is not a valid name
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("scala.library")
     }
     module("com.lihaoyi:sourcecode_2.13", "com.lihaoyi.sourcecode") {
+        overrideModuleName() // sourcecode_2.13 is not a valid name
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("scala.library")
     }
     module("com.lihaoyi:geny_2.13", "com.lihaoyi.geny") {
+        overrideModuleName() // geny_2.13 is not a valid name
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("scala.library")
@@ -133,7 +139,7 @@ extraJavaModuleInfo {
     module("com.googlecode.plist:dd-plist", "dd.plist")
     module("com.h2database:h2-mvstore", "com.h2database.mvstore")
     module("com.ibm.icu:icu4j", "com.ibm.icu")
-    module("com.knuddels:jtokkit", "com.knuddels.jtokkit")
+    module("com.knuddels:jtokkit", "jtokkit")
     module("com.konghq:unirest-java-core", "unirest.java.core") {
         exportAllPackages()
         requires("java.net.http")
@@ -146,33 +152,33 @@ extraJavaModuleInfo {
     module("com.squareup.retrofit2:converter-jackson", "retrofit2.converter.jackson")
     module("com.squareup.retrofit2:retrofit", "retrofit2")
     module("com.vladsch.flexmark:flexmark", "flexmark")
-    module("com.vladsch.flexmark:flexmark-ext-emoji", "com.vladsch.flexmark.ext.emoji")
-    module("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough", "com.vladsch.flexmark.ext.gfm.strikethrough")
-    module("com.vladsch.flexmark:flexmark-ext-ins", "com.vladsch.flexmark.ext.ins")
-    module("com.vladsch.flexmark:flexmark-ext-superscript", "com.vladsch.flexmark.ext.superscript")
-    module("com.vladsch.flexmark:flexmark-ext-tables", "com.vladsch.flexmark.ext.tables")
-    module("com.vladsch.flexmark:flexmark-ext-wikilink", "com.vladsch.flexmark.ext.wikilink")
+    module("com.vladsch.flexmark:flexmark-ext-emoji", "flexmark.ext.emoji")
+    module("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough", "flexmark.ext.gfm.strikethrough")
+    module("com.vladsch.flexmark:flexmark-ext-ins", "flexmark.ext.ins")
+    module("com.vladsch.flexmark:flexmark-ext-superscript", "flexmark.ext.superscript")
+    module("com.vladsch.flexmark:flexmark-ext-tables", "flexmark.ext.tables")
+    module("com.vladsch.flexmark:flexmark-ext-wikilink", "flexmark.ext.wikilink")
     module("com.vladsch.flexmark:flexmark-html2md-converter", "flexmark.html2md.converter")
-    module("com.vladsch.flexmark:flexmark-jira-converter", "com.vladsch.flexmark.jira.converter")
-    module("com.vladsch.flexmark:flexmark-util", "com.vladsch.flexmark.util")
+    module("com.vladsch.flexmark:flexmark-jira-converter", "flexmark.jira.converter")
+    module("com.vladsch.flexmark:flexmark-util", "flexmark.util")
     module("com.vladsch.flexmark:flexmark-util-ast", "flexmark.util.ast")
-    module("com.vladsch.flexmark:flexmark-util-builder", "com.vladsch.flexmark.util.builder")
-    module("com.vladsch.flexmark:flexmark-util-collection", "com.vladsch.flexmark.util.collection")
+    module("com.vladsch.flexmark:flexmark-util-builder", "flexmark.util.builder")
+    module("com.vladsch.flexmark:flexmark-util-collection", "flexmark.util.collection")
     module("com.vladsch.flexmark:flexmark-util-data", "flexmark.util.data")
-    module("com.vladsch.flexmark:flexmark-util-dependency", "com.vladsch.flexmark.util.dependency")
-    module("com.vladsch.flexmark:flexmark-util-format", "com.vladsch.flexmark.util.format")
-    module("com.vladsch.flexmark:flexmark-util-html", "com.vladsch.flexmark.util.html")
-    module("com.vladsch.flexmark:flexmark-util-misc", "com.vladsch.flexmark.util.misc")
-    module("com.vladsch.flexmark:flexmark-util-options", "com.vladsch.flexmark.util.options")
-    module("com.vladsch.flexmark:flexmark-util-sequence", "com.vladsch.flexmark.util.sequence")
-    module("com.vladsch.flexmark:flexmark-util-visitor", "com.vladsch.flexmark.util.visitor")
+    module("com.vladsch.flexmark:flexmark-util-dependency", "flexmark.util.dependency")
+    module("com.vladsch.flexmark:flexmark-util-format", "flexmark.util.format")
+    module("com.vladsch.flexmark:flexmark-util-html", "flexmark.util.html")
+    module("com.vladsch.flexmark:flexmark-util-misc", "flexmark.util.misc")
+    module("com.vladsch.flexmark:flexmark-util-options", "flexmark.util.options")
+    module("com.vladsch.flexmark:flexmark-util-sequence", "flexmark.util.sequence")
+    module("com.vladsch.flexmark:flexmark-util-visitor", "flexmark.util.visitor")
     module("commons-beanutils:commons-beanutils", "commons.beanutils")
     module("commons-collections:commons-collections", "commons.collections")
     module("commons-digester:commons-digester", "commons.digester")
-    module("de.rototor.jeuclid:jeuclid-core", "de.rototor.jeuclid.core")
+    module("de.rototor.jeuclid:jeuclid-core", "jeuclid.core")
     module("de.rototor.snuggletex:snuggletex-core", "snuggletex.core")
-    module("de.rototor.snuggletex:snuggletex-jeuclid", "de.rototor.snuggletex.jeuclid")
-    module("de.swiesend:secret-service", "de.swiesend.secret.service")
+    module("de.rototor.snuggletex:snuggletex-jeuclid", "snuggletex.jeuclid")
+    module("de.swiesend:secret-service", "secret.service")
     module("de.undercouch:citeproc-java", "citeproc.java") {
         exportAllPackages()
         requires("java.xml")
@@ -191,16 +197,16 @@ extraJavaModuleInfo {
     module("dev.langchain4j:langchain4j-hugging-face", "langchain4j.hugging.face")
     module("dev.langchain4j:langchain4j-mistral-ai", "langchain4j.mistral.ai")
     module("dev.langchain4j:langchain4j-open-ai", "langchain4j.open.ai")
-    module("eu.lestard:doc-annotations", "eu.lestard.doc.annotations")
+    module("eu.lestard:doc-annotations", "doc.annotations")
     module("info.debatty:java-string-similarity", "java.string.similarity")
     module("io.github.adr:e-adr", "io.github.adr")
     module("io.github.java-diff-utils:java-diff-utils", "io.github.javadiffutils")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-darwin-amd64", "io.zonky.test.postgres.embedded.postgres.binaries.darwin.amd64")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-darwin-arm64v8", "io.zonky.test.postgres.embedded.postgres.binaries.darwin.arm64v8")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64", "io.zonky.test.postgres.embedded.postgres.binaries.linux.amd64")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64-alpine", "io.zonky.test.postgres.embedded.postgres.binaries.linux.amd64.alpine")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-arm64v8", "io.zonky.test.postgres.embedded.postgres.binaries.linux.arm64v8")
-    module("io.zonky.test.postgres:embedded-postgres-binaries-windows-amd64", "io.zonky.test.postgres.embedded.postgres.binaries.windows.amd64")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-darwin-amd64", "embedded.postgres.binaries.darwin.amd64")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-darwin-arm64v8", "embedded.postgres.binaries.darwin.arm64v8")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64", "embedded.postgres.binaries.linux.amd64")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-amd64-alpine", "embedded.postgres.binaries.linux.amd64.alpine")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-linux-arm64v8", "embedded.postgres.binaries.linux.arm64v8")
+    module("io.zonky.test.postgres:embedded-postgres-binaries-windows-amd64", "embedded.postgres.binaries.windows.amd64")
     module("net.harawata:appdirs", "net.harawata.appdirs")
     module("net.java.dev.jna:jna", "com.sun.jna") {
         patchRealModule()
@@ -208,8 +214,8 @@ extraJavaModuleInfo {
         requires("java.logging")
     }
     module("net.java.dev.jna:jna-platform", "com.sun.jna.platform")
-    module("net.jcip:jcip-annotations", "net.jcip.annotations")
-    module("net.jodah:typetools", "net.jodah.typetools")
+    module("net.jcip:jcip-annotations", "jcip.annotations")
+    module("net.jodah:typetools", "typetools")
     module("org.abego.treelayout:org.abego.treelayout.core", "org.abego.treelayout.core")
     module("org.antlr:antlr4-runtime", "org.antlr.antlr4.runtime")
     module("org.apache.httpcomponents.client5:httpclient5", "org.apache.httpcomponents.client5.httpclient5")
@@ -226,7 +232,7 @@ extraJavaModuleInfo {
     module("org.apache.velocity:velocity-engine-core", "velocity.engine.core")
     module("org.eclipse.jgit:org.eclipse.jgit", "org.eclipse.jgit")
     module("org.fxmisc.undo:undofx", "org.fxmisc.undo")
-    module("org.fxmisc.wellbehaved:wellbehavedfx", "org.fxmisc.wellbehaved") {
+    module("org.fxmisc.wellbehaved:wellbehavedfx", "wellbehavedfx") {
         exportAllPackages()
         requires("javafx.graphics")
     }
@@ -235,7 +241,7 @@ extraJavaModuleInfo {
         exportAllPackages()
     }
     module("org.scala-lang:scala-library", "scala.library")
-    module("pt.davidafsilva.apple:jkeychain", "pt.davidafsilva.apple.jkeychain")
+    module("pt.davidafsilva.apple:jkeychain", "jkeychain")
 
     module("org.testfx:testfx-core", "org.testfx") {
         patchRealModule()
@@ -296,46 +302,46 @@ extraJavaModuleInfo {
     }
 
     module("org.glassfish.hk2.external:aopalliance-repackaged", "org.aopalliance")
-    module("org.glassfish.jersey.core:jersey-server", "org.glassfish.jersey.server") {
+    module("org.glassfish.jersey.core:jersey-server", "jersey.server") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
         requires("jakarta.xml.bind")
-        requires("org.glassfish.jersey.hk2")
+        requires("jersey.hk2")
     }
-    // module("org.glassfish.jersey.containers:jersey-container-servlet", "org.glassfish.jersey.servlet")
-    module("org.glassfish.jersey.inject:jersey-hk2", "org.glassfish.jersey.hk2") {
+    // module("org.glassfish.jersey.containers:jersey-container-servlet", "jersey.servlet")
+    module("org.glassfish.jersey.inject:jersey-hk2", "jersey.hk2") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
     }
-    module("org.glassfish.jersey.core:jersey-client", "org.glassfish.jersey.client") {
+    module("org.glassfish.jersey.core:jersey-client", "jersey.client") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
     }
-    module("org.glassfish.jersey.core:jersey-common", "org.glassfish.jersey.common") {
+    module("org.glassfish.jersey.core:jersey-common", "jersey.common") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
         requires("java.xml")
     }
-    module("org.glassfish.jersey.containers:jersey-container-grizzly2-http", "org.glassfish.jersey.grizzly2.http") {
+    module("org.glassfish.jersey.containers:jersey-container-grizzly2-http", "jersey.container.grizzly2.http") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
         requires("org.glassfish.grizzly")
         requires("org.glassfish.grizzly.http")
     }
-    module("org.glassfish.jersey.test-framework:jersey-test-framework-core", "org.glassfish.jersey.test.framework.core") {
+    module("org.glassfish.jersey.test-framework:jersey-test-framework-core", "jersey.test.framework.core") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
     }
-    module("org.glassfish.jersey.containers:jersey-container-grizzly2-servlet", "org.glassfish.jersey.container.grizzly2.servlet") {
+    module("org.glassfish.jersey.containers:jersey-container-grizzly2-servlet", "jersey.container.grizzly2.servlet") {
         // requires("org.glassfish.jersey.servlet")
     }
-    module("org.glassfish.jersey.containers:jersey-container-servlet", "org.glassfish.jersey.container.servlet") {
+    module("org.glassfish.jersey.containers:jersey-container-servlet", "jersey.container.servlet") {
         exportAllPackages()
         // requireAllDefinedDependencies()
         requires("org.glassfish.jersey.container.servlet.core")
@@ -345,17 +351,17 @@ extraJavaModuleInfo {
         patchRealModule()
         exportAllPackages()
     }
-    module("org.glassfish.jersey.containers:jersey-container-servlet-core", "org.glassfish.jersey.container.servlet.core") {
+    module("org.glassfish.jersey.containers:jersey-container-servlet-core", "jersey.container.servlet.core") {
         exportAllPackages()
         requires("jakarta.servlet.api")
     }
-    module("org.glassfish.jersey.media:jersey-media-jaxb", "org.glassfish.jersey.media.jaxb") {
+    module("org.glassfish.jersey.media:jersey-media-jaxb", "jersey.media.jaxb") {
         requireAllDefinedDependencies()
         requires("java.logging")
         requires("java.xml")
         requires("jakarta.xml.bind")
     }
-    module("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2", "org.glassfish.jersey.test.provider.grizzly2") {
+    module("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2", "jersey.test.provider.grizzly2") {
         requireAllDefinedDependencies()
         requires("java.logging")
     }
@@ -374,7 +380,7 @@ extraJavaModuleInfo {
         requireAllDefinedDependencies()
         requires("java.logging")
     }
-    module("org.glassfish.hk2:osgi-resource-locator", "org.glassfish.hk2.osgi.resource.locator") {
+    module("org.glassfish.hk2:osgi-resource-locator", "osgi.resource.locator") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requires("java.logging")
@@ -397,7 +403,7 @@ extraJavaModuleInfo {
         requireAllDefinedDependencies()
         requiresTransitive("javafx.base")
     }
-    module("org.reactfx:reactfx", "org.reactfx") {
+    module("org.reactfx:reactfx", "reactfx") {
         exportAllPackages()
         requireAllDefinedDependencies()
         requiresTransitive("javafx.controls")

--- a/jabgui/src/main/java/module-info.java
+++ b/jabgui/src/main/java/module-info.java
@@ -46,7 +46,7 @@ open module org.jabref {
     provides org.kordamp.ikonli.IkonProvider
             with org.jabref.gui.icon.JabrefIconProvider;
 
-    requires org.reactfx;
+    requires reactfx;
     // endregion
 
     // region: Logging
@@ -155,7 +155,7 @@ open module org.jabref {
     // uses ai.djl.engine.EngineProvider;
     // uses ai.djl.repository.RepositoryFactory;
     // uses ai.djl.repository.zoo.ZooProvider;
-    // uses dev.langchain4j.spi.prompt.PromptTemplateFactory;
+    // uses langchain4j.spi.prompt.PromptTemplateFactory;
     // requires velocity.engine.core;
     // endregion
 

--- a/jabsrv-cli/src/main/java/module-info.java
+++ b/jabsrv-cli/src/main/java/module-info.java
@@ -26,7 +26,7 @@ module org.jabref.jabsrv.cli {
     requires jakarta.validation;
     requires jakarta.ws.rs;
 
-    requires org.glassfish.jersey.common;
+    requires jersey.common;
 
     requires info.picocli;
 
@@ -39,6 +39,6 @@ module org.jabref.jabsrv.cli {
 
     requires transitive org.jspecify;
     requires java.logging;
-    requires org.glassfish.jersey.grizzly2.http;
-    requires org.glassfish.jersey.server;
+    requires jersey.container.grizzly2.http;
+    requires jersey.server;
 }

--- a/jabsrv/build.gradle.kts
+++ b/jabsrv/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
 
 javaModuleTesting.whitebox(testing.suites["test"]) {
     requires.add("jul.to.slf4j")
-    requires.add("org.glassfish.jersey.test.framework.core")
+    requires.add("jersey.test.framework.core")
     requires.add("org.junit.jupiter.api")
     requires.add("org.mockito")
 }

--- a/jabsrv/src/main/java/module-info.java
+++ b/jabsrv/src/main/java/module-info.java
@@ -38,7 +38,7 @@ module org.jabref.jabsrv {
     requires jakarta.validation;
     requires jakarta.ws.rs;
 
-    requires org.glassfish.jersey.common;
+    requires jersey.common;
 
     requires net.harawata.appdirs;
     requires com.sun.jna;
@@ -49,6 +49,6 @@ module org.jabref.jabsrv {
 
     requires transitive org.jspecify;
     requires java.logging;
-    requires org.glassfish.jersey.grizzly2.http;
-    requires org.glassfish.jersey.server;
+    requires jersey.container.grizzly2.http;
+    requires jersey.server;
 }


### PR DESCRIPTION
Closes #13509

### Steps to test

This is a follow up to #13511 that also reverts the names of "unnamed" modules not used in `jablib` but in other components. I think this is good to have consistency in this topic.

This was done using a new (not yet released) check in the `extra-java-module-info` plugin:
https://github.com/gradlex-org/extra-java-module-info/pull/189

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- ~[ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)~
- ~[ ] Tests created for changes (if applicable)~
- [x] Manually tested changed features in running JabRef (always required)
- ~[ ] Screenshots added in PR description (if change is visible to the user)~
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
