### PR TITLE
Feature: Move group sort actions to a submenu

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.swing.JMenu;
 import javax.swing.undo.UndoManager;
 
 import javafx.application.Platform;
@@ -610,14 +611,20 @@ public class GroupTreeView extends BorderPane {
                     new ContextAction(StandardActions.GROUP_SUGGESTED_GROUPS_ADD, group)));
         }
 
+        Menu sortSubgroupsMenu = new Menu(Localization.lang("Sort Subgroups"));
+
+        sortSubgroupsMenu.getItems().addAll(
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, group)),
+                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, group))
+        );
+
         contextMenu.getItems().addAll(
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_ADD, new ContextAction(StandardActions.GROUP_SUBGROUP_ADD, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_RENAME, new ContextAction(StandardActions.GROUP_SUBGROUP_RENAME, group)),
                 factory.createMenuItem(StandardActions.GROUP_SUBGROUP_REMOVE, new ContextAction(StandardActions.GROUP_SUBGROUP_REMOVE, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, group)),
-                factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, group)),
+                sortSubgroupsMenu,
                 new SeparatorMenuItem(),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_ADD, new ContextAction(StandardActions.GROUP_ENTRIES_ADD, group)),
                 factory.createMenuItem(StandardActions.GROUP_ENTRIES_REMOVE, new ContextAction(StandardActions.GROUP_ENTRIES_REMOVE, group))


### PR DESCRIPTION
Closes #14017

This change improves the user interface by moving the four "Sort subgroups..." actions from the main group context menu into their own dedicated "Sort subgroups..." submenu. This makes the menu cleaner and more organized for users.

### Steps to test

1.  Run the JabRef application.
2.  In the "Groups" panel on the left, create a parent group (e.g., "My Research").
3.  Select the parent group and then create at least one subgroup (e.g., "Papers").
4.  Right-click on the parent group ("My Research").
5.  Confirm that you see a new "Sort subgroups..." menu item.
6.  Hover your mouse over it and confirm that the four sorting options (A-Z, Z-A, etc.) appear in a fly-out submenu.

<img width="1920" height="1080" alt="Screenshot 2025-10-12 160749" src="https://github.com/user-attachments/assets/1d0d953d-f08f-41f1-b097-eb4e19bfba8f" />


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
