### PR TITLE
Allow suffix letters and '+' in page number validation

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java
@@ -11,7 +11,7 @@ import org.jabref.model.database.BibDatabaseContext;
 
 public class PagesChecker implements ValueChecker {
 
-    private static final String SINGLE_PAGE_PATTERN = "[A-Za-z]?\\d+[A-Za-z]?(\\+)?"; // updated regex
+    private static final String SINGLE_PAGE_PATTERN = "[A-Za-z]?\\d+[A-Za-z]?(\\+)?"; // optional prefix, required digit(s), optional suffix letter, optional '+'
     private static final String BIBTEX_RANGE_SEPARATOR = "(\\+|-{2}|\u2013)";      // separator, must contain exactly two dashes
     private static final String BIBLATEX_RANGE_SEPARATOR = "(\\+|-{1,2}|\u2013)";  // separator
 


### PR DESCRIPTION
### **User description**
Closes #13701

This pull request fixes page number validation so that valid BibTeX/BibLaTeX page formats such as `43+` and `7+,41--43,73` are accepted.  
Previously, these valid formats were incorrectly rejected during cleanup and integrity checks.

### Steps to test

1. Open JabRef
2. Create or edit a BibTeX/BibLaTeX entry
3. Set the `pages` field to values like:
   - `43+`
   - `7+,41--43,73`
4. Run **Cleanup Entries** or integrity checks
5. Verify that no validation error is shown for these page numbers

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef
- [x] I added JUnit tests for changes
- [/] I added screenshots in the PR description (not applicable, no UI change)
- [/] I described the change in CHANGELOG.md (not applicable, internal validation change)
- [/] I checked the user documentation (not applicable)

___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed page number validation regex to accept valid BibTeX/BibLaTeX formats

- Now correctly validates pages with suffix letters and '+' operator

- Supports formats like '43+' and '7+,41--43,73' without errors

- Updated regex pattern in PagesChecker to require at least one digit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Pattern<br/>[A-Za-z]?\\d*"] -->|"Rejected valid<br/>formats"| B["Invalid pages<br/>43+, 7+"]
  C["New Pattern<br/>[A-Za-z]?\\d+[A-Za-z]?(\\+)?"] -->|"Accepts valid<br/>formats"| D["Valid pages<br/>43+, 7+,41--43,73"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PagesChecker.java</strong><dd><code>Updated regex pattern for page number validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/main/java/org/jabref/logic/integrity/PagesChecker.java

<ul><li>Updated <code>SINGLE_PAGE_PATTERN</code> regex from <code>[A-Za-z]?\\d*</code> to <br><code>[A-Za-z]?\\d+[A-Za-z]?(\\+)?</code><br> <li> Pattern now requires at least one digit (<code>\\d+</code> instead of <code>\\d*</code>)<br> <li> Added support for optional suffix letters and '+' operator at end of <br>page numbers<br> <li> Fixes validation to accept BibTeX/BibLaTeX formats like '43+' and <br>'7+,41--43,73'</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14935/files#diff-71d7f800b73b94173e0a270ee167db66cf53dcd92b9b9cf5ff0c64252cab9200">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

