### PR TITLE
Use JavaFX 25 for ARM

### DIFF
--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -10,7 +10,7 @@ javaPlatform {
 val isLinux = providers.systemProperty("os.name").map { it.contains("linux", true) }
 val isArm64 = providers.systemProperty("os.arch").map { it.contains("aarch64", true) || it.contains("arm64", true) }
 val javafxProvider = isLinux.zip(isArm64) { linux, arm -> if (linux && arm) "25.0.1" else "25" }
-val javafx = javafxProvider.get() // if you need the String at config time
+val javafx = javafxProvider.get()
 
 val lucene = "10.3.1"
 val pdfbox = "3.0.5"


### PR DESCRIPTION
JavaFX 25.0.1 is not available for Linux-ARM.

This adds a workaround for building.

I tried to make GluonHQ aware at https://github.com/gluonhq/openjfx-smoke-tests/issues/14

I see this as hotfix and therefore do an automerge.

### Steps to test

Just check if binaries workflow succeeds.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
