### PR TITLE
Switch from jbang-action to setup-jbang for ghprcomment.java

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -112,6 +112,9 @@ jobs:
           key: ${{ steps.cache-key.outputs.cache_key }}
           restore-keys:
             jbang-
+      - name: Setup JBang
+        if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
+        uses: jbangdev/setup-jbang@main
       - name: ghprcomment@main
         if: ${{ github.event_name == 'workflow_dispatch' || (steps.check-label.outputs.has_label == 'false' && steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
         run: |


### PR DESCRIPTION
[`ghprcomment`](https://github.com/koppor/ghprcomment/) is currently run using `jbang-action`.

Yesterday, we had:

```
Run jbangdev/jbang-action@v0.132.1
...
[jbang] Trusting permanently: [https://github.com/koppor/ghprcomment/]
jbang https://github.com/koppor/ghprcomment/blob/main/ghprcomment.java
[jbang] Downloading JDK 21. Be patient, this can take several minutes...
Error:  [ERROR] Unable to download or install JDK version 21
[jbang] Run with --verbose for more details. The --verbose must be placed before the jbang command. I.e. jbang --verbose run [...]
```

See https://github.com/JabRef/jabref/actions/runs/19552163310/job/55986082848

---

I ~~think~~thought, this can be solved with caching. I think [gg.cmd](https://github.com/eirikb/gg) with its caching capabilities is best. So, let's try. - GitHub actions is right: This is a security hole. Thus, `setup-jbang` is used instead.

---

### Steps to test

See workflow "Comment on PR" working after this is in main.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
