### PR TITLE
Pre-compile regex patterns

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
+++ b/jablib/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jabref.logic.cleanup.ConvertToBibtexCleanup;
 import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
@@ -22,6 +23,11 @@ import org.slf4j.LoggerFactory;
 public final class BstPreviewLayout implements PreviewLayout {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BstPreviewLayout.class);
+
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("%.*");
+    private static final Pattern BIBITEM_PATTERN = Pattern.compile("\\\\bibitem[{].*[}]");
+    private static final Pattern LATEX_COMMAND_PATTERN = Pattern.compile("(?m)^\\\\.*$");
+    private static final Pattern MULTIPLE_SPACES_PATTERN = Pattern.compile("  +");
 
     private final String name;
     private String source;
@@ -55,23 +61,23 @@ public final class BstPreviewLayout implements PreviewLayout {
         if (error != null) {
             return error;
         }
-        // ensure that the entry is of BibTeX format (and do not modify the original entry)
+        // Ensure that the entry is of BibTeX format (and do not modify the original entry)
         BibEntry entry = new BibEntry(originalEntry);
         new ConvertToBibtexCleanup().cleanup(entry);
         String result = bstVM.render(List.of(entry));
         // Remove all comments
-        result = result.replaceAll("%.*", "");
+        result = COMMENT_PATTERN.matcher(result).replaceAll("");
         // Remove all LaTeX comments
         // The RemoveLatexCommandsFormatter keeps the words inside latex environments. Therefore, we remove them manually
         result = result.replace("\\begin{thebibliography}{1}", "");
         result = result.replace("\\end{thebibliography}", "");
         // The RemoveLatexCommandsFormatter keeps the word inside the latex command, but we want to remove that completely
-        result = result.replaceAll("\\\\bibitem[{].*[}]", "");
+        result = BIBITEM_PATTERN.matcher(result).replaceAll("");
         // We want to replace \newblock by a space instead of completely removing it
         result = result.replace("\\newblock", " ");
-        // remove all latex commands statements - assumption: command in a separate line
-        result = result.replaceAll("(?m)^\\\\.*$", "");
-        // remove some IEEEtran.bst output (resulting from a multiline \providecommand)
+        // Remove all latex commands statements - assumption: command in a separate line
+        result = LATEX_COMMAND_PATTERN.matcher(result).replaceAll("");
+        // Remove some IEEEtran.bst output (resulting from a multiline \providecommand)
         result = result.replace("#2}}", "");
         // Have quotes right - and more
         result = new LatexToUnicodeFormatter().format(result);
@@ -81,7 +87,7 @@ public final class BstPreviewLayout implements PreviewLayout {
         result = new RemoveNewlinesFormatter().format(result);
         result = new RemoveLatexCommandsFormatter().format(result);
         result = new RemoveTilde().format(result);
-        result = result.trim().replaceAll("  +", " ");
+        result = MULTIPLE_SPACES_PATTERN.matcher(result.trim()).replaceAll(" ");
         return result;
     }
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.formatter.bibtexfields;
 
+import java.util.regex.Pattern;
+
 import org.jabref.architecture.AllowedToUseApacheCommonsLang3;
 import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
@@ -10,6 +12,8 @@ import org.jspecify.annotations.NonNull;
 
 @AllowedToUseApacheCommonsLang3("There is no equivalent in Google's Guava")
 public class HtmlToUnicodeFormatter extends Formatter implements LayoutFormatter {
+
+    private static final Pattern HTML_TAGS_PATTERN = Pattern.compile("<[^>]*>");
 
     @Override
     public String getName() {
@@ -34,6 +38,7 @@ public class HtmlToUnicodeFormatter extends Formatter implements LayoutFormatter
     @Override
     public String format(@NonNull String fieldText) {
         // StringEscapeUtils converts characters and regex kills tags
-        return StringEscapeUtils.unescapeHtml4(fieldText).replaceAll("<[^>]*>", "");
+        String plainText = StringEscapeUtils.unescapeHtml4(fieldText);
+        return HTML_TAGS_PATTERN.matcher(plainText).replaceAll("");
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/EuropePmcFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/EuropePmcFetcher.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.jabref.logic.cleanup.FieldFormatterCleanup;
 import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
@@ -35,6 +36,9 @@ import org.slf4j.LoggerFactory;
 
 public class EuropePmcFetcher implements IdBasedParserFetcher, SearchBasedParserFetcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(EuropePmcFetcher.class);
+
+    // Prefer a full ISO date if provided
+    private static final Pattern DATE_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
 
     @Override
     public URL getUrlForIdentifier(String identifier) throws URISyntaxException, MalformedURLException {
@@ -101,13 +105,12 @@ public class EuropePmcFetcher implements IdBasedParserFetcher, SearchBasedParser
             if (result.has("journalInfo") && result.getJSONObject("journalInfo").has("issn")) {
                 entry.setField(StandardField.ISSN, result.getJSONObject("journalInfo").getString("issn"));
             }
-            // Prefer a full ISO date if provided
-            final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
+
             String printPubDate = result.optString("printPublicationDate");
             String dateOfPublication = result.optString("dateOfPublication");
-            if (printPubDate != null && printPubDate.matches(datePattern)) {
+            if (printPubDate != null && DATE_PATTERN.matcher(printPubDate).matches()) {
                 entry.setField(StandardField.DATE, printPubDate);
-            } else if (dateOfPublication != null && dateOfPublication.matches(datePattern)) {
+            } else if (dateOfPublication != null && DATE_PATTERN.matcher(dateOfPublication).matches()) {
                 entry.setField(StandardField.DATE, dateOfPublication);
             }
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/JstorFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/JstorFetcher.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.importer.FetcherException;
@@ -43,6 +44,8 @@ public class JstorFetcher implements SearchBasedParserFetcher, FulltextFetcher, 
     private static final String CITE_HOST = HOST + "/citation/text/";
     private static final String URL_QUERY_REGEX = "(?<=\\?).*";
 
+    private static final Pattern URL_QUERY_PATTERN = Pattern.compile(URL_QUERY_REGEX);
+
     private final ImportFormatPreferences importFormatPreferences;
 
     public JstorFetcher(ImportFormatPreferences importFormatPreferences) {
@@ -63,10 +66,10 @@ public class JstorFetcher implements SearchBasedParserFetcher, FulltextFetcher, 
             identifier = identifier.replace("https://www.jstor.org/stable", "");
             identifier = identifier.replace("http://www.jstor.org/stable", "");
         }
-        identifier = identifier.replaceAll(URL_QUERY_REGEX, "");
+        identifier = URL_QUERY_PATTERN.matcher(identifier).replaceAll("");
 
         if (identifier.contains("/")) {
-            // if identifier links to a entry with a valid doi
+            // if identifier links to an entry with a valid doi
             return URLUtil.create(start + identifier);
         }
         // else use default doi start.


### PR DESCRIPTION
Closes #14103

Pre-compile regex patterns as private static final Pattern fields at the class level

### Steps to test

To test this code run tests related to the files to confirm they are still working:
```
./gradlew :jablib:test \
  --tests org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatterTest.java \
  --tests org/jabref/logic/importer/fetcher/JstorFetcherTest.java \
  --tests org/jabref/logic/bst/BstPreviewLayoutTest.java \
  --tests org/jabref/logic/importer/fetcher/EuropePmcFetcherTest.java \

  ```

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
