### PR TITLE
fixed the issue

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/SearchShortScienceAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/SearchShortScienceAction.java
@@ -23,6 +23,7 @@ public class SearchShortScienceAction extends SimpleCommand {
     private final StateManager stateManager;
     private final GuiPreferences preferences;
 
+
     public SearchShortScienceAction(DialogService dialogService, StateManager stateManager, GuiPreferences preferences) {
         this.dialogService = dialogService;
         this.stateManager = stateManager;
@@ -43,7 +44,9 @@ public class SearchShortScienceAction extends SimpleCommand {
             }
             ExternalLinkCreator.getShortScienceSearchURL(bibEntries.getFirst()).ifPresent(url -> {
                 try {
+
                     NativeDesktop.openExternalViewer(databaseContext, preferences, url, StandardField.URL, dialogService, bibEntries.getFirst());
+
                 } catch (IOException ex) {
                     dialogService.showErrorDialogAndWait(Localization.lang("Unable to open ShortScience."), ex);
                 }

--- a/jablib/src/main/java/org/jabref/logic/util/ExternalLinkCreator.java
+++ b/jablib/src/main/java/org/jabref/logic/util/ExternalLinkCreator.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.strings.LatexToUnicodeAdapter;
 
 import org.apache.hc.core5.net.URIBuilder;
 
@@ -26,8 +27,10 @@ public class ExternalLinkCreator {
                 // This should never be able to happen as it would require the field to be misconfigured.
                 throw new AssertionError("ShortScience URL is invalid.", e);
             }
+            //Filtering the title if it contains {} in it
+            String filteredTitle = LatexToUnicodeAdapter.format(title);
             // Direct the user to the search results for the title.
-            uriBuilder.addParameter("q", title.trim());
+            uriBuilder.addParameter("q", filteredTitle.trim());
             return uriBuilder.toString();
         });
     }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13418

Basically the title was not being filtered before the URL for "Search ShortSience" building. so I updated it to passing the filtered title. I am filtering the title using org.jabref.model.strings.LatexToUnicodeAdapter

I am opening a draft PR right now, i just need to create the test for it and hopefully i should be done with it shortly.

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
