### PR TITLE
Added Button to Shorten the DOI

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -10,6 +10,7 @@ import org.jabref.gui.autocompleter.ContentSelectorSuggestionProvider;
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.fieldeditors.identifier.IdentifierEditor;
+import org.jabref.gui.fieldeditors.identifier.doi.DoiEditor;
 import org.jabref.gui.fieldeditors.optioneditors.LanguageEditorViewModel;
 import org.jabref.gui.fieldeditors.optioneditors.MonthEditorViewModel;
 import org.jabref.gui.fieldeditors.optioneditors.OptionEditor;
@@ -72,7 +73,10 @@ public class FieldEditors {
             return new UrlEditor(field, suggestionProvider, fieldCheckers, undoAction, redoAction);
         } else if (fieldProperties.contains(FieldProperty.JOURNAL_NAME)) {
             return new JournalEditor(field, suggestionProvider, fieldCheckers, undoAction, redoAction);
-        } else if (fieldProperties.contains(FieldProperty.IDENTIFIER) && field != StandardField.PMID || field == StandardField.ISBN) {
+        } else if (field == StandardField.DOI) {
+            // Identifier editor does not support PMID, therefore excluded at the condition above
+            return new DoiEditor(field, suggestionProvider, fieldCheckers);
+        }else if (fieldProperties.contains(FieldProperty.IDENTIFIER) && field != StandardField.PMID || field == StandardField.ISBN) {
             // Identifier editor does not support PMID, therefore excluded at the condition above
             return new IdentifierEditor(field, suggestionProvider, fieldCheckers);
         } else if (field == StandardField.CITATIONCOUNT) {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/doi/DoiEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/doi/DoiEditor.java
@@ -1,4 +1,4 @@
-package org.jabref.gui.fieldeditors.identifier;
+package org.jabref.gui.fieldeditors.identifier.doi;
 
 import java.util.Optional;
 
@@ -18,7 +18,6 @@ import org.jabref.gui.fieldeditors.EditorValidator;
 import org.jabref.gui.fieldeditors.FieldEditorFX;
 import org.jabref.gui.fieldeditors.contextmenu.DefaultMenu;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
-import org.jabref.gui.fieldeditors.identifier.doi.DoiIdentifierEditorViewModel;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
@@ -30,16 +29,18 @@ import com.airhacks.afterburner.injection.Injector;
 import com.airhacks.afterburner.views.ViewLoader;
 import jakarta.inject.Inject;
 
-import static org.jabref.model.entry.field.StandardField.DOI;
-import static org.jabref.model.entry.field.StandardField.EPRINT;
-import static org.jabref.model.entry.field.StandardField.ISBN;
+import org.jabref.gui.fieldeditors.identifier.BaseIdentifierEditorViewModel;
 
-public class IdentifierEditor extends HBox implements FieldEditorFX {
+import static org.jabref.model.entry.field.StandardField.DOI;
+
+
+public class DoiEditor extends HBox implements FieldEditorFX {
 
     @FXML private BaseIdentifierEditorViewModel<?> viewModel;
     @FXML private EditorTextField textField;
     @FXML private Button fetchInformationByIdentifierButton;
     @FXML private Button lookupIdentifierButton;
+    @FXML private Button shortenDoiButton;
 
     @Inject private DialogService dialogService;
     @Inject private TaskExecutor taskExecutor;
@@ -48,7 +49,7 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
     @Inject private StateManager stateManager;
     private Optional<BibEntry> entry = Optional.empty();
 
-    public IdentifierEditor(Field field,
+    public DoiEditor(Field field,
                             SuggestionProvider<?> suggestionProvider,
                             FieldCheckers fieldCheckers) {
 
@@ -57,10 +58,8 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
         Injector.registerExistingAndInject(this);
 
         switch (field) {
-            case ISBN ->
-                    this.viewModel = new ISBNIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences, undoManager, stateManager);
-            case EPRINT ->
-                    this.viewModel = new EprintIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences, undoManager);
+            case DOI ->
+                    this.viewModel = new DoiIdentifierEditorViewModel(suggestionProvider, fieldCheckers, dialogService, taskExecutor, preferences, undoManager, stateManager);
 
             // TODO: Add support for PMID
             case null, default -> {
@@ -70,8 +69,8 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
         }
 
         ViewLoader.view(this)
-                  .root(this)
-                  .load();
+                .root(this)
+                .load();
 
         textField.textProperty().bindBidirectional(viewModel.textProperty());
 
@@ -80,7 +79,8 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
         lookupIdentifierButton.setTooltip(
                 new Tooltip(Localization.lang("Look up %0", field.getDisplayName())));
 
-        textField.initContextMenu(new DefaultMenu(textField), preferences.getKeyBindingRepository());
+
+        textField.initContextMenu(EditorMenus.getDOIMenu(textField, dialogService), preferences.getKeyBindingRepository());
 
 
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textField);
@@ -114,5 +114,10 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
     @FXML
     private void openExternalLink() {
         viewModel.openExternalLink();
+    }
+
+    @FXML
+    private void shortenDoi() {
+        //viewModel.shortenDoi();
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/doi/DoiIdentifierEditorViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/identifier/doi/DoiIdentifierEditorViewModel.java
@@ -1,4 +1,4 @@
-package org.jabref.gui.fieldeditors.identifier;
+package org.jabref.gui.fieldeditors.identifier.doi;
 
 import javax.swing.undo.UndoManager;
 
@@ -6,6 +6,7 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.StateManager;
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.gui.desktop.os.NativeDesktop;
+import org.jabref.gui.fieldeditors.identifier.BaseIdentifierEditorViewModel;
 import org.jabref.gui.mergeentries.FetchAndMergeEntry;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.importer.fetcher.CrossRef;
@@ -69,4 +70,6 @@ public class DoiIdentifierEditorViewModel extends BaseIdentifierEditorViewModel<
         identifier.get().map(DOI::asString)
                   .ifPresent(s -> NativeDesktop.openCustomDoi(s, preferences, dialogService));
     }
+
+
 }

--- a/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
+++ b/jabgui/src/main/java/org/jabref/gui/icon/IconTheme.java
@@ -370,7 +370,8 @@ public class IconTheme {
         CONSISTENCY_OPTIONAL_FIELD(MaterialDesignC.CIRCLE_OUTLINE),
         CONSISTENCY_UNKNOWN_FIELD(MaterialDesignH.HELP),
         ABSOLUTE_PATH(MaterialDesignF.FAMILY_TREE),
-        RELATIVE_PATH(MaterialDesignF.FILE_TREE_OUTLINE);
+        RELATIVE_PATH(MaterialDesignF.FILE_TREE_OUTLINE),
+        SHORTEN_DOI(MaterialDesignA.ARROW_COLLAPSE_HORIZONTAL);
 
         private final JabRefIcon icon;
 

--- a/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/doi/DoiEditor.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/fieldeditors/identifier/doi/DoiEditor.fxml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ProgressIndicator?>
+<?import javafx.scene.control.Tooltip?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import org.jabref.gui.fieldeditors.EditorTextField?>
+<?import org.jabref.gui.icon.JabRefIconView?>
+<fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112"
+         fx:controller="org.jabref.gui.fieldeditors.identifier.doi.DoiEditor">
+    <EditorTextField fx:id="textField" prefHeight="0.0" HBox.hgrow="ALWAYS"/>
+    <Button fx:id="shortenDoiButton" disable="${controller.viewModel.isInvalidIdentifier}"
+            onAction="#shortenDoi"
+            styleClass="icon-button"
+            managed="${controller.viewModel.canFetchBibliographyInformationById}"
+            visible="${controller.viewModel.canFetchBibliographyInformationById}">
+        <graphic>
+            <JabRefIconView glyph="SHORTEN_DOI"/>
+        </graphic>
+    </Button>
+    <Button disable="${controller.viewModel.isInvalidIdentifier}" onAction="#openExternalLink"
+            styleClass="icon-button">
+        <graphic>
+            <JabRefIconView glyph="OPEN_LINK"/>
+        </graphic>
+        <tooltip>
+            <Tooltip text="%Open"/>
+        </tooltip>
+    </Button>
+    <Button fx:id="lookupIdentifierButton" onAction="#lookupIdentifier" styleClass="icon-button"
+            visible="${controller.viewModel.canLookupIdentifier}"
+            managed="${controller.viewModel.canLookupIdentifier}">
+        <graphic>
+            <StackPane>
+                <JabRefIconView glyph="LOOKUP_IDENTIFIER"
+                                visible="${controller.viewModel.identifierLookupInProgress == false}"/>
+                <ProgressIndicator maxHeight="12.0" maxWidth="12.0"
+                                   visible="${controller.viewModel.identifierLookupInProgress}"/>
+            </StackPane>
+        </graphic>
+    </Button>
+    <Button fx:id="fetchInformationByIdentifierButton" disable="${controller.viewModel.isInvalidIdentifier}"
+            onAction="#fetchInformationByIdentifier"
+            styleClass="icon-button"
+            managed="${controller.viewModel.canFetchBibliographyInformationById}"
+            visible="${controller.viewModel.canFetchBibliographyInformationById}">
+        <graphic>
+            <JabRefIconView glyph="FETCH_BY_IDENTIFIER"/>
+        </graphic>
+    </Button>
+</fx:root>


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

Created new DOI package for handling DOI data. Created new DOIEditor class and fxml file, moving the logic for DOI from IdentifierEditor. Added an if statement to the FieldEditors to implement the new DOIEditor class. 

Yet to be implemented:
- Will add shorten DOI logic to the button.

### Steps to test

Open the program and create a new example library.
Double click an entry and click the 'General' tab.
There should be a button that indicates shortening near the DOI field.
<img width="1214" height="989" alt="Screenshot From 2025-08-05 01-49-23" src="https://github.com/user-attachments/assets/6e40db05-ef83-4780-ab1c-da337182e8d3" />



### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
