### PR TITLE
Refine workflows

### DIFF
--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -13,7 +13,7 @@ jobs:
       (github.repository == 'JabRef/jabref') &&
       (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
       !(
-        (github.actor == 'dependabot[bot]') ||
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
         (
           startsWith(github.event.pull_request.title, '[Bot] ') ||
           startsWith(github.event.pull_request.title, 'Bump ') ||

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   changelog_modification_consistency:
     name: CHANGELOG.md needs to be modified if indicated
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: (github.actor != 'dependabot[bot]') && (github.actor != 'renovate-bot')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -1,0 +1,80 @@
+name: Check PR CHANGELOG.md
+
+# Seperate check PR, because of triggers both at code update and at comment update
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changelog_modification_consistency:
+    name: CHANGELOG.md needs to be modified if indicated
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Check PR body for changelog note
+        id: changelog_check
+        run: |
+          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
+          echo "Body: $BODY"
+
+          if echo "$BODY" | grep -q '\- \[x\] Change in `CHANGELOG.md`'; then
+            echo "found"
+            echo "found=yes" >> $GITHUB_OUTPUT
+          else
+            echo "not found"
+            echo "found=no" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: CHANGELOG.md modified
+        id: changelog_modified
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            CHANGELOG.md
+      - name: Check for CHANGELOG.md modifications
+        id: check_changelog_modification
+        run: |
+          set -euo pipefail
+          found="${{ steps.changelog_check.outputs.found }}"
+          any_changed="${{ steps.changelog_modified.outputs.any_changed }}"
+
+          echo "found=${found}"
+          echo "any_changed=${any_changed}"
+
+          if [[ "${any_changed}" == "true" && "${found}" != "yes" ]]; then
+            echo "❌ CHANGELOG.md modified, but not indicated in checklist"
+            exit 1
+          fi
+
+          if [[ "${any_changed}" != "true" && "${found}" == "yes" ]]; then
+            echo "❌ CHANGELOG.md NOT modified, but indicated in checklist"
+            exit 1
+          fi
+
+          if [[ "${any_changed}" == "true" && "${found}" == "yes" ]]; then
+            echo "✅ CHANGELOG.md was modified and indicated in checklist"
+          else
+            echo "✅ CHANGELOG.md was NOT modified and NOT indicated in checklist"
+          fi
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,7 +8,7 @@ name: Comment on PR
 on:
   workflow_run:
     # note when updating via a PR and testing - `workflow_run` executes from the `main` branch and not the PR branch
-    workflows: ["Source Code Tests", "On PR opened/updated", "PR Tests", "PR Format"]
+    workflows: ["Source Code Tests", "On PR opened/updated", "Check PR Format", "Check PR Modifications", "Check PR CHANGELOG.md"]
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
     types: [completed]
   workflow_dispatch:
@@ -33,6 +33,7 @@ jobs:
       - name: Download PR number
         if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/download-artifact@v5
+        continue-on-error: true
         with:
           name: pr_number
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +43,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: read-pr_number
         run: |
+          touch pr_number.txt
           PR_NUMBER=$(cat pr_number.txt)
           echo "Read PR number $PR_NUMBER"
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -10,7 +10,17 @@ permissions:
 jobs:
   check_title_format:
     name: PR title must not contain "issue <number>"
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -34,8 +44,9 @@ jobs:
 
   mandatory-checks-section-exists:
     if: >
-      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') && !(
-        (github.actor == 'dependabot[bot]') ||
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
         (
           startsWith(github.event.pull_request.title, '[Bot] ') ||
           startsWith(github.event.pull_request.title, 'Bump ') ||
@@ -72,7 +83,7 @@ jobs:
     if: >
       (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
       !(
-        (github.actor == 'dependabot[bot]') ||
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
         (
           startsWith(github.event.pull_request.title, '[Bot] ') ||
           startsWith(github.event.pull_request.title, 'Bump ') ||

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -1,4 +1,4 @@
-name: PR Format
+name: Check PR Format
 
 on:
   pull_request:
@@ -122,3 +122,13 @@ jobs:
           echo "✅ All checkboxes are present and in the correct format."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt

--- a/.github/workflows/pr-modifications.yml
+++ b/.github/workflows/pr-modifications.yml
@@ -1,4 +1,4 @@
-name: PR Tests
+name: Check PR Modifications
 
 on:
   pull_request:
@@ -12,51 +12,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  upload-pr-number:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create pr_number.txt
-        run: echo "${{ github.event.number }}" > pr_number.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr_number
-          path: pr_number.txt
-
-  changelog_modified:
-    name: CHANGELOG.md needs to be modified
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Check PR body for changelog note
-        id: changelog_check
-        run: |
-          BODY=$(gh pr view "${{ github.event.number }}" --json body --template '{{.body}}')
-          echo "Body: $BODY"
-
-          if echo "$BODY" | grep -q '\- \[x\] Change in `CHANGELOG.md`'; then
-            echo "found"
-            echo "found=yes" >> $GITHUB_OUTPUT
-          else
-            echo "not found"
-            echo "found=no" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check for CHANGELOG.md modifications
-        id: check_changelog_modification
-        if: steps.changelog_check.outputs.found == 'yes'
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^CHANGELOG\.md$'; then
-            echo "✅ CHANGELOG.md was modified"
-          else
-            echo "❌ CHANGELOG.md was NOT modified"
-            exit 1
-          fi
-
   # This ensures that no git merge conflict markers (<<<, ...) are contained
   merge_conflict_job:
     name: Find merge conflicts
@@ -122,3 +77,14 @@ jobs:
         with:
           script: |
               core.setFailed('Pull requests should come from a branch other than "main"\n\n👉 Please read [the CONTRIBUTING guide](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md#contributing) carefully again. 👈')
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+

--- a/.github/workflows/pr-modifications.yml
+++ b/.github/workflows/pr-modifications.yml
@@ -15,7 +15,17 @@ jobs:
   # This ensures that no git merge conflict markers (<<<, ...) are contained
   merge_conflict_job:
     name: Find merge conflicts
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -25,7 +35,17 @@ jobs:
         uses: olivernybroe/action-conflict-finder@v4.1
 
   no-force-push:
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -49,7 +69,7 @@ jobs:
 
   unmodified_submodules:
     name: Submodules not modified
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       # No checkout -> the action uses GitHub's API (which is more reliable for submodule changes due to our submodule settings)
@@ -69,7 +89,17 @@ jobs:
 
   other_than_main:
     name: Source branch is other than "main"
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name != 'JabRef/jabref'
+    if: >
+      (github.event.pull_request.head.repo.full_name != 'JabRef/jabref') &&
+      !(
+        (github.actor == 'dependabot[bot]') || (github.actor != 'renovate-bot') ||
+        (
+          startsWith(github.event.pull_request.title, '[Bot] ') ||
+          startsWith(github.event.pull_request.title, 'Bump ') ||
+          startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
+          startsWith(github.event.pull_request.title, 'Update Gradle Wrapper from')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - if: github.head_ref == 'main'

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   upload-pr-number:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Create pr_number.txt


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13850

- Rename workflow file for better grouping
- Factors out CHANGELOG.md modification check, because needs to be checked on both PR comment edit and PR content change
- Fix forgotten upload of PR number
- Add check for not uploading PR number if no PR
- Fix "pr-commentyml" to raise no error on main branch


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
