### PR TITLE
fix: Fix the rename test [windows]

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -65,6 +65,11 @@ class RenamePdfCleanupTest {
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         cleanup.cleanup(entry);
 
+        /* This special handling is for Windows. Window file system is case-insensitive,
+        so renaming "toot.tmp" to "Toot.tmp" would overwrite the original file.
+        Therefore, the file is renamed to `Toot (1).tmp` in Windows. Prior to testing,
+        delete `AppData/Local/Temp/junit-*` folders, as the test doesn't clean up the
+        renamed file and could potentially interfere with subsequent test runs. */
         assertTrue(Pattern.matches("^:Toot(?:\\s+\\(\\d+\\))?\\.tmp:$",
                 entry.getField(StandardField.FILE).get()));
     }

--- a/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.bibtex.FileFieldWriter;
@@ -15,6 +16,7 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.MetaData;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -63,8 +65,8 @@ class RenamePdfCleanupTest {
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         cleanup.cleanup(entry);
 
-        LinkedFile newFileField = new LinkedFile("", Path.of("Toot.tmp"), "");
-        assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
+        Assertions.assertTrue(Pattern.matches("^:Toot(?:\\s+\\(\\d+\\))?\\.tmp:$",
+                entry.getField(StandardField.FILE).get()));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -16,7 +16,6 @@ import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.MetaData;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +66,7 @@ class RenamePdfCleanupTest {
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         cleanup.cleanup(entry);
 
-        Assertions.assertTrue(Pattern.matches("^:Toot(?:\\s+\\(\\d+\\))?\\.tmp:$",
+        assertTrue(Pattern.matches("^:Toot(?:\\s+\\(\\d+\\))?\\.tmp:$",
                 entry.getField(StandardField.FILE).get()));
     }
 


### PR DESCRIPTION
Closes N/A

### Steps to test

Fix the rename PDF test. Run the test to test.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
