### PR TITLE
Fix duplicate key error on insertion

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
+++ b/jablib/src/main/java/org/jabref/logic/search/indexing/BibFieldsIndexer.java
@@ -190,12 +190,17 @@ public class BibFieldsIndexer {
         String insertFieldQuery = """
                 INSERT INTO %s ("%s", "%s", "%s", "%s")
                 VALUES (?, ?, ?, ?)
+                ON CONFLICT ("%s", "%s")
+                DO UPDATE SET "%s" = EXCLUDED."%s", "%s" = EXCLUDED."%s"
                 """.formatted(
                 schemaMainTableReference,
                 ENTRY_ID,
                 FIELD_NAME,
                 FIELD_VALUE_LITERAL,
-                FIELD_VALUE_TRANSFORMED);
+                FIELD_VALUE_TRANSFORMED,
+                ENTRY_ID, FIELD_NAME,
+                FIELD_VALUE_LITERAL, FIELD_VALUE_LITERAL,
+                FIELD_VALUE_TRANSFORMED, FIELD_VALUE_TRANSFORMED);
 
         String insertIntoSplitTable = """
                 INSERT INTO %s ("%s", "%s", "%s", "%s")
@@ -210,7 +215,7 @@ public class BibFieldsIndexer {
         try (PreparedStatement preparedStatement = connection.prepareStatement(insertFieldQuery);
              PreparedStatement preparedStatementSplitValues = connection.prepareStatement(insertIntoSplitTable)) {
             String entryId = bibEntry.getId();
-            LOGGER.atTrace().setMessage("Adding entry {}").addArgument(() -> bibEntry.getKeyAuthorTitleYear()).log();
+            LOGGER.atTrace().setMessage("Adding entry {}").addArgument(bibEntry::getKeyAuthorTitleYear).log();
             for (Map.Entry<Field, String> fieldPair : bibEntry.getFieldMap().entrySet()) {
                 Field field = fieldPair.getKey();
                 String value = fieldPair.getValue();
@@ -342,7 +347,23 @@ public class BibFieldsIndexer {
                 LOGGER.error("Could not add an entry to the index.", e);
             }
         } else {
-            try (PreparedStatement preparedStatement = connection.prepareStatement(insertFieldQuery)) {
+            // Use upsert for all non-date fields to avoid duplicate key errors when the same field is inserted multiple times quickly
+            String upsertFieldQuery = """
+                    INSERT INTO %s ("%s", "%s", "%s", "%s")
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT ("%s", "%s")
+                    DO UPDATE SET "%s" = EXCLUDED."%s", "%s" = EXCLUDED."%s"
+                    """.formatted(
+                    schemaMainTableReference,
+                    ENTRY_ID,
+                    FIELD_NAME,
+                    FIELD_VALUE_LITERAL,
+                    FIELD_VALUE_TRANSFORMED,
+                    ENTRY_ID, FIELD_NAME,
+                    FIELD_VALUE_LITERAL, FIELD_VALUE_LITERAL,
+                    FIELD_VALUE_TRANSFORMED, FIELD_VALUE_TRANSFORMED);
+
+            try (PreparedStatement preparedStatement = connection.prepareStatement(upsertFieldQuery)) {
                 String value = entry.getField(field).orElse("");
 
                 Optional<String> resolvedFieldLatexFree = entry.getResolvedFieldOrAliasLatexFree(field, this.databaseContext.getDatabase());

--- a/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
@@ -65,7 +65,6 @@ public class BibFieldsIndexerTest {
         indexer.addToIndex(List.of(entry), dummyTask);
         indexer.addToIndex(List.of(entry), dummyTask);
 
-
         // Verify that there's exactly one row for (entryid, 'citationkey')
         String tableRef = PostgreConstants.getMainTableSchemaReference(indexer.getTable());
         String sql = "SELECT COUNT(*) FROM " + tableRef + " WHERE \"" + PostgreConstants.ENTRY_ID + "\" = ? AND \"" + PostgreConstants.FIELD_NAME + "\" = ?";

--- a/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
@@ -43,7 +43,7 @@ public class BibFieldsIndexerTest {
     }
 
     @Test
-    void addToIndexIsIdempotentForSameEntry() throws SQLException {
+    void addToIndexIsIdempotentForSameEntry() throws Exception^ {
         BibDatabaseContext databaseContext = new BibDatabaseContext();
         Connection connection = postgreServer.getConnection();
         BibFieldsIndexer indexer = new BibFieldsIndexer(bibEntryPreferences, databaseContext, connection);

--- a/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
@@ -3,7 +3,6 @@ package org.jabref.logic.search.indexing;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 
 import org.jabref.logic.search.PostgreServer;
@@ -43,7 +42,7 @@ public class BibFieldsIndexerTest {
     }
 
     @Test
-    void addToIndexIsIdempotentForSameEntry() throws Exception^ {
+    void addToIndexIsIdempotentForSameEntry() throws Exception {
         BibDatabaseContext databaseContext = new BibDatabaseContext();
         Connection connection = postgreServer.getConnection();
         BibFieldsIndexer indexer = new BibFieldsIndexer(bibEntryPreferences, databaseContext, connection);

--- a/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/indexing/BibFieldsIndexerTest.java
@@ -1,0 +1,96 @@
+package org.jabref.logic.search.indexing;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.jabref.logic.search.PostgreServer;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryPreferences;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+import org.jabref.model.search.PostgreConstants;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BibFieldsIndexerTest {
+
+    private PostgreServer postgreServer;
+
+    private final BibEntryPreferences bibEntryPreferences = mock(BibEntryPreferences.class);
+
+    @BeforeEach
+    void setUp() {
+        when(bibEntryPreferences.getKeywordSeparator()).thenReturn(',');
+        postgreServer = new PostgreServer();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (postgreServer != null) {
+            postgreServer.shutdown();
+        }
+    }
+
+    @Test
+    void addToIndexIsIdempotentForSameEntry() throws SQLException {
+        BibDatabaseContext databaseContext = new BibDatabaseContext();
+        Connection connection = postgreServer.getConnection();
+        BibFieldsIndexer indexer = new BibFieldsIndexer(bibEntryPreferences, databaseContext, connection);
+
+        BibEntry entry = new BibEntry(StandardEntryType.Article);
+        entry.withCitationKey("https://doi.org/10.48550/arxiv.2405.02318");
+        entry.withField(StandardField.TITLE, "Cool Paper");
+        entry.withField(StandardField.AUTHOR, "Doe, John");
+        entry.withField(StandardField.GROUPS, "Imported entries, Other");
+
+        BackgroundTask<?> dummyTask = new BackgroundTask<>() {
+            @Override
+            public Object call() {
+                return null;
+            }
+        };
+
+        // Index the same entry twice - this used to throw due to a duplicate key on (entryid, field_name)
+        indexer.addToIndex(List.of(entry), dummyTask);
+        indexer.addToIndex(List.of(entry), dummyTask);
+
+
+        // Verify that there's exactly one row for (entryid, 'citationkey')
+        String tableRef = PostgreConstants.getMainTableSchemaReference(indexer.getTable());
+        String sql = "SELECT COUNT(*) FROM " + tableRef + " WHERE \"" + PostgreConstants.ENTRY_ID + "\" = ? AND \"" + PostgreConstants.FIELD_NAME + "\" = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, entry.getId());
+            ps.setString(2, "citationkey");
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                int count = rs.getInt(1);
+                assertEquals(1, count);
+            }
+        }
+
+        // Verify that there's exactly one row for (entryid, 'groups') in the main table as well
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, entry.getId());
+            ps.setString(2, "groups");
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                int count = rs.getInt(1);
+                assertEquals(1, count);
+            }
+        }
+
+        // Cleanup resources gracefully
+        indexer.closeAndWait();
+    }
+}


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/13978#issuecomment-3339978514

<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
