### PR TITLE
Add link to latest development version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
 
   - type: checkboxes
     attributes:
-      label: Checked with the latest development build (copy version output from About dialog)
+      label: Checked with the [latest development build](https://builds.jabref.org/main/) (copy version output from About dialog)
       description: |
         Please always test if the bug is still reproducible in the latest development version. We are constantly improving JabRef and some bugs may already be fixed. If you already use a development version, ensure that you use the latest one.
         You can download the latest development build at: https://builds.jabref.org/main/ . **Please make a backup of your library before you try out this version.**


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/issues/14318

Not sure if it renders nicely in the UI.

Any other ideas? More text?

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
