### PR TITLE
Change recursion into two calls

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -494,27 +494,31 @@ public class EntryEditor extends BorderPane implements PreviewControls, AdaptVis
 
     public void setFocusToField(Field field) {
         UiTaskExecutor.runInJavaFXThread(() -> {
-            Field actualField = field;
-            boolean fieldFound = false;
-            for (Tab tab : tabbed.getTabs()) {
-                tabbed.getSelectionModel().select(tab);
-                if ((tab instanceof FieldsEditorTab fieldsEditorTab)
-                        && fieldsEditorTab.getShownFields().contains(actualField)) {
-                    tabbed.getSelectionModel().select(tab);
-                    Platform.runLater(() -> fieldsEditorTab.requestFocus(actualField));
-                    // This line explicitly brings focus back to the main window containing the Entry Editor.
-                    getScene().getWindow().requestFocus();
-                    fieldFound = true;
-                    break;
-                }
-            }
-            if (!fieldFound) {
-                Field aliasField = EntryConverter.FIELD_ALIASES.get(field);
-                if (aliasField != null) {
-                    setFocusToField(aliasField);
-                }
-            }
+            getTabContainingField(field).ifPresentOrElse(
+                    tab -> selectTabAndField(tab, field),
+                    () -> {
+                        Field aliasField = EntryConverter.FIELD_ALIASES.get(field);
+                        getTabContainingField(aliasField).ifPresent(tab -> selectTabAndField(tab, aliasField));
+                    }
+            );
         });
+    }
+
+    private void selectTabAndField(FieldsEditorTab tab, Field field) {
+        Platform.runLater(() -> {
+            tabbed.getSelectionModel().select(tab);
+            tab.requestFocus(field);
+        });
+        // This line explicitly brings focus back to the main window containing the Entry Editor.
+        getScene().getWindow().requestFocus();
+    }
+
+    private Optional<FieldsEditorTab> getTabContainingField(Field field) {
+        return tabbed.getTabs().stream()
+                     .filter(FieldsEditorTab.class::isInstance)
+                     .map(FieldsEditorTab.class::cast)
+                     .filter(tab -> tab.getShownFields().contains(field))
+                     .findFirst();
     }
 
     @Override


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/12022. 

The code is now split-up into sub methods. Avoids endless recursion in case of non-found fields.

### Steps to test

See https://github.com/JabRef/jabref/pull/12022#pullrequestreview-2379311269

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
