### PR TITLE
Fix path

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -475,7 +475,7 @@ jobs:
         run: |
           # We modify the JBang scripts directly to avoid issues with relative paths
           for f in ${{ steps.changed-jablib-files.outputs.all_changed_files }}; do
-            echo "//SOURCES $f" >> ".jbang/${{ matrix.launcher }}.java"
+            echo "//SOURCES ../$f" >> ".jbang/${{ matrix.launcher }}.java"
           done
           jbang build --fresh ".jbang/${{ matrix.launcher }}.java"
 


### PR DESCRIPTION
- Follow-up to https://github.com/JabRef/jabref/pull/13765
- Risen by https://github.com/JabRef/jabref/pull/13584

JBang:

```
Error:  [ERROR] Could not find: jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
```

Our JBang files:

    //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/BibEntryDTO.java

Thus adding `../`

Squash-merge directly as can only be tested on PRs.

### Steps to test

Merge into a PR

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
