### PR TITLE
Refine 'Update with bibliographic information' logic (Fixes #14185)

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/importer/actions/UpdateWithWebInfoAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/importer/actions/UpdateWithWebInfoAction.java
@@ -1,0 +1,69 @@
+package org.jabref.gui.importer.actions;
+
+import java.util.Set;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.ActionHelper;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.mergeentries.multiwaymerge.MultiMergeEntriesView;
+import org.jabref.gui.preferences.GuiPreferences;
+import org.jabref.logic.importer.EntryBasedFetcher;
+import org.jabref.logic.importer.FetcherException;
+import org.jabref.logic.importer.WebFetchers;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.TaskExecutor;
+import org.jabref.model.entry.BibEntry;
+
+public class UpdateWithWebInfoAction extends SimpleCommand {
+
+    private final StateManager stateManager;
+    private final DialogService dialogService;
+    private final GuiPreferences preferences;
+    private final TaskExecutor taskExecutor;
+
+    public UpdateWithWebInfoAction(StateManager stateManager,
+                                   DialogService dialogService,
+                                   GuiPreferences preferences,
+                                   TaskExecutor taskExecutor) {
+        this.stateManager = stateManager;
+        this.dialogService = dialogService;
+        this.preferences = preferences;
+        this.taskExecutor = taskExecutor;
+
+        // Bind enablement to selection
+        this.executable.bind(ActionHelper.needsEntriesSelected(1, stateManager));
+    }
+
+    @Override
+    public void execute() {
+        if (stateManager.getActiveDatabase().isEmpty() || stateManager.getSelectedEntries().isEmpty()) {
+            return;
+        }
+
+        BibEntry selectedEntry = stateManager.getSelectedEntries().getFirst();
+
+        MultiMergeEntriesView mergeView = new MultiMergeEntriesView(preferences, taskExecutor);
+
+        mergeView.addSource(Localization.lang("Original"), () -> selectedEntry);
+
+        Set<EntryBasedFetcher> fetchers = WebFetchers.getEntryBasedFetchers(
+                preferences.getImporterPreferences(),
+                preferences.getImportFormatPreferences(),
+                preferences.getFilePreferences(),
+                stateManager.getActiveDatabase().get()
+        );
+
+        for (EntryBasedFetcher fetcher : fetchers) {
+            mergeView.addSource(fetcher.getName(), () -> {
+                try {
+                    return fetcher.performSearch(selectedEntry).stream().findFirst().orElse(null);
+                } catch (FetcherException e) {
+                    return null;
+                }
+            });
+        }
+
+        dialogService.showCustomDialogAndWait(mergeView);
+    }
+}

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1349,6 +1349,7 @@ When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\
 Canceled\ merging\ entries=Canceled merging entries
 
 Merge\ entries=Merge entries
+Original=Original
 Merged\ entry=Merged entry
 Merged\ entries=Merged entries
 None=None
@@ -1823,6 +1824,8 @@ remove\ string\ %0=remove string %0
 undefined=undefined
 Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Cannot get info based on given %0: %1
 Get\ bibliographic\ data\ from\ %0=Get bibliographic data from %0
+Update\ with\ bibliographic\ information\ via\ identifier(s)=Update with bibliographic information via identifier(s)
+Update\ with\ bibliographic\ information\ from\ the\ web\ via\ entry\ data=Update with bibliographic information from the web via entry data
 No\ %0\ found=No %0 found
 Entry\ from\ %0=Entry from %0
 Merge\ entry\ with\ %0\ information=Merge entry with %0 information


### PR DESCRIPTION
Closes #14185

I implemented the logic to update bibliographic information using entry data (Title/Author) via the `MultiMergeEntriesView`. This adds a new action to the "Lookup" menu and renames the existing identifier-based action for clarity.

### Steps to test

1. Create a new entry with only a Title and Author (e.g., Title: `Attention is All You Need`, Author: `Vaswani`).
2. Select the entry in the main table.
3. Go to **Lookup** -> **Update with bibliographic information from the web via entry data**.
4. The merge dialog should appear with fetched data.

### Screenshots
![Screenshot 1](https://github.com/user-attachments/assets/adee43ea-a98f-40d3-9879-1f295cc16ac2)
![Screenshot 2](https://github.com/user-attachments/assets/a0111c59-35cd-4f31-a62a-872032f6128d)

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
