### PR TITLE
feat: add "Close library" to File menu

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -741,7 +741,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
         }
     }
 
-    private class CloseOthersDatabaseAction extends SimpleCommand {
+    public class CloseOthersDatabaseAction extends SimpleCommand {
 
         private final LibraryTab libraryTab;
 
@@ -753,22 +753,27 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
         @Override
         public void execute() {
             LibraryTab toKeepLibraryTab = Optional.of(libraryTab).get();
-            for (Tab tab : tabbedPane.getTabs()) {
-                LibraryTab libraryTab = (LibraryTab) tab;
-                if (libraryTab != toKeepLibraryTab) {
-                    Platform.runLater(() -> closeTab(libraryTab));
-                }
+            List<LibraryTab> libraryTabs = tabbedPane.getTabs().stream()
+                    .filter(LibraryTab.class::isInstance)
+                    .map(LibraryTab.class::cast)
+                    .filter(tab -> tab != toKeepLibraryTab)
+                    .toList();
+            for (LibraryTab tab : libraryTabs) {
+                Platform.runLater(() -> closeTab(tab));
             }
         }
     }
 
-    private class CloseAllDatabaseAction extends SimpleCommand {
+    public class CloseAllDatabaseAction extends SimpleCommand {
 
         @Override
         public void execute() {
-            tabbedPane.getTabs().removeIf(t -> t instanceof WelcomeTab);
-            for (Tab tab : tabbedPane.getTabs()) {
-                Platform.runLater(() -> closeTab((LibraryTab) tab));
+            List<LibraryTab> libraryTabs = tabbedPane.getTabs().stream()
+                    .filter(LibraryTab.class::isInstance)
+                    .map(LibraryTab.class::cast)
+                    .toList();
+            for (LibraryTab tab : libraryTabs) {
+                Platform.runLater(() -> closeTab(tab));
             }
         }
     }


### PR DESCRIPTION
Fixes Issue : #14381

This PR adds three new library-management actions to the File menu:
- **Close library** – closes the currently active library.
- **Close others** – closes all libraries except the currently active one.
- **Close all** – closes all open libraries.

Previously, these actions were only available in the library tab’s context menu,
making them harder to discover. Adding them to the File menu improves usability,
aligns with common desktop application UX patterns, and provides faster access
to library management operations.

### Steps to test
1. Start JabRef.
2. Open multiple libraries (e.g., Library A, Library B, Library C).
3. Go to **File → Close library**:
   - Only the active library should close.
4. Go to **File → Close others**:
   - The active library remains open.
   - All other libraries close.
5. Go to **File → Close all**:
   - All open libraries close.
   - JabRef returns to the empty state with no libraries open.

<img width="1512" height="853" alt="Screenshot 2025-11-22 at 3 11 46 AM" src="https://github.com/user-attachments/assets/0423cf8d-2d4b-420c-b215-ce034c11f248" />
