### PR TITLE
Add auto close of PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,4 +32,4 @@ jobs:
 
           days-before-pr-close: 7
           close-pr-message: >
-            Closing this PR, because there were 21 days of inactivity without any work on the requested changes.
+            This PR is being closed due to continued inactivity.


### PR DESCRIPTION
Triggered by following wall of unaddressed changes

<img width="523" height="965" alt="grafik" src="https://github.com/user-attachments/assets/b0d0e7bb-50f3-43f6-a620-3adcf51b6f59" />

We cannot go through all PRs manually.

I propose to remind a contributor after 14 days and auto close 7 days later. We could also do 10 +10 or 7 + 14.

### Steps to test

Merge and see the bot running.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
