### PR TITLE
LSP Refactor to use ranges instead of string matching

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -103,7 +103,7 @@ public class ParserResult {
      * @param s String Warning text. Must be pretranslated. Only added if there isn't already a dupe.
      */
     public void addWarning(String s) {
-        warnings.put(Range.NULL_RANGE, s);
+        addWarning(Range.NULL_RANGE, s);
     }
 
     public void addWarning(Range range, String s) {

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -188,8 +188,7 @@ public class ParserResult {
     }
 
     /// Returns a `Range` indicating that a complete entry is hit. We use the line of the key. No key is found, the complete entry range is used.
-    public Range getFieldRange(BibEntry entry, Field
-            field) {
+    public Range getFieldRange(BibEntry entry, Field field) {
         Map<Field, Range> rangeMap = fieldRanges.getOrDefault(entry, Collections.emptyMap());
 
         if (rangeMap.isEmpty()) {

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -102,7 +102,7 @@ public class ParserResult {
     /**
      * Add a parser warning.
      *
-     * @param s String Warning text. Must be pretranslated. Only added if there isn't already a dupe.
+     * @param s String Warning text. Must be pre-translated. Only added if there isn't already a dupe.
      */
     public void addWarning(String s) {
         addWarning(Range.NULL_RANGE, s);

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -172,7 +172,7 @@ public class ParserResult {
         public static final Range NULL_RANGE = new Range(0, 0, 0, 0);
     }
 
-    /// returns the range of the field if it exists, respecting field alieasses with `NULL_RANGE` as fallback.
+    /// returns the range of the field if it exists, respecting field aliases with `NULL_RANGE` as fallback.
     public Range getFieldRangeOrFallback(BibEntry entry, Field field) {
         Map<Field, Range> rangeMap = fieldRanges.getOrDefault(entry, Collections.emptyMap());
 
@@ -185,20 +185,23 @@ public class ParserResult {
             return range;
         }
 
-        Field alias = field.getAlias().orElse(InternalField.KEY_FIELD);
-        range = rangeMap.get(alias);
-        if (range != null) {
-            return range;
+        Field alias = field.getAlias().get();
+        if (alias != null) {
+            range = rangeMap.get(alias);
+            if (range != null) {
+                return range;
+            }
         }
 
-        return articleRanges.getOrDefault(entry, Range.NULL_RANGE);
+        return getKeyRangeOrFallback(entry);
     }
 
     public Range getKeyRangeOrFallback(BibEntry entry) {
         Map<Field, Range> rangeMap = fieldRanges.getOrDefault(entry, Collections.emptyMap());
         Range range = rangeMap.get(InternalField.KEY_FIELD);
         if (range != null) {
-            return range;
+            // this ensures that the line is highlighted from the beginning of the entry so it highlights "@Article{key," (but only if on the same line) and not just the citation key
+            return new Range(range.startLine(), 0, range.endLine(), range.endColumn());
         }
 
         return articleRanges.getOrDefault(entry, Range.NULL_RANGE);

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -103,13 +103,11 @@ public class ParserResult {
      * @param s String Warning text. Must be pretranslated. Only added if there isn't already a dupe.
      */
     public void addWarning(String s) {
-        if (!warnings.containsValue(s)) {
-            warnings.put(Range.NULL_RANGE, s);
-        }
+        warnings.put(Range.NULL_RANGE, s);
     }
 
     public void addWarning(Range range, String s) {
-        if (!warnings.containsKey(range) && !warnings.containsValue(s)) {
+        if (!warnings.containsEntry(range, s)) {
             warnings.put(range, s);
         }
     }
@@ -177,7 +175,11 @@ public class ParserResult {
         return articleRanges;
     }
 
-    public record Range(int startLine, int startColumn, int endLine, int endColumn) {
+    public record Range(
+            int startLine,
+            int startColumn,
+            int endLine,
+            int endColumn) {
         public static final Range NULL_RANGE = new Range(0, 0, 0, 0);
 
         public Range(int startLine, int startColumn) {
@@ -187,7 +189,7 @@ public class ParserResult {
 
     /// Returns a `Range` indicating that a complete entry is hit. We use the line of the key. No key is found, the complete entry range is used.
     public Range getFieldRange(BibEntry entry, Field
-        field) {
+            field) {
         Map<Field, Range> rangeMap = fieldRanges.getOrDefault(entry, Collections.emptyMap());
 
         if (rangeMap.isEmpty()) {
@@ -199,14 +201,9 @@ public class ParserResult {
             return range;
         }
 
-        if (field.getAlias().isPresent()) {
-            range = rangeMap.get(field.getAlias().get());
-            if (range != null) {
-                return range;
-            }
-        }
-
-        return getCompleteEntryIndicator(entry);
+        return field.getAlias()
+                    .map(rangeMap::get)
+                    .orElseGet(() -> getCompleteEntryIndicator(entry));
     }
 
     /// Returns a `Range` indicating that a complete entry is hit. We use the line of the key. No key is found, the complete entry range is used.

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -185,9 +185,8 @@ public class ParserResult {
             return range;
         }
 
-        Field alias = field.getAlias().get();
-        if (alias != null) {
-            range = rangeMap.get(alias);
+        if (field.getAlias().isPresent()) {
+            range = rangeMap.get(field.getAlias().get());
             if (range != null) {
                 return range;
             }

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -23,10 +23,11 @@ import org.jabref.model.metadata.MetaData;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
 
 public class ParserResult {
     private final Set<BibEntryType> entryTypes;
-    private final Multimap<Range, String> warnings = ArrayListMultimap.create();
+    private final Multimap<Range, String> warnings;
     private BibDatabase database;
     private MetaData metaData;
     private Path file;
@@ -52,6 +53,7 @@ public class ParserResult {
         this.database = Objects.requireNonNull(database);
         this.metaData = Objects.requireNonNull(metaData);
         this.entryTypes = Objects.requireNonNull(entryTypes);
+        this.warnings = MultimapBuilder.hashKeys().hashSetValues().build();
     }
 
     public static ParserResult fromErrorMessage(String message) {
@@ -107,9 +109,7 @@ public class ParserResult {
     }
 
     public void addWarning(Range range, String s) {
-        if (!warnings.containsEntry(range, s)) {
-            warnings.put(range, s);
-        }
+        warnings.put(range, s);
     }
 
     public void addException(Range range, Exception exception) {

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -21,7 +21,6 @@ import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.metadata.MetaData;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -96,7 +96,7 @@ public class BibtexParser implements Parser {
     private static final String BIB_DESK_ROOT_GROUP_NAME = "BibDeskGroups";
     private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
     private static final int INDEX_RELATIVE_PATH_IN_PLIST = 4;
-    private static final Pattern EPILOG_PATTERN = Pattern.compile("\\w+\\s*=.*,");
+    private final Pattern epilogPattern;
     private final Deque<Character> pureTextFromFile = new LinkedList<>();
     private final ImportFormatPreferences importFormatPreferences;
     private PushbackReader pushbackReader;
@@ -121,6 +121,7 @@ public class BibtexParser implements Parser {
         this.importFormatPreferences = Objects.requireNonNull(importFormatPreferences);
         this.metaDataParser = new MetaDataParser(fileMonitor);
         this.parsedBibDeskGroups = new HashMap<>();
+        this.epilogPattern = Pattern.compile("\\w+\\s*=.*,");
     }
 
     public BibtexParser(ImportFormatPreferences importFormatPreferences) {
@@ -312,7 +313,7 @@ public class BibtexParser implements Parser {
     private void checkEpilog() {
         // This is an incomplete and inaccurate try to verify if something went wrong with previous parsing activity even though there were no warnings so far
         // regex looks for something like 'identifier = blabla ,'
-        if (!parserResult.hasWarnings() && EPILOG_PATTERN.matcher(database.getEpilog()).find()) {
+        if (!parserResult.hasWarnings() && epilogPattern.matcher(database.getEpilog()).find()) {
             parserResult.addWarning(new ParserResult.Range(line, column, line, column), "following BibTeX fragment has not been parsed:\n" + database.getEpilog());
         }
     }

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -96,6 +96,7 @@ public class BibtexParser implements Parser {
     private static final String BIB_DESK_ROOT_GROUP_NAME = "BibDeskGroups";
     private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
     private static final int INDEX_RELATIVE_PATH_IN_PLIST = 4;
+    private static final Pattern EPILOG_PATTERN = Pattern.compile("\\w+\\s*=.*,");
     private final Deque<Character> pureTextFromFile = new LinkedList<>();
     private final ImportFormatPreferences importFormatPreferences;
     private PushbackReader pushbackReader;
@@ -269,6 +270,7 @@ public class BibtexParser implements Parser {
         }
 
         addBibDeskGroupEntriesToJabRefGroups();
+
         int startLine = line;
         int startColumn = column;
         try {
@@ -310,8 +312,8 @@ public class BibtexParser implements Parser {
     private void checkEpilog() {
         // This is an incomplete and inaccurate try to verify if something went wrong with previous parsing activity even though there were no warnings so far
         // regex looks for something like 'identifier = blabla ,'
-        if (!parserResult.hasWarnings() && Pattern.compile("\\w+\\s*=.*,").matcher(database.getEpilog()).find()) {
-            parserResult.addWarning(new ParserResult.Range(line, column, line, column), "following BibTex fragment has not been parsed:\n" + database.getEpilog());
+        if (!parserResult.hasWarnings() && EPILOG_PATTERN.matcher(database.getEpilog()).find()) {
+            parserResult.addWarning(new ParserResult.Range(line, column, line, column), "following BibTeX fragment has not been parsed:\n" + database.getEpilog());
         }
     }
 

--- a/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
@@ -21,7 +21,7 @@ public class IntegrityCheckResultErrorFormatWriter extends IntegrityCheckResultW
     @Override
     public void writeFindings() throws IOException {
         for (IntegrityMessage message : messages) {
-            ParserResult.Range fieldRange = parserResult.getFieldRangeOrFallback(message.entry(), message.field());
+            ParserResult.Range fieldRange = parserResult.getFieldRange(message.entry(), message.field());
             writer.append("%s:%d:%d: %s\n".formatted(
                     inputFile,
                     fieldRange.startLine(),

--- a/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jabref.logic.importer.ParserResult;
+import org.jabref.model.entry.EntryConverter;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 
@@ -24,9 +25,9 @@ public class IntegrityCheckResultErrorFormatWriter extends IntegrityCheckResultW
     @Override
     public void writeFindings() throws IOException {
         for (IntegrityMessage message : messages) {
-            Map<Field, ParserResult.Range> fieldRangeMap = parserResult.getFieldRanges().getOrDefault(message.entry(), Map.of());
-            ParserResult.Range fieldRange = fieldRangeMap.getOrDefault(message.field(), fieldRangeMap.getOrDefault(InternalField.KEY_FIELD, parserResult.getArticleRanges().getOrDefault(message.entry(), ParserResult.Range.NULL_RANGE)));
-
+            Field field = message.field();
+            Map<Field, ParserResult.Range> rangeMap = parserResult.getFieldRanges().getOrDefault(message.entry(), Map.of());
+            ParserResult.Range fieldRange = rangeMap.getOrDefault(field, rangeMap.getOrDefault(field.getAlias().orElse(EntryConverter.FIELD_ALIASES.getOrDefault(field, InternalField.KEY_FIELD)), parserResult.getArticleRanges().getOrDefault(message.entry(), ParserResult.Range.NULL_RANGE)));
             writer.append("%s:%d:%d: %s\n".formatted(
                     inputFile,
                     fieldRange.startLine(),

--- a/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultErrorFormatWriter.java
@@ -4,12 +4,8 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
 import org.jabref.logic.importer.ParserResult;
-import org.jabref.model.entry.EntryConverter;
-import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.InternalField;
 
 public class IntegrityCheckResultErrorFormatWriter extends IntegrityCheckResultWriter {
 
@@ -25,9 +21,7 @@ public class IntegrityCheckResultErrorFormatWriter extends IntegrityCheckResultW
     @Override
     public void writeFindings() throws IOException {
         for (IntegrityMessage message : messages) {
-            Field field = message.field();
-            Map<Field, ParserResult.Range> rangeMap = parserResult.getFieldRanges().getOrDefault(message.entry(), Map.of());
-            ParserResult.Range fieldRange = rangeMap.getOrDefault(field, rangeMap.getOrDefault(field.getAlias().orElse(EntryConverter.FIELD_ALIASES.getOrDefault(field, InternalField.KEY_FIELD)), parserResult.getArticleRanges().getOrDefault(message.entry(), ParserResult.Range.NULL_RANGE)));
+            ParserResult.Range fieldRange = parserResult.getFieldRangeOrFallback(message.entry(), message.field());
             writer.append("%s:%d:%d: %s\n".formatted(
                     inputFile,
                     fieldRange.startLine(),

--- a/jablib/src/main/java/org/jabref/model/entry/field/Field.java
+++ b/jablib/src/main/java/org/jabref/model/entry/field/Field.java
@@ -3,6 +3,7 @@ package org.jabref.model.entry.field;
 import java.util.EnumSet;
 import java.util.Optional;
 
+import org.jabref.model.entry.EntryConverter;
 import org.jabref.model.strings.StringUtil;
 
 public interface Field {
@@ -36,7 +37,7 @@ public interface Field {
     }
 
     default Optional<Field> getAlias() {
-        return Optional.empty();
+        return Optional.ofNullable(EntryConverter.FIELD_ALIASES.get(this));
     }
 
     default boolean isNumeric() {

--- a/jabls/build.gradle.kts
+++ b/jabls/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j")
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.websocket")
 
+    implementation("com.google.guava:guava")
+
     // route all requests to java.util.logging to SLF4J (which in turn routes to tinylog)
     testImplementation("org.slf4j:jul-to-slf4j")
 }

--- a/jabls/src/main/java/module-info.java
+++ b/jabls/src/main/java/module-info.java
@@ -6,11 +6,12 @@ module org.jabref.jabls {
 
     requires org.jabref.jablib;
 
+    requires com.google.common;
+    requires com.google.gson;
+
     requires org.slf4j;
 
     requires org.eclipse.lsp4j;
     requires org.eclipse.lsp4j.jsonrpc;
     requires org.eclipse.lsp4j.websocket;
-    requires com.google.gson;
-    requires com.google.common;
 }

--- a/jabls/src/main/java/module-info.java
+++ b/jabls/src/main/java/module-info.java
@@ -12,4 +12,5 @@ module org.jabref.jabls {
     requires org.eclipse.lsp4j.jsonrpc;
     requires org.eclipse.lsp4j.websocket;
     requires com.google.gson;
+    requires com.google.common;
 }

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspConsistencyCheck.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspConsistencyCheck.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
-import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.BibField;
@@ -21,10 +21,10 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 
 public class LspConsistencyCheck {
 
-    public List<Diagnostic> check(BibDatabaseContext bibDatabaseContext, String content) {
+    public List<Diagnostic> check(ParserResult parserResult) {
         List<Diagnostic> diagnostics = new ArrayList<>();
         BibliographyConsistencyCheck consistencyCheck = new BibliographyConsistencyCheck();
-        BibliographyConsistencyCheck.Result result = consistencyCheck.check(bibDatabaseContext, (_, _) -> {
+        BibliographyConsistencyCheck.Result result = consistencyCheck.check(parserResult.getDatabaseContext(), (_, _) -> {
         });
 
         List<Field> allReportedFields = result.entryTypeToResultMap().values().stream()
@@ -34,7 +34,7 @@ public class LspConsistencyCheck {
                                               .toList();
 
         result.entryTypeToResultMap().forEach((entryType, entryTypeResult) -> {
-            Optional<BibEntryType> bibEntryType = new BibEntryTypesManager().enrich(entryType, bibDatabaseContext.getMode());
+            Optional<BibEntryType> bibEntryType = new BibEntryTypesManager().enrich(entryType, parserResult.getDatabaseContext().getMode());
             Set<Field> requiredFields = bibEntryType
                     .map(BibEntryType::getRequiredFields)
                     .stream()
@@ -44,9 +44,8 @@ public class LspConsistencyCheck {
 
             entryTypeResult.sortedEntries().forEach(entry -> requiredFields.forEach(requiredField -> {
                 if (entry.getFieldOrAlias(requiredField).isEmpty()) {
-                    LspDiagnosticBuilder diagnosticBuilder = LspDiagnosticBuilder.create(Localization.lang("Required field \"%0\" is empty.", requiredField.getName()));
+                    LspDiagnosticBuilder diagnosticBuilder = LspDiagnosticBuilder.create(parserResult, Localization.lang("Required field \"%0\" is empty.", requiredField.getName()));
                     diagnosticBuilder.setSeverity(DiagnosticSeverity.Error);
-                    diagnosticBuilder.setContent(content);
                     diagnosticBuilder.setEntry(entry);
                     diagnostics.add(diagnosticBuilder.build());
                 }
@@ -62,8 +61,7 @@ public class LspConsistencyCheck {
 
             optionalFields.forEach(optionalField -> entryTypeResult.sortedEntries().forEach(entry -> {
                 if (entry.getFieldOrAlias(optionalField).isEmpty()) {
-                    LspDiagnosticBuilder diagnosticBuilder = LspDiagnosticBuilder.create(Localization.lang("Optional field \"%0\" is empty.", optionalField.getName()));
-                    diagnosticBuilder.setContent(content);
+                    LspDiagnosticBuilder diagnosticBuilder = LspDiagnosticBuilder.create(parserResult, Localization.lang("Optional field \"%0\" is empty.", optionalField.getName()));
                     diagnosticBuilder.setEntry(entry);
                     diagnostics.add(diagnosticBuilder.build());
                 }

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
@@ -10,18 +10,26 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public final class LspDiagnosticBuilder {
 
     private static final String DEFAULT_SOURCE = "JabRef";
 
+    @Nullable
     private String message;
     private DiagnosticSeverity severity = DiagnosticSeverity.Warning;
     private String source = DEFAULT_SOURCE;
 
+    @Nullable
     private BibEntry entry;
+    @Nullable
     private ParserResult parserResult;
+    @Nullable
     private Field field;
+    @Nullable
     private Range explicitRange;
 
     private LspDiagnosticBuilder() { }
@@ -64,6 +72,11 @@ public final class LspDiagnosticBuilder {
         return this;
     }
 
+    public LspDiagnosticBuilder setRange(ParserResult.Range range) {
+        this.explicitRange = convertToLspRange(range);
+        return this;
+    }
+
     public LspDiagnosticBuilder setParserResult(ParserResult parserResult) {
         this.parserResult = parserResult;
         return this;
@@ -85,10 +98,10 @@ public final class LspDiagnosticBuilder {
         }
 
         if (field == null) {
-            return parserResult.getKeyRangeOrFallback(entry);
+            return parserResult.getCompleteEntryIndicator(entry);
         }
 
-        return parserResult.getFieldRangeOrFallback(entry, field);
+        return parserResult.getFieldRange(entry, field);
     }
 
     private Range convertToLspRange(ParserResult.Range range) {

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.EntryConverter;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 
@@ -91,7 +92,8 @@ public final class LspDiagnosticBuilder {
         }
 
         Map<Field, ParserResult.Range> rangeMap = parserResult.getFieldRanges().getOrDefault(entry, Map.of());
-        return rangeMap.getOrDefault(field, rangeMap.getOrDefault(field.getAlias().orElse(InternalField.KEY_FIELD), ParserResult.Range.NULL_RANGE));
+
+        return rangeMap.getOrDefault(field, rangeMap.get(field.getAlias().orElse(EntryConverter.FIELD_ALIASES.getOrDefault(field, InternalField.KEY_FIELD))));
     }
 
     private Range convertToLspRange(ParserResult.Range range) {

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
@@ -1,13 +1,10 @@
 package org.jabref.languageserver.util;
 
-import java.util.Map;
 import java.util.Objects;
 
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.EntryConverter;
 import org.jabref.model.entry.field.Field;
-import org.jabref.model.entry.field.InternalField;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -88,12 +85,10 @@ public final class LspDiagnosticBuilder {
         }
 
         if (field == null) {
-            return parserResult.getFieldRanges().getOrDefault(entry, Map.of()).getOrDefault(InternalField.KEY_FIELD, parserResult.getArticleRanges().getOrDefault(entry, ParserResult.Range.NULL_RANGE));
+            return parserResult.getKeyRangeOrFallback(entry);
         }
 
-        Map<Field, ParserResult.Range> rangeMap = parserResult.getFieldRanges().getOrDefault(entry, Map.of());
-
-        return rangeMap.getOrDefault(field, rangeMap.get(field.getAlias().orElse(EntryConverter.FIELD_ALIASES.getOrDefault(field, InternalField.KEY_FIELD))));
+        return parserResult.getFieldRangeOrFallback(entry, field);
     }
 
     private Range convertToLspRange(ParserResult.Range range) {

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspIntegrityCheck.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspIntegrityCheck.java
@@ -2,10 +2,10 @@ package org.jabref.languageserver.util;
 
 import java.util.List;
 
+import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.integrity.IntegrityCheck;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.preferences.CliPreferences;
-import org.jabref.model.database.BibDatabaseContext;
 
 import org.eclipse.lsp4j.Diagnostic;
 
@@ -21,20 +21,20 @@ public class LspIntegrityCheck {
         this.abbreviationRepository = abbreviationRepository;
     }
 
-    public List<Diagnostic> check(BibDatabaseContext bibDatabaseContext, String content) {
+    public List<Diagnostic> check(ParserResult parserResult) {
         IntegrityCheck integrityCheck = new IntegrityCheck(
-                bibDatabaseContext,
+                parserResult.getDatabaseContext(),
                 cliPreferences.getFilePreferences(),
                 cliPreferences.getCitationKeyPatternPreferences(),
                 abbreviationRepository,
                 ALLOW_INTEGER_EDITION
         );
 
-        return bibDatabaseContext.getEntries().stream().flatMap(entry -> integrityCheck.checkEntry(entry).stream().map(message -> {
+        return parserResult.getDatabaseContext().getEntries().stream().flatMap(entry -> integrityCheck.checkEntry(entry).stream().map(message -> {
             if (entry.getField(message.field()).isPresent()) {
-                return LspDiagnosticBuilder.create(message.message()).setField(message.field()).setContent(content).setEntry(entry).build();
+                return LspDiagnosticBuilder.create(parserResult, message.message()).setField(message.field()).setEntry(entry).build();
             } else {
-                return LspDiagnosticBuilder.create(message.message()).setContent(content).setEntry(entry).build();
+                return LspDiagnosticBuilder.create(parserResult, message.message()).setEntry(entry).build();
             }
         })).toList();
     }

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspIntegrityCheck.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspIntegrityCheck.java
@@ -31,7 +31,7 @@ public class LspIntegrityCheck {
         );
 
         return parserResult.getDatabaseContext().getEntries().stream().flatMap(entry -> integrityCheck.checkEntry(entry).stream().map(message -> {
-            if (entry.getField(message.field()).isPresent()) {
+            if (entry.getFieldOrAlias(message.field()).isPresent()) {
                 return LspDiagnosticBuilder.create(parserResult, message.message()).setField(message.field()).setEntry(entry).build();
             } else {
                 return LspDiagnosticBuilder.create(parserResult, message.message()).setEntry(entry).build();


### PR DESCRIPTION
Closes https://github.com/palukku/jabref/issues/42 & Closes https://github.com/palukku/jabref/issues/45 & Closes https://github.com/palukku/jabref/issues/50
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

In #13746 the ranges of the fields and entries it self got added now the lsp utilizes these ranges instead of simple string matching.

Also aliases are now handled so if there the error occurs on an alias field the alias is also correctly detected.

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
