### PR TITLE
fix: Implement --version flag output in JabKit CLI

### DIFF
--- a/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
@@ -77,6 +77,10 @@ public class JabKit implements Runnable {
 
     @Override
     public void run() {
+        if (versionInfoRequested) {
+            System.out.println(new BuildInfo().version);
+            return;
+        }
         System.out.printf(BuildInfo.JABREF_BANNER + "%n", new BuildInfo().version);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the `jabkit --version` flag which currently outputs nothing.

## Problem

As described in #14428, running `jabkit --version` produces no output, while `jabkit --help` correctly displays the version information in the banner.

## Solution

Modified the `run()` method in `JabKit.java` to check the `versionInfoRequested` flag. When this flag is set (via `-v` or `--version`), the method now:
1. Outputs just the version string (e.g., "6.0-alpha.197--2025-11-24--0a9793a")
2. Returns early without printing the full banner

This behavior matches other CLI tools like `jbang --version`.

## Steps to test

1. Build JabKit: `gradlew jabkit:build`
2. Run: `jabkit --version`
3. Should output the version string like: `6.0-alpha.197--2025-11-24--0a9793a`

Fixes #14428