### PR TITLE
fix #12112 - too much space between the file and group fields 

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
@@ -1,10 +1,8 @@
+//owner editor
+
 package org.jabref.gui.fieldeditors;
 
 import javax.swing.undo.UndoManager;
-
-import javafx.fxml.FXML;
-import javafx.scene.Parent;
-import javafx.scene.layout.HBox;
 
 import org.jabref.gui.autocompleter.SuggestionProvider;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
@@ -17,11 +15,15 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 
 import com.airhacks.afterburner.views.ViewLoader;
+
 import jakarta.inject.Inject;
+import javafx.fxml.FXML;
+import javafx.scene.Parent;
+import javafx.scene.layout.HBox;
 
 public class OwnerEditor extends HBox implements FieldEditorFX {
 
-    @FXML private OwnerEditorViewModel viewModel;
+    private OwnerEditorViewModel viewModel;
     @FXML private EditorTextField textField;
 
     @Inject private GuiPreferences preferences;


### PR DESCRIPTION
### **User description**
Closes #12112 issue- too much space between keywords file and group

This PR fixes a layout issue in the Entry Editor where the vertical spacing between fields, becomes excessively large when the Keywords field wraps to multiple lines by introducing the scroll pane at the keywords field

Result:
1. Keywords can wrap to multiple lines without affecting spacing.
2. No excessive gaps between fields inside the scrollable editor.
3. Labels and editors remain vertically aligned.

before:
<img width="1620" height="585" alt="380511320-3fb30730-34ae-4771-b535-570f00210363" src="https://github.com/user-attachments/assets/f444ac90-3e31-4d6d-a51f-acacdfdd14ec" />
 

After:
<img width="2879" height="1339" alt="Screenshot 2025-12-25 160728" src="https://github.com/user-attachments/assets/fbcd3645-4c5f-45a9-803d-6e75457131be" />


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix excessive spacing between Keywords and Group fields in Entry Editor

- Implement ScrollPane for Keywords field to handle multi-line wrapping

- Refactor KeywordsEditor with code cleanup and improved formatting

- Remove drag-and-drop and double-click editing features from tags

Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Keywords Field"] -->|"Wrapped to ScrollPane"| B["ScrollPane Container"]
  B -->|"Max Height 150px"| C["Controlled Layout"]
  C -->|"Prevents Excessive Spacing"| D["Fixed Spacing Issue"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeywordsEditor.java</strong><dd><code>Add ScrollPane layout fix for Keywords field spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/fieldeditors/KeywordsEditor.java

<ul><li>Added ScrollPane wrapper around keywordTagsField with max height of <br>150px to prevent excessive spacing when keywords wrap to multiple <br>lines<br> <li> Removed drag-and-drop functionality and double-click editing from tag <br>labels<br> <li> Removed clipboard notification messages from COPY and CUT context menu <br>actions<br> <li> Refactored code formatting for improved readability with proper line <br>breaks<br> <li> Reorganized imports and removed unused imports (javafx.scene.input <br>classes, Localization, JabRefDialogService)<br> <li> Changed weight from 2 to 1 and removed getViewModel() method<br> <li> Simplified tag creation logic and improved method chaining</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14721/files#diff-e6019fac2536b94b683cff88ce375cd65796a934e8e780cdf02421f7202c4f49">+70/-96</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OwnerEditor.java</strong><dd><code>Clean up imports and remove FXML annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java

<ul><li>Removed @FXML annotation from viewModel field declaration<br> <li> Reorganized imports with proper grouping and blank line separation<br> <li> Added file header comment</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14721/files#diff-41c4b4498de417248f3c4c5af3f266fc0c1c78dece9c1fca4aef9a8ac99c3437">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

