### PR TITLE
Fix citation relation when adding new entry from an entry in the cited by tab

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -337,8 +337,7 @@ public class DuplicateCheck {
         }
 
         // TODO: Work on haveDifferentEntryType - InCollection and InProceedings could point to the same publication
-        if (haveDifferentEntryType(one, two) ||
-                haveDifferentEditions(one, two) ||
+        if (haveDifferentEditions(one, two) ||
                 haveDifferentChaptersOrPagesOfTheSameBook(one, two)) {
             return false;
         }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/12967

This PR fix the issue when a new entry is added from the cited by tab and that new entry type is modifidied , then it gets deselected from the cited By , in the original entry that was selected. 

Next steps: 
- define if this is the right approach. Right now we don't know if this the right solution, because eliminating this validation seems dubious. 
- Additional step to implement is disabled entry to be modified manually, this way, information continue being compliant with fetched one

### Steps to test
- Add a new entry.
-  from the entry added, go to the citations relation ,cited by tab and selected a new entry.
-  In the library, select the recently added entry, and go to BibTex Soruce Tab. 
-  if the entry is Misc, change it manually for Article 
- Now, with this change, the entry will continue being selected even though the type change

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
