### PR TITLE
Preferences(Web search): Keep Search Engine URL Templates table compact + correct row height

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTab.java
@@ -20,6 +20,8 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.beans.binding.Bindings;
+import javafx.scene.control.Label;
 
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
@@ -93,6 +95,29 @@ public class WebSearchTab extends AbstractPreferenceTabView<WebSearchTabViewMode
         searchEngineUrlTemplate.setEditable(true);
 
         searchEngineTable.setItems(viewModel.getSearchEngines());
+
+        // Make the search engine table compact instead of letting it stretch to fill the entire preferences pane.
+        // Show a friendly placeholder when empty:
+        searchEngineTable.setPlaceholder(new Label(Localization.lang("No search engines configured")));
+
+        // Use a fixed cell size so we can compute a reliable preferred height:
+        searchEngineTable.setFixedCellSize(32); // tweak 32 if rows look too tight/loose in your UI
+
+        // Bind preferred height to header + number of rows, but cap it at a sensible max so it won't swallow the pane:
+        searchEngineTable.prefHeightProperty().bind(Bindings.createDoubleBinding(() -> {
+            int rows = Math.max(1, searchEngineTable.getItems().size());
+            double headerHeight = 28; // approximate header height; adjust if header looks clipped
+            double pref = headerHeight + (rows * searchEngineTable.getFixedCellSize());
+            double maxHeight = 300; // maximum height in px; change as desired
+            return Math.min(pref, maxHeight);
+        }, searchEngineTable.getItems()));
+
+        // Prevent parent layout from forcing the table to grow beyond the computed preferred size:
+        searchEngineTable.setMaxHeight(Region.USE_PREF_SIZE);
+        searchEngineTable.setMinHeight(Region.USE_PREF_SIZE);
+
+        // If the parent is a VBox, avoid forcing vertical grow on the table:
+        VBox.setVgrow(searchEngineTable, Priority.NEVER);
 
         enableWebSearch.selectedProperty().bindBidirectional(viewModel.enableWebSearchProperty());
         warnAboutDuplicatesOnImport.selectedProperty().bindBidirectional(viewModel.warnAboutDuplicatesOnImportProperty());


### PR DESCRIPTION
Closes: N/A

<!-- No issue exists for this specific layout bug -->

This PR improves the layout of the Web search → Search Engine URL Templates table in the Preferences dialog.
Previously, the table expanded to fill almost all available vertical space, leaving a large empty blank area under the rows.
This fix limits the table height and restores proper row height, resulting in a cleaner, more compact, and more readable UI.

Steps to test

->Start JabRef.
->Open File → Preferences → Web search.
->Check that:
-The “Search Engine URL Templates” table no longer stretches vertically.
-The rows have normal readable height.
-The table grows only as needed and scrolls if many rows are present.
-The large empty yellow area below the table is no longer present.

### Screenshots
**Before**
<img width="1043" height="813" alt="before" src="https://github.com/user-attachments/assets/ef56075b-4ff7-44b0-a12e-d7b337fd66bd" />
**After**
<img width="1643" height="985" alt="after" src="https://github.com/user-attachments/assets/927cec71-f54f-4e64-95f7-2004cd5346a3" />

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
