### PR TITLE
feat: support committing local changes

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitAction.java
@@ -1,0 +1,29 @@
+package org.jabref.gui.git;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.ActionHelper;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.preferences.GuiPreferences;
+
+public class GitCommitAction extends SimpleCommand {
+
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private final GuiPreferences preferences;
+
+    public GitCommitAction(DialogService dialogService, StateManager stateManager, GuiPreferences preferences) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.preferences = preferences;
+
+        this.executable.bind(ActionHelper.needsDatabase(stateManager));
+    }
+
+    @Override
+    public void execute() {
+        dialogService.showCustomDialogAndWait(
+                new GitCommitDialogView()
+        );
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogView.java
@@ -1,0 +1,59 @@
+package org.jabref.gui.git;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.TextArea;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.util.BaseDialog;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.TaskExecutor;
+
+import com.airhacks.afterburner.views.ViewLoader;
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
+import jakarta.inject.Inject;
+
+public class GitCommitDialogView extends BaseDialog<Void> {
+
+    @FXML private TextArea commitMessage;
+    @FXML private ButtonType commitButton;
+
+    private GitCommitDialogViewModel viewModel;
+
+    @Inject
+    private StateManager stateManager;
+
+    @Inject
+    private DialogService dialogService;
+
+    @Inject
+    private GuiPreferences preferences;
+    @Inject
+    private TaskExecutor taskExecutor;
+
+    private final ControlsFxVisualizer visualizer = new ControlsFxVisualizer();
+
+    public GitCommitDialogView() {
+        ViewLoader.view(this)
+                  .load()
+                  .setAsDialogPane(this);
+    }
+
+    @FXML
+    private void initialize() {
+        setTitle(Localization.lang("Git Commit"));
+        this.viewModel = new GitCommitDialogViewModel(stateManager, dialogService, preferences, taskExecutor);
+
+        commitMessage.textProperty().bindBidirectional(viewModel.commitMessageProperty());
+        commitMessage.setPromptText(Localization.lang("Enter commit message here"));
+
+        this.setResultConverter(button -> {
+            if (button != ButtonType.CANCEL) {
+                viewModel.commit(() -> this.close());
+            }
+            return null;
+        });
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/git/GitCommitDialogViewModel.java
@@ -1,0 +1,122 @@
+package org.jabref.gui.git;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+import org.jabref.gui.AbstractViewModel;
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.logic.JabRefException;
+import org.jabref.logic.git.GitSyncService;
+import org.jabref.logic.git.merge.GitSemanticMergeExecutorImpl;
+import org.jabref.logic.git.util.GitHandlerRegistry;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+
+import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
+import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
+import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
+import de.saxsys.mvvmfx.utils.validation.Validator;
+
+public class GitCommitDialogViewModel extends AbstractViewModel {
+
+    private final StateManager stateManager;
+    private final DialogService dialogService;
+    private final GuiPreferences preferences;
+    private final TaskExecutor taskExecutor;
+
+    private final StringProperty commitMessage = new SimpleStringProperty("");
+    private final BooleanProperty amend = new SimpleBooleanProperty(false);
+
+    private final Validator commitMessageValidator;
+
+    public GitCommitDialogViewModel(
+            StateManager stateManager,
+            DialogService dialogService,
+            GuiPreferences preferences,
+            TaskExecutor taskExecutor) {
+        this.stateManager = stateManager;
+        this.dialogService = dialogService;
+        this.preferences = preferences;
+        this.taskExecutor = taskExecutor;
+
+        this.commitMessageValidator = new FunctionBasedValidator<>(
+                commitMessage,
+                message -> message != null && !message.trim().isEmpty(),
+                ValidationMessage.error(Localization.lang("Commit message cannot be empty"))
+        );
+    }
+
+    public void commit(Runnable onSuccess) {
+        commitTask()
+                .onSuccess(ignore -> {
+                    dialogService.notify(Localization.lang("Committed successfully."));
+                    onSuccess.run();
+                })
+                .onFailure(ex ->
+                        dialogService.showErrorDialogAndWait(
+                                Localization.lang("Git Commit Failed"),
+                                ex.getMessage(),
+                                ex
+                        )
+                )
+                .executeWith(taskExecutor);
+    }
+
+    public BackgroundTask<Void> commitTask() {
+        return BackgroundTask.wrap(() -> {
+            Optional<BibDatabaseContext> activeDatabaseOpt = stateManager.getActiveDatabase();
+            if (activeDatabaseOpt.isEmpty()) {
+                throw new JabRefException(Localization.lang("No library open"));
+            }
+
+            BibDatabaseContext dbContext = activeDatabaseOpt.get();
+            Optional<Path> bibFilePathOpt = dbContext.getDatabasePath();
+            if (bibFilePathOpt.isEmpty()) {
+                throw new JabRefException(Localization.lang("No library file path. Please save the library to a file first."));
+            }
+
+            Path bibFilePath = bibFilePathOpt.get();
+
+            GitHandlerRegistry registry = new GitHandlerRegistry();
+            GitSyncService gitSyncService = new GitSyncService(
+                    preferences.getImportFormatPreferences(),
+                    registry,
+                    null,
+                    new GitSemanticMergeExecutorImpl(preferences.getImportFormatPreferences())
+            );
+
+            boolean committed = gitSyncService.commitLocalChanges(
+                    bibFilePath,
+                    commitMessage.get().trim(),
+                    amend.get()
+            );
+
+            if (!committed) {
+                throw new JabRefException(Localization.lang("Nothing to commit."));
+            }
+
+            return null;
+        });
+    }
+
+    public StringProperty commitMessageProperty() {
+        return commitMessage;
+    }
+
+    public BooleanProperty amendProperty() {
+        return amend;
+    }
+
+    public ValidationStatus commitMessageValidation() {
+        return commitMessageValidator.getValidationStatus();
+    }
+}

--- a/jabgui/src/main/resources/org/jabref/gui/git/GitCommitDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/git/GitCommitDialog.fxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.ButtonType?>
+<?import javafx.scene.control.DialogPane?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.VBox?>
+<DialogPane
+        xmlns="http://javafx.com/javafx"
+        xmlns:fx="http://javafx.com/fxml"
+        fx:controller="org.jabref.gui.git.GitCommitDialogView"
+        prefHeight="400.0"
+        prefWidth="600.0">
+    <content>
+        <VBox spacing="15">
+            <padding>
+                <Insets top="20" right="20" bottom="20" left="20"/>
+            </padding>
+
+            <TextArea fx:id="commitMessage"
+                      prefRowCount="6"
+                      wrapText="true"
+                      VBox.vgrow="ALWAYS"/>
+        </VBox>
+    </content>
+    <buttonTypes>
+        <ButtonType fx:id="commitButton" text="%Commit" buttonData="OK_DONE"/>
+        <ButtonType fx:constant="CANCEL"/>
+    </buttonTypes>
+</DialogPane>


### PR DESCRIPTION
Closes #12350 

This PR implements the basic Git commit functionality for JabRef’s Git integration, adds a commit button and input field to commit changes of the currently opened .bib library.

### Steps to test
1. Open a .bib file located in a Git repository.
2. Click File -> Git -> Commit

<img width="1920" height="979" alt="image" src="https://github.com/user-attachments/assets/8a808990-8905-4266-887e-a9337700c69e" />

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [/] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (if change is visible to the user)
- [/] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [/] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
