### PR TITLE
Try to fix IOB in clear and select

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTable.java
@@ -314,13 +314,9 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
             // keep original entry selected and reset citation merge mode
             this.citationMergeMode = false;
         } else {
-            // select new entry
-            // Use Platform.runLater to avoid JavaFX bug with selection change events
             findEntry(bibEntry).ifPresent(entry -> {
                 int index = getItems().indexOf(entry);
                 if (index >= 0) {
-                    // Use clearAndSelect(index) instead of separate clear() + select()
-                    // to avoid JavaFX bug with selection change events
                     getSelectionModel().clearAndSelect(index);
                     scrollTo(index);
                 }
@@ -337,9 +333,7 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
             // select new entries
             List<Integer> indices = bibEntries.stream()
                                               .filter(bibEntry -> bibEntry.getCitationKey().isPresent())
-                                              .map(bibEntry -> findEntryByCitationKey(bibEntry.getCitationKey().get()))
-                                              .filter(Optional::isPresent)
-                                              .map(Optional::get)
+                                              .flatMap(bibEntry -> findEntryByCitationKey(bibEntry.getCitationKey().get()).stream())
                                               .map(entry -> getItems().indexOf(entry))
                                               .filter(index -> index >= 0)
                                               .toList();
@@ -350,6 +344,8 @@ public class MainTable extends TableView<BibEntryTableViewModel> {
                 indices.forEach(index -> {
                     if (index < getItems().size()) {
                         getSelectionModel().select(index);
+                    } else {
+                        LOGGER.debug("Could not select entry at index {} since it is out of bounds", index);
                     }
                 });
                 scrollTo(indices.getFirst());


### PR DESCRIPTION
Try to use clear and select directly 

Fixes https://github.com/JabRef/jabref/issues/14986
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
