### PR TITLE
Proxy Preference reset

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/net/ProxyPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/net/ProxyPreferences.java
@@ -33,6 +33,33 @@ public class ProxyPreferences {
         this.persistPassword = new SimpleBooleanProperty(persistPassword);
     }
 
+    // Creates object with default preference values
+    private ProxyPreferences() {
+        this(
+                false,      // useProxy: Whether to enable proxy usage
+                "",         // proxyHostname: The hostname of proxy
+                "80",       // proxyPort: Port number on which the proxy is listening
+                false,      // useAuthentication: Whether proxy authentication should be enabled
+                "",         // proxyUsername: Username for proxy authentication (if enabled)
+                "",         // proxyPassword: Password for proxy authentication (if enabled)
+                false       // persistPassword: Whether the proxy password should be saved/persisted
+        );
+    }
+
+    public static ProxyPreferences getDefault() {
+        return new ProxyPreferences();
+    }
+
+    public void setAll(ProxyPreferences preferences) {
+        this.useProxy.set(preferences.shouldUseProxy());
+        this.hostname.set(preferences.getHostname());
+        this.port.set(preferences.getPort());
+        this.useAuthentication.set(preferences.shouldUseAuthentication());
+        this.username.set(preferences.getUsername());
+        this.password.set(preferences.getPassword());
+        this.persistPassword.set(preferences.shouldPersistPassword());
+    }
+
     public final boolean shouldUseProxy() {
         return useProxy.getValue();
     }


### PR DESCRIPTION
Closes #14505

Addressed in this PR:

Enables resetting of Proxy Preferences following the steps of issue #14400 

### Steps to test

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
