### PR TITLE
Add support for transliterated citation keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added a field for the latest ICORE conference ranking lookup on the General Tab. [#13476](https://github.com/JabRef/jabref/issues/13476)
 - We added BibLaTeX datamodel validation support in order to improve error message quality in entries' fields validation. [#13318](https://github.com/JabRef/jabref/issues/13318)
 - We added more supported formats of CAYW endpoint of HTTP server. [#13578](https://github.com/JabRef/jabref/issues/13578)
+- We added support for transliteration of citation keys. [#11377](https://github.com/JabRef/jabref/issues/11377) [#9605](https://github.com/JabRef/jabref/issues/9605)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.java
@@ -21,6 +21,7 @@ import com.airhacks.afterburner.views.ViewLoader;
 
 public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKeyPatternTabViewModel> implements PreferencesTab {
 
+    @FXML private CheckBox transliterateFields;
     @FXML private CheckBox overwriteAllow;
     @FXML private CheckBox overwriteWarning;
     @FXML private CheckBox generateOnSave;
@@ -48,6 +49,7 @@ public class CitationKeyPatternTab extends AbstractPreferenceTabView<CitationKey
     public void initialize() {
         this.viewModel = new CitationKeyPatternTabViewModel(preferences.getCitationKeyPatternPreferences(), preferences.getImporterPreferences());
 
+        transliterateFields.selectedProperty().bindBidirectional(viewModel.transliterateFieldsProperty());
         overwriteAllow.selectedProperty().bindBidirectional(viewModel.overwriteAllowProperty());
         overwriteWarning.selectedProperty().bindBidirectional(viewModel.overwriteWarningProperty());
         generateOnSave.selectedProperty().bindBidirectional(viewModel.generateOnSaveProperty());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTabViewModel.java
@@ -19,6 +19,7 @@ import org.jabref.logic.importer.ImporterPreferences;
 
 public class CitationKeyPatternTabViewModel implements PreferenceTabViewModel {
 
+    private final BooleanProperty transliterateFieldsProperty = new SimpleBooleanProperty();
     private final BooleanProperty overwriteAllowProperty = new SimpleBooleanProperty();
     private final BooleanProperty overwriteWarningProperty = new SimpleBooleanProperty();
     private final BooleanProperty generateOnSaveProperty = new SimpleBooleanProperty();
@@ -53,6 +54,7 @@ public class CitationKeyPatternTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public void setValues() {
+        transliterateFieldsProperty.setValue(keyPatternPreferences.shouldTransliterateFields());
         overwriteAllowProperty.setValue(!keyPatternPreferences.shouldAvoidOverwriteCiteKey());
         overwriteWarningProperty.setValue(keyPatternPreferences.shouldWarnBeforeOverwriteCiteKey());
         generateOnSaveProperty.setValue(keyPatternPreferences.shouldGenerateCiteKeysBeforeSaving());
@@ -106,6 +108,7 @@ public class CitationKeyPatternTabViewModel implements PreferenceTabViewModel {
             keySuffix = CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_B;
         }
 
+        keyPatternPreferences.setShouldTransliterateFields(transliterateFieldsProperty.getValue());
         keyPatternPreferences.setAvoidOverwriteCiteKey(!overwriteAllowProperty.getValue());
         keyPatternPreferences.setWarnBeforeOverwriteCiteKey(overwriteWarningProperty.getValue());
         keyPatternPreferences.setGenerateCiteKeysBeforeSaving(generateOnSaveProperty.getValue());
@@ -115,6 +118,10 @@ public class CitationKeyPatternTabViewModel implements PreferenceTabViewModel {
         keyPatternPreferences.setKeyPatternReplacement(keyPatternReplacementProperty.getValue());
         keyPatternPreferences.setUnwantedCharacters(unwantedCharactersProperty.getValue());
         keyPatternPreferences.setKeyPatterns(newKeyPattern);
+    }
+
+    public BooleanProperty transliterateFieldsProperty() {
+        return transliterateFieldsProperty;
     }
 
     public BooleanProperty overwriteAllowProperty() {

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/citationkeypattern/CitationKeyPatternTab.fxml
@@ -20,6 +20,7 @@
     <Label styleClass="titleHeader" text="%Citation key patterns"/>
 
     <Label styleClass="sectionHeader" text="%General"/>
+    <CheckBox fx:id="transliterateFields" text="%Transliterate fields"/>
     <CheckBox fx:id="overwriteAllow" text="%Overwrite existing keys"/>
     <CheckBox fx:id="overwriteWarning" text="%Warn before overwriting existing keys" disable="${!overwriteAllow.selected}">
         <padding>

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
@@ -44,6 +44,7 @@ class AutoRenameFileOnEntryChangeTest {
         GuiPreferences guiPreferences = mock(GuiPreferences.class);
         filePreferences = mock(FilePreferences.class);
         CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 true,
                 false,

--- a/jablib/src/main/java/org/jabref/logic/bibtex/BibtexStandard.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/BibtexStandard.java
@@ -1,0 +1,11 @@
+package org.jabref.logic.bibtex;
+
+import java.util.Arrays;
+import java.util.List;
+
+/// Contains various information or constants about the BibTeX standard.
+public class BibtexStandard {
+    /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
+    /// These characters are disallowed in BibTeX keys.
+    public static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
+}

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -1,12 +1,12 @@
 package org.jabref.logic.citationkeypattern;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.PatternSyntaxException;
 
+import org.jabref.logic.bibtex.BibtexStandard;
 import org.jabref.logic.util.strings.Transliteration;
 import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabase;
@@ -34,10 +34,6 @@ public class CitationKeyGenerator extends BracketedPattern {
     ///
     /// See also #DISALLOWED_CHARACTERS
     public static final String DEFAULT_UNWANTED_CHARACTERS = "?!;^`ʹ";
-
-    /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
-    /// These characters are disallowed in BibTeX keys.
-    public static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
 
@@ -81,7 +77,7 @@ public class CitationKeyGenerator extends BracketedPattern {
     public static String removeUnwantedCharacters(String key, String unwantedCharacters) {
         String newKey = key.chars()
                            .filter(c -> unwantedCharacters.indexOf(c) == -1)
-                           .filter(c -> !DISALLOWED_CHARACTERS.contains((char) c))
+                           .filter(c -> !BibtexStandard.DISALLOWED_CHARACTERS.contains((char) c))
                            .collect(StringBuilder::new,
                                    StringBuilder::appendCodePoint, StringBuilder::append)
                            .toString();
@@ -158,7 +154,8 @@ public class CitationKeyGenerator extends BracketedPattern {
             return key;
         }
 
-        return Transliteration.transliterate(key, false);
+        String result = Transliteration.transliterate(key);
+        return result.replace(" ", "");
     }
 
     /**

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.PatternSyntaxException;
 
+import org.jabref.logic.util.strings.Transliteration;
 import org.jabref.model.FieldChange;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -14,7 +15,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.strings.StringUtil;
 
-import com.ibm.icu.text.Transliterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +37,9 @@ public class CitationKeyGenerator extends BracketedPattern {
 
     /// Source of disallowed characters: <https://tex.stackexchange.com/a/408548/9075>
     /// These characters are disallowed in BibTeX keys.
-    private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
+    public static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
-
-    // This transliterator configuration will transliterate from any language to Latin script
-    // that uses only allowed characters for citation keys (letters and numbers, hyphen and underscore).
-    private static final String TRANSLITERATOR_CONFIG = buildTransliteratorConfig();
-    private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(TRANSLITERATOR_CONFIG);
 
     private final AbstractCitationKeyPatterns citeKeyPattern;
     private final BibDatabase database;
@@ -98,18 +93,6 @@ public class CitationKeyGenerator extends BracketedPattern {
 
     public static String cleanKey(String key, String unwantedCharacters) {
         return removeUnwantedCharacters(key, unwantedCharacters).replaceAll("\\s", "");
-    }
-
-    private static String buildTransliteratorConfig() {
-        StringBuilder pattern = new StringBuilder();
-
-        for (Character c : DISALLOWED_CHARACTERS) {
-            // Generally, only characters like `-` or `[` need to be escaped with a backslash,
-            // but for future proofing we escape all characters.
-            pattern.append("\\").append(c);
-        }
-
-        return "Any-Latin; Latin-ASCII; [" + pattern + "] Remove";
     }
 
     /**
@@ -175,7 +158,7 @@ public class CitationKeyGenerator extends BracketedPattern {
             return key;
         }
 
-        return TRANSLITERATOR.transliterate(key);
+        return Transliteration.transliterate(key, false);
     }
 
     /**

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -14,6 +14,7 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.strings.StringUtil;
 
+import com.ibm.icu.text.Transliterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,11 @@ public class CitationKeyGenerator extends BracketedPattern {
     private static final List<Character> DISALLOWED_CHARACTERS = Arrays.asList('{', '}', '(', ')', ',', '=', '\\', '"', '#', '%', '~', '\'');
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CitationKeyGenerator.class);
+
+    // This transliterator configuration will transliterate from any language to Latin script
+    // that uses only allowed characters for citation keys (letters and numbers, hyphen and underscore).
+    private static final String TRANSLITERATOR_CONFIG = buildTransliteratorConfig();
+    private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(TRANSLITERATOR_CONFIG);
 
     private final AbstractCitationKeyPatterns citeKeyPattern;
     private final BibDatabase database;
@@ -94,6 +100,18 @@ public class CitationKeyGenerator extends BracketedPattern {
         return removeUnwantedCharacters(key, unwantedCharacters).replaceAll("\\s", "");
     }
 
+    private static String buildTransliteratorConfig() {
+        StringBuilder pattern = new StringBuilder();
+
+        for (Character c : DISALLOWED_CHARACTERS) {
+            // Generally, only characters like `-` or `[` need to be escaped with a backslash,
+            // but for future proofing we escape all characters.
+            pattern.append("\\").append(c);
+        }
+
+        return "Any-Latin; Latin-ASCII; [" + pattern + "] Remove";
+    }
+
     /**
      * Generate a citation key for the given {@link BibEntry}.
      *
@@ -107,7 +125,8 @@ public class CitationKeyGenerator extends BracketedPattern {
         String newKey = createCitationKeyFromPattern(entry);
         newKey = replaceWithRegex(newKey);
         newKey = appendLettersToKey(newKey, currentKey);
-        return cleanKey(newKey, unwantedCharacters);
+        newKey = cleanKey(newKey, unwantedCharacters);
+        return transliterateIfNeeded(newKey);
     }
 
     /**
@@ -149,6 +168,14 @@ public class CitationKeyGenerator extends BracketedPattern {
             key = moddedKey;
         }
         return key;
+    }
+
+    public String transliterateIfNeeded(String key) {
+        if (!citationKeyPatternPreferences.shouldTransliterateFields()) {
+            return key;
+        }
+
+        return TRANSLITERATOR.transliterate(key);
     }
 
     /**

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
@@ -10,6 +10,8 @@ import javafx.beans.property.StringProperty;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
+
 public class CitationKeyPatternPreferences {
 
     public enum KeySuffix {
@@ -18,6 +20,7 @@ public class CitationKeyPatternPreferences {
         SECOND_WITH_B   // CiteKey, CiteKeyB, CiteKeyC ...
     }
 
+    private final BooleanProperty shouldTransliterateFields = new SimpleBooleanProperty();
     private final BooleanProperty shouldAvoidOverwriteCiteKey = new SimpleBooleanProperty();
     private final BooleanProperty shouldWarnBeforeOverwriteCiteKey = new SimpleBooleanProperty();
     private final BooleanProperty shouldGenerateCiteKeysBeforeSaving = new SimpleBooleanProperty();
@@ -29,7 +32,8 @@ public class CitationKeyPatternPreferences {
     private final String defaultPattern;
     private final ReadOnlyObjectProperty<Character> keywordDelimiter;
 
-    public CitationKeyPatternPreferences(boolean shouldAvoidOverwriteCiteKey,
+    public CitationKeyPatternPreferences(boolean shouldTransliterateFields,
+                                         boolean shouldAvoidOverwriteCiteKey,
                                          boolean shouldWarnBeforeOverwriteCiteKey,
                                          boolean shouldGenerateCiteKeysBeforeSaving,
                                          KeySuffix keySuffix,
@@ -40,6 +44,7 @@ public class CitationKeyPatternPreferences {
                                          String defaultPattern,
                                          ReadOnlyObjectProperty<Character> keywordDelimiter) {
 
+        this.shouldTransliterateFields.set(shouldTransliterateFields);
         this.shouldAvoidOverwriteCiteKey.set(shouldAvoidOverwriteCiteKey);
         this.shouldWarnBeforeOverwriteCiteKey.set(shouldWarnBeforeOverwriteCiteKey);
         this.shouldGenerateCiteKeysBeforeSaving.set(shouldGenerateCiteKeysBeforeSaving);
@@ -54,7 +59,8 @@ public class CitationKeyPatternPreferences {
     }
 
     @VisibleForTesting
-    public CitationKeyPatternPreferences(boolean shouldAvoidOverwriteCiteKey,
+    public CitationKeyPatternPreferences(boolean shouldTransliterateFields,
+                                         boolean shouldAvoidOverwriteCiteKey,
                                          boolean shouldWarnBeforeOverwriteCiteKey,
                                          boolean shouldGenerateCiteKeysBeforeSaving,
                                          KeySuffix keySuffix,
@@ -65,7 +71,8 @@ public class CitationKeyPatternPreferences {
                                          String defaultPattern,
                                          Character keywordDelimiter) {
 
-        this(shouldAvoidOverwriteCiteKey,
+        this(shouldTransliterateFields,
+                shouldAvoidOverwriteCiteKey,
                 shouldWarnBeforeOverwriteCiteKey,
                 shouldGenerateCiteKeysBeforeSaving,
                 keySuffix,
@@ -75,6 +82,35 @@ public class CitationKeyPatternPreferences {
                 keyPatterns,
                 defaultPattern,
                 new SimpleObjectProperty<>(keywordDelimiter));
+    }
+
+    @VisibleForTesting
+    public static CitationKeyPatternPreferences getInstanceForTesting() {
+        return new CitationKeyPatternPreferences(
+                true,
+                false,
+                false,
+                false,
+                CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_A,
+                "",
+                "",
+                DEFAULT_UNWANTED_CHARACTERS,
+                GlobalCitationKeyPatterns.fromPattern("[auth][year]"),
+                "",
+                ','
+        );
+    }
+
+    public boolean shouldTransliterateFields() {
+        return shouldTransliterateFields.get();
+    }
+
+    public BooleanProperty shouldTransliterateFieldsProperty() {
+        return shouldTransliterateFields;
+    }
+
+    public void setShouldTransliterateFields(boolean shouldTransliterateFields) {
+        this.shouldTransliterateFields.set(shouldTransliterateFields);
     }
 
     public boolean shouldAvoidOverwriteCiteKey() {

--- a/jablib/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -30,6 +30,7 @@ import org.jabref.logic.formatter.bibtexfields.RegexFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveEnclosingBracesFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveWordEnclosingAndOuterEnclosingBracesFormatter;
 import org.jabref.logic.formatter.bibtexfields.ShortenDOIFormatter;
+import org.jabref.logic.formatter.bibtexfields.TransliterateFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
 import org.jabref.logic.formatter.casechanger.CamelFormatter;
@@ -65,7 +66,8 @@ public class Formatters {
                 new HtmlToUnicodeFormatter(),
                 new LatexToUnicodeFormatter(),
                 new UnicodeToLatexFormatter(),
-                new ConvertMSCCodesFormatter()
+                new ConvertMSCCodesFormatter(),
+                new TransliterateFormatter()
         );
     }
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
@@ -1,0 +1,32 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.strings.Transliteration;
+
+public class TransliterateFormatter extends Formatter {
+    @Override
+    public String getName() {
+        return Localization.lang("Transliterate");
+    }
+
+    @Override
+    public String getKey() {
+        return "transliterate";
+    }
+
+    @Override
+    public String format(String value) {
+        return Transliteration.transliterate(value, false);
+    }
+
+    @Override
+    public String getDescription() {
+        return Localization.lang("Converts non-Latin characters to their Latin equivalents.");
+    }
+
+    @Override
+    public String getExampleInput() {
+        return "Карпенко Надежда";
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
@@ -17,7 +17,7 @@ public class TransliterateFormatter extends Formatter {
 
     @Override
     public String format(String value) {
-        return Transliteration.transliterate(value, false);
+        return Transliteration.transliterate(value);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -240,6 +240,7 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String UNWANTED_CITATION_KEY_CHARACTERS = "defaultUnwantedBibtexKeyCharacters";
     public static final String CONFIRM_LINKED_FILE_DELETE = "confirmLinkedFileDelete";
     public static final String TRASH_INSTEAD_OF_DELETE = "trashInsteadOfDelete";
+    public static final String TRANSLITERATE_FIELDS = "transliterateFields";
     public static final String WARN_BEFORE_OVERWRITING_KEY = "warnBeforeOverwritingKey";
     public static final String AVOID_OVERWRITING_KEY = "avoidOverwritingKey";
     public static final String AUTOLINK_EXACT_KEY_ONLY = "autolinkExactKeyOnly";
@@ -649,6 +650,7 @@ public class JabRefCliPreferences implements CliPreferences {
 
         defaults.put(USE_OWNER, Boolean.FALSE);
         defaults.put(OVERWRITE_OWNER, Boolean.FALSE);
+        defaults.put(TRANSLITERATE_FIELDS, Boolean.TRUE);
         defaults.put(AVOID_OVERWRITING_KEY, Boolean.FALSE);
         defaults.put(WARN_BEFORE_OVERWRITING_KEY, Boolean.TRUE);
         defaults.put(CONFIRM_LINKED_FILE_DELETE, Boolean.TRUE);
@@ -1542,6 +1544,7 @@ public class JabRefCliPreferences implements CliPreferences {
         }
 
         citationKeyPatternPreferences = new CitationKeyPatternPreferences(
+                getBoolean(TRANSLITERATE_FIELDS),
                 getBoolean(AVOID_OVERWRITING_KEY),
                 getBoolean(WARN_BEFORE_OVERWRITING_KEY),
                 getBoolean(GENERATE_KEYS_BEFORE_SAVING),
@@ -1553,6 +1556,8 @@ public class JabRefCliPreferences implements CliPreferences {
                 (String) defaults.get(DEFAULT_CITATION_KEY_PATTERN),
                 getBibEntryPreferences().keywordSeparatorProperty());
 
+        EasyBind.listen(citationKeyPatternPreferences.shouldTransliterateFieldsProperty(),
+                (_, _, newValue) -> putBoolean(TRANSLITERATE_FIELDS, newValue));
         EasyBind.listen(citationKeyPatternPreferences.shouldAvoidOverwriteCiteKeyProperty(),
                 (_, _, newValue) -> putBoolean(AVOID_OVERWRITING_KEY, newValue));
         EasyBind.listen(citationKeyPatternPreferences.shouldWarnBeforeOverwriteCiteKeyProperty(),

--- a/jablib/src/main/java/org/jabref/logic/util/strings/Transliteration.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/Transliteration.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.util.strings;
 
-import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
+import org.jabref.logic.bibtex.BibtexStandard;
 
 import com.ibm.icu.text.Transliterator;
 
@@ -11,21 +11,14 @@ public class Transliteration {
     private static final String TRANSLITERATOR_CONFIG = buildTransliteratorConfig();
     private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(TRANSLITERATOR_CONFIG);
 
-    public static String transliterate(String input, boolean removeSpaces) {
-        String result = TRANSLITERATOR.transliterate(input);
-
-        // For some reason, icu4j sometimes leaves spaces in the result, so we remove them here if needed.
-        if (removeSpaces) {
-            result = result.replace(" ", "");
-        }
-
-        return result;
+    public static String transliterate(String input) {
+        return TRANSLITERATOR.transliterate(input);
     }
 
     private static String buildTransliteratorConfig() {
         StringBuilder pattern = new StringBuilder();
 
-        for (Character c : CitationKeyGenerator.DISALLOWED_CHARACTERS) {
+        for (Character c : BibtexStandard.DISALLOWED_CHARACTERS) {
             // Generally, only characters like `-` or `[` need to be escaped with a backslash,
             // but for future proofing we escape all characters.
             pattern.append("\\").append(c);

--- a/jablib/src/main/java/org/jabref/logic/util/strings/Transliteration.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/Transliteration.java
@@ -1,0 +1,36 @@
+package org.jabref.logic.util.strings;
+
+import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
+
+import com.ibm.icu.text.Transliterator;
+
+public class Transliteration {
+
+    // This transliterator configuration will transliterate from any language to Latin script
+    // that uses only allowed characters for citation keys.
+    private static final String TRANSLITERATOR_CONFIG = buildTransliteratorConfig();
+    private static final Transliterator TRANSLITERATOR = Transliterator.getInstance(TRANSLITERATOR_CONFIG);
+
+    public static String transliterate(String input, boolean removeSpaces) {
+        String result = TRANSLITERATOR.transliterate(input);
+
+        // For some reason, icu4j sometimes leaves spaces in the result, so we remove them here if needed.
+        if (removeSpaces) {
+            result = result.replace(" ", "");
+        }
+
+        return result;
+    }
+
+    private static String buildTransliteratorConfig() {
+        StringBuilder pattern = new StringBuilder();
+
+        for (Character c : CitationKeyGenerator.DISALLOWED_CHARACTERS) {
+            // Generally, only characters like `-` or `[` need to be escaped with a backslash,
+            // but for future proofing we escape all characters.
+            pattern.append("\\").append(c);
+        }
+
+        return "Any-Latin; Latin-ASCII; Title; [" + pattern + "] Remove";
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -94,6 +94,7 @@ class CitationKeyGeneratorTest {
     static String generateKey(BibEntry entry, String pattern, BibDatabase database) {
         GlobalCitationKeyPatterns keyPattern = GlobalCitationKeyPatterns.fromPattern(pattern);
         CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -1040,6 +1041,7 @@ class CitationKeyGeneratorTest {
         String pattern = "[title]";
         GlobalCitationKeyPatterns keyPattern = GlobalCitationKeyPatterns.fromPattern(pattern);
         CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -1082,5 +1084,12 @@ class CitationKeyGeneratorTest {
         BibEntry entry = createABibEntryAuthor("Alexander Artemenko and others");
         entry.setField(StandardField.YEAR, "2019");
         assertEquals("Artemenko2019", generateKey(entry, "[auth][year]"));
+    }
+
+    @Test
+    void generateKeyWithTransliteration() {
+        BibEntry entry = createABibEntryAuthor("Надежда Карпенко");
+        entry.setField(StandardField.YEAR, "2025");
+        assertEquals("Karpenko2025", generateKey(entry, "[auth][year]"));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/CitationKeyGeneratorTest.java
@@ -88,13 +88,21 @@ class CitationKeyGeneratorTest {
     }
 
     static String generateKey(BibEntry entry, String pattern) {
-        return generateKey(entry, pattern, new BibDatabase());
+        return generateKey(entry, true, pattern, new BibDatabase());
+    }
+
+    static String generateKey(BibEntry entry, boolean transliterate, String pattern) {
+        return generateKey(entry, transliterate, pattern, new BibDatabase());
     }
 
     static String generateKey(BibEntry entry, String pattern, BibDatabase database) {
+        return generateKey(entry, true, pattern, database);
+    }
+
+    static String generateKey(BibEntry entry, boolean transliterate, String pattern, BibDatabase database) {
         GlobalCitationKeyPatterns keyPattern = GlobalCitationKeyPatterns.fromPattern(pattern);
         CitationKeyPatternPreferences patternPreferences = new CitationKeyPatternPreferences(
-                true,
+                transliterate,
                 false,
                 false,
                 false,
@@ -1088,6 +1096,13 @@ class CitationKeyGeneratorTest {
 
     @Test
     void generateKeyWithTransliteration() {
+        BibEntry entry = createABibEntryAuthor("Надежда Карпенко");
+        entry.setField(StandardField.YEAR, "2025");
+        assertEquals("Karpenko2025", generateKey(entry, "[auth][year]"));
+    }
+
+    @Test
+    void generateKeyWithoutTransliteration() {
         BibEntry entry = createABibEntryAuthor("Надежда Карпенко");
         entry.setField(StandardField.YEAR, "2025");
         assertEquals("Karpenko2025", generateKey(entry, "[auth][year]"));

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithDatabaseTest.java
@@ -38,6 +38,7 @@ class MakeLabelWithDatabaseTest {
         pattern = GlobalCitationKeyPatterns.fromPattern("[auth][year]");
         bibtexKeyPattern = new DatabaseCitationKeyPatterns(pattern);
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -70,6 +71,7 @@ class MakeLabelWithDatabaseTest {
     @Test
     void generateDefaultKeyAlwaysLetter() {
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -88,6 +90,7 @@ class MakeLabelWithDatabaseTest {
     @Test
     void generateDefaultKeyAlwaysLetterAlreadyExistsDuplicatesStartAtB() {
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -111,6 +114,7 @@ class MakeLabelWithDatabaseTest {
     @Test
     void generateDefaultKeyStartDuplicatesAtB() {
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -129,6 +133,7 @@ class MakeLabelWithDatabaseTest {
     @Test
     void generateDefaultKeyAlreadyExistsDuplicatesStartAtB() {
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,
@@ -430,6 +435,7 @@ class MakeLabelWithDatabaseTest {
     @Test
     void generateKeyRegExReplace() {
         preferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -25,6 +25,7 @@ class MakeLabelWithoutDatabaseTest {
         GlobalCitationKeyPatterns keyPattern = new GlobalCitationKeyPatterns(CitationKeyPattern.NULL_CITATION_KEY_PATTERN);
         keyPattern.setDefaultValue("[auth]");
         patternPreferences = new CitationKeyPatternPreferences(
+                true,
                 false,
                 false,
                 false,

--- a/jablib/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupTest.java
@@ -3,6 +3,7 @@ package org.jabref.logic.cleanup;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jabref.logic.formatter.bibtexfields.TransliterateFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
 import org.jabref.logic.formatter.casechanger.UpperCaseFormatter;
 import org.jabref.model.entry.BibEntry;
@@ -90,5 +91,13 @@ class FieldFormatterCleanupTest {
         cleanup.cleanup(entry);
 
         assertEquals("Fran{\\c{c}}ois-Marie Arouet", entry.getField(InternalField.KEY_FIELD).get());
+    }
+
+    @Test
+    void cleanupTransliterateField() {
+        FieldFormatterCleanup cleanup = new FieldFormatterCleanup(StandardField.TITLE, new TransliterateFormatter());
+        entry.setField(StandardField.TITLE, "Тiло Е");
+        cleanup.cleanup(entry);
+        assertEquals("Tilo E", entry.getField(StandardField.TITLE).get());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/CrawlerTest.java
@@ -11,7 +11,6 @@ import javafx.collections.FXCollections;
 
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SaveException;
 import org.jabref.logic.git.SlrGitHandler;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
-import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -62,17 +60,7 @@ class CrawlerTest {
     void setUp() throws GitAPIException, URISyntaxException {
         setUpRepository();
 
-        CitationKeyPatternPreferences citationKeyPatternPreferences = new CitationKeyPatternPreferences(
-                false,
-                false,
-                false,
-                CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_A,
-                "",
-                "",
-                DEFAULT_UNWANTED_CHARACTERS,
-                GlobalCitationKeyPatterns.fromPattern("[auth][year]"),
-                "",
-                ',');
+        CitationKeyPatternPreferences citationKeyPatternPreferences = CitationKeyPatternPreferences.getInstanceForTesting();
 
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         importerPreferences = mock(ImporterPreferences.class);

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyRepositoryTest.java
@@ -15,7 +15,6 @@ import org.jabref.logic.JabRefException;
 import org.jabref.logic.LibraryPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.database.DatabaseMerger;
 import org.jabref.logic.exporter.SaveConfiguration;
 import org.jabref.logic.exporter.SaveException;
@@ -39,7 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
-import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,22 +70,12 @@ class StudyRepositoryTest {
         saveConfiguration = mock(SaveConfiguration.class, Answers.RETURNS_DEEP_STUBS);
         importFormatPreferences = mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS);
         preferences = mock(CliPreferences.class, Answers.RETURNS_DEEP_STUBS);
-        citationKeyPatternPreferences = new CitationKeyPatternPreferences(
-                false,
-                false,
-                false,
-                CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_A,
-                "",
-                "",
-                DEFAULT_UNWANTED_CHARACTERS,
-                GlobalCitationKeyPatterns.fromPattern("[auth][year]"),
-                "",
-                ',');
+        citationKeyPatternPreferences = CitationKeyPatternPreferences.getInstanceForTesting();
         when(preferences.getCitationKeyPatternPreferences()).thenReturn(citationKeyPatternPreferences);
         when(preferences.getImporterPreferences().getApiKeys()).thenReturn(FXCollections.emptyObservableSet());
         when(importFormatPreferences.bibEntryPreferences().getKeywordSeparator()).thenReturn(',');
         when(preferences.getImportFormatPreferences()).thenReturn(importFormatPreferences);
-        when(preferences.getTimestampPreferences().getTimestampField()).then(invocation -> StandardField.TIMESTAMP);
+        when(preferences.getTimestampPreferences().getTimestampField()).then(_ -> StandardField.TIMESTAMP);
         entryTypesManager = new BibEntryTypesManager();
         getTestStudyRepository();
     }

--- a/jablib/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/jablib/src/test/java/org/jabref/logic/integrity/IntegrityCheckTest.java
@@ -9,9 +9,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.jabref.logic.FilePreferences;
-import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
@@ -138,7 +136,7 @@ class IntegrityCheckTest {
 
         new IntegrityCheck(context,
                 mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
+                CitationKeyPatternPreferences.getInstanceForTesting(),
                 JournalAbbreviationLoader.loadBuiltInRepository(),
                 false)
                 .check();
@@ -173,7 +171,7 @@ class IntegrityCheckTest {
 
         messages = new IntegrityCheck(context,
                 mock(FilePreferences.class),
-                createCitationKeyPatternPreferences(),
+                CitationKeyPatternPreferences.getInstanceForTesting(),
                 JournalAbbreviationLoader.loadBuiltInRepository(),
                 false)
                 .check();
@@ -188,26 +186,12 @@ class IntegrityCheckTest {
 
         messages = new IntegrityCheck(context,
                 filePreferencesMock,
-                createCitationKeyPatternPreferences(),
+                CitationKeyPatternPreferences.getInstanceForTesting(),
                 JournalAbbreviationLoader.loadBuiltInRepository(),
                 false)
                 .check();
 
         assertEquals(List.of(), messages);
-    }
-
-    private CitationKeyPatternPreferences createCitationKeyPatternPreferences() {
-        return new CitationKeyPatternPreferences(
-                false,
-                false,
-                false,
-                CitationKeyPatternPreferences.KeySuffix.SECOND_WITH_B,
-                "",
-                "",
-                CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS,
-                GlobalCitationKeyPatterns.fromPattern("[auth][year]"),
-                "",
-                ',');
     }
 
     private BibDatabaseContext withMode(BibDatabaseContext context, BibDatabaseMode mode) {

--- a/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
@@ -1,0 +1,35 @@
+package org.jabref.logic.util.strings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TransliterationTest {
+    @ParameterizedTest(name = "string={0}, expected={1}")
+    @CsvSource({
+            "Hello, Hello",                     // English
+            "Grüße, Grusse",                   // German
+            "संस्कृतम्, Sanskrtam",             // Sanskrit
+            "नमस्ते, Namaste",                  // Hindi
+            "Привет, Privet",                   // Russian
+            "Привіт, Privit",                   // Ukrainian, though "Pryvit" is better for expected result.
+            "你好, Ni Hao",                      // Chinese
+            "안녕하세요, Annyeonghaseyo",         // Korean
+            "مرحبا, Mrhba"                   // Arabic
+    })
+    void transliterates(String string, String expected) {
+        assertEquals(expected, Transliteration.transliterate(string, false));
+    }
+
+    @Test
+    void removesSpaces(){
+        assertEquals("DzabRef", Transliteration.transliterate("Джаб Реф", true));
+    }
+
+    @Test
+    void keepsSpaces(){
+        assertEquals("Dzab Ref", Transliteration.transliterate("Джаб Реф", false));
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
@@ -9,15 +9,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class TransliterationTest {
     @ParameterizedTest(name = "string={0}, expected={1}")
     @CsvSource({
-            "Hello, Hello",                     // English
-            "Grüße, Grusse",                   // German
-            "संस्कृतम्, Sanskrtam",             // Sanskrit
-            "नमस्ते, Namaste",                  // Hindi
-            "Привет, Privet",                   // Russian
-            "Привіт, Privit",                   // Ukrainian, though "Pryvit" is better for expected result.
-            "你好, Ni Hao",                      // Chinese
-            "안녕하세요, Annyeonghaseyo",         // Korean
-            "مرحبا, Mrhba"                   // Arabic
+            "Hello, Hello",            // English
+            "Grüße, Grusse",           // German
+            "संस्कृतम्, Sanskrtam",        // Sanskrit
+            "नमस्ते, Namaste",            // Hindi
+            "Привет, Privet",          // Russian
+            "Привіт, Privit",          // Ukrainian, though "Pryvit" is better for expected result.
+            "你好, Ni Hao",             // Chinese
+            "안녕하세요, Annyeonghaseyo", // Korean
+            "مرحبا, Mrhba"             // Arabic
     })
     void transliterates(String string, String expected) {
         assertEquals(expected, Transliteration.transliterate(string, false));

--- a/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/TransliterationTest.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.util.strings;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -14,22 +13,12 @@ class TransliterationTest {
             "संस्कृतम्, Sanskrtam",        // Sanskrit
             "नमस्ते, Namaste",            // Hindi
             "Привет, Privet",          // Russian
-            "Привіт, Privit",          // Ukrainian, though "Pryvit" is better for expected result.
+            "Привіт, Privit",          // Ukrainian, though "Pryvit" is better for the expected result.
             "你好, Ni Hao",             // Chinese
             "안녕하세요, Annyeonghaseyo", // Korean
             "مرحبا, Mrhba"             // Arabic
     })
     void transliterates(String string, String expected) {
-        assertEquals(expected, Transliteration.transliterate(string, false));
-    }
-
-    @Test
-    void removesSpaces(){
-        assertEquals("DzabRef", Transliteration.transliterate("Джаб Реф", true));
-    }
-
-    @Test
-    void keepsSpaces(){
-        assertEquals("Dzab Ref", Transliteration.transliterate("Джаб Реф", false));
+        assertEquals(expected, Transliteration.transliterate(string));
     }
 }


### PR DESCRIPTION
Closes #11377 and #9605.

Added:

- Transliteration field formatter.
- Transliteration of citation keys.
- Ability to turn off or on transliteration for citation keys.

Result:

<img width="1099" height="701" alt="2025-09-13_12-00" src="https://github.com/user-attachments/assets/e48dadf7-f1cc-4005-9d1a-881b7806c6d4" />

### Steps to test

- Enter author in Cyrillic script or Chinese language.
- Turn on "Transliterate fields" (turned on by default).
- Click "Generate key".

Results:

<img width="404" height="412" alt="2025-09-13_11-49" src="https://github.com/user-attachments/assets/fadebb6a-20f2-4cc5-b187-a515f2a344f9" />

<img width="256" height="279" alt="2025-09-13_12-55" src="https://github.com/user-attachments/assets/066385d7-d732-4f2b-b367-2e31a4012c3f" />

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
