### PR TITLE
fix(ai): remove deprecated Hugging Face client

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -166,7 +166,6 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-open-ai")
     implementation("dev.langchain4j:langchain4j-mistral-ai")
     implementation("dev.langchain4j:langchain4j-google-ai-gemini")
-    implementation("dev.langchain4j:langchain4j-hugging-face")
     implementation("dev.langchain4j:langchain4j-http-client")
     implementation("dev.langchain4j:langchain4j-http-client-jdk")
 

--- a/jablib/src/main/java/org/jabref/logic/ai/chatting/model/JabRefChatLanguageModel.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/chatting/model/JabRefChatLanguageModel.java
@@ -18,7 +18,6 @@ import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
-import dev.langchain4j.model.huggingface.HuggingFaceChatModel;
 import dev.langchain4j.model.mistralai.MistralAiChatModel;
 
 /**
@@ -60,7 +59,9 @@ public class JabRefChatLanguageModel implements ChatModel, AutoCloseable {
         }
 
         switch (aiPreferences.getAiProvider()) {
-            case OPEN_AI ->
+            // Hugging Face uses OpenAI API.
+            case OPEN_AI,
+                 HUGGING_FACE ->
                     langchainChatModel = Optional.of(new JvmOpenAiChatLanguageModel(aiPreferences, httpClient));
 
             case GPT4ALL ->
@@ -85,16 +86,6 @@ public class JabRefChatLanguageModel implements ChatModel, AutoCloseable {
                             .modelName(aiPreferences.getSelectedChatModel())
                             .temperature(aiPreferences.getTemperature())
                             .logRequestsAndResponses(true)
-                            .build()
-                    );
-
-            case HUGGING_FACE -> // NOTE: {@link HuggingFaceChatModel} doesn't support API base url.
-                    langchainChatModel = Optional.of(HuggingFaceChatModel
-                            .builder()
-                            .accessToken(apiKey)
-                            .modelId(aiPreferences.getSelectedChatModel())
-                            .temperature(aiPreferences.getTemperature())
-                            .timeout(Duration.ofMinutes(2))
                             .build()
                     );
         }

--- a/jablib/src/main/java/org/jabref/model/ai/AiProvider.java
+++ b/jablib/src/main/java/org/jabref/model/ai/AiProvider.java
@@ -6,7 +6,7 @@ public enum AiProvider implements Serializable {
     OPEN_AI("OpenAI (or API compatible)", "https://api.openai.com/v1", "https://openai.com/policies/privacy-policy/"),
     MISTRAL_AI("Mistral AI", "https://api.mistral.ai/v1", "https://mistral.ai/terms/#privacy-policy"),
     GEMINI("Gemini", "https://generativelanguage.googleapis.com/v1beta/", "https://ai.google.dev/gemini-api/terms"),
-    HUGGING_FACE("Hugging Face", "https://huggingface.co/api", "https://huggingface.co/privacy"),
+    HUGGING_FACE("Hugging Face", "https://router.huggingface.co/v1", "https://huggingface.co/privacy"),
     GPT4ALL("GPT4All", "http://localhost:4891/v1", "https://www.nomic.ai/gpt4all/legal/privacy-policy");
 
     private final String label;


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/1089

Hugging Face client was marked for removal, I removed it.

Now, to use Hugging Face LLM API you just need a different base URL. And it now uses OpenAI API. Old URL doesn't work anymore.

### Steps to test

1. Select Hugging Face as provider
2. Chat

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
