### PR TITLE
Allow spaces at checkout w.r.t. JBang

### DIFF
--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -252,7 +252,7 @@ var taskGenerateJournalListMV = tasks.register<JBangTask>("generateJournalListMV
     description = "Converts the comma-separated journal abbreviation file to a H2 MVStore"
     dependsOn(tasks.named("generateGrammarSource"))
 
-    script = rootProject.layout.projectDirectory.file("build-support/src/main/java/JournalListMvGenerator.java").asFile.absolutePath
+    script = '"' + rootProject.layout.projectDirectory.file("build-support/src/main/java/JournalListMvGenerator.java").asFile.absolutePath + '"'
 
     inputs.dir(abbrvJabRefOrgDir)
     outputs.file(generatedJournalFile)
@@ -266,7 +266,7 @@ var taskGenerateCitationStyleCatalog = tasks.register<JBangTask>("generateCitati
     // The JBang gradle plugin doesn't handle parallization well - thus we enforce sequential execution
     mustRunAfter(taskGenerateJournalListMV)
 
-    script = rootProject.layout.projectDirectory.file("build-support/src/main/java/CitationStyleCatalogGenerator.java").asFile.absolutePath
+    script = '"' + rootProject.layout.projectDirectory.file("build-support/src/main/java/CitationStyleCatalogGenerator.java").asFile.absolutePath + '"'
 
     inputs.dir(layout.projectDirectory.dir("src/main/resources/csl-styles"))
     val cslCatalogJson = layout.buildDirectory.file("generated/resources/citation-style-catalog.json")
@@ -281,7 +281,7 @@ var taskGenerateLtwaListMV = tasks.register<JBangTask>("generateLtwaListMV") {
     // The JBang gradle plugin doesn't handle parallization well - thus we enforce sequential execution
     mustRunAfter(taskGenerateCitationStyleCatalog)
 
-    script = rootProject.layout.projectDirectory.file("build-support/src/main/java/LtwaListMvGenerator.java").asFile.absolutePath
+    script = '"' + rootProject.layout.projectDirectory.file("build-support/src/main/java/LtwaListMvGenerator.java").asFile.absolutePath + '"'
 
     inputs.file(layout.buildDirectory.file("../src/main/resources/ltwa/ltwa_20210702.csv"))
     val ltwaListMv = layout.buildDirectory.file("generated/resources/journals/ltwa-list.mv")


### PR DESCRIPTION
### **User description**
<img width="1270" height="321" alt="image" src="https://github.com/user-attachments/assets/dbedb3e6-b80b-474f-9496-4c36c417b0fe" />


### Steps to test

Just see CI passing - and locally JabRef building


### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap JBang script paths with quotes to support spaces

- Fixes path handling in three build tasks

- Ensures compatibility with checkout directories containing spaces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JBang Tasks"] -->|"Add quotes around"| B["Script Paths"]
  B -->|"Enables support for"| C["Spaces in Directory"]
  C -->|"Fixes"| D["Build Failures"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Quote JBang script paths for space handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/build.gradle.kts

<ul><li>Wrapped <code>script</code> path assignments with double quotes in three JBang <br>tasks<br> <li> Modified <code>generateJournalListMV</code> task script path<br> <li> Modified <code>generateCitationStyleCatalog</code> task script path<br> <li> Modified <code>generateLtwaListMV</code> task script path</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14899/files#diff-97b29e486a6f1ead0c3bb51ba59dca43b67d1bbcf8ff6009bfc90ebc80130e4d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

