### PR TITLE
Keep label removal

### DIFF
--- a/.github/workflows/on-pr-opened-updated.yml
+++ b/.github/workflows/on-pr-opened-updated.yml
@@ -162,8 +162,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   remove_label:
     if: >
-      (github.repository == 'JabRef/jabref') &&
-      (github.event.pull_request.head.repo.full_name == 'JabRef/jabref')
+      (github.repository == 'JabRef/jabref')
     name: 'Remove label "status: changes-required"'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13936

The PR runs on `pull_request_target`, thus using the version of the workflow of this repository and also the token of this repository.

The really required fix was the passing of GH_TOKEN

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
