### PR TITLE
Reuse CoarseGrainedFilter for autosave and backup

### DIFF
--- a/docs/code-howtos/eventbus.md
+++ b/docs/code-howtos/eventbus.md
@@ -68,3 +68,9 @@ The `event` package contains some specific events which occur in JabRef.
 For example: Every time an entry was added to the database a new `EntryAddedEvent` is sent through the `eventBus` which is located in `BibDatabase`.
 
 If you want to catch the event you'll have to register your listener class with the `registerListener(Object listener)` method in `BibDatabase`. `EntryAddedEvent` provides also methods to get the inserted `BibEntry`.
+
+## Throttling events
+
+There is `CoarseChangeFilter` which filters out events (e.g., typing in the same field) that are sent too frequently.
+It is used to prevent the event bus from being flooded with events that are too close together in time.
+The `LibraryTab` offers an instance where subscribers in the UI should use.

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -71,6 +71,7 @@ import org.jabref.logic.search.IndexManager;
 import org.jabref.logic.search.PostgreServer;
 import org.jabref.logic.shared.DatabaseLocation;
 import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.logic.util.OptionalObjectProperty;
 import org.jabref.logic.util.TaskExecutor;
 import org.jabref.logic.util.io.FileUtil;
@@ -98,6 +99,7 @@ import com.tobiasdiez.easybind.EasyBind;
 import com.tobiasdiez.easybind.Subscription;
 import org.controlsfx.control.NotificationPane;
 import org.controlsfx.control.action.Action;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,6 +119,11 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     private final BooleanProperty nonUndoableChangeProperty = new SimpleBooleanProperty(false);
 
     private BibDatabaseContext bibDatabaseContext;
+
+    // All subsccribers needing "coarse" change events should use this filter
+    // See https://devdocs.jabref.org/code-howtos/eventbus.html for details
+    private CoarseChangeFilter coarseChangeFilter;
+
     private MainTableDataModel tableModel;
     private FileAnnotationCache annotationCache;
     private MainTable mainTable;
@@ -158,8 +165,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
      *                       If the index is created for the dummy context, the actual context will not be able to open the index until it is closed by the dummy context.
      *                       Closing the index takes time and will slow down opening the library.
      */
-    private LibraryTab(BibDatabaseContext bibDatabaseContext,
-                       LibraryTabContainer tabContainer,
+    private LibraryTab(@NonNull BibDatabaseContext bibDatabaseContext,
+                       @NonNull LibraryTabContainer tabContainer,
                        DialogService dialogService,
                        AiService aiService,
                        GuiPreferences preferences,
@@ -170,8 +177,9 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
                        ClipBoardManager clipBoardManager,
                        TaskExecutor taskExecutor,
                        boolean isDummyContext) {
-        this.tabContainer = Objects.requireNonNull(tabContainer);
-        this.bibDatabaseContext = Objects.requireNonNull(bibDatabaseContext);
+        this.bibDatabaseContext = bibDatabaseContext;
+        this.coarseChangeFilter = new CoarseChangeFilter(bibDatabaseContext);
+        this.tabContainer = tabContainer;
         this.undoManager = undoManager;
         this.dialogService = dialogService;
         this.preferences = Objects.requireNonNull(preferences);
@@ -344,11 +352,11 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
     public void installAutosaveManagerAndBackupManager() {
         if (isDatabaseReadyForAutoSave(bibDatabaseContext)) {
-            AutosaveManager autosaveManager = AutosaveManager.start(bibDatabaseContext);
+            AutosaveManager autosaveManager = AutosaveManager.start(bibDatabaseContext, coarseChangeFilter);
             autosaveManager.registerListener(new AutosaveUiManager(this, dialogService, preferences, entryTypesManager, stateManager));
         }
         if (isDatabaseReadyForBackup(bibDatabaseContext) && preferences.getFilePreferences().shouldCreateBackup()) {
-            BackupManager.start(this, bibDatabaseContext, Injector.instantiateModelOrService(BibEntryTypesManager.class), preferences);
+            BackupManager.start(this, bibDatabaseContext, coarseChangeFilter, Injector.instantiateModelOrService(BibEntryTypesManager.class), preferences);
         }
     }
 
@@ -690,6 +698,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         } catch (RuntimeException e) {
             LOGGER.error("Problem when closing index manager", e);
         }
+
         try {
             AutosaveManager.shutdown(bibDatabaseContext);
         } catch (RuntimeException e) {

--- a/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/AutosaveManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/autosaveandbackup/AutosaveManager.java
@@ -31,15 +31,14 @@ public class AutosaveManager {
     private final BibDatabaseContext bibDatabaseContext;
 
     private final EventBus eventBus;
-    private final CoarseChangeFilter changeFilter;
     private final ScheduledThreadPoolExecutor executor;
+    private final CoarseChangeFilter coarseChangeFilter;
     private boolean needsSave = false;
 
-    private AutosaveManager(BibDatabaseContext bibDatabaseContext) {
+    private AutosaveManager(BibDatabaseContext bibDatabaseContext, CoarseChangeFilter coarseChangeFilter) {
         this.bibDatabaseContext = bibDatabaseContext;
+        this.coarseChangeFilter = coarseChangeFilter;
         this.eventBus = new EventBus();
-        this.changeFilter = new CoarseChangeFilter(bibDatabaseContext);
-        changeFilter.registerListener(this);
 
         this.executor = new ScheduledThreadPoolExecutor(2);
         this.executor.scheduleAtFixedRate(
@@ -62,9 +61,8 @@ public class AutosaveManager {
     }
 
     private void shutdown() {
-        changeFilter.unregisterListener(this);
-        changeFilter.shutdown();
-        executor.shutdown();
+        coarseChangeFilter.unregisterListener(this);
+        runningInstances.remove(this);
     }
 
     /**
@@ -72,8 +70,8 @@ public class AutosaveManager {
      *
      * @param bibDatabaseContext Associated {@link BibDatabaseContext}
      */
-    public static AutosaveManager start(BibDatabaseContext bibDatabaseContext) {
-        AutosaveManager autosaveManager = new AutosaveManager(bibDatabaseContext);
+    public static AutosaveManager start(BibDatabaseContext bibDatabaseContext, CoarseChangeFilter coarseChangeFilter) {
+        AutosaveManager autosaveManager = new AutosaveManager(bibDatabaseContext, coarseChangeFilter);
         runningInstances.add(autosaveManager);
         return autosaveManager;
     }
@@ -85,10 +83,7 @@ public class AutosaveManager {
      */
     public static void shutdown(BibDatabaseContext bibDatabaseContext) {
         runningInstances.stream().filter(instance -> instance.bibDatabaseContext == bibDatabaseContext).findAny()
-                        .ifPresent(instance -> {
-                            instance.shutdown();
-                            runningInstances.remove(instance);
-                        });
+                        .ifPresent(instance -> instance.shutdown());
     }
 
     public void registerListener(Object listener) {
@@ -100,7 +95,7 @@ public class AutosaveManager {
             eventBus.unregister(listener);
         } catch (IllegalArgumentException e) {
             // occurs if the event source has not been registered, should not prevent shutdown
-            LOGGER.debug("Problem unregistering", e);
+            LOGGER.error("Problem unregistering", e);
         }
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerDiscardedTest.java
@@ -12,6 +12,7 @@ import org.jabref.logic.exporter.BibDatabaseWriter;
 import org.jabref.logic.exporter.BibWriter;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -19,6 +20,7 @@ import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -57,9 +59,17 @@ class BackupManagerDiscardedTest {
 
         saveDatabase();
 
-        backupManager = new BackupManager(mock(LibraryTab.class), bibDatabaseContext, bibEntryTypesManager, preferences);
+        // We need a real CoarseChangeFilter to ensure that the BackupManager works correctly
+        CoarseChangeFilter coarseChangeFilter = new CoarseChangeFilter(bibDatabaseContext);
+
+        backupManager = BackupManager.start(mock(LibraryTab.class), bibDatabaseContext, coarseChangeFilter, bibEntryTypesManager, preferences);
 
         makeBackup();
+    }
+
+    @AfterEach
+    void shutdown() {
+        BackupManager.shutdown(bibDatabaseContext, backupDir, false);
     }
 
     private void saveDatabase() throws IOException {

--- a/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/autosaveandbackup/BackupManagerTest.java
@@ -13,6 +13,7 @@ import org.jabref.gui.LibraryTab;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.BackupFileType;
+import org.jabref.logic.util.CoarseChangeFilter;
 import org.jabref.logic.util.Directories;
 import org.jabref.logic.util.io.BackupFileUtil;
 import org.jabref.model.database.BibDatabase;
@@ -147,6 +148,7 @@ class BackupManagerTest {
         BackupManager manager = BackupManager.start(
                 mock(LibraryTab.class),
                 databaseContext,
+                mock(CoarseChangeFilter.class),
                 mock(BibEntryTypesManager.class, Answers.RETURNS_DEEP_STUBS),
                 preferences);
         manager.listen(new MetaDataChangedEvent(new MetaData()));
@@ -174,6 +176,7 @@ class BackupManagerTest {
         BackupManager manager = BackupManager.start(
                 mock(LibraryTab.class),
                 databaseContext,
+                mock(CoarseChangeFilter.class),
                 mock(BibEntryTypesManager.class, Answers.RETURNS_DEEP_STUBS),
                 preferences);
         manager.listen(new MetaDataChangedEvent(new MetaData()));

--- a/jablib/src/main/java/org/jabref/logic/util/CoarseChangeFilter.java
+++ b/jablib/src/main/java/org/jabref/logic/util/CoarseChangeFilter.java
@@ -21,13 +21,14 @@ public class CoarseChangeFilter {
 
     private Optional<Field> lastFieldChanged;
     private Optional<BibEntry> lastEntryChanged;
-    private int totalDelta;
 
     public CoarseChangeFilter(BibDatabaseContext bibDatabaseContext) {
-        // Listen for change events
         this.context = bibDatabaseContext;
+
+        // Listen for change events
         context.getDatabase().registerListener(this);
         context.getMetaData().registerListener(this);
+
         this.lastFieldChanged = Optional.empty();
         this.lastEntryChanged = Optional.empty();
     }

--- a/jablib/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/jablib/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -189,16 +189,15 @@ public class BibDatabase {
         insertEntries(entries, EntriesEventSource.LOCAL);
     }
 
-    public synchronized void insertEntries(List<BibEntry> newEntries, EntriesEventSource eventSource) {
-        Objects.requireNonNull(newEntries);
+    public synchronized void insertEntries(@NonNull List<BibEntry> newEntries, EntriesEventSource eventSource) {
+        if (newEntries.isEmpty()) {
+            return;
+        }
+
         for (BibEntry entry : newEntries) {
             entry.registerListener(this);
         }
-        if (newEntries.isEmpty()) {
-            eventBus.post(new EntriesAddedEvent(newEntries, eventSource));
-        } else {
-            eventBus.post(new EntriesAddedEvent(newEntries, newEntries.getFirst(), eventSource));
-        }
+        eventBus.post(new EntriesAddedEvent(newEntries, eventSource));
         entries.addAll(newEntries);
         newEntries.forEach(entry -> {
                     entriesId.put(entry.getId(), entry);

--- a/jablib/src/main/java/org/jabref/model/database/event/EntriesAddedEvent.java
+++ b/jablib/src/main/java/org/jabref/model/database/event/EntriesAddedEvent.java
@@ -7,6 +7,8 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.event.EntriesEvent;
 import org.jabref.model.entry.event.EntriesEventSource;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * {@link EntriesAddedEvent} is fired when at least {@link BibEntry} is being added to the {@link BibDatabase}.
  */
@@ -17,25 +19,19 @@ public class EntriesAddedEvent extends EntriesEvent {
     private final BibEntry firstEntry;
 
     /**
-     * @param bibEntries the entries which are being added
-     * @param firstEntry the first entry being added
-     */
-
-    public EntriesAddedEvent(List<BibEntry> bibEntries, BibEntry firstEntry, EntriesEventSource location) {
-        super(bibEntries, location);
-        this.firstEntry = firstEntry;
-    }
-
-    /**
      * @param bibEntries <code>List</code> of <code>BibEntry</code> objects which are being added.
      * @param location   Location affected by this event
      */
     public EntriesAddedEvent(List<BibEntry> bibEntries, EntriesEventSource location) {
         super(bibEntries, location);
-        this.firstEntry = null;
+        if (bibEntries.isEmpty()) {
+            this.firstEntry = null;
+        } else {
+            this.firstEntry = bibEntries.getFirst();
+        }
     }
 
-    public BibEntry getFirstEntry() {
+    public @Nullable BibEntry getFirstEntry() {
         return this.firstEntry;
     }
 }


### PR DESCRIPTION
Needed for https://github.com/JabRef/jabref/pull/13295

While reviewing https://github.com/JabRef/jabref/pull/13295, we thought, we need a CoarseChangeFilter. There were too many in JabRef. fixed here.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
