### PR TITLE
Updated architecture and components link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Some are simpler, while others are more complex. Our primary aim is to guide you
 
 * Select an issue to work on from the [Issues Page](https://github.com/JabRef/jabref/issues). If you are a newcomer, we have a few issues labeled as <https://github.com/JabRef/jabref/labels/good%20first%20issue> to help you get started. You can start with any of the [unassigned good first issues](https://github.com/JabRef/jabref/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22%20no%3Aassignee).
 * Once you get your first PR merged, you can move on to <https://github.com/JabRef/jabref/labels/good%20second%20issue>, <https://github.com/JabRef/jabref/labels/good%20third%20issue>, and finally <https://github.com/JabRef/jabref/labels/good%20fourth%20issue> before taking up some more major bug fixes or features. Note that not all beginner friendly issues are labeled, so you may find suitable untagged issues to solve as well.
-  
+
 Always make sure that the issue you select is not presently assigned to anyone.
 
 ### I am a student and I want to choose from a curated list of university projects
@@ -98,7 +98,7 @@ GitHub will then automatically assign you.
 1. Follow the steps at [Pre Condition 3: Code on the local machine](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.html) to a) create a fork and b) have the fork checked out on your local machine
 2. Ensure that you followed the [steps to set up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/) to have the code running properly in IntelliJ.
 3. **Create a new branch** (such as `fix-for-issue-121`). Be sure to create a **separate branch** for each improvement you implement.
-4. Read our [high-level documentation](https://devdocs.jabref.org/getting-into-the-code/high-level-documentation).
+4. Read our [architecture and components](https://devdocs.jabref.org/architecture-and-components.html).
 5. Work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/code-howtos) if you have questions about your implementation.
 6. Create a [pull request to JabRef main repository](https://github.com/JabRef/jabref/pulls).
    For an overview on the concept of pull requests, take a look at GitHub's [pull request help documentation](https://help.github.com/articles/about-pull-requests/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ The challenge of these issues is to understand **where** in the code base someth
 
 ### I am a lecturer
 
-If you ask yourself how to integrate JabRef into your class, please read the [documentation about how to integrate JabRef into a class of software engineering training](https://devdocs.jabref.org/teaching.html#jabref-and-software-engineering-training).
+If you ask yourself how to integrate JabRef into your class, please read the [documentation about how to integrate JabRef into a class of software engineering training](https://devdocs.jabref.org/teaching#jabref-and-software-engineering-training).
 As student, you may notify your lecturer about this possibility.
 
 ### I want something with huge impact
@@ -71,7 +71,7 @@ A typical subclassifications scheme is "priority" (high, normal and low). Fixing
 
 ### I want to know how to contribute code and set up my workspace
 
-Check out the [documentation for developers](https://devdocs.jabref.org/contributing.html#contribute-code)
+Check out the [documentation for developers](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/)
 
 ### I want to improve the developer's documentation
 
@@ -95,10 +95,10 @@ GitHub will then automatically assign you.
 
 ## Pull Request Process
 
-1. Follow the steps at [Pre Condition 3: Code on the local machine](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code.html) to a) create a fork and b) have the fork checked out on your local machine
+1. Follow the steps at [Pre Condition 3: Code on the local machine](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/pre-03-code) to a) create a fork and b) have the fork checked out on your local machine
 2. Ensure that you followed the [steps to set up a local workspace](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/) to have the code running properly in IntelliJ.
 3. **Create a new branch** (such as `fix-for-issue-121`). Be sure to create a **separate branch** for each improvement you implement.
-4. Read our [architecture and components](https://devdocs.jabref.org/architecture-and-components.html).
+4. Read our [architecture and components](https://devdocs.jabref.org/architecture-and-components).
 5. Work on the **new branch — not the `main` branch.** Refer to our [code how-tos](https://devdocs.jabref.org/code-howtos) if you have questions about your implementation.
 6. Create a [pull request to JabRef main repository](https://github.com/JabRef/jabref/pulls).
    For an overview on the concept of pull requests, take a look at GitHub's [pull request help documentation](https://help.github.com/articles/about-pull-requests/).
@@ -184,7 +184,7 @@ Please look into them and handle accordingly.
 After implementing changes, commit to the branch your pull request is *from* and push.
 The pull request will automatically be updated with your changes.
 To maintain a clean git history, your commits will also be automatically squashed upon acceptance of the pull request, during merging.
-Thus, no need to worry about WIP commits or [fixing git submodule issues](https://devdocs.jabref.org/code-howtos/faq.html#submodules).
+Thus, no need to worry about WIP commits or [fixing git submodule issues](https://devdocs.jabref.org/code-howtos/faq#submodules).
 As a concequece, force-pushing is not required - and must be **avoided**.
 
 After all the basic checks are green, maintainers will look at your pull request.
@@ -236,7 +236,7 @@ Add the above snippet to the English translation file located at `src/main/resou
 
 You can also directly run the specific test in your IDE.
 The test "`LocalizationConsistencyTest`" is placed under `src/test/java/org.jabref.logic.l10n/LocalizationConsistencyTest.java`.
-Find more information in the [JabRef developer docs](https://devdocs.jabref.org/code-howtos/localization.html).
+Find more information in the [JabRef developer docs](https://devdocs.jabref.org/code-howtos/localization).
 
 #### **Format of keyboard shortcuts**
 


### PR DESCRIPTION
Closes #13586

In the pull request process for CONTRIBUTING.md, the steps previously linked to high-level documentation. Needed to be updated to architecture and components and its corresponding link.

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
To test this feature, check if the link to leads to the the architecture and components devdocs page when reviewing the 'Pull Request Process' section on CONTRIBUTING.md. Note: While I did see the mention for the .md link, I used .html since CONTRIBUTING.md is primarily viewed on Github. Users clicking on .md link would receive a 404 error. This link format matches other documentation links in the same file. If any changes are needed, or if there any issues due to this I am welcome to change it accordingly. 

<img width="1181" height="661" alt="image" src="https://github.com/user-attachments/assets/a1f4d6a7-258f-4ff7-9425-5f411d560609" />

Users should see the above screenshot when clicking the corresponding link. 

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
