### PR TITLE
Add fixed IndexOutOfBoundsException to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where the "Applications to push entries to" list in the preferences was not sorted alphabetically. [#14058](https://github.com/JabRef/jabref/issues/14058)
 - We fixed an issue where notice text in AI chat was not automatically refreshed when the user changed preferences.[#13855](https://github.com/JabRef/jabref/issues/13855)
 - We fixed an issue where the user could add custom entry types with spaces in their names. [#14088](https://github.com/JabRef/jabref/issues/14088)
-- We fixed various issues that triggered `IndexOutOfBoundsException`s, when editing entries. [#8012](https://github.com/JabRef/jabref/issues/8012), [#8826](https://github.com/JabRef/jabref/issues/8826), [#8217](https://github.com/JabRef/jabref/issues/8217)
+- We fixed various issues that triggered `IndexOutOfBoundsException`s, when editing entries. [#8012](https://github.com/JabRef/jabref/issues/8012), [#8826](https://github.com/JabRef/jabref/issues/8826), [#8217](https://github.com/JabRef/jabref/issues/8217), [#8281](https://github.com/JabRef/jabref/issues/8281)
 
 ### Removed
 


### PR DESCRIPTION
closes https://github.com/JabRef/jabref/issues/8012
closes https://github.com/JabRef/jabref/issues/8826
closes https://github.com/JabRef/jabref/issues/8217
closes https://github.com/JabRef/jabref/issues/8281
closes https://github.com/JabRef/jabref/issues/10403
closes https://github.com/JabRef/jabref/issues/10379
closes https://github.com/JabRef/jabref/issues/10373
closes https://github.com/JabRef/jabref/issues/11877

does not close issue https://github.com/JabRef/jabref/issues/8719

Not sure, what commit(s) exactly fixed all these issues, but since they have been very annoying to users, I think it's something worth mentioning in the changelog that they seem to be gone.

Successful commits could be found via [Git-bisect](https://git-scm.com/docs/git-bisect)

Unfortunately there are still a few other index out of bounds issues left to address, but JabRef has become better and the 6.0 release is definitely something to look forward to!



- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
