### PR TITLE
Fix Springer Fetcher names

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
@@ -28,7 +28,7 @@ import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
 import org.jabref.logic.importer.fetcher.CompositeSearchBasedFetcher;
 import org.jabref.logic.importer.fetcher.DBLPFetcher;
 import org.jabref.logic.importer.fetcher.IEEE;
-import org.jabref.logic.importer.fetcher.SpringerFetcher;
+import org.jabref.logic.importer.fetcher.SpringerNatureWebFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.study.Study;
 import org.jabref.model.study.StudyDatabase;
@@ -48,7 +48,7 @@ public class ManageStudyDefinitionViewModel {
     private static final Set<String> DEFAULT_SELECTION = Set.of(
             ACMPortalFetcher.FETCHER_NAME,
             IEEE.FETCHER_NAME,
-            SpringerFetcher.FETCHER_NAME,
+            SpringerNatureWebFetcher.FETCHER_NAME,
             DBLPFetcher.FETCHER_NAME);
 
     private final StringProperty title = new SimpleStringProperty();

--- a/jablib/src/main/java/org/jabref/logic/importer/FulltextFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/FulltextFetcher.java
@@ -20,7 +20,7 @@ public interface FulltextFetcher {
      * @return The fulltext PDF URL Optional, if found, or an empty Optional if not found.
      * @throws NullPointerException if no BibTex entry is given
      * @throws java.io.IOException  if an IO operation has failed
-     * @throws FetcherException     if a fetcher specific error occurred
+     * @throws FetcherException     if a fetcher-specific error occurred
      */
     Optional<URL> findFullText(BibEntry entry) throws IOException, FetcherException;
 

--- a/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -44,8 +44,8 @@ import org.jabref.logic.importer.fetcher.RfcFetcher;
 import org.jabref.logic.importer.fetcher.ScholarArchiveFetcher;
 import org.jabref.logic.importer.fetcher.ScienceDirect;
 import org.jabref.logic.importer.fetcher.SemanticScholar;
-import org.jabref.logic.importer.fetcher.SpringerFetcher;
-import org.jabref.logic.importer.fetcher.SpringerLink;
+import org.jabref.logic.importer.fetcher.SpringerNatureFullTextFetcher;
+import org.jabref.logic.importer.fetcher.SpringerNatureWebFetcher;
 import org.jabref.logic.importer.fetcher.TitleFetcher;
 import org.jabref.logic.importer.fetcher.ZbMATH;
 import org.jabref.logic.importer.fetcher.isbntobibtex.IsbnFetcher;
@@ -118,7 +118,7 @@ public class WebFetchers {
         set.add(new ACMPortalFetcher());
         // set.add(new GoogleScholar(importFormatPreferences));
         set.add(new DBLPFetcher(importFormatPreferences));
-        set.add(new SpringerFetcher(importerPreferences));
+        set.add(new SpringerNatureWebFetcher(importerPreferences));
         set.add(new CrossRef());
         set.add(new CiteSeer());
         set.add(new DOAJFetcher(importFormatPreferences));
@@ -209,7 +209,7 @@ public class WebFetchers {
 
         // Publishers
         fetchers.add(new ScienceDirect(importerPreferences));
-        fetchers.add(new SpringerLink(importerPreferences));
+        fetchers.add(new SpringerNatureFullTextFetcher(importerPreferences));
         fetchers.add(new ACS());
         fetchers.add(new ArXivFetcher(importFormatPreferences));
         fetchers.add(new IEEE(importFormatPreferences, importerPreferences));
@@ -232,7 +232,7 @@ public class WebFetchers {
     public static Set<CustomizableKeyFetcher> getCustomizableKeyFetchers(ImportFormatPreferences importFormatPreferences, ImporterPreferences importerPreferences) {
         Set<CustomizableKeyFetcher> fetchers = new HashSet<>();
         fetchers.add(new IEEE(importFormatPreferences, importerPreferences));
-        fetchers.add(new SpringerFetcher(importerPreferences));
+        fetchers.add(new SpringerNatureWebFetcher(importerPreferences));
         fetchers.add(new ScienceDirect(importerPreferences));
         fetchers.add(new AstrophysicsDataSystem(importFormatPreferences, importerPreferences));
         fetchers.add(new BiodiversityLibrary(importerPreferences));

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CustomizableKeyFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CustomizableKeyFetcher.java
@@ -2,7 +2,14 @@ package org.jabref.logic.importer.fetcher;
 
 import org.jabref.logic.importer.WebFetcher;
 
+/// Fetchers implementing this interface support customizable keys
 public interface CustomizableKeyFetcher extends WebFetcher {
+
+    /// Returns an URL for testing a key
+    ///
+    /// The key is appended at the URL
+    ///
+    /// @return null if key validity checking is not supported
     default String getTestUrl() {
         return null;
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureFullTextFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureFullTextFetcher.java
@@ -26,17 +26,17 @@ import org.slf4j.LoggerFactory;
  * <p>
  * Uses Springer API, see <a href="https://dev.springer.com">https://dev.springer.com</a>
  */
-public class SpringerLink implements FulltextFetcher, CustomizableKeyFetcher {
+public class SpringerNatureFullTextFetcher implements FulltextFetcher, CustomizableKeyFetcher {
     public static final String FETCHER_NAME = "Springer";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SpringerLink.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringerNatureFullTextFetcher.class);
 
     private static final String API_URL = "https://api.springer.com/meta/v1/json";
     private static final String CONTENT_HOST = "link.springer.com";
 
     private final ImporterPreferences importerPreferences;
 
-    public SpringerLink(ImporterPreferences importerPreferences) {
+    public SpringerNatureFullTextFetcher(ImporterPreferences importerPreferences) {
         this.importerPreferences = importerPreferences;
     }
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
@@ -37,10 +37,10 @@ import org.slf4j.LoggerFactory;
  *
  * @see <a href="https://dev.springernature.com/">API documentation</a> for more details
  */
-public class SpringerFetcher implements PagedSearchBasedParserFetcher, CustomizableKeyFetcher {
+public class SpringerNatureWebFetcher implements PagedSearchBasedParserFetcher, CustomizableKeyFetcher {
     public static final String FETCHER_NAME = "Springer";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SpringerFetcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpringerNatureWebFetcher.class);
 
     private static final String API_URL = "https://api.springernature.com/meta/v1/json";
     // Springer query using the parameter 'q=doi:10.1007/s11276-008-0131-4s=1' will respond faster
@@ -48,7 +48,7 @@ public class SpringerFetcher implements PagedSearchBasedParserFetcher, Customiza
 
     private final ImporterPreferences importerPreferences;
 
-    public SpringerFetcher(ImporterPreferences importerPreferences) {
+    public SpringerNatureWebFetcher(ImporterPreferences importerPreferences) {
         this.importerPreferences = importerPreferences;
     }
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -61,7 +61,7 @@ import org.jabref.logic.importer.fetcher.DBLPFetcher;
 import org.jabref.logic.importer.fetcher.IEEE;
 import org.jabref.logic.importer.fetcher.MrDlibPreferences;
 import org.jabref.logic.importer.fetcher.ScienceDirect;
-import org.jabref.logic.importer.fetcher.SpringerFetcher;
+import org.jabref.logic.importer.fetcher.SpringerNatureWebFetcher;
 import org.jabref.logic.importer.fetcher.citation.semanticscholar.SemanticScholarCitationFetcher;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
@@ -520,7 +520,7 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(SEARCH_WINDOW_DIVIDER_POS, 0.5);
         defaults.put(SEARCH_CATALOGS, convertListToString(List.of(
                 ACMPortalFetcher.FETCHER_NAME,
-                SpringerFetcher.FETCHER_NAME,
+                SpringerNatureWebFetcher.FETCHER_NAME,
                 DBLPFetcher.FETCHER_NAME,
                 IEEE.FETCHER_NAME)));
         defaults.put(DEFAULT_PLAIN_CITATION_PARSER, PlainCitationParserChoice.RULE_BASED.name());
@@ -2322,7 +2322,7 @@ public class JabRefCliPreferences implements CliPreferences {
         keys.put(AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey);
         keys.put(BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey);
         keys.put(ScienceDirect.FETCHER_NAME, buildInfo.scienceDirectApiKey);
-        keys.put(SpringerFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
+        keys.put(SpringerNatureWebFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
         // SpringerLink uses the same key and fetcher name as SpringerFetcher
 
         return keys;

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcherTest.java
@@ -116,7 +116,7 @@ class CompositeSearchBasedFetcherTest {
         when(importerPreferences.getApiKey(eq(SemanticScholarCitationFetcher.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.semanticScholarApiKey));
         when(importerPreferences.getApiKey(eq(BiodiversityLibrary.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.biodiversityHeritageApiKey));
         when(importerPreferences.getApiKey(eq(ScienceDirect.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.scienceDirectApiKey));
-        when(importerPreferences.getApiKey(eq(SpringerFetcher.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.springerNatureAPIKey));
+        when(importerPreferences.getApiKey(eq(SpringerNatureWebFetcher.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.springerNatureAPIKey));
         when(importerPreferences.getApiKey(eq(IEEE.FETCHER_NAME))).thenReturn(Optional.of(buildInfo.ieeeAPIKey));
 
         List<Set<SearchBasedFetcher>> fetcherParameters = new ArrayList<>();
@@ -130,7 +130,7 @@ class CompositeSearchBasedFetcherTest {
                 new ZbMATH(importFormatPreferences),
                 new GoogleScholar(importFormatPreferences),
                 new DBLPFetcher(importFormatPreferences),
-                new SpringerFetcher(importerPreferences),
+                new SpringerNatureWebFetcher(importerPreferences),
                 new CrossRef(),
                 new CiteSeer(),
                 new DOAJFetcher(importFormatPreferences),

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureFullTextFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureFullTextFetcherTest.java
@@ -22,18 +22,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
-class SpringerLinkTest {
+class SpringerNatureFullTextFetcherTest {
 
     private final ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
-    private SpringerLink finder;
+    private SpringerNatureFullTextFetcher finder;
     private BibEntry entry;
 
     @BeforeEach
     void setUp() {
         Optional<String> apiKey = Optional.of(new BuildInfo().springerNatureAPIKey);
-        when(importerPreferences.getApiKey(SpringerLink.FETCHER_NAME)).thenReturn(apiKey);
+        when(importerPreferences.getApiKey(SpringerNatureFullTextFetcher.FETCHER_NAME)).thenReturn(apiKey);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
-        finder = new SpringerLink(importerPreferences);
+        finder = new SpringerNatureFullTextFetcher(importerPreferences);
         entry = new BibEntry();
     }
 

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcherTest.java
@@ -27,15 +27,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @FetcherTest
-class SpringerFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTest {
+class SpringerNatureWebFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSearchFetcherTest {
 
     ImporterPreferences importerPreferences = mock(ImporterPreferences.class);
-    SpringerFetcher fetcher;
+    SpringerNatureWebFetcher fetcher;
 
     @BeforeEach
     void setUp() {
         BuildInfo buildInfo = Injector.instantiateModelOrService(BuildInfo.class);
-        fetcher = new SpringerFetcher(importerPreferences);
+        fetcher = new SpringerNatureWebFetcher(importerPreferences);
         when(importerPreferences.getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
         when(importerPreferences.getApiKey(fetcher.getName())).thenReturn(Optional.of(buildInfo.springerNatureAPIKey));
     }
@@ -159,7 +159,7 @@ class SpringerFetcherTest implements SearchBasedFetcherCapabilityTest, PagedSear
                         }""";
 
         JSONObject jsonObject = new JSONObject(jsonString);
-        BibEntry bibEntry = SpringerFetcher.parseSpringerJSONtoBibtex(jsonObject);
+        BibEntry bibEntry = SpringerNatureWebFetcher.parseSpringerJSONtoBibtex(jsonObject);
         assertEquals(Optional.of("1992"), bibEntry.getField(StandardField.YEAR));
         assertEquals(Optional.of("5"), bibEntry.getField(StandardField.NUMBER));
         assertEquals(Optional.of("#sep#"), bibEntry.getField(StandardField.MONTH));


### PR DESCRIPTION
SpringerNature offers two fetchers: One for full text, the other one for meta data. It is the "same" company. Thus, the fetcher names should be similar.

### Steps to test

Run JabRef and test fetchers

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
