### PR TITLE
Fix notification showing exception details in citation relations tab

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java
@@ -29,7 +29,11 @@ import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.sciteTallies.TalliesResponse;
 import org.jabref.model.util.FileUpdateMonitor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CitationsRelationsTabViewModel {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CitationsRelationsTabViewModel.class);
 
     public enum SciteStatus {
         IN_PROGRESS,
@@ -161,9 +165,11 @@ public class CitationsRelationsTabViewModel {
                                        status.set(SciteStatus.FOUND);
                                    })
                                    .onFailure(error -> {
-                                       searchError.set(error.getMessage());
+                                       LOGGER.error("Error while fetching citation relations from scite.ai", error);
+                                       searchError.set(Localization.lang("Could not load citation relations."));
                                        status.set(SciteStatus.ERROR);
                                    })
+
                                    .executeWith(taskExecutor);
     }
 


### PR DESCRIPTION
### **User description**
Closes #14893

Closes https://github.com/JabRef/jabref/issues/14886

Fixes an issue where notifications incorrectly displayed exception details
in the citation relations tab, improving error handling and user feedback.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace exception message display with localized user-friendly message

- Add proper logging of citation relation fetch errors

- Prevent exception details from appearing in UI notifications


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fetch Error Occurs"] --> B["Log Error Details"]
  B --> C["Display Localized Message"]
  C --> D["User-Friendly Notification"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CitationsRelationsTabViewModel.java</strong><dd><code>Add logging and localize error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationsRelationsTabViewModel.java

<ul><li>Added SLF4J logger import and static logger instance<br> <li> Changed error handling to log exception details instead of exposing <br>them<br> <li> Replaced raw error message with localized user-friendly message<br> <li> Improved error feedback by separating logging from UI display</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14895/files#diff-dd21da8056b2674ba013a3aa6178b5bf84863bb27338ae738166c38f27bc2684">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

