### PR TITLE
Refine description for force-push

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -130,7 +130,7 @@
     Hey, we noticed that you **force-pushed** your changes.
     Force pushing is a bad practice when working together on a project (mainly because it is [not supported well by GitHub itself](https://github.com/orgs/community/discussions/3478)).
     Commits are lost and comments on commits lose their context, thus making it harder to review changes.
-    Morevoer, [`gh pr co`](https://cli.github.com/manual/gh_pr_checkout) does not work any more at the reviewer's side, because the checked-out branches diverge.
+    Moreover, [`gh pr co`](https://cli.github.com/manual/gh_pr_checkout) does not work anymore on the reviewer's side, because the checked-out branches diverge.
 
 
     When the pull request is getting integrated into `main`, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -134,7 +134,7 @@
 
 
     When the pull request is getting integrated into `main`, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway.
-    Thus, the individual commit history will not be visislbe in `main`.
+    Thus, your individual commit history will not be visible in `main`.
 
 
     In future, **please avoid that**. For now, you can continue working.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -130,7 +130,11 @@
     Hey, we noticed that you **force-pushed** your changes.
     Force pushing is a bad practice when working together on a project (mainly because it is [not supported well by GitHub itself](https://github.com/orgs/community/discussions/3478)).
     Commits are lost and comments on commits lose their context, thus making it harder to review changes.
-    At the end, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway before being merged into the `main` branch.
+    Morevoer, [`gh pr co`](https://cli.github.com/manual/gh_pr_checkout) does not work any more at the reviewer's side, because the checked-out branches diverge.
+
+
+    When the pull request is getting integrated into `main`, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway.
+    Thus, the individual commit history will not be visislbe in `main`.
 
 
     In future, **please avoid that**. For now, you can continue working.

--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -130,7 +130,6 @@
     Hey, we noticed that you **force-pushed** your changes.
     Force pushing is a bad practice when working together on a project (mainly because it is [not supported well by GitHub itself](https://github.com/orgs/community/discussions/3478)).
     Commits are lost and comments on commits lose their context, thus making it harder to review changes.
-    Moreover, [`gh pr co`](https://cli.github.com/manual/gh_pr_checkout) does not work anymore on the reviewer's side, because the checked-out branches diverge.
 
 
     When the pull request is getting integrated into `main`, all commits will be [squashed](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits) anyway.


### PR DESCRIPTION
I just encountered that I cannot use `gh co`. I think, this should be also put as argument to the contributors.

```bash
koppor@DESKTOP-KAK953S MINGW64 /c/git-repositories/jabref (update-gradle)
$ gh co 13553
remote: Enumerating objects: 374, done.
remote: Counting objects: 100% (170/170), done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 374 (delta 162), reused 151 (delta 151), pack-reused 204 (from 3)
Receiving objects: 100% (374/374), 74.55 KiB | 641.00 KiB/s, done.
Resolving deltas: 100% (185/185), completed with 45 local objects.
From github.com:JabRef/jabref
 ! [rejected]              refs/pull/13553/head -> fix-for-issue-12995  (non-fast-forward)
failed to run git: exit status 1
```

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
