### PR TITLE
Add #12810: Implement escaping for keyword separators (FKA #12888)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added escaping characters `\ ,`for KeyworList.parse(). [#12810](https://github.com/JabRef/jabref/issues/12810)
 - We added focus on the field Link in the "Add file link" dialog. [#13486](https://github.com/JabRef/jabref/issues/13486)
 - We introduced a settings parameter to manage citations' relations local storage time-to-live with a default value set to 30 days. [#11189](https://github.com/JabRef/jabref/issues/11189)
 - We distribute arm64 images for Linux. [#10842](https://github.com/JabRef/jabref/issues/10842)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added escaping characters `\ ,`for KeyworList.parse(). [#12810](https://github.com/JabRef/jabref/issues/12810)
+- We added escaping characters `\ ,`for KeywordList.parse(). [#12810](https://github.com/JabRef/jabref/issues/12810)
 - We added focus on the field Link in the "Add file link" dialog. [#13486](https://github.com/JabRef/jabref/issues/13486)
 - We introduced a settings parameter to manage citations' relations local storage time-to-live with a default value set to 30 days. [#11189](https://github.com/JabRef/jabref/issues/11189)
 - We distribute arm64 images for Linux. [#10842](https://github.com/JabRef/jabref/issues/10842)

--- a/jablib/src/test/java/org/jabref/model/entry/KeywordListTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/KeywordListTest.java
@@ -115,4 +115,41 @@ class KeywordListTest {
     void mergeTwoListsOfKeywordsShouldReturnTheKeywordsMerged() {
         assertEquals(new KeywordList("Figma", "Adobe", "JabRef", "Eclipse", "JetBrains"), KeywordList.merge("Figma, Adobe, JetBrains, Eclipse", "Adobe, JabRef", ','));
     }
+
+    @Test
+    void parseKeywordWithEscapedDelimiterDoesNotSplitKeyword() {
+        assertEquals(new KeywordList("keyword,one", "keywordTwo"),
+                KeywordList.parse("keyword\\,one, keywordTwo", ',', '>'));
+    }
+
+    @Test
+    void parseKeywordWithEscapedDelimiterAtEndPreservesDelimiter() {
+        assertEquals(new KeywordList("keywordOne,", "keywordTwo"),
+                KeywordList.parse("keywordOne\\,, keywordTwo", ',', '>'));
+    }
+
+    @Test
+    void parseKeywordWithEscapedBackslashTreatsItAsLiteral() {
+        assertEquals(new KeywordList("keyword\\", "keywordTwo"),
+                KeywordList.parse("keyword\\\\, keywordTwo", ',', '>'));
+    }
+
+    @Test
+    void parseKeywordWithEscapedDelimiterAndHierarchicalDelimiterCreatesHierarchy() {
+        Keyword expected = Keyword.of("keyword,one", "sub");
+        assertEquals(new KeywordList(expected),
+                KeywordList.parse("keyword\\,one > sub", ',', '>'));
+    }
+
+    @Test
+    void parseKeywordWithMultipleEscapedDelimitersTreatsThemAsLiteral() {
+        assertEquals(new KeywordList("one,two,three", "four"),
+                KeywordList.parse("one\\,two\\,three, four", ',', '>'));
+    }
+
+    @Test
+    void parseKeywordWithTrailingEscapeCharacterTreatsItAsLiteralBackslash() {
+        assertEquals(new KeywordList("keywordOne\\"),
+                KeywordList.parse("keywordOne\\\\", ',', '>'));
+    }
 }


### PR DESCRIPTION
- Addresses unresolved previous review [comments](https://github.com/JabRef/jabref/pull/12888#discussion_r2030256080) 

Closes #12810 
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
