### PR TITLE
Fix adapting labels

### DIFF
--- a/.github/workflows/on-pr-opened-updated-adapt-label.yml
+++ b/.github/workflows/on-pr-opened-updated-adapt-label.yml
@@ -74,7 +74,6 @@ jobs:
       - name: 'Adapt label "status: changes-required"'
         if: ${{ github.event_name == 'workflow_dispatch' || (steps.read-pr_number.outputs.pr_number != '' && steps.isCrossRepository.outputs.isCrossRepository == 'true') }}
         run: |
-          PR_NUMBER="${{ steps.set-vars.outputs.pr_number }}"
           REPO="${{ github.repository }}"
 
           COMMENTS=$(gh api \
@@ -92,3 +91,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.set-vars.outputs.pr_number }}


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/14475, where the label was not set in all cases. 

I add manual triggering to be able to try out

### Steps to test

1. Have a PR in place
2. Trigger this workflow with the number of the chosen PR
3. See that label "changes required" is either added or removed

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
