### PR TITLE
Refactor pages checker

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
@@ -6,29 +6,34 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class PagesChecker implements ValueChecker {
 
+    private static final String SINGLE_PAGE_PATTERN = "[A-Za-z]?\\d*";
+
+    private static final String BIBTEX_RANGE_SEPARATOR = "(\\+|-{2}|\u2013)";
+    private static final String BIBLATEX_RANGE_SEPARATOR = "(\\+|-{1,2}|\u2013)";
+
     private static final String PAGES_EXP_BIBTEX =
-            "\\A"                 // begin String
-                    + "[A-Za-z]?\\d*"       // optional prefix and number
+                    "\\A"                       // begin String
+                    + SINGLE_PAGE_PATTERN
                     + "("
-                    + "(\\+|-{2}|\u2013)"   // separator, must contain exactly two dashes
-                    + "[A-Za-z]?\\d*"       // optional prefix and number
+                    + BIBTEX_RANGE_SEPARATOR
+                    + SINGLE_PAGE_PATTERN
                     + ")?"
-                    + "\\z";                // end String
+                    + "\\z";            // end String
 
     // See https://packages.oth-regensburg.de/ctan/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsubsection.3.15.3 for valid content
     private static final String PAGES_EXP_BIBLATEX =
-            "\\A"               // begin String
-                    + "[A-Za-z]?\\d*"     // optional prefix and number
+                    "\\A"                       // begin String
+                    + SINGLE_PAGE_PATTERN
                     + "("
-                    + "(\\+|-{1,2}|\u2013)" // separator
-                    + "[A-Za-z]?\\d*"     // optional prefix and number
+                    + BIBLATEX_RANGE_SEPARATOR
+                    + SINGLE_PAGE_PATTERN
                     + ")?"
-                    + "\\z";              // end String
+                    + "\\z";            // end String
 
     private final Predicate<String> isValidPageNumber;
 


### PR DESCRIPTION
Closes 14562
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->
Refactors `PagesChecker` by extracting duplicated regex patterns for page numbers and separators into named constants (e.g., `SINGLE_PAGE_PATTERN`). 
<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

Please run the tests:
- `PagesCheckerBibtexTest` 
- `PagesCheckerBiblatexTest` 
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
