### PR TITLE
Enhance PR validation actions

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -169,24 +169,24 @@
     Give it a read, and you’ll discover the ancient wisdom of assigning issues to yourself. Trust me, it’s worth it. 🚀
 
 - jobName: 'PR title must not start with "Fix for issue <number>"'
-  workflowName: 'PR Tests'
+  workflowName: 'PR Format'
   always: true
   message: >
     The title of the pull request must not start with "Fix for issue xyz".
     Please use a concise one-line summary that explains what the fix or change actually does.
     Example of a good title: "Prevent crash when importing malformed BibTeX entries".
 - jobName: 'Mandatory Checks present'
-  workflowName: 'PR Tests'
+  workflowName: 'PR Format'
   always: true
   message: >
     You have removed the "Mandatory Checks" section from your pull request description. Please adhere to our [pull request template](https://github.com/JabRef/jabref/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L10).
 - jobName: 'PR checklist OK'
-  workflowName: 'PR Tests'
+  workflowName: 'PR Format'
   always: true
   message: >
     Note that your PR will not be reviewed/accepted until you have gone through the mandatory checks in the description and marked each of them them exactly in the format of `[x]` (done), `[ ]` (not done yet) or `[/]` (not applicable).
 - jobName: 'Determine issue number'
-  workflowName: 'PR Tests'
+  workflowName: 'On PR opened/updated'
   always: true
   message: |
     Your pull request needs to link an issue correctly.

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,0 +1,124 @@
+name: PR Format
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_title_format:
+    name: PR title must not contain "issue <number>"
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+      - name: Check PR title
+        run: |
+          TITLE=$(gh pr view "${{ github.event.number }}" --json title --template '{{.title}}')
+          echo "Title: $TITLE"
+
+          if echo "$TITLE" | grep -Eiq 'issue ?#?[0-9]+.+'; then
+            echo "❌ Title contains 'issue <number>' — not allowed."
+            exit 1
+          fi
+
+          echo "✅ Title format OK"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mandatory-checks-section-exists:
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') && !(
+        (github.actor == 'dependabot[bot]') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
+    name: Mandatory Checks present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+
+      - name: Check for existence of Mandatory Checks section
+        id: check_mandatory_section
+        run: |
+          set -e
+
+          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
+
+          if echo "$BODY" | grep -q "### Mandatory checks"; then
+            echo "✅ '### Mandatory checks' section found."
+          else
+            echo "❌ '### Mandatory checks' section is missing!"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  checklist-checked:
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
+    name: PR checklist OK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          submodules: 'false'
+          show-progress: 'false'
+      - name: Check for PR checklist
+        id: check_changelog_modification
+        run: |
+          set -e
+
+          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}' | grep -A5000 '### Mandatory checks')
+          echo "Found body: $BODY"
+
+          # Ensure the section exists
+          if ! printf '%s\n' "$BODY" | grep -q "### Mandatory checks"; then
+              echo "❌ '### Mandatory checks' section is missing!"
+              exit 1
+          fi
+
+          BOXES=$(printf '%s\n' "$BODY" | grep "^- \[")
+          echo "Found boxes: $BOXES"
+
+          while IFS= read -r line; do
+              if ! printf '%s\n' "$line" | grep -Eq "^- \[(x|/| )\] "; then
+                  echo "❌ Found improperly formatted checkbox: '$line'"
+                  exit 1
+              fi
+          done <<< "$BOXES"
+
+          LINE_COUNT=$(echo "$BOXES" | wc -l)
+
+          if [ "$LINE_COUNT" -ne 6 ]; then
+            echo "❌ Found $LINE_COUNT lines instead of 6 required lines"
+            exit 1
+          fi
+
+          echo "✅ All checkboxes are present and in the correct format."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -2,6 +2,7 @@ name: PR Tests
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
@@ -20,122 +21,6 @@ jobs:
         with:
           name: pr_number
           path: pr_number.txt
-
-  check_title_format:
-    name: PR title must not contain "issue <number>"
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-        with:
-          submodules: 'false'
-          show-progress: 'false'
-      - name: Check PR title
-        run: |
-          TITLE=$(gh pr view "${{ github.event.number }}" --json title --template '{{.title}}')
-          echo "Title: $TITLE"
-
-          if echo "$TITLE" | grep -Eiq 'issue ?#?[0-9]+.+'; then
-            echo "❌ Title contains 'issue <number>' — not allowed."
-            exit 1
-          fi
-
-          echo "✅ Title format OK"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  mandatory-checks-section-exists:
-    if: >
-      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') && !(
-        (github.actor == 'dependabot[bot]') ||
-        (
-          startsWith(github.event.pull_request.title, '[Bot] ') ||
-          startsWith(github.event.pull_request.title, 'Bump ') ||
-          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
-          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
-        )
-      )
-    name: Mandatory Checks present
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-        with:
-          submodules: 'false'
-          show-progress: 'false'
-
-      - name: Check for existence of Mandatory Checks section
-        id: check_mandatory_section
-        run: |
-          set -e
-
-          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
-
-          if echo "$BODY" | grep -q "### Mandatory checks"; then
-            echo "✅ '### Mandatory checks' section found."
-          else
-            echo "❌ '### Mandatory checks' section is missing!"
-            exit 1
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  checklist-checked:
-    if: >
-      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
-      !(
-        (github.actor == 'dependabot[bot]') ||
-        (
-          startsWith(github.event.pull_request.title, '[Bot] ') ||
-          startsWith(github.event.pull_request.title, 'Bump ') ||
-          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
-          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
-        )
-      )
-    name: PR checklist OK
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-        with:
-          submodules: 'false'
-          show-progress: 'false'
-      - name: Check for PR checklist
-        id: check_changelog_modification
-        run: |
-          set -e
-
-          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}' | grep -A5000 '### Mandatory checks')
-          echo "Found body: $BODY"
-
-          # Ensure the section exists
-          if ! printf '%s\n' "$BODY" | grep -q "### Mandatory checks"; then
-              echo "❌ '### Mandatory checks' section is missing!"
-              exit 1
-          fi
-
-          BOXES=$(printf '%s\n' "$BODY" | grep "^- \[")
-          echo "Found boxes: $BOXES"
-
-          while IFS= read -r line; do
-              if ! printf '%s\n' "$line" | grep -Eq "^- \[(x|/| )\] "; then
-                  echo "❌ Found improperly formatted checkbox: '$line'"
-                  exit 1
-              fi
-          done <<< "$BOXES"
-
-          LINE_COUNT=$(echo "$BOXES" | wc -l)
-
-          if [ "$LINE_COUNT" -ne 6 ]; then
-            echo "❌ Found $LINE_COUNT lines instead of 6 required lines"
-            exit 1
-          fi
-
-          echo "✅ All checkboxes are present and in the correct format."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   changelog_modified:
     name: CHANGELOG.md needs to be modified


### PR DESCRIPTION
By default, specifying no `types:` under `pull_request:` would not make the PR title/description format tests re-run if someone edited the PR title or description (it would implicitly run only for `opened`, `reopened` and `synchronize`).
This fixes it.

Also fixes a comment workflow name mismatch for Determine issue number job.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
