### PR TITLE
Initialize search bar auto-completion with real database context (no tab switch needed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
 - We fixed an issue where theme or font size are not respected for all dialogs [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We removed unnecessary spacing and margin in the AutomaticFieldEditor. [#13792](https://github.com/JabRef/jabref/pull/13792)
+- We fixed an issue where global search auto-completion only worked after switching tabs, it now initializes with the real database context right after a library loads. (https://github.com/JabRef/jabref/issues/11428)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
 - We fixed an issue where theme or font size are not respected for all dialogs [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We removed unnecessary spacing and margin in the AutomaticFieldEditor. [#13792](https://github.com/JabRef/jabref/pull/13792)
-- We fixed an issue where global search auto-completion only worked after switching tabs, it now initializes with the real database context right after a library loads. (https://github.com/JabRef/jabref/issues/11428)
+- We fixed an issue where global search auto-completion only worked after switching tabs, it now initializes with the real database context right after a library loads. [#11428](https://github.com/JabRef/jabref/issues/11428)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Enhanced field selection logic in the Merge Entries dialog when fetching from DOI to prefer valid years and entry types. [#12549](https://github.com/JabRef/jabref/issues/12549)
 - We fixed an issue where theme or font size are not respected for all dialogs [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We removed unnecessary spacing and margin in the AutomaticFieldEditor. [#13792](https://github.com/JabRef/jabref/pull/13792)
-- We fixed an issue where global search auto-completion only worked after switching tabs, it now initializes with the real database context right after a library loads. [#11428](https://github.com/JabRef/jabref/issues/11428)
+- We fixed an issue where global search auto-completion only worked after switching tabs. [#11428](https://github.com/JabRef/jabref/issues/11428)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -260,7 +260,7 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         });
     }
 
-    public void setAutoCompleterChangedListener(Runnable listener) {
+    public void setAutoCompleterChangedListener(@NonNull Runnable listener) {
         this.autoCompleterChangedListener = listener;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -161,6 +161,8 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
     private final AiService aiService;
 
+    private Runnable autoCompleterChangedListener;
+
     /**
      * @param isDummyContext Indicates whether the database context is a dummy. A dummy context is used to display a progress indicator while parsing the database.
      *                       If the context is a dummy, the Lucene index should not be created, as both the dummy context and the actual context share the same index path {@link BibDatabaseContext#getFulltextIndexPath()}.
@@ -258,6 +260,10 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         });
     }
 
+    public void setAutoCompleterChangedListener(Runnable listener) {
+        this.autoCompleterChangedListener = listener;
+    }
+
     private static void addChangedInformation(StringBuilder text) {
         text.append("\n");
         text.append(Localization.lang("The library has been modified."));
@@ -303,7 +309,10 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         }
 
         setDatabaseContext(result.getDatabaseContext());
-
+        // Notify listeners that the auto-completer may have changed
+        if (autoCompleterChangedListener != null) {
+            autoCompleterChangedListener.run();
+        }
         LOGGER.trace("loading.set(false);");
         loading.set(false);
         dataLoadingTask = null;

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -404,7 +404,6 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
                 stateManager.searchResultSize(SearchType.NORMAL_SEARCH).bind(libraryTab.resultSizeProperty());
                 globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter());
 
-
                 // Listen for auto-completer changes after real context is loaded
                 libraryTab.setAutoCompleterChangedListener(() -> globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter()));
 

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -111,7 +111,6 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     private final TabPane tabbedPane = new TabPane();
     private final EntryEditor entryEditor;
     private final ObjectProperty<PanelMode> panelMode = new SimpleObjectProperty<>(PanelMode.MAIN_TABLE);
-    private Runnable autoCompleterChangedListener;
 
     // We need to keep a reference to the subscription, otherwise the binding gets garbage collected
     private Subscription horizontalDividerSubscription;

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -111,6 +111,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
     private final TabPane tabbedPane = new TabPane();
     private final EntryEditor entryEditor;
     private final ObjectProperty<PanelMode> panelMode = new SimpleObjectProperty<>(PanelMode.MAIN_TABLE);
+    private Runnable autoCompleterChangedListener;
 
     // We need to keep a reference to the subscription, otherwise the binding gets garbage collected
     private Subscription horizontalDividerSubscription;
@@ -402,6 +403,10 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
                 }
                 stateManager.searchResultSize(SearchType.NORMAL_SEARCH).bind(libraryTab.resultSizeProperty());
                 globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter());
+
+
+                // Listen for auto-completer changes after real context is loaded
+                libraryTab.setAutoCompleterChangedListener(() -> globalSearchBar.setAutoCompleter(libraryTab.getAutoCompleter()));
 
                 // [impl->req~maintable.focus~1]
                 Platform.runLater(() -> libraryTab.getMainTable().requestFocus());


### PR DESCRIPTION
Closes #11428

This PR ensures that the search bar's auto-completion is correctly initialized as soon as a database is opened, without requiring the user to switch tabs. The auto-completer is now updated immediately after the real database context is loaded, improving the user experience and resolving the issue where auto-completion was unavailable until a tab switch.

### Steps to test


1. **Launch JabRef.**
2. Go to **File → Open library…** and open `jablib/src/main/resources/Chocolate.bib`.
3. Wait until the Chocolate tab finishes loading (spinner disappears).
4. Click the **Global Search** bar (top toolbar) and type `s` or `sm`.

**Before**
 No suggestions appear at this step.

**After**
 Auto-completion popup appears immediately.

---


<img width="2743" height="1654" alt="Screenshot from 2025-09-02 21-31-58" src="https://github.com/user-attachments/assets/2ddf8198-2739-4354-a0cb-bacea470ae0e" />


### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
