### PR TITLE
Enable resetting of NameDisplayPreferences

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -381,7 +381,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         // endregion
 
         // region NewEntryUnifierPreferences
-        defaults.put(CREATEi_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(NewEntryDialogTab.CHOOSE_ENTRY_TYPE));
+        defaults.put(CREATE_ENTRY_APPROACH, List.of(NewEntryDialogTab.values()).indexOf(NewEntryDialogTab.CHOOSE_ENTRY_TYPE));
         defaults.put(CREATE_ENTRY_EXPAND_RECOMMENDED, true);
         defaults.put(CREATE_ENTRY_EXPAND_OTHER, false);
         defaults.put(CREATE_ENTRY_EXPAND_CUSTOM, true);


### PR DESCRIPTION
Closes #14412

This PR enables resetting for NameDisplayPreferences according to the requirements in the parent issue.
A private default constructor was added with all default values, along with getDefault() and setAll(). The loading and clearing logic in JabRefGuiPreferences has been updated so that NameDisplayPreferences can now be reset independently via the preferences reset/import system.

Steps to test

Open Options → Preferences → Entry table / Name display.

Change any setting related to NameDisplayPreferences (e.g., name formatting options).

Use Reset preferences or Import settings.

Verify that:

All NameDisplayPreferences values return to their defaults.

Restarting JabRef preserves the reset state.

Exporting/importing settings includes this preference and restores it correctly.

Mandatory checks

 I own the copyright of the code submitted and I license it under the MIT license

 I manually tested my changes in running JabRef (always required)

 I added JUnit tests for changes (if applicable)

 I added screenshots in the PR description (if change is visible to the user)

 I described the change in CHANGELOG.md in a way that is understandable for the average user (if change is visible to the user)

 I checked the user documentation; if updates were needed, I opened an issue or PR in the user-docs repository
