### PR TITLE
ui(groups): move 'Sort ...' items into 'Sort ...' submenu

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -36,7 +36,6 @@
       </option>
       <option name="RECORD_COMPONENTS_WRAP" value="0" />
       <option name="MULTI_CATCH_TYPES_WRAP" value="0" />
-      <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
     </JavaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />

--- a/jabgui/src/main/java/org/jabref/gui/actions/StandardActions.java
+++ b/jabgui/src/main/java/org/jabref/gui/actions/StandardActions.java
@@ -226,6 +226,8 @@ public enum StandardActions implements Action {
     GROUP_SUBGROUP_RENAME(Localization.lang("Rename subgroup"), KeyBinding.GROUP_SUBGROUP_RENAME),
     GROUP_ENTRIES_REMOVE(Localization.lang("Remove selected entries from this group")),
 
+    GROUP_SUBGROUP_SORT_MENU(Localization.lang("Sort...")),
+
     CLEAR_EMBEDDINGS_CACHE(Localization.lang("Clear embeddings cache")),
 
     GIT(Localization.lang("Git"), IconTheme.JabRefIcons.GIT_SYNC),

--- a/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/jabgui/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -602,6 +602,18 @@ public class GroupTreeView extends BorderPane {
                 factory.createMenuItem(StandardActions.GROUP_GENERATE_EMBEDDINGS, new ContextAction(StandardActions.GROUP_GENERATE_EMBEDDINGS, group)),
                 factory.createMenuItem(StandardActions.GROUP_GENERATE_SUMMARIES, new ContextAction(StandardActions.GROUP_GENERATE_SUMMARIES, group)),
                 removeGroup,
+                new Menu(
+                        Localization.lang("Sort..."),
+                        null,
+                        factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT,
+                                new ContextAction(StandardActions.GROUP_SUBGROUP_SORT, group)),
+                        factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_REVERSE,
+                                new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_REVERSE, group)),
+                        factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES,
+                                new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES, group)),
+                        factory.createMenuItem(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE,
+                                new ContextAction(StandardActions.GROUP_SUBGROUP_SORT_ENTRIES_REVERSE, group))
+                ),
                 new SeparatorMenuItem()
         );
 


### PR DESCRIPTION
Closes _____
<!-- Closes #14017 -->

<!-- I have added functionality of a subgroup sort menu to have all the sort options open to a Sort... button -->


### Steps to test

<!-- Reviewers can look at the code, then when testing hover over the Sort... button to make sure it works as intended. -->


<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
