### PR TITLE
Fix #14771: Limit filename length to fix "file in use" error on Windows

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -421,6 +421,13 @@ public class FileUtil {
         // Removes illegal characters from filename
         targetName = FileNameCleaner.cleanFileName(targetName);
 
+        //Truncates filename to prevent MAX_PATH issues on Windows
+        //Limits the length to 128 characters to reserve space for the directory path and file extension
+        final int MAX_FILENAME_LENGTH = 128; 
+        if (targetName.length() > MAX_FILENAME_LENGTH) {
+            targetName = targetName.substring(0, MAX_FILENAME_LENGTH);
+        }
+
         return Optional.of(targetName);
     }
 

--- a/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import org.jabref.architecture.AllowedToUseLogic;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.os.OS;
+import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.LinkedFile;
@@ -509,6 +510,18 @@ class FileUtilTest {
         } else {
             assertTrue(FileUtil.detectBadFileName(fileName));
         }
+    }
+    
+    @Test
+    void createFileNameFromPatternTruncatesVeryLongTitles() {
+        BibDatabase database = new BibDatabase();
+        BibEntry entry = new BibEntry();
+        entry.setField(StandardField.TITLE, "a".repeat(300));
+
+        Optional<String> result = FileUtil.createFileNameFromPattern(database, entry, "[title]");
+
+        assertTrue(result.isPresent());
+        assertEquals(128, result.get().length());
     }
 
     /// Tests for issue <https://github.com/JabRef/jabref/issues/12995>


### PR DESCRIPTION
### **User description**
Closes #14771

I've fixed the "file in use" error that happens on Windows when renaming files with very long metadata (long titles). 

The issue was that the generated filename could exceed the Windows `MAX_PATH` limit, causing an `IOException`. 

I updated `FileUtil.createFileNameFromPattern` to cap the filename at 128 characters. This leaves plenty of room for the folder path while keeping the filename safe. I also ensured the truncation happens *after* the cleanup logic so it doesn't leave any broken syntax.

### Code Summary

- **`FileUtil.java`**: Added a check in `createFileNameFromPattern` to truncate filenames to **128 characters** if they exceed the limit.
- **`FileUtilTest.java`**: Added unit test `createFileNameFromPatternTruncatesVeryLongTitles` which asserts that a 300-char input results in a 128-char output.

### Steps to test

1. Create a dummy entry with a very long title (more than 260 characters).
2. Attach any file to it.
3. Right-click the file and choose **"Rename to a given pattern"** (using the default `[title]` pattern).
4. **Result:** The rename should succeed (giving a shortened filename) instead of failing with an error.

*I verified this with a new unit test `createFileNameFromPatternTruncatesVeryLongTitles` that proves the truncation works correctly.*

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Bug fix


___

### **Description**
- Truncate filenames to 128 characters to prevent Windows MAX_PATH errors

- Truncation occurs after LaTeX command removal and filename cleaning

- Added unit test verifying long titles are properly truncated to 128 chars


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Long filename from pattern"] --> B["Remove LaTeX commands"]
  B --> C["Clean illegal characters"]
  C --> D["Truncate to 128 chars"]
  D --> E["Return safe filename"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileUtil.java</strong><dd><code>Add filename length truncation for Windows compatibility</code>&nbsp; </dd></summary>
<hr>

jablib/src/main/java/org/jabref/logic/util/io/FileUtil.java

<ul><li>Added filename truncation logic to <code>createFileNameFromPattern</code> method<br> <li> Limits filename length to 128 characters to prevent Windows MAX_PATH <br>issues<br> <li> Truncation applied after LaTeX command removal and filename cleaning<br> <li> Preserves space for directory path and file extension</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14872/files#diff-61a87d550e9b7fab61f95c9a5c050b56ccd473558ec599724b2c60c971c2e3d8">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FileUtilTest.java</strong><dd><code>Add test for filename truncation with long titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java

<ul><li>Added import for <code>BibDatabase</code> class<br> <li> Added new test method <code>createFileNameFromPatternTruncatesVeryLongTitles</code><br> <li> Test verifies that 300-character title is truncated to exactly 128 <br>characters<br> <li> Validates the fix prevents filename length issues</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14872/files#diff-c9fb4296d85cc740c5a61d48ce217ee0db215bec0465155231ae9ad55265ff1c">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

