### PR TITLE
Add Wix Toolset to Windows setup

### DIFF
--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-02-software.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-02-software.md
@@ -21,12 +21,13 @@ It is strongly recommended that you have git installed.
 
 ### Windows
 
-* Use [git for windows](https://git-for-windows.github.io), no additional git tooling required
+* Install [Git for Windows](https://git-for-windows.github.io), no additional git tooling required. Git for Windows includes Git Bash.
   * [Download the installer](http://git-scm.com/download/win) and install it.
   * Activate the option "Use Git and optional Unix tools from the Windows Command Prompt".
   * [Git Credential Manager for Windows](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) is included. Ensure that you include that in the installation. Aim: Store password for GitHub permanently for `https` repository locations
   * [Configure using Visual Studio Code as editor](https://code.visualstudio.com/docs/sourcecontrol/overview#_vs-code-as-git-editor) for any git prompts (commit messages at merge, ...)
-* We recommend using [Windows Terminal](https://aka.ms/terminal).
+* We recommend using [Windows Terminal](https://aka.ms/terminal), [configured to start Git Bash].
+* Install [WixToolSet](https://github.com/wixtoolset/wix).
 
 {: note}
 You can use [chocolatey](https://chocolatey.org/) to install git more smoothly.


### PR DESCRIPTION
This replaces https://github.com/JabRef/jabref/pull/13567

Closes https://github.com/JabRef/user-documentation/issues/578
Related to https://github.com/JabRef/user-documentation/pull/579

* Adds Wix Toolset to Windows requirements.
* Recommends Bash for Windows. 

I recommend Git for Windows because (1) it is installed with Git Bash and (2) it is commonly used by Windows developers to have a linux-like environment. This generally eliminates the need for separate Windows build instructions. I realize this is kind of pushy so would be happy to remove it from this PR and/or create an issue.

### Steps to test

n/a

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
