### PR TITLE
Refactor StringUtilTest to use parameterized tests

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/strings/StringUtilTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -212,12 +213,12 @@ class StringUtilTest {
     }
 
     @ParameterizedTest
-    @MethodSource("provideDecodeStringDoubleArrayData")
+    @MethodSource
     void decodeStringDoubleArray(String input, String[][] expected) {
         assertArrayEquals(expected, StringUtil.decodeStringDoubleArray(input));
     }
 
-    static Stream<Arguments> provideDecodeStringDoubleArrayData() {
+    static Stream<Arguments> decodeStringDoubleArray() {
         return Stream.of(
                 Arguments.of("a:b;c:d", new String[][] {{"a", "b"}, {"c", "d"}}),
                 Arguments.of("a:;c:d", new String[][] {{"a", ""}, {"c", "d"}}),
@@ -227,43 +228,64 @@ class StringUtilTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            false,
-            true, {}
-            true, {a}
-            true, '{a{a}}'
-            true, '{{\\AA}sa {\\AA}Stor{\\aa}}'
-            false, {
-            false, }
-            false, a{}a
-            false, '{\\AA}sa {\\AA}Stor{\\aa}'
+            {}
+            {a}
+            '{a{a}}'
+            '{{\\AA}sa {\\AA}Stor{\\aa}}'
             """)
-    void isInCurlyBrackets(boolean expected, String input) {
-        assertEquals(expected, StringUtil.isInCurlyBrackets(input));
+    void isInCurlyBrackets(String input) {
+        assertTrue(StringUtil.isInCurlyBrackets(input));
     }
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            false,
-            true, []
-            true, [a]
-            false, [
-            false, ]
-            false, a[]a
+            ''
+            {
+            }
+            a{}a
+            '{\\AA}sa {\\AA}Stor{\\aa}'
             """)
-    void isInSquareBrackets(boolean expected, String input) {
-        assertEquals(expected, StringUtil.isInSquareBrackets(input));
+    void isNotInCurlyBrackets(String input) {
+        assertFalse(StringUtil.isInCurlyBrackets(input));
     }
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            false,
-            true, ""
-            true, "a"
-            false, "
-            false, a""a
+            []
+            [a]
             """)
-    void isInCitationMarks(boolean expected, String input) {
-        assertEquals(expected, StringUtil.isInCitationMarks(input));
+    void isInSquareBrackets(String input) {
+        assertTrue(StringUtil.isInSquareBrackets(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            ''
+            [
+            ]
+            a[]a
+            """)
+    void isINotnSquareBrackets(String input) {
+        assertFalse(StringUtil.isInSquareBrackets(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            ""
+            "a"
+            """)
+    void isInCitationMarks(String input) {
+        assertTrue(StringUtil.isInCitationMarks(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            ''
+            "
+            a""a
+            """)
+    void isNotInCitationMarks(String input) {
+        assertFalse(StringUtil.isInCitationMarks(input));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/issues/676

This PR refactors `StringUtilTest` to use parameterized tests (`@CsvSource` and `@MethodSource`) following the one-assertion-per-test guideline.

Note: My classmates are also contributing to this issue.

@espertusnu

### How to test:
./gradlew :jablib:test --tests org.jabref.model.strings.StringUtilTest

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.