### PR TITLE
Fix: condition to check if jumpToKey is not blank

### DIFF
--- a/jabgui/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/jabgui/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -67,7 +67,7 @@ public class ArgumentProcessor {
             return uiCommands;
         }
 
-        if (StringUtil.isBlank(guiCli.jumpToKey)) {
+        if (StringUtil.isNotBlank(guiCli.jumpToKey)) {
             uiCommands.add(new UiCommand.JumpToEntryKey(guiCli.jumpToKey));
         }
 


### PR DESCRIPTION
Fixes an error where the ArgumentProcessor only accepts blank citationkeys which should check the other way around

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
