### PR TITLE
Observable Preferences Y (Resetting preferences)

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/WorkspacePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/WorkspacePreferences.java
@@ -1,6 +1,7 @@
 package org.jabref.gui;
 
 import java.util.List;
+import java.util.Locale;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
@@ -15,6 +16,16 @@ import org.jabref.gui.theme.Theme;
 import org.jabref.logic.l10n.Language;
 
 public class WorkspacePreferences {
+    public static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize";
+    public static final String MAIN_FONT_SIZE = "mainFontSize";
+    public static final String THEME = "fxTheme";
+    public static final String THEME_SYNC_OS = "themeSyncOs";
+    public static final String OPEN_LAST_EDITED = "openLastEdited";
+    public static final String SHOW_ADVANCED_HINTS = "showAdvancedHints";
+    public static final String CONFIRM_DELETE = "confirmDelete";
+    public static final String CONFIRM_HIDE_TAB_BAR = "confirmHideTabBar";
+    public static final String SELECTED_SLR_CATALOGS = "selectedSlrCatalogs";
+
     private final ObjectProperty<Language> language;
     private final BooleanProperty shouldOverrideDefaultFontSize;
     private final IntegerProperty mainFontSize;
@@ -23,7 +34,6 @@ public class WorkspacePreferences {
     private final BooleanProperty themeSyncOs;
     private final BooleanProperty shouldOpenLastEdited;
     private final BooleanProperty showAdvancedHints;
-    private final BooleanProperty warnAboutDuplicatesInInspection;
     private final BooleanProperty confirmDelete;
     private final BooleanProperty confirmHideTabBar;
     private final ObservableList<String> selectedSlrCatalogs;
@@ -36,7 +46,6 @@ public class WorkspacePreferences {
                                 boolean themeSyncOs,
                                 boolean shouldOpenLastEdited,
                                 boolean showAdvancedHints,
-                                boolean warnAboutDuplicatesInInspection,
                                 boolean confirmDelete,
                                 boolean confirmHideTabBar,
                                 List<String> selectedSlrCatalogs) {
@@ -48,10 +57,41 @@ public class WorkspacePreferences {
         this.themeSyncOs = new SimpleBooleanProperty(themeSyncOs);
         this.shouldOpenLastEdited = new SimpleBooleanProperty(shouldOpenLastEdited);
         this.showAdvancedHints = new SimpleBooleanProperty(showAdvancedHints);
-        this.warnAboutDuplicatesInInspection = new SimpleBooleanProperty(warnAboutDuplicatesInInspection);
         this.confirmDelete = new SimpleBooleanProperty(confirmDelete);
         this.confirmHideTabBar = new SimpleBooleanProperty(confirmHideTabBar);
         this.selectedSlrCatalogs = FXCollections.observableArrayList(selectedSlrCatalogs);
+    }
+
+    /// Creates Object with default values
+    public WorkspacePreferences() {
+        this(
+                Language.getLanguageFor(Locale.getDefault().getLanguage()),
+                false,
+                9,
+                9,
+                new Theme(Theme.BASE_CSS),
+                false,
+                true,
+                true,
+                true,
+                true,
+                List.of()
+        );
+    }
+
+    public void reset() {
+        WorkspacePreferences defaults = new WorkspacePreferences();
+        this.language.set(defaults.getLanguage());
+        this.shouldOverrideDefaultFontSize.set(defaults.shouldOverrideDefaultFontSize());
+        this.mainFontSize.set(defaults.getMainFontSize());
+        this.defaultFontSize.set(defaults.getDefaultFontSize());
+        this.theme.set(defaults.getTheme());
+        this.themeSyncOs.set(defaults.shouldThemeSyncOs());
+        this.shouldOpenLastEdited.set(defaults.shouldOpenLastEdited());
+        this.showAdvancedHints.set(defaults.shouldShowAdvancedHints());
+        this.confirmDelete.set(defaults.shouldConfirmDelete());
+        this.confirmHideTabBar.set(defaults.shouldHideTabBar());
+        this.selectedSlrCatalogs.setAll(defaults.getSelectedSlrCatalogs());
     }
 
     public Language getLanguage() {
@@ -140,18 +180,6 @@ public class WorkspacePreferences {
 
     public void setShowAdvancedHints(boolean showAdvancedHints) {
         this.showAdvancedHints.set(showAdvancedHints);
-    }
-
-    public boolean shouldWarnAboutDuplicatesInInspection() {
-        return warnAboutDuplicatesInInspection.get();
-    }
-
-    public BooleanProperty warnAboutDuplicatesInInspectionProperty() {
-        return warnAboutDuplicatesInInspection;
-    }
-
-    public void setWarnAboutDuplicatesInInspection(boolean warnAboutDuplicatesInInspection) {
-        this.warnAboutDuplicatesInInspection.set(warnAboutDuplicatesInInspection);
     }
 
     public boolean shouldConfirmDelete() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.SequencedMap;
 import java.util.Set;
+import java.util.prefs.BackingStoreException;
 import java.util.stream.Collectors;
 
 import javafx.beans.InvalidationListener;
@@ -83,7 +84,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
     // Public because needed for pref migration
     public static final String AUTOCOMPLETER_COMPLETE_FIELDS = "autoCompleteFields";
-    public static final String MAIN_FONT_SIZE = "mainFontSize";
 
     // region Preview - public for pref migrations
     public static final String PREVIEW_STYLE = "previewStyle";
@@ -150,16 +150,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String FILE_BROWSER_COMMAND = "fileBrowserCommand";
     // endregion
 
-    // region workspace
-    private static final String THEME = "fxTheme";
-    private static final String THEME_SYNC_OS = "themeSyncOs";
-    private static final String OPEN_LAST_EDITED = "openLastEdited";
-    private static final String OVERRIDE_DEFAULT_FONT_SIZE = "overrideDefaultFontSize";
-    private static final String SHOW_ADVANCED_HINTS = "showAdvancedHints";
-    private static final String CONFIRM_DELETE = "confirmDelete";
-    private static final String CONFIRM_HIDE_TAB_BAR = "confirmHideTabBar";
-    // endregion
-
     private static final String ENTRY_EDITOR_HEIGHT = "entryEditorHeightFX";
 
     /**
@@ -196,7 +186,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
     private static final String SPECIALFIELDSENABLED = "specialFieldsEnabled";
     // endregion
 
-    private static final String SELECTED_SLR_CATALOGS = "selectedSlrCatalogs";
+
     private static final String UNLINKED_FILES_SELECTED_EXTENSION = "unlinkedFilesSelectedExtension";
     private static final String UNLINKED_FILES_SELECTED_DATE_RANGE = "unlinkedFilesSelectedDateRange";
     private static final String UNLINKED_FILES_SELECTED_SORT = "unlinkedFilesSelectedSort";
@@ -267,17 +257,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         defaults.put(AUTOCOMPLETER_FIRST_LAST, Boolean.FALSE); // "Autocomplete names in 'Firstname Lastname' format only"
         defaults.put(AUTOCOMPLETER_LAST_FIRST, Boolean.FALSE); // "Autocomplete names in 'Lastname, Firstname' format only"
         defaults.put(AUTOCOMPLETER_COMPLETE_FIELDS, "author;editor;title;journal;publisher;keywords;crossref;related;entryset");
-        // endregion
-
-        // region workspace
-        defaults.put(MAIN_FONT_SIZE, 9);
-        defaults.put(OVERRIDE_DEFAULT_FONT_SIZE, false);
-        defaults.put(OPEN_LAST_EDITED, Boolean.TRUE);
-        defaults.put(THEME, Theme.BASE_CSS);
-        defaults.put(THEME_SYNC_OS, Boolean.FALSE);
-        defaults.put(CONFIRM_DELETE, Boolean.TRUE);
-        defaults.put(CONFIRM_HIDE_TAB_BAR, Boolean.TRUE);
-        defaults.put(SHOW_ADVANCED_HINTS, Boolean.TRUE);
         // endregion
 
         // region unlinkedFilesDialogPreferences
@@ -427,6 +406,12 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         EasyBind.listen(copyToPreferences.shouldIncludeCrossReferencesProperty(), (obs, oldValue, newValue) -> putBoolean(INCLUDE_CROSS_REFERENCES, newValue));
 
         return copyToPreferences;
+    }
+
+    @Override
+    public void clear() throws BackingStoreException {
+        super.clear();
+        getWorkspacePreferences().reset();
     }
 
     // region EntryEditorPreferences
@@ -641,21 +626,22 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return workspacePreferences;
         }
 
+        WorkspacePreferences defaults = new WorkspacePreferences();
+
         workspacePreferences = new WorkspacePreferences(
                 getLanguage(),
-                getBoolean(OVERRIDE_DEFAULT_FONT_SIZE),
-                getInt(MAIN_FONT_SIZE),
-                (Integer) defaults.get(MAIN_FONT_SIZE),
-                new Theme(get(THEME)),
-                getBoolean(THEME_SYNC_OS),
-                getBoolean(OPEN_LAST_EDITED),
-                getBoolean(SHOW_ADVANCED_HINTS),
-                getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION),
-                getBoolean(CONFIRM_DELETE),
-                getBoolean(CONFIRM_HIDE_TAB_BAR),
-                getStringList(SELECTED_SLR_CATALOGS));
+                getBoolean(WorkspacePreferences.OVERRIDE_DEFAULT_FONT_SIZE, defaults.shouldOverrideDefaultFontSize()),
+                getInt(WorkspacePreferences.MAIN_FONT_SIZE, defaults.getMainFontSize()),
+                new WorkspacePreferences().getDefaultFontSize(),
+                new Theme(get(WorkspacePreferences.THEME, Theme.BASE_CSS)),
+                getBoolean(WorkspacePreferences.THEME_SYNC_OS, defaults.shouldThemeSyncOs()),
+                getBoolean(WorkspacePreferences.OPEN_LAST_EDITED, defaults.shouldOpenLastEdited()),
+                getBoolean(WorkspacePreferences.SHOW_ADVANCED_HINTS, defaults.shouldShowAdvancedHints()),
+                getBoolean(WorkspacePreferences.CONFIRM_DELETE, defaults.shouldConfirmDelete()),
+                getBoolean(WorkspacePreferences.CONFIRM_HIDE_TAB_BAR, defaults.shouldHideTabBar()),
+                getStringList(WorkspacePreferences.SELECTED_SLR_CATALOGS));
 
-        EasyBind.listen(workspacePreferences.languageProperty(), (obs, oldValue, newValue) -> {
+        EasyBind.listen(workspacePreferences.languageProperty(), (_, oldValue, newValue) -> {
             put(LANGUAGE, newValue.getId());
             if (oldValue != newValue) {
                 setLanguageDependentDefaultValues();
@@ -663,17 +649,16 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             }
         });
 
-        EasyBind.listen(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), (obs, oldValue, newValue) -> putBoolean(OVERRIDE_DEFAULT_FONT_SIZE, newValue));
-        EasyBind.listen(workspacePreferences.mainFontSizeProperty(), (obs, oldValue, newValue) -> putInt(MAIN_FONT_SIZE, newValue));
-        EasyBind.listen(workspacePreferences.themeProperty(), (obs, oldValue, newValue) -> put(THEME, newValue.getName()));
-        EasyBind.listen(workspacePreferences.themeSyncOsProperty(), (obs, oldValue, newValue) -> putBoolean(THEME_SYNC_OS, newValue));
-        EasyBind.listen(workspacePreferences.openLastEditedProperty(), (obs, oldValue, newValue) -> putBoolean(OPEN_LAST_EDITED, newValue));
-        EasyBind.listen(workspacePreferences.showAdvancedHintsProperty(), (obs, oldValue, newValue) -> putBoolean(SHOW_ADVANCED_HINTS, newValue));
-        EasyBind.listen(workspacePreferences.warnAboutDuplicatesInInspectionProperty(), (obs, oldValue, newValue) -> putBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION, newValue));
-        EasyBind.listen(workspacePreferences.confirmDeleteProperty(), (obs, oldValue, newValue) -> putBoolean(CONFIRM_DELETE, newValue));
-        EasyBind.listen(workspacePreferences.hideTabBarProperty(), (obs, oldValue, newValue) -> putBoolean(CONFIRM_HIDE_TAB_BAR, newValue));
-        workspacePreferences.getSelectedSlrCatalogs().addListener((ListChangeListener<String>) change ->
-                putStringList(SELECTED_SLR_CATALOGS, workspacePreferences.getSelectedSlrCatalogs()));
+        EasyBind.listen(workspacePreferences.shouldOverrideDefaultFontSizeProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.OVERRIDE_DEFAULT_FONT_SIZE, newValue));
+        EasyBind.listen(workspacePreferences.mainFontSizeProperty(), (_, _, newValue) -> putInt(WorkspacePreferences.MAIN_FONT_SIZE, newValue));
+        EasyBind.listen(workspacePreferences.themeProperty(), (_, _, newValue) -> put(WorkspacePreferences.THEME, newValue.getName()));
+        EasyBind.listen(workspacePreferences.themeSyncOsProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.THEME_SYNC_OS, newValue));
+        EasyBind.listen(workspacePreferences.openLastEditedProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.OPEN_LAST_EDITED, newValue));
+        EasyBind.listen(workspacePreferences.showAdvancedHintsProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.SHOW_ADVANCED_HINTS, newValue));
+        EasyBind.listen(workspacePreferences.confirmDeleteProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.CONFIRM_DELETE, newValue));
+        EasyBind.listen(workspacePreferences.hideTabBarProperty(), (_, _, newValue) -> putBoolean(WorkspacePreferences.CONFIRM_HIDE_TAB_BAR, newValue));
+        workspacePreferences.getSelectedSlrCatalogs().addListener((ListChangeListener<String>) _ ->
+                putStringList(WorkspacePreferences.SELECTED_SLR_CATALOGS, workspacePreferences.getSelectedSlrCatalogs()));
         return workspacePreferences;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTab.java
@@ -13,20 +13,23 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
 import javafx.util.converter.IntegerStringConverter;
 
+import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.StandardActions;
+import org.jabref.gui.frame.UiMessageHandler;
 import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
 import org.jabref.gui.theme.ThemeTypes;
 import org.jabref.gui.util.IconValidationDecorator;
 import org.jabref.gui.util.ViewModelListCellFactory;
+import org.jabref.http.manager.HttpServerManager;
+import org.jabref.languageserver.controller.LanguageServerController;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Language;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.remote.server.RemoteListenerServerManager;
 import org.jabref.model.database.BibDatabaseMode;
-import org.jabref.model.entry.BibEntryTypesManager;
-import org.jabref.model.util.FileUpdateMonitor;
 
 import com.airhacks.afterburner.views.ViewLoader;
 import com.tobiasdiez.easybind.EasyBind;
@@ -34,6 +37,12 @@ import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 import jakarta.inject.Inject;
 
 public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> implements PreferencesTab {
+
+    @Inject private HttpServerManager httpServerManager;
+    @Inject private LanguageServerController languageServerController;
+    @Inject private UiMessageHandler uiMessageHandler;
+    @Inject private RemoteListenerServerManager remoteListenerServerManager;
+    @Inject private StateManager stateManager;
 
     @FXML private ComboBox<Language> language;
     @FXML private ComboBox<ThemeTypes> theme;
@@ -44,7 +53,6 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     @FXML private Spinner<Integer> fontSize;
     @FXML private CheckBox openLastStartup;
     @FXML private CheckBox showAdvancedHints;
-    @FXML private CheckBox inspectionWarningDuplicate;
 
     @FXML private CheckBox confirmDelete;
     @FXML private CheckBox shouldAskForIncludingCrossReferences;
@@ -63,8 +71,6 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     @FXML private CheckBox enableLanguageServer;
     @FXML private TextField languageServerPort;
     @FXML private Button remoteHelp;
-    @Inject private FileUpdateMonitor fileUpdateMonitor;
-    @Inject private BibEntryTypesManager entryTypesManager;
 
     private final ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
 
@@ -90,7 +96,14 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
     }
 
     public void initialize() {
-        this.viewModel = new GeneralTabViewModel(dialogService, preferences, fileUpdateMonitor);
+        this.viewModel = new GeneralTabViewModel(
+                dialogService,
+                preferences,
+                httpServerManager,
+                languageServerController,
+                uiMessageHandler,
+                remoteListenerServerManager,
+                stateManager);
 
         new ViewModelListCellFactory<Language>()
                 .withText(Language::getDisplayName)
@@ -124,7 +137,6 @@ public class GeneralTab extends AbstractPreferenceTabView<GeneralTabViewModel> i
 
         openLastStartup.selectedProperty().bindBidirectional(viewModel.openLastStartupProperty());
         showAdvancedHints.selectedProperty().bindBidirectional(viewModel.showAdvancedHintsProperty());
-        inspectionWarningDuplicate.selectedProperty().bindBidirectional(viewModel.inspectionWarningDuplicateProperty());
         confirmDelete.selectedProperty().bindBidirectional(viewModel.confirmDeleteProperty());
         shouldAskForIncludingCrossReferences.selectedProperty().bindBidirectional(viewModel.shouldAskForIncludingCrossReferences());
         confirmHideTabBar.selectedProperty().bindBidirectional(viewModel.confirmHideTabBarProperty());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/general/GeneralTabViewModel.java
@@ -45,23 +45,17 @@ import org.jabref.logic.remote.server.RemoteListenerServerManager;
 import org.jabref.logic.util.StandardFileType;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.strings.StringUtil;
-import org.jabref.model.util.FileUpdateMonitor;
 
-import com.airhacks.afterburner.injection.Injector;
 import de.saxsys.mvvmfx.utils.validation.CompositeValidator;
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import de.saxsys.mvvmfx.utils.validation.ValidationStatus;
 import de.saxsys.mvvmfx.utils.validation.Validator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     protected static SpinnerValueFactory<Integer> fontSizeValueFactory =
             new SpinnerValueFactory.IntegerSpinnerValueFactory(9, Integer.MAX_VALUE);
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(GeneralTabViewModel.class);
 
     private final ReadOnlyListProperty<Language> languagesListProperty =
             new ReadOnlyListWrapper<>(FXCollections.observableArrayList(Language.getSorted()));
@@ -81,7 +75,6 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     private final BooleanProperty openLastStartupProperty = new SimpleBooleanProperty();
     private final BooleanProperty showAdvancedHintsProperty = new SimpleBooleanProperty();
-    private final BooleanProperty inspectionWarningDuplicateProperty = new SimpleBooleanProperty();
     private final BooleanProperty confirmDeleteProperty = new SimpleBooleanProperty();
     private final BooleanProperty shouldAskForIncludingCrossReferencesProperty = new SimpleBooleanProperty();
     private final BooleanProperty hideTabBarProperty = new SimpleBooleanProperty();
@@ -102,6 +95,11 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
     private final LibraryPreferences libraryPreferences;
     private final FilePreferences filePreferences;
     private final RemotePreferences remotePreferences;
+    private final HttpServerManager httpServerManager;
+    private final LanguageServerController languageServerController;
+    private final UiMessageHandler uiMessageHandler;
+    private final RemoteListenerServerManager remoteListenerServerManager;
+    private final StateManager stateManager;
 
     private final Validator fontSizeValidator;
     private final Validator customPathToThemeValidator;
@@ -118,20 +116,28 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
     private final StringProperty languageServerPortProperty = new SimpleStringProperty("");
     private final TrustStoreManager trustStoreManager;
 
-    private final FileUpdateMonitor fileUpdateMonitor;
-
-    public GeneralTabViewModel(DialogService dialogService, GuiPreferences preferences, FileUpdateMonitor fileUpdateMonitor) {
+    public GeneralTabViewModel(DialogService dialogService,
+                               GuiPreferences preferences,
+                               HttpServerManager httpServerManager,
+                               LanguageServerController languageServerController,
+                               UiMessageHandler uiMessageHandler,
+                               RemoteListenerServerManager remoteListenerServerManager,
+                               StateManager stateManager) {
         this.dialogService = dialogService;
         this.preferences = preferences;
         this.workspacePreferences = preferences.getWorkspacePreferences();
         this.libraryPreferences = preferences.getLibraryPreferences();
         this.filePreferences = preferences.getFilePreferences();
         this.remotePreferences = preferences.getRemotePreferences();
-        this.fileUpdateMonitor = fileUpdateMonitor;
+        this.httpServerManager = httpServerManager;
+        this.languageServerController = languageServerController;
+        this.uiMessageHandler = uiMessageHandler;
+        this.remoteListenerServerManager = remoteListenerServerManager;
+        this.stateManager = stateManager;
 
         fontSizeValidator = new FunctionBasedValidator<>(
                 fontSizeProperty,
-                input -> {
+                _ -> {
                     try {
                         return Integer.parseInt(fontSizeProperty().getValue()) > 8;
                     } catch (NumberFormatException ex) {
@@ -207,7 +213,6 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
         openLastStartupProperty.setValue(workspacePreferences.shouldOpenLastEdited());
         showAdvancedHintsProperty.setValue(workspacePreferences.shouldShowAdvancedHints());
-        inspectionWarningDuplicateProperty.setValue(workspacePreferences.shouldWarnAboutDuplicatesInInspection());
 
         confirmDeleteProperty.setValue(workspacePreferences.shouldConfirmDelete());
         shouldAskForIncludingCrossReferencesProperty.setValue(preferences.getCopyToPreferences().getShouldAskForIncludingCrossReferences());
@@ -257,7 +262,6 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
         workspacePreferences.setOpenLastEdited(openLastStartupProperty.getValue());
         workspacePreferences.setShowAdvancedHints(showAdvancedHintsProperty.getValue());
-        workspacePreferences.setWarnAboutDuplicatesInInspection(inspectionWarningDuplicateProperty.getValue());
 
         workspacePreferences.setConfirmDelete(confirmDeleteProperty.getValue());
         preferences.getCopyToPreferences().setShouldAskForIncludingCrossReferences(shouldAskForIncludingCrossReferencesProperty.getValue());
@@ -284,8 +288,6 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
             }
         });
 
-        UiMessageHandler uiMessageHandler = Injector.instantiateModelOrService(UiMessageHandler.class);
-        RemoteListenerServerManager remoteListenerServerManager = Injector.instantiateModelOrService(RemoteListenerServerManager.class);
         // stop in all cases, because the port might have changed
         remoteListenerServerManager.stop();
         if (remoteServerProperty.getValue()) {
@@ -310,19 +312,17 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
             }
         });
 
-        HttpServerManager httpServerManager = Injector.instantiateModelOrService(HttpServerManager.class);
         // stop in all cases, because the port might have changed
         httpServerManager.stop();
         if (enableHttpServerProperty.getValue()) {
             remotePreferences.setEnableHttpServer(true);
             URI uri = remotePreferences.getHttpServerUri();
-            httpServerManager.start(Injector.instantiateModelOrService(StateManager.class), uri);
+            httpServerManager.start(stateManager, uri);
         } else {
             remotePreferences.setEnableHttpServer(false);
             httpServerManager.stop();
         }
 
-        LanguageServerController languageServerController = Injector.instantiateModelOrService(LanguageServerController.class);
         // stop in all cases, because the port might have changed (or other settings that can't be easily tracked https://github.com/JabRef/jabref/pull/13697#discussion_r2285997003)
         languageServerController.stop();
         if (enableLanguageServerProperty.getValue()) {
@@ -433,10 +433,6 @@ public class GeneralTabViewModel implements PreferenceTabViewModel {
 
     public BooleanProperty showAdvancedHintsProperty() {
         return this.showAdvancedHintsProperty;
-    }
-
-    public BooleanProperty inspectionWarningDuplicateProperty() {
-        return this.inspectionWarningDuplicateProperty;
     }
 
     public BooleanProperty confirmDeleteProperty() {

--- a/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/jabgui/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import javafx.scene.control.TableColumn;
 
+import org.jabref.gui.WorkspacePreferences;
 import org.jabref.gui.entryeditor.CommentsTab;
 import org.jabref.gui.maintable.ColumnPreferences;
 import org.jabref.gui.maintable.MainTableColumnModel;
@@ -477,9 +478,9 @@ public class PreferencesMigrations {
         try {
             // some versions stored the font size as double to the **same** key
             // since the preference store is type-safe, we need to add this workaround
-            String fontSizeAsString = preferences.get(JabRefGuiPreferences.MAIN_FONT_SIZE);
+            String fontSizeAsString = preferences.get(WorkspacePreferences.MAIN_FONT_SIZE);
             int fontSizeAsInt = (int) Math.round(Double.parseDouble(fontSizeAsString));
-            preferences.putInt(JabRefGuiPreferences.MAIN_FONT_SIZE, fontSizeAsInt);
+            preferences.putInt(WorkspacePreferences.MAIN_FONT_SIZE, fontSizeAsInt);
         } catch (ClassCastException e) {
             // already an integer
         }

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/general/GeneralTab.fxml
@@ -62,14 +62,12 @@
         </HBox>
     </GridPane>
 
-    <Hyperlink fx:id="moreThemes" text = "%Get more themes..." onAction="#openBrowser"/>
+    <Hyperlink text = "%Get more themes..." onAction="#openBrowser"/>
 
     <Label styleClass="sectionHeader" text="%User interface"/>
     <CheckBox fx:id="openLastStartup" text="%Open last edited libraries on startup"/>
     <CheckBox fx:id="showAdvancedHints"
               text="%Show advanced hints (i.e. helpful tooltips, suggestions and explanation)"/>
-    <CheckBox fx:id="inspectionWarningDuplicate"
-              text="%Warn about unresolved duplicates when closing inspection window"/>
 
     <CheckBox fx:id="confirmDelete" text="%Show confirmation dialog when deleting entries"/>
     <CheckBox fx:id="shouldAskForIncludingCrossReferences" text="%Ask whether to include cross-references when copying to another library"/>

--- a/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
+++ b/jabgui/src/test/java/org/jabref/migrations/GuiPreferencesMigrationsTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.prefs.Preferences;
 
+import org.jabref.gui.WorkspacePreferences;
 import org.jabref.gui.preferences.JabRefGuiPreferences;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.preferences.JabRefCliPreferences;
@@ -187,7 +188,7 @@ class GuiPreferencesMigrationsTest {
 
         when(preferences.getStringList("columnNames")).thenReturn(updatedNames);
 
-        when(preferences.get(JabRefGuiPreferences.MAIN_FONT_SIZE)).thenReturn("11.2");
+        when(preferences.get(WorkspacePreferences.MAIN_FONT_SIZE)).thenReturn("11.2");
 
         PreferencesMigrations.restoreVariablesForBackwardCompatibility(preferences);
 
@@ -196,7 +197,7 @@ class GuiPreferencesMigrationsTest {
         verify(preferences).put("columnSortTypes", "");
         verify(preferences).put("columnSortOrder", "");
 
-        verify(preferences).putInt(JabRefGuiPreferences.MAIN_FONT_SIZE, 11);
+        verify(preferences).putInt(WorkspacePreferences.MAIN_FONT_SIZE, 11);
     }
 
     @Test

--- a/jablib/src/main/java/org/jabref/logic/l10n/Language.java
+++ b/jablib/src/main/java/org/jabref/logic/l10n/Language.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Contains all supported languages.
@@ -65,6 +66,13 @@ public enum Language {
         }
 
         return Optional.of(locale);
+    }
+
+    public static Language getLanguageFor(String languageString) {
+        return Stream.of(Language.values())
+                     .filter(language -> language.getId().equalsIgnoreCase(languageString))
+                     .findFirst()
+                     .orElse(Language.ENGLISH);
     }
 
     public String getDisplayName() {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -24,7 +24,6 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
@@ -142,7 +141,6 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 public class JabRefCliPreferences implements CliPreferences {
-
     public static final String LANGUAGE = "language";
 
     public static final String BIBLATEX_DEFAULT_MODE = "biblatexMode";
@@ -958,12 +956,16 @@ public class JabRefCliPreferences implements CliPreferences {
         return prefs.getInt(key, getIntDefault(key));
     }
 
-    public double getDouble(String key) {
-        return prefs.getDouble(key, getDoubleDefault(key));
+    public int getInt(String key, int def) {
+        return prefs.getInt(key, def);
     }
 
     public int getIntDefault(String key) {
         return (Integer) defaults.get(key);
+    }
+
+    public double getDouble(String key) {
+        return prefs.getDouble(key, getDoubleDefault(key));
     }
 
     private double getDoubleDefault(String key) {
@@ -1656,10 +1658,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     protected Language getLanguage() {
-        return Stream.of(Language.values())
-                     .filter(language -> language.getId().equalsIgnoreCase(get(LANGUAGE)))
-                     .findFirst()
-                     .orElse(Language.ENGLISH);
+        return Language.getLanguageFor(get(LANGUAGE));
     }
 
     @Override


### PR DESCRIPTION
Refs #12655 (Importing into a present, observable and mutable preferences object)

Refs #10177 (Cleaning up dependencies to prefs)
Refs #12990 (Cleaning up JabRefGuiPreferences / JabRefCliPreferences
Follow up to #10002

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
