### PR TITLE
Fixed TAB navigation in the EntryEditor so that pressing TAB moves focus to the next tab's first field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where pressing "Tab" in the last TextField of a Tab did not move the focus to the next Tab in the Entry Editor. [#11937](https://github.com/JabRef/jabref/issues/11937)
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -3,6 +3,7 @@ package org.jabref.gui.entryeditor;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -24,6 +25,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
 import javafx.scene.input.DataFormat;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.TransferMode;
@@ -38,6 +40,7 @@ import org.jabref.gui.entryeditor.citationrelationtab.CitationRelationsTab;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
 import org.jabref.gui.entryeditor.fileannotationtab.FulltextSearchResultsTab;
 import org.jabref.gui.externalfiles.ExternalFilesEntryLinker;
+import org.jabref.gui.fieldeditors.EditorTextField;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.importer.GrobidUseDialogHelper;
 import org.jabref.gui.keyboard.KeyBinding;
@@ -162,6 +165,11 @@ public class EntryEditor extends BorderPane implements PreviewControls, AdaptVis
         });
 
         setupDragAndDrop();
+
+        EditorTextField.setupTabNavigation(
+                this::isLastFieldInCurrentTab,
+                () -> tabbed.getSelectionModel().selectNext()
+        );
 
         EasyBind.subscribe(tabbed.getSelectionModel().selectedItemProperty(), tab -> {
             EntryEditorTab activeTab = (EntryEditorTab) tab;
@@ -527,5 +535,33 @@ public class EntryEditor extends BorderPane implements PreviewControls, AdaptVis
     @Override
     public void previousPreviewStyle() {
         this.previewPanel.previousPreviewStyle();
+    }
+
+    /**
+     * Checks if the given TextField is the last field in the currently selected tab.
+     *
+     * @param textField the TextField to check
+     * @return true if this is the last field in the current tab, false otherwise
+     */
+    private boolean isLastFieldInCurrentTab(TextField textField) {
+        if (textField == null || tabbed.getSelectionModel().getSelectedItem() == null) {
+            return false;
+        }
+
+        Tab selectedTab = tabbed.getSelectionModel().getSelectedItem();
+        if (!(selectedTab instanceof FieldsEditorTab currentTab)) {
+            return false;
+        }
+
+        Collection<Field> shownFields = currentTab.getShownFields();
+        if (shownFields.isEmpty() || textField.getId() == null) {
+            return false;
+        }
+
+        Field lastField = shownFields.stream()
+                                     .reduce((first, second) -> second)
+                                     .orElse(null);
+
+        return lastField != null && lastField.getDisplayName().equalsIgnoreCase(textField.getId());
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/CitationKeyEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/CitationKeyEditor.java
@@ -56,6 +56,8 @@ public class CitationKeyEditor extends HBox implements FieldEditorFX {
                 undoManager,
                 dialogService);
 
+        textField.setId(field.getDisplayName());
+
         establishBinding(textField, viewModel.textProperty(), keyBindingRepository, undoAction, redoAction);
         textField.initContextMenu(Collections::emptyList, keyBindingRepository);
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textField);

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -25,10 +25,6 @@ public class EditorTextField extends TextField implements Initializable, Context
     private static Predicate<TextField> isLastFieldChecker;
     private final ContextMenu contextMenu = new ContextMenu();
 
-    // Callbacks for tab navigation - replaces static dependency
-    private static Predicate<TextField> isLastFieldChecker;
-    private static Runnable nextTabSelector;
-
     private Runnable additionalPasteActionHandler = () -> {
         // No additional paste behavior
     };

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/EditorTextField.java
@@ -4,12 +4,14 @@ import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
@@ -19,6 +21,8 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 
 public class EditorTextField extends TextField implements Initializable, ContextMenuAddable {
 
+    private static Runnable nextTabSelector;
+    private static Predicate<TextField> isLastFieldChecker;
     private final ContextMenu contextMenu = new ContextMenu();
     private Runnable additionalPasteActionHandler = () -> {
         // No additional paste behavior
@@ -26,6 +30,17 @@ public class EditorTextField extends TextField implements Initializable, Context
 
     public EditorTextField() {
         this("");
+        this.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            String keyText = event.getText();
+            if ("\t".equals(keyText) &&
+                    isLastFieldChecker != null &&
+                    isLastFieldChecker.test(this)) {
+                if (nextTabSelector != null) {
+                    nextTabSelector.run();
+                }
+                event.consume();
+            }
+        });
     }
 
     public EditorTextField(final String text) {
@@ -36,6 +51,11 @@ public class EditorTextField extends TextField implements Initializable, Context
         HBox.setHgrow(this, Priority.ALWAYS);
 
         ClipBoardManager.addX11Support(this);
+    }
+
+    public static void setupTabNavigation(Predicate<TextField> isLastFieldChecker, Runnable nextTabSelector) {
+        EditorTextField.isLastFieldChecker = isLastFieldChecker;
+        EditorTextField.nextTabSelector = nextTabSelector;
     }
 
     @Override

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/MarkdownEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/MarkdownEditor.java
@@ -22,7 +22,7 @@ public class MarkdownEditor extends SimpleEditor {
     }
 
     @Override
-    protected TextInputControl createTextInputControl() {
+    protected TextInputControl createTextInputControl(Field field) {
         return new EditorTextArea() {
             @Override
             public void paste() {

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -38,6 +38,7 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
 
         this.viewModel = new PersonsEditorViewModel(field, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers, undoManager);
         textInput = isMultiLine ? new EditorTextArea() : new EditorTextField();
+        textInput.setId(field.getName());
         decoratedStringProperty = new UiThreadStringProperty(viewModel.textProperty());
         establishBinding(textInput, decoratedStringProperty, keyBindingRepository, undoAction, redoAction);
         ((ContextMenuAddable) textInput).initContextMenu(EditorMenus.getNameMenu(textInput), keyBindingRepository);

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -35,7 +35,7 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         this.viewModel = new SimpleEditorViewModel(field, suggestionProvider, fieldCheckers, undoManager);
         this.isMultiLine = isMultiLine;
 
-        textInput = createTextInputControl();
+        textInput = createTextInputControl(field);
         HBox.setHgrow(textInput, Priority.ALWAYS);
 
         establishBinding(textInput, viewModel.textProperty(), preferences.getKeyBindingRepository(), undoAction, redoAction);
@@ -54,8 +54,10 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textInput);
     }
 
-    protected TextInputControl createTextInputControl() {
-        return isMultiLine ? new EditorTextArea() : new EditorTextField();
+    protected TextInputControl createTextInputControl(Field field) {
+        TextInputControl inputControl = isMultiLine ? new EditorTextArea() : new EditorTextField();
+        inputControl.setId(field.getName());
+        return inputControl;
     }
 
     @Override


### PR DESCRIPTION
Closes #11937 

### Description

- Pressing TAB on the last field of a tab now correctly moves the focus to the first field of the next tab in the EntryEditor.

- The navigation is limited to fields within the EntryEditor and does not move focus to unrelated UI components outside the editor.

- Added static helper methods in EditorTextField to manage the TAB navigation logic.

- All TextField instances within SimpleEditor, CitationKeyEditor, PersonsEditor, and MarkdownEditor now have their id set correctly, enabling proper identification as the last field in a tab.

- Co Contributor: [Noah-Martin1](https://github.com/Noah-Martin1)

### Steps to test

1. Open JabRef and load any entry in the Entry Editor.
2. Navigate through the fields in a tab using the TAB key.
3. When the focus reaches the last field of the current tab, press TAB again.
4. Verify that the focus moves directly to the first field of the next tab in the Entry Editor.
5. Repeat the process for multiple tabs to ensure that the focus does not jump to any fields outside the Entry Editor.
6. Test both single-line and multi-line fields (e.g., SimpleEditor, PersonsEditor, MarkdownEditor) to ensure TAB navigation works consistently.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
