### PR TITLE
Fix version for SNAPSHOT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,5 +97,6 @@ jobs:
           file ${{ steps.secring.outputs.filePath }}
           md5sum ${{ steps.secring.outputs.filePath }}
       - name: publishAllPublicationsToMavenCentralRepository
-        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.AssemblySemVer }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ steps.istagbuild.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository
+        # different version at maven centrl: 6.0-SNAPSHOT - and not 6.0.23234-SNAPSHOT
+        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ steps.istagbuild.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository
       # endregion

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,5 +111,5 @@ jobs:
           else
             tagbuild="false"
           fi
-          echo ./gradlew -PprojVersion="${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="$tagbuild" :jablib:publishAllPublicationsToMavenCentralRepository
+          ./gradlew -PprojVersion="${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="$tagbuild" :jablib:publishAllPublicationsToMavenCentralRepository
       # endregion

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,12 @@ on:
     # run on each Monday
     - cron: '2 3 * * 1'
   workflow_dispatch:
+    inputs:
+      tagbuild:
+        description: 'Trigger a full maven central release'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: write
@@ -97,6 +103,13 @@ jobs:
           file ${{ steps.secring.outputs.filePath }}
           md5sum ${{ steps.secring.outputs.filePath }}
       - name: publishAllPublicationsToMavenCentralRepository
-        # different version at maven centrl: 6.0-SNAPSHOT - and not 6.0.23234-SNAPSHOT
-        run: ./gradlew -PprojVersion="${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="${{ steps.istagbuild.outputs.tagbuild }}" :jablib:publishAllPublicationsToMavenCentralRepository
+        # Different version at maven centrl: 6.0-SNAPSHOT - and not 6.0.23234-SNAPSHOT
+        # We need to manually trigger a full maven central release - to avoid 6.0-alpha3 being published as 6.0 on maven central.
+        run: |
+          if [[ "${{ github.event.inputs.tagbuild }}" == "true" ]]; then
+            tagbuild="true"
+          else
+            tagbuild="false"
+          fi
+          echo ./gradlew -PprojVersion="${{ steps.gitversion.outputs.Major }}.${{ steps.gitversion.outputs.Minor }}" -PprojVersionInfo="${{ steps.gitversion.outputs.InformationalVersion }}" -Ptagbuild="$tagbuild" :jablib:publishAllPublicationsToMavenCentralRepository
       # endregion

--- a/.jbang/JabKitLauncher.java
+++ b/.jbang/JabKitLauncher.java
@@ -21,8 +21,8 @@
 //FILES tinylog.properties=../jabkit/src/main/resources/tinylog.properties
 
 // REPOS mavencentral,snapshots=https://central.sonatype.com/repository/maven-snapshots/
-//REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
-// REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots,raw=https://raw.githubusercontent.com/JabRef/jabref/refs/heads/main/jablib/lib/
+// REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
+//REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots,raw=https://raw.githubusercontent.com/JabRef/jabref/refs/heads/main/jablib/lib/
 // REPOS mavencentral,jitpack=https://jitpack.io
 
 // TODO: ASCII things won't work, but we accept for now to keep things going
@@ -30,9 +30,9 @@
 
 // Choose one - both should work
 // https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/jabref/jablib/
-// DEPS org.jabref:jablib:6.+
+//DEPS org.jabref:jablib:6.0-SNAPSHOT
 // https://jitpack.io/#jabref/jabref/main-SNAPSHOT
-//DEPS com.github.jabref:jabref:main-SNAPSHOT
+// DEPS com.github.jabref:jabref:main-SNAPSHOT
 
 //DEPS info.picocli:picocli:4.7.7
 

--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -40,8 +40,8 @@
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/server/services/ServerUtils.java
 
 // REPOS mavencentral,snapshots=https://central.sonatype.com/repository/maven-snapshots/
-//REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
-// REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots,raw=https://raw.githubusercontent.com/JabRef/jabref/refs/heads/main/jablib/lib/
+// REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots
+//REPOS mavencentral,mavencentralsnapshots=https://central.sonatype.com/repository/maven-snapshots/,s01oss=https://s01.oss.sonatype.org/content/repositories/snapshots/,oss=https://oss.sonatype.org/content/repositories,jitpack=https://jitpack.io,oss2=https://oss.sonatype.org/content/groups/public,ossrh=https://oss.sonatype.org/content/repositories/snapshots,raw=https://raw.githubusercontent.com/JabRef/jabref/refs/heads/main/jablib/lib/
 // REPOS mavencentral,jitpack=https://jitpack.io
 
 // TODO: ASCII things won't work, but we accept for now to keep things going
@@ -49,9 +49,9 @@
 
 // Choose one - both should work
 // https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/jabref/jablib/
-// DEPS org.jabref:jablib:6.+
+//DEPS org.jabref:jablib:6.0-SNAPSHOT
 // https://jitpack.io/#jabref/jabref/main-SNAPSHOT
-//DEPS com.github.jabref:jabref:main-SNAPSHOT
+// DEPS com.github.jabref:jabref:main-SNAPSHOT
 
 //DEPS info.picocli:picocli:4.7.7
 //DEPS org.jspecify:jspecify:1.0.0


### PR DESCRIPTION
JBang and maven central did not work well together - I think, it is because I mixed up `-SNAPSHOT` with our AssemblyVersion magic.

Now, we have 6.0-SNAPSHOT as library versions - independent of 6.0-alpha.2 relases etc.

We could to more intelligent, but we need something working now :)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
