### PR TITLE
Add initial search requirements

### DIFF
--- a/docs/requirements/search-within-library.md
+++ b/docs/requirements/search-within-library.md
@@ -1,15 +1,20 @@
 ---
 parent: Requirements
 ---
-# Search
+# Search within a library
 
-This page collects requirements on the search.
+This page collects requirements on the search within a library.
+Typically, a user uses the search bar to trigger a search in the current library.
+They can also open up a popup to search across all libraries.
+
+> Requirements on search regarding a fetcher are not covered here.
+> Requirements on the syntax itself are not covered here, oo.
+{: .prompt-note}
+
+## Requirements sources
 
 Indirectly, the requirements are listed at <https://docs.jabref.org/finding-sorting-and-cleaning-entries/search>.
 This page tries to collect issues from users as requirements to enable better tracing in the code.
-
-> ![NOTE]
-> Currently, no implementation is linked
 
 ## Search for the name of the first authors
 `req~jabgui.search.syntax.author-first-name~1`
@@ -40,5 +45,8 @@ It is possible by regular expressions, but the user asked for "quickly".
 Issue: [#10490](https://github.com/JabRef/jabref/issues/10490)
 
 Enable to quickly search for a citation key.
+
+> Currently, no implementation is linked
+{: .prompt-note}
 
 <!-- markdownlint-disable-file MD022 -->


### PR DESCRIPTION
Triggered by https://github.com/JabRef/jabref/issues/14632

The vision is to collect relevant issues and sort them into requirements.

This is a first step to provide a file skeleton.

This is contrary to https://github.com/JabRef/jabref/pull/13851, which collects the requirements from the user documentation (https://docs.jabref.org/finding-sorting-and-cleaning-entries/search.

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
