### PR TITLE
Fix Web Search panel opening on every startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the Web Search panel would open on every startup regardless of user preferences. [#14818](https://github.com/JabRef/jabref/issues/14818)
 - We Improved detection of arXiv identifiers when pasting arXiv URLs that include URL fragments. [#14659](https://github.com/JabRef/jabref/issues/14659)
 - We fixed an error on startup when using portable preferences. [#14729](https://github.com/JabRef/jabref/issues/14729)
 - We fixed an issue when warning for duplicate entries in the "New Entry" dialog. [#14662](https://github.com/JabRef/jabref/pull/14662)

--- a/jabgui/src/main/java/org/jabref/gui/frame/SidePanePreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/SidePanePreferences.java
@@ -27,7 +27,7 @@ public class SidePanePreferences {
 
     private SidePanePreferences() {
         this(
-                EnumSet.of(SidePaneType.WEB_SEARCH, SidePaneType.GROUPS), // Default visible panes (OPEN_OFFICE omitted)
+                EnumSet.of(SidePaneType.GROUPS), // Default visible panes (WEB_SEARCH and OPEN_OFFICE omitted)
                 Map.of(),                                                 // Default preferred positions
                 0                                                         // Default web search fetcher index
         );


### PR DESCRIPTION
Closes #14818

## Summary

Removed WEB_SEARCH from default visible side panes. Now only GROUPS panel is shown by default on first startup. User preferences for side pane visibility are properly restored from previous sessions.

## Changes

- Modified `SidePanePreferences.java`: Changed default visible panes from `EnumSet.of(SidePaneType.WEB_SEARCH, SidePaneType.GROUPS)` to `EnumSet.of(SidePaneType.GROUPS)`

## Steps to test

1. Start JabRef with a fresh configuration (delete preferences)
2. Verify that only Groups panel is visible, Web Search is closed
3. Open Web Search panel, restart JabRef → Web Search should open
4. Close Web Search panel, restart JabRef → Web Search should stay closed

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable) - N/A, this is a configuration change
- [x] I added screenshots in the PR description (if change is visible to the user) - N/A, behavior change not visible in screenshot
- [x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.