### PR TITLE
Fix path

### DIFF
--- a/build-support/src/main/java/CitationStyleCatalogGenerator.java
+++ b/build-support/src/main/java/CitationStyleCatalogGenerator.java
@@ -68,7 +68,7 @@ public class CitationStyleCatalogGenerator {
             List<CitationStyle> styles = discoverStyles(stylesRoot);
 
             Path catalogPath = root.resolve(CATALOG_PATH);
-            generateCatalog(styles, catalogPath);
+            generateCatalog(styles, stylesRoot, catalogPath);
         } catch (IOException e) {
             LOGGER.error("Error generating citation style catalog", e);
         }
@@ -84,14 +84,14 @@ public class CitationStyleCatalogGenerator {
         }
     }
 
-    private static void generateCatalog(List<CitationStyle> styles, Path catalogPath) throws IOException {
+    private static void generateCatalog(List<CitationStyle> styles, Path stylesRoot, Path catalogPath) throws IOException {
         // Create a JSON representation of the styles
         ObjectMapper mapper = new ObjectMapper();
         List<Map<String, Object>> styleInfoList = styles.stream()
                                                         .map(style -> {
                                                             Map<String, Object> info = new HashMap<>();
                                                             Path stylePath = Path.of(style.getFilePath());
-                                                            Path relativePath = STYLES_ROOT.toAbsolutePath().relativize(stylePath.toAbsolutePath());
+                                                            Path relativePath = stylesRoot.toAbsolutePath().relativize(stylePath.toAbsolutePath());
                                                             info.put("path", relativePath.toString());
                                                             info.put("title", style.getTitle());
                                                             info.put("shortTitle", style.getShortTitle());

--- a/build-support/src/main/java/CitationStyleCatalogGenerator.java
+++ b/build-support/src/main/java/CitationStyleCatalogGenerator.java
@@ -54,7 +54,8 @@ public class CitationStyleCatalogGenerator {
         try {
             // JBang's gradle plugin has a strange path handling. If "application->run" is started from the IDE, the path ends with "jabgui"
             Path root = Path.of(".").toAbsolutePath().normalize();
-            if (root.getFileName().toString().startsWith("jab")) {
+            String rootFilename = root.getFileName().toString();
+            if (!"jabref".equalsIgnoreCase(rootFilename) && rootFilename.startsWith("jab")) {
                 LOGGER.info("Running from IDE, adjusting path to styles root");
                 root = root.getParent();
             }

--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -234,7 +234,6 @@ tasks.generateGrammarSource {
     arguments = arguments + listOf("-visitor", "-long-messages")
 }
 
-
 val abbrvJabRefOrgDir = layout.projectDirectory.dir("src/main/abbrv.jabref.org")
 val generatedJournalFile = layout.buildDirectory.file("generated/resources/journals/journal-list.mv")
 


### PR DESCRIPTION
When executing a gradle task within a sub project - and the citation style cache was not existing; generation faild.

### Steps to test

1. Remove `jablib/build/generated/resources/citation-style-catalog.json`
2. Double click "run" from the IDE\
    ![image.png](https://app.gitbutler.com/uploads/7399c2c4-dd57-4741-b012-d46799c1c68f)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [/] Manually tested changed features in running JabRef (always required)
- [/] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
