### PR TITLE
Auto add and remove of "status: changes-required" label

### DIFF
--- a/.github/workflows/on-pr-changes-requested.yml
+++ b/.github/workflows/on-pr-changes-requested.yml
@@ -1,0 +1,15 @@
+name: Label PRs with "status: changes-requested"
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  label-changes-required:
+    if: github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "status: changes-required" label
+        run: gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --add-label "status: changes-required"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-changes-requested.yml
+++ b/.github/workflows/on-pr-changes-requested.yml
@@ -1,4 +1,4 @@
-name: Label PRs with "status: changes-requested"
+name: Adapt PR status labels
 
 on:
   pull_request_review:
@@ -9,7 +9,10 @@ jobs:
     if: github.event.review.state == 'changes_requested'
     runs-on: ubuntu-latest
     steps:
-      - name: Add "status: changes-required" label
-        run: gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --add-label "status: changes-required"
+      - name: Adapt labels
+        run: |
+          gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --remove-label "status: ready-for-review"
+          gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --remove-label "status: awaiting-second-review"
+          gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --add-label "status: changes-required"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -165,9 +165,7 @@ jobs:
     name: Remove label "status: changes-required"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - run: gh issue edit ${{ github.event.pull_request.number }} --remove-label "status: changes-required"
-
+      - run: gh issue --repo ${{ github.repository }} edit ${{ github.event.pull_request.number }} --remove-label "status: changes-required"
   upload-pr-number:
     if: github.repository == 'JabRef/jabref'
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -160,6 +160,14 @@ jobs:
           echo "✅ No merge conflicts"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  remove_label:
+    if: github.repository == 'JabRef/jabref'
+    name: Remove label "status: changes-required"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: gh issue edit ${{ github.event.pull_request.number }} --remove-label "status: changes-required"
+
   upload-pr-number:
     if: github.repository == 'JabRef/jabref'
     runs-on: ubuntu-latest


### PR DESCRIPTION
We more and more make use of the label [status: changes-required](https://github.com/JabRef/jabref/issues?q=sort%3Aupdated-desc%20is%3Apr%20is%3Aopen%20label%3A%22status%3A%20changes-required%22)

For each PR with the label, we need to check now and then if the label is still valid.

With the label removed, we "only" need to check if the changes were really adressed.

GitHub itself does not handle the whole status properly: https://github.com/orgs/community/discussions/17875

### Steps to test

Work with PRs :)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
