### PR TITLE
Quickfix unknown css property

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -1780,7 +1780,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 .welcome-top-titles {
     -fx-spacing: 0.833em;
-    -fx-alignment: left;
+    -fx-alignment: top-left;
     -fx-padding: 0 0 1.667em 0;
 }
 


### PR DESCRIPTION
Running JabRef i get
```
2025-08-09 17:52:20 [JavaFX Application Thread] sun.util.logging.internal.LoggingProviderImpl$JULWrapper.log()
WARN: Caught java.lang.IllegalArgumentException: No enum constant javafx.geometry.Pos.left' while calculating value for '-fx-alignment' from rule '*.welcome-top-titles' in stylesheet jar:file:///C:/Users/Carl%20Christian/dev/jabref/jabgui/build/libs/jabgui-100.0.0.jar!/org/jabref/gui/Base.css
``´

Documentation has allowed constants:
<img width="1062" height="32" alt="grafik" src="https://github.com/user-attachments/assets/36c964f8-f8a4-4c15-b1bb-d4d403a3b2c8" />

Changed to default: top-left

### Steps to test

Run and check console

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
