### PR TITLE
Add direct tests of BracketedPattern.lastAuthor()

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * <code>2017_Kitsune_123</code> when expanded using the BibTeX entry <code>@Article{ authors = {O. Kitsune}, year = {2017},
  * pages={123-6}}</code>.
  * <p>
- * The embedding in JabRef is explained at <a href="https://docs.jabref.org/setup/citationkeypattern">Customize the citation key generator</a>.
+ * The embedding in JabRef is explained at <a href="https://docs.jabref.org/setup/citationkeypatterns">Customize the citation key generator</a>.
  * </p>
  */
 public class BracketedPattern {
@@ -807,7 +807,8 @@ public class BracketedPattern {
      * @param authorList an {@link AuthorList}
      * @return the surname of an author/editor
      */
-    private static String lastAuthor(AuthorList authorList) {
+    @VisibleForTesting
+    static String lastAuthor(AuthorList authorList) {
         if (authorList.isEmpty()) {
             return "";
         }
@@ -1221,7 +1222,7 @@ public class BracketedPattern {
 
     /**
      * <p>
-     * An author or editor may be and institution not a person. In that case the key generator builds very long keys,
+     * An author or editor may be an institution not a person. In that case the key generator builds very long keys,
      * e.g.: for &ldquo;The Attributed Graph Grammar System (AGG)&rdquo; -> &ldquo;TheAttributedGraphGrammarSystemAGG&rdquo;.
      * </p>
      *

--- a/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
+++ b/jablib/src/test/java/org/jabref/logic/citationkeypattern/BracketedPatternTest.java
@@ -330,6 +330,24 @@ class BracketedPatternTest {
     }
 
     @ParameterizedTest
+    @CsvSource({
+            "'Newton', 'Isaac Newton'",
+            "'Maxwell', 'Isaac Newton and James Maxwell'",
+            "'Einstein', 'Isaac Newton and James Maxwell and Albert Einstein'",
+            "'Bohr', 'Isaac Newton and James Maxwell and Albert Einstein and N. Bohr'",
+            "'Aachen', 'Aachen'",
+            "'Berlin', 'Aachen and Berlin'",
+            "'Chemnitz', 'Aachen and Berlin and Chemnitz'",
+            "'Düsseldorf', 'Aachen and Berlin and Chemnitz and Düsseldorf'",
+            "'Essen', 'Aachen and Berlin and Chemnitz and Düsseldorf and Essen'",
+            "'Aalst', 'Wil van der Aalst'",
+            "'Lessen', 'Wil van der Aalst and Tammo van Lessen'"
+    })
+    void authLast(String expected, AuthorList list) {
+        assertEquals(expected, BracketedPattern.lastAuthor(list));
+    }
+
+    @ParameterizedTest
     @MethodSource
     void authShort(String expected, AuthorList list) {
         assertEquals(expected, BracketedPattern.authShort(list));


### PR DESCRIPTION
Refs #13930

Supesedes #13625

- Moves tests of `lastAuthor` from `CitationKeyGeneratorTest` to `BracketedPatternTest`
- Fixes typo and broken link in javadoc

I used single quotation marks that were not strictly necessary in the `@CsvSource` I added. This matches the style of the file, but I would be happy to remove them.

### Steps to test

`./gradlew :jablib:test --tests org.jabref.logic.citationkeypattern.BracketedPatternTest`

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
