### PR TITLE
Add label "changed-required" on PR comment by maintainers

### DIFF
--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -1,0 +1,27 @@
+name: On PR comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add-label:
+    if: >
+      github.repository_owner == 'JabRef' &&
+      github.event.issue.pull_request &&
+      (github.event.comment.user.login == 'callixtus' ||
+       github.event.comment.user.login == 'koppor' ||
+       github.event.comment.user.login == 'siedlerchr' ||
+       github.event.comment.user.login == 'subhramit')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Add label
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "status: changes-required"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13778

**Update** Maybe, not appropriate, because not all our comments lead to changes... -- maybe, we need to set the label manually.

### Steps to test

Merge and then comment on pull requerst

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
