### PR TITLE
Fix JBang tests

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -555,12 +555,16 @@ jobs:
           # We modify the JBang scripts directly to avoid issues with relative paths
           for f in ${{ steps.changed-jablib-files.outputs.all_changed_files }}; do
             case "$f" in
+              .jbang/*)
+                # skip scripts
+                continue
+                ;;
               jablib-examples/*)
                 # skip scripts
                 continue
                 ;;
               jabkit/*)
-                # only JabKit needs its modified sources
+                # only JabKit needs its modified sources if jabkit was modified
                 if [ "${{ matrix.script }}" != ".jbang/JabKitLauncher.java" ]; then
                   continue
                 fi


### PR DESCRIPTION
.jbang scripts should not be included inside themselves

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
