### PR TITLE
Fix Javadoc comments to use // instead of ///

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -1,27 +1,27 @@
-/// Copyright (c) 2014, 2015, ControlsFX
-/// All rights reserved.
-///
-/// Redistribution and use in source and binary forms, with or without
-/// modification, are permitted provided that the following conditions are met:
-/// * Redistributions of source code must retain the above copyright
-/// notice, this list of conditions and the following disclaimer.
-/// * Redistributions in binary form must reproduce the above copyright
-/// notice, this list of conditions and the following disclaimer in the
-/// documentation and/or other materials provided with the distribution.
-/// * Neither the name of ControlsFX, any associated website, nor the
-/// names of its contributors may be used to endorse or promote products
-/// derived from this software without specific prior written permission.
-///
-/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-/// DISCLAIMED. IN NO EVENT SHALL CONTROLSFX BE LIABLE FOR ANY
-/// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-/// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-/// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-/// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-/// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-/// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright (c) 2014, 2015, ControlsFX
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// * Neither the name of ControlsFX, any associated website, nor the
+// names of its contributors may be used to endorse or promote products
+// derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL CONTROLSFX BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.jabref.gui.autocompleter;
 
 import java.util.Collection;

--- a/jabgui/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/slr/StartNewStudyAction.java
@@ -22,15 +22,15 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/// Used to start a new study:
-/// <ol>
-/// - Let the user input meta data for the study.
-/// - Let JabRef do the crawling afterwards.
-/// </ol>
-///
-/// Needs to inherit {@link ExistingStudySearchAction}, because that action implements the real crawling.
-///
-/// There is the hook {@link StartNewStudyAction#crawlPreparation(Path)}, which is used by {@link ExistingStudySearchAction#crawl()}.
+// Used to start a new study:
+// <ol>
+// - Let the user input meta data for the study.
+// - Let JabRef do the crawling afterwards.
+// </ol>
+//
+// Needs to inherit {@link ExistingStudySearchAction}, because that action implements the real crawling.
+//
+// There is the hook {@link StartNewStudyAction#crawlPreparation(Path)}, which is used by {@link ExistingStudySearchAction#crawl()}.
 public class StartNewStudyAction extends ExistingStudySearchAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(StartNewStudyAction.class);
 

--- a/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/SearchBasedParserFetcher.java
@@ -10,33 +10,33 @@ import java.util.List;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.query.BaseQueryNode;
 
-/// Provides a convenient interface for search-based fetcher, which follows the usual three-step procedure:
-/// <ol>
-/// - Open a URL based on the search query
-/// - Parse the response to get a list of {@link BibEntry}
-/// - Post-process fetched entries
-/// </ol>
-///
-/// This interface is used for web resources which do NOT provide BibTeX data {@link BibEntry}.
-/// JabRef's infrastructure to convert arbitrary input data to BibTeX is {@link Parser}.
-///
-///
-/// This interface inherits {@link SearchBasedFetcher}, because the methods `performSearch` have to be provided by both.
-/// As non-BibTeX web fetcher one could do "magic" stuff without this helper interface and directly use {@link WebFetcher}, but this is more work.
-///
-///
-/// Note that this interface "should" be an abstract class.
-/// However, Java does not support multi inheritance with classes (but with interfaces).
-/// We need multi inheritance, because a fetcher might implement multiple query types (such as id fetching {@link IdBasedFetcher}), complete entry {@link EntryBasedFetcher}, and search-based fetcher (this class).
-///
+// Provides a convenient interface for search-based fetcher, which follows the usual three-step procedure:
+// <ol>
+// - Open a URL based on the search query
+// - Parse the response to get a list of {@link BibEntry}
+// - Post-process fetched entries
+// </ol>
+//
+// This interface is used for web resources which do NOT provide BibTeX data {@link BibEntry}.
+// JabRef's infrastructure to convert arbitrary input data to BibTeX is {@link Parser}.
+//
+//
+// This interface inherits {@link SearchBasedFetcher}, because the methods `performSearch` have to be provided by both.
+// As non-BibTeX web fetcher one could do "magic" stuff without this helper interface and directly use {@link WebFetcher}, but this is more work.
+//
+//
+// Note that this interface "should" be an abstract class.
+// However, Java does not support multi inheritance with classes (but with interfaces).
+// We need multi inheritance, because a fetcher might implement multiple query types (such as id fetching {@link IdBasedFetcher}), complete entry {@link EntryBasedFetcher}, and search-based fetcher (this class).
+//
 
 public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetcher {
 
-    /// This method is used to send queries with advanced URL parameters.
-    /// This method is necessary as the performSearch method does not support certain URL parameters that are used for
-    /// fielded search, such as a title, author, or year parameter.
-    ///
-    /// @param queryNode the first search node
+    // This method is used to send queries with advanced URL parameters.
+    // This method is necessary as the performSearch method does not support certain URL parameters that are used for
+    // fielded search, such as a title, author, or year parameter.
+    //
+    // @param queryNode the first search node
     @Override
     default List<BibEntry> performSearch(BaseQueryNode queryNode) throws FetcherException {
         // ADR-0014
@@ -63,11 +63,11 @@ public interface SearchBasedParserFetcher extends SearchBasedFetcher, ParserFetc
         }
     }
 
-    /// Returns the parser used to convert the response to a list of {@link BibEntry}.
+    // Returns the parser used to convert the response to a list of {@link BibEntry}.
     Parser getParser();
 
-    /// Constructs a URL based on the lucene query.
-    ///
-    /// @param queryList the list that contains the parsed nodes
+    // Constructs a URL based on the lucene query.
+    //
+    // @param queryList the list that contains the parsed nodes
     URL getURLForQuery(BaseQueryNode queryList) throws URISyntaxException, MalformedURLException, FetcherException;
 }


### PR DESCRIPTION
I have fixed the Javadoc comments to use `//` instead of `///` in the following files:
- `AutoCompletionTextInputBinding.java`
- `StartNewStudyAction.java`
- `SearchBasedParserFetcher.java`

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.