### PR TITLE
fix: prevent Windows tempdir deletion failure

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/git/merge/MergeBookkeeperTest.java
+++ b/jablib/src/test/java/org/jabref/logic/git/merge/MergeBookkeeperTest.java
@@ -110,7 +110,6 @@ public class MergeBookkeeperTest {
         if (remoteGit != null) {
             remoteGit.close();
         }
-        
         RepositoryCache.clear();
         WindowCache.reconfigure(new WindowCacheConfig());
     }


### PR DESCRIPTION
Closes #12350 

This PR fixes a Windows test cleanup issue that was reported by @Siedlerchr in our group chat.
Adds `RepositoryCache.clear()` and `WindowCache.reconfigure(...)` in `MergeBookkeeperTest` to the test teardown.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
