### PR TITLE
Hw5 builder pattern refactor

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -163,4 +163,43 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
     public void setShowOnFocus(boolean showOnFocus) {
         this.showOnFocus = showOnFocus;
     }
+
+    /**
+         * Builder for {@link AutoCompletionTextInputBinding}.
+         */
+        public static class Builder<T> {
+            private TextInputControl textInputControl;
+            private Callback<ISuggestionRequest, Collection<T>> suggestionProvider;
+            private StringConverter<T> converter = AutoCompletionTextInputBinding.defaultStringConverter();
+            private AutoCompletionStrategy inputAnalyzer = new ReplaceStrategy();
+
+            public Builder<T> textInputControl(TextInputControl textInputControl) {
+                this.textInputControl = textInputControl;
+                return this;
+            }
+
+            public Builder<T> suggestionProvider(Callback<ISuggestionRequest, Collection<T>> suggestionProvider) {
+                this.suggestionProvider = suggestionProvider;
+                return this;
+            }
+
+            public Builder<T> converter(StringConverter<T> converter) {
+                this.converter = converter;
+                return this;
+            }
+
+            public Builder<T> inputAnalyzer(AutoCompletionStrategy inputAnalyzer) {
+                this.inputAnalyzer = inputAnalyzer;
+                return this;
+            }
+
+            /**
+             * Builds the AutoCompletionTextInputBinding.
+             *
+             * @return a new instance
+             */
+            public AutoCompletionTextInputBinding<T> build() {
+                return new AutoCompletionTextInputBinding<>(textInputControl, suggestionProvider, converter, inputAnalyzer);
+            }
+        }
 }

--- a/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -349,4 +349,42 @@ public class BibDatabaseContext {
     public String getUid() {
         return uid;
     }
+    /**
+     * Builder for {@link BibDatabaseContext}.
+     */
+    public static class Builder {
+        private BibDatabase database = new BibDatabase();
+        private MetaData metaData = new MetaData();
+        private Path path;
+        private DatabaseLocation location = DatabaseLocation.LOCAL;
+
+        public Builder database(BibDatabase database) {
+            this.database = database;
+            return this;
+        }
+
+        public Builder metaData(MetaData metaData) {
+            this.metaData = metaData;
+            return this;
+        }
+
+        public Builder path(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder location(DatabaseLocation location) {
+            this.location = location;
+            return this;
+        }
+
+        /**
+         * Builds the BibDatabaseContext.
+         *
+         * @return a new instance
+         */
+        public BibDatabaseContext build() {
+            return new BibDatabaseContext(database, metaData, path, location);
+        }
+    }
 }

--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -94,6 +94,19 @@ public class LinkedFile implements Serializable {
         this("", link, "");
     }
 
+    // Static factory methods
+    public static LinkedFile fromPath(String description, Path link, String fileType) {
+        return new LinkedFile(description, link, fileType);
+    }
+
+    public static LinkedFile fromUrl(String description, URL link, String fileType) {
+        return new LinkedFile(description, link, fileType);
+    }
+
+    public static LinkedFile of(String description, String link, String fileType) {
+        return new LinkedFile(description, link, fileType);
+    }
+
     public StringProperty descriptionProperty() {
         return description;
     }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/14066

Implemented Builder pattern for AutoCompletionTextInputBinding and BibDatabaseContext classes. Added static factory methods to LinkedFile class for clearer object creation.
This is a homework assignment for CS 5010 addressing issue 14066

### Steps to test

This is a refactoring that doesn't change functionality. Existing tests should pass. The new Builder classes and factory methods are demonstrated in the generated Javadoc.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
