### PR TITLE
Add final modifier and private constructor for MathMLParser

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/util/MathMLParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/MathMLParser.java
@@ -26,7 +26,7 @@ public final class MathMLParser {
     private static final String XSLT_FILE_PATH = "/xslt/mathml_latex/mmltex.xsl";
 
     private MathMLParser() {
-        throw new UnsupportedOperationException("Utility class");
+        throw new UnsupportedOperationException("Cannot instantiate a utility class");
     }
 
     /**


### PR DESCRIPTION
Closes [#14346]( https://github.com/JabRef/jabref/issues/14346)

Added `final` modifier and private constructor to `MathMLParser` utility class to prevent instantiation and subclassing, following Java best practices for utility classes containing only static methods.

@espertusnu - This addresses the utility class refactoring discussed on Gitter.

### Steps to test
1. Build the project: `./gradlew build`
2. Run existing tests: `./gradlew test`
3. Verify all tests pass - no functionality should be affected

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
