### PR TITLE
Add support for automatic ICORE conference ranking lookup [#13476]

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DuplicateCheck.java
@@ -289,42 +289,16 @@ public class DuplicateCheck {
         final String[] w1 = s1.split("\\s");
         final String[] w2 = s2.split("\\s");
         final int n = Math.min(w1.length, w2.length);
+        final StringSimilarity match = new StringSimilarity();
         int misses = 0;
         for (int i = 0; i < n; i++) {
-            double corr = similarity(w1[i], w2[i]);
+            double corr = match.similarity(w1[i], w2[i]);
             if (corr < 0.75) {
                 misses++;
             }
         }
         final double missRate = (double) misses / (double) n;
         return 1 - missRate;
-    }
-
-    /**
-     * Calculates the similarity (a number within 0 and 1) between two strings.
-     * http://stackoverflow.com/questions/955110/similarity-string-comparison-in-java
-     */
-    private static double similarity(final String first, final String second) {
-        final String longer;
-        final String shorter;
-
-        if (first.length() < second.length()) {
-            longer = second;
-            shorter = first;
-        } else {
-            longer = first;
-            shorter = second;
-        }
-
-        final int longerLength = longer.length();
-        // both strings are zero length
-        if (longerLength == 0) {
-            return 1.0;
-        }
-        final double distanceIgnoredCase = new StringSimilarity().editDistanceIgnoreCase(longer, shorter);
-        final double similarity = (longerLength - distanceIgnoredCase) / longerLength;
-        LOGGER.trace("Longer string: {} Shorter string: {} Similarity: {}", longer, shorter, similarity);
-        return similarity;
     }
 
     /**

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
@@ -3,8 +3,12 @@ package org.jabref.logic.util.strings;
 import java.util.Locale;
 
 import info.debatty.java.stringsimilarity.Levenshtein;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StringSimilarity {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringSimilarity.class);
+
     private final Levenshtein METRIC_DISTANCE = new Levenshtein();
     // edit distance threshold for entry title comparison
     private final int METRIC_THRESHOLD = 4;
@@ -23,5 +27,32 @@ public class StringSimilarity {
     public double editDistanceIgnoreCase(String a, String b) {
         // TODO: Locale is dependent on the language of the strings. English is a good denominator.
         return METRIC_DISTANCE.distance(a.toLowerCase(Locale.ENGLISH), b.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Calculates the similarity (a number within 0 and 1) between two strings.
+     * http://stackoverflow.com/questions/955110/similarity-string-comparison-in-java
+     */
+    public double similarity(final String first, final String second) {
+        final String longer;
+        final String shorter;
+
+        if (first.length() < second.length()) {
+            longer = second;
+            shorter = first;
+        } else {
+            longer = first;
+            shorter = second;
+        }
+
+        final int longerLength = longer.length();
+        // both strings are zero length
+        if (longerLength == 0) {
+            return 1.0;
+        }
+        final double distanceIgnoredCase = editDistanceIgnoreCase(longer, shorter);
+        final double similarity = (longerLength - distanceIgnoredCase) / longerLength;
+        LOGGER.trace("Longer string: {} Shorter string: {} Similarity: {}", longer, shorter, similarity);
+        return similarity;
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/util/strings/StringSimilarityTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/StringSimilarityTest.java
@@ -1,11 +1,14 @@
 package org.jabref.logic.util.strings;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringSimilarityTest {
+    private final double EPSILON_SIMILARITY = 0.00001;
 
     private StringSimilarity similarityChecker = new StringSimilarity();
 
@@ -26,5 +29,65 @@ class StringSimilarityTest {
     })
     void stringSimilarity(String a, String b, String expectedResult) {
         assertEquals(Boolean.valueOf(expectedResult), similarityChecker.isSimilar(a, b));
+    }
+
+    @Test
+    void similarityReturnsOneForExactStrings() {
+        String a = "abcdef";
+        String b = "abcdef";
+        double expectedResult = 1.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertEquals(expectedResult, similarity, EPSILON_SIMILARITY);
+    }
+
+    @Test
+    void similarityReturnsZeroForNonMatchingStrings() {
+        String a = "abcdef";
+        String b = "uvwxyz";
+        double expectedResult = 0.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertEquals(expectedResult, similarity, EPSILON_SIMILARITY);
+    }
+
+    @Test
+    void similarityReturnsValueBetweenZeroAndOneForSimilarStrings() {
+        String a = "abc";
+        String b = "abcdefgh";
+        double exactMatch = 1.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertTrue(similarity >= EPSILON_SIMILARITY && similarity < exactMatch);
+    }
+
+    @Test
+    void similarityReturnsOneForEmptyStrings() {
+        String a = "";
+        String b = "";
+        double expectedResult = 1.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertEquals(expectedResult, similarity, EPSILON_SIMILARITY);
+    }
+
+    @Test
+    void similarityReturnsZeroWhenOneStringIsEmpty() {
+        String a = "abcdef";
+        String b = "";
+        double expectedResult = 0.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertEquals(expectedResult, similarity, EPSILON_SIMILARITY);
+    }
+
+    @Test
+    void similarityIsCaseInsensitive() {
+        String a = "abcdef";
+        String b = "ABCDEF";
+        double expectedResult = 1.0;
+        double similarity = similarityChecker.similarity(a, b);
+
+        assertEquals(expectedResult, similarity, EPSILON_SIMILARITY);
     }
 }


### PR DESCRIPTION
Closes #13476: Add support for automatic ICORE conference ranking lookup

This PR will eventually add the required feature to enable ICORE conference ranking lookups whenever a BibTeX entry includes a conference title.

As per the original issue, I'll be making my way through the provided task list as I go along:

- [x] Move DuplicateCheck#similarity from org.jabref.logic.database to a new utility class: org.jabref.logic.util.strings.StringSimilarity.
- [ ] TODO Add ICORE.csv to src/main/resources/
- [ ] TODO Create a class that loads and indexes the ICORE data at instantiation.
- [ ] TODO Implement the logic to detect and return the ranking from a full conference name.
- [ ] TODO Create a new field: ICORANKING ('icoranking') and add it to org.jabref.model.entry.field.StandardField at the // JabRef-specific fields section.
- [ ] TODO Create a new field editor ICoreRankingEditor (inspired by IdentifierEditor) and integrate it into the UI by modifying FieldEditors#getForField(...). - The lookup button (like DOI lookup) to lookup the ranking in the CSV file
- [ ] TODO Write unit tests for acronym matching and similarity fallback.


### Steps to test

I will add the required steps and screenshots here once I've completed the relevant task.

### Mandatory checks

<!--
Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] TODO Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [ ] TODO Tests created for changes (if applicable)
- [ ] TODO Manually tested changed features in running JabRef (always required)
- [ ] TODO Screenshots added in PR description (if change is visible to the user)
- [ ] TODO [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] TODO [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
