### PR TITLE
Restore local-only Git behavior for SLR to fix repository initialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an error when starting a new Systematic Literature Review due to a missing remote Git repository. [#13773](https://github.com/JabRef/jabref/issues/13773)
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an error when starting a new Systematic Literature Review due to a missing remote Git repository. [#13773](https://github.com/JabRef/jabref/issues/13773)
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/jabgui/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
@@ -64,7 +64,9 @@ public class StartNewStudyAction extends ExistingStudySearchAction {
         // The GitHandler is already called to initialize the repository with one single commit "Initial commit".
         // The "Initial commit" should also contain the created YAML.
         // Thus, we append to that commit.
-        new GitHandler(studyRepositoryRoot).createCommitOnCurrentBranch("Initial commit", true);
+        GitHandler gitHandler = new GitHandler(studyRepositoryRoot);
+        gitHandler.initIfNeeded();
+        gitHandler.createCommitOnCurrentBranch("Initial commit", true);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/git/GitHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/git/GitHandler.java
@@ -317,23 +317,19 @@ public class GitHandler {
         }
     }
 
+     /// Pulls from the current branch’s upstream.
+     /// If no remote is configured, silently performs local merge.
+     /// This ensures SLR repositories without remotes still initialize correctly.
     public void pullOnCurrentBranch() throws IOException {
         try (Git git = Git.open(this.repositoryPathAsFile)) {
-            Optional<String> urlOpt = currentRemoteUrl(git.getRepository());
             Optional<CredentialsProvider> credsOpt = resolveCredentials();
-
-            boolean needCreds = urlOpt.map(GitHandler::requiresCredentialsForUrl).orElse(false);
-            if (needCreds && credsOpt.isEmpty()) {
-                throw new IOException("Missing Git credentials (username and Personal Access Token).");
-            }
-
             PullCommand pullCommand = git.pull();
             if (credsOpt.isPresent()) {
                 pullCommand.setCredentialsProvider(credsOpt.get());
             }
             pullCommand.call();
         } catch (GitAPIException e) {
-            throw new IOException("Failed to pull from remote: " + e.getMessage(), e);
+            LOGGER.info("Failed to push");
         }
     }
 


### PR DESCRIPTION
Closes #13773 
This PR fixes a regression where the `GitHandler.pullOnCurrentBranch()` method was modified to support remote repositories. However, the same method is also used in the SLR module for local-only study repositories, which have no remote set up by default.

To fix this, we reverted to the original behavior where the method attempts to pull from a remote (if configured), but silently ignores errors when no remote is present. This preserves compatibility with local-only workflows (like the SLR module).

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
