### PR TITLE
Refactor tests to use parameterized tests

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsReplacerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsReplacerTest.java
@@ -13,23 +13,17 @@ class AuthorAndsReplacerTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorAndsReplacer#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource({
-            // Empty case
-            "'', ''",
-
-            // Single name (unchanged)
-            "'Someone, Van Something', 'Someone, Van Something'",
-
-            // 'and' replaced with '&' in two names
-            "'John Smith and Black Brown, Peter', 'John Smith & Black Brown, Peter'",
-
-            // 'and' replaced with ';' and '&' for three names
-            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, John; Smith, John & Black Brown, Peter'",
-
-            // 'and' replaced with ';' and '&' for three names
-            "'John von Neumann and John Smith and Peter Black Brown', 'John von Neumann; John Smith & Peter Black Brown'"
-    })
-    void format(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        '' -> ''
+                        'Someone, Van Something' -> 'Someone, Van Something'
+                        'John Smith & Black Brown, Peter' -> 'John Smith and Black Brown, Peter'
+                        'von Neumann, John; Smith, John & Black Brown, Peter' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+                        'John von Neumann; John Smith & Peter Black Brown' -> 'John von Neumann and John Smith and Peter Black Brown'
+                    """
+    )
+    void format(String expected, String input) {
         LayoutFormatter a = new AuthorAndsReplacer();
         assertEquals(expected, a.format(input));
     }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommasTest.java
@@ -13,21 +13,17 @@ class AuthorFirstLastOxfordCommasTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorFirstLastOxfordCommas#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource({
-            // Empty case
-            "'', ''",
-
-            // Single Names
-            "'Someone, Van Something', Van Something Someone",
-
-            // Two names
-            "John von Neumann and Peter Black Brown, John von Neumann and Peter Black Brown",
-
-            // Three names
-            "'von Neumann, John and Smith, John and Black Brown, Peter', 'John von Neumann, John Smith, and Peter Black Brown'",
-            "'John von Neumann and John Smith and Black Brown, Peter', 'John von Neumann, John Smith, and Peter Black Brown'"
-    })
-    void format(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        '' -> ''
+                        'Van Something Someone' -> 'Someone, Van Something'
+                        'John von Neumann and Peter Black Brown' -> 'John von Neumann and Peter Black Brown'
+                        'John von Neumann, John Smith, and Peter Black Brown' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+                        'John von Neumann, John Smith, and Peter Black Brown' -> 'John von Neumann and John Smith and Black Brown, Peter'
+                    """
+    )
+    void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorFirstLastOxfordCommas();
         assertEquals(expected, formatter.format(input));
     }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommasTest.java
@@ -13,21 +13,17 @@ class AuthorLastFirstAbbrOxfordCommasTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstAbbrOxfordCommas#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource({
-            // Empty case
-            "'', ''",
-
-            // Single Names
-            "Van Something Someone, 'Someone, V. S.'",
-
-            // Two names
-            "'John von Neumann and Black Brown, Peter', 'von Neumann, J. and Black Brown, P.'",
-
-            // Three names
-            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, J., Smith, J., and Black Brown, P.'",
-            "'John von Neumann and John Smith and Black Brown, Peter', 'von Neumann, J., Smith, J., and Black Brown, P.'"
-    })
-    void format(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        '' -> ''
+                        'Someone, V. S.' -> 'Van Something Someone'
+                        'von Neumann, J. and Black Brown, P.' -> 'John von Neumann and Black Brown, Peter'
+                        'von Neumann, J., Smith, J., and Black Brown, P.' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+                        'von Neumann, J., Smith, J., and Black Brown, P.' -> 'John von Neumann and John Smith and Black Brown, Peter'
+                    """
+    )
+    void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstAbbrOxfordCommas();
         assertEquals(expected, formatter.format(input));
     }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTest.java
@@ -6,39 +6,27 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Test case  that verifies the functionalities of the formater AuthorLastFirstAbbreviator.
+ * Test case that verifies the functionalities of the formatter AuthorLastFirstAbbreviator.
  */
 class AuthorLastFirstAbbreviatorTest {
 
     private final AuthorLastFirstAbbreviator abbreviator = new AuthorLastFirstAbbreviator();
 
     @ParameterizedTest
-    @CsvSource({
-            // One author, simple name
-            "'Lastname, Name', 'Lastname, N.'",
-
-            // One author, common name with middle name
-            "'Lastname, Name Middlename', 'Lastname, N. M.'",
-
-            // Two authors with common names
-            "'Lastname, Name Middlename and Sobrenome, Nome Nomedomeio', 'Lastname, N. M. and Sobrenome, N. N.'",
-
-            // Author with Jr. suffix
-            "'Other, Jr., Anthony N.', 'Other, Jr., A. N.'",
-
-            // Empty input returns empty
-            "'', ''",
-
-            // Author with prefix like Van
-            "'Someone, Van Something', 'Someone, V. S.'",
-
-            // Single author
-            "'Smith, John', 'Smith, J.'",
-
-            // Multiple authors with complex last names
-            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, J. and Smith, J. and Black Brown, P.'"
-    })
-    void abbreviate(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        'Lastname, N.' -> 'Lastname, Name'
+                        'Lastname, N. M.' -> 'Lastname, Name Middlename'
+                        'Lastname, N. M. and Sobrenome, N. N.' -> 'Lastname, Name Middlename and Sobrenome, Nome Nomedomeio'
+                        'Other, Jr., A. N.' -> 'Other, Jr., Anthony N.'
+                        '' -> ''
+                        'Someone, V. S.' -> 'Someone, Van Something'
+                        'Smith, J.' -> 'Smith, John'
+                        'von Neumann, J. and Smith, J. and Black Brown, P.' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+                    """
+    )
+    void abbreviate(String expected, String input) {
         assertEquals(expected, abbreviator.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
@@ -17,23 +17,17 @@ class RemoveBracketsTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-            // Brace pair correctly removed
-            "{some text}, some text",
-
-            // Single opening brace correctly removed
-            "{some text, some text",
-
-            // Single closing brace correctly removed
-            "some text}, some text",
-
-            // Brace pair with escaped backslash correctly removed
-            "'\\\\{some text\\\\}', '\\\\some text\\\\'",
-
-            // Without brackets unmodified
-            "some text, some text"
-    })
-    void format(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        some text -> '{some text}'
+                        some text -> '{some text'
+                        some text -> 'some text}'
+                        '\\some text\\' -> '\\{some text\\}'
+                        some text -> some text
+                    """
+    )
+    void format(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
@@ -16,35 +16,21 @@ class RemoveLatexCommandsFormatterTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-            // Without LaTeX commands
-            "some text, some text",
-
-            // Single command wiped
-            "\\sometext, ''",
-
-            // Single space after command removed
-            "\\some text, text",
-
-            // Multiple spaces after command removed
-            "\\some     text, text",
-
-            // Escaped backslash becomes backslash
-            "'\\\\', '\\'",
-
-            // Escaped backslash followed by text
-            "'\\\\some text', '\\some text'",
-
-            // Escaped backslash kept
-            "'\\\\some text\\\\', '\\some text\\'",
-
-            // Escaped underscore replaced
-            "some\\_text, some_text",
-
-            // Realistic LaTeX URL with escaped underscores
-            "'http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf', 'http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf'"
-    })
-    void format(String input, String expected) {
+    @CsvSource(
+            delimiterString = "->",
+            textBlock = """
+                        some text -> some text
+                        '' -> '\\sometext'
+                        text -> '\\some text'
+                        text -> '\\some     text'
+                        '\\' -> '\\\\'
+                        '\\some text' -> '\\\\some text'
+                        '\\some text\\' -> '\\\\some text\\\\'
+                        some_text -> 'some\\_text'
+                        'http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf' -> 'http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf'
+                    """
+    )
+    void format(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }
 }


### PR DESCRIPTION
Refs JabRef#676
I am part of a Java graduate school class. My classmates will submit other PRs that address this issue as well.
 
This PR refactors multiple test classes to follow the one-assertion-per-test guideline and improve overall test readability and maintainability. Parameterized tests (`@CsvSource`) were introduced where appropriate to replace repetitive assertions.
 
Steps to test
To test this code run:
```
./gradlew :jablib:test \
--tests org.jabref.logic.layout.format.AuthorAndsReplacerTest \
--tests org.jabref.logic.layout.format.AuthorFirstLastOxfordCommasTest \
--tests org.jabref.logic.layout.format.AuthorLastFirstAbbrOxfordCommasTest \
--tests org.jabref.logic.layout.format.AuthorLastFirstAbbreviatorTest \
--tests org.jabref.logic.layout.format.RemoveBracketsTest \
--tests org.jabref.logic.layout.format.RemoveLatexCommandsFormatterTest
```
 
### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <[https://github.com/JabRef/user-documentation/issues>](https://github.com/JabRef/user-documentation/issues%3E) or, even better, I submitted a pull request updating file(s) in <[https://github.com/JabRef/user-documentation/tree/main/en>.](https://github.com/JabRef/user-documentation/tree/main/en%3E.)
