### PR TITLE
Reformat BibTex in Show BibTex Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved JabRef's internal document viewer. It now allows text section, searching and highlighting of search terms and page rotation [#13193](https://github.com/JabRef/jabref/pull/13193).
 - When importing a PDF, there is no empty entry column shown in the multi merge dialog. [#13132](https://github.com/JabRef/jabref/issues/13132)
 - We added a progress dialog to the "Check consistency" action and progress output to the corresponding cli command. [#12487](https://github.com/JabRef/jabref/issues/12487)
+- The BibTeX source is now formatted using the JabRef style at the import inspection dialog. [#13015](https://github.com/JabRef/jabref/issues/13015)
 - We made the `check-consistency` command of the toolkit always return an exit code; 0 means no issues found, a non-zero exit code reflects any issues, which allows CI to fail in these cases [#13328](https://github.com/JabRef/jabref/issues/13328).
 - We changed the validation error dialog for overriding the default file directories to a confirmation dialog for saving other preferences under the library properties. [#13488](https://github.com/JabRef/jabref/pull/13488)
 - We made the copy sub menu on the context menu consistent with the copy sub menu at "Edit". [#13280](https://github.com/JabRef/jabref/pull/13280)

--- a/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/ImportEntriesViewModel.java
@@ -125,9 +125,11 @@ public class ImportEntriesViewModel extends AbstractViewModel {
         BibWriter bibWriter = new BibWriter(writer, OS.NEWLINE);
         FieldWriter fieldWriter = FieldWriter.buildIgnoreHashes(preferences.getFieldPreferences());
         try {
-            new BibEntryWriter(fieldWriter, entryTypesManager).write(entry, bibWriter, selectedDb.getValue().getMode());
+            // Force reformatting so the displayed BibTeX is consistently formatted
+            new BibEntryWriter(fieldWriter, entryTypesManager).write(entry, bibWriter, selectedDb.getValue().getMode(), true);
         } catch (IOException ioException) {
-            return "";
+            // In case of error, fall back to the original parsed serialization if available
+            return entry.getParsedSerialization();
         }
         return writer.toString();
     }


### PR DESCRIPTION
Closes #13015 


Reformats the BibTeX shown in the Import dialog’s “Show BibTeX source” preview to JabRef’s canonical style. The incoming string is parsed into a `BibEntry` and rendered via `BibEntryWriter` with `reformat=true`; if parsing fails, the raw string is shown unchanged. This makes the preview readable and consistent with JabRef’s formatting guidelines.

### Steps to test

1.Open JabRef
2.Create new library
3.Open Firefox
4.Ensure that JabRef plugin is installed
5.Navigate to https://learning.oreilly.com/library/view/infrastructure-as-code/9781098150341/
6.Click on "Import references..."
<img width="1913" height="544" alt="438116402-11652d55-4e96-4518-8ac2-797dba772d8c" src="https://github.com/user-attachments/assets/96bcaeea-52f9-4a23-95c8-323e4ffd9d07" />

7.See Popup
<img width="1536" height="1149" alt="image" src="https://github.com/user-attachments/assets/8da57d52-6e06-49df-82fa-84d8bfe3c84d" />

8.Select "Show BibTeX source"
9.See the formatting

Before : 
<img width="1211" height="435" alt="image" src="https://github.com/user-attachments/assets/68bca582-51c1-4b16-940c-30bb87399445" />

After : 
<img width="1235" height="352" alt="image" src="https://github.com/user-attachments/assets/d0459405-f336-4f58-9be0-20a6dca45e5b" />



### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [x] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at https://github.com/JabRef/user-documentation/issues or, even better, I submitted a pull request to the documentation repository.