### PR TITLE
Fix gitignore not working for subdir patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where hierarchical keywords would only show the parent keyword in the entry editor. [#11390](https://github.com/JabRef/jabref/issues/11390)
 - We fixed an issue where some file choosers regarding LaTeX-aux files did not open in the directory of the last selected file. [#13861](https://github.com/JabRef/jabref/pull/13861)
 - We fixed an issue where the LaTeX file directory was not stored correctly in combination with the usage of groups from aux files. [#8344](https://github.com/JabRef/jabref/issues/8344)
+- We fixed an issue where ignoring of subdirectories via `.gitingore` patterns did not work in the "Find unlinked files dialog". [forum#5425](https://discourse.jabref.org/t/set-list-of-ignored-folders-paths/5425/6)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/GitIgnoreFileFilter.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/GitIgnoreFileFilter.java
@@ -6,9 +6,9 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +19,8 @@ public class GitIgnoreFileFilter implements DirectoryStream.Filter<Path> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitIgnoreFileFilter.class);
 
-    private Set<PathMatcher> gitIgnorePatterns;
+    private final Set<PathMatcher> gitIgnorePatterns;
+    private final Path baseDir;
 
     public GitIgnoreFileFilter(Path path) {
         Path currentPath = path;
@@ -27,40 +28,61 @@ public class GitIgnoreFileFilter implements DirectoryStream.Filter<Path> {
             currentPath = currentPath.getParent();
         }
         if (currentPath == null) {
-            // we did not find any gitignore, lets use the default
+            // we did not find any gitignore, set baseDir to provided path and use default ignores
+            this.baseDir = path;
             gitIgnorePatterns = Set.of(".git", ".DS_Store", "desktop.ini", "Thumbs.db").stream()
                                    // duplicate code as below
                                    .map(line -> "glob:" + line)
                                    .map(matcherString -> FileSystems.getDefault().getPathMatcher(matcherString))
                                    .collect(Collectors.toSet());
         } else {
+            this.baseDir = currentPath;
             Path gitIgnore = currentPath.resolve(".gitignore");
+            Set<PathMatcher> patterns;
             try {
-                Set<PathMatcher> plainGitIgnorePatternsFromGitIgnoreFile = Files.readAllLines(gitIgnore).stream()
-                                                                                .map(String::trim)
-                                                                                .filter(not(String::isEmpty))
-                                                                                .filter(line -> !line.startsWith("#"))
-                                                                                // convert to Java syntax for Glob patterns
-                                                                                .map(line -> "glob:" + line)
-                                                                                .map(matcherString -> FileSystems.getDefault().getPathMatcher(matcherString))
-                                                                                .collect(Collectors.toSet());
-                gitIgnorePatterns = new HashSet<>(plainGitIgnorePatternsFromGitIgnoreFile);
+                patterns = Files.readAllLines(gitIgnore).stream()
+                                .map(String::trim)
+                                .filter(not(String::isEmpty))
+                                .filter(line -> !line.startsWith("#"))
+                                // expand patterns so that leading "**/" also matches files in the base directory
+                                .flatMap(line -> {
+                                    if (line.startsWith("**/")) {
+                                        return Stream.of(line, line.substring(3));
+                                    }
+                                    return Stream.of(line);
+                                })
+                                // convert to Java syntax for Glob patterns
+                                .map(line -> "glob:" + line)
+                                .map(matcherString -> FileSystems.getDefault().getPathMatcher(matcherString))
+                                .collect(Collectors.toSet());
                 // we want to ignore ".gitignore" itself
-                gitIgnorePatterns.add(FileSystems.getDefault().getPathMatcher("glob:.gitignore"));
+                patterns.add(FileSystems.getDefault().getPathMatcher("glob:.gitignore"));
             } catch (IOException e) {
                 LOGGER.info("Could not read .gitignore from {}", gitIgnore, e);
-                gitIgnorePatterns = Set.of();
+                patterns = Set.of();
             }
+            gitIgnorePatterns = patterns;
         }
     }
 
     @Override
     public boolean accept(Path path) throws IOException {
-        // We assume that git does not stop at a patern, but tries all. We implement that behavior
+        // Match patterns relative to baseDir because .gitignore patterns are applied relative to their location
+        Path relative = safeRelativize(baseDir, path);
+        // We assume that git does not stop at a pattern, but tries all. We implement that behavior
         return gitIgnorePatterns.stream().noneMatch(filter ->
-                // we need this one for "*.png"
-                filter.matches(path.getFileName()) ||
-                        // we need this one for "**/*.png"
-                        filter.matches(path));
+                // for patterns like "*.png" or ".gitignore"
+                filter.matches(relative.getFileName()) ||
+                        // for patterns like "ignore/*" or "**/*.png"
+                        filter.matches(relative));
+    }
+
+    private static Path safeRelativize(Path base, Path child) {
+        try {
+            return base.relativize(child);
+        } catch (IllegalArgumentException e) {
+            // If paths are on different roots, fall back to just the file name for relative matching
+            return child.getFileName();
+        }
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/GitIgnoreFileFilterTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/GitIgnoreFileFilterTest.java
@@ -48,4 +48,20 @@ class GitIgnoreFileFilterTest {
         GitIgnoreFileFilter gitIgnoreFileFilter = new GitIgnoreFileFilter(dir);
         assertFalse(gitIgnoreFileFilter.accept(dir.resolve("test.png")));
     }
+
+    @Test
+    void checkDirectoryGitIgnoreSubDir(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve(".gitignore"), """
+                ignore/.*
+                ignore/*
+                ignore/**
+                ignore/**/*
+                """);
+        Path subDir = dir.resolve("ignore");
+        Files.createDirectories(subDir);
+        Files.createFile(subDir.resolve("test.png"));
+        GitIgnoreFileFilter gitIgnoreFileFilter = new GitIgnoreFileFilter(dir);
+        assertFalse(gitIgnoreFileFilter.accept(subDir.resolve("test.png")));
+
+    }
 }

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/GitIgnoreFileFilterTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/GitIgnoreFileFilterTest.java
@@ -62,6 +62,5 @@ class GitIgnoreFileFilterTest {
         Files.createFile(subDir.resolve("test.png"));
         GitIgnoreFileFilter gitIgnoreFileFilter = new GitIgnoreFileFilter(dir);
         assertFalse(gitIgnoreFileFilter.accept(subDir.resolve("test.png")));
-
     }
 }


### PR DESCRIPTION
Fixes https://discourse.jabref.org/t/set-list-of-ignored-folders-paths/5425/6?u=siedlerchr

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
