### PR TITLE
Improved BibTeX brace check with more information in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the event viewer for debugging [#13783](https://github.com/JabRef/jabref/pull/13783).
 - We improved "REDACTED" replacement of API key value in web fetcher search URL [#13796](https://github.com/JabRef/jabref/issues/13796)
 - When the pin "Keep dialog always on top" in the global search dialog is selected, the search window stays open when double-clicking on an entry. [#13840](https://github.com/JabRef/jabref/issues/13840)
-- We improved the way we check for matching curly braces in BibTeX fields and make error messages easier to understand. [#12605](https://github.com/JabRef/jabref/issues/12605)
+- We improved the way we check for matching curly braces in BibTeX fields and made error messages easier to understand. [#12605](https://github.com/JabRef/jabref/issues/12605)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We improved the event viewer for debugging [#13783](https://github.com/JabRef/jabref/pull/13783).
 - We improved "REDACTED" replacement of API key value in web fetcher search URL [#13796](https://github.com/JabRef/jabref/issues/13796)
 - When the pin "Keep dialog always on top" in the global search dialog is selected, the search window stays open when double-clicking on an entry. [#13840](https://github.com/JabRef/jabref/issues/13840)
+- We improved the way we check for matching curly braces in BibTeX fields and make error messages easier to understand. [#12605](https://github.com/JabRef/jabref/issues/12605)
 
 ### Fixed
 

--- a/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
@@ -2,6 +2,7 @@ package org.jabref.logic.bibtex;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.StringJoiner;
 
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
@@ -54,11 +55,11 @@ public class FieldWriter {
 
             if (!isEscaped(text, i)) {
                 if (item == '{') {
-                    queue.add(String.format("Line %d, column %d (index %d): in '%s'",
+                    queue.add("Line %d, column %d (index %d): in '%s'".formatted(
                             line + 1, i - lastLineIndex + 1, i, getErrorContextSnippet(text, i)));
                 } else if (item == '}') {
                     if (queue.pollLast() == null) {
-                        String errorMessage = String.format("Unescaped '}' without matching opening bracket found at line %d, column %d (index %d): in '%s'",
+                        String errorMessage = "Unescaped '}' without matching opening bracket found at line %d, column %d (index %d): in '%s'".formatted(
                                 line + 1, i - lastLineIndex + 1, i, getErrorContextSnippet(text, i));
                         LOGGER.error(errorMessage);
                         throw new InvalidFieldValueException(errorMessage);
@@ -68,7 +69,11 @@ public class FieldWriter {
         }
 
         if (!queue.isEmpty()) {
-            String errorMessage = String.format(" The following unescaped '{' do not have matching closing bracket:\n%s", String.join("\n", queue));
+            StringJoiner joiner = new StringJoiner("\n");
+            for (String error : queue) {
+                joiner.add(error);
+            }
+            String errorMessage = "The following unescaped '{' do not have matching closing bracket:\n%s".formatted(joiner);
             LOGGER.error(errorMessage);
             throw new InvalidFieldValueException(errorMessage);
         }

--- a/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
@@ -1,5 +1,8 @@
 package org.jabref.logic.bibtex;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.InternalField;
 
@@ -36,38 +39,66 @@ public class FieldWriter {
     }
 
     private static void checkBraces(String text) throws InvalidFieldValueException {
-        int left = 0;
-        int right = 0;
+        Deque<String> queue = new ArrayDeque<>();
+        int line = 0;
+        int lastLineIndex = 0;
 
         // First we collect all occurrences:
         for (int i = 0; i < text.length(); i++) {
             char item = text.charAt(i);
-
-            boolean charBeforeIsEscape = false;
-            if ((i > 0) && (text.charAt(i - 1) == '\\')) {
-                charBeforeIsEscape = true;
+            if (item == '\n') {
+                line++;
+                lastLineIndex = i;
+                continue;
             }
 
-            if (!charBeforeIsEscape && (item == '{')) {
-                left++;
-            } else if (!charBeforeIsEscape && (item == '}')) {
-                right++;
+            if (!isEscaped(text, i)) {
+                if (item == '{') {
+                    queue.add(String.format("Line %d, column %d (index %d): in '%s'",
+                            line + 1, i - lastLineIndex + 1, i, getErrorContextSnippet(text, i)));
+                } else if (item == '}') {
+                    if (queue.pollLast() == null) {
+                        String errorMessage = String.format("Unescaped '}' without matching opening bracket found at line %d, column %d (index %d): in '%s'",
+                                line + 1, i - lastLineIndex + 1, i, getErrorContextSnippet(text, i));
+                        LOGGER.error(errorMessage);
+                        throw new InvalidFieldValueException(errorMessage);
+                    }
+                }
             }
         }
 
-        // Then we throw an exception if the error criteria are met.
-        if (right != 0 && (left == 0)) {
-            LOGGER.error("Unescaped '}' character without opening bracket ends string prematurely. Field value: {}", text);
-            throw new InvalidFieldValueException("Unescaped '}' character without opening bracket ends string prematurely. Field value: " + text);
+        if (!queue.isEmpty()) {
+            String errorMessage = String.format(" The following unescaped '{' do not have matching closing bracket:\n%s", String.join("\n", queue));
+            LOGGER.error(errorMessage);
+            throw new InvalidFieldValueException(errorMessage);
         }
-        if (right != 0 && (right < left)) {
-            LOGGER.error("Unescaped '}' character without opening bracket ends string prematurely. Field value: {}", text);
-            throw new InvalidFieldValueException("Unescaped '}' character without opening bracket ends string prematurely. Field value: " + text);
+    }
+
+    private static String getErrorContextSnippet(String text, int index) {
+        int neighbourSize = 5;
+        return text.substring(Math.max(0, index - neighbourSize), index)
+                + "*" + text.charAt(index) + "*"
+                + text.substring(index + 1, Math.min(text.length(), index + neighbourSize + 1));
+    }
+
+    /**
+     * Checks if the character at the specified index in the given text is escaped.
+     * A character is considered escaped if it is preceded by an odd number of backslashes (\).
+     *
+     * @param text  the input string to check for escaped characters
+     * @param index the index of the character in the text to check for escaping
+     * @return true if the character at the specified index is escaped, false otherwise
+     */
+    private static boolean isEscaped(String text, int index) {
+        int indexCounter = 0;
+        for (int i = index - 1; i >= 0; i--) {
+            if (text.charAt(i) == '\\') {
+                indexCounter++;
+            } else {
+                break;
+            }
         }
-        if (left != right) {
-            LOGGER.error("Braces don't match. Field value: {}", text);
-            throw new InvalidFieldValueException("Braces don't match. Field value: " + text);
-        }
+        return indexCounter % 2 == 1;
     }
 
     /**

--- a/jablib/src/test/java/org/jabref/logic/bibtex/FieldWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/bibtex/FieldWriterTest.java
@@ -126,8 +126,15 @@ class FieldWriterTest {
     }
 
     @Test
-    void reportUnbalancedBracingWithEscapedBraces() {
+    void reportUnbalancedBracingWithEscapedClosingBraces() {
         String unbalanced = "{\\}";
+
+        assertThrows(InvalidFieldValueException.class, () -> writer.write(new UnknownField("anyfield"), unbalanced));
+    }
+
+    @Test
+    void reportUnbalancedBracingWithEscapedOpeningBraces() {
+        String unbalanced = "\\{}";
 
         assertThrows(InvalidFieldValueException.class, () -> writer.write(new UnknownField("anyfield"), unbalanced));
     }


### PR DESCRIPTION
Closes #12605 

Updated the `org.jabref.logic.bibtex.FieldWriter#checkBraces` method with more information written in error message and added a method that checks whether a character is escaped.

### Steps to test

1. Open JabRef
2. Create empty library
3. Click "Add entry"
4. Enter D\{"u}sseldorf in the author field
5. The unmatched bracket is shown between `*`.
<img width="485" height="394" alt="image" src="https://github.com/user-attachments/assets/41be0f57-b69a-414d-b09a-5de072ee7539" />


### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
