### PR TITLE
Add findInText to ArXivIdentifier

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/identifier/ArXivIdentifier.java
+++ b/jablib/src/main/java/org/jabref/model/entry/identifier/ArXivIdentifier.java
@@ -1,15 +1,16 @@
 package org.jabref.model.entry.identifier;
 
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.util.strings.StringUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -137,5 +138,32 @@ public class ArXivIdentifier extends EprintIdentifier {
         } catch (URISyntaxException e) {
             return Optional.empty();
         }
+    }
+    public static Optional<ArXivIdentifier> findInText(String text) {
+        if (text == null) {
+            return Optional.empty();
+        }
+
+        // Remove strange characters
+        text = text.replaceAll("[�]", "");
+
+        // Match arXiv URLs like:
+        // https://arxiv.org/abs/2503.08641v1
+        // https://arxiv.org/html/2503.08641v1#bib.bib5
+        Pattern arxivPattern = Pattern.compile(
+                "arxiv\\.org/(abs|html)/([0-9]{4}\\.[0-9]{5}(v[0-9]+)?)",
+                Pattern.CASE_INSENSITIVE
+        );
+
+        Matcher matcher = arxivPattern.matcher(text);
+        if (matcher.find()) {
+            String arxivId = matcher.group(2);
+            String identifier = matcher.group(2);
+            String version = matcher.group(3) != null ? matcher.group(3).substring(1) : "";
+
+            return Optional.of(new ArXivIdentifier(identifier, version, ""));
+        }
+
+        return Optional.empty();
     }
 }

--- a/jablib/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
@@ -192,4 +192,16 @@ class ArXivIdentifierTest {
 
         assertEquals(Optional.of(new ArXivIdentifier("1502.05795", "1", "")), parsed);
     }
+
+    @Test
+    void findsArXivIdentifierInUrl() {
+        String text = "https://arxiv.org/html/2503.08641v1#bib.bib5";
+
+        Optional<ArXivIdentifier> identifier = ArXivIdentifier.findInText(text);
+
+        assertTrue(identifier.isPresent());
+        assertEquals("2503.08641", identifier.get().getIdentifier());
+        assertEquals("1", identifier.get().getVersion());
+    }
+
 }


### PR DESCRIPTION
Closes #14659

This pull request adds support for detecting arXiv identifiers from text by implementing findInText for ArXivIdentifier.
It enables automatic extraction of arXiv IDs from common arXiv URLs and includes a unit test to verify the behavior.

### Steps to test

1. Copy an arXiv URL such as https://arxiv.org/html/2503.08641v1#bib.bib5
2. Use the identifier detection functionality in JabRef.
3. Verify that the arXiv identifier is detected correctly with identifier "2503.08641" and version "1".

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [/] I manually tested my changes in running JabRef
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in CHANGELOG.md (if change is visible to the user)
- [/] I checked the user documentation
