### PR TITLE
Revise JavaDoc links in README.md

### DIFF
--- a/jablib/README.md
+++ b/jablib/README.md
@@ -4,7 +4,7 @@
 All code in `src/main/java` is published as a Maven artifact at `org.jabref:jablib`.
 Example code is made available at <https://github.com/JabRef/jabref/tree/main/jablib-examples>.
 
-You can browse JavaDoc at APIdia: <https://apidia.net/java/JabRef/6.0-snapshot-2025-12-02/?cls=org.jabref.jablib-module>.
+You can browse JavaDoc at APIdia: [latest development version](https://apidia.net/java/JabRef/jablib/main) and [latest released version](https://apidia.net/java/JabRef/jablib/latest).
 
 ## Development information
 


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/pull/14511#discussion_r2592772228. Refs https://github.com/APIdia-net/apidia.net/issues/28.

Although both links point to the same version, this will change after the next alpha release.

### Steps to test

Click on the links :)

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
