### PR TITLE
Unassign issues on stale

### DIFF
--- a/.github/workflows/on-pr-closed.yml
+++ b/.github/workflows/on-pr-closed.yml
@@ -2,17 +2,25 @@ name: On PR closed
 
 on:
   pull_request_target:
-    types: [ closed ]
+    types: [closed]
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to process
+        required: true
+        type: number
 
 jobs:
-  determine_issue_number:
-    name: Determine issue number
+  collect_parameters:
+    name: Collect parameters
     runs-on: ubuntu-latest
     if: >
-      (github.repository == 'JabRef/jabref') &&
-      !(
-        (github.event.pull_request.user.login == 'dependabot[bot]') ||
-        (
+      github.repository == 'JabRef/jabref' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        !(
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
           startsWith(github.event.pull_request.title, '[Bot] ') ||
           startsWith(github.event.pull_request.title, 'Bump ') ||
           startsWith(github.event.pull_request.title, 'New Crowdin updates') ||
@@ -20,15 +28,59 @@ jobs:
         )
       )
     permissions:
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.pick.outputs.pr_number }}
+      pr_url:    ${{ steps.pick.outputs.pr_url }}
+      pr_body:   ${{ steps.pick.outputs.pr_body }}
+    steps:
+      - name: From workflow_dispatch input (fetch PR)
+        id: from_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const prNumber = Number(core.getInput("pr_number"));
+            const {data: pr} = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("pr_url", pr.html_url ?? "");
+            core.setOutput("pr_body", pr.body ?? "");
+      - name: Pick outputs
+        id: pick
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "pr_number=${{ steps.from_dispatch.outputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_url=${{ steps.from_dispatch.outputs.pr_url }}"       >> "$GITHUB_OUTPUT"
+            cat >> "$GITHUB_OUTPUT" <<'EOF'
+          pr_body<<BODY
+          ${{ steps.from_dispatch.outputs.pr_body }}
+          BODY
+          EOF
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_url=${{ github.event.pull_request.html_url }}"  >> "$GITHUB_OUTPUT"
+            cat >> "$GITHUB_OUTPUT" <<'EOF'
+          pr_body<<BODY
+          ${{ github.event.pull_request.body }}
+          BODY
+          EOF
+          fi
+
+  determine_issue_number:
+    name: Determine issue number
+    needs: collect_parameters
+    runs-on: ubuntu-latest
+    permissions:
       contents: read
     outputs:
       issue_number: ${{ steps.get_issue_number.outputs.ticketNumber }}
     steps:
       - name: echo PR data
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ needs.collect_parameters.outputs.pr_number }}
+          PR_URL:    ${{ needs.collect_parameters.outputs.pr_url }}
+          PR_BODY:   ${{ needs.collect_parameters.outputs.pr_body }}
         run: |
           echo "PR Number: $PR_NUMBER"
           echo "PR URL: $PR_URL"
@@ -39,27 +91,25 @@ jobs:
           EOF
       - name: Determine issue number
         id: get_issue_number
-        uses: koppor/ticket-check-action@add-output
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ticketLink: 'https://github.com/JabRef/jabref/issues/%ticketNumber%'
-          ticketPrefix: '#'
-          titleRegex: '^#(?<ticketNumber>\d+)'
-          branchRegex: '^(?<ticketNumber>\d+)'
-          # Matches GitHub's closes/fixes/resolves #{number}, but does not match our example `Closes #13109` in PULL_REQUEST_TEMPLATE
-          bodyRegex: '(?<action>fixes|closes|resolves)\s+(?:https?:\/\/github\.com\/JabRef\/jabref\/issues\/)?#?(?<ticketNumber>(?!13109\b)\d+)'
-          bodyRegexFlags: 'i'
-          outputOnly: true
-      - run: |
-          echo "${{ steps.get_issue_number.outputs.ticketNumber }}"
-          echo "Determined issue [#${{ steps.get_issue_number.outputs.ticketNumber }}](https://github.com/JabRef/jabref/issues/${{ steps.get_issue_number.outputs.ticketNumber }})" >> $GITHUB_STEP_SUMMARY
+        env:
+          PR_BODY: ${{ env.PR_BODY }}
+        run: |
+          ticketNumber=$(printf '%s\n' "$PR_BODY" \
+            | grep -Eio '(fixes|closes|resolves)[[:space:]]+(https://github.com/JabRef/jabref/issues/)?#?[0-9]+' \
+            | grep -Eo '[0-9]+' \
+            | grep -Ev '^13109$' \
+            | head -n1 || true)
+
+          echo "ticketNumber=$ticketNumber" >> "$GITHUB_OUTPUT"
+          echo "Determined issue [#$ticketNumber}(https://github.com/JabRef/jabref/issues/$ticketNumber)" >> $GITHUB_STEP_SUMMARY
+
   unassign_issue:
     name: Mark issue as available
     runs-on: ubuntu-latest
     needs: determine_issue_number
     if: >
-      (needs.determine_issue_number.outputs.issue_number != '-1') &&
-      (!github.event.pull_request.merged)
+      (needs.determine_issue_number.outputs.issue_number != '') &&
+      (github.event_name == 'workflow_dispatch' || !github.event.pull_request.merged)
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
+        id: stale
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           exempt-pr-labels: "📌 Pinned,dev: no-bot-comments"
@@ -33,3 +34,16 @@ jobs:
           days-before-pr-close: 7
           close-pr-message: >
             This PR is being closed due to continued inactivity.
+      - name: Process closed issues/PRs
+        if: steps.stale.outputs.closed-issues-prs
+        env:
+          CLOSED: ${{ steps.stale.outputs.closed-issues-prs }}
+        run: |
+          echo ${{ steps.stale.outputs.closed-issues-prs }}
+          # CLOSED is comma-separated like: "12,34,56"
+          IFS=',' read -r -a nums <<< "${CLOSED}"
+          for n in "${nums[@]}"; do
+            [ -n "$n" ] || continue
+            echo "Handling #$n"
+            gh workflow run "On PR closed" --ref main --field pr_number=$n
+          done


### PR DESCRIPTION
As far as I understand GitHub actions triggers, there is no event-provessing on trigger. Thus, if the stale action closes a PR, there is no follow-up.

That follow-up is introduced here by a work-around: 

1. manual trigger of on-pr-closed
2. triggering that workflow for each pr by tool `gh`

### Steps to test

Can only be tested on main.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
