### PR TITLE
Fix #14927: Skip unknown groups in GroupsParser

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -72,6 +72,10 @@ public class GroupsParser {
                 }
                 int level = Integer.parseInt(string.substring(0, spaceIndex));
                 AbstractGroup group = GroupsParser.fromString(string.substring(spaceIndex + 1), keywordSeparator, fileMonitor, metaData, userAndHost);
+                if (group == null) {
+                // Skip unknown group types (e.g., DirectoryGroup from future versions)
+                continue;
+                }
                 GroupTreeNode newNode = GroupTreeNode.fromGroup(group);
                 if (cursor == null) {
                     // create new root
@@ -133,7 +137,8 @@ public class GroupsParser {
             return texGroupFromString(input, fileMonitor, metaData, userAndHost);
         }
 
-        throw new ParseException("Unknown group: " + input);
+        LOGGER.warn("Skipping unknown group: {}", input);
+        return null;
     }
 
     private static AbstractGroup texGroupFromString(String input, FileUpdateMonitor fileMonitor, MetaData metaData, String userAndHost) throws ParseException {


### PR DESCRIPTION
### **User description**
Return null for unrecognized group types instead of throwing ParseException. Added tests for DirectoryGroup and generic unknown group handling.

Closes #14927


<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... Summarize changes and DO NOT list modified classes one-by-one. (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

## Steps to test

### How to Test
#### Manual Test

Create a test file test.bib with the following content (contains the problematic DirectoryGroup from issue #14927):
@Comment{jabref-meta: grouping:
0 AllEntriesGroup:;
1 StaticGroup:KnownGroup\;0\;1\;0x000000ff\;\;\;;
1 DirectoryGroup:fs-mirror\;0\;C:/TEMP/jabref/fs-mirror\;1\;\;\;;
1 StaticGroup:AnotherKnown\;0\;1\;0x000000ff\;\;\;;
}

Open the file in JabRef (File → Open Library)
Expected behavior:
No error dialog appears (previously showed "This should not happen")
Library opens successfully
Groups "KnownGroup" and "AnotherKnown" are visible in the groups panel
DirectoryGroup is silently skipped (check log for warning)
Check the log (Help → View Event Log) for message: Skipping unknown group: DirectoryGroup:...

#### Automated Tests

Run the new test cases:

./gradlew test --tests "org.jabref.logic.importer.util.GroupsParserTest.unknownGroupTypeReturnsNull"
./gradlew test --tests "org.jabref.logic.importer.util.GroupsParserTest.directoryGroupReturnsNull"
./gradlew test --tests "org.jabref.logic.importer.util.GroupsParserTest.importGroupsSkipsUnknownGroups"

All tests should pass.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Bug fix


___

### **Description**
- Skip unknown group types instead of throwing ParseException

- Return null for unrecognized groups like DirectoryGroup

- Add null check in importGroups to continue on unknown groups

- Add comprehensive test coverage for unknown group handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unknown Group Type"] --> B["fromString method"]
  B --> C{"Group recognized?"}
  C -->|Yes| D["Return AbstractGroup"]
  C -->|No| E["Log warning"]
  E --> F["Return null"]
  F --> G["importGroups checks null"]
  G --> H["Skip unknown group"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GroupsParser.java</strong><dd><code>Handle unknown groups gracefully with null return</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/main/java/org/jabref/logic/importer/util/GroupsParser.java

<ul><li>Modified <code>fromString</code> method to return null and log warning instead of <br>throwing ParseException for unknown group types<br> <li> Added null check in <code>importGroups</code> method to skip unknown groups with <br>continue statement<br> <li> Changed exception handling to graceful degradation for unrecognized <br>group formats</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14928/files#diff-e2d200ab73099cbfc076fda4dcdc339b48327cea8eb42443baa39872279cefea">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GroupsParserTest.java</strong><dd><code>Add tests for unknown group handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java

<ul><li>Added <code>unknownGroupTypeReturnsNull</code> test for generic unknown group types<br> <li> Added <code>directoryGroupReturnsNull</code> test for DirectoryGroup specifically<br> <li> Added <code>importGroupsSkipsUnknownGroups</code> test verifying unknown groups are <br>skipped during import<br> <li> Added imports for <code>assertNull</code> and <code>mock</code> utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14928/files#diff-97d29295d24b4d0c4d60977ff19c0c9d730cd213c87afeb9b7c5338f99e1a1fb">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

