### PR TITLE
Fix class name for SciteAiFetcher

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
@@ -18,7 +18,7 @@ import org.jabref.gui.externalfiles.ImportHandler;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.importer.fetcher.CrossRef;
-import org.jabref.logic.importer.fetcher.ScienceAiFetcher;
+import org.jabref.logic.importer.fetcher.SciteAiFetcher;
 import org.jabref.logic.importer.fetcher.citation.CitationFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BackgroundTask;
@@ -47,7 +47,7 @@ public class CitationsRelationsTabViewModel {
     private final FileUpdateMonitor fileUpdateMonitor;
     private final TaskExecutor taskExecutor;
 
-    private final ScienceAiFetcher scienceAiFetcher;
+    private final SciteAiFetcher sciteAiFetcher;
 
     private final ObjectProperty<SciteStatus> status;
     private final StringProperty searchError;
@@ -64,7 +64,7 @@ public class CitationsRelationsTabViewModel {
 
         this.status = new SimpleObjectProperty<>(SciteStatus.IN_PROGRESS);
         this.searchError = new SimpleStringProperty("");
-        this.scienceAiFetcher = new ScienceAiFetcher();
+        this.sciteAiFetcher = new SciteAiFetcher();
     }
 
     public void importEntries(List<CitationRelationItem> entriesToImport, CitationFetcher.SearchType searchType, BibEntry existingEntry) {
@@ -154,7 +154,7 @@ public class CitationsRelationsTabViewModel {
             return;
         }
 
-        searchTask = BackgroundTask.wrap(() -> scienceAiFetcher.fetchTallies(entry.getDOI().get()))
+        searchTask = BackgroundTask.wrap(() -> sciteAiFetcher.fetchTallies(entry.getDOI().get()))
                                    .onRunning(() -> status.set(SciteStatus.IN_PROGRESS))
                                    .onSuccess(result -> {
                                        currentResult = Optional.of(result);

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SciteAiFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SciteAiFetcher.java
@@ -14,11 +14,12 @@ import kong.unirest.core.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ScienceAiFetcher {
+/// Fetches citation information from <https://scite.ai/>
+public class SciteAiFetcher {
     private static final String BASE_URL = "https://api.scite.ai/";
-    private static final Logger LOGGER = LoggerFactory.getLogger(ScienceAiFetcher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SciteAiFetcher.class);
 
-    public ScienceAiFetcher() {
+    public SciteAiFetcher() {
     }
 
     public TalliesResponse fetchTallies(DOI doi) throws FetcherException {

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/SciteAiFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/SciteAiFetcherTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ScienceAiFetcherTest {
+public class SciteAiFetcherTest {
     @Test
     void sciteTallyDTO() {
         JSONObject jsonObject = new JSONObject();
@@ -36,7 +36,7 @@ public class ScienceAiFetcherTest {
 
     @Test
     void fetchTallies() throws FetcherException {
-        ScienceAiFetcher viewModel = new ScienceAiFetcher();
+        SciteAiFetcher viewModel = new SciteAiFetcher();
         DOI doi = new DOI("10.1109/ICECS.2010.5724443");
         Optional<DOI> actual = DOI.parse(viewModel.fetchTallies(doi).doi());
         assertEquals(Optional.of(doi), actual);


### PR DESCRIPTION
"Science" is not "Scite". I think, the PR #14045 did a wrong rename

### Steps to test

1. Start JabRef
2. Open Chocolate.bib
3. Go to a paper
4. Select tab "Citations"

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
