### PR TITLE
Add more JBang tests

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -463,6 +463,9 @@ jobs:
       - run: jbang build --fresh .jbang/JabKitLauncher.java
       - run: jbang build --fresh .jbang/JabLsLauncher.java
       - run: jbang build --fresh .jbang/JabSrvLauncher.java
+      - run: jbang run .jbang/JabKitLauncher.java --help
+      - run: jbang run .jbang/JabLsLauncher.java --help
+      - run: jbang run .jbang/JabSrvLauncher.java --help
 
   jbang-pr:
     name: JBang (PR)
@@ -499,7 +502,6 @@ jobs:
             jbang-
       - name: Setup JBang
         uses: jbangdev/setup-jbang@main
-
       - name: Detect changed jablib classes
         id: changed-jablib-files
         uses: tj-actions/changed-files@v47
@@ -508,7 +510,6 @@ jobs:
             jablib/src/main/java/**/*.java
           files_ignore: |
             jablib/src/main/java/**/*-*.java
-
       - name: Build ${{ matrix.launcher }} launcher including changed classes
         shell: bash
         # We always run, because changes in jabls, jabsrv also could cause JBang to fail
@@ -518,6 +519,8 @@ jobs:
             echo "//SOURCES ../$f" >> ".jbang/${{ matrix.launcher }}.java"
           done
           jbang build --fresh ".jbang/${{ matrix.launcher }}.java"
+      - run: jbang ".jbang/${{ matrix.launcher }}.java" --help
+        shell: bash
 
   codecoverage:
     if: false


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/13933

Sometimes, JBang does not work locally - this adds some kind of test

### Steps to test

Check workflow output

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
