### PR TITLE
fix: Improper icon sizing with respect to font size

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/Base.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Base.css
@@ -1097,12 +1097,26 @@ TextFlow > .tooltip-text-monospaced {
     -fx-border-width: 0;
 }
 
+.mainToolbar .icon-button {
+    -fx-padding: 0.5em;
+}
+
+/*
+ * -fx-icon-size is intentionally omitted to prevent a rendering loop. The library sets font size
+ * based on the computed icon size, which is itself relative to the font size.
+ */
 .mainToolbar .glyph-icon,
 .mainToolbar .ikonli-font-icon {
-    -fx-font-size: 1.7em;
+    /* `!important` is override library's default font size */
+    -fx-font-size: 1.7em!important;
     -fx-fill: -jr-theme-text;
     -fx-text-fill: -jr-theme-text;
     -fx-icon-color: -jr-theme-text;
+}
+
+.mainToolbar .progress-indicator {
+    -fx-min-width: 2.8em;
+    -fx-max-width: 2.8em;
 }
 
 .search-field {
@@ -3207,7 +3221,7 @@ journalInfo .grid-cell-b {
     -fx-hgap: 1.5em;
     -fx-vgap: 0.8em;
 }
-  
+
 /* Automatic Field Editor */
 .edit-field-content-pane {
     -fx-padding: 0em 1em;


### PR DESCRIPTION
Closes N/A

### Steps to test

Open JabRef and tweak font size. Now the icon in toolbar works properly under all sort of font size.

default:
<img width="1920" height="1057" alt="image" src="https://github.com/user-attachments/assets/526998f9-6f8d-4bd8-9266-a728c7d3dca2" />
13pt:
<img width="1920" height="1057" alt="image" src="https://github.com/user-attachments/assets/785ba706-4019-4d24-b8d6-8254641cc821" />
10pt:
<img width="1920" height="1057" alt="image" src="https://github.com/user-attachments/assets/262b2edc-9232-4f2b-ab7c-8e024535cd29" />

Would greatly appreciate testing from other platforms. The screenshot above is obtained from a Windows 25H2 machine.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
