### PR TITLE
Refine justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,54 +1,62 @@
 set windows-shell := ["powershell"]
 
 [unix]
-checkout-pr pr-id:
+ensure-gg-cmd:
+    [ ! -f gg.cmd ] && ( echo "gg.cmd not found — downloading..."; ( command -v wget >/dev/null 2>&1 && wget -O gg.cmd https://ggcmd.io/gg.cmd ) || ( command -v curl >/dev/null 2>&1 && curl -L https://ggcmd.io/gg.cmd -o gg.cmd ) || { echo "Error: neither wget nor curl is installed." >&2; exit 1; } )
+
+[unix]
+checkout-pr pr-id: ensure-gg-cmd
     sh ./gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
 
 [unix]
-run branch:
+run-brach branch: ensure-gg-cmd
     sh ./gg.cmd jbang git@jbangdev checkout {{branch}}
     sh ./gg.cmd jbang git@jbangdev fetch origin
     sh ./gg.cmd jbang git@jbangdev merge origin/main
-    just run-gui
+    just run
 
 [unix]
-run-gui:
+run: ensure-gg-cmd
     sh ./gg.cmd gradle :jabgui:run
 
 [unix]
-run-jabkit *FLAGS:
+run-jabkit *FLAGS: ensure-gg-cmd
     sh ./gg.cmd gradle :jabkit:run --args="{{FLAGS}}"
 
 [unix]
-run-jabsrv *FLAGS:
+run-jabsrv *FLAGS: ensure-gg-cmd
     sh ./gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
 
 [windows]
-checkout-pr pr-id:
+ensure-gg-cmd:
+    if (-not (Test-Path 'gg.cmd')) { Write-Host 'gg.cmd not found — downloading...'; Invoke-WebRequest 'https://ggcmd.io/gg.cmd' -OutFile 'gg.cmd' }
+
+[windows]
+checkout-pr pr-id: ensure-gg-cmd
     .\gg.cmd jbang https://github.com/JabRef/jabref/blob/main/.jbang/CheckoutPR.java {{pr-id}}
 
 [windows]
-run branch:
+run-branch branch: ensure-gg-cmd
     .\gg.cmd jbang git@jbangdev checkout {{branch}}
     .\gg.cmd jbang git@jbangdev fetch origin
     .\gg.cmd jbang git@jbangdev merge origin/main
-    just run-gui
+    just run
 
 [windows]
-run-gui:
+run: ensure-gg-cmd
     .\gg.cmd gradle :jabgui:run
 
 [windows]
-run-jabkit *FLAGS:
+run-jabkit *FLAGS: ensure-gg-cmd
     .\gg.cmd gradle :jabkit:run --args="{{FLAGS}}"
 
 [windows]
-run-jabsrv *FLAGS:
+run-jabsrv *FLAGS: ensure-gg-cmd
     .\gg.cmd gradle :jabsrv-cli:run --args="{{FLAGS}}"
 
 run-main:
-    just run main
+    just run-branch main
 
 run-pr pr-id:
     just checkout-pr {{pr-id}}
-    just run-gui
+    just run


### PR DESCRIPTION
In the last call, the command `gg.cmd just run-gui` could not be remembered. I think, it was because of the spaces and dashes. Now

    ./gg.cmd just run

should do the job :)

Moreover, I have `gg.cmd` installed globally - then, this script did not work. Added downloading of gg.cmd

### Steps to test

Either `gg.cmd just run` or `just run` (if you have [just](https://github.com/casey/just) installed)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
