### PR TITLE
Fix groups not appearing in sidebar after import

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/database/DatabaseMerger.java
+++ b/jablib/src/main/java/org/jabref/logic/database/DatabaseMerger.java
@@ -28,30 +28,27 @@ public class DatabaseMerger {
         this.keywordDelimiter = keywordDelimiter;
     }
 
-    /**
-     * Merges all entries and strings of the other database into the target database.
-     * Any duplicates are ignored.
-     * In case a string has a different content, it is added with a new unique name.
-     *
-     * @param target the target database
-     * @param other  the database that is merged into the target
-     */
+    /// Merges all entries and strings of the other database into the target database.
+    /// Any duplicates are ignored.
+    /// In case a string has a different content, it is added with a new unique name.
+    ///
+    /// @param target the target database
+    /// @param other  the database that is merged into the target
     public synchronized void merge(BibDatabase target, BibDatabase other) {
         mergeEntries(target, other);
         mergeStrings(target, other);
     }
 
-    /**
-     * Merges all entries, strings, and metadata of the other database context
-     * into the target database context.
-     *
-     * @param target        the target database context
-     * @param other         the database context to merge from
-     * @param otherFileName the filename of the imported library
-     */
-    public synchronized void merge(BibDatabaseContext target,
-                                   BibDatabaseContext other,
-                                   String otherFileName) {
+    /// Merges all entries, strings, and metadata of the other database context
+    /// into the target database context.
+    ///
+    /// @param target        the target database context
+    /// @param other         the database context to merge from
+    /// @param otherFileName the filename of the imported library
+    public synchronized void merge(
+            BibDatabaseContext target,
+            BibDatabaseContext other,
+            String otherFileName) {
 
         mergeEntries(target.getDatabase(), other.getDatabase());
         mergeStrings(target.getDatabase(), other.getDatabase());
@@ -80,37 +77,37 @@ public class DatabaseMerger {
 
     public void mergeStrings(BibDatabase target, BibDatabase other) {
         for (BibtexString bibtexString : other.getStringValues()) {
-            String bibtexStringName = bibtexString.getName();
+            String name = bibtexString.getName();
             String importedContent = bibtexString.getContent();
 
-            if (target.hasStringByName(bibtexStringName)) {
-                target.getStringByName(bibtexStringName).ifPresent(existingString -> {
-                    String existingContent = existingString.getContent();
+            if (target.hasStringByName(name)) {
+                target.getStringByName(name).ifPresent(existing -> {
+                    String existingContent = existing.getContent();
 
                     if (!importedContent.equals(existingContent)) {
                         LOGGER.info(
                                 "String contents differ for {}: {} != {}",
-                                bibtexStringName,
+                                name,
                                 importedContent,
                                 existingContent);
 
                         int suffix = 1;
-                        String newName = bibtexStringName + "_" + suffix;
+                        String newName = name + "_" + suffix;
 
                         while (target.hasStringByName(newName)) {
                             suffix++;
-                            newName = bibtexStringName + "_" + suffix;
+                            newName = name + "_" + suffix;
                         }
 
-                        BibtexString newBibtexString =
+                        BibtexString newString =
                                 new BibtexString(newName, importedContent);
 
-                        target.addString(newBibtexString);
+                        target.addString(newString);
 
                         LOGGER.info(
                                 "New string added: {} = {}",
-                                newBibtexString.getName(),
-                                newBibtexString.getContent());
+                                newString.getName(),
+                                newString.getContent());
                     }
                 });
             } else {
@@ -119,35 +116,33 @@ public class DatabaseMerger {
         }
     }
 
-    /**
-     * Merges metadata from another library into the target metadata.
-     *
-     * @param target          the metadata merge target
-     * @param other           the metadata to merge from
-     * @param otherFilename   the filename of the imported library
-     * @param allOtherEntries all entries from the imported library
-     */
-    public void mergeMetaData(@NonNull MetaData target,
-                              @NonNull MetaData other,
-                              @NonNull String otherFilename,
-                              @NonNull List<BibEntry> allOtherEntries) {
+    /// Merges metadata from another library into the target metadata.
+    ///
+    /// @param target          the metadata merge target
+    /// @param other           the metadata to merge from
+    /// @param otherFilename   the filename of the imported library
+    /// @param allOtherEntries all entries from the imported library
+    public void mergeMetaData(
+            @NonNull MetaData target,
+            @NonNull MetaData other,
+            @NonNull String otherFilename,
+            @NonNull List<BibEntry> allOtherEntries) {
 
         mergeGroups(target, other, otherFilename, allOtherEntries);
         mergeContentSelectors(target, other);
     }
 
-    /**
-     * Merges groups from the imported metadata into the target metadata.
-     *
-     * @param target          the metadata merge target
-     * @param other           the metadata to merge from
-     * @param otherFilename   the filename of the imported library
-     * @param allOtherEntries all entries from the imported library
-     */
-    private void mergeGroups(@NonNull MetaData target,
-                             @NonNull MetaData other,
-                             @NonNull String otherFilename,
-                             @NonNull List<BibEntry> allOtherEntries) {
+    /// Merges groups from the imported metadata into the target metadata.
+    ///
+    /// @param target          the metadata merge target
+    /// @param other           the metadata to merge from
+    /// @param otherFilename   the filename of the imported library
+    /// @param allOtherEntries all entries from the imported library
+    private void mergeGroups(
+            @NonNull MetaData target,
+            @NonNull MetaData other,
+            @NonNull String otherFilename,
+            @NonNull List<BibEntry> allOtherEntries) {
 
         other.getGroups().ifPresent(newGroups -> {
             if (newGroups.getGroup() instanceof AllEntriesGroup) {
@@ -172,12 +167,10 @@ public class DatabaseMerger {
         });
     }
 
-    /**
-     * Merges content selectors from the imported metadata into the target metadata.
-     *
-     * @param target the metadata merge target
-     * @param other  the metadata to merge from
-     */
+    /// Merges content selectors from the imported metadata into the target metadata.
+    ///
+    /// @param target the metadata merge target
+    /// @param other  the metadata to merge from
     private void mergeContentSelectors(MetaData target, MetaData other) {
         for (ContentSelector selector : other.getContentSelectorsSorted()) {
             target.addContentSelector(selector);


### PR DESCRIPTION
### **User description**
Closes #13684

When importing a `.bib` file into an existing library, group metadata was merged
correctly but the Groups sidebar was not updated.

This fix explicitly invalidates the groups binding after merging groups,
ensuring the Groups sidebar refreshes immediately after import.

### Steps to test

1. Create `A.bib` with one entry belonging to group `A`
2. Create `B.bib` with one entry belonging to group `B`
3. Open `B.bib` in JabRef → verify Group `B` is visible
4. Use **File → Import into current library** and select `A.bib`
5. Verify that Group `A` appears alongside Group `B`

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef
- [/] I added JUnit tests for changes (not applicable – UI refresh via binding invalidation)
- [/] I added screenshots in the PR description (not applicable)
- [/] I described the change in `CHANGELOG.md` (not visible to end users directly)
- [/] I checked the user documentation (no documentation change required)


___

### **PR Type**
Bug fix


___

### **Description**
- Invalidate groups binding after merging to refresh UI

- Ensures Groups sidebar updates when importing libraries

- Fixes issue where imported groups weren't visible


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import .bib file"] --> B["Merge group metadata"]
  B --> C["Invalidate groupsBinding"]
  C --> D["UI refreshes with new groups"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatabaseMerger.java</strong><dd><code>Invalidate groups binding after merge operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/main/java/org/jabref/logic/database/DatabaseMerger.java

<ul><li>Added explicit invalidation of <code>groupsBinding()</code> after merging groups<br> <li> Ensures UI notification when group tree is mutated<br> <li> Fixes sidebar not updating with imported groups</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14938/files#diff-3f2b39f85361e76576e6d85fa31a91c64f356c996d5abaed83d449688ba0dde5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___
