### PR TITLE
Have the picker always on top

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SearchDialog.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SearchDialog.java
@@ -103,10 +103,7 @@ public class SearchDialog {
         dialogStage.setX((screenBounds.getWidth() - dialogWidth) / 2);
         dialogStage.setY((screenBounds.getHeight() - dialogHeight) / 2);
 
-        // Ensure that dialog is not just flashing in the taskbar, but really in front
-        // TODO: Investigate why this is not working
-        // scene.getWindow().requestFocus();
-
+        dialogStage.setAlwaysOnTop(true);
         dialogStage.showAndWait();
 
         return selectedItems;


### PR DESCRIPTION
When the CAYW picker is triggered, it should be shown.

According to https://stackoverflow.com/a/38801936/873282, `setAlwaysOnTop(true)` is the only way. true and then false did not have any effect here: https://stackoverflow.com/a/48798192/873282

### Steps to test

Trigger CAYW - e.g., by `cayw.http` and executing the first GET

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
