### PR TITLE
Fix inconsistent CLI help output

### DIFF
--- a/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
+++ b/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
@@ -18,12 +18,12 @@ public class GuiCommandLine {
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"--importBibtex"}, description = "Import bibtex string")
+    @Option(names = {"--importBibtex"}, description = "Import BibTeX string.")
     public String importBibtex;
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"-importToOpen", "--importToOpen"}, description = "Same as --import, but will be imported to the opened tab")
+    @Option(names = {"-importToOpen", "--importToOpen"}, description = "Same as --import, but will be imported to the opened tab.")
     public String importToOpen;
 
     @Option(names = {"--reset"}, description = "Reset all preferences to default values.")

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/JabKit.java
@@ -67,7 +67,7 @@ public class JabKit implements Runnable {
     @Mixin
     private SharedOptions sharedOptions = new SharedOptions();
 
-    @Option(names = {"-v", "--version"}, versionHelp = true, description = "display version info")
+    @Option(names = {"-v", "--version"}, versionHelp = true, description = "Display version info.")
     private boolean versionInfoRequested;
 
     public JabKit(CliPreferences cliPreferences, BibEntryTypesManager entryTypesManager) {
@@ -251,13 +251,13 @@ public class JabKit implements Runnable {
     }
 
     public static class SharedOptions {
-        @Option(names = {"-d", "--debug"}, description = "Enable debug output")
+        @Option(names = {"-d", "--debug"}, description = "Enable debug output.")
         boolean debug;
 
-        @Option(names = {"-p", "--porcelain"}, description = "Enable script-friendly output")
+        @Option(names = {"-p", "--porcelain"}, description = "Enable script-friendly output.")
         boolean porcelain;
 
-        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message")
+        @Option(names = {"-h", "--help"}, usageHelp = true, description = "Display this help message.")
         private boolean usageHelpRequested = true;
     }
 }


### PR DESCRIPTION
 Closes #14358

Description
This PR addresses issue #14358 by making the CLI help output consistent. I have updated the option descriptions in 
GuiCommandLine.java
 and 
JabKit.java
 to ensure they all start with a capital letter and end with a period.

Changes
GuiCommandLine.java: Updated descriptions for --importBibtex and --importToOpen.
JabKit.java: Updated descriptions for --version, --debug, --porcelain, and --help.
Steps to test
Run ./gradlew :jabgui:run --args="--help" and verify the output descriptions end with a period.
Run ./gradlew :jabkit:run --args="--help" and verify the output descriptions end with a period.
Mandatory checks
 I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
 I manually tested my changes in running JabRef (always required)
I added JUnit tests for changes (if applicable)
I added screenshots in the PR description (if change is visible to the user)
I described the change in 
CHANGELOG.md
 in a way that is understandable for the average user (if change is visible to the user)
I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at https://github.com/JabRef/user-documentation/issues or, even better, I submitted a pull request updating file(s) in https://github.com/JabRef/user-documentation/tree/main/en.