### PR TITLE
Fix Intel crash in ThemeManager on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
+- We fixed an issue where JabRef crashed on startup on Apple Silicon Macs due to native library compatibility issues in the theme manager. [#13536](https://github.com/JabRef/jabref/issues/13536)
 
 ### Removed
 
@@ -197,7 +198,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where libraries would sometimes be hidden when closing tabs with the Welcome tab open. [#12894](https://github.com/JabRef/jabref/issues/12894)
 - We fixed an issue with deleting entries in large libraries that caused it to take a long time. [#8976](https://github.com/JabRef/jabref/issues/8976)
 - We fixed an issue where "Reveal in file explorer" option was disabled for newly saved libraries until reopening the file. [#12722](https://github.com/JabRef/jabref/issues/12722)
-- We fixed an issue where JabRef crashed on startup on Apple Silicon Macs due to native library compatibility issues in the theme manager. [#13536](https://github.com/JabRef/jabref/issues/13536)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - When creating a library, if you drag a PDF file containing only a single column, the dialog will now automatically close. [#13262](https://github.com/JabRef/jabref/issues/13262)
 - We fixed an issue where the tab showing the fulltext search results would appear blank after switching library. [#13241](https://github.com/JabRef/jabref/issues/13241)
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
-- We fixed an issue where JabRef crashed on startup on Apple Silicon Macs due to native library compatibility issues in the theme manager. [#13536](https://github.com/JabRef/jabref/issues/13536)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where libraries would sometimes be hidden when closing tabs with the Welcome tab open. [#12894](https://github.com/JabRef/jabref/issues/12894)
 - We fixed an issue with deleting entries in large libraries that caused it to take a long time. [#8976](https://github.com/JabRef/jabref/issues/8976)
 - We fixed an issue where "Reveal in file explorer" option was disabled for newly saved libraries until reopening the file. [#12722](https://github.com/JabRef/jabref/issues/12722)
+- We fixed an issue where JabRef crashed on startup on Apple Silicon Macs due to native library compatibility issues in the theme manager. [#13536](https://github.com/JabRef/jabref/issues/13536)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -58,7 +58,7 @@ public class ThemeManager {
     private final WorkspacePreferences workspacePreferences;
     private final FileUpdateMonitor fileUpdateMonitor;
     private final Consumer<Runnable> updateRunner;
-    private final ThemeWindowManager themeWindowManager;
+    private ThemeWindowManager themeWindowManager;
 
     private final StyleSheet baseStyleSheet;
     private Theme theme;
@@ -73,13 +73,12 @@ public class ThemeManager {
         this.workspacePreferences = Objects.requireNonNull(workspacePreferences);
         this.fileUpdateMonitor = Objects.requireNonNull(fileUpdateMonitor);
         this.updateRunner = Objects.requireNonNull(updateRunner);
-        ThemeWindowManager tempThemeWindowManager = null;
         try {
-            tempThemeWindowManager = ThemeWindowManagerFactory.create();
+            this.themeWindowManager = ThemeWindowManagerFactory.create();
         } catch (UnsatisfiedLinkError | RuntimeException e) {
             LOGGER.error("Failed to create ThemeWindowManager (likely due to native library compatibility issues on ARM64)", e);
+            this.themeWindowManager = null;
         }
-        this.themeWindowManager = tempThemeWindowManager;
 
         this.baseStyleSheet = StyleSheet.create(Theme.BASE_CSS).get();
         this.theme = workspacePreferences.getTheme();

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -124,12 +124,12 @@ public class ThemeManager {
 
         try {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
+            LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
         } catch (UnsatisfiedLinkError | RuntimeException e) {
             // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86)
             // See https://github.com/dukke/FXThemes/issues/13 for details
-            LOGGER.debug("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
+            LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
         }
-        LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
     }
 
     private void applyDarkModeToAllWindows(boolean darkMode) {

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -125,7 +125,7 @@ public class ThemeManager {
         try {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
             LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
-        } catch (UnsatisfiedLinkError | RuntimeException e) {
+        } catch (ExceptionInInitializerError e) {
             // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86).
             // See https://github.com/dukke/FXThemes/issues/13 for details.
             LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -126,8 +126,8 @@ public class ThemeManager {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
             LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
         } catch (UnsatisfiedLinkError | RuntimeException e) {
-            // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86)
-            // See https://github.com/dukke/FXThemes/issues/13 for details
+            // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86).
+            // See https://github.com/dukke/FXThemes/issues/13 for details.
             LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -128,7 +128,7 @@ public class ThemeManager {
         } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
             // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86).
             // See https://github.com/dukke/FXThemes/issues/13 for details.
-            LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
+            LOGGER.debug("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
         }
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -123,10 +123,10 @@ public class ThemeManager {
 
         try {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
-            LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
-        } catch (RuntimeException e) {
+        } catch (UnsatisfiedLinkError | RuntimeException e) {
             LOGGER.error("Failed to set dark mode for window frame (likely due to native library compatibility issues on ARM64)", e);
         }
+        LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
     }
 
     private void applyDarkModeToAllWindows(boolean darkMode) {

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -125,7 +125,7 @@ public class ThemeManager {
         try {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
             LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
-        } catch (ExceptionInInitializerError | UnsatisfiedLinkError e) {
+        } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
             // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86).
             // See https://github.com/dukke/FXThemes/issues/13 for details.
             LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -125,7 +125,7 @@ public class ThemeManager {
         try {
             themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
             LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
-        } catch (ExceptionInInitializerError e) {
+        } catch (ExceptionInInitializerError | UnsatisfiedLinkError e) {
             // We need to handle these exceptions because the native library may not be available on all platforms (e.g., x86).
             // See https://github.com/dukke/FXThemes/issues/13 for details.
             LOGGER.info("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -76,7 +76,7 @@ public class ThemeManager {
         try {
             this.themeWindowManager = ThemeWindowManagerFactory.create();
         } catch (UnsatisfiedLinkError | RuntimeException e) {
-            LOGGER.error("Failed to create ThemeWindowManager (likely due to native library compatibility issues on ARM64)", e);
+            LOGGER.debug("Failed to create ThemeWindowManager (likely due to native library compatibility issues on intel)", e);
             this.themeWindowManager = null;
         }
 
@@ -130,7 +130,7 @@ public class ThemeManager {
             try {
                 themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
             } catch (UnsatisfiedLinkError | RuntimeException e) {
-                LOGGER.error("Failed to set dark mode for window frame (likely due to native library compatibility issues on ARM64)", e);
+                LOGGER.debug("Failed to set dark mode for window frame (likely due to native library compatibility issues on intel)", e);
             }
         }
         LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);

--- a/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/theme/ThemeManager.java
@@ -121,8 +121,12 @@ public class ThemeManager {
             return;
         }
 
-        themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
-        LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
+        try {
+            themeWindowManager.setDarkModeForWindowFrame(stage, darkMode);
+            LOGGER.debug("Applied {} mode to window: {}", darkMode ? "dark" : "light", stage);
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to set dark mode for window frame (likely due to native library compatibility issues on ARM64)", e);
+        }
     }
 
     private void applyDarkModeToAllWindows(boolean darkMode) {


### PR DESCRIPTION
- Add try/catch around themeWindowManager.install() to handle RuntimeException
- Prevents crash when native libraries are incompatible with ARM64 architecture
- Fixes #13536

Closes https://github.com/JabRef/jabref/issues/13536

## Changes
- Added try/catch block around `themeWindowManager.install(scene)` in ThemeManager
- Prevents RuntimeException crash when native libraries are incompatible with ARM64 architecture

## Testing
- [x] Tested on macOS ARM64 - no longer crashes on startup
- [x] Build passes successfully
- [x] Application starts and runs normally

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
