### PR TITLE
fix(feat): Apply secure DocumentBuilderFactory / XMLInputFactory settings across import modules

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.XMLConstants;
 
 import org.jabref.logic.cleanup.EprintCleanup;
 import org.jabref.logic.help.HelpFile;
@@ -554,7 +555,14 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
             }
 
             try {
-                DocumentBuilder builder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+                DocumentBuilderFactory secureFactory = DocumentBuilderFactory.newInstance();
+                // Prevent XXE (XML External Entity) attacks
+                secureFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                secureFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                secureFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                secureFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                secureFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                DocumentBuilder builder = secureFactory.newDocumentBuilder();
 
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 if (connection.getResponseCode() == 400) {

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java
@@ -35,7 +35,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-
+import javax.xml.XMLConstants;
 /**
  * Fetcher for <a href="https://isidore.science">ISIDORE</a>```
  * Will take in the link to the website or the last six digits that identify the reference
@@ -47,8 +47,30 @@ public class ISIDOREFetcher implements PagedSearchBasedParserFetcher {
 
     private static final String SOURCE_WEB_SEARCH = "https://api.isidore.science/resource/search";
 
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
-
+    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
+    static {
+        DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (ParserConfigurationException e) {
+            LOGGER.warn("Could not disable DOCTYPE declarations on XML parser", e);
+        }
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        } catch (ParserConfigurationException e) {
+            LOGGER.warn("Could not disable external general entities on XML parser", e);
+        }
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        } catch (ParserConfigurationException e) {
+            LOGGER.warn("Could not disable external parameter entities on XML parser", e);
+        }
+        try {
+            DOCUMENT_BUILDER_FACTORY.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException e) {
+            LOGGER.warn("Could not enable secure processing on XML parser", e);
+        }
+    }
     @Override
     public Parser getParser() {
         return xmlData -> {

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
+import javax.xml.XMLConstants;
 import org.jabref.logic.importer.AuthorListParser;
 import org.jabref.logic.importer.ParseException;
 import org.jabref.logic.importer.Parser;
@@ -51,8 +51,22 @@ import org.xml.sax.SAXException;
 ///
 public class MarcXmlParser implements Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(MarcXmlParser.class);
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
-
+    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
+    static {
+        DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        try {
+            // This will completely disable DTDs and external entity expansion:
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            DOCUMENT_BUILDER_FACTORY.setXIncludeAware(false);
+            DOCUMENT_BUILDER_FACTORY.setExpandEntityReferences(false);
+        } catch (ParserConfigurationException ex) {
+            // In case of failure, log and proceed (safe fail)
+            LOGGER.error("Failed to configure XML parser securely in MarcXmlParser", ex);
+        }
+    }
     @Override
     public List<BibEntry> parseEntries(InputStream inputStream) throws ParseException {
         try {

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -65,7 +65,9 @@ public class MedlineImporter extends Importer implements Parser {
         xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
         // TODO: decide if necessary, if disabled MedlineImporterTestNbib fails
         xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
-        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, true);
+        // Prevent XXE attacks: disable external entity processing and DTD support
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java
@@ -58,10 +58,14 @@ public class ModsImporter extends Importer implements Parser {
     public ModsImporter(ImportFormatPreferences importFormatPreferences) {
         keywordSeparator = importFormatPreferences.bibEntryPreferences().getKeywordSeparator() + " ";
         xmlInputFactory = XMLInputFactory.newInstance();
-        // prevent xxe (https://rules.sonarsource.com/java/RSPEC-2755)
-        // Not supported by aalto-xml
-        // xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        // xmlInputFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        // Prevent XXE by disabling external entities and DTDs
+        try {
+            xmlInputFactory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+            xmlInputFactory.setProperty("javax.xml.stream.supportDTD", false);
+        } catch (IllegalArgumentException e) {
+            // The XMLInputFactory implementation does not support these properties; log but continue
+            LOGGER.warn("Cannot disable external entities or DTD for XMLInputFactory: {}", e.getMessage());
+        }
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java
@@ -29,6 +29,19 @@ import org.xml.sax.SAXException;
 public class PicaXmlParser implements Parser {
     private static final Logger LOGGER = LoggerFactory.getLogger(PicaXmlParser.class);
     private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+    static {
+        try {
+            // This prevents XXE
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setExpandEntityReferences(false);
+            // Optionally, disable XInclude
+            DOCUMENT_BUILDER_FACTORY.setXIncludeAware(false);
+        } catch (ParserConfigurationException e) {
+            throw new ExceptionInInitializerError("Failed to securely configure XML parser for PicaXmlParser: " + e.getMessage());
+        }
+    }
 
     @Override
     public List<BibEntry> parseEntries(InputStream inputStream) throws ParseException {


### PR DESCRIPTION
Multiple XML parser usages in JabRef do not disable DTDs and external entity resolution. This exposes the application to XML External Entity (XXE) attacks and related threats (sensitive file disclosure, SSRF, or arbitrary URL access). This PR hardens parser factory initializations by disabling DOCTYPEs and external entity resolution and enabling secure processing where appropriate.



All fixes are limited to factory initialization and parser configuration. No parsing logic is changed.

1. **`PicaXmlParser.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fileformat/PicaXmlParser.java` (static `DOCUMENT_BUILDER_FACTORY`)
   * **Fix:** Configure `DocumentBuilderFactory` at initialization to disallow DOCTYPEs and external entities.

2. **`MedlineImporter.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fileformat/MedlineImporter.java` (StAX `XMLInputFactory`)
   * **Fix:** Set `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES = false` and `XMLInputFactory.SUPPORT_DTD = false` in the constructor; remove any code that enables external entities.

3. **`MarcXmlParser.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java` (static `DOCUMENT_BUILDER_FACTORY`)
   * **Fix:** Harden factory as in PicaXmlParser (disallow DOCTYPE, disable external entities, secure processing).

4. **`ISIDOREFetcher.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fetcher/ISIDOREFetcher.java` (static factory)
   * **Fix:** Configure `DOCUMENT_BUILDER_FACTORY` with secure features in static initialization block.

5. **`ArXivFetcher.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java` (uses `DOCUMENT_BUILDER_FACTORY`)
   * **Fix:** Prefer global hardened factory; if constrained to this file, initialize a local factory with secure features for `callApi()`.

6. **`ModsImporter.java`**

   * **Location:** `jablib/src/main/java/org/jabref/logic/importer/fileformat/ModsImporter.java` (StAX `XMLInputFactory`)
   * **Fix:** After `XMLInputFactory.newInstance()`, set `isSupportingExternalEntities=false` and `supportDTD=false`.



## Detailed recommended changes 
### DocumentBuilderFactory — recommended initialization (apply where `DOCUMENT_BUILDER_FACTORY` is created)

Add immediately after factory creation (static init / helper):

```java
import javax.xml.XMLConstants;
import javax.xml.parsers.DocumentBuilderFactory;
import javax.xml.parsers.ParserConfigurationException;

private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = createSecureDocumentBuilderFactory();

private static DocumentBuilderFactory createSecureDocumentBuilderFactory() {
    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
    try {
        // Disallow DOCTYPE
        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
        // Disable external entities
        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
        // Disable external DTDs loading
        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
        // Secure processing
        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
        // Additional defensive settings
        factory.setXIncludeAware(false);
        factory.setExpandEntityReferences(false);
    } catch (ParserConfigurationException e) {
        LOGGER.warn("Could not set all XML parser features; defaulting to safer subset", e);
        // Optionally rethrow if you prefer fail-fast in init
    }
    return factory;
}
```

* Place in each file where `DOCUMENT_BUILDER_FACTORY` is declared, or centralize in a shared helper class if preferred.

### XMLInputFactory (StAX) — constructor snippet

After `XMLInputFactory.newInstance()`:

```java
XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
try {
    xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
    xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
} catch (IllegalArgumentException e) {
    LOGGER.warn("XMLInputFactory does not support disabling external entities via standard properties", e);
}
```

* Apply in `MedlineImporter` and `ModsImporter` (and any other StAX-based importers).

### Refferences
[XML External Entity (XXE) Processing](https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing)
[guidance on parsing xml  XXE Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java)
[XML Schema, DTD, and Entity Attacks](https://research.nccgroup.com/2014/05/19/xml-schema-dtd-and-entity-attacks-a-compendium-of-known-techniques/)
[XML Out-Of-Band Data Retrieval](https://www.slideshare.net/qqlan/bh-ready-v4)
[Billion Laughs](https://en.wikipedia.org/wiki/Billion_laughs)
[Processing Limit Definitions.](https://docs.oracle.com/javase/tutorial/jaxp/limits/limits.html)

---

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
