### PR TITLE
Add link to PR template also if checklist is present, but not OK

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -189,12 +189,14 @@
   workflowName: 'Check PR Format'
   always: true
   message: >
-    You have removed the "Mandatory Checks" section from your pull request description. Please adhere to our [pull request template](https://github.com/JabRef/jabref/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1#L10).
+    You have removed the "Mandatory Checks" section from your pull request description.
+    Please adhere to our [pull request template](https://github.com/JabRef/jabref/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1).
 - jobName: 'PR checklist OK'
   workflowName: 'Check PR Format'
   always: true
   message: >
     Note that your PR will not be reviewed/accepted until you have gone through the mandatory checks in the description and marked each of them them exactly in the format of `[x]` (done), `[ ]` (not done yet) or `[/]` (not applicable).
+    Please adhere to our [pull request template](https://github.com/JabRef/jabref/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1).
 - jobName: 'Determine issue number'
   workflowName: 'Link PR to Issue'
   always: true


### PR DESCRIPTION
### **User description**
Triggered by https://github.com/JabRef/jabref/pull/14668

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Enhancement


___

### **Description**
- Add PR template link to checklist validation message

- Update PR template link to remove anchor reference

- Ensure users see template guidance even when checklist incomplete


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Checklist Validation"] -->|"Missing Checks"| B["Show Template Link"]
  A -->|"Incomplete Checks"| C["Add Template Guidance"]
  B --> D["User Sees Template"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghprcomment.yml</strong><dd><code>Add template link to checklist validation messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/ghprcomment.yml

<ul><li>Updated message for "Mandatory Checks present" job to split text <br>across lines for better readability<br> <li> Modified PR template link by removing the anchor reference (#L10) to <br>point to the full template page<br> <li> Added PR template link guidance to "PR checklist OK" job message to <br>ensure users see template reference even when checklist is incomplete</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14694/files#diff-47317f0dfa009599b6061b5f6079a3627ffded8f668e16978d5cb75fd9800e19">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

