### PR TITLE
fix: Tab bar tabs not visible

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -460,7 +460,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
         // Hide tab bar
         stateManager.getOpenDatabases().addListener((ListChangeListener<BibDatabaseContext>) _ -> updateTabBarVisible());
-        EasyBind.subscribe(preferences.getWorkspacePreferences().hideTabBarProperty(), _ -> updateTabBarVisible());
+        tabbedPane.getTabs().addListener((ListChangeListener<Tab>) _ -> updateTabBarVisible());
 
         stateManager.canGoBackProperty().bind(
                 stateManager.activeTabProperty().flatMap(


### PR DESCRIPTION
Closes #13897

### Steps to test

Open JabRef, then open an arbitrary library of your choice, then go to Help > Welcome Tab. You should see that the title bar is visible whenever you have both welcome tab and a library open.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
