### PR TITLE
Add findInText method for ArXivIdentifier

### DIFF
--- a/jablib/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/identifier/ArXivIdentifierTest.java
@@ -192,4 +192,83 @@ class ArXivIdentifierTest {
 
         assertEquals(Optional.of(new ArXivIdentifier("1502.05795", "1", "")), parsed);
     }
+
+    // Tests for findInText method
+
+    @Test
+    void findInTextWithPlainIdentifier() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("Check out this paper 2503.08641 for more details");
+
+        assertEquals(Optional.of(new ArXivIdentifier("2503.08641")), found);
+    }
+
+    @Test
+    void findInTextWithArxivUrl() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("See https://arxiv.org/abs/2503.08641v1 for the paper");
+
+        assertEquals(Optional.of(new ArXivIdentifier("2503.08641", "1", "")), found);
+    }
+
+    @Test
+    void findInTextWithHtmlUrl() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("Reference: https://arxiv.org/html/2503.08641v1#bib.bib5");
+
+        assertEquals(Optional.of(new ArXivIdentifier("2503.08641", "1", "")), found);
+    }
+
+    @Test
+    void findInTextWithArxivPrefix() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("The paper arXiv:2503.08641 discusses this topic");
+
+        assertEquals(Optional.of(new ArXivIdentifier("2503.08641")), found);
+    }
+
+    @Test
+    void findInTextWithOldStyleIdentifier() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("See hep-th/9901001 for the original work");
+
+        assertEquals(Optional.of(new ArXivIdentifier("hep-th/9901001", "hep-th")), found);
+    }
+
+    @Test
+    void findInTextWithOldStyleUrl() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("Check https://arxiv.org/abs/hep-ex/0307015v1 for details");
+
+        assertEquals(Optional.of(new ArXivIdentifier("hep-ex/0307015", "1", "hep-ex")), found);
+    }
+
+    @Test
+    void findInTextReturnsEmptyForNoIdentifier() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("This text contains no arXiv identifier");
+
+        assertEquals(Optional.empty(), found);
+    }
+
+    @Test
+    void findInTextReturnsEmptyForNull() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText(null);
+
+        assertEquals(Optional.empty(), found);
+    }
+
+    @Test
+    void findInTextReturnsEmptyForBlank() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("   ");
+
+        assertEquals(Optional.empty(), found);
+    }
+
+    @Test
+    void findInTextWithVersionInMiddleOfText() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("Paper 1502.05795v2 was published last year");
+
+        assertEquals(Optional.of(new ArXivIdentifier("1502.05795", "2", "")), found);
+    }
+
+    @Test
+    void findInTextWithFiveDigitIdentifier() {
+        Optional<ArXivIdentifier> found = ArXivIdentifier.findInText("See arXiv:2301.12345 for more");
+
+        assertEquals(Optional.of(new ArXivIdentifier("2301.12345")), found);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #14659

This PR adds a findInText static method to ArXivIdentifier class, similar to the existing DOI.findInText method.

## Changes
- Added findInText method to ArXivIdentifier.java that searches for arXiv identifiers within arbitrary text
- Supports both new-style identifiers (YYMM.NNNNN, e.g., 2503.08641) and old-style identifiers (e.g., hep-th/9901001)
- Added 11 comprehensive tests covering various scenarios

## Use Case
When a user copies a URL like https://arxiv.org/html/2503.08641v1#bib.bib5 to the clipboard and selects New Entry, JabRef can now automatically detect and extract the arXiv identifier from the text.

## Testing
All existing and new tests pass.