### PR TITLE
Remove "speedup"

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -259,7 +259,6 @@ var taskGenerateCitationStyleCatalog = tasks.register<JBangTask>("generateCitati
     inputs.dir(layout.projectDirectory.dir("src/main/resources/csl-styles"))
     val cslCatalogJson = layout.buildDirectory.file("generated/resources/citation-style-catalog.json")
     outputs.file(cslCatalogJson)
-    onlyIf {!cslCatalogJson.get().asFile.exists()}
 }
 
 var ltwaCsvFile = layout.buildDirectory.file("tmp/ltwa_20210702.csv")


### PR DESCRIPTION
Solution proposed at https://github.com/JabRef/jabref/pull/13734#issuecomment-3215306641

The mentioned "hack" was introduced at https://github.com/JabRef/jabref/pull/13388

We have been warned at https://discuss.gradle.org/t/trying-to-run-task-based-on-existence-of-a-file-or-not/15330/5

Assumptions of this PR

- `.json` will be updated if csl-styles update (good)
- `.json` will be updated if generator changes (good)
- `.json` will not be updated if some dependend .java files are updated (acceptable).

### Steps to test

Observe `gradle` behavior during time and if `generateCitationStyleCatalog` is executed too often.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
