### PR TITLE
Improve CAYW search result popup width

### DIFF
--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SearchResultContainer.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SearchResultContainer.java
@@ -18,7 +18,7 @@ public class SearchResultContainer extends ListView<CAYWEntry> {
     private final static int MAX_LINES = 3;
     private final static int ESTIMATED_CHARS_PER_LINE = 80;
     private final static int TOOLTIP_WIDTH = 400;
-    private final static double PREF_WIDTH = 300;
+    private final static double PREF_WIDTH = 420;
 
     private ObservableList<CAYWEntry> selectedEntries = javafx.collections.FXCollections.observableArrayList();
 


### PR DESCRIPTION
### **User description**
Closes https://github.com/JabRef/jabref/issues/14281

This PR slightly increases the default width of the Cite As You Write (CAYW) search result popup so that labels and descriptions are easier to read. The fallback width is adjusted for cases where the parent container size is not yet available, which helps avoid clipped text and results in a more balanced layout, especially on Windows and HiDPI displays.

### Steps to test

1. Start JabRef and open any BibTeX library with at least one entry.
2. Trigger the Cite As You Write search (for example, from an external editor).
3. Check the search result popup:
   - Labels and descriptions should be fully visible.
   - Text wrapping should look balanced and not feel cramped.
4. On Windows, note that triggering the popup may not work in `./gradlew run` due to known limitations of the development setup.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef
- [/] I added JUnit tests for changes (not applicable for a UI layout adjustment)
- [ ] I added screenshots in the PR description (can be added if requested)
- [ ] I described the change in `CHANGELOG.md` (will add if maintainers consider it necessary)
- [/] I checked the user documentation (not applicable for a small UI layout change)


___

### **PR Type**
Enhancement


___

### **Description**
- Increases CAYW search result popup default width from 300 to 420

- Improves readability of labels and descriptions in popup

- Prevents text clipping on Windows and HiDPI displays


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SearchResultContainer<br/>PREF_WIDTH constant"] -- "increased from 300<br/>to 420 pixels" --> B["Wider popup display<br/>with better text visibility"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SearchResultContainer.java</strong><dd><code>Increase popup preferred width constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabsrv/src/main/java/org/jabref/http/server/cayw/gui/SearchResultContainer.java

<ul><li>Updated <code>PREF_WIDTH</code> constant from 300 to 420 pixels<br> <li> Improves layout balance and text readability in CAYW search popup<br> <li> Addresses issue with clipped text on Windows and HiDPI displays</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14913/files#diff-cbdd51fa0b99c70c30d85bc2dc845da9daa8f43b1520235195215a4866f24400">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

