### PR TITLE
Make Web Search 'Configure API key' searchable in preferences #13929

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ## [6.0-alpha2] – 2025-04-27
 
 ### Added
-
+- Made "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
 - We added a button in Privacy notice and Mr. DLib Privacy settings notice for hiding related tabs. [#11707](https://github.com/JabRef/jabref/issues/11707)
 - We added buttons "Add example entry" and "Import existing PDFs" when a library is empty, making it easier for new users to get started. [#12662](https://github.com/JabRef/jabref/issues/12662)
 - In the Open/LibreOffice integration, we added the provision to modify the bibliography title and its format for CSL styles, in the "Select style" dialog. [#12663](https://github.com/JabRef/jabref/issues/12663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ## [6.0-alpha2] – 2025-04-27
 
 ### Added
+
 - Made "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
 - We added a button in Privacy notice and Mr. DLib Privacy settings notice for hiding related tabs. [#11707](https://github.com/JabRef/jabref/issues/11707)
 - We added buttons "Add example entry" and "Import existing PDFs" when a library is empty, making it easier for new users to get started. [#12662](https://github.com/JabRef/jabref/issues/12662)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- Made "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
+- We made the "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
 - We added the integrity check to the jabkit cli application. [#13848](https://github.com/JabRef/jabref/issues/13848)
 - We added support for Cygwin-file paths on a Windows Operating System. [#13274](https://github.com/JabRef/jabref/issues/13274)
 - We fixed an issue where "Print preview" would throw a `NullPointerException` if no printers were available. [#13708](https://github.com/JabRef/jabref/issues/13708)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- Made "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
 - We added the integrity check to the jabkit cli application. [#13848](https://github.com/JabRef/jabref/issues/13848)
 - We added support for Cygwin-file paths on a Windows Operating System. [#13274](https://github.com/JabRef/jabref/issues/13274)
 - We fixed an issue where "Print preview" would throw a `NullPointerException` if no printers were available. [#13708](https://github.com/JabRef/jabref/issues/13708)
@@ -153,7 +154,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- Made "Configure API key" option in the Web Search preferences tab searchable via preferences search. [#13929](https://github.com/JabRef/jabref/issues/13929)
 - We added a button in Privacy notice and Mr. DLib Privacy settings notice for hiding related tabs. [#11707](https://github.com/JabRef/jabref/issues/11707)
 - We added buttons "Add example entry" and "Import existing PDFs" when a library is empty, making it easier for new users to get started. [#12662](https://github.com/JabRef/jabref/issues/12662)
 - In the Open/LibreOffice integration, we added the provision to modify the bibliography title and its format for CSL styles, in the "Select style" dialog. [#12663](https://github.com/JabRef/jabref/issues/12663)

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesSearchHandler.java
@@ -70,7 +70,8 @@ class PreferencesSearchHandler {
      * @return True if the tab matches the query.
      */
     private boolean tabMatchesQuery(PreferencesTab tab, String query) {
-        boolean tabNameMatches = tab.getTabName().toLowerCase(Locale.ROOT).contains(query);
+        boolean tabNameMatches = tab.getSearchKeywords().stream()
+                                    .anyMatch(keyword -> keyword.toLowerCase(Locale.ROOT).contains(query));
 
         boolean controlMatches = preferenceTabsControls.get(tab).stream()
                                                        .filter(control -> controlMatchesQuery(control, query))

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesTab.java
@@ -11,11 +11,9 @@ import javafx.scene.Node;
  */
 public interface PreferencesTab {
 
-
     default List<String> getSearchKeywords() {
         return List.of(getTabName());
     }
-
 
     Node getBuilder();
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/PreferencesTab.java
@@ -11,6 +11,12 @@ import javafx.scene.Node;
  */
 public interface PreferencesTab {
 
+
+    default List<String> getSearchKeywords() {
+        return List.of(getTabName());
+    }
+
+
     Node getBuilder();
 
     /**

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -57,7 +57,6 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
                   .load();
     }
 
-
     @Override
     public List<String> getSearchKeywords() {
         return List.of(
@@ -69,7 +68,6 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
                 "apikey"
         );
     }
-
 
     @Override
     public String getTabName() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.preferences.websearch;
 
+import java.util.List;
 import java.util.Optional;
 
 import javafx.beans.InvalidationListener;
@@ -55,6 +56,20 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
                   .root(this)
                   .load();
     }
+
+
+    @Override
+    public List<String> getSearchKeywords() {
+        return List.of(
+                getTabName(),
+                Localization.lang("Configure API key"),
+                Localization.lang("Custom API key"),
+                "api",
+                "api key",
+                "apikey"
+        );
+    }
+
 
     @Override
     public String getTabName() {

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2007,6 +2007,7 @@ JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ pr
 Remove\ line\ breaks=Remove line breaks
 Removes\ all\ line\ breaks\ in\ the\ field\ content.=Removes all line breaks in the field content.
 Web\ search\ fetchers=Web search fetchers
+Custom\ API\ key=Custom API key
 API\ Key\ for\ %0=API Key for %0
 Test\ connection=Test connection
 API\ Key=API Key


### PR DESCRIPTION
Closes #13929

This PR adds the ability to search for the "Configure API key" option in the Web Search preferences tab

### Changes
- Updated `WebSearchTab.java` to add search keywords such as "Configure API key", "Custom API key", "api", "api key", "apikey"
- Updated `PreferencesTab.java` to include a default `getSearchKeywords()` method
- Modified `PreferencesSearchHandler.java` to consider keywords when filtering tabs

With this change, users can quickly find the "Configure API key" option by typing relevant search terms in the preferences search bar

### Steps to Test
1. Open JabRef
2. Go to **Preferences → Web Search** tab
3. In the search bar at the top of Preferences, type any of the following:
   - "Configure API key"
   - "Custom API key"
   - "api"
   - "api key"
4. Verify that the Web Search tab is highlighted as a search result

### Visual Reference
![Web Search Preferences](https://github.com/user-attachments/assets/13e5b5ba-3e7f-4957-bec0-fc91950f5efa)

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef
- [x] I described the change in `CHANGELOG.md`
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I checked the user documentation: Is the information available and up to date?