### PR TITLE
Do not show transport info messages

### DIFF
--- a/jabgui/src/main/resources/tinylog.properties
+++ b/jabgui/src/main/resources/tinylog.properties
@@ -13,6 +13,7 @@ level@org.apache.fontbox.util.autodetect.FontFileFinder = warn
 level@org.apache.fontbox.ttf = warn
 level@ai.djl = info
 level@io.zonky.test.db.postgres.embedded = warn
+level@org.freedesktop.dbus.connections.transports.TransportBuilder = warn
 
 #level@org.jabref.gui.JabRefGUI = debug
 


### PR DESCRIPTION
On CachyOS, Gnome, I get > 10 messages on start

```
2025-09-14 17:42:22 [JavaFX Application Thread] org.freedesktop.dbus.connections.transports.TransportBuilder.build()
INFO: Using transport dbus-java-transport-native-unixsocket to connect to unix:path=/run/user/1000/bus
```

With this PR, they are gone.

Maybe they are a hint that we open the key manager too often? (Wrong lifecycle?)

<img width="800" height="1607" alt="image" src="https://github.com/user-attachments/assets/8093a5cd-18a5-4c4e-af66-d065fbe9941c" />

### Steps to test

Start JabRef on Gnome ^^

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
