### PR TITLE
Use Java 11 isBlank

### DIFF
--- a/jablib/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -635,19 +635,18 @@ public class StringUtil {
     }
 
     public static boolean isBlank(String string) {
-        return !isNotBlank(string);
+        return (string == null) || string.isBlank();
     }
 
     public static boolean isBlank(Optional<String> string) {
-        return !isNotBlank(string);
+        return !string.isPresent() || isBlank(string.get());
     }
 
     /**
      * Checks if a CharSequence is not empty (""), not null and not whitespace only.
      */
     public static boolean isNotBlank(String string) {
-        // No Guava equivalent existing
-        return StringUtils.isNotBlank(string);
+        return !isBlank(string);
     }
 
     public static boolean isNotBlank(Optional<String> string) {


### PR DESCRIPTION
Since Java 11, there is `isBlank`. - https://stackoverflow.com/q/51299126/873282.

No need for Apache Commons usage here.

Triggered by https://github.com/JabRef/jabref/pull/13519

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
