### PR TITLE
Output binaries workflow decisions to summary

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -67,65 +67,78 @@ jobs:
         run: |
           if [[ "$GITHUB_WORKFLOW" == *"early access"* && "$REPO_OWNER" != "JabRef" ]]; then
             echo "🚫 Early access workflow for JabRef disabled for non-JabRef owner"
+            echo "🚫 Early access workflow for JabRef disabled for non-JabRef owner" >> $GITHUB_STEP_SUMMARY
             echo "should-build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ "$EVENT_NAME" != "labeled" || "$LABEL_NAME" == "automerge"  || "$LABEL_NAME" == "dev: binaries" ]]; then
             echo "📦 build enabled"
+            echo "📦 build enabled" >> $GITHUB_STEP_SUMMARY
             echo "should-build=true" >> "$GITHUB_OUTPUT"
           else
             echo "🚫 build should be skipped"
+            echo "🚫 build should be skipped" >> $GITHUB_STEP_SUMMARY
             echo "should-build=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ -z "$BUILDJABREFPRIVATEKEY" ]; then
+            echo "🚫 Secret BUILDJABREFPRIVATEKEY not present – skipping upload"
+            echo "🚫 Secret BUILDJABREFPRIVATEKEY not present – skipping upload"
             echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
             echo "secretspresent=false" >> "$GITHUB_OUTPUT"
-            echo "🚫 Secret BUILDJABREFPRIVATEKEY not present – skipping upload"
             exit 0
           fi
           echo "secretspresent=true" >> "$GITHUB_OUTPUT"
 
           if [[ "$GITHUB_REF" == refs/heads/gh-readonly-queue* ]]; then
-            echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
             echo "🚫 merge queue – skipping upload"
+            echo "🚫 merge queue – skipping upload" >> $GITHUB_STEP_SUMMARY
+            echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag bulid" >> $GITHUB_STEP_SUMMARY
             echo "tagbuild=true" >> "$GITHUB_OUTPUT"
           else
+            echo "no tag bulid" >> $GITHUB_STEP_SUMMARY
             echo "tagbuild=false" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]] || [[ "${{ inputs.notarization }}" == "true" ]]; then
             # This workflow runs on ubuntu-latest even for notarization for macOS; need to check later if really on macOS
              echo "🧾 macOS notarization"
+             echo "🧾 macOS notarization" >> $GITHUB_STEP_SUMMARY
              echo "should-notarize=true" >> "$GITHUB_OUTPUT"
              echo "☁️ will upload"
+             echo "☁️ will upload" >> $GITHUB_STEP_SUMMARY
              echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"
              exit 0;
           else
             echo "🚫 no macOS notarization"
+            echo "🚫 no macOS notarization" >> $GITHUB_STEP_SUMMARY
             echo "should-notarize=false" >> "$GITHUB_OUTPUT"
           fi
 
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"
             echo "☁️ Non-PR event – will upload"
+            echo "☁️ Non-PR event – will upload" >> $GITHUB_STEP_SUMMARY
+            echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
 
           if echo "$LABELS" | grep -q "^dev: binaries$"; then
-            echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"
             echo "☁️ Label 'dev: binaries' found – will upload"
+            echo "☁️ Label 'dev: binaries' found – will upload" >> $GITHUB_STEP_SUMMARY
+            echo "upload-to-builds-jabref-org=true" >> "$GITHUB_OUTPUT"
           else
-            echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
             echo "🚫 Label 'dev: binaries' not found – skipping upload"
+            echo "🚫 Label 'dev: binaries' not found – skipping upload" >> $GITHUB_STEP_SUMMARY
+            echo "upload-to-builds-jabref-org=false" >> "$GITHUB_OUTPUT"
           fi
 
   disk-space-check:
@@ -138,8 +151,9 @@ jobs:
         if: needs.conditions.outputs.upload-to-builds-jabref-org == 'false'
         shell: bash
         run: |
-          echo "available=false" >> "$GITHUB_OUTPUT"
           echo "🚫 no upload – skipping upload"
+          echo "🚫 no upload – skipping upload" >> $GITHUB_STEP_SUMMARY
+          echo "available=false" >> "$GITHUB_OUTPUT"
       - name: Setup SSH key
         if: needs.conditions.outputs.upload-to-builds-jabref-org == 'true'
         run: |
@@ -152,13 +166,16 @@ jobs:
           USAGE=$(ssh -p 9922 -i sshkey -o StrictHostKeyChecking=no jrrsync@build-upload.jabref.org \
             "df --output=pcent /var/www/builds.jabref.org | tail -n1 | tr -dc '0-9'")
           echo "Remote usage: ${USAGE}%"
+          echo "Remote usage: ${USAGE}%" >> $GITHUB_STEP_SUMMARY
 
           if [ "$USAGE" -lt 80 ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
             echo "☁️ enough disk space available – will upload"
+            echo "☁️ enough disk space available – will upload" >> $GITHUB_STEP_SUMMARY
+            echo "available=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> "$GITHUB_OUTPUT"
             echo "🚫 not enough disk space – skipping upload"
+            echo "🚫 not enough disk space – skipping upload" >> $GITHUB_STEP_SUMMARY
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
   build:


### PR DESCRIPTION
Follow-up to https://github.com/JabRef/jabref/pull/14331

Uses the [summary functionality of GitHub workflows](https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/) to output the decisions.

### Steps to test

Check the summary of the binary workflow.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
