### PR TITLE
Fix for Pagetotal was sorting alphabetically instead of numerically #12533

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved file exists warning dialog with clearer options and tooltips [#12565](https://github.com/JabRef/jabref/issues/12565)]
 
 ### Fixed
-
+- We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)
 - We fixed dark mode of BibTeX Source dialog in Citation Relations tab. [#13599](https://github.com/JabRef/jabref/issues/13599)
 - We fixed an issue where the LibreOffice integration did not support citation keys containing Unicode characters. [#13301](https://github.com/JabRef/jabref/issues/13301)
 - We fixed an issue where the "Search ShortScience" action did not convert LaTeX-formatted titles to Unicode.[#13418](https://github.com/JabRef/jabref/issues/13418)

--- a/jablib/src/main/java/org/jabref/model/entry/field/StandardField.java
+++ b/jablib/src/main/java/org/jabref/model/entry/field/StandardField.java
@@ -93,7 +93,7 @@ public enum StandardField implements Field {
     ORIGDATE("origdate", FieldProperty.DATE),
     ORIGLANGUAGE("origlanguage", FieldProperty.LANGUAGE),
     PAGES("pages"),
-    PAGETOTAL("pagetotal"),
+    PAGETOTAL("pagetotal", FieldProperty.NUMERIC),
     PAGINATION("pagination", FieldProperty.PAGINATION),
     PART("part"),
     PDF("pdf", "PDF"),


### PR DESCRIPTION


Closes https://github.com/JabRef/jabref/issues/12533
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

- Added `FieldProperty.NUMERIC` to the `PAGETOTAL` field in StandardField.java. 
- Pagetotal column was sorting alphabetically because it was missing `FieldProperty.NUMERIC` and was not using the comparator in `NumericFieldComparator.java` because of this. 


<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test
1. Add Pagetotal in the columns. (You can add it from **File -> Preferences -> Entry Table**.)
2. In the Entry Editor, add the value for Pagetotal which will be in the Required or Optional fields, or add it manually in the source editor (biblatex source -> add **pagetotal = some value**)  
3. Sort 


<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<img width="143" height="431" alt="image" src="https://github.com/user-attachments/assets/f680872b-d6b2-4dd6-ad54-a71dd7898d62" />
<img width="135" height="442" alt="image" src="https://github.com/user-attachments/assets/f693e683-0e3a-4207-910b-5971c1ada6b3" />

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [x] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
