### PR TITLE
Add right-click option to delete custom BST styles for entry preview

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/preview/PreviewTab.java
@@ -21,7 +21,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.control.MenuItem;
 
-
 import org.jabref.gui.StateManager;
 import org.jabref.gui.actions.ActionFactory;
 import org.jabref.gui.actions.SimpleCommand;

--- a/jabgui/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/preview/PreviewTabViewModel.java
@@ -505,7 +505,7 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
         chosenListProperty().add(bstPreviewLayout);
     }
 
-    public void removeCustomStyle(PreviewLayout layout){
+    public void removeCustomStyle(PreviewLayout layout) {
         if (layout instanceof BstPreviewLayout) {
             availableListProperty.remove(layout);
             chosenListProperty.remove(layout);
@@ -513,5 +513,4 @@ public class PreviewTabViewModel implements PreferenceTabViewModel {
             bstStylesPaths.remove(((BstPreviewLayout) layout).getFilePath());
         }
     }
-
 }

--- a/jablib/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
+++ b/jablib/src/main/java/org/jabref/logic/bst/BstPreviewLayout.java
@@ -119,7 +119,7 @@ public final class BstPreviewLayout implements PreviewLayout {
     public static boolean isBstStyleFile(String styleFile) {
         return StandardFileType.BST.getExtensions().stream().anyMatch(styleFile::endsWith);
     }
-    
+
     public Path getFilePath() {
         return path;
     }


### PR DESCRIPTION
Fixes #14352

### Description
Added a context menu to the "Entry Preview" preferences tab that allows users to remove custom BST styles.

* **UI:** Added a "Remove" context menu item to both the Available and Selected lists in `PreviewTab.java`.
* **Logic:** Implemented `removeCustomStyle` in `PreviewTabViewModel.java` to remove the style from the lists and the preference storage.
* **Persistence:** Updated `BstPreviewLayout.java` to store the file path so the removal persists after a restart.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation update
- [ ] Other (Please describe):

### Checklist:
- [x] I have tested this on my local machine
- [x] I have read the [contribution guidelines](https://github.com/JabRef/jabref/blob/main/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly