### PR TITLE
Fixed consistency check test

### DIFF
--- a/jabkit/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
+++ b/jabkit/src/test/java/org/jabref/cli/ArgumentProcessorTest.java
@@ -30,7 +30,6 @@ import org.jabref.model.util.DummyFileUpdateMonitor;
 import org.jabref.support.BibEntryAssert;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
@@ -135,7 +134,6 @@ class ArgumentProcessorTest {
     }
 
     @Test
-    @Disabled("Does not work in this branch, but we did not touch it. TODO: Fix this")
     void checkConsistency() throws URISyntaxException {
         Path testBib = Path.of(Objects.requireNonNull(ArgumentProcessorTest.class.getResource("origin.bib")).toURI());
         String testBibFile = testBib.toAbsolutePath().toString();
@@ -147,9 +145,9 @@ class ArgumentProcessorTest {
 
         int executionResult = commandLine.execute(args.toArray(String[]::new));
 
-        String output = outContent.toString();
-        assertTrue(output.contains("Checking consistency for entry type 1 of 1\n"));
-        assertTrue(output.contains("Consistency check completed"));
+        String output = outContent.toString().replace("\r\n", "\n");
+        assertTrue(output.contains("Checking consistency for entry type 1 of 1\n"), "Expected output to contain sentence: Checking consistency for entry type 1 of 1");
+        assertTrue(output.contains("Consistency check completed"), "Expected output to contain sentence: Consistency check completed");
         assertEquals(0, executionResult);
 
         System.setOut(System.out);


### PR DESCRIPTION
Closes #13709

Fixed the test `org.jabref.cli.ArgumentProcessorTest#checkConsistency` by replacing "\r\n" with "\n" in the test output and added fail message.

### Steps to test
Run the test `org.jabref.cli.ArgumentProcessorTest#checkConsistency`, which should pass.

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
