### PR TITLE
Fix committed idea config

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,8 +2,12 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/abbrv.jabref.org" vcs="" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/resources/csl-locales" vcs="" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/resources/csl-styles" vcs="" />
   </component>
+    <component name="VcsProjectSettings">
+        <option name="detectVcsMappingsAutomatically" value="false" />
+    </component>
 </project>


### PR DESCRIPTION
Follow up to #13913

### Steps to test

Open IntelliJ, look for automatically changed vcs.xml, should not be
Open Settings > Directory Mappings: 

<img width="1004" height="300" alt="grafik" src="https://github.com/user-attachments/assets/508ba903-3a15-4b30-91ce-3ef3f7dad30e" />

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
