### PR TITLE
[WIP] Update to JDK25 (Amazon)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,9 +31,9 @@
         // Install java.
         // See https://github.com/devcontainers/features/tree/main/src/java#options for details.
         "ghcr.io/devcontainers/features/java:1": {
-            "version": "24.0.2-amzn",
+            "version": "latest",
             "installGradle": true,
-            "gradleVersion": "8.14.3",
+            "gradleVersion": "latest",
             "jdkDistro": "Corretto"
         }
     }

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle

--- a/.github/workflows/run-openrewrite.yml
+++ b/.github/workflows/run-openrewrite.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle

--- a/.github/workflows/sbom-pr.yml
+++ b/.github/workflows/sbom-pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '24'
+          java-version: 25
           check-latest: true
           cache: 'gradle'
 

--- a/.github/workflows/tests-code-fetchers.yml
+++ b/.github/workflows/tests-code-fetchers.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Run checkstyle reporter
@@ -92,7 +92,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -139,7 +139,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -257,7 +257,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -293,7 +293,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Generate JBang cache key
@@ -342,7 +342,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -392,7 +392,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -441,7 +441,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Generate JBang cache key
@@ -482,7 +482,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Generate JBang cache key
@@ -559,7 +559,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle
@@ -605,7 +605,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 24
+          java-version: 25
           distribution: 'corretto'
           check-latest: true
       - name: Setup Gradle

--- a/.moderne/moderne.yml
+++ b/.moderne/moderne.yml
@@ -1,3 +1,3 @@
 specs: specs.moderne.ai/v1/cli
 java:
-  selectedJdk: '24'
+  selectedJdk: '25'

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,2 @@
-java=24.0.2-amzn
+java=25-amzn
 #visualvm=2.1.10

--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.compile.gradle.kts
@@ -12,10 +12,9 @@ java {
         // - .github/workflows/binaries*.yml
         // - .github/workflows/publish.yml
         // - .github/workflows/tests*.yml
-        // - .github/workflows/update-gradle-wrapper.yml
         // - docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
         // - .sdkmanrc
-        languageVersion = JavaLanguageVersion.of(24)
+        languageVersion = JavaLanguageVersion.of(25)
         // See https://docs.gradle.org/current/javadoc/org/gradle/jvm/toolchain/JvmVendorSpec.html for a full list
         // Temurin does not ship jmods, thus we need to use another JDK -- see https://github.com/actions/setup-java/issues/804
         // We also need a JDK without JavaFX, because we patch JavaFX due to modularity issues
@@ -24,5 +23,5 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 24
+    options.release = 25
 }

--- a/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
+++ b/docs/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.md
@@ -33,13 +33,13 @@ Go to "File > Project Structure" or press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>
 ![Open Project Structure](12-02-open-project-settings.png)
 {% endfigure %}
 
-Click on "Project" on the left side. Then, select **temurin-24** as the project SDK (continue reading if this option is not available).
+Click on "Project" on the left side. Then, select **temurin-25** as the project SDK (continue reading if this option is not available).
 
 {% figure caption:"Project Structure - Project SDK" %}
 ![Project Structure - Project SDK](12-03-project-sdk.png)
 {% endfigure %}
 
-If you do not have the access to this JDK, download it by clicking on "Download JDK..." In the dialog that opens, select version 24, vendor "Eclipse Temurin (AdoptOpenJDK HotSpot)", and click "Download".
+If you do not have the access to this JDK, download it by clicking on "Download JDK..." In the dialog that opens, select version 25, vendor "Eclipse Temurin (AdoptOpenJDK HotSpot)", and click "Download".
 
 {% figure caption:"Dropdown to select Download JDK" %}
 ![Dropdown to select Download JDK](12-04-download-jdk.png)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 jdk:
-  - openjdk24
+  - openjdk25
 install:
   - ./gradlew :versions:publishToMavenLocal
   - ./gradlew :jablib:publishToMavenLocal


### PR DESCRIPTION
Eclipse Temurin's binaries should soon be available:

<img width="538" height="126" alt="image" src="https://github.com/user-attachments/assets/1d5afc87-2e09-4262-b20c-95b5f83439d3" />

WIP, because Temurin is not yet available. AKA blocked by https://github.com/adoptium/temurin/issues/96.

Hopefully, we can go back to Temurin (refs https://github.com/adoptium/adoptium-support/issues/1271#issuecomment-3155899373 and https://github.com/JabRef/jabref/pull/13749

Uses "latest" for the dev container to reduce the places where we need to adapt version numbers.

Refs  https://github.com/JabRef/jabref/pull/13933

### Steps to test

Run JabRef 😅

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
