### PR TITLE
Add additional hint

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -7,7 +7,7 @@ java {
         // If this is updated, also update
         // - build.gradle -> jacoco -> toolVersion (because JaCoCo does not support newest JDK out of the box. Check versions at https://www.jacoco.org/jacoco/trunk/doc/changes.html)
         // - jitpack.yml
-        // - .devcontainer/devcontainer.json#L34 and
+        // - .devcontainer/devcontainer.json#L34 - there, also check if the gradleVersion matches the one of gradle/wrapper/gradle-wrapper.properties
         // - .moderne/moderne.yml
         // - .github/workflows/binaries*.yml
         // - .github/workflows/publish.yml


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13632

Our gradle update workflow (https://github.com/JabRef/jabref/blob/main/.github/workflows/update-gradle-wrapper.yml) cannot update `devcontainer` gradle version.

Therefore, we need a manual check.

Other options:

- Create an issue in our repository as soon as gradle is updated
- Try with regex magic to update the gradle version in `devcontainer.json` after a gradle update. (can be a good AI task)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
