### PR TITLE
Fix Full text search does not find substring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed localization of the "New Entries" dialog. [#14455](https://github.com/JabRef/jabref/pull/14455)
 - We fixed an issue where keybindings could not be edited and saved. [#14237](https://github.com/JabRef/jabref/issues/14237)
 - We readded the missing gui commands for importing and exporting preferences. [#14492](https://github.com/JabRef/jabref/pull/14492)
+- We fixed an issue where fulltext search failed to find partial words (substrings) in linked files. [#14569](https://github.com/JabRef/jabref/issues/14569)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The URL integrity check now checks the complete URL syntax. [#14370](https://github.com/JabRef/jabref/pull/14370)
 - <kbd>Tab</kbd> in the last text field of a tab moves the focus to the next tab in the entry editor. [#11937](https://github.com/JabRef/jabref/issues/11937)
 - We changed fixed-value ComboBoxes to SearchableComboBox for better usability. [#14083](https://github.com/JabRef/jabref/issues/14083)
+- We renamed "Search pre-configured" to "Search pre-selected" and "Web search fetchers" to "Pre-selected fetchers". [#14557](https://github.com/JabRef/jabref/issues/14557)
 
 ### Fixed
 

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/websearch/WebSearchTab.fxml
@@ -71,6 +71,6 @@
         </columnResizePolicy>
     </TableView>
 
-    <Label styleClass="sectionHeader" text="%Web search fetchers"/>
+    <Label styleClass="sectionHeader" text="%Pre-selected fetchers"/>
     <VBox fx:id="fetchersContainer"/>
 </fx:root>

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/CompositeSearchBasedFetcher.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class CompositeSearchBasedFetcher implements SearchBasedFetcher {
 
-    public static final String FETCHER_NAME = "Search pre-configured";
+    public static final String FETCHER_NAME = "Search pre-selected";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompositeSearchBasedFetcher.class);
 

--- a/jablib/src/main/java/org/jabref/logic/search/retrieval/LinkedFilesSearcher.java
+++ b/jablib/src/main/java/org/jabref/logic/search/retrieval/LinkedFilesSearcher.java
@@ -50,6 +50,7 @@ public final class LinkedFilesSearcher {
         this.filePreferences = filePreferences;
         this.parser = new MultiFieldQueryParser(LinkedFilesConstants.PDF_FIELDS.toArray(new String[0]), LinkedFilesConstants.LINKED_FILES_ANALYZER);
         parser.setDefaultOperator(QueryParser.Operator.AND);
+        parser.setAllowLeadingWildcard(true);
     }
 
     public SearchResults search(SearchQuery searchQuery) {
@@ -82,6 +83,9 @@ public final class LinkedFilesSearcher {
 
     private Optional<Query> getLuceneQuery(SearchQuery searchQuery) {
         String query = SearchQueryConversion.searchToLucene(searchQuery);
+        if (!query.contains("*") && !query.contains("?")) {
+            query = "*" + query + "*";
+        }
         try {
             return Optional.of(parser.parse(query));
         } catch (ParseException e) {

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2039,7 +2039,7 @@ JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ pr
 
 Remove\ line\ breaks=Remove line breaks
 Removes\ all\ line\ breaks\ in\ the\ field\ content.=Removes all line breaks in the field content.
-Web\ search\ fetchers=Web search fetchers
+Web\ search\ fetchers=Pre-selected fetchers
 Custom\ API\ key=Custom API key
 API\ Key\ for\ %0=API Key for %0
 Test\ connection=Test connection

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2039,7 +2039,7 @@ JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ pr
 
 Remove\ line\ breaks=Remove line breaks
 Removes\ all\ line\ breaks\ in\ the\ field\ content.=Removes all line breaks in the field content.
-Web\ search\ fetchers=Pre-selected fetchers
+Pre-selected\ fetchers=Pre-selected fetchers
 Custom\ API\ key=Custom API key
 API\ Key\ for\ %0=API Key for %0
 Test\ connection=Test connection


### PR DESCRIPTION
Closes #14569
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... Summarize changes and DO NOT list modified classes one-by-one. (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Description 
This PR addresses the issue where searching for partial words (e.g., "dorf") in linked file content failed to find documents containing the full word (e.g., "Düsseldorf").

I modified LinkedFilesSearcher.java to:

**Enable Leading Wildcards**: Updated the Lucene query parser configuration to allow leading wildcards (parser.setAllowLeadingWildcard(true)).

**Automate Wildcard Wrapping:** Modified the query logic to automatically wrap search terms in asterisks (e.g., transforming query to \*query\*) if the user hasn't explicitly provided wildcards. This ensures that terms like "dorf" effectively search for \*dorf\*, enabling substring matches.

### Steps to test
1. Have a PDF file [Dusseldorf.pdf](https://github.com/user-attachments/files/24111096/Dusseldorf.pdf) containing unique text (e.g., the word "Düsseldorf").
2. Create a BibTeX entry and link this PDF to it.
Note: Ensure the file link includes the .pdf extension in the BibTeX source (e.g., file = {:Dusseldorf.pdf:PDF}) to ensure the indexer reads the content correctly.
3. In the search bar, type a substring of the word (e.g., eldorf).
4. Verify that the entry containing "Düsseldorf" appears in the search results.

<img width="1241" height="397" alt="image" src="https://github.com/user-attachments/assets/444b07ea-c652-48d2-833e-8dc57f3339f3" />
<img width="1377" height="452" alt="image" src="https://github.com/user-attachments/assets/03e8d133-1cc3-4e92-ab93-71c109a39eeb" />

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
