### PR TITLE
Remove unnecessary spacing and margin in the AutomaticFieldEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where "Copy to" was enabled even if no other library was opened. [#13280](https://github.com/JabRef/jabref/pull/13280)
 - We fixed an issue where the groups were still displayed after closing all libraries. [#13382](https://github.com/JabRef/jabref/issues/13382)
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
+- We removed unnecessary spacing and margin in the AutomaticFieldEditor.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where "Copy to" was enabled even if no other library was opened. [#13280](https://github.com/JabRef/jabref/pull/13280)
 - We fixed an issue where the groups were still displayed after closing all libraries. [#13382](https://github.com/JabRef/jabref/issues/13382)
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
-- We removed unnecessary spacing and margin in the AutomaticFieldEditor.
+- We removed unnecessary spacing and margin in the AutomaticFieldEditor. [#13792](https://github.com/JabRef/jabref/pull/13792)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AbstractAutomaticFieldEditorTabView.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AbstractAutomaticFieldEditorTabView.java
@@ -1,11 +1,11 @@
 package org.jabref.gui.edit.automaticfiededitor;
 
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.VBox;
 
-public abstract class AbstractAutomaticFieldEditorTabView extends AnchorPane implements AutomaticFieldEditorTab {
+public abstract class AbstractAutomaticFieldEditorTabView extends VBox implements AutomaticFieldEditorTab {
 
     @Override
-    public AnchorPane getContent() {
+    public VBox getContent() {
         return this;
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
@@ -60,12 +60,6 @@ public class AutomaticFieldEditorDialog extends BaseDialog<String> {
             }
             return "";
         });
-
-        // This will prevent all dialog buttons from having the same size
-        // Read more: https://stackoverflow.com/questions/45866249/javafx-8-alert-different-button-sizes
-        getDialogPane().getButtonTypes().stream()
-            .map(getDialogPane()::lookupButton)
-            .forEach(btn -> ButtonBar.setButtonUniformSize(btn, false));
     }
 
     @FXML

--- a/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.java
@@ -70,7 +70,7 @@ public class AutomaticFieldEditorDialog extends BaseDialog<String> {
 
     @FXML
     public void initialize() {
-        viewModel = new AutomaticFieldEditorViewModel(selectedEntries, database, undoManager, stateManager);
+        viewModel = new AutomaticFieldEditorViewModel(database, undoManager, stateManager);
 
         for (AutomaticFieldEditorTab tabModel : viewModel.getFieldEditorTabs()) {
             NotificationPaneAdapter notificationPane = new NotificationPaneAdapter(tabModel.getContent());

--- a/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorViewModel.java
@@ -1,7 +1,5 @@
 package org.jabref.gui.edit.automaticfiededitor;
 
-import java.util.List;
-
 import javax.swing.undo.UndoManager;
 
 import javafx.collections.FXCollections;
@@ -14,7 +12,6 @@ import org.jabref.gui.edit.automaticfiededitor.editfieldcontent.EditFieldContent
 import org.jabref.gui.edit.automaticfiededitor.renamefield.RenameFieldTabView;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.model.database.BibDatabase;
-import org.jabref.model.entry.BibEntry;
 
 public class AutomaticFieldEditorViewModel extends AbstractViewModel {
     public static final String NAMED_COMPOUND_EDITS = "EDIT_FIELDS";
@@ -23,7 +20,7 @@ public class AutomaticFieldEditorViewModel extends AbstractViewModel {
 
     private final UndoManager undoManager;
 
-    public AutomaticFieldEditorViewModel(List<BibEntry> selectedEntries, BibDatabase database, UndoManager undoManager, StateManager stateManager) {
+    public AutomaticFieldEditorViewModel(BibDatabase database, UndoManager undoManager, StateManager stateManager) {
         this.undoManager = undoManager;
         fieldEditorTabs.addAll(
                 new EditFieldContentTabView(database, stateManager),

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -3157,3 +3157,27 @@ journalInfo .grid-cell-b {
     -fx-border-color: -jr-error;
     -fx-border-width: 1px;
 }
+
+/* Automatic Field Editor */
+.edit-field-content-pane {
+    -fx-padding: 0em 1em;
+    -fx-spacing: 1em;
+}
+
+.edit-field-content-pane .text-field {
+    -fx-padding: 0.5625em 0.75em;
+}
+
+.edit-field-content-pane .actions {
+    -fx-spacing: 0.75em;
+    -fx-alignment: BASELINE_LEFT;
+}
+
+.edit-field-content-pane .grid-pane {
+    -fx-hgap: 0.75em;
+    -fx-vgap: 0.75em;
+}
+
+.edit-field-content-pane .grid-pane .label {
+    -fx-min-width: 3.5em;
+}

--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -3181,3 +3181,7 @@ journalInfo .grid-cell-b {
 .edit-field-content-pane .grid-pane .label {
     -fx-min-width: 3.5em;
 }
+
+.automatic-field-editor .button-bar .button:default {
+    -fx-min-width: 12em;
+}

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/AutomaticFieldEditorDialog.fxml
@@ -5,10 +5,10 @@
 <?import javafx.scene.control.TabPane?>
 <DialogPane xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
             fx:controller="org.jabref.gui.edit.automaticfiededitor.AutomaticFieldEditorDialog"
-            prefHeight="400.0" prefWidth="600.0">
+            prefHeight="400.0" prefWidth="600.0" styleClass="automatic-field-editor">
     <content>
         <TabPane fx:id="tabPane" tabClosingPolicy="UNAVAILABLE"/>
     </content>
-    <ButtonType fx:id="saveButton" text="%Keep Modifications" buttonData="OK_DONE"/>
+    <ButtonType text="%Keep Modifications" buttonData="OK_DONE" />
     <ButtonType fx:constant="CANCEL"/>
 </DialogPane>

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/copyormovecontent/CopyOrMoveFieldContentTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/copyormovecontent/CopyOrMoveFieldContentTab.fxml
@@ -1,61 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
-<fx:root prefHeight="400.0" prefWidth="600.0" type="AnchorPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.edit.automaticfiededitor.copyormovecontent.CopyOrMoveFieldContentTabView">
-    <children>
-          <GridPane hgap="8.0" layoutX="16.0" layoutY="246.0" minHeight="160.0" prefHeight="230.0" prefWidth="568.0" vgap="8.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="8.0">
-              <columnConstraints>
-                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="379.20001220703125" minWidth="40.0" prefWidth="65.00001220703125" />
-                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="726.3999938964844" minWidth="10.0" prefWidth="324.1999877929687" />
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="726.3999938964844" minWidth="10.0" prefWidth="206.5999877929687" />
-              </columnConstraints>
-              <rowConstraints>
-            <RowConstraints maxHeight="35.200015258789065" minHeight="10.0" prefHeight="20.800006103515624" vgrow="SOMETIMES" />
-            <RowConstraints maxHeight="33.000008010864256" minHeight="8.999984741210938" prefHeight="23.39999389648438" vgrow="SOMETIMES" />
-                  <RowConstraints maxHeight="33.000008010864256" minHeight="10.0" prefHeight="26.60001220703125" vgrow="SOMETIMES" />
-                  <RowConstraints maxHeight="35.99998168945312" minHeight="10.0" prefHeight="35.99998168945312" vgrow="SOMETIMES" />
-                  <RowConstraints maxHeight="25.600012207031256" minHeight="10.0" prefHeight="23.20001831054688" vgrow="SOMETIMES" />
-                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-              </rowConstraints>
-              <children>
-                  <Label prefHeight="19.0" prefWidth="48.0" text="%From" GridPane.rowIndex="2" />
-                  <Label text="%To" GridPane.rowIndex="3" />
-                  <ComboBox fx:id="fromFieldComboBox" editable="true" minWidth="-Infinity" prefHeight="32.0" prefWidth="150.0" GridPane.columnIndex="1" GridPane.hgrow="NEVER" GridPane.rowIndex="2" GridPane.vgrow="NEVER" />
-                  <ComboBox fx:id="toFieldComboBox" editable="true" minWidth="-Infinity" prefHeight="32.0" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-                  <CheckBox fx:id="overwriteFieldContentCheckBox"
-                            mnemonicParsing="false" prefHeight="19.0" prefWidth="210.0" text="%Overwrite field content" GridPane.columnSpan="2147483647" GridPane.rowIndex="4" />
-                  <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="8.0" GridPane.columnSpan="2147483647" GridPane.rowIndex="5">
-                      <children>
-                          <Button fx:id="copyContentButton"
-                                  mnemonicParsing="false" onAction="#copyContent" text="%Copy content" />
-                          <Button fx:id="moveContentButton"
-                                  mnemonicParsing="false" onAction="#moveContent" text="%Move content" />
-                          <Button fx:id="swapContentButton"
-                                  mnemonicParsing="false" onAction="#swapContent" text="%Swap content" />
-                      </children>
-                  </HBox>
-            <HBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="3" GridPane.rowSpan="2">
-               <children>
-                      <Label alignment="BOTTOM_LEFT" minHeight="-Infinity" minWidth="-Infinity" styleClass="sectionHeader" text="%Copy or move the content of one field to another">
-                     <HBox.margin>
-                        <Insets bottom="10.0" />
-                     </HBox.margin>
-                      </Label>
-               </children>
-               <GridPane.margin>
-                  <Insets />
-               </GridPane.margin>
-            </HBox>
-              </children>
-          </GridPane>
-    </children>
+<?import javafx.scene.layout.VBox?>
+
+<fx:root type="VBox" styleClass="edit-field-content-pane" xmlns="http://javafx.com/javafx/17"
+         xmlns:fx="http://javafx.com/fxml/1"
+         fx:controller="org.jabref.gui.edit.automaticfiededitor.copyormovecontent.CopyOrMoveFieldContentTabView">
+    <Label styleClass="sectionHeader" text="%Copy or move the content of one field to another"/>
+    <GridPane styleClass="grid-pane">
+        <columnConstraints>
+            <ColumnConstraints hgrow="NEVER"/>
+            <ColumnConstraints hgrow="ALWAYS"/>
+        </columnConstraints>
+        <rowConstraints>
+            <RowConstraints/>
+            <RowConstraints/>
+        </rowConstraints>
+        <Label text="%From" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
+        <ComboBox fx:id="fromFieldComboBox" editable="true" maxWidth="Infinity" GridPane.columnIndex="1"
+                  GridPane.rowIndex="0"/>
+        <Label text="%To" GridPane.columnIndex="0" GridPane.rowIndex="1"/>
+        <ComboBox fx:id="toFieldComboBox" editable="true" maxWidth="Infinity" GridPane.columnIndex="1"
+                  GridPane.rowIndex="1"/>
+    </GridPane>
+    <CheckBox fx:id="overwriteFieldContentCheckBox" mnemonicParsing="false" text="%Overwrite field content"/>
+    <HBox styleClass="actions">
+        <Button fx:id="copyContentButton" mnemonicParsing="false" onAction="#copyContent" text="%Copy content"/>
+        <Button fx:id="moveContentButton" mnemonicParsing="false" onAction="#moveContent" text="%Move content"/>
+        <Button fx:id="swapContentButton" mnemonicParsing="false" onAction="#swapContent" text="%Swap content"/>
+    </HBox>
 </fx:root>

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/editfieldcontent/EditFieldContentTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/editfieldcontent/EditFieldContentTab.fxml
@@ -1,70 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
-<fx:root prefHeight="400.0" prefWidth="600.0" type="AnchorPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.edit.automaticfiededitor.editfieldcontent.EditFieldContentTabView">
-   <children>
-      <GridPane hgap="8.0" prefWidth="568.0" vgap="8.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="0.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-            <CheckBox fx:id="overwriteFieldContentCheckBox"
-                      mnemonicParsing="false" text="%Overwrite field content" GridPane.columnSpan="2147483647" GridPane.rowIndex="3">
-               <GridPane.margin>
-                  <Insets left="2.0" />
-               </GridPane.margin>
-            </CheckBox>
-            <HBox prefHeight="100.0" prefWidth="200.0" spacing="8.0" GridPane.columnSpan="2147483647" GridPane.rowIndex="4">
-               <children>
-                  <Button fx:id="setValueButton" mnemonicParsing="false" onAction="#setFieldValue" text="%Set" />
-                  <Button fx:id="appendValueButton" mnemonicParsing="false" onAction="#appendToFieldValue" text="%Append" />
-                  <Separator maxHeight="1.7976931348623157E308" minWidth="10.0" orientation="VERTICAL" prefWidth="11.0" />
-                  <Button fx:id="clearFieldButton" mnemonicParsing="false" onAction="#clearField" text="%Clear field content" >
-                      <graphic>
-                          <JabRefIconView glyph="DELETE_ENTRY"/>
-                      </graphic>
-                  </Button>
-               </children>
-            </HBox>
-            <HBox spacing="8.0" GridPane.columnSpan="3" GridPane.hgrow="ALWAYS" GridPane.rowIndex="2" GridPane.vgrow="NEVER">
-               <children>
-                  <ComboBox fx:id="fieldComboBox" editable="true" maxHeight="1.7976931348623157E308" minHeight="36.0" prefHeight="36.0" prefWidth="184.0" HBox.hgrow="ALWAYS" />
-                  <TextField fx:id="fieldValueTextField" minHeight="32.0" minWidth="-Infinity" prefHeight="36.0" prefWidth="184.0" promptText="%Set or append content" HBox.hgrow="ALWAYS"/>
-               </children>
-            </HBox>
-            <HBox alignment="BOTTOM_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" GridPane.hgrow="ALWAYS" GridPane.rowSpan="2" GridPane.vgrow="ALWAYS">
-               <children>
-                  <Label alignment="BOTTOM_LEFT" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" styleClass="sectionHeader" text="%Edit field content for selected entries">
-                     <HBox.margin>
-                        <Insets bottom="10.0" />
-                     </HBox.margin>
-                  </Label>
-               </children>
-            </HBox>
-         </children>
-      </GridPane>
-   </children>
+<fx:root type="VBox" styleClass="edit-field-content-pane" xmlns="http://javafx.com/javafx/17"
+         xmlns:fx="http://javafx.com/fxml/1"
+         fx:controller="org.jabref.gui.edit.automaticfiededitor.editfieldcontent.EditFieldContentTabView">
+    <Label styleClass="sectionHeader" text="%Edit field content for selected entries"/>
+    <HBox styleClass="actions">
+        <ComboBox fx:id="fieldComboBox" editable="true" HBox.hgrow="ALWAYS"/>
+        <TextField fx:id="fieldValueTextField" promptText="%Set or append content" HBox.hgrow="ALWAYS"/>
+    </HBox>
+    <CheckBox fx:id="overwriteFieldContentCheckBox" mnemonicParsing="false" text="%Overwrite field content"/>
+    <HBox styleClass="actions">
+        <Button fx:id="setValueButton" mnemonicParsing="false" onAction="#setFieldValue" text="%Set"/>
+        <Button fx:id="appendValueButton" mnemonicParsing="false" onAction="#appendToFieldValue"
+                text="%Append"/>
+        <Separator orientation="VERTICAL"/>
+        <Button fx:id="clearFieldButton" mnemonicParsing="false" onAction="#clearField"
+                text="%Clear field content">
+            <graphic>
+                <JabRefIconView glyph="DELETE_ENTRY"/>
+            </graphic>
+        </Button>
+    </HBox>
 </fx:root>

--- a/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/renamefield/RenameFieldTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/edit/automaticfiededitor/renamefield/RenameFieldTab.fxml
@@ -1,55 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
-<fx:root prefHeight="400.0" prefWidth="600.0" type="AnchorPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.edit.automaticfiededitor.renamefield.RenameFieldTabView">
-   <children>
-      <GridPane hgap="8.0" layoutY="85.0" prefWidth="568.0" vgap="8.0" AnchorPane.leftAnchor="16.0" AnchorPane.rightAnchor="16.0" AnchorPane.topAnchor="0.0">
-        <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="279.20001220703125" minWidth="10.0" prefWidth="164.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="404.0" minWidth="10.0" prefWidth="404.0" />
-        </columnConstraints>
-        <rowConstraints>
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-        </rowConstraints>
-         <children>
-             <HBox alignment="BOTTOM_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" GridPane.hgrow="ALWAYS" GridPane.rowSpan="2" GridPane.vgrow="ALWAYS">
-                 <children>
-                     <Label alignment="BOTTOM_LEFT" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" styleClass="sectionHeader" text="%Rename field">
-                         <HBox.margin>
-                             <Insets bottom="10.0" />
-                         </HBox.margin>
-                     </Label>
-                 </children>
-             </HBox>
-            <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="2" GridPane.rowIndex="3" GridPane.rowSpan="2">
-               <children>
-                  <Button fx:id="renameButton" alignment="TOP_LEFT" mnemonicParsing="false" onAction="#renameField" text="%Rename">
-                     <HBox.margin>
-                        <Insets top="4.0" />
-                     </HBox.margin>
-                  </Button>
-               </children>
-            </HBox>
-            <HBox prefHeight="100.0" prefWidth="200.0" spacing="8.0" GridPane.columnSpan="2" GridPane.rowIndex="2">
-               <children>
-                  <ComboBox fx:id="fieldComboBox" editable="true" minWidth="-Infinity" prefHeight="36.0" prefWidth="184.0" HBox.hgrow="ALWAYS" />
-                  <TextField fx:id="newFieldNameTextField" minHeight="-Infinity" prefHeight="36.0" promptText="%New field name" HBox.hgrow="ALWAYS" />
-               </children>
-            </HBox>
-         </children>
-      </GridPane>
-   </children>
+<?import javafx.scene.layout.VBox?>
+
+<fx:root type="VBox" styleClass="edit-field-content-pane" xmlns="http://javafx.com/javafx/17"
+         xmlns:fx="http://javafx.com/fxml/1"
+         fx:controller="org.jabref.gui.edit.automaticfiededitor.renamefield.RenameFieldTabView">
+    <Label styleClass="sectionHeader" text="%Rename field"/>
+    <HBox styleClass="actions">
+        <ComboBox fx:id="fieldComboBox" editable="true" HBox.hgrow="ALWAYS"/>
+        <TextField fx:id="newFieldNameTextField" promptText="%New field name" HBox.hgrow="ALWAYS"/>
+    </HBox>
+    <Button fx:id="renameButton" mnemonicParsing="false" onAction="#renameField" text="%Rename"/>
 </fx:root>


### PR DESCRIPTION
- **fix: Update the UI for the automatic field editor**
- **docs: Update CHANGELOG.md**

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/780

### Steps to test

1. Open Example Library
2. Select some entries
3. Select Edit > Automatic Field Editor

<img width="599" height="398" alt="image" src="https://github.com/user-attachments/assets/79d53631-f485-4ae2-9236-3059885eadaf" />

<img width="599" height="398" alt="image" src="https://github.com/user-attachments/assets/6932dffe-1361-41e8-9084-d732d9e1879d" />

<img width="599" height="398" alt="image" src="https://github.com/user-attachments/assets/c6a8fb2e-4142-4dfb-8ac7-e80e44b737a1" />

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
