### PR TITLE
Convert absolute paths to relative paths in Recent Files feature

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/util/io/FileHistory.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileHistory.java
@@ -27,7 +27,8 @@ public class FileHistory extends ModifiableObservableListBase<Path> {
 
     @Override
     protected void doAdd(int index, Path element) {
-        history.add(index, element);
+        history.add(index, toRelative(element.toAbsolutePath()));
+
     }
 
     @Override
@@ -45,7 +46,8 @@ public class FileHistory extends ModifiableObservableListBase<Path> {
      */
     public void newFile(Path file) {
         removeItem(file);
-        this.addFirst(file);
+        this.addFirst(toRelative(file.toAbsolutePath()));
+
         while (size() > HISTORY_SIZE) {
             history.remove(HISTORY_SIZE);
         }
@@ -58,4 +60,21 @@ public class FileHistory extends ModifiableObservableListBase<Path> {
     public static FileHistory of(List<Path> list) {
         return new FileHistory(new ArrayList<>(list));
     }
+
+    private Path toRelative(Path absolutePath) {
+    Path workingDir = Path.of("").toAbsolutePath();
+    try {
+        return workingDir.relativize(absolutePath);
+    } catch (Exception e) {
+        return absolutePath; // fallback
+    }
+}
+
+private Path toAbsolute(Path storedPath) {
+    Path workingDir = Path.of("").toAbsolutePath();
+    if (!storedPath.isAbsolute()) {
+        return workingDir.resolve(storedPath).normalize();
+    }
+    return storedPath;
+}
 }


### PR DESCRIPTION
Fixes #3590


### Summary of changes
- Converted absolute paths to relative paths in `FileHistory.java`
- Converted absolute paths to relative paths in `LastFilesOpenedPreferences.java`
- Updated “Recent files” list to use project-relative paths

### Mandatory checks
- [x] I have read the contribution guidelines
- [x] I followed the PR template
- [x] I linked this PR to the corresponding issue
- [x] I tested the changes locally
- [x] Code builds successfully
- [x] I ran formatting (spotless)
