### PR TITLE
[ISSUE-13404] Get fulltext does not work for Wiley.

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -47,6 +47,7 @@ import org.jabref.logic.importer.fetcher.SemanticScholar;
 import org.jabref.logic.importer.fetcher.SpringerFetcher;
 import org.jabref.logic.importer.fetcher.SpringerLink;
 import org.jabref.logic.importer.fetcher.TitleFetcher;
+import org.jabref.logic.importer.fetcher.WillyFetcher;
 import org.jabref.logic.importer.fetcher.ZbMATH;
 import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
 import org.jabref.logic.importer.fileformat.PdfMergeMetadataImporter;
@@ -215,6 +216,7 @@ public class WebFetchers {
         fetchers.add(new IEEE(importFormatPreferences, importerPreferences));
         fetchers.add(new ApsFetcher());
         fetchers.add(new IacrEprintFetcher(importFormatPreferences));
+        fetchers.add(new WillyFetcher());
 
         // Meta search
         // fetchers.add(new JstorFetcher(importFormatPreferences));

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/WillyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/WillyFetcher.java
@@ -1,0 +1,35 @@
+package org.jabref.logic.importer.fetcher;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.FulltextFetcher;
+import org.jabref.logic.util.URLUtil;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.identifier.DOI;
+
+public class WillyFetcher implements FulltextFetcher {
+
+    private static final String PDF_URL = "https://onlinelibrary.wiley.com/doi/pdf/";
+
+    @Override
+    public Optional<URL> findFullText(BibEntry entry) throws IOException, FetcherException {
+        Objects.requireNonNull(entry);
+
+        Optional<DOI> doi = entry.getField(StandardField.DOI).flatMap(DOI::parse);
+        if (doi.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(URLUtil.create(PDF_URL + doi.get().asString()));
+    }
+
+    @Override
+    public TrustLevel getTrustLevel() {
+        return TrustLevel.SOURCE;
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/WillyFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/WillyFetcherTest.java
@@ -1,0 +1,52 @@
+package org.jabref.logic.importer.fetcher;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.util.URLUtil;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.support.DisabledOnCIServer;
+import org.jabref.testutils.category.FetcherTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@FetcherTest
+class WillyFetcherTest {
+    public static final String URL = "https://onlinelibrary.wiley.com/doi/pdf/";
+    public static final String DOI = "10.1002/we.2952";
+    public static final String INVALID_DOI = "10.1021/acsc.4c00971";
+
+    WillyFetcher sut = new WillyFetcher();
+
+    @Test
+    @DisabledOnCIServer("CI server is unreliable")
+    void shouldFindUrlByDoi() throws IOException, FetcherException {
+        BibEntry entry = new BibEntry().withField(StandardField.DOI, DOI);
+
+        Optional<URL> result = sut.findFullText(entry);
+
+        assertEquals(Optional.of(URLUtil.create(URL + DOI)), result);
+    }
+//
+//    @Test
+//    @DisabledOnCIServer("CI server is unreliable")
+//    void shouldHandleInvalidDoi() throws FetcherException, IOException {
+//        BibEntry entry = new BibEntry().withField(StandardField.DOI, INVALID_DOI);
+//        assertEquals(Optional.empty(), sut.findFullText(entry));
+//    }
+
+    @Test
+    void shouldHandleEntityWithoutDoi() throws FetcherException, IOException {
+        assertEquals(Optional.empty(), sut.findFullText(new BibEntry()));
+    }
+
+    @Test
+    void shouldReturnCorrectTrustLevel() {
+        assertEquals(TrustLevel.SOURCE, sut.getTrustLevel());
+    }
+}


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
