### PR TITLE
Disable fetcher-gui-test

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModelTest.java
@@ -16,8 +16,8 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/actions/runs/19331263969/job/55294684836?pr=14295

### Steps to test

Run `org.jabref.gui.fieldeditors.LinkedFilesEditorViewModelTest#urlFieldShouldDownloadFile` in your IDE

### Mandatory checks


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
