### PR TITLE
[JBang] Fix files matched

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -483,6 +483,8 @@ jobs:
         with:
           files: |
             jablib/src/main/java/**/*.java
+          files_ignore: |
+            jablib/src/main/java/**/*-*.java
 
       - name: Build ${{ matrix.launcher }} launcher including changed classes
         shell: bash


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13765 to exclude non-source Java files

Risen by https://github.com/JabRef/jabref/pull/13490

### Steps to test

Merge into a PR modify `jablib` and there some `module-info` file

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
