### PR TITLE
Fix: update group and version for JabRef language server

### DIFF
--- a/jabls-cli/build.gradle.kts
+++ b/jabls-cli/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("application")
 }
 
+group = "org.jabref.languageserver"
+version = project.findProperty("projVersion") ?: "100.0.0"
+
 application{
     mainClass.set("org.jabref.languageserver.cli.ServerCli")
     mainModule.set("org.jabref.jabls.cli")
@@ -58,7 +61,7 @@ tasks.named<JavaExec>("run") {
 }
 
 javaModulePackaging {
-    applicationName = "jabös"
+    applicationName = "jabls"
     vendor = "JabRef"
 
     // All targets have to have "app-image" as sole target, since we do not distribute an installer


### PR DESCRIPTION

### Steps to test

Try running `gradle jabls-cli:jpackage` and it should work, before it threw an error.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
