### PR TITLE
Reduce time for initial PR to 14 days

### DIFF
--- a/.github/workflows/on-issue-comment.yml
+++ b/.github/workflows/on-issue-comment.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           github_token: '${{ secrets.GH_TOKEN_ASSIGN_ISSUE_ACTION  || github.token }}'
           # If this is updated, also update the number at unassign-issues.yml
-          days_until_unassign: 21
+          days_until_unassign: 14
           # One person should work on one issue only
           max_assignments: 1
           maintainers: '@JabRef/developers,Siedlerchr,ThiloteE,calixtus,HoussemNasri,subhramit,InAnYan'

--- a/.github/workflows/unassign-issues.yml
+++ b/.github/workflows/unassign-issues.yml
@@ -41,7 +41,7 @@ jobs:
               </details>
 
               We appreciate your contribution and are here to help if needed!
-          days_until_unassign: 21
+          days_until_unassign: 14
           unassigned_comment: |
             ### 📋 Assignment Update
 


### PR DESCRIPTION
I think it should be possible within 14 days to either (a) pin the issue or (b) open a draft PR—especially for our good first issues. When contributors open a PR, the issue is pinned and not unassigned.

This change is also driven by the highly demanded good-first-issues and we cannot craft new good-first-issues to have multiple free ones available.

### Steps to test

Watch out in production

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
