### PR TITLE
Refactor PagesChecker: Extract duplicate regex constants

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
@@ -11,13 +11,9 @@ import org.jabref.model.database.BibDatabaseContext;
 
 public class PagesChecker implements ValueChecker {
 
-    // optional prefix and number
-    private static final String SINGLE_PAGE_PATTERN = "[A-Za-z]?\\d*";
-
-    // separator, must contain exactly two dashes
-    private static final String BIBTEX_RANGE_SEPARATOR = "(\\+|-{2}|\u2013)";
-    // separator
-    private static final String BIBLATEX_RANGE_SEPARATOR = "(\\+|-{1,2}|\u2013)";
+    private static final String SINGLE_PAGE_PATTERN = "[A-Za-z]?\\d*";             // optional prefix and number
+    private static final String BIBTEX_RANGE_SEPARATOR = "(\\+|-{2}|\u2013)";      // separator, must contain exactly two dashes
+    private static final String BIBLATEX_RANGE_SEPARATOR = "(\\+|-{1,2}|\u2013)";  // separator
 
     private static final String PAGES_EXP_BIBTEX =
             "\\A"                       // begin String


### PR DESCRIPTION
Closes #14562 
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

Refactors `PagesChecker` by extracting duplicated regex patterns for page numbers and separators into named constants (e.g., SINGLE_PAGE_PATTERN).

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

Please run the tests:
* PagesCheckerBibtexTest
* PagesCheckerBiblatexTest
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
