### PR TITLE
Fix for issue 12351: Area of preview on hover should be shrink to the size of the text displayed

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
@@ -1,10 +1,8 @@
 package org.jabref.gui.maintable;
 
-import javafx.animation.PauseTransition;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.VBox;
-import javafx.util.Duration;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.GuiPreferences;
@@ -33,10 +31,7 @@ public class MainTableTooltip extends Tooltip {
             preview.setLayout(preferences.getPreviewPreferences().getSelectedPreviewLayout());
             preview.setDatabaseContext(databaseContext);
             preview.setEntry(entry);
-//            this.setGraphic(tooltipContent);
-            PauseTransition delay = new PauseTransition(Duration.millis(150)); // Tune this value if needed
-            delay.setOnFinished(e -> this.setGraphic(tooltipContent));
-            delay.play();
+            this.setGraphic(tooltipContent);
         } else {
             this.setGraphic(fieldValueLabel);
         }

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableTooltip.java
@@ -1,8 +1,10 @@
 package org.jabref.gui.maintable;
 
+import javafx.animation.PauseTransition;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.GuiPreferences;
@@ -31,7 +33,10 @@ public class MainTableTooltip extends Tooltip {
             preview.setLayout(preferences.getPreviewPreferences().getSelectedPreviewLayout());
             preview.setDatabaseContext(databaseContext);
             preview.setEntry(entry);
-            this.setGraphic(tooltipContent);
+//            this.setGraphic(tooltipContent);
+            PauseTransition delay = new PauseTransition(Duration.millis(150)); // Tune this value if needed
+            delay.setOnFinished(e -> this.setGraphic(tooltipContent));
+            delay.play();
         } else {
             this.setGraphic(fieldValueLabel);
         }

--- a/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
+++ b/jabgui/src/main/java/org/jabref/gui/preview/PreviewViewer.java
@@ -125,6 +125,12 @@ public class PreviewViewer extends ScrollPane implements InvalidationListener {
                 return;
             }
 
+            Object height = previewView.getEngine().executeScript("document.getElementById('content').scrollHeight");
+            if (height instanceof java.lang.Number) {
+                double actualHeight = ((java.lang.Number) height).doubleValue();
+                previewView.setPrefHeight(actualHeight + 10);
+            }
+
             // https://stackoverflow.com/questions/15555510/javafx-stop-opening-url-in-webview-open-in-browser-instead
             NodeList anchorList = previewView.getEngine().getDocument().getElementsByTagName("a");
             for (int i = 0; i < anchorList.getLength(); i++) {


### PR DESCRIPTION
Closes (https://github.com/JabRef/jabref/issues/12351)
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->
The issue was basically the box height was not getting set based on the contents of the entry. The default height was always being used. 

So currently I have updated the PreivewViewer.java file to get the current height based on the content of the entry. Initially I did not add any extra padding but then the last bit of the content was getting cut off. So as of now i have added extra 10 and it gives me the last bit content properly and lil extra room. I can reduce that if you want.
 
I have fixed 90% fixed the issue. However still on the first render the old tooltip box height is being displayed but after that I am getting the correct box height based on the text. So figuring out how to fix that.

#### Current look with extra 10 padding:

<img width="1255" height="357" alt="image" src="https://github.com/user-attachments/assets/c1353e73-7b6f-4a73-bf7c-8258afc9bf48" />

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->



### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
