### PR TITLE
Add proper closing at testing

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/git/status/GitStatusCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/git/status/GitStatusCheckerTest.java
@@ -137,19 +137,18 @@ class GitStatusCheckerTest {
     @Test
     void behindStatusWhenRemoteHasNewCommit(@TempDir Path tempDir) throws Exception {
         Path remoteWork = tempDir.resolve("remoteWork");
-        Git remoteClone = Git.cloneRepository()
+        try (Git remoteClone = Git.cloneRepository()
                              .setURI(remoteGit.getRepository().getDirectory().toURI().toString())
                              .setDirectory(remoteWork.toFile())
                              .setBranchesToClone(List.of("refs/heads/main"))
                              .setBranch("main")
-                             .call();
-        Path remoteFile = remoteWork.resolve("library.bib");
-        commitFile(remoteClone, remoteUpdatedContent, "Remote update");
-        remoteClone.push()
-                   .setRemote("origin")
-                   .setRefSpecs(new RefSpec("refs/heads/main:refs/heads/main"))
-                   .call();
-
+                             .call()) {
+            commitFile(remoteClone, remoteUpdatedContent, "Remote update");
+            remoteClone.push()
+                       .setRemote("origin")
+                       .setRefSpecs(new RefSpec("refs/heads/main:refs/heads/main"))
+                       .call();
+        }
         localGit.fetch().setRemote("origin").call();
         GitStatusSnapshot snapshot = GitStatusChecker.checkStatus(localLibrary);
         assertEquals(SyncStatus.BEHIND, snapshot.syncStatus());
@@ -167,19 +166,18 @@ class GitStatusCheckerTest {
         commitFile(localGit, localUpdatedContent, "Local update");
 
         Path remoteWork = tempDir.resolve("remoteWork");
-        Git remoteClone = Git.cloneRepository()
+        try (Git remoteClone = Git.cloneRepository()
                              .setURI(remoteGit.getRepository().getDirectory().toURI().toString())
                              .setDirectory(remoteWork.toFile())
                              .setBranchesToClone(List.of("refs/heads/main"))
                              .setBranch("main")
-                             .call();
-        Path remoteFile = remoteWork.resolve("library.bib");
-        commitFile(remoteClone, remoteUpdatedContent, "Remote update");
-        remoteClone.push()
-                   .setRemote("origin")
-                   .setRefSpecs(new RefSpec("refs/heads/main:refs/heads/main"))
-                   .call();
-
+                             .call()) {
+            commitFile(remoteClone, remoteUpdatedContent, "Remote update");
+            remoteClone.push()
+                       .setRemote("origin")
+                       .setRefSpecs(new RefSpec("refs/heads/main:refs/heads/main"))
+                       .call();
+        }
         localGit.fetch().setRemote("origin").call();
         GitStatusSnapshot snapshot = GitStatusChecker.checkStatus(localLibrary);
         assertEquals(SyncStatus.DIVERGED, snapshot.syncStatus());


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13518

Adds some fixes because of https://github.com/eclipse-jgit/jgit/issues/155#issuecomment-3144903502

Tetss now run on Windows again.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
