### PR TITLE
Jabref dialog doesnt respect font size 13558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We introduced walkthrough functionality [#12664](https://github.com/JabRef/jabref/issues/12664)
 
 ### Fixed
-
+  
+- We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558) 
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)
 - We fixed dark mode of BibTeX Source dialog in Citation Relations tab. [#13599](https://github.com/JabRef/jabref/issues/13599)
 - We fixed an issue where the LibreOffice integration did not support citation keys containing Unicode characters. [#13301](https://github.com/JabRef/jabref/issues/13301)

--- a/jabgui/src/main/java/org/jabref/gui/help/AboutAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/help/AboutAction.java
@@ -8,18 +8,15 @@ import com.airhacks.afterburner.injection.Injector;
 public class AboutAction extends SimpleCommand {
 
     private final AboutDialogView aboutDialogView;
+    private final DialogService dialogService;
 
     public AboutAction() {
         this.aboutDialogView = new AboutDialogView();
+        this.dialogService = Injector.instantiateModelOrService(DialogService.class);
     }
 
     @Override
     public void execute() {
-        DialogService dialogService = Injector.instantiateModelOrService(DialogService.class);
         dialogService.showCustomDialog(aboutDialogView);
-    }
-
-    public AboutDialogView getAboutDialogView() {
-        return aboutDialogView;
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/help/AboutDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/help/AboutDialogView.java
@@ -36,11 +36,11 @@ public class AboutDialogView extends BaseDialog<Void> {
                   .load()
                   .setAsDialogPane(this);
 
-        ControlHelper.setAction(copyVersionButton, getDialogPane(), event -> copyVersionToClipboard());
+        ControlHelper.setAction(copyVersionButton, getDialogPane(), ignored -> copyVersionToClipboard());
 
         getDialogPane()
                 .sceneProperty()
-                .addListener((obs, oldScene, newScene) -> {
+                .addListener((_, ignored, newScene) -> {
                     if (newScene != null) {
                         themeManager.updateFontStyle(newScene);
                     }

--- a/jabgui/src/main/java/org/jabref/gui/help/AboutDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/help/AboutDialogView.java
@@ -7,6 +7,7 @@ import javafx.scene.control.TextArea;
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.util.BaseDialog;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.logic.l10n.Localization;
@@ -24,6 +25,7 @@ public class AboutDialogView extends BaseDialog<Void> {
     @Inject private GuiPreferences preferences;
     @Inject private ClipBoardManager clipBoardManager;
     @Inject private BuildInfo buildInfo;
+    @Inject private ThemeManager themeManager;
 
     private AboutDialogViewModel viewModel;
 
@@ -35,6 +37,14 @@ public class AboutDialogView extends BaseDialog<Void> {
                   .setAsDialogPane(this);
 
         ControlHelper.setAction(copyVersionButton, getDialogPane(), event -> copyVersionToClipboard());
+
+        getDialogPane()
+                .sceneProperty()
+                .addListener((obs, oldScene, newScene) -> {
+                    if (newScene != null) {
+                        themeManager.updateFontStyle(newScene);
+                    }
+                });
     }
 
     public AboutDialogViewModel getViewModel() {

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -1853,7 +1853,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 /* AboutDialog */
 #aboutDialog .about-heading {
-    -fx-font-size: 30;
+    -fx-font-size: 2.40em;
     -fx-text-fill: -jr-theme;
 }
 
@@ -1866,12 +1866,12 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 #aboutDialog .dev-heading {
-    -fx-font-size: 18;
+    -fx-font-size: 1.44em;
     -fx-padding: -10 0 0 0;
 }
 
 #aboutDialog .sub-heading {
-    -fx-font-size: 18;
+    -fx-font-size: 1.44em;
     -fx-padding: 0.312em;
 }
 


### PR DESCRIPTION
Closes #13558

I fixed the issue whereby the About dialog was not honouring (it was using constant font-sizes in the .css file) the user's configured font (&size) preferences.

A also fixed the issue such that the application needed to be restarted for the About dialog to pick up changed font preferences.

Both done in the same way, by utilising `themeManager.updateFontStyle`  in `AboutDialogView` whenever the dialog pane's scene property changes.

### Steps to test

#### Manually testing the default font size

- Run app before pulling
- Ensure the `File`|`Preferences`|`General`|`Override default font settings` is unchecked
- Take a screenshot of the `Help`|`About` dialog
- Terminate the app
- Pull in code with fixes 
- Run app
- Ensure the `File`|`Preferences`|`General`|`Override default font settings` is unchecked
- Take screenshot of the `Help`|`About` dialog

Compare the before and after shots. In particular the font-sizes can be examined.

#### Manually testing various font-sizes

- Repeat the above tests for varying sizes of user-defined font size preferences

#### Testing that the About dialog responds to updated user font preferences

- Run the app
- Ensure the `File`|`Preferences`|`General`|`Override default font settings` control is checked
- Choose a font size, say 9pt.
- Close the Preferences dialog
- Open the `Help`|`About` dialog
- Note the size of the text (small/normal)
- Close the `Help`|`About` dialog
- Open the `File`|`Preferences`|`General` dialog
- Choose a large (noticable) font size, say 22pt.
- Close the Preferences diagog
- Open the `Help`|`About` dialog and note the size of the text (it should be big)

I've done lots of manual testing and i'm happy with the changes. 

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date?
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date?


#### `New` About Dialog 9pt Font Size
<img width="1083" height="1113" alt="jabref_13558__about_dialog__9pt" src="https://github.com/user-attachments/assets/9655980a-6aad-472b-8133-29d7cc59921c" />

#### `New` About Dialog 12pt Font Size
<img width="1097" height="1155" alt="jabref_13558__about_dialog__12pt" src="https://github.com/user-attachments/assets/e3a3ed66-51a8-49ad-a306-e9e21c5e492f" />

####  `New` About Dialog 15pt Font Size
<img width="1098" height="1425" alt="jabref_13558__about_dialog__15pt" src="https://github.com/user-attachments/assets/81016b5e-50cf-43c1-ac90-91bfcc156fb6" />

####  `New` About Dialog 18pt Font Size
<img width="1194" height="1676" alt="jabref_13558__about_dialog__18pt" src="https://github.com/user-attachments/assets/7ff2635e-74e6-4917-b3cc-fe711a7e33a2" />

####  `New` About Dialog 21pt Font Size
<img width="1371" height="1908" alt="jabref_13558__about_dialog__21pt" src="https://github.com/user-attachments/assets/fc9d0a38-2e52-4b93-af38-3895b827ae2e" />

####  `New` About Dialog with System Default Font Settings
<img width="1077" height="1118" alt="jabref_13558__about_dialog__default" src="https://github.com/user-attachments/assets/60b2cd80-4d7a-47ee-9bb9-9ab7dc75d470" />

#### `Old` About Dialog with System Default Font Settings
<img width="1083" height="1113" alt="jabref_13558__about_dialog__original" src="https://github.com/user-attachments/assets/ab3c7f33-2397-41c9-b5bb-2cdd646554fe" />