### PR TITLE
Mode aware consistency check #13467 clean

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/consistency/ConsistencyCheckAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/consistency/ConsistencyCheckAction.java
@@ -1,24 +1,21 @@
 package org.jabref.gui.consistency;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-
-import javafx.concurrent.Task;
 
 import org.jabref.gui.DialogService;
 import org.jabref.gui.LibraryTab;
 import org.jabref.gui.StateManager;
+import static org.jabref.gui.actions.ActionHelper.needsDatabase;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.util.UiTaskExecutor;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 
-import static org.jabref.gui.actions.ActionHelper.needsDatabase;
+import javafx.concurrent.Task;
 
 public class ConsistencyCheckAction extends SimpleCommand {
 
@@ -55,10 +52,11 @@ public class ConsistencyCheckAction extends SimpleCommand {
                 if (databaseContext.isEmpty()) {
                     throw new IllegalStateException((Localization.lang("No library present")));
                 }
-                List<BibEntry> entries = databaseContext.get().getEntries();
+
+                BibDatabaseContext bibContext = databaseContext.orElseThrow(() -> new IllegalStateException("database not present"));
 
                 BibliographyConsistencyCheck consistencyCheck = new BibliographyConsistencyCheck();
-                return consistencyCheck.check(entries, (count, total) ->
+                return consistencyCheck.check(bibContext, (count, total) ->
                         UiTaskExecutor.runInJavaFXThread(() -> {
                             updateProgress(count, total);
                             updateMessage(Localization.lang("%0/%1 entry types", count + 1, total));

--- a/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
@@ -60,10 +60,9 @@ class CheckConsistency implements Callable<Integer> {
         }
 
         BibDatabaseContext databaseContext = parserResult.get().getDatabaseContext();
-        BibDatabaseContext bibContext = databaseContext;
 
         BibliographyConsistencyCheck consistencyCheck = new BibliographyConsistencyCheck();
-        BibliographyConsistencyCheck.Result result = consistencyCheck.check(bibContext, (count, total) -> {
+        BibliographyConsistencyCheck.Result result = consistencyCheck.check(databaseContext, (count, total) -> {
             if (!sharedOptions.porcelain) {
                 System.out.println(Localization.lang("Checking consistency for entry type %0 of %1", count + 1, total));
             }

--- a/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/cli/CheckConsistency.java
@@ -3,7 +3,6 @@ package org.jabref.cli;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
@@ -14,15 +13,13 @@ import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultCs
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultTxtWriter;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultWriter;
 import org.jabref.model.database.BibDatabaseContext;
-import org.jabref.model.entry.BibEntry;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static picocli.CommandLine.Command;
-import static picocli.CommandLine.Mixin;
-import static picocli.CommandLine.Option;
-import static picocli.CommandLine.ParentCommand;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
 
 @Command(name = "check-consistency", description = "Check consistency of the library.")
 class CheckConsistency implements Callable<Integer> {
@@ -63,10 +60,10 @@ class CheckConsistency implements Callable<Integer> {
         }
 
         BibDatabaseContext databaseContext = parserResult.get().getDatabaseContext();
-        List<BibEntry> entries = databaseContext.getDatabase().getEntries();
+        BibDatabaseContext bibContext = databaseContext;
 
         BibliographyConsistencyCheck consistencyCheck = new BibliographyConsistencyCheck();
-        BibliographyConsistencyCheck.Result result = consistencyCheck.check(entries, (count, total) -> {
+        BibliographyConsistencyCheck.Result result = consistencyCheck.check(bibContext, (count, total) -> {
             if (!sharedOptions.porcelain) {
                 System.out.println(Localization.lang("Checking consistency for entry type %0 of %1", count + 1, total));
             }

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -50,7 +50,7 @@ public class BibliographyConsistencyCheck {
                      .collect(Collectors.toSet());
     }
 
-    public record Result(Map<EntryType, EntryTypeResult  > entryTypeToResultMap) {
+    public record Result(Map<EntryType, EntryTypeResult> entryTypeToResultMap) {
     }
 
     public record EntryTypeResult(Collection<Field> fields, SequencedCollection<BibEntry> sortedEntries) {
@@ -158,6 +158,5 @@ public class BibliographyConsistencyCheck {
                     .add(entry);
                 }
             }
-
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -50,7 +50,7 @@ public class BibliographyConsistencyCheck {
                      .collect(Collectors.toSet());
     }
 
-    public record Result(Map<EntryType, EntryTypeResult> entryTypeToResultMap) {
+    public record Result(Map<EntryType, EntryTypeResult  > entryTypeToResultMap) {
     }
 
     public record EntryTypeResult(Collection<Field> fields, SequencedCollection<BibEntry> sortedEntries) {

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -114,18 +114,19 @@ public class BibliographyConsistencyCheck {
         BibDatabaseMode mode = bibContext.getMode();
         List<BibEntry> entries = bibContext.getEntries();
 
-       
-        Set<EntryType> biblatexSet = new HashSet<>();
-        Set<EntryType> bibtexSet = new HashSet<>();
+        Set<EntryType> biblatexSet = Set.of();
+        Set<EntryType> bibtexSet = Set.of();
 
         if (mode == BibDatabaseMode.BIBLATEX) {
-            for (BibEntryType biblatexEntryType : BiblatexEntryTypeDefinitions.ALL) {
-                biblatexSet.add(biblatexEntryType.getType());
-            }
+            biblatexSet = BiblatexEntryTypeDefinitions.ALL
+                .stream()
+                .map(BibEntryType::getType)
+                .collect(Collectors.toSet());
         } else if (mode == BibDatabaseMode.BIBTEX) {
-            for (BibEntryType bibtexEntryType : BibtexEntryTypeDefinitions.ALL) {
-                bibtexSet.add(bibtexEntryType.getType());
-            }
+            bibtexSet = BibtexEntryTypeDefinitions.ALL
+                .stream()
+                .map(BibEntryType::getType)
+                .collect(Collectors.toSet());
         }
 
         for (BibEntry entry : entries) {

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -14,11 +15,16 @@ import java.util.stream.Collectors;
 import org.jabref.logic.bibtex.comparator.BibEntryByCitationKeyComparator;
 import org.jabref.logic.bibtex.comparator.BibEntryByFieldsComparator;
 import org.jabref.logic.bibtex.comparator.FieldComparatorStack;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.OrFields;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UserSpecificCommentField;
+import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
 import org.jabref.model.entry.types.EntryType;
 
 public class BibliographyConsistencyCheck {
@@ -62,7 +68,7 @@ public class BibliographyConsistencyCheck {
      *
      * @implNote This class does not implement {@link org.jabref.logic.integrity.DatabaseChecker}, because it returns a list of {@link org.jabref.logic.integrity.IntegrityMessage}, which are too fine-grained.
      */
-    public Result check(List<BibEntry> entries, BiConsumer<Integer, Integer> entriesGroupingProgress) {
+    public Result check(BibDatabaseContext bibContext, BiConsumer<Integer, Integer> entriesGroupingProgress) {
         // collects fields existing in any entry, scoped by entry type
         Map<EntryType, Set<Field>> entryTypeToFieldsInAnyEntryMap = new HashMap<>();
         // collects fields existing in all entries, scoped by entry type
@@ -70,7 +76,7 @@ public class BibliographyConsistencyCheck {
         // collects entries of the same type
         Map<EntryType, Set<BibEntry>> entryTypeToEntriesMap = new HashMap<>();
 
-        collectEntriesIntoMaps(entries, entryTypeToFieldsInAnyEntryMap, entryTypeToFieldsInAllEntriesMap, entryTypeToEntriesMap);
+        collectEntriesIntoMaps(bibContext, entryTypeToFieldsInAnyEntryMap, entryTypeToFieldsInAllEntriesMap, entryTypeToEntriesMap);
 
         Map<EntryType, EntryTypeResult> resultMap = new HashMap<>();
 
@@ -105,7 +111,19 @@ public class BibliographyConsistencyCheck {
         return new Result(resultMap);
     }
 
-    private static void collectEntriesIntoMaps(List<BibEntry> entries, Map<EntryType, Set<Field>> entryTypeToFieldsInAnyEntryMap, Map<EntryType, Set<Field>> entryTypeToFieldsInAllEntriesMap, Map<EntryType, Set<BibEntry>> entryTypeToEntriesMap) {
+    private static void collectEntriesIntoMaps(BibDatabaseContext bibContext, Map<EntryType, Set<Field>> entryTypeToFieldsInAnyEntryMap, Map<EntryType, Set<Field>> entryTypeToFieldsInAllEntriesMap, Map<EntryType, Set<BibEntry>> entryTypeToEntriesMap) {
+        BibEntryType onlineType = BiblatexEntryTypeDefinitions.ALL.stream().filter(e -> e.getType().getDisplayName().equalsIgnoreCase("Online")).findFirst().orElseThrow(IllegalArgumentException::new);
+        BibDatabaseMode mode = bibContext.getMode();
+
+        if (mode == BibDatabaseMode.BIBLATEX) {
+            // do something
+        } else if (mode == BibDatabaseMode.BIBTEX) {
+            // do something else
+        }
+
+        SequencedSet<OrFields> fields = onlineType.getRequiredFields();
+
+        //old entries way
         for (BibEntry entry : entries) {
             EntryType entryType = entry.getType();
 

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -139,8 +139,6 @@ public class BibliographyConsistencyCheck {
         }
 
 
-
-        //old entries way
         for (BibEntry entry : entries) {
             EntryType entryType = entry.getType();
 

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
-import java.util.SequencedSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -20,11 +19,11 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.OrFields;
 import org.jabref.model.entry.field.SpecialField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 import org.jabref.model.entry.types.BiblatexEntryTypeDefinitions;
+import org.jabref.model.entry.types.BibtexEntryTypeDefinitions;
 import org.jabref.model.entry.types.EntryType;
 
 public class BibliographyConsistencyCheck {
@@ -112,16 +111,34 @@ public class BibliographyConsistencyCheck {
     }
 
     private static void collectEntriesIntoMaps(BibDatabaseContext bibContext, Map<EntryType, Set<Field>> entryTypeToFieldsInAnyEntryMap, Map<EntryType, Set<Field>> entryTypeToFieldsInAllEntriesMap, Map<EntryType, Set<BibEntry>> entryTypeToEntriesMap) {
-        BibEntryType onlineType = BiblatexEntryTypeDefinitions.ALL.stream().filter(e -> e.getType().getDisplayName().equalsIgnoreCase("Online")).findFirst().orElseThrow(IllegalArgumentException::new);
         BibDatabaseMode mode = bibContext.getMode();
+        List<BibEntry> entries = bibContext.getEntries();
+        
+        Set<EntryType> entryTypes = new HashSet<>();
 
-        if (mode == BibDatabaseMode.BIBLATEX) {
-            // do something
-        } else if (mode == BibDatabaseMode.BIBTEX) {
-            // do something else
+        for (BibEntry entry : entries) {
+            entryTypes.add(entry.getType());
         }
 
-        SequencedSet<OrFields> fields = onlineType.getRequiredFields();
+
+
+        if (mode == BibDatabaseMode.BIBLATEX) {
+            List<BibEntryType> biblatexEntryTypes = BiblatexEntryTypeDefinitions.ALL;
+            for (BibEntryType biblatexEntryType : biblatexEntryTypes) {
+                if (entryTypes.contains(biblatexEntryType.getType())) {
+                    System.out.println("all good");
+                }
+            }
+        } else if (mode == BibDatabaseMode.BIBTEX) {
+            List<BibEntryType> bibtextEntryTypes = BibtexEntryTypeDefinitions.ALL;
+            for (BibEntryType bibtexEntryType : bibtextEntryTypes) {
+                if (entryTypes.contains(bibtexEntryType.getType())) {
+                    System.out.println("all good");
+                }
+            }
+        }
+
+
 
         //old entries way
         for (BibEntry entry : entries) {

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultCsvWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultCsvWriterTest.java
@@ -5,10 +5,10 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -36,7 +36,12 @@ class BibliographyConsistencyCheckResultCsvWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PUBLISHER, "publisher");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(first);
+        database.insertEntry(second);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(database);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (count, total) -> { });
 
         Path csvFile = tempDir.resolve("checkSimpleLibrary-result.csv");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(csvFile));
@@ -60,7 +65,12 @@ class BibliographyConsistencyCheckResultCsvWriterTest {
                 .withField(customField, "custom"); // unknown
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(first);
+        database.insertEntry(second);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(database);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (count, total) -> { });
 
         Path csvFile = tempDir.resolve("checkDifferentOutputSymbols-result.csv");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(csvFile));
@@ -95,7 +105,12 @@ class BibliographyConsistencyCheckResultCsvWriterTest {
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.YEAR, "2024");
 
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second, third, fourth, fifth), (_, _) -> { });
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(first);
+        database.insertEntry(second);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(database);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (count, total) -> { });
 
         Path csvFile = tempDir.resolve("checkSimpleLibrary-result.csv");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(csvFile));
@@ -119,7 +134,12 @@ class BibliographyConsistencyCheckResultCsvWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PAGES, "some pages");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(first);
+        database.insertEntry(second);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(database);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (count, total) -> { });
 
         Path csvFile = tempDir.resolve("checkLibraryWithoutIssues-result.csv");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(csvFile));
@@ -137,7 +157,7 @@ class BibliographyConsistencyCheckResultCsvWriterTest {
         Path file = Path.of("C:\\TEMP\\JabRef\\biblio-anon.bib");
         Path csvFile = file.resolveSibling("biblio-cited.csv");
         BibDatabaseContext databaseContext = importer.importDatabase(file).getDatabaseContext();
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(databaseContext.getEntries(), (_, _) -> { });
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(databaseContext, (_, _) -> { });
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(csvFile));
              BibliographyConsistencyCheckResultCsvWriter paperConsistencyCheckResultCsvWriter = new BibliographyConsistencyCheckResultCsvWriter(result, writer, true)) {
             paperConsistencyCheckResultCsvWriter.writeFindings();

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultTxtWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultTxtWriterTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
@@ -35,7 +36,12 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PUBLISHER, "publisher");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        BibDatabase database = new BibDatabase();
+        database.insertEntry(first);
+        database.insertEntry(second);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(database);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (count, total) -> { });
 
         Path txtFile = tempDir.resolve("checkSimpleLibrary-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -69,8 +75,14 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withCitationKey("withoutDate")
                 .withField(StandardField.URLDATE, "urldate");
 
+        List<BibEntry> bibEntryList = List.of(withDate, withoutDate);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
+
         BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck()
-                .check(List.of(withDate, withoutDate), (_, _) -> {
+                .check(bibContext, (_, _) -> {
                 });
 
         Path txtFile = tempDir.resolve("checkSimpleLibrary-result.txt");
@@ -104,7 +116,12 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withField(customField, "custom"); // unknown
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        List<BibEntry> bibEntryList = List.of(first, second);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
+
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
         Path txtFile = tempDir.resolve("checkDifferentOutputSymbols-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -137,7 +154,11 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withField(customField, "custom"); // unknown
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        List<BibEntry> bibEntryList = List.of(first, second);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
         Path txtFile = tempDir.resolve("checkDifferentOutputSymbols-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -186,8 +207,12 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry sixth = new BibEntry(StandardEntryType.InProceedings, "sixth")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.YEAR, "2024");
+        List<BibEntry> bibEntryList = List.of(first, second, third, fourth, fifth, sixth);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
 
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second, third, fourth, fifth, sixth), (_, _) -> { });
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
         Path txtFile = tempDir.resolve("checkSimpleLibrary-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -222,7 +247,12 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PAGES, "some pages");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        List<BibEntry> bibEntryList = List.of(first, second);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
+
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
         Path txtFile = tempDir.resolve("checkLibraryWithoutIssues-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -244,7 +274,12 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PAGES, "some pages");
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(List.of(first, second), (_, _) -> { });
+        List<BibEntry> bibEntryList = List.of(first, second);
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntries(bibEntryList);
+        BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
+
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
         Path txtFile = tempDir.resolve("checkLibraryWithoutIssues-result.txt");
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
@@ -260,7 +295,7 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         Path file = Path.of("C:\\TEMP\\JabRef\\biblio-anon.bib");
         Path txtFile = file.resolveSibling("biblio-cited.txt");
         BibDatabaseContext databaseContext = importer.importDatabase(file).getDatabaseContext();
-        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(databaseContext.getEntries(), (_, _) -> { });
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(databaseContext, (_, _) -> { });
         try (Writer writer = new OutputStreamWriter(Files.newOutputStream(txtFile));
              BibliographyConsistencyCheckResultTxtWriter BibliographyConsistencyCheckResultTxtWriter = new BibliographyConsistencyCheckResultTxtWriter(result, writer, true)) {
             BibliographyConsistencyCheckResultTxtWriter.writeFindings();

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultTxtWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultTxtWriterTest.java
@@ -75,9 +75,9 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withCitationKey("withoutDate")
                 .withField(StandardField.URLDATE, "urldate");
 
-        List<BibEntry> bibEntryList = List.of(withDate, withoutDate);
+        List<BibEntry> bibEntriesList = List.of(withDate, withoutDate);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntries(bibEntryList);
+        bibDatabase.insertEntries(bibEntriesList);
 
         BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
 
@@ -116,9 +116,9 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withField(customField, "custom"); // unknown
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One");
-        List<BibEntry> bibEntryList = List.of(first, second);
+        List<BibEntry> bibEntriesList = List.of(first, second);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntries(bibEntryList);
+        bibDatabase.insertEntries(bibEntriesList);
         BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
 
         BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
@@ -154,9 +154,9 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
                 .withField(customField, "custom"); // unknown
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One");
-        List<BibEntry> bibEntryList = List.of(first, second);
+        List<BibEntry> bibEntriesList = List.of(first, second);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntries(bibEntryList);
+        bibDatabase.insertEntries(bibEntriesList);
         BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
         BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
 
@@ -207,9 +207,9 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry sixth = new BibEntry(StandardEntryType.InProceedings, "sixth")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.YEAR, "2024");
-        List<BibEntry> bibEntryList = List.of(first, second, third, fourth, fifth, sixth);
+        List<BibEntry> bibEntriesList = List.of(first, second, third, fourth, fifth, sixth);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntries(bibEntryList);
+        bibDatabase.insertEntries(bibEntriesList);
         BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
 
         BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });
@@ -274,9 +274,9 @@ class BibliographyConsistencyCheckResultTxtWriterTest {
         BibEntry second = new BibEntry(StandardEntryType.Article, "second")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PAGES, "some pages");
-        List<BibEntry> bibEntryList = List.of(first, second);
+        List<BibEntry> bibEntriesList = List.of(first, second);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntries(bibEntryList);
+        bibDatabase.insertEntries(bibEntriesList);
         BibDatabaseContext bibContext = new BibDatabaseContext(bibDatabase);
 
         BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck().check(bibContext, (_, _) -> { });

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckTest.java
@@ -12,7 +12,7 @@ import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-import org.junit.jupiter.api.Disabled;
+/* import org.junit.jupiter.api.Disabled; */
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -133,7 +133,7 @@ class BibliographyConsistencyCheckTest {
     }
 
     @Test
-    @Disabled("Fixed when https://github.com/JabRef/jabref/issues/13467 is resolved")
+    // @Disabled("Fixed when https://github.com/JabRef/jabref/issues/13467 is resolved")
     void unsetFieldsReported() {
         BibEntry withDate = new BibEntry(StandardEntryType.Online)
                 .withCitationKey("withDate")

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckTest.java
@@ -12,7 +12,6 @@ import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 import org.jabref.model.entry.types.StandardEntryType;
 
-/* import org.junit.jupiter.api.Disabled; */
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -133,7 +132,6 @@ class BibliographyConsistencyCheckTest {
     }
 
     @Test
-    // @Disabled("Fixed when https://github.com/JabRef/jabref/issues/13467 is resolved")
     void unsetFieldsReported() {
         BibEntry withDate = new BibEntry(StandardEntryType.Online)
                 .withCitationKey("withDate")


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13467

This draft PR refactors BibliographyConsistencyCheck to take a full BibDatabaseContext instead of just a list of entries.
The goal is to prepare the logic for BibTeX/BibLaTeX-aware consistency checking, as discussed in the issue.
So far, logic separation for mode (BibDatabaseMode) and extraction of EntryType has been implemented.

Steps to test
This is a work-in-progress. No final test procedure yet.
Initial behavior should be unchanged (functional refactoring).
Can be tested with a .bib file containing @online entries with and without date.

Mandatory checks
 I own the copyright ...
[/] Change in CHANGELOG.md ...
 Tests created ...
[/] Manually tested ...
[/] Screenshots added ...
[/] Checked developer's documentation ...
[/] Checked documentation ...