### PR TITLE
Support : in the search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Changed
 
 - We changed `ISSNCleanup` into `NormalizeIssn` a `ISSN` formatter. [#13748](https://github.com/JabRef/jabref/issues/13748)
-- The character `:` in a search is now also accepted for searching for containment. [#TODO](https://github.com/JabRef/jabref/pull/todo)
+- The character `:` in a search is now also accepted for searching for containment. [#13825](https://github.com/JabRef/jabref/pull/13825)
 - We changed Citation Relations tab and gave tab panes more descriptive titles and tooltips. [#13619](https://github.com/JabRef/jabref/issues/13619)
 - We changed the name from Open AI Provider to Open AI (or API compatible). [#13585](https://github.com/JabRef/jabref/issues/13585)
 - We improved the citations relations caching by implementing an offline storage. [#11189](https://github.com/JabRef/jabref/issues/11189)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Changed
 
 - We changed `ISSNCleanup` into `NormalizeIssn` a `ISSN` formatter. [#13748](https://github.com/JabRef/jabref/issues/13748)
+- The character `:` in a search is now also accepted for searching for containment. [#TODO](https://github.com/JabRef/jabref/pull/todo)
 - We changed Citation Relations tab and gave tab panes more descriptive titles and tooltips. [#13619](https://github.com/JabRef/jabref/issues/13619)
 - We changed the name from Open AI Provider to Open AI (or API compatible). [#13585](https://github.com/JabRef/jabref/issues/13585)
 - We improved the citations relations caching by implementing an offline storage. [#11189](https://github.com/JabRef/jabref/issues/11189)

--- a/jablib/src/main/antlr/org/jabref/search/Search.g4
+++ b/jablib/src/main/antlr/org/jabref/search/Search.g4
@@ -15,7 +15,7 @@ WS: [ \t\n\r]+ -> skip; // whitespace is ignored/skipped
 LPAREN: '(';
 RPAREN: ')';
 
-EQUAL: '='; // case insensitive contains, semantically the same as CONTAINS
+EQUAL: ('=' | ':'); // case insensitive contains, semantically the same as CONTAINS
 CEQUAL: '=!'; // case sensitive contains
 
 EEQUAL: '=='; // exact match case insensitive, semantically the same as MATCHES
@@ -41,7 +41,7 @@ NOT: 'NOT';
 
 FIELD: [A-Z]([A-Z] | '-' | '_')*;           // field name should allow for - or _
 STRING_LITERAL: '"' ('\\"' | ~["])* '"';    // " should be escaped with a backslash
-TERM: ('\\' [=!~()] | ~[ \t\n\r=!~()])+;    // =!~() should be escaped with a backslash
+TERM: ('\\' [ :=!~()] | ~[ :=!~()\t\r\n])+; // space and :, =, !, ~, (, ) should be escaped with a backslash; \t\r\n cannot be escaped
 
 start
     : EOF

--- a/jablib/src/test/java/org/jabref/logic/search/query/SearchQueryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/query/SearchQueryTest.java
@@ -12,6 +12,7 @@ public class SearchQueryTest {
     @ParameterizedTest
     @CsvSource({
             "term",
+            "101.1007/JHEP02(2023)082", // invalid DOI but valid search term
             "term1 term2",
             "term1 term2 term3",
             "term1 AND term2",

--- a/jablib/src/test/java/org/jabref/logic/search/query/SearchQueryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/query/SearchQueryTest.java
@@ -26,6 +26,7 @@ public class SearchQueryTest {
             "Breitenb{\\\"{u}}cher",
             "K{\\'{a}}lm{\\'{a}}n K{\\'{e}}pes",
             "field = value",
+            "field : value",
             "filed CONTAINS value",
             "field MATCHES value",
             "field != value",
@@ -46,6 +47,7 @@ public class SearchQueryTest {
             "t\\~erm",
             "t\\(1\\)erm",
             "t\\\"erm",
+            "t\\ erm",
     })
     public void validSearchQuery(String searchExpression) {
         assertTrue(new SearchQuery(searchExpression).isValid());


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/13801 while trying out.

1. Support `:` as an alias for `=`
2. Allow space to be used (escaped) in terms.

### Steps to test

1. Open example library
3. Search for `title:on`
4. See 8 matches (instead of 0 matches as in `main`)

#### This PR

<img width="1297" height="604" alt="image" src="https://github.com/user-attachments/assets/27804a14-7a1e-4352-8e88-58d306804e59" />

#### main

<img width="1299" height="590" alt="image" src="https://github.com/user-attachments/assets/ad68d26a-2eaa-415e-b6f5-0136e130e6ae" />


### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
