### PR TITLE
Fix package of Formatter

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanel.java
@@ -19,7 +19,7 @@ import org.jabref.gui.util.FieldsUtil;
 import org.jabref.gui.util.ValueTableCellFactory;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.logic.cleanup.FieldFormatterCleanup;
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldTextMapper;

--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanelViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/FieldFormatterCleanupsPanelViewModel.java
@@ -16,7 +16,7 @@ import org.jabref.gui.StateManager;
 import org.jabref.gui.util.NoSelectionModel;
 import org.jabref.logic.cleanup.FieldFormatterCleanup;
 import org.jabref.logic.cleanup.FieldFormatterCleanups;
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.Formatters;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/contextmenu/DefaultMenu.java
@@ -8,7 +8,7 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TextInputControl;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.Formatters;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.StringUtil;

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
@@ -12,7 +12,7 @@ import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;
 import org.jabref.gui.icon.IconTheme;
 import org.jabref.gui.icon.JabRefIcon;
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.logic.l10n.Localization;

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/BracketedPattern.java
@@ -18,7 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.Formatters;
 import org.jabref.logic.formatter.bibtexfields.RemoveEnclosingBracesFormatter;
 import org.jabref.logic.formatter.casechanger.Word;

--- a/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanup.java
+++ b/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanup.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.event.EntriesEventSource;

--- a/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
+++ b/jablib/src/main/java/org/jabref/logic/cleanup/FieldFormatterCleanups.java
@@ -11,6 +11,7 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.Formatters;
 import org.jabref.logic.formatter.IdentityFormatter;
 import org.jabref.logic.formatter.bibtexfields.ConvertMSCCodesFormatter;

--- a/jablib/src/main/java/org/jabref/logic/formatter/Formatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/Formatter.java
@@ -1,4 +1,4 @@
-package org.jabref.logic.cleanup;
+package org.jabref.logic.formatter;
 
 import org.jspecify.annotations.NonNull;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.formatter.bibtexfields.CleanupUrlFormatter;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.formatter.bibtexfields.ConvertMSCCodesFormatter;

--- a/jablib/src/main/java/org/jabref/logic/formatter/IdentityFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/IdentityFormatter.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.formatter;
 
-import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/AddBracesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/AddBracesFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/CleanupUrlFormatter.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ClearFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ClearFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ConvertMSCCodesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ConvertMSCCodesFormatter.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.logic.preferences.JabRefCliPreferences;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeAmpersandsFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeDollarSignFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeDollarSignFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Matcher;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeUnderscoresFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/EscapeUnderscoresFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.logic.util.strings.HTMLUnicodeConversionMaps;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.bibtexfields;
 import java.util.regex.Pattern;
 
 import org.jabref.architecture.AllowedToUseApacheCommonsLang3;
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeDateFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeDateFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.Optional;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.Date;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeEnDashesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeEnDashesFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeIssn.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeIssn.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.identifier.ISSN;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.Optional;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.Month;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.AuthorList;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.bibtexfields;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.casechanger.UnprotectTermsFormatter;
 import org.jabref.logic.l10n.Localization;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeUnicodeFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeUnicodeFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.text.Normalizer;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 
 import org.jspecify.annotations.NonNull;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeWhitespaceFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeWhitespaceFormatter.java
@@ -3,6 +3,7 @@ package org.jabref.logic.formatter.bibtexfields;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.bibtex.FieldPreferences;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
 
@@ -12,7 +13,7 @@ import org.jspecify.annotations.NonNull;
  * Replaces two subsequent whitespaces (and tabs) to one space in case of single-line fields. In case of multine fields,
  * the field content is kept as is.
  * <p>
- * Due to the distinction between single line and multiline fields, this formatter does not implement the interface {@link org.jabref.logic.cleanup.Formatter}.
+ * Due to the distinction between single line and multiline fields, this formatter does not implement the interface {@link Formatter}.
  */
 public class NormalizeWhitespaceFormatter {
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/OrdinalsToSuperscriptFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/OrdinalsToSuperscriptFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.bibtexfields;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveDigitsFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveDigitsFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveEnclosingBracesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveEnclosingBracesFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NullMarked;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveHyphenatedNewlinesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveHyphenatedNewlinesFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveNewlinesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveNewlinesFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveRedundantSpacesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveRedundantSpacesFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveWordEnclosingAndOuterEnclosingBracesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/RemoveWordEnclosingAndOuterEnclosingBracesFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.StringJoiner;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.StringUtil;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ReplaceTabsBySpaceFormater.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ReplaceTabsBySpaceFormater.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/ShortenDOIFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.bibtexfields;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.importer.util.ShortDOIService;
 import org.jabref.logic.importer.util.ShortDOIServiceException;
 import org.jabref.logic.l10n.Localization;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TransliterateFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.Transliteration;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TrimWhitespaceFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/TrimWhitespaceFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.bibtexfields;
 
 import java.util.Map;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.logic.util.strings.HTMLUnicodeConversionMaps;

--- a/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatter.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.StringLengthComparator;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CamelFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CamelFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.casechanger;
 
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CamelNFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CamelNFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.casechanger;
 
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.casechanger;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/LowerCaseFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/LowerCaseFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.casechanger;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/ProtectTermsFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/ProtectTermsFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.casechanger;
 
 import java.util.List;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;
 import org.jabref.logic.util.strings.StringLengthComparator;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.casechanger;
 
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.StringUtil;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/ShortTitleFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/ShortTitleFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.casechanger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/TitleCaseFormatter.java
@@ -2,7 +2,7 @@ package org.jabref.logic.formatter.casechanger;
 
 import java.util.stream.Collectors;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.strings.StringUtil;
 

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/UnprotectTermsFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/UnprotectTermsFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.casechanger;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/UpperCaseFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/UpperCaseFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.casechanger;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/casechanger/VeryShortTitleFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/casechanger/VeryShortTitleFormatter.java
@@ -3,7 +3,7 @@ package org.jabref.logic.formatter.casechanger;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/minifier/MinifyNameListFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/minifier/MinifyNameListFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.minifier;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/formatter/minifier/TruncateFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/formatter/minifier/TruncateFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.formatter.minifier;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 
 import org.jspecify.annotations.NonNull;

--- a/jablib/src/main/java/org/jabref/logic/importer/ParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ParserFetcher.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.importer;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.model.entry.BibEntry;
 
 public interface ParserFetcher {

--- a/jablib/src/main/java/org/jabref/logic/layout/LayoutFormatterBasedFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/LayoutFormatterBasedFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.layout;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 
 import org.jspecify.annotations.NonNull;
 

--- a/jablib/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -1,6 +1,6 @@
 package org.jabref.logic.layout.format;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.strings.LatexToUnicodeAdapter;

--- a/jablib/src/main/java/org/jabref/logic/layout/format/ReplaceUnicodeLigaturesFormatter.java
+++ b/jablib/src/main/java/org/jabref/logic/layout/format/ReplaceUnicodeLigaturesFormatter.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.jabref.logic.cleanup.Formatter;
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.logic.util.strings.UnicodeLigaturesMap;

--- a/jablib/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/FieldFormatterCleanupsTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.jabref.logic.formatter.Formatter;
 import org.jabref.logic.formatter.IdentityFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeAmpersandsFormatter;
 import org.jabref.logic.formatter.bibtexfields.EscapeDollarSignFormatter;

--- a/jablib/src/test/java/org/jabref/logic/formatter/FormatterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/formatter/FormatterTest.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jabref.logic.cleanup.Formatter;
 import org.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import org.jabref.logic.formatter.minifier.TruncateFormatter;
 import org.jabref.logic.protectedterms.ProtectedTermsLoader;


### PR DESCRIPTION
Refs https://github.com/JabRef/jabref/issues/14280

I think, the issue is right. Somehow the class `Formatter` was not moved.

This only applies the refactorings of IntelliJ. No other change.

### Steps to test

One could check with https://github.com/tsantalis/RefactoringMiner for correctness.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
