### PR TITLE
Publish SNAPSHOT on jablib change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,15 +2,14 @@ name: Publish to maven central
 
 on:
   pull_request:
-    paths:
-     - .github/workflows/publish.yml
   push:
     paths:
-     - .github/workflows/publish.yml
+     - '*'
     tags:
       - '*'
   schedule:
-    # run on each Monday
+    # Run on each Monday
+    # Additional run in addition to the other events, because some resources could have changes
     - cron: '2 3 * * 1'
   workflow_dispatch:
     inputs:
@@ -34,9 +33,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Detect changed jablib classes or workflow
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            jablib/src/main/java/**/*.java
+            .github/workflows/publish.yml
+
   publish:
     name: jablib
-    if: (github.repository == 'JabRef/jabref') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
+    needs: detect_changes
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (needs.detect_changes.outputs.changed == 'true' &&
+        ((github.event_name == 'push' && github.repository == 'JabRef/jabref') ||
+         (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'JabRef/jabref'))
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Fetch all history for all tags and branches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
   push:
     paths:
-     - '*'
+     - '**'
     tags:
-      - '*'
+      - '**'
   schedule:
     # Run on each Monday
     # Additional run in addition to the other events, because some resources could have changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   publish:
     name: jablib
-    if: github.repository == 'JabRef/jabref'
+    if: (github.repository == 'JabRef/jabref') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
     runs-on: ubuntu-latest
     steps:
       - name: Fetch all history for all tags and branches

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -8,7 +8,11 @@ on:
   pull_request:
   merge_group:
   workflow_dispatch:
-
+  # Re-run JBang tests after the SNAPSHOT is updated
+  workflow_run:
+    workflows: ["Publish to maven central"]
+    types:
+      - completed
 env:
   AstrophysicsDataSystemAPIKey: ${{ secrets.AstrophysicsDataSystemAPIKey_FOR_TESTS }}
   BiodiversityHeritageApiKey: ${{ secrets.BiodiversityHeritageApiKey_FOR_TESTS}}


### PR DESCRIPTION
- Follow-up to https://github.com/JabRef/jabref/pull/13765: Refine tests
- Follow-up to https://github.com/JabRef/jabref/pull/13584 - to trigger SNAPSHOT update if interface changes

### Steps to test

Merge into main and update something in jablib in a PR and then merge. See that SNAPSHOT will get updated :)

AKA code-and-fix

### Mandatory checks


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
