### PR TITLE
Reformatted database variable to catalogue

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/slr/ManageStudyDefinitionViewModel.java
@@ -103,7 +103,7 @@ public class ManageStudyDefinitionViewModel {
         title.setValue(study.getTitle());
         researchQuestions.addAll(study.getResearchQuestions());
         queries.addAll(study.getQueries().stream().map(StudyQuery::getQuery).toList());
-        List<StudyDatabase> studyDatabases = study.getDatabases();
+        List<StudyDatabase> studyDatabases = study.getCatalogues();
         databases.addAll(WebFetchers.getSearchBasedFetchers(importFormatPreferences, importerPreferences)
                                     .stream()
                                     .map(SearchBasedFetcher::getName)

--- a/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
+++ b/jablib/src/main/java/org/jabref/logic/crawler/StudyRepository.java
@@ -197,7 +197,7 @@ public class StudyRepository {
      * @throws IllegalArgumentException If a transformation from Library entry to LibraryDefinition fails
      */
     public List<StudyDatabase> getActiveLibraryEntries() throws IllegalArgumentException {
-        return study.getDatabases()
+        return study.getCatalogues()
                     .parallelStream()
                     .filter(StudyDatabase::isEnabled)
                     .collect(Collectors.toList());

--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -16,10 +16,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *
  * The file is parsed using by {@link StudyYamlParser}
  */
-@JsonPropertyOrder({"authors", "title", "research-questions", "queries", "databases"})
+@JsonPropertyOrder({"version", "authors", "title", "research-questions", "queries", "catalogues"})
 // The user might add arbitrary content to the YAML
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Study {
+    private String version = "2.0";
     private List<String> authors;
 
     private String title;
@@ -29,20 +30,28 @@ public class Study {
 
     private List<StudyQuery> queries;
 
-    private List<StudyDatabase> databases;
+    private List<StudyDatabase> catalogues;
 
-    public Study(List<String> authors, String title, List<String> researchQuestions, List<StudyQuery> queryEntries, List<StudyDatabase> databases) {
+    public Study(List<String> authors, String title, List<String> researchQuestions, List<StudyQuery> queryEntries, List<StudyDatabase> catalogues) {
         this.authors = authors;
         this.title = title;
         this.researchQuestions = researchQuestions;
         this.queries = queryEntries;
-        this.databases = databases;
+        this.catalogues = catalogues;
     }
 
     /**
      * Used for Jackson deserialization
      */
     private Study() {
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     public List<String> getAuthors() {
@@ -61,12 +70,12 @@ public class Study {
         this.queries = queries;
     }
 
-    public List<StudyDatabase> getDatabases() {
-        return databases;
+    public List<StudyDatabase> getCatalogues() {
+        return catalogues;
     }
 
-    public void setDatabases(List<StudyDatabase> databases) {
-        this.databases = databases;
+    public void setCatalogues(List<StudyDatabase> catalogues) {
+        this.catalogues = catalogues;
     }
 
     public String getTitle() {
@@ -92,7 +101,7 @@ public class Study {
                 ", studyName='" + title + '\'' +
                 ", researchQuestions=" + researchQuestions +
                 ", queries=" + queries +
-                ", libraries=" + databases +
+                ", libraries=" + catalogues +
                 '}';
     }
 
@@ -111,12 +120,12 @@ public class Study {
                 Objects.equals(title, otherStudy.title) &&
                 Objects.equals(researchQuestions, otherStudy.researchQuestions) &&
                 Objects.equals(queries, otherStudy.queries) &&
-                Objects.equals(databases, otherStudy.databases);
+                Objects.equals(catalogues, otherStudy.catalogues);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(authors, title, researchQuestions, queries, databases);
+        return Objects.hash(authors, title, researchQuestions, queries, catalogues);
     }
 }
 


### PR DESCRIPTION
Closes #12642
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

The study.yml is refactored to a new format to implement SEMVER versioning, variable 'databases' is renamed to 'catalogues' for UI consistency.

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->
In the course of working on this draft pull request the query structure is planned to be enhanced to support multiple query formats including catalog-specific variations.

### Steps to test

The study.yml file created when a new slr is started should be in a new format and slr search should function as intended.

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [ ] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
