### PR TITLE
Fix refine check for getSuggestedFileName

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,8 +2,12 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/abbrv.jabref.org" vcs="" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/resources/csl-locales" vcs="" />
     <mapping directory="$PROJECT_DIR$/jablib/src/main/resources/csl-styles" vcs="" />
   </component>
+    <component name="VcsProjectSettings">
+        <option name="detectVcsMappingsAutomatically" value="false" />
+    </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- When filename pattern missing, pattern handling included to avoid suggesting meaningless filenames like "-" for linked files. [#13735](https://github.com/JabRef/jabref/issues/13735)
+- When filename pattern is missing for linked files, pattern handling has been introduced to avoid suggesting meaningless filenames like "-". [#13735](https://github.com/JabRef/jabref/issues/13735)
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- When filename pattern missing, pattern handling to avoid suggesting meaningless filenames like "-" for linked files.
+- When filename pattern missing, pattern handling included to avoid suggesting meaningless filenames like "-" for linked files.
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- When filename pattern missing, pattern handling to avoid suggesting meaningless filenames like "-" for linked files.
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- When filename pattern missing, pattern handling included to avoid suggesting meaningless filenames like "-" for linked files.
+- When filename pattern missing, pattern handling included to avoid suggesting meaningless filenames like "-" for linked files. [#13735](https://github.com/JabRef/jabref/issues/13735)
 - We fixed an issue where "Specify Bib(La)TeX" tab was not focused when Bib(La)TeX was in the clipboard [#13597](https://github.com/JabRef/jabref/issues/13597)
 - We fixed an issue whereby the 'About' dialog was not honouring the user's configured font preferences. [#13558](https://github.com/JabRef/jabref/issues/13558)
 - We fixed an issue where the Pagetotal column was sorting the values alphabetically instead of numerically. [#12533](https://github.com/JabRef/jabref/issues/12533)

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
@@ -249,10 +249,8 @@ public class LinkedFileHandler {
      * @return A filename based on the pattern specified in the preferences and valid for the file system.
      */
     public String getSuggestedFileName(@NonNull String extension) {
-        String targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePattern()).trim();
-        if ((targetFileName.isEmpty() || "-".equals(targetFileName)) && linkedFile.isOnlineLink()) {
-            // "-" is part of the default pattern (org.jabref.logic.FilePreferences.DEFAULT_FILENAME_PATTERNS) and is returned if no fields have been replaced.
-            // All other patterns are not yet handled. See <https://github.com/jabref/jabref/issues/13735> for a sketch of a solution.
+        Optional<String> targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePattern());
+        if (targetFileName.isEmpty() && linkedFile.isOnlineLink()) {
             String oldFileName = linkedFile.getLink();
             int lastSlashIndex = oldFileName.lastIndexOf('/');
             if (lastSlashIndex >= 0 && lastSlashIndex < oldFileName.length() - 1) {
@@ -261,20 +259,23 @@ public class LinkedFileHandler {
                 if (queryIndex > 0) {
                     fileNameFromUrl = fileNameFromUrl.substring(0, queryIndex);
                 }
-                if (!extension.isEmpty()) {
-                    Optional<String> existingExtension = FileUtil.getFileExtension(fileNameFromUrl);
-                    if (existingExtension.isEmpty() || !existingExtension.get().equalsIgnoreCase(extension)) {
-                        String baseName = FileUtil.getBaseName(fileNameFromUrl);
-                        fileNameFromUrl = baseName + "." + extension;
+                if (!fileNameFromUrl.isEmpty()) {
+                    if (!extension.isEmpty()) {
+                        Optional<String> existingExtension = FileUtil.getFileExtension(fileNameFromUrl);
+                        if (existingExtension.isEmpty() || !existingExtension.get().equalsIgnoreCase(extension)) {
+                            String baseName = FileUtil.getBaseName(fileNameFromUrl);
+                            fileNameFromUrl = baseName + "." + extension;
+                        }
                     }
+                    return FileUtil.getValidFileName(fileNameFromUrl);
                 }
-                return FileUtil.getValidFileName(fileNameFromUrl);
             }
         }
-        if (!extension.isEmpty()) {
-            targetFileName = targetFileName + '.' + extension;
-        }
-        return FileUtil.getValidFileName(targetFileName);
+
+        String baseName = targetFileName.orElse("-");
+        String suggestedName = extension.isEmpty() ? baseName : baseName + "." + extension;
+
+        return FileUtil.getValidFileName(suggestedName);
     }
 
     /**

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
@@ -272,7 +272,7 @@ public class LinkedFileHandler {
             }
         }
 
-        String baseName = targetFileName.orElse("-");
+        String baseName = targetFileName.orElse("file");
         String suggestedName = extension.isEmpty() ? baseName : baseName + "." + extension;
 
         return FileUtil.getValidFileName(suggestedName);

--- a/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -346,11 +346,15 @@ public class FileUtil {
      * @param fileNamePattern the filename pattern
      * @return a suggested fileName
      */
-    public static String createFileNameFromPattern(BibDatabase database, BibEntry entry, String fileNamePattern) {
-        String targetName = BracketedPattern.expandBrackets(fileNamePattern, ';', entry, database);
+    public static Optional<String> createFileNameFromPattern(BibDatabase database, BibEntry entry, String fileNamePattern) {
+        String targetName = BracketedPattern.expandBrackets(fileNamePattern, ';', entry, database).trim();
 
-        if (targetName.isEmpty()) {
+        if (targetName.isEmpty() || targetName.equals("-")) {
             targetName = entry.getCitationKey().orElse("default");
+        }
+
+        if (targetName.equals("default")) {
+            return Optional.empty();
         }
 
         // Remove LaTeX commands (e.g., \mkbibquote{}) from expanded fields before cleaning filename
@@ -359,7 +363,7 @@ public class FileUtil {
         // Removes illegal characters from filename
         targetName = FileNameCleaner.cleanFileName(targetName);
 
-        return targetName;
+        return Optional.of(targetName);
     }
 
     /**

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -386,6 +386,15 @@ class BracketedPatternTest {
     }
 
     @Test
+    void expandBracketsWithMissingAuthorAndYear() {
+        BibEntry bibEntry = new BibEntry()
+                .withField(StandardField.AUTHOR, "").withField(StandardField.YEAR, "");
+
+        assertEquals(" - ",
+                BracketedPattern.expandBrackets("[author] - [year]", ';', bibEntry, database));
+    }
+
+    @Test
     void bibentryExpansionTest() {
         BracketedPattern pattern = new BracketedPattern("[year]_[auth]_[firstpage]");
         assertEquals("2017_Kitsune_213", pattern.expand(bibentry));

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -393,7 +392,6 @@ class BracketedPatternTest {
 
         assertEquals(" - ",
                 BracketedPattern.expandBrackets("[author] - [year]", ';', bibEntry, database));
-        assertNotNull(BracketedPattern.expandBrackets("[author] - [year]", ';', bibEntry, database));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -392,6 +393,7 @@ class BracketedPatternTest {
 
         assertEquals(" - ",
                 BracketedPattern.expandBrackets("[author] - [year]", ';', bibEntry, database));
+        assertNotNull(BracketedPattern.expandBrackets("[author] - [year]", ';', bibEntry, database));
     }
 
     @Test

--- a/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
@@ -67,8 +67,8 @@ class LinkedFileHandlerTest {
             "file.pdf, https://example.com/file.doc, pdf",
             "file.pdf, https://example.com/file, pdf",
             "file.pdf, https://example.com/file.pdf, ''",
-            "-.pdf, https://example.com/, pdf",
-            "-.pdf, path/to/file.pdf, pdf",
+            "file.pdf, https://example.com/, pdf",
+            "file.pdf, path/to/file.pdf, pdf",
             "OAM-Webinar-V2.pdf, https://www.cncf.io/wp-content/uploads/2020/08/OAM-Webinar-V2.pdf, pdf"
     })
     void getSuggestedFileName(String expectedFileName, String link, String extension) {

--- a/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -82,7 +82,7 @@ class FileUtilTest {
         entry.setField(StandardField.TITLE, "mytitle");
 
         assertEquals("1234 - mytitle",
-                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -93,7 +93,7 @@ class FileUtilTest {
         entry.setField(StandardField.TITLE, "mytitle");
 
         assertEquals("1234 - mytitle",
-                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -104,7 +104,7 @@ class FileUtilTest {
         entry.setField(StandardField.TITLE, "mytitle");
 
         assertEquals("1234",
-                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+                FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -114,7 +114,7 @@ class FileUtilTest {
         entry.setCitationKey("1234");
         entry.setField(StandardField.TITLE, "mytitle");
 
-        assertEquals("1234", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+        assertEquals("1234", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -123,7 +123,7 @@ class FileUtilTest {
         BibEntry entry = new BibEntry();
         entry.setField(StandardField.TITLE, "mytitle");
 
-        assertEquals("default", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+        assertEquals(Optional.empty(), FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
     }
 
     @Test
@@ -132,7 +132,7 @@ class FileUtilTest {
         BibEntry entry = new BibEntry();
         entry.setCitationKey("1234");
 
-        assertEquals("1234", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+        assertEquals("1234", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -140,7 +140,23 @@ class FileUtilTest {
         String fileNamePattern = "[title]";
         BibEntry entry = new BibEntry();
 
-        assertEquals("default", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+        assertEquals(Optional.empty(), FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+    }
+
+    @Test
+    void getLinkedFileNameGetOptionalEmptyIfDashAsPattern() {
+        String fileNamePattern = "-";
+        BibEntry entry = new BibEntry();
+
+        assertEquals(Optional.empty(), FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+    }
+
+    @Test
+    void getLinkedFileNameGetOptionalEmptyIfDefaultAsPattern() {
+        String fileNamePattern = "default";
+        BibEntry entry = new BibEntry();
+
+        assertEquals(Optional.empty(), FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
     }
 
     @Test
@@ -151,7 +167,7 @@ class FileUtilTest {
         entry.setField(StandardField.YEAR, "1868");
         entry.setField(StandardField.PAGES, "567-579");
 
-        assertEquals("1868_Kitsune_567", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern));
+        assertEquals("1868_Kitsune_567", FileUtil.createFileNameFromPattern(null, entry, fileNamePattern).get());
     }
 
     @Test
@@ -161,8 +177,8 @@ class FileUtilTest {
                 .withCitationKey("BrayBuildingCommunity")
                 .withField(StandardField.TITLE, "Building \\mkbibquote{Community}");
         String expected = "BrayBuildingCommunity - Building Community";
-        String result = FileUtil.createFileNameFromPattern(null, entry, pattern);
-        assertEquals(expected, result);
+        Optional<String> result = FileUtil.createFileNameFromPattern(null, entry, pattern);
+        assertEquals(expected, result.get());
     }
 
     @Test


### PR DESCRIPTION
Closes #13735

- Refractored`FileUtil.createFileNameFromPattern` to return an `Optional<String>`, ensuring that empty pattern resolutions correctly result in an empty Optional instead of a "-" string. 
- The `LinkedFileHandler.getSuggestedFileName` method has been updated to handle this new return type.
- The corresponding JUnit tests are also being adapted to reflect these changes.



### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
