### PR TITLE
Issue676 author last

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * <code>2017_Kitsune_123</code> when expanded using the BibTeX entry <code>@Article{ authors = {O. Kitsune}, year = {2017},
  * pages={123-6}}</code>.
  * <p>
- * The embedding in JabRef is explained at <a href="https://docs.jabref.org/setup/citationkeypattern">Customize the citation key generator</a>.
+ * The embedding in JabRef is explained at <a href="https://docs.jabref.org/setup/citationkeypatterns">Customize the citation key generator</a>.
  * </p>
  */
 public class BracketedPattern {
@@ -807,7 +807,7 @@ public class BracketedPattern {
      * @param authorList an {@link AuthorList}
      * @return the surname of an author/editor
      */
-    private static String lastAuthor(AuthorList authorList) {
+    static String lastAuthor(AuthorList authorList) {
         if (authorList.isEmpty()) {
             return "";
         }

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -179,8 +179,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authIni1(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authIniN(list, 1));
+    void authShort(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authShort(list));
     }
 
     static Stream<Arguments> authIni1() {
@@ -204,8 +204,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authIni2(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authIniN(list, 2));
+    void authIni1(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 1));
     }
 
     static Stream<Arguments> authIni2() {
@@ -230,8 +230,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authIni3(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authIniN(list, 3));
+    void authIni2(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 2));
     }
 
     static Stream<Arguments> authIni3() {
@@ -256,8 +256,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authIni4(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authIniN(list, 4));
+    void authIni3(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 3));
     }
 
     static Stream<Arguments> authIni4() {
@@ -281,8 +281,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authEtAlDotDotEal(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authEtal(list, ".", ".etal"));
+    void authIni4(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authIniN(list, 4));
     }
 
     static Stream<Arguments> authEtAlDotDotEal() {
@@ -306,8 +306,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authAuthEa(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authAuthEa(list));
+    void authEtAlDotDotEal(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authEtal(list, ".", ".etal"));
     }
 
     static Stream<Arguments> authAuthEa() {
@@ -331,8 +331,8 @@ class BracketedPatternTest {
 
     @ParameterizedTest
     @MethodSource
-    void authShort(String expected, AuthorList list) {
-        assertEquals(expected, BracketedPattern.authShort(list));
+    void authAuthEa(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.authAuthEa(list));
     }
 
     static Stream<Arguments> authLast() {

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -335,6 +335,26 @@ class BracketedPatternTest {
         assertEquals(expected, BracketedPattern.authShort(list));
     }
 
+    static Stream<Arguments> authLast() {
+        return Stream.of(
+                Arguments.of("Newton", "Isaac Newton"),
+                Arguments.of("Maxwell", "Isaac Newton and James Maxwell"),
+                Arguments.of("Einstein", "Isaac Newton and James Maxwell and Albert Einstein"),
+                Arguments.of("Bohr", "Isaac Newton and James Maxwell and Albert Einstein and N. Bohr"),
+                Arguments.of("Aachen", "Aachen"),
+                Arguments.of("Berlin", "Aachen and Berlin"),
+                Arguments.of("Chemnitz", "Aachen and Berlin and Chemnitz"),
+                Arguments.of("Düsseldorf", "Aachen and Berlin and Chemnitz and Düsseldorf"),
+                Arguments.of("Essen", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void authLast(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.lastAuthor(list));
+    }
+
     @ParameterizedTest
     @CsvSource({
             "'Newton', '[auth]', 'Isaac Newton'",

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -345,7 +345,9 @@ class BracketedPatternTest {
                 Arguments.of("Berlin", "Aachen and Berlin"),
                 Arguments.of("Chemnitz", "Aachen and Berlin and Chemnitz"),
                 Arguments.of("Düsseldorf", "Aachen and Berlin and Chemnitz and Düsseldorf"),
-                Arguments.of("Essen", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen")
+                Arguments.of("Essen", "Aachen and Berlin and Chemnitz and Düsseldorf and Essen"),
+                Arguments.of("Aalst", "Wil van der Aalst"),
+                Arguments.of("Lessen", "Wil van der Aalst and Tammo van Lessen")
         );
     }
 

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -548,21 +548,6 @@ class CitationKeyGeneratorTest {
     }
 
     /**
-     * Tests [authorLast]
-     */
-    @Test
-    void lastAuthor() {
-        assertEquals("Newton", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_1, AUTHORLAST));
-        assertEquals("Maxwell", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_2, AUTHORLAST));
-        assertEquals("Einstein", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_3, AUTHORLAST));
-        assertEquals("Bohr", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_4, AUTHORLAST));
-        assertEquals("Unknown", generateKey(AUTHOR_FIRSTNAME_INITIAL_LASTNAME_FULL_COUNT_5, AUTHORLAST));
-
-        assertEquals("Aalst", generateKey(AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_1, AUTHORLAST));
-        assertEquals("Lessen", generateKey(AUTHOR_FIRSTNAME_FULL_LASTNAME_FULL_WITH_VAN_COUNT_2, AUTHORLAST));
-    }
-
-    /**
      * Tests [authorLastForeIni]
      */
     @Test


### PR DESCRIPTION
Addresses https://github.com/JabRef/jabref-koppor/issues/676

* Moves tests of `lastAuthor` from `CitationKeyGeneratorTest` to `BracketedPatternTest`
* Fixes a link from javadoc to documentation
* Reorders methods in `BracketedPatternTest` so argument providers consistently appear before tests using them

I made these changes as preparation for a class session in mid-September where I will demonstrate how to make a change and PR. It would be easiest for me if this is reviewed but not merged; however, if it is easier for you to merge once approved, I can create a pre-merge branch for the class demonstration.

The first commit message has a typo; it should be "Add test of [authLast]".

### Steps to test

Rerun the tests in `logic/citationkeypattern`.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/'] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
