### PR TITLE
Fix workflow names in comment

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -88,8 +88,8 @@
 
 # CHANGELOG.md and *.md
 
-- jobName: 'CHANGELOG.md needs to be modified'
-  workflowName: 'PR Tests'
+- jobName: 'CHANGELOG.md needs to be modified if indicated'
+  workflowName: 'Check PR CHANGELOG.md'
   message: >
     You ticked that you modified `CHANGELOG.md`, but no new entry was found there.
 
@@ -127,14 +127,14 @@
 # Submodules and branches
 
 - jobName: 'Submodules not modified'
-  workflowName: 'PR Tests'
+  workflowName: 'Check PR Modifications'
   message: >
     Your pull request modified git submodules.
 
 
     Please follow our [FAQ on submodules](https://devdocs.jabref.org/code-howtos/faq.html#submodules) to fix.
 - jobName: no-force-push
-  workflowName: 'PR Tests'
+  workflowName: 'Check PR Modifications'
   always: true
   message: >
     Hey, we noticed that you **force-pushed** your changes.
@@ -156,7 +156,7 @@
     Please [merge `upstream/main`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line) with your code.
     For a step-by-step guide to resolve merge conflicts, see <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line>.
 - jobName: 'Source branch is other than "main"'
-  workflowName: 'PR Tests'
+  workflowName: 'Check PR Modifications'
   message: >
     You committed your code on the `main` brach of your fork. This is a bad practice.
     The right way is to branch out from `main`, work on your patch/feature in that new branch, and then get that branch merged via the pull request (see [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow)).


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/14060#issuecomment-3388981089

Follow-up to https://github.com/JabRef/jabref/pull/13942. There, we modified workflow-names, but forgot to adapt `ghprcomment.yml`.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
