### PR TITLE
Add documentation for JabRef-specific metadata in bib files

### DIFF
--- a/docs/getting-into-the-code/jabref-bib-metadata.md
+++ b/docs/getting-into-the-code/jabref-bib-metadata.md
@@ -20,6 +20,7 @@ by BibTeX and biblatex processors and therefore do not affect bibliography compi
 The metadata is typically stored in `@Comment` blocks with a `jabref-meta` prefix.
 
 Example:
+
 ```bibtex
 @Comment{jabref-meta: groupstree:
 0 AllEntriesGroup:;


### PR DESCRIPTION
### **User description**
Closes #7502

### Description
This pull request adds documentation explaining how JabRef stores application-specific
metadata (such as group definitions) inside `.bib` files using BibTeX comment blocks.

It also clarifies compatibility aspects between JabRef 4 and JabRef 5, addressing
frequently asked questions by contributors and advanced users.

### Steps to test
1. Open the documentation file:
   docs/getting-into-the-code/jabref-bib-metadata.md
2. Verify that the explanation of JabRef-specific metadata is clear and accurate.
3. Confirm that the BibTeX example is properly formatted and easy to understand.

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [/] I manually tested my changes in running JabRef (documentation-only change)
- [/] I added JUnit tests for changes (not applicable)
- [/] I added screenshots in the PR description (not applicable)
- [/] I described the change in CHANGELOG.md (documentation-only change)
- [/] I checked the user documentation (documentation added to core repository)


___

### **PR Type**
Documentation


___

### **Description**
- Adds documentation explaining JabRef-specific metadata storage in .bib files

- Describes BibTeX comment block format for persisting application state

- Clarifies JabRef 4 and 5 compatibility and version detection limitations

- Documents interoperability considerations with external BibTeX tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JabRef Metadata Storage"] --> B["BibTeX Comment Blocks"]
  B --> C["Group Definitions & State"]
  A --> D["Compatibility Information"]
  D --> E["JabRef 4 vs 5"]
  A --> F["Interoperability Notes"]
  F --> G["External Tool Handling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jabref-bib-metadata.md</strong><dd><code>JabRef metadata storage and compatibility documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/getting-into-the-code/jabref-bib-metadata.md

<ul><li>New documentation file explaining how JabRef stores <br>application-specific metadata using BibTeX comment blocks<br> <li> Includes overview of metadata storage format with practical example of <br><code>@Comment{jabref-meta:</code> syntax<br> <li> Addresses JabRef 4 and 5 compatibility, clarifying that version <br>detection relies on metadata parsing rather than explicit version <br>markers<br> <li> Documents limitations and interoperability considerations for external <br>BibTeX tools</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14811/files#diff-819046ac6065c385d3675fce1a5dff73e99fa03db14333c03f2b7ba2e2513383">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

