### PR TITLE
Fix typos in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ GitHub will then automatically assign you.
 5. Refer to our [code how-tos](https://devdocs.jabref.org/code-howtos) if you have questions about your implementation.
 6. Implement and test your changes.
    * Create JUnit tests for your changes, apart from manual testing. Maybe even use [Test-driven Development](https://en.wikipedia.org/wiki/Test-driven_development) to speed up your development.
-   * Have fun. Learn. Communictate.
+   * Have fun. Learn. Communicate.
 7. Create a [pull request to JabRef main repository](https://github.com/JabRef/jabref/pulls).
    * For an overview on the concept of pull requests, take a look at GitHub's [pull request help documentation](https://help.github.com/articles/about-pull-requests/).
    * For text inspirations, consider [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request).
@@ -195,11 +195,11 @@ After implementing changes, commit to the branch your pull request is *from* and
 The pull request will automatically be updated with your changes.
 To maintain a clean git history, your commits will also be automatically squashed upon acceptance of the pull request, during merging.
 Thus, no need to worry about WIP commits or [fixing git submodule issues](https://devdocs.jabref.org/code-howtos/faq#submodules).
-As a concequece, force-pushing is not required - and must be **avoided**.
+As a consequence, force-pushing is not required - and must be **avoided**.
 
 After all the basic checks are green, maintainers will look at your pull request.
 Since JabRef is driven by volunteers in their spare time, reviews may take more time than a project with full time developers.
-The pull request may be approved immediatly, or a reviewer may request changes and/or have discussions regarding your approach.
+The pull request may be approved immediately, or a reviewer may request changes and/or have discussions regarding your approach.
 In that case, you are expected to answer any questions and implement the requested changes.
 
 Please – **never ever close a pull request and open a new one** -


### PR DESCRIPTION
Closes #14362

### Description
I have corrected three grammatical errors in the `CONTRIBUTING.md` file to improve the professionalism of the documentation:
1. "Communictate" -> "Communicate" (Section: Pull Request Process)
2. "concequece" -> "consequence" (Section: After submission)
3. "immediatly" -> "immediately" (Section: After submission)

### Steps to test
1. Open the `CONTRIBUTING.md` file in this branch.
2. Search for the corrected words to verify the spelling is now correct.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.