### PR TITLE
Add DeepWiki and remove draft feedback proposal

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -35,7 +35,7 @@ jobs:
             In case you encounter failing tests during development, please check our [developer FAQs](https://devdocs.jabref.org/code-howtos/faq.html)!
 
 
-            Having any questions or issues?
+            Still facing issues or having more questions?
             Feel free to ask here on GitHub or on [JabRef's Gitter chat](https://gitter.im/JabRef/jabref).
             Please don't hesitate to open a (draft) pull request early on to show the direction you are heading towards if unsure.
 


### PR DESCRIPTION
Our welcome message missed DeepWiki (which @HoussemNasri tends to recommend). I find it better than the JabRef.guru. Thus, I put the link there.

Not sure if we should update CONTRIBUTING.md, too.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
