### PR TITLE
Include entry type and comment comparison in compareEntriesStrictly

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -241,29 +241,41 @@ public class DuplicateCheck {
         allFields.addAll(one.getFields());
         allFields.addAll(two.getFields());
 
+        // totalCount counts the equal "properties" of an entry, i.e. the number of fields, the entry type, and the comment
+        int totalCount = allFields.size();
+
         int score = 0;
         for (final Field field : allFields) {
             if (isSingleFieldEqual(one, two, field)) {
                 score++;
             }
         }
-        if (score == allFields.size()) {
+
+        totalCount++;
+        if (!haveDifferentEntryType(one, two)) {
+            score++;
+        }
+
+        totalCount++;
+        if (isCommentEqual(one, two)) {
+            score++;
+        }
+
+        if (score == totalCount) {
             return 1.01; // Just to make sure we can use score > 1 without trouble.
         }
-        return (double) score / allFields.size();
+        return (double) score / totalCount;
     }
 
+    private static boolean isCommentEqual(BibEntry one, BibEntry two) {
+        return StringUtil.equalsUnifiedLineBreak(Optional.of(one.getUserComments()), Optional.of(two.getUserComments()));
+    }
+
+    /// Compares the string content of the given field at each entry character by character.
+    ///
+    /// @return true if the content is equal (with normalized linebreaks), false otherwise.
     private static boolean isSingleFieldEqual(BibEntry one, BibEntry two, Field field) {
-        final Optional<String> stringOne = one.getField(field);
-        final Optional<String> stringTwo = two.getField(field);
-        if (stringOne.isEmpty() && stringTwo.isEmpty()) {
-            return true;
-        }
-        if (stringOne.isEmpty() || stringTwo.isEmpty()) {
-            return false;
-        }
-        return StringUtil.unifyLineBreaks(stringOne.get(), OS.NEWLINE).equals(
-                StringUtil.unifyLineBreaks(stringTwo.get(), OS.NEWLINE));
+        return StringUtil.equalsUnifiedLineBreak(one.getField(field), two.getField(field));
     }
 
     /**
@@ -324,6 +336,7 @@ public class DuplicateCheck {
             return true;
         }
 
+        // TODO: Work on haveDifferentEntryType - InCollection and InProceedings could point to the same publication
         if (haveDifferentEntryType(one, two) ||
                 haveDifferentEditions(one, two) ||
                 haveDifferentChaptersOrPagesOfTheSameBook(one, two)) {

--- a/jablib/src/main/java/org/jabref/model/strings/StringUtil.java
+++ b/jablib/src/main/java/org/jabref/model/strings/StringUtil.java
@@ -740,6 +740,17 @@ public class StringUtil {
         return StringUtils.containsIgnoreCase(text, searchString);
     }
 
+    public static boolean equalsUnifiedLineBreak(Optional<String> stringOne, Optional<String> stringTwo) {
+        if (stringOne.isEmpty() && stringTwo.isEmpty()) {
+            return true;
+        }
+        if (stringOne.isEmpty() || stringTwo.isEmpty()) {
+            return false;
+        }
+        return StringUtil.unifyLineBreaks(stringOne.get(), OS.NEWLINE).equals(
+                StringUtil.unifyLineBreaks(stringTwo.get(), OS.NEWLINE));
+    }
+
     public static String substringBetween(String str, String open, String close) {
         return StringUtils.substringBetween(str, open, close);
     }

--- a/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/database/DuplicateCheckTest.java
@@ -132,7 +132,39 @@ public class DuplicateCheckTest {
                 .withField(StandardField.JOURNAL, "B");
 
         assertTrue(duplicateChecker.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
-        assertEquals(0.75, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
+        assertEquals(0.83, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
+    }
+
+    @Test
+    void scoreWithDifferentEntryType() {
+        BibEntry one = new BibEntry(StandardEntryType.Misc)
+                .withField(StandardField.AUTHOR, "Billy Bob")
+                .withField(StandardField.YEAR, "2005")
+                .withField(StandardField.TITLE, "A title");
+
+        BibEntry two = new BibEntry(StandardEntryType.Article)
+                .withField(StandardField.AUTHOR, "Billy Bob")
+                .withField(StandardField.YEAR, "2005")
+                .withField(StandardField.TITLE, "A title");
+
+        assertEquals(0.8, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
+    }
+
+    @Test
+    void scoreWithDifferentUserComment() {
+        BibEntry one = new BibEntry(StandardEntryType.Article)
+                .withUserComments("Bill's favorite article")
+                .withField(StandardField.AUTHOR, "Billy Bob")
+                .withField(StandardField.YEAR, "2005")
+                .withField(StandardField.TITLE, "A title");
+
+        BibEntry two = new BibEntry(StandardEntryType.Article)
+                .withUserComments("Bill's best paper award")
+                .withField(StandardField.AUTHOR, "Billy Bob")
+                .withField(StandardField.YEAR, "2005")
+                .withField(StandardField.TITLE, "A title");
+
+        assertEquals(0.8, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/model/strings/StringUtilTest.java
+++ b/jablib/src/test/java/org/jabref/model/strings/StringUtilTest.java
@@ -32,7 +32,7 @@ class StringUtilTest {
         Path path = Path.of("src", "main", "java", StringUtil.class.getName().replace('.', '/') + ".java");
         int lineCount = Files.readAllLines(path, StandardCharsets.UTF_8).size();
 
-        assertTrue(lineCount <= 819, "StringUtil increased in size to " + lineCount + ". "
+        assertTrue(lineCount <= 830, "StringUtil increased in size to " + lineCount + ". "
                 + "We try to keep this class as small as possible. "
                 + "Thus think twice if you add something to StringUtil.");
     }


### PR DESCRIPTION
`compareEntriesStrictly` did not take all "properties" of a BibEntry into account

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
