### PR TITLE
Walkthrough additions

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
@@ -414,7 +414,6 @@ public class WalkthroughAction extends SimpleCommand {
                         .trigger(Trigger.onClick())
                         .position(TooltipPosition.RIGHT)
                         .highlight(HighlightEffect.SPOT_LIGHT))
-                // TODO: Add drag and drop for the Walkthrough
                 .addStep(WalkthroughStep
                         .tooltip(Localization.lang("Right-click on your group"))
                         .content(new TextBlock(Localization.lang("Now right-click on your \"%0\" group to open the context menu.", groupName)))

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
@@ -314,8 +314,7 @@ public class WalkthroughAction extends SimpleCommand {
                 new WindowEffect(HighlightEffect.PING),
                 new WindowEffect(mainResolver, HighlightEffect.FULL_SCREEN_DARKEN)
         );
-        // FIXME: Reduce the amount of the typing that's needed to going to the next step of the walkthrough
-        String groupName = Localization.lang("Research Papers");
+        String groupName = Localization.lang("Research");
         String addGroup = Localization.lang("Add group");
         String addSelectedEntries = Localization.lang("Add selected entries to this group");
 

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughAction.java
@@ -314,6 +314,7 @@ public class WalkthroughAction extends SimpleCommand {
                 new WindowEffect(HighlightEffect.PING),
                 new WindowEffect(mainResolver, HighlightEffect.FULL_SCREEN_DARKEN)
         );
+        // FIXME: Reduce the amount of the typing that's needed to going to the next step of the walkthrough
         String groupName = Localization.lang("Research Papers");
         String addGroup = Localization.lang("Add group");
         String addSelectedEntries = Localization.lang("Add selected entries to this group");
@@ -414,6 +415,7 @@ public class WalkthroughAction extends SimpleCommand {
                         .trigger(Trigger.onClick())
                         .position(TooltipPosition.RIGHT)
                         .highlight(HighlightEffect.SPOT_LIGHT))
+                // TODO: Add drag and drop for the Walkthrough
                 .addStep(WalkthroughStep
                         .tooltip(Localization.lang("Right-click on your group"))
                         .content(new TextBlock(Localization.lang("Now right-click on your \"%0\" group to open the context menu.", groupName)))

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WalkthroughRenderer.java
@@ -41,11 +41,11 @@ public class WalkthroughRenderer {
         titleContainer.getChildren().add(titleFlow);
 
         VBox contentContainer = createContent(step, walkthrough, beforeNavigate);
-        contentContainer.getStyleClass().add("walkthrough-tooltip-content");
+        contentContainer.getStyleClass().add("walkthrough-content");
         VBox.setVgrow(contentContainer, Priority.ALWAYS);
 
         HBox actionsContainer = createActions(step, walkthrough, beforeNavigate);
-        actionsContainer.getStyleClass().add("walkthrough-tooltip-actions");
+        actionsContainer.getStyleClass().add("walkthrough-actions");
 
         step.maxHeight().ifPresent(tooltip::setMaxHeight);
         step.maxWidth().ifPresent(tooltip::setMaxWidth);

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/WindowOverlay.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/WindowOverlay.java
@@ -267,7 +267,8 @@ class WindowOverlay {
     private PopOver createPopover(TooltipStep step, Runnable beforeNavigate) {
         Node content = renderer.render(step, walkthrough, beforeNavigate);
         PopOver popover = new PopOver();
-        popover.getScene().getStylesheets().setAll(window.getScene().getStylesheets());
+        popover.getStyleClass().add("walkthrough-tooltip");
+        popover.getScene().getStylesheets().setAll(window.getScene().getStylesheets()); // NOTE: Hack because ThemeManager cannot consistently apply themes
         popover.setContentNode(content);
         popover.setDetachable(false);
         popover.setCloseButtonEnabled(false);

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
@@ -79,7 +79,7 @@ public interface NodeResolver {
     /// @return a resolver that finds the node matching the predicate
     static NodeResolver predicate(@NonNull Predicate<Node> predicate) {
         return scene -> Optional.ofNullable(findNode(scene.getRoot(),
-                (node) -> NodeHelper.isTreeVisible(node) && predicate.test(node)));
+                node -> NodeHelper.isTreeVisible(node) && predicate.test(node)));
     }
 
     /// Creates a resolver that finds a button by its StandardAction. The button is

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/declarative/NodeResolver.java
@@ -6,7 +6,6 @@ import java.util.function.Predicate;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.ContextMenu;
@@ -19,6 +18,7 @@ import org.jabref.gui.icon.JabRefIconView;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.Streams;
+import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.control.LabeledText;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -33,55 +33,87 @@ public interface NodeResolver {
     /// @return an optional containing the found node, or empty if not found
     Optional<Node> resolve(@NonNull Scene scene);
 
-    /// Creates a resolver that finds a node by CSS selector.
+    /// Creates a resolver that finds a node by CSS selector. The returned node is
+    /// guaranteed to be visible.
     ///
     /// @param selector the CSS selector to find the node
     /// @return a resolver that finds the node by selector
     static NodeResolver selector(@NonNull String selector) {
-        return scene -> Optional.ofNullable(scene.lookup(selector));
+        return scene -> scene.getRoot().lookupAll(selector).stream().filter(NodeHelper::isTreeVisible).findFirst();
     }
 
-    /// Creates a resolver that finds a node by its fx:id.
+    /// Creates a resolver that finds a node by its fx:id. The returned node is
+    /// guaranteed to be visible.
     ///
     /// @param fxId the fx:id of the node
     /// @return a resolver that finds the node by fx:id
     static NodeResolver fxId(@NonNull String fxId) {
-        return scene -> Optional.ofNullable(scene.lookup("#" + fxId));
+        return selector("#" + fxId);
     }
 
-    /// Creates a resolver that finds a button by its graphic.
+    /// Creates a resolver that finds a button by its graphic. The returned button is
+    /// guaranteed to be visible.
     ///
     /// @param glyph the graphic of the button
     /// @return a resolver that finds the button by graphic
     static NodeResolver buttonWithGraphic(IconTheme.JabRefIcons glyph) {
-        // .icon-button, .button selector is not used, because lookupAll doesn't support multiple selectors
-        return scene -> Streams.concat(scene.getRoot().lookupAll(".button").stream(),
-                                       scene.getRoot().lookupAll(".icon-button").stream())
-                               .filter(node -> {
-                                   if (!(node instanceof ButtonBase button)) {
-                                       return false;
-                                   }
-                                   Node graphic = button.getGraphic();
-                                   return (graphic instanceof JabRefIconView jabRefIconView) && jabRefIconView.getGlyph() == glyph ||
-                                           (graphic instanceof FontIcon fontIcon) && fontIcon.getIconCode() == glyph.getIkon();
-                               })
-                               .findFirst();
+        return scene -> Streams
+                // .icon-button, .button selector is not used, because lookupAll doesn't support multiple selectors
+                .concat(scene.getRoot().lookupAll(".button").stream(),
+                        scene.getRoot().lookupAll(".icon-button").stream())
+                .filter(node -> {
+                    if (!(node instanceof ButtonBase button) || !NodeHelper.isTreeVisible(button)) {
+                        return false;
+                    }
+                    Node graphic = button.getGraphic();
+                    return (graphic instanceof JabRefIconView jabRefIconView) && jabRefIconView.getGlyph() == glyph ||
+                            (graphic instanceof FontIcon fontIcon) && fontIcon.getIconCode() == glyph.getIkon();
+                })
+                .findFirst();
     }
 
-    /// Creates a resolver that finds a node by a predicate.
+    /// Creates a resolver that finds a node by a predicate. The returned node is
+    /// guaranteed to be visible.
     ///
     /// @param predicate the predicate to match the node
     /// @return a resolver that finds the node matching the predicate
     static NodeResolver predicate(@NonNull Predicate<Node> predicate) {
-        return scene -> Optional.ofNullable(findNode(scene.getRoot(), predicate));
+        return scene -> Optional.ofNullable(findNode(scene.getRoot(),
+                (node) -> NodeHelper.isTreeVisible(node) && predicate.test(node)));
     }
 
-    /// Creates a resolver that finds a button by its StandardAction.
+    /// Creates a resolver that finds a button by its StandardAction. The button is
+    /// matched by its tooltip text or button text. The returned button is guaranteed to
+    /// be visible.
     ///
     /// @param action the StandardAction associated with the button
     /// @return a resolver that finds the button by action
     static NodeResolver action(@NonNull StandardActions action) {
-        return scene -> Optional.ofNullable(findNodeByAction(scene, action));
+        return scene -> Optional.ofNullable(findNode(scene.getRoot(), node -> {
+            if (!(node instanceof ButtonBase button) || !NodeHelper.isTreeVisible(button)) {
+                return false;
+            }
+
+            if (button.getTooltip() != null) {
+                String tooltipText = button.getTooltip().getText();
+                if (tooltipText != null && tooltipText.equals(action.getText())) {
+                    return true;
+                }
+            }
+
+            if (button.getStyleClass().contains("icon-button")) {
+                String actionText = action.getText();
+                if (button.getTooltip() != null && button.getTooltip().getText() != null) {
+                    String tooltipText = button.getTooltip().getText();
+                    if (tooltipText.startsWith(actionText) || tooltipText.contains(actionText)) {
+                        return true;
+                    }
+                }
+                return button.getText() != null && button.getText().equals(actionText);
+            }
+
+            return false;
+        }));
     }
 
     /// Creates a resolver that finds a button by its button type, assuming the node
@@ -95,14 +127,20 @@ public interface NodeResolver {
                 .map(node -> node instanceof DialogPane pane ? pane.lookupButton(buttonType) : null);
     }
 
-    /// Creates a resolver that finds a node by selector first, then predicate.
+    /// Creates a resolver that finds a node by selector first, then matches text
+    /// content in the node and the node's LabeledText children. The returned node is
+    /// guaranteed to be visible.
     ///
     /// @param selector    the style class to match
     /// @param textMatcher predicate to match text content in LabeledText children
     /// @return a resolver that finds the node by style class and text content
     static NodeResolver selectorWithText(@NonNull String selector, @NonNull Predicate<String> textMatcher) {
-        return scene -> scene.getRoot().lookupAll(selector).stream().filter(
-                node -> textMatcher.test(node.toString()) || node.lookupAll(".text").stream().anyMatch(child -> {
+        return scene -> scene
+                .getRoot()
+                .lookupAll(selector)
+                .stream()
+                .filter(NodeHelper::isTreeVisible)
+                .filter(node -> textMatcher.test(node.toString()) || node.lookupAll(".text").stream().anyMatch(child -> {
                             if (child instanceof LabeledText text) {
                                 String textContent = text.getText();
                                 return textContent != null && textMatcher.test(textContent);
@@ -127,39 +165,13 @@ public interface NodeResolver {
             }
 
             return menu.getItems().stream()
+                       .filter(item -> NodeHelper.isTreeVisible(item.getStyleableNode()))
                        .filter(item -> Optional
                                .ofNullable(item.getText())
                                .map(str -> str.contains(Localization.lang(key)))
                                .orElse(false))
                        .map(MenuItem::getStyleableNode).findFirst();
         };
-    }
-
-    @Nullable
-    private static Node findNodeByAction(@NonNull Scene scene, @NonNull StandardActions action) {
-        return findNode(scene.getRoot(), node -> {
-            if (node instanceof Button button) {
-                if (button.getTooltip() != null) {
-                    String tooltipText = button.getTooltip().getText();
-                    if (tooltipText != null && tooltipText.equals(action.getText())) {
-                        return true;
-                    }
-                }
-
-                if (button.getStyleClass().contains("icon-button")) {
-                    String actionText = action.getText();
-                    if (button.getTooltip() != null && button.getTooltip().getText() != null) {
-                        String tooltipText = button.getTooltip().getText();
-                        if (tooltipText.startsWith(actionText) || tooltipText.contains(actionText)) {
-                            return true;
-                        }
-                    }
-
-                    return button.getText() != null && button.getText().equals(actionText);
-                }
-            }
-            return false;
-        });
     }
 
     @Nullable

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/effects/Spotlight.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/effects/Spotlight.java
@@ -1,12 +1,10 @@
 package org.jabref.gui.walkthrough.effects;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
-import javafx.beans.value.ChangeListener;
+import javafx.beans.InvalidationListener;
 import javafx.geometry.Bounds;
 import javafx.scene.Node;
 import javafx.scene.input.MouseEvent;
@@ -29,19 +27,6 @@ public final class Spotlight extends BaseWindowEffect {
     private volatile @Nullable Shape overlayShape;
     private @Nullable Runnable onClickHandler;
     private @Nullable Timeline transitionAnimation;
-
-    /// Ensure the overlay shape is not updated concurrently. Consider a scenario where
-    /// overlay shape is updated concurrently from two different threads,
-    /// 1. We don't keep track of a new overlay shape is needed. Caller 1 first removed
-    /// the overlay shape, thinking it needs to be removed. Caller 2 then realized no
-    /// shape is present and added a new one.
-    /// 2. Caller 1 continues (after context switch to caller 2) to finish updating the
-    /// overlay shape without knowing that a new overlay shape has been added by caller
-    /// 2.
-    /// 3. Now, we have two overlay shapes in the pane, one from caller 1 and one from
-    /// caller 2. We only have reference to the one from caller 2, but the one from
-    /// caller 1 is still in the pane, leading to unexpected behavior.
-    private final AtomicBoolean isUpdatingOverlayShape = new AtomicBoolean(false);
 
     public Spotlight(@NonNull Pane pane) {
         super(pane);
@@ -90,11 +75,11 @@ public final class Spotlight extends BaseWindowEffect {
                 )
         );
 
-        ChangeListener<Number> changeListener = (_, _, _) -> updateOverlayShape();
-        hole.xProperty().addListener(changeListener);
-        hole.yProperty().addListener(changeListener);
-        hole.widthProperty().addListener(changeListener);
-        hole.heightProperty().addListener(changeListener);
+        InvalidationListener updater = _ -> updateOverlayShape();
+        hole.xProperty().addListener(updater);
+        hole.yProperty().addListener(updater);
+        hole.widthProperty().addListener(updater);
+        hole.heightProperty().addListener(updater);
 
         transitionAnimation.setOnFinished(_ -> {
             if (this.node != null) {
@@ -104,10 +89,10 @@ public final class Spotlight extends BaseWindowEffect {
             setupListeners(this.node);
             updateLayout();
 
-            hole.xProperty().removeListener(changeListener);
-            hole.yProperty().removeListener(changeListener);
-            hole.widthProperty().removeListener(changeListener);
-            hole.heightProperty().removeListener(changeListener);
+            hole.xProperty().removeListener(updater);
+            hole.yProperty().removeListener(updater);
+            hole.widthProperty().removeListener(updater);
+            hole.heightProperty().removeListener(updater);
         });
 
         transitionAnimation.play();
@@ -138,6 +123,12 @@ public final class Spotlight extends BaseWindowEffect {
     @Override
     protected void updateLayout() {
         if (WalkthroughUtils.cannotPositionNode(node)) {
+            if (overlayShape == null) {
+                // The callee must guarantee the node to be attached is at least visible
+                // in the scene to begin with. If such exception is thrown, it indicates
+                // a bug in the caller side. Consider adjusting WalkthroughResolver.
+                throw new IllegalStateException("Failed to attach the node.");
+            }
             hideEffect();
             return;
         }
@@ -172,10 +163,6 @@ public final class Spotlight extends BaseWindowEffect {
     }
 
     private void updateOverlayShape() {
-        if (isUpdatingOverlayShape.getAndSet(true)) {
-            throw new IllegalStateException("Overlay shape is enjoying an update!");
-        }
-
         int oldIndex;
         if (overlayShape == null || !pane.getChildren().contains(overlayShape)) {
             oldIndex = pane.getChildren().size();
@@ -196,8 +183,6 @@ public final class Spotlight extends BaseWindowEffect {
 
         this.overlayShape = overlayShape;
         this.pane.getChildren().add(oldIndex, this.overlayShape);
-
-        isUpdatingOverlayShape.set(false);
     }
 
     private void handleClick(MouseEvent event) {

--- a/jabgui/src/main/java/org/jabref/gui/walkthrough/utils/WalkthroughReverter.java
+++ b/jabgui/src/main/java/org/jabref/gui/walkthrough/utils/WalkthroughReverter.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
 import javafx.stage.Window;
+import javafx.util.Duration;
 
+import org.jabref.gui.util.DelayedExecution;
 import org.jabref.gui.walkthrough.Walkthrough;
 import org.jabref.gui.walkthrough.declarative.WindowResolver;
 import org.jabref.gui.walkthrough.declarative.sideeffect.SideEffectExecutor;
@@ -22,6 +24,24 @@ import org.slf4j.LoggerFactory;
 
 public class WalkthroughReverter {
     private static final Logger LOGGER = LoggerFactory.getLogger(WalkthroughReverter.class);
+    /// The use of delay is related to the following error that can be reproduced as of
+    /// [00fc407](https://github.com/JabRef/jabref/tree/00fc407620b3132c0cdea8c65750d0e5616bb597):
+    ///
+    /// If the "Add Group" walkthrough is launched, the following action is performed:
+    /// 1. Launch walkthrough
+    /// 2. Create the new group "Research Papers"
+    /// 3. In step 8 (i.e., immediately after the new group is created), click on other
+    /// group
+    /// 4. The reversion occur because the first-entry that are present in the "All
+    /// Groups" is not visible
+    /// 5. [IndexOutOfBoundsException] is thrown by JavaFX and the walkthrough become
+    /// entirely non-responsive.
+    ///
+    /// It's not clear why such delay fixes this issue, but it's necessary. A possible
+    /// hypothesis is that a re-render occurred during the change in the selection state,
+    /// which leads to restoration to the default event dispatcher and error due to the
+    /// monkey-patched dispatcher isn't perfectly compatible with JavaFX's inner work.
+    private static final Duration REVERSION_DELAY = Duration.millis(50);
 
     private final Walkthrough walkthrough;
     private final Window fallbackWindow;
@@ -32,6 +52,7 @@ public class WalkthroughReverter {
 
     private @Nullable Window resolvedWindow;
     private @Nullable Node resolvedNode;
+    private @Nullable DelayedExecution reversion;
 
     public WalkthroughReverter(@NonNull Walkthrough walkthrough,
                                @NonNull Window fallbackWindow,
@@ -50,7 +71,11 @@ public class WalkthroughReverter {
         windowShowingListener = (_, wasShowing, isShowing) -> {
             if (wasShowing && !isShowing) {
                 LOGGER.debug("Window for step '{}' closed. Reverting.", walkthrough.getCurrentStep().title());
-                findAndUndo();
+                if (reversion != null) {
+                    reversion.cancel();
+                }
+                reversion = new DelayedExecution(REVERSION_DELAY, this::findAndUndo);
+                reversion.start();
             }
         };
         this.resolvedWindow.showingProperty().addListener(windowShowingListener);
@@ -59,7 +84,11 @@ public class WalkthroughReverter {
             nodeVisibleListener = (_, wasVisible, isVisible) -> {
                 if (wasVisible && !isVisible) {
                     LOGGER.debug("Node for step '{}' is no longer visible. Reverting.", walkthrough.getCurrentStep().title());
-                    findAndUndo();
+                    if (reversion != null) {
+                        reversion.cancel();
+                    }
+                    reversion = new DelayedExecution(REVERSION_DELAY, this::findAndUndo);
+                    reversion.start();
                 }
             };
             NodeHelper.treeVisibleProperty(this.resolvedNode).addListener(nodeVisibleListener);
@@ -67,6 +96,11 @@ public class WalkthroughReverter {
     }
 
     public void detach() {
+        if (reversion != null) {
+            reversion.cancel();
+        }
+        reversion = null;
+
         if (resolvedWindow != null && windowShowingListener != null) {
             resolvedWindow.showingProperty().removeListener(windowShowingListener);
         }
@@ -87,29 +121,26 @@ public class WalkthroughReverter {
         undoTo(currentIndex);
     }
 
+    /// Reverts the walkthrough to the last valid step before the given index. This
+    /// method assumes that the step in the given index is not valid anymore without
+    /// checking whether it's valid.
     private void undoTo(int from) {
-        for (int i = from; i >= 0; i--) {
-            WalkthroughStep step = walkthrough.getStepAtIndex(i);
-            if (step instanceof SideEffect) {
-                undo(i);
-            }
-        }
-
         for (int i = from - 1; i >= 0; i--) {
-            if (!(walkthrough.getStepAtIndex(i) instanceof VisibleComponent previousStep)) {
-                continue;
-            }
-
-            Optional<Window> window = previousStep.windowResolver().flatMap(WindowResolver::resolve);
-            if (window.isEmpty() && previousStep.windowResolver().isPresent()) {
-                continue;
-            }
-            Window activeWindow = window.orElse(fallbackWindow);
-            if (activeWindow.getScene() != null &&
-                    (previousStep.nodeResolver().isEmpty() || previousStep.nodeResolver().get().resolve(activeWindow.getScene()).isPresent())) {
-                LOGGER.info("Reverting to step {} from step {}", i, from);
-                walkthrough.goToStep(i);
-                return;
+            switch (walkthrough.getStepAtIndex(i)) {
+                case VisibleComponent component -> {
+                    Optional<Window> window = component.windowResolver().flatMap(WindowResolver::resolve);
+                    if (window.isEmpty() && component.windowResolver().isPresent()) {
+                        continue;
+                    }
+                    Window activeWindow = window.orElse(fallbackWindow);
+                    if (activeWindow.getScene() != null &&
+                            (component.nodeResolver().isEmpty() || component.nodeResolver().get().resolve(activeWindow.getScene()).isPresent())) {
+                        LOGGER.info("Reverting to step {} from step {}", i, from);
+                        walkthrough.goToStep(i);
+                        return;
+                    }
+                }
+                case SideEffect _ -> undo(i);
             }
         }
 
@@ -119,7 +150,9 @@ public class WalkthroughReverter {
 
     private void undo(int stepIndex) {
         WalkthroughStep step = walkthrough.getStepAtIndex(stepIndex);
-        if (step instanceof SideEffect(String title, WalkthroughSideEffect sideEffect)) {
+        if (step instanceof SideEffect(
+                String title, WalkthroughSideEffect sideEffect
+        )) {
             if (!sideEffectExecutor.executeBackward(sideEffect, walkthrough)) {
                 LOGGER.warn("Failed to revert side effect {}: {}", title, sideEffect.description());
             }

--- a/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/WelcomeTab.java
@@ -37,6 +37,7 @@ import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.theme.ThemeManager;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.util.URLs;
+import org.jabref.gui.walkthrough.utils.WalkthroughUtils;
 import org.jabref.gui.welcome.components.DonationProvider;
 import org.jabref.gui.welcome.components.QuickSettings;
 import org.jabref.gui.welcome.components.Walkthroughs;
@@ -74,8 +75,9 @@ public class WelcomeTab extends Tab {
     private final Stage stage;
     private final WorkspacePreferences workspacePreferences;
     private final ThemeManager themeManager;
-    private Walkthroughs walkthroughs;
 
+    private final VBox main;
+    private Walkthroughs walkthroughs;
     private QuickSettings quickSettings;
     private final DonationProvider donationProvider;
 
@@ -114,15 +116,11 @@ public class WelcomeTab extends Tab {
         this.recentLibrariesBox = new VBox();
         recentLibrariesBox.getStyleClass().add("welcome-recent-libraries");
 
-        Node titles = createTopTitles();
-        Node communityBox = createCommunityBox();
-        ScrollPane columnsScroll = createColumnsContainerScrollable();
+        main = new VBox(createTopTitles(), new VBox(), createCommunityBox());
+        main.getStyleClass().add("welcome-main-container");
+        initializeColumns();
 
-        VBox mainStack = new VBox(titles, columnsScroll, communityBox);
-        mainStack.getStyleClass().add("welcome-main-container");
-        VBox.setVgrow(columnsScroll, Priority.ALWAYS);
-
-        VBox container = new VBox(mainStack);
+        VBox container = new VBox(main);
         container.setAlignment(Pos.CENTER);
 
         StackPane rootPane = new StackPane(container);
@@ -144,7 +142,7 @@ public class WelcomeTab extends Tab {
         return topTitles;
     }
 
-    private ScrollPane createColumnsContainerScrollable() {
+    private void initializeColumns() {
         GridPane grid = new GridPane();
         grid.getStyleClass().add("welcome-columns-container");
 
@@ -154,17 +152,24 @@ public class WelcomeTab extends Tab {
         VBox rightColumn = createRightColumn();
         GridPane.setHgrow(rightColumn, Priority.ALWAYS);
 
-        Runnable applyLayout = () -> updateColumnsLayout(grid, leftColumn, rightColumn, grid.getWidth());
-        grid.widthProperty().addListener((_, _, _) -> applyLayout.run());
-        applyLayout.run();
+        WalkthroughUtils.DebouncedRunnable updater = WalkthroughUtils.debounced(() -> updateColumnsLayout(grid, leftColumn, rightColumn, grid.getWidth()));
 
-        ScrollPane scrollPane = new ScrollPane(grid);
-        scrollPane.setFitToWidth(true);
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        scrollPane.getStyleClass().add("welcome-columns-scroll");
-        scrollPane.setStyle("-fx-background-color: transparent;"); // Using class selector is insufficient to prevent background from turning white on click.
-        return scrollPane;
+        grid.localToSceneTransformProperty().addListener(_ -> updater.run());
+        grid.layoutBoundsProperty().addListener(_ -> updater.run());
+        contentProperty().addListener((_, _, newContent) -> {
+            if (newContent == null) {
+                return;
+            }
+            newContent.boundsInParentProperty().addListener(_ -> updater.run());
+            newContent.parentProperty().addListener((_, _, newParent) -> {
+                if (newParent == null) {
+                    return;
+                }
+                newParent.boundsInParentProperty().addListener(_ -> updater.run());
+            });
+        });
+        VBox.setVgrow(grid, Priority.ALWAYS);
+        updater.run();
     }
 
     private VBox createLeftColumn() {
@@ -181,8 +186,6 @@ public class WelcomeTab extends Tab {
         this.walkthroughs = new Walkthroughs(stage, tabContainer, stateManager, preferences);
         VBox rightColumn = new VBox(quickSettings, walkthroughs);
         rightColumn.getStyleClass().add("welcome-content-column");
-        VBox.setVgrow(quickSettings, Priority.ALWAYS);
-        VBox.setVgrow(walkthroughs, Priority.ALWAYS);
         return rightColumn;
     }
 
@@ -193,6 +196,7 @@ public class WelcomeTab extends Tab {
         grid.getChildren().clear();
         grid.getColumnConstraints().clear();
 
+        boolean scrollNeeded = false;
         double threshold = 48 * workspacePreferences.getMainFontSize();
         if (availableWidth < threshold) {
             grid.getStyleClass().add("compact");
@@ -201,8 +205,7 @@ public class WelcomeTab extends Tab {
             grid.getColumnConstraints().add(single);
             grid.add(leftColumn, 0, 0);
             grid.add(rightColumn, 0, 1);
-            quickSettings.disableScroll();
-            walkthroughs.disableScroll();
+            scrollNeeded = true;
         } else {
             grid.getStyleClass().remove("compact");
             ColumnConstraints half = new ColumnConstraints();
@@ -210,9 +213,38 @@ public class WelcomeTab extends Tab {
             grid.getColumnConstraints().addAll(half, half);
             grid.add(leftColumn, 0, 0);
             grid.add(rightColumn, 1, 0);
+        }
+//
+//        Node parent = getContent() != null ? getContent().getParent() : null;
+//        if (parent != null) {
+//            double parentHeight = parent.getBoundsInParent().getHeight();
+//            double topTitleHeight = main.getChildren().get(0).getBoundsInParent().getHeight();
+//            double communityLinksHeight = main.getChildren().get(2).getBoundsInParent().getHeight();
+//            double space = main.getSpacing() * 2 + main.getPadding().getTop() + main.getPadding().getBottom();
+//            double requiredHeight = topTitleHeight + communityLinksHeight + leftColumn.getBoundsInParent().getHeight() + space;
+//            scrollNeeded = parentHeight < requiredHeight;
+//        }
+
+        if (!scrollNeeded) {
+            if (!(main.getChildren().get(1) instanceof GridPane)) {
+                main.getChildren().set(1, grid);
+            }
             quickSettings.enableScroll();
             walkthroughs.enableScroll();
+            return;
         }
+
+        ScrollPane scrollPane = new ScrollPane(grid);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.getStyleClass().add("welcome-columns-scroll");
+        scrollPane.setStyle("-fx-background-color: transparent;"); // Using class selector is insufficient to prevent background from turning white on click.
+        if (!(main.getChildren().get(1) instanceof ScrollPane)) {
+            main.getChildren().set(1, scrollPane);
+        }
+        quickSettings.disableScroll();
+        walkthroughs.disableScroll();
     }
 
     private VBox createWelcomeStartBox() {

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/QuickSettings.java
@@ -3,6 +3,7 @@ package org.jabref.gui.welcome.components;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 
 import org.jabref.gui.DialogService;
@@ -100,12 +101,14 @@ public class QuickSettings extends VBox {
     }
 
     private ScrollPane createScrollPane(VBox contentPane) {
-        ScrollPane newScrollPane = new ScrollPane(contentPane);
-        newScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        newScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        newScrollPane.setFitToWidth(true);
-        newScrollPane.getStyleClass().add("quick-settings-scroll-pane");
-        return newScrollPane;
+        ScrollPane scrollPane = new ScrollPane(contentPane);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setFitToWidth(true);
+        scrollPane.getStyleClass().add("quick-settings-scroll-pane");
+        scrollPane.setMaxHeight(Double.MAX_VALUE);
+        VBox.setVgrow(scrollPane, Priority.ALWAYS);
+        return scrollPane;
     }
 
     private Button createButton(String text, IconTheme.JabRefIcons icon, Runnable action) {

--- a/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
+++ b/jabgui/src/main/java/org/jabref/gui/welcome/components/Walkthroughs.java
@@ -3,6 +3,7 @@ package org.jabref.gui.welcome.components;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
@@ -88,12 +89,14 @@ public class Walkthroughs extends VBox {
     }
 
     private ScrollPane createScrollPane(VBox content) {
-        ScrollPane newScrollPane = new ScrollPane(content);
-        newScrollPane.setFitToWidth(true);
-        newScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        newScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        newScrollPane.getStyleClass().add("walkthroughs-scroll-pane");
-        return newScrollPane;
+        ScrollPane scrollPane = new ScrollPane(content);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.getStyleClass().add("walkthroughs-scroll-pane");
+        scrollPane.setMaxHeight(Double.MAX_VALUE);
+        VBox.setVgrow(scrollPane, Priority.ALWAYS);
+        return scrollPane;
     }
 
     private Button createWalkthroughButton(String text, IconTheme.JabRefIcons icon, String walkthroughId) {

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -1779,13 +1779,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 2.667em 2em;
 }
 
-.welcome-columns-container,
-.welcome-columns-container:focus,
-.welcome-columns-scroll,
-.welcome-columns-scroll:focus {
-    -fx-background-color: transparent;
-}
-
 .welcome-top-titles {
     -fx-spacing: 0.833em;
     -fx-alignment: top-left;
@@ -2655,12 +2648,6 @@ journalInfo .grid-cell-b {
 .walkthroughs-container {
     -fx-spacing: 0.3333em;
     -fx-alignment: top-left;
-}
-
-.walkthroughs-scroll-pane,
-.quick-settings-scroll-pane {
-    -fx-max-height: 12em;
-    -fx-pref-height: 12em;
 }
 
 .quick-settings-button {

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -1752,7 +1752,7 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
     -fx-font-family: "Arial";
-    -fx-text-fill: -jr-gray-3;
+    -fx-text-fill: -jr-head-fg;
 }
 
 .welcome-no-recent-label {
@@ -2894,6 +2894,15 @@ journalInfo .grid-cell-b {
 
 /* Tooltip Content */
 .walkthrough-tooltip-content-container {
+    -fx-background-color: -jr-background-alt;
+}
+
+.walkthrough-tooltip .border {
+    /* The arrow of the PopOver. Need to override the default `.popover > .border` (https://github.com/controlsfx/controlsfx/blob/194b10bb948389bf18c463006adcec7c92ca6403/controlsfx/src/main/resources/org/controlsfx/control/popover.css#L8) */
+    -fx-fill: -jr-background-alt!important;
+}
+
+.walkthrough-tooltip-content-container {
     -fx-spacing: 1em;
     -fx-padding: 1em;
 }
@@ -2915,7 +2924,7 @@ journalInfo .grid-cell-b {
 .walkthrough-side-panel-horizontal {
     -fx-spacing: 1em;
     -fx-padding: 2em;
-    -fx-background-color: derive(-jr-gray-1, 40%);
+    -fx-background-color: -jr-background-alt;
 }
 
 .walkthrough-side-panel-vertical {
@@ -3007,7 +3016,7 @@ journalInfo .grid-cell-b {
 }
 
 .walkthrough-quit-button {
-    -fx-background-color: -jr-gray-1;
+    -fx-background-color: -jr-base;
     -fx-border-color: transparent;
     /* For easy clipping */
     -fx-padding: 0.5em;
@@ -3020,11 +3029,11 @@ journalInfo .grid-cell-b {
 }
 
 .walkthrough-quit-button:hover {
-    -fx-background-color: derive(-jr-gray-1, -20%);
+    -fx-background-color: derive(-jr-base, -20%);
 }
 
 .walkthrough-quit-button:pressed {
-    -fx-background-color: derive(-jr-gray-1, 30%);
+    -fx-background-color: derive(-jr-base, 30%);
 }
 
 .walkthrough-quit-button .glyph-icon,

--- a/jabgui/src/main/resources/org/jabref/gui/Dark.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Dark.css
@@ -189,7 +189,19 @@
     -fx-icon-color: -fx-light-text-color;
 }
 
-
 .file-row-text {
     -fx-text-fill: -fx-light-text-color;
+}
+
+.walkthrough-spotlight {
+    -fx-fill: rgba(0, 0, 0, 0.65);
+}
+
+.walkthrough-darken {
+    -fx-fill: rgba(0, 0, 0, 0.65);
+}
+
+.walkthrough-ping {
+    /* -jr-accent with 75% Alpha */
+    -fx-fill: rgba(37, 86, 82, 0.75);
 }

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3122,7 +3122,7 @@ Let's\ create\ your\ first\ group.\ Click\ the\ \"%0\"\ button\ at\ the\ bottom\
 
 # Step 4.1
 Enter\ group\ name=Enter group name
-Research\ Papers=Research Papers
+Research=Research
 Type\ \"%0\"\ as\ the\ name\ for\ your\ group.=Type "%0" as the name for your group.
 # Step 4.2
 Add\ a\ description\ (optional)=Add a description (optional)


### PR DESCRIPTION
Closes https://github.com/Yubo-Cao/jabref/issues/6

This PR fixes the following error:
1. IllegalStateException in search walkthrough
2. IndexOutOfBounds and cannot close database during DialogService.showAndWait in the add group walkthrough

### Steps to test

1. The Search walkthrough should work properly even if multiple library tab is open
2. The Add Group walkthrough should be more robust to unwanted user interaction. Specifically, you may launch the add group walkthrough and:
   a. Click on other group in the entry tab during the walkthrough without leading to error
   b. Close the add group dialog in the middle without leading to error

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
