### PR TITLE
Fix resource bundle issues

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/bibtex/comparator/MetaDataDiffTest.java
+++ b/jablib/src/test/java/org/jabref/logic/bibtex/comparator/MetaDataDiffTest.java
@@ -12,10 +12,15 @@ import org.jabref.model.metadata.ContentSelector;
 import org.jabref.model.metadata.MetaData;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+@ResourceLock("Localization.lang")
+@Execution(ExecutionMode.SAME_THREAD)
 class MetaDataDiffTest {
     @Test
     void compareWithSameContentSelectorsDoesNotReportAnyDiffs() {


### PR DESCRIPTION
This should fix following issue

```

        Test allEntriesGroupContainingGroupNotIgnored() FAILED

        java.lang.NullPointerException: Cannot invoke "org.jabref.logic.l10n.Localization$LocalizationBundle.containsKey(String)" because "bundle" is null
            at org.jabref.jablib/org.jabref.logic.bibtex.comparator.MetaDataDiffTest.allEntriesGroupContainingGroupNotIgnored(MetaDataDiffTest.java:55)
```

Follow-up to https://github.com/JabRef/jabref/pull/14571

### Steps to test

See CI passing

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
