### PR TITLE
Enable JMX connection

### DIFF
--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -138,6 +138,7 @@ application {
         // https://github.com/uncomplicate/neanderthal/issues/55
         "--add-opens", "java.base/jdk.internal.ref=org.apache.pdfbox.io",
         "--add-modules", "jdk.incubator.vector",
+        "--add-modules", "jdk.management.agent",
 
         "-XX:+UnlockExperimentalVMOptions",
         "-XX:+UseCompactObjectHeaders",
@@ -162,6 +163,7 @@ javaModulePackaging {
     jpackageResources = layout.projectDirectory.dir("buildres")
     verbose = true
     addModules.add("jdk.incubator.vector")
+    addModules.add("jdk.management.agent")
     targetsWithOs("windows") {
         options.addAll(
             "--win-upgrade-uuid", "d636b4ee-6f10-451e-bf57-c89656780e36",

--- a/jabgui/build.gradle.kts
+++ b/jabgui/build.gradle.kts
@@ -143,7 +143,11 @@ application {
         "-XX:+UseCompactObjectHeaders",
         "-XX:+UseZGC",
         "-XX:+ZUncommit",
-        "-XX:+UseStringDeduplication"
+        "-XX:+UseStringDeduplication",
+        "-Dcom.sun.management.jmxremote",
+        "-Dcom.sun.management.jmxremote.port=54219",
+        "-Dcom.sun.management.jmxremote.ssl=false",
+        "-Dcom.sun.management.jmxremote.authenticate=false"
     )
 }
 


### PR DESCRIPTION
This enables profiling and monitoring JabRef production builds using tools supporting JMX such as VisualVM and JConsole.

This PR is never meant to be merged, but to provide a JMX-enabled build (we have a pipeline for building and deploying code in PRs labeled with dev: binaries) for users to use for profiling JabRef performance or memory usage.

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
