### PR TITLE
Add export buttons for AI summary and chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We added support for `html` when parsing the arXiv identifiers. [#14451](https://github.com/JabRef/jabref/issues/14451)
 - When parsing a plain text citation, we added support for recognizing and extracting arXiv identifiers. [#14455](https://github.com/JabRef/jabref/pull/14455)
 - We introduced a new "Search Engine URL Template" setting in Preferences to allow users to customize their search engine URL templates [#12268](https://github.com/JabRef/jabref/issues/12268)
+- We added export options (Markdown and JSON) for AI Summary and AI Chat. [#13868](https://github.com/JabRef/jabref/issues/13868)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
+++ b/jabgui/src/main/java/org/jabref/gui/ai/components/summary/SummaryShowingComponent.java
@@ -26,10 +26,14 @@ public class SummaryShowingComponent extends VBox {
     private WebView contentWebView;
     private final Summary summary;
     private final Runnable regenerateCallback;
+    private final Runnable exportMarkdownCallback;
+    private final Runnable exportJsonCallback;
 
-    public SummaryShowingComponent(Summary summary, Runnable regenerateCallback) {
+    public SummaryShowingComponent(Summary summary, Runnable regenerateCallback, Runnable exportMarkdownCallback, Runnable exportJsonCallback) {
         this.summary = summary;
         this.regenerateCallback = regenerateCallback;
+        this.exportMarkdownCallback = exportMarkdownCallback;
+        this.exportJsonCallback = exportJsonCallback;
 
         ViewLoader.view(this)
                   .root(this)
@@ -84,5 +88,14 @@ public class SummaryShowingComponent extends VBox {
     @FXML
     private void onRegenerateButtonClick() {
         regenerateCallback.run();
+    }
+
+    @FXML
+    private void onExportMarkdown() {
+        if (exportMarkdownCallback != null) {exportMarkdownCallback.run();}
+    }
+    @FXML
+    private void onExportJson() {
+        if (exportJsonCallback != null) {exportJsonCallback.run();}
     }
 }

--- a/jabgui/src/main/resources/org/jabref/gui/ai/components/aichat/AiChatComponent.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/components/aichat/AiChatComponent.fxml
@@ -12,6 +12,8 @@
 <?import org.jabref.gui.ai.components.aichat.chatprompt.ChatPromptComponent?>
 <?import org.jabref.gui.ai.components.util.Loadable?>
 <?import org.jabref.gui.icon.JabRefIconView?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
 <fx:root type="javafx.scene.layout.VBox"
          spacing="10"
          xmlns="http://javafx.com/javafx/17.0.2-ea"
@@ -44,6 +46,18 @@
                 <Tooltip text="%Notifications"/>
             </tooltip>
         </Button>
+        <MenuButton styleClass="icon-button,narrow">
+            <graphic>
+                <JabRefIconView glyph="SAVE"/>
+            </graphic>
+            <items>
+                <MenuItem text="%Export in human-readable format (Markdown)" onAction="#exportMarkdown"/>
+                <MenuItem text="%Export in machine-readable format (JSON)" onAction="#exportJson"/>
+            </items>
+            <tooltip>
+                <Tooltip text="%Export chat history"/>
+            </tooltip>
+        </MenuButton>
         <ChatPromptComponent fx:id="chatPrompt" HBox.hgrow="ALWAYS"/>
     </HBox>
     <HBox alignment="CENTER" spacing="50">

--- a/jabgui/src/main/resources/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/ai/components/summary/SummaryShowingComponent.fxml
@@ -6,6 +6,9 @@
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
+<?import org.jabref.gui.icon.JabRefIconView?>
 <fx:root alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="400.0" minWidth="-Infinity" spacing="8.0" type="VBox" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.ai.components.summary.SummaryShowingComponent">
     <children>
         <BorderPane minHeight="30.0">
@@ -15,6 +18,17 @@
             <center>
                 <Button mnemonicParsing="false" onAction="#onRegenerateButtonClick" text="%Regenerate" translateX="-40" />
             </center>
+            <right>
+                <MenuButton text="Export" >
+                    <graphic>
+                        <JabRefIconView glyph="SAVE"/>
+                    </graphic>
+                    <items>
+                        <MenuItem text="Export in human-readable format (Markdown)" onAction="#onExportMarkdown"/>
+                        <MenuItem text="Export in machine-readable format (JSON)" onAction="#onExportJson"/>
+                    </items>
+                </MenuButton>
+            </right>
         </BorderPane>
         <Text fx:id="summaryInfoText" strokeType="OUTSIDE" strokeWidth="0.0" text="%Generated at %0 by %1" />
     </children>

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -3475,3 +3475,12 @@ Already\ up\ to\ date\ or\ local\ branch\ is\ ahead.=Already up to date or local
 
 Back=Back
 Forward=Forward
+
+Export\ successful=Export successful
+Save\ failed=Save failed
+Export\ in\ human-readable\ format\ (Markdown)=Export in human-readable format (Markdown)
+Export\ in\ machine-readable\ format\ (JSON)=Export in machine-readable format (JSON)
+Export\ chat\ history=Export chat history
+No\ summary\ available\ to\ export=No summary available to export
+No\ chat\ history\ to\ export=No chat history to export
+Problem\ occurred\ while\ writing\ the\ export\ file=Problem occurred while writing the export file


### PR DESCRIPTION
Closes #13868

Implemented the export functionality for AI Summary and AI Chat as requested. Users can now save the content to Markdown (human-readable) or JSON (machine-readable, OpenAI format). Added an export menu button to the UI and handled the file saving logic.

### Steps to test

1. Open an entry that has a citation key and a linked PDF. I tested the UI logic in a simulated local environment (since I don't have an AI API key)

2. Go to the **AI Summary** or **AI Chat** tab.
<img width="1106" height="690" alt="image" src="https://github.com/user-attachments/assets/cee1c1fa-f2d0-4733-a9dd-eeb8e14784fe" />
3. Even without an API key (interface might show an error), you should see the new **Export** button (floppy disk icon) in the toolbar. In the AI Summary tab, the Export button is only visible after a summary has been successfully generated.

<img width="2148" height="170" alt="屏幕截图 2025-12-01 104756" src="https://github.com/user-attachments/assets/b99d2bcf-4134-4820-8565-44dde87e581c" />
<img width="2200" height="248" alt="屏幕截图 2025-11-30 194147" src="https://github.com/user-attachments/assets/49c43b82-b388-40c0-b9c1-a7375143db06" />


4. Click the button and select **Export to Markdown** or **Export to JSON**.
<img width="458" height="167" alt="屏幕截图 2025-12-01 104854" src="https://github.com/user-attachments/assets/161365aa-1fe6-45ae-b176-3f83f4b66213" />
5. Save the file and verify the content:
   - **Markdown:** Should contain the BibTeX source and the text.
   - **JSON:** Should contain metadata and a `conversation` list compatible with OpenAI format.
   - I confirmed that clicking the Export button correctly triggers the 'Save As' file dialog and generates the file with the expected structure.

### Mandatory checks

- [x] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in local environment
- [x] Screenshots added (for UI changes)
- [ ] Documentation updated (check report below)
