### PR TITLE
Make JDK25 available for jbang

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -314,6 +314,13 @@ jobs:
 
       - uses: ./.github/actions/setup-gradle
         if: steps.changed-jablib-files.outputs.any_changed != 'true'
+      - name: Setup JDK
+        if: steps.changed-jablib-files.outputs.any_changed != 'true'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'corretto'
+          check-latest: true
 
       # Build all JBang scripts
       - run: |
@@ -364,6 +371,12 @@ jobs:
           files_ignore: |
             jablib/src/main/java/**/*-*.java
       - uses: ./.github/actions/setup-gradle
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'corretto'
+          check-latest: true
       - name: Modify ${{ matrix.script }} to include changed classes
         shell: bash
         # We always run, because changes in jabls, jabsrv also could cause JBang to fail


### PR DESCRIPTION
### **User description**
Fix CI 

Follow-up to https://github.com/JabRef/jabref/pull/14859

### Steps to test

Can only be seen in main

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Enhancement


___

### **Description**
- Add JDK 25 setup to CI workflows for jbang testing

- Configure Corretto distribution with latest version check

- Apply JDK setup to two separate workflow jobs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflows"] --> B["tests-code.yml"]
  B --> C["Add JDK 25 Setup"]
  C --> D["Job 1: Conditional Setup"]
  C --> E["Job 2: Unconditional Setup"]
  D --> F["Corretto Distribution"]
  E --> F
  F --> G["Check Latest Version"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests-code.yml</strong><dd><code>Add JDK 25 setup to workflow jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/tests-code.yml

<ul><li>Added JDK 25 setup step using <code>actions/setup-java@v5</code> in first job with <br>conditional execution<br> <li> Added JDK 25 setup step in second job without condition<br> <li> Configured Corretto distribution with <code>check-latest: true</code> flag<br> <li> Both setups target Java version '25' for jbang script testing</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14861/files#diff-de8e2dfe255ad289c174205fd5281dad4ae220c71c1132b8766389b5236c14e5">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

