### PR TITLE
Change output to utility method

### DIFF
--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
@@ -2,7 +2,6 @@ package org.jabref.toolkit.commands;
 
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.importer.ParserResult;
@@ -73,9 +72,7 @@ class GenerateCitationKeys implements Runnable {
                     parserResult.get().getDatabase(),
                     outputFile);
         } else {
-            System.out.println(databaseContext.getEntries().stream()
-                                              .map(BibEntry::toString)
-                                              .collect(Collectors.joining("\n\n")));
+            JabKit.outputDatabaseContext(argumentProcessor.cliPreferences, parserResult.get().getDatabaseContext());
         }
     }
 }


### PR DESCRIPTION
There are utility methods in JabKit. Still not consistent to each other, but we should use them nevertheless...

### Steps to test

    ./gradlew :jabkit:run --args="generate-citation-keys --input=../jablib/bin/test/testbib/complex.bib"

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
