### PR TITLE
One more Git close

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -305,7 +305,7 @@ jobs:
         run: scripts/after-failure.sh
 
   tests-windows:
-    name: "Unit tests (Windows) – jablib"
+    name: "Unit tests (Windows)"
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.repository_owner == 'JabRef')
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -305,7 +305,7 @@ jobs:
         run: scripts/after-failure.sh
 
   tests-windows:
-    name: "Unit tests (Windows) – ${{ matrix.module }}"
+    name: "Unit tests (Windows) – jablib"
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.repository_owner == 'JabRef')
     runs-on: windows-latest
     strategy:

--- a/jablib/src/main/java/org/jabref/logic/git/GitHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/git/GitHandler.java
@@ -40,10 +40,12 @@ public class GitHandler {
         this.repositoryPathAsFile = this.repositoryPath.toFile();
         if (!isGitRepository()) {
             try {
-                Git.init()
+                try (Git git = Git.init()
                    .setDirectory(repositoryPathAsFile)
                    .setInitialBranch("main")
-                   .call();
+                   .call()) {
+                    // "git" object is not used later, but we need to close it after initialization
+                }
                 setupGitIgnore();
                 String initialCommit = "Initial commit";
                 if (!createCommitOnCurrentBranch(initialCommit, false)) {

--- a/jablib/src/test/java/org/jabref/logic/git/SlrGitHandlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/git/SlrGitHandlerTest.java
@@ -7,6 +7,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.internal.storage.file.WindowCache;
+import org.eclipse.jgit.lib.RepositoryCache;
+import org.eclipse.jgit.storage.file.WindowCacheConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,11 +24,21 @@ class SlrGitHandlerTest {
 
     @TempDir
     Path repositoryPath;
+
     private SlrGitHandler gitHandler;
 
     @BeforeEach
     void setUpGitHandler() {
         gitHandler = new SlrGitHandler(repositoryPath);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        // Required by JGit
+        // See https://github.com/eclipse-jgit/jgit/issues/155#issuecomment-2765437816 for details
+        RepositoryCache.clear();
+        // See https://github.com/eclipse-jgit/jgit/issues/155#issuecomment-3095957214
+        WindowCache.reconfigure(new WindowCacheConfig());
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/git/status/GitStatusCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/git/status/GitStatusCheckerTest.java
@@ -7,8 +7,11 @@ import java.util.List;
 
 import org.eclipse.jgit.api.CreateBranchCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.internal.storage.file.WindowCache;
 import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.RepositoryCache;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.WindowCacheConfig;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.URIish;
 import org.junit.jupiter.api.AfterEach;
@@ -117,6 +120,12 @@ class GitStatusCheckerTest {
         if (remoteGit != null) {
             remoteGit.close();
         }
+
+        // Required by JGit
+        // See https://github.com/eclipse-jgit/jgit/issues/155#issuecomment-2765437816 for details
+        RepositoryCache.clear();
+        // See https://github.com/eclipse-jgit/jgit/issues/155#issuecomment-3095957214
+        WindowCache.reconfigure(new WindowCacheConfig());
     }
 
     @Test


### PR DESCRIPTION
Should fix failing `aheadStatusWhenLocalHasNewCommit`

```
> Task :jablib:test
org.jabref.logic.git.status.GitStatusCheckerTest

  Test aheadStatusWhenLocalHasNewCommit() FAILED

  org.junit.platform.commons.JUnitException: Failed to close extension context

  Caused by: java.io.IOException: Failed to delete temp directory C:UsersRUNNER~1AppDataLocalTempjunit-3955357767749560680. The following paths could not be deleted (see suppressed exceptions for details): <root>, remote.git, remote.gitobjects, remote.gitobjectspack, remote.gitobjectspackpack-ecbf2dd4bbf508163d7476aaef9cafd6984af163.pack
```

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
