### PR TITLE
LSP add definition links for Markdown

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserResult.java
@@ -105,11 +105,11 @@ public class ParserResult {
      *
      * @param s String Warning text. Must be pre-translated. Only added if there isn't already a dupe.
      */
-    public void addWarning(String s) {
+    public void addWarning(@NonNull String s) {
         addWarning(Range.NULL_RANGE, s);
     }
 
-    public void addWarning(Range range, String s) {
+    public void addWarning(Range range, @NonNull String s) {
         warnings.put(range, s);
     }
 

--- a/jabls/src/main/java/org/jabref/languageserver/BibtexTextDocumentService.java
+++ b/jabls/src/main/java/org/jabref/languageserver/BibtexTextDocumentService.java
@@ -1,17 +1,23 @@
 package org.jabref.languageserver;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.jabref.languageserver.util.LspDefinitionHandler;
 import org.jabref.languageserver.util.LspDiagnosticHandler;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -20,11 +26,16 @@ import org.jspecify.annotations.NonNull;
 public class BibtexTextDocumentService implements TextDocumentService {
 
     private final LspDiagnosticHandler diagnosticHandler;
-
+    private final LspDefinitionHandler definitionHandler;
+    private final Map<String, String> fileUriToLanguageId;
+    private final Map<String, String> contentCache;
     private LanguageClient client;
 
-    public BibtexTextDocumentService(@NonNull LspDiagnosticHandler diagnosticHandler) {
+    public BibtexTextDocumentService(@NonNull LspDiagnosticHandler diagnosticHandler, @NonNull LspDefinitionHandler definitionHandler) {
         this.diagnosticHandler = diagnosticHandler;
+        this.definitionHandler = definitionHandler;
+        this.fileUriToLanguageId = new ConcurrentHashMap<>();
+        this.contentCache = new ConcurrentHashMap<>();
     }
 
     public void setClient(LanguageClient client) {
@@ -33,20 +44,41 @@ public class BibtexTextDocumentService implements TextDocumentService {
 
     @Override
     public void didOpen(DidOpenTextDocumentParams params) {
-        diagnosticHandler.computeAndPublishDiagnostics(client, params.getTextDocument().getUri(), params.getTextDocument().getText(), params.getTextDocument().getVersion());
+        fileUriToLanguageId.putIfAbsent(params.getTextDocument().getUri(), params.getTextDocument().getLanguageId());
+        if ("bibtex".equals(params.getTextDocument().getLanguageId())) {
+            diagnosticHandler.computeAndPublishDiagnostics(client, params.getTextDocument().getUri(), params.getTextDocument().getText(), params.getTextDocument().getVersion());
+        } else {
+            contentCache.put(params.getTextDocument().getUri(), params.getTextDocument().getText());
+        }
     }
 
     @Override
     public void didChange(DidChangeTextDocumentParams params) {
-        diagnosticHandler.computeAndPublishDiagnostics(client, params.getTextDocument().getUri(), params.getContentChanges().getFirst().getText(), params.getTextDocument().getVersion());
+        String languageId = fileUriToLanguageId.get(params.getTextDocument().getUri());
+        if ("bibtex".equals(languageId)) {
+            diagnosticHandler.computeAndPublishDiagnostics(client, params.getTextDocument().getUri(), params.getContentChanges().getFirst().getText(), params.getTextDocument().getVersion());
+        } else {
+            contentCache.put(params.getTextDocument().getUri(), params.getContentChanges().getFirst().getText());
+        }
     }
 
     @Override
     public void didClose(DidCloseTextDocumentParams params) {
+        fileUriToLanguageId.remove(params.getTextDocument().getUri());
+        contentCache.remove(params.getTextDocument().getUri());
     }
 
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
+    }
+
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(DefinitionParams params) {
+        if (fileUriToLanguageId.containsKey(params.getTextDocument().getUri())) {
+            String fileUri = params.getTextDocument().getUri();
+            return definitionHandler.provideDefinition(fileUriToLanguageId.get(fileUri), fileUri, contentCache.get(fileUri), params.getPosition());
+        }
+        return CompletableFuture.completedFuture(Either.forLeft(List.of()));
     }
 
     @Override

--- a/jabls/src/main/java/org/jabref/languageserver/BibtexWorkspaceService.java
+++ b/jabls/src/main/java/org/jabref/languageserver/BibtexWorkspaceService.java
@@ -24,7 +24,6 @@ public class BibtexWorkspaceService implements WorkspaceService {
         this.diagnosticHandler = diagnosticHandler;
     }
 
-    // Todo: handle event
     @Override
     public void didChangeConfiguration(DidChangeConfigurationParams didChangeConfigurationParams) {
         if (didChangeConfigurationParams.getSettings() instanceof JsonObject settings) {

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDefinitionHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDefinitionHandler.java
@@ -1,0 +1,35 @@
+package org.jabref.languageserver.util;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.jabref.languageserver.util.definition.MarkdownDefinitionProvider;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LspDefinitionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LspDiagnosticHandler.class);
+
+    private final LspParserHandler parserHandler;
+
+    public LspDefinitionHandler(LspParserHandler parserHandler) {
+        this.parserHandler = parserHandler;
+    }
+
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> provideDefinition(String languageId, String uri, String content, Position position) {
+        List<Location> locations = List.of();
+        switch (languageId.toLowerCase()) {
+            case "markdown" -> {
+                locations = new MarkdownDefinitionProvider(parserHandler).provideDefinition(content, position);
+            }
+            default -> LOGGER.warn("Definition request for unsupported language: {}", languageId);
+        }
+        return CompletableFuture.completedFuture(Either.forLeft(locations));
+    }
+}

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticBuilder.java
@@ -1,14 +1,11 @@
 package org.jabref.languageserver.util;
 
-import java.util.Objects;
-
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -74,7 +71,7 @@ public final class LspDiagnosticBuilder {
     }
 
     public LspDiagnosticBuilder setRange(ParserResult.Range range) {
-        this.explicitRange = convertToLspRange(range);
+        this.explicitRange = LspRangeUtil.convertToLspRange(range);
         return this;
     }
 
@@ -84,11 +81,9 @@ public final class LspDiagnosticBuilder {
     }
 
     public Diagnostic build() {
-        Objects.requireNonNull(message, "message must be set");
-
         Range range = explicitRange;
         if (explicitRange == null) {
-            range = convertToLspRange(computeRange());
+            range = LspRangeUtil.convertToLspRange(computeRange());
         }
         return new Diagnostic(range, message, severity, source);
     }
@@ -103,12 +98,5 @@ public final class LspDiagnosticBuilder {
         }
 
         return parserResult.getFieldRange(entry, field);
-    }
-
-    private Range convertToLspRange(ParserResult.Range range) {
-        return new Range(
-                new Position(Math.max(range.startLine() - 1, 0), Math.max(range.startColumn() - 1, 0)),
-                new Position(Math.max(range.endLine() - 1, 0), Math.max(range.endColumn() - 1, 0))
-        );
     }
 }

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspDiagnosticHandler.java
@@ -1,7 +1,6 @@
 package org.jabref.languageserver.util;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -13,9 +12,7 @@ import java.util.stream.Stream;
 import org.jabref.languageserver.ExtensionSettings;
 import org.jabref.languageserver.LspClientHandler;
 import org.jabref.logic.JabRefException;
-import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.importer.ParserResult;
-import org.jabref.logic.importer.fileformat.BibtexParser;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.CliPreferences;
@@ -32,18 +29,18 @@ public class LspDiagnosticHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(LspDiagnosticHandler.class);
     private static final int NO_VERSION = -1;
 
-    private final CliPreferences jabRefCliPreferences;
     private final LspIntegrityCheck lspIntegrityCheck;
     private final LspConsistencyCheck lspConsistencyCheck;
     private final LspClientHandler clientHandler;
+    private final LspParserHandler parserHandler;
+    private final CliPreferences cliPreferences;
     private final Map<String, List<Diagnostic>> integrityDiagnosticsCache; // Maps file URIs to the corresponding list of integrity diagnostics
     private final Map<String, List<Diagnostic>> consistencyDiagnosticsCache; // Maps file URIs to the corresponding list of consistency diagnostics
 
-    private LanguageClient client;
-
-    public LspDiagnosticHandler(LspClientHandler clientHandler, CliPreferences cliPreferences, JournalAbbreviationRepository abbreviationRepository) {
+    public LspDiagnosticHandler(LspClientHandler clientHandler, LspParserHandler parserHandler, CliPreferences cliPreferences, JournalAbbreviationRepository abbreviationRepository) {
         this.clientHandler = clientHandler;
-        this.jabRefCliPreferences = cliPreferences;
+        this.parserHandler = parserHandler;
+        this.cliPreferences = cliPreferences;
         this.lspIntegrityCheck = new LspIntegrityCheck(cliPreferences, abbreviationRepository);
         this.lspConsistencyCheck = new LspConsistencyCheck(clientHandler.getSettings());
         this.integrityDiagnosticsCache = new ConcurrentHashMap<>();
@@ -70,8 +67,9 @@ public class LspDiagnosticHandler {
     private List<Diagnostic> computeDiagnostics(String content, String uri) {
         List<Diagnostic> diagnostics = new ArrayList<>();
         ParserResult parserResult;
+
         try {
-            parserResult = parserResultFromString(content, jabRefCliPreferences.getImportFormatPreferences());
+            parserResult = parserHandler.parserResultFromString(uri, content, cliPreferences.getImportFormatPreferences());
         } catch (JabRefException | IOException e) {
             Diagnostic parseDiagnostic = LspDiagnosticBuilder.create(Localization.lang(
                     "Failed to parse entries.\nThe following error was encountered:\n%0",
@@ -116,10 +114,5 @@ public class LspDiagnosticHandler {
             List<Diagnostic> diagnostics = getFinalDiagnosticsList(uri);
             publishDiagnostics(client, uri, diagnostics);
         });
-    }
-
-    private ParserResult parserResultFromString(String content, ImportFormatPreferences importFormatPreferences) throws JabRefException, IOException {
-        BibtexParser parser = new BibtexParser(importFormatPreferences);
-        return parser.parse(Reader.of(content));
     }
 }

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspParserHandler.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspParserHandler.java
@@ -1,0 +1,45 @@
+package org.jabref.languageserver.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jabref.logic.JabRefException;
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.importer.fileformat.BibtexParser;
+import org.jabref.model.entry.BibEntry;
+
+public class LspParserHandler {
+
+    private final Map<String, ParserResult> parserResults;
+
+    public LspParserHandler() {
+        this.parserResults = new ConcurrentHashMap<>();
+    }
+
+    public ParserResult parserResultFromString(String fileUri, String content, ImportFormatPreferences importFormatPreferences) throws JabRefException, IOException {
+        BibtexParser parser = new BibtexParser(importFormatPreferences);
+        ParserResult parserResult = parser.parse(Reader.of(content));
+        parserResults.put(fileUri, parserResult);
+        return parserResult;
+    }
+
+    public Optional<ParserResult> getParserResultForUri(String fileUri) {
+        return Optional.ofNullable(parserResults.get(fileUri));
+    }
+
+    public Map<String, List<BibEntry>> searchForEntryByCitationKey(String citationKey) {
+        Map<String, List<BibEntry>> result = new ConcurrentHashMap<>();
+        parserResults.forEach((fileUri, parserResult) -> {
+            List<BibEntry> entries = parserResult.getDatabase().getEntriesByCitationKey(citationKey);
+            if (!entries.isEmpty()) {
+                result.put(fileUri, entries);
+            }
+        });
+        return result;
+    }
+}

--- a/jabls/src/main/java/org/jabref/languageserver/util/LspRangeUtil.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/LspRangeUtil.java
@@ -1,0 +1,45 @@
+package org.jabref.languageserver.util;
+
+import org.jabref.logic.importer.ParserResult;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+public class LspRangeUtil {
+
+    public static int toOffset(String content, Position pos) {
+        int line = Math.max(0, pos.getLine());
+        int character = Math.max(0, pos.getCharacter());
+
+        int currentLine = 0;
+        int i = 0;
+        int lineStart = 0;
+
+        while (i < content.length() && currentLine < line) {
+            char c = content.charAt(i++);
+            if (c == '\n') {
+                lineStart = i;
+                currentLine++;
+            }
+        }
+
+        if (currentLine < line) {
+            return content.length();
+        }
+
+        int lineEnd = content.indexOf('\n', lineStart);
+        if (lineEnd == -1) {
+            lineEnd = content.length();
+        }
+
+        int offset = lineStart + Math.min(character, Math.max(0, lineEnd - lineStart));
+        return Math.max(0, Math.min(content.length(), offset));
+    }
+
+    public static Range convertToLspRange(ParserResult.Range range) {
+        return new Range(
+                new Position(Math.max(range.startLine() - 1, 0), Math.max(range.startColumn() - 1, 0)),
+                new Position(Math.max(range.endLine() - 1, 0), Math.max(range.endColumn() - 1, 0))
+        );
+    }
+}

--- a/jabls/src/main/java/org/jabref/languageserver/util/definition/DefinitionProvider.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/definition/DefinitionProvider.java
@@ -1,0 +1,11 @@
+package org.jabref.languageserver.util.definition;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+
+public interface DefinitionProvider {
+
+    List<Location> provideDefinition(String content, Position position);
+}

--- a/jabls/src/main/java/org/jabref/languageserver/util/definition/MarkdownDefinitionProvider.java
+++ b/jabls/src/main/java/org/jabref/languageserver/util/definition/MarkdownDefinitionProvider.java
@@ -1,0 +1,120 @@
+package org.jabref.languageserver.util.definition;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.languageserver.util.LspParserHandler;
+import org.jabref.languageserver.util.LspRangeUtil;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.model.entry.BibEntry;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+public class MarkdownDefinitionProvider implements DefinitionProvider {
+
+    private final LspParserHandler parserHandler;
+
+    public MarkdownDefinitionProvider(LspParserHandler parserHandler) {
+        this.parserHandler = parserHandler;
+    }
+
+    @Override
+    public List<Location> provideDefinition(String content, Position position) {
+        Optional<String> citationKey = getCitationKeyAtPosition(content, position);
+        if (citationKey.isPresent()) {
+            Map<String, List<BibEntry>> entriesMap = parserHandler.searchForEntryByCitationKey(citationKey.get());
+            if (!entriesMap.isEmpty()) {
+                return entriesMap.entrySet().stream()
+                        .flatMap(listEntry -> listEntry.getValue().stream().map(entry -> new Location(listEntry.getKey(), getRangeFromEntry(listEntry.getKey(), entry))))
+                        .toList();
+            }
+        }
+        return List.of();
+    }
+
+    private Range getRangeFromEntry(String fileUri, BibEntry entry) {
+        ParserResult parserResult = parserHandler.getParserResultForUri(fileUri).get(); // always present if we have an entry from provideDefinition
+        return LspRangeUtil.convertToLspRange(parserResult.getArticleRanges().get(entry));
+    }
+
+    private Optional<String> getCitationKeyAtPosition(String content, Position position) {
+        if (content == null || content.isEmpty() || position == null) {
+            return Optional.empty();
+        }
+
+        int around = LspRangeUtil.toOffset(content, position);
+        if (around < 0 || around > content.length()) {
+            return Optional.empty();
+        }
+
+        int start = lookaheadForCitationKeyStart(content, position);
+        if (start < 0) {
+            return Optional.empty();
+        }
+
+        int end = lookaheadForCitationKeyEnd(content, position);
+        if (end < 0 || end <= start) {
+            return Optional.empty();
+        }
+
+        return Optional.of(content.substring(start, end));
+    }
+
+    private int lookaheadForCitationKeyEnd(String content, Position position) {
+        int i = lookaheadForCitationKeyStart(content, position);
+        while (i < content.length() && isCitationKeyCharacter(content.charAt(i))) {
+            i++;
+        }
+        return i;
+    }
+
+    private int lookaheadForCitationKeyStart(String content, Position position) {
+        int caretOffset = clamp(LspRangeUtil.toOffset(content, position), 0, content.length());
+        int scanIndex = Math.min(Math.max(0, caretOffset - 1), Math.max(0, content.length() - 1));
+        while (scanIndex >= 0 && isCitationKeyCharacter(content.charAt(scanIndex))) {
+            scanIndex--;
+        }
+
+        if (scanIndex >= 0 && content.charAt(scanIndex) == '@') {
+            if (isValidCitationKeyCharBefore(content, scanIndex - 1)) {
+                return scanIndex + 1;
+            }
+            return -1;
+        }
+        if (caretOffset < content.length() && content.charAt(caretOffset) == '@' && isValidCitationKeyCharBefore(content, caretOffset - 1)) {
+            return caretOffset + 1;
+        }
+        return -1;
+    }
+
+    private int clamp(int i, int min, int max) {
+        return Math.max(min, Math.min(i, max));
+    }
+
+    private boolean isCitationKeyCharacter(char c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || c == '_' || c == '-' || c == ':' || c == '.' || c == '+';
+    }
+
+    private boolean isValidCitationKeyCharBefore(String content, int idBeforeAt) {
+        if (idBeforeAt < 0) {
+            return true;
+        }
+        char p = content.charAt(idBeforeAt);
+
+        if (Character.isLetterOrDigit(p) || p == '_' || p == '.') {
+            return false;
+        }
+
+        return Character.isWhitespace(p)
+                || p == '[' || p == '(' || p == '{'
+                || p == ';' || p == ',' || p == ':'
+                || p == '-' || p == '—' || p == '–' || p == '«' || p == '“' || p == '"'
+                || p == '\'';
+    }
+}


### PR DESCRIPTION
Closes https://github.com/palukku/jabref/issues/57 partially

Added the ability to ctrl + click on an `[@citationKey]` in markdown files and it jumps to the according entry in the bib file also ctrl + hover shows a preview of the entry.

<img width="999" height="298" alt="image" src="https://github.com/user-attachments/assets/cf5ee457-d138-4a39-a2a7-ced48e99936c" />


(Future work would be to have an option to select it in jabref if jabref is running)

### Steps to test

Start the Language Server and an VSCode instance with the extension enabled.

Have a .bib file with entries in it.

Cite one entry in an markdown file and ctrl + click on it.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
