### PR TITLE
Keep global search bar open when  keep on top pin is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved nested scrolling for the web search tab in the preferences dialog [#13791](https://github.com/JabRef/jabref/pull/13791)
 - We improved the event viewer for debugging [#13783](https://github.com/JabRef/jabref/pull/13783).
 - We improved "REDACTED" replacement of API key value in web fetcher search URL [#13796](https://github.com/JabRef/jabref/issues/13796)
+- When the pin "Keep dialog always on top" in the global search dialog is selected, the search window stays open when double-clicking on an entry. [#13840](https://github.com/JabRef/jabref/issues/13840)
 
 ### Fixed
 

--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
@@ -97,7 +97,6 @@ public class GlobalSearchResultDialog extends BaseDialog<Void> {
 
                 stateManager.activeSearchQuery(SearchType.NORMAL_SEARCH).set(stateManager.activeSearchQuery(SearchType.GLOBAL_SEARCH).get());
                 stateManager.activeTabProperty().get().ifPresent(tab -> tab.clearAndSelect(selectedEntry.getEntry()));
-
                 if (!keepOnTop.isSelected()) {
                     stage.hide();
                 }

--- a/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/search/GlobalSearchResultDialog.java
@@ -97,7 +97,10 @@ public class GlobalSearchResultDialog extends BaseDialog<Void> {
 
                 stateManager.activeSearchQuery(SearchType.NORMAL_SEARCH).set(stateManager.activeSearchQuery(SearchType.GLOBAL_SEARCH).get());
                 stateManager.activeTabProperty().get().ifPresent(tab -> tab.clearAndSelect(selectedEntry.getEntry()));
-                stage.close();
+
+                if (!keepOnTop.isSelected()) {
+                    stage.hide();
+                }
             }
         });
 


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13840

I could not get the "Just move the window to the back" thing working. Either the whole application was moved to background or nothing happened. Tried various things

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

Have library with entries
Open global search dialog
click on pin to keep on top
double click on entry 
=> window stays open


<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
