### PR TITLE
Rework json adr for consistency check options

### DIFF
--- a/.jbang/JabLsLauncher.java
+++ b/.jbang/JabLsLauncher.java
@@ -34,10 +34,10 @@
 //DEPS org.jspecify:jspecify:1.0.0
 
 // from jabls
+//DEPS com.fasterxml.jackson.core:jackson-databind:2.17.1
 //DEPS com.github.eclipse:lsp4j:0.24.0
 //DEPS info.picocli:picocli:4.7.7
 //DEPS org.apache.logging.log4j:log4j-to-slf4j:2.25.2
-//DEPS org.hisp.dhis:json-tree:1.8.1
 //DEPS org.jabref:afterburner.fx:2.0.0
 //DEPS org.slf4j:jul-to-slf4j:2.0.17
 //DEPS org.slf4j:slf4j-api:2.0.17

--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -463,10 +463,6 @@ extraJavaModuleInfo {
         requires("java.logging")
     }
 
-    module("org.hisp.dhis:json-tree", "org.hisp.dhis.jsontree") {
-        preserveExisting()
-    }
-
     module("com.github.sialcasa.mvvmFX:mvvmfx-validation", "de.saxsys.mvvmfx.validation") {
         exportAllPackages()
         requireAllDefinedDependencies()

--- a/docs/decisions/0051-handle-nested-json-paths.md
+++ b/docs/decisions/0051-handle-nested-json-paths.md
@@ -12,13 +12,14 @@ When trying to parse nested JSON structures in JabLS which receives the VSCode s
 ## Considered Options
 
 * Use `org.hisp.dhis:json-tree`
+* Use Jackson
 * Use Unirest and Optional
 * Use GSON and chaining Optional
 * Use an own method to parse the path
 
 ## Decision Outcome
 
-Chosen option: "Use `org.hisp.dhis:json-tree`", because comes out best (see below).
+Chosen option: "Use Jackson" because it comes out best (see below).
 
 ## Pros and Cons of the Options
 
@@ -33,6 +34,17 @@ this.integrityCheck = json.getBoolean("jabref.integrityCheck.enabled").booleanVa
 * Good, because it supports nested paths directly
 * Good, because it has a fallback value
 * Bad, because it introduces a new dependency
+
+### Use Jackson
+
+```java
+this.consistencyCheck = node.at("/jabref/consistencyCheck/enabled").asBoolean(this.consistencyCheck);
+```
+
+* Good, because very compact and readable
+* Good, because no Exception is thrown if path does not exist
+* Good, because it supports nested paths directly
+* Good, because it has a fallback value
 
 ### Use Unirest and Optional
 

--- a/jabls/build.gradle.kts
+++ b/jabls/build.gradle.kts
@@ -16,8 +16,6 @@ dependencies {
 
     implementation("com.google.guava:guava")
 
-    implementation("org.hisp.dhis:json-tree")
-
     // route all requests to java.util.logging to SLF4J (which in turn routes to tinylog)
     testImplementation("org.slf4j:jul-to-slf4j")
 }

--- a/jabls/src/main/java/module-info.java
+++ b/jabls/src/main/java/module-info.java
@@ -16,4 +16,5 @@ module org.jabref.jabls {
     requires org.eclipse.lsp4j.websocket;
 
     requires org.hisp.dhis.jsontree;
+    requires com.fasterxml.jackson.databind;
 }

--- a/jabls/src/main/java/module-info.java
+++ b/jabls/src/main/java/module-info.java
@@ -6,6 +6,8 @@ module org.jabref.jabls {
 
     requires org.jabref.jablib;
 
+    requires com.fasterxml.jackson.databind;
+
     requires com.google.common;
     requires com.google.gson;
 
@@ -15,6 +17,4 @@ module org.jabref.jabls {
     requires org.eclipse.lsp4j.jsonrpc;
     requires org.eclipse.lsp4j.websocket;
 
-    requires org.hisp.dhis.jsontree;
-    requires com.fasterxml.jackson.databind;
 }

--- a/jabls/src/main/java/org/jabref/languageserver/ExtensionSettings.java
+++ b/jabls/src/main/java/org/jabref/languageserver/ExtensionSettings.java
@@ -1,7 +1,9 @@
 package org.jabref.languageserver;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.JsonObject;
-import org.hisp.dhis.jsontree.JsonMixed;
 import org.slf4j.Logger;
 
 public class ExtensionSettings {
@@ -27,12 +29,17 @@ public class ExtensionSettings {
     }
 
     public void copyFromJsonObject(JsonObject object) {
-        org.hisp.dhis.jsontree.JsonObject json = JsonMixed.of(object.toString());
-        this.consistencyCheck = json.getBoolean("jabref.consistencyCheck.enabled").booleanValue(this.consistencyCheck);
-        this.consistencyCheckRequired = json.getBoolean("jabref.consistencyCheck.required").booleanValue(this.consistencyCheckRequired);
-        this.consistencyCheckOptional = json.getBoolean("jabref.consistencyCheck.optional").booleanValue(this.consistencyCheckOptional);
-        this.consistencyCheckUnknown = json.getBoolean("jabref.consistencyCheck.unknown").booleanValue(this.consistencyCheckUnknown);
-        this.integrityCheck = json.getBoolean("jabref.integrityCheck.enabled").booleanValue(this.integrityCheck);
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode node = mapper.readTree(object.toString());
+            this.consistencyCheck = node.at("/jabref/consistencyCheck/enabled").asBoolean(this.consistencyCheck);
+            this.consistencyCheckRequired = node.at("/jabref/consistencyCheck/required").asBoolean(this.consistencyCheckRequired);
+            this.consistencyCheckOptional = node.at("/jabref/consistencyCheck/optional").asBoolean(this.consistencyCheckOptional);
+            this.consistencyCheckUnknown = node.at("/jabref/consistencyCheck/unknown").asBoolean(this.consistencyCheckUnknown);
+            this.integrityCheck = node.at("/jabref/integrityCheck/enabled").asBoolean(this.integrityCheck);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Error parsing settings from JSON", e);
+        }
     }
 
     public boolean isConsistencyCheck() {


### PR DESCRIPTION
Follow up to #13910 andhttps://github.com/JabRef/jabref/pull/13910#discussion_r2370553427
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
