### PR TITLE
Enable updating entries from web sources without identifiers

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/FetchAndMergeEntry.java
@@ -109,6 +109,11 @@ public class FetchAndMergeEntry {
         }
     }
 
+    public void mergeFetchedEntry(BibEntry originalEntry, BibEntry fetchedEntry, WebFetcher fetcher) {
+        showMergeDialog(originalEntry, fetchedEntry, fetcher);
+    }
+
+
     private void showMergeDialog(BibEntry originalEntry, BibEntry fetchedEntry, WebFetcher fetcher) {
         MergeEntriesDialog dialog = new MergeEntriesDialog(originalEntry, fetchedEntry, preferences, stateManager);
         dialog.setTitle(Localization.lang("Merge entry with %0 information", fetcher.getName()));

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/UpdateEntryFromWebSourcesAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/UpdateEntryFromWebSourcesAction.java
@@ -1,0 +1,104 @@
+package org.jabref.gui.mergeentries;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.swing.undo.UndoManager;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.ActionHelper;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.mergeentries.multiwaymerge.MultiMergeEntriesView;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.gui.undo.NamedCompoundEdit;
+import org.jabref.gui.undo.UndoableFieldChange;
+import org.jabref.logic.importer.EntryBasedFetcher;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.ImportCleanup;
+import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.NotificationService;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
+
+public class UpdateEntryFromWebSourcesAction extends SimpleCommand {
+    private final StateManager stateManager;
+    private final UndoManager undoManager;
+    private final GuiPreferences preferences;
+    private final NotificationService notificationService;
+    private final TaskExecutor taskExecutor;
+    private final DialogService dialogService;
+
+    public UpdateEntryFromWebSourcesAction(StateManager stateManager, UndoManager undoManager, GuiPreferences preferences, NotificationService notificationService, TaskExecutor taskExecutor, DialogService dialogService) {
+        this.stateManager = stateManager;
+        this.undoManager = undoManager;
+        this.preferences = preferences;
+        this.notificationService = notificationService;
+        this.taskExecutor = taskExecutor;
+        this.dialogService = dialogService;
+
+        this.executable.bind(ActionHelper.needsDatabase(stateManager));
+    }
+
+    @Override
+    public void execute() {
+        Optional<BibDatabaseContext> activeDatabase = stateManager.getActiveDatabase();
+        if (activeDatabase.isEmpty()) {
+            return;
+        }
+        BibDatabaseContext databaseContext = activeDatabase.get();
+
+        if (stateManager.getSelectedEntries().size() != 1) {
+            notificationService.notify(Localization.lang("Select exactly one entry to update from web sources"));
+            return;
+        }
+        BibEntry entry = stateManager.getSelectedEntries().getFirst();
+
+        FetchAndMergeEntry fetchAndMergeEntry = new FetchAndMergeEntry(
+                databaseContext,
+                taskExecutor,
+                preferences,
+                dialogService,
+                undoManager,
+                stateManager
+        );
+
+        SortedSet<EntryBasedFetcher> fetchers = WebFetchers.getEntryBasedFetchers(
+                preferences.getImporterPreferences(),
+                preferences.getImportFormatPreferences(),
+                preferences.getFilePreferences(),
+                databaseContext
+        );
+
+        for (EntryBasedFetcher fetcher : fetchers) {
+            BackgroundTask.wrap(() -> fetcher.performSearch(entry).stream().findFirst())
+                          .onSuccess(firstResult -> {
+                              if (firstResult.isPresent()) {
+                                  ImportCleanup cleanup = ImportCleanup.targeting(
+                                          databaseContext.getMode(),
+                                          preferences.getFieldPreferences()
+                                  );
+                                  cleanup.doPostCleanup(firstResult.get());
+                                  fetchAndMergeEntry.mergeFetchedEntry(entry, firstResult.get(), fetcher);
+                              }
+                          })
+                          .onFailure(exception -> {
+                              dialogService.showErrorDialogAndWait(
+                                      Localization.lang("Error while fetching from %0", fetcher.getName()),
+                                      exception
+                              );
+                          })
+                          .executeWith(taskExecutor);
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #14185

Adds a new Lookup menu action that updates an existing bibliographic entry using web sources based on the entry’s current metadata (title, authors, year), without requiring identifiers. The action retrieves one candidate per source and presents the results in the multi-merge dialog, updating the original entry only after user confirmation.

### Steps to test

1. Open JabRef and create or open a library.
2. Add an entry without DOI/ISBN but with at least a title (for example: Vicsek et al., 1995).
3. Select exactly one entry.
4. Open the Lookup menu and click the new entry-based update action.
5. Verify that the multi-merge dialog opens with proposals from web sources.
6. Confirm the merge and verify that new fields (such as journal, volume, pages, or DOI) are added to the existing entry.
7. Use undo (Ctrl+Z) to verify that changes can be reverted.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef
- [/] I added JUnit tests for changes
- [/] I added screenshots in the PR description
- [ ] I described the change in `CHANGELOG.md` in a way that is understandable for the average user
- [/] I checked the [user documentation](https://docs.jabref.org/)
