### PR TITLE
#13301 Fix/unicode reference marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- we fixed an issue where LibreOffice/Writer integration did not support citation keys containing Unicode characters (e.g. Cyrillic, Chinese)[#13301](https://github.com/JabRef/jabref/issues/13301)
+- We fixed an issue where the LibreOffice integration did not support citation keys containing Unicode characters. [#13301](https://github.com/JabRef/jabref/issues/13301)
 - We fixed an issue where the "Search ShortScience" action did not convert LaTeX-formatted titles to Unicode.[#13418](https://github.com/JabRef/jabref/issues/13418)
 - We added a fallback for the "Convert to biblatex" cleanup when it failed to populate the `date` field if `year` contained a full date in ISO format (e.g., `2011-11-11`). [#11868](https://github.com/JabRef/jabref/issues/11868)
 - We fixed an issue where directory check for relative path was not handled properly under library properties. [#13017](https://github.com/JabRef/jabref/issues/13017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved file exists warning dialog with clearer options and tooltips [#12565](https://github.com/JabRef/jabref/issues/12565)]
 
 ### Fixed
-
+- we fixed an issue where LibreOffice/Writer integration did not support citation keys containing Unicode characters (e.g. Cyrillic, Chinese)[#13301](https://github.com/JabRef/jabref/issues/13301)
 - We fixed an issue where the "Search ShortScience" action did not convert LaTeX-formatted titles to Unicode.[#13418](https://github.com/JabRef/jabref/issues/13418)
 - We added a fallback for the "Convert to biblatex" cleanup when it failed to populate the `date` field if `year` contained a full date in ISO format (e.g., `2011-11-11`). [#11868](https://github.com/JabRef/jabref/issues/11868)
 - We fixed an issue where directory check for relative path was not handled properly under library properties. [#13017](https://github.com/JabRef/jabref/issues/13017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved file exists warning dialog with clearer options and tooltips [#12565](https://github.com/JabRef/jabref/issues/12565)]
 
 ### Fixed
+
 - we fixed an issue where LibreOffice/Writer integration did not support citation keys containing Unicode characters (e.g. Cyrillic, Chinese)[#13301](https://github.com/JabRef/jabref/issues/13301)
 - We fixed an issue where the "Search ShortScience" action did not convert LaTeX-formatted titles to Unicode.[#13418](https://github.com/JabRef/jabref/issues/13418)
 - We added a fallback for the "Convert to biblatex" cleanup when it failed to populate the `date` field if `year` contained a full date in ISO format (e.g., `2011-11-11`). [#11868](https://github.com/JabRef/jabref/issues/11868)

--- a/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,8 +15,6 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    // Enable UNICODE_CHARACTER_CLASS to properly match citation keys containing non-ASCII (e.g. Cyrillic, Chinese) characters.
-    // We Keep the pattern visually unchanged while broadening the definition of \w to the full Unicode range (letters, digits, underscore).
     private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile(
             "^(JABREF_[\\w-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$",
             Pattern.UNICODE_CHARACTER_CLASS);

--- a/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -15,8 +15,15 @@ public class ReferenceMark {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceMark.class);
 
-    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile("^(JABREF_[\\w-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$");
-    private static final Pattern ENTRY_PATTERN = Pattern.compile("JABREF_([\\w-:./]+) CID_(\\d+)");
+    // Enable UNICODE_CHARACTER_CLASS to properly match citation keys containing non-ASCII (e.g. Cyrillic, Chinese) characters.
+    // We Keep the pattern visually unchanged while broadening the definition of \w to the full Unicode range (letters, digits, underscore).
+    private static final Pattern REFERENCE_MARK_FORMAT = Pattern.compile(
+            "^(JABREF_[\\w-:./]+ CID_\\d+(?:, JABREF_[\\w-:./]+ CID_\\d+)*) (\\w+)$",
+            Pattern.UNICODE_CHARACTER_CLASS);
+
+    private static final Pattern ENTRY_PATTERN = Pattern.compile(
+            "JABREF_([\\w-:./]+) CID_(\\d+)",
+            Pattern.UNICODE_CHARACTER_CLASS);
 
     private final String name;
     private List<String> citationKeys;

--- a/jablib/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
@@ -53,6 +53,16 @@ class ReferenceMarkTest {
                 Arguments.of(
                         "JABREF_PGF/TikZTeam2023 CID_8 kyu75a4s",
                         List.of("PGF/TikZTeam2023"), List.of(8), "kyu75a4s"
+                ),
+
+                // Unicode citation keys (Cyrillic)
+                Arguments.of(
+                        "JABREF_Ты2025 CID_1 abc123",
+                        List.of("Ты2025"), List.of(1), "abc123"
+                ),
+                Arguments.of(
+                        "JABREF_Я2025 CID_2 def456",
+                        List.of("Я2025"), List.of(2), "def456"
                 )
         );
     }


### PR DESCRIPTION
Uses `Pattern.UNICODE_CHARACTER_CLASS` so that `\w` also matches non-ASCII characters (e.g. Cyrillic, Chinese) in citation keys.  
Adds unit tests with Cyrillic keys.

Closes [#<13301>](https://github.com/JabRef/jabref/issues/13301)
<!-- Example: Closes https://github.com/JabRef/jabref/issues/13109 -->

### Summary of changes
* **ReferenceMark.java**  
  Compiles both regex patterns with `Pattern.UNICODE_CHARACTER_CLASS`, allowing Unicode citation keys.
* **ReferenceMarkTest.java**  
  Adds two test cases (`Ты2025`, `Я2025`) to verify parsing of Cyrillic keys.
* Manual verification in LibreOffice Writer confirms bibliography generation now works with non-Latin keys.

### Steps to test
1. Build & launch JabRef from this branch
   
2. In JabRef, create a new library containing:
   ```bibtex
   @Article{Ты2025,
     author = {Ты},
     title  = {You},
     year   = {2025},
   }

   @Article{Я2025},
     author = {Я},
     title  = {I},
     year   = {2025},
   }
   ```
4. Connect to an open LibreOffice Writer document via the OO/LO panel.
5. Insert citations for both entries, then click **Make/Sync bibliography**.  
   *Expected:* bibliography appears without error; Writer’s field names show in LibreOffice Writer.
6. Run automated tests  
   ```bash
   ./gradlew jablib:test --tests org.jabref.logic.openoffice.ReferenceMarkTest
   ```

https://github.com/user-attachments/assets/49022e14-1659-48cf-92d9-bb81da986c7e


### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user   “We fixed an issue where the LibreOffice integration did not support citation keys containing Unicode characters.”
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Screen Recording added in PR description.
- [ ] Checked developer's documentation: N/A (no docs change needed)
- [ ] Checked user documentation: opened issue / PR if docs need updating