### PR TITLE
Check for disk space only once

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -130,17 +130,23 @@ jobs:
 
   disk-space-check:
     needs: conditions
-    if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
     runs-on: ubuntu-latest
     outputs:
       available: ${{ steps.diskspace.outputs.available }}
     steps:
+      - name: No upload
+        if: needs.conditions.outputs.upload-to-builds-jabref-org == 'false'
+        shell: bash
+        run: |
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "🚫 no upload – skipping upload"
       - name: Setup SSH key
+        if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
         run: |
           echo "${{ secrets.buildJabRefPrivateKey }}" > sshkey
           chmod 600 sshkey
       - name: Check disk space on builds.jabref.org
-        id: diskspace
+        if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
         shell: bash
         run: |
           USAGE=$(ssh -p 9922 -i sshkey -o StrictHostKeyChecking=no jrrsync@build-upload.jabref.org \


### PR DESCRIPTION
This separates the job for disk space check to enable easy check why some binaries are not uploaded any more (and avoid partial updates)

### Steps to test

Create binaries and see if they are still uploaded.

Check if binaries are still created even if they are not uploaded

See what happens if there is too little disk space (can be done after merge)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
