### PR TITLE
Remove --strip-debug

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.targets.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.targets.gradle.kts
@@ -13,8 +13,8 @@ javaModulePackaging {
         "--compress", "zip-6",
         "--no-header-files",
         "--no-man-pages",
-        "--bind-services",
-        "--strip-debug"
+        "--bind-services"
+        // "--strip-debug" // We need to keep this removed to get line numbers at stack traces
     )
     target("ubuntu-22.04") {
         operatingSystem = OperatingSystemFamily.LINUX


### PR DESCRIPTION
### **User description**
Refs https://github.com/JabRef/jabref/issues/14729

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `--strip-debug` jlink option from build configuration

- Add comment explaining need for debug symbols in stack traces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["jlink Options Configuration"] -- "Remove --strip-debug flag" --> B["Keep Debug Symbols"]
  B -- "Enable line numbers" --> C["Improved Stack Traces"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>org.jabref.gradle.base.targets.gradle.kts</strong><dd><code>Remove --strip-debug jlink option with explanation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build-logic/src/main/kotlin/org.jabref.gradle.base.targets.gradle.kts

<ul><li>Removed <code>--strip-debug</code> from jlinkOptions list<br> <li> Added explanatory comment about keeping debug symbols for stack trace <br>line numbers<br> <li> Maintains all other jlink options unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14731/files#diff-cb5d6dab16ce9fcceeb2c157b00a2833ac13a40e0989d671c81207914cd03d98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

