### PR TITLE
test: add unit tests for BibDatabaseMode enum

### DIFF
--- a/jablib/src/test/java/org/jabref/model/database/BibDatabaseModeTest.java
+++ b/jablib/src/test/java/org/jabref/model/database/BibDatabaseModeTest.java
@@ -1,0 +1,40 @@
+package org.jabref.model.database;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BibDatabaseModeTest {
+
+    @Test
+    void getFormattedNameReturnsExpectedValues() {
+        assertEquals("BibTeX", BibDatabaseMode.BIBTEX.getFormattedName());
+        assertEquals("biblatex", BibDatabaseMode.BIBLATEX.getFormattedName());
+    }
+
+    @Test
+    void getOppositeModeReturnsExpectedValues() {
+        assertEquals(BibDatabaseMode.BIBLATEX, BibDatabaseMode.BIBTEX.getOppositeMode());
+        assertEquals(BibDatabaseMode.BIBTEX, BibDatabaseMode.BIBLATEX.getOppositeMode());
+    }
+
+    @Test
+    void parseAcceptsDifferentCasing() {
+        assertEquals(BibDatabaseMode.BIBTEX, BibDatabaseMode.parse("bibtex"));
+        assertEquals(BibDatabaseMode.BIBTEX, BibDatabaseMode.parse("BIBTEX"));
+        assertEquals(BibDatabaseMode.BIBLATEX, BibDatabaseMode.parse("BibLaTex"));
+    }
+
+    @Test
+    void parseThrowsExceptionOnInvalidValue() {
+        assertThrows(IllegalArgumentException.class, () -> BibDatabaseMode.parse("unknown"));
+        assertThrows(IllegalArgumentException.class, () -> BibDatabaseMode.parse(""));
+        assertThrows(IllegalArgumentException.class, () -> BibDatabaseMode.parse("bibtexlatex"));
+    }
+
+    @Test
+    void getAsStringReturnsLowercaseNames() {
+        assertEquals("bibtex", BibDatabaseMode.BIBTEX.getAsString());
+        assertEquals("biblatex", BibDatabaseMode.BIBLATEX.getAsString());
+    }
+}


### PR DESCRIPTION
Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
