### PR TITLE
Fix: reset NameDisplayPreferences on preferences reset

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
@@ -32,24 +32,24 @@ public class NameDisplayPreferences {
         return displayStyle.get();
     }
 
-    public ObjectProperty<DisplayStyle> displayStyleProperty() {
-        return displayStyle;
-    }
-
     public void setDisplayStyle(DisplayStyle displayStyle) {
         this.displayStyle.set(displayStyle);
+    }
+
+    public ObjectProperty<DisplayStyle> displayStyleProperty() {
+        return displayStyle;
     }
 
     public AbbreviationStyle getAbbreviationStyle() {
         return abbreviationStyle.get();
     }
 
-    public ObjectProperty<AbbreviationStyle> abbreviationStyleProperty() {
-        return abbreviationStyle;
-    }
-
     public void setAbbreviationStyle(AbbreviationStyle abbreviationStyle) {
         this.abbreviationStyle.set(abbreviationStyle);
+    }
+
+    public ObjectProperty<AbbreviationStyle> abbreviationStyleProperty() {
+        return abbreviationStyle;
     }
 
     public void resetToDefaults() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -311,6 +311,30 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         return JabRefGuiPreferences.singleton;
     }
 
+    private static List<String> getColumnNamesAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(MainTableColumnModel::getName)
+                                .toList();
+    }
+
+    private static List<String> getColumnWidthsAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(column -> column.widthProperty().getValue().toString())
+                                .toList();
+    }
+
+    private static List<String> getColumnSortTypesAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(column -> column.sortTypeProperty().getValue().toString())
+                                .toList();
+    }
+
+    private static List<String> getColumnSortOrderAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumnSortOrder().stream()
+                                .map(MainTableColumnModel::getName)
+                                .collect(Collectors.toList());
+    }
+
     public CopyToPreferences getCopyToPreferences() {
         if (copyToPreferences != null) {
             return copyToPreferences;
@@ -351,7 +375,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences().setAll(AutoCompletePreferences.getDefault());
         getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().resetToDefaults();
-
     }
 
     @Override
@@ -376,6 +399,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences().setAll(getAutoCompletePreferencesFromBackingStore(getAutoCompletePreferences()));
         getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
     }
+
+    // endregion
 
     // region EntryEditorPreferences
     public EntryEditorPreferences getEntryEditorPreferences() {
@@ -463,7 +488,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         getEntryEditorTabs();
     }
-
     // endregion
 
     @Override
@@ -499,6 +523,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                         get(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaults.getAllEntriesDuplicateResolverDecision().name()))
         );
     }
+    // endregion
 
     // region auto complete preferences
     @Override
@@ -546,7 +571,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 nameFormat,
                 getFieldSequencedSet(AUTOCOMPLETER_COMPLETE_FIELDS, defaults.getCompleteFields()));
     }
-    // endregion
 
     // region core GUI preferences
     public CoreGuiPreferences getGuiPreferences() {
@@ -577,7 +601,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getDouble(MAIN_WINDOW_SIDEPANE_WIDTH, defaults.getHorizontalDividerPosition()),
                 getDouble(MAIN_WINDOW_EDITOR_HEIGHT, defaults.getVerticalDividerPosition()));
     }
-    // endregion
 
     @Override
     public WorkspacePreferences getWorkspacePreferences() {
@@ -680,6 +703,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getInt(SELECTED_FETCHER_INDEX, defaults.getWebSearchFetcherSelected())
         );
     }
+    // endregion
 
     private Set<SidePaneType> getVisibleSidePanes(Set<SidePaneType> defaults) {
         Set<SidePaneType> visiblePanes = new HashSet<>();
@@ -741,7 +765,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         putStringList(SIDE_PANE_COMPONENT_NAMES, names);
         putStringList(SIDE_PANE_COMPONENT_PREFERRED_POSITIONS, positions);
     }
-    // endregion
 
     @Override
     public ExternalApplicationsPreferences getExternalApplicationsPreferences() {
@@ -868,6 +891,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         EasyBind.listen(previewPreferences.shouldDownloadCoversProperty(), (_, _, newValue) -> putBoolean(COVER_IMAGE_DOWNLOAD, newValue));
         return this.previewPreferences;
     }
+    // endregion
+
+    // region NameDisplayPreferences
 
     private void storeBstPaths(List<Path> bstPaths) {
         putStringList(PREVIEW_BST_LAYOUT_PATHS, bstPaths.stream().map(Path::toAbsolutePath).map(Path::toString).toList());
@@ -917,6 +943,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         );
     }
 
+    // endregion
+
+    // region: Main table, main table column, and search dialog column preferences
+
     private int getPreviewCyclePosition(List<PreviewLayout> layouts) {
         int storedCyclePos = getInt(CYCLE_PREVIEW_POS);
         if (storedCyclePos < layouts.size()) {
@@ -925,9 +955,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return 0; // fallback if stored position is no longer valid
         }
     }
-    // endregion
-
-    // region NameDisplayPreferences
 
     @Override
     public NameDisplayPreferences getNameDisplayPreferences() {
@@ -973,10 +1000,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         }
         return displayStyle;
     }
-
-    // endregion
-
-    // region: Main table, main table column, and search dialog column preferences
 
     public MainTablePreferences getMainTablePreferences() {
         if (mainTablePreferences != null) {
@@ -1099,30 +1122,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                                                                        .ifPresent(columnsOrdered::add));
 
         return columnsOrdered;
-    }
-
-    private static List<String> getColumnNamesAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(MainTableColumnModel::getName)
-                                .toList();
-    }
-
-    private static List<String> getColumnWidthsAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(column -> column.widthProperty().getValue().toString())
-                                .toList();
-    }
-
-    private static List<String> getColumnSortTypesAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(column -> column.sortTypeProperty().getValue().toString())
-                                .toList();
-    }
-
-    private static List<String> getColumnSortOrderAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumnSortOrder().stream()
-                                .map(MainTableColumnModel::getName)
-                                .collect(Collectors.toList());
     }
     // endregion
 


### PR DESCRIPTION
### **User description**
Fixes name display settings not resetting when preferences are reset


___

### **PR Type**
Bug fix


___

### **Description**
- Add default constants for name display preferences

- Initialize properties with default values instead of null

- Implement resetToDefaults() method in NameDisplayPreferences

- Call resetToDefaults() when clearing all preferences


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NameDisplayPreferences"] -->|"add defaults"| B["DEFAULT_DISPLAY_STYLE<br/>DEFAULT_ABBREVIATION_STYLE"]
  A -->|"initialize with"| C["ObjectProperty instances"]
  A -->|"add method"| D["resetToDefaults()"]
  E["JabRefGuiPreferences.clear()"] -->|"calls"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NameDisplayPreferences.java</strong><dd><code>Add defaults and reset method to NameDisplayPreferences</code>&nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java

<ul><li>Added public static final constants for default display and <br>abbreviation styles<br> <li> Modified ObjectProperty initialization to use default values instead <br>of null<br> <li> Implemented new resetToDefaults() method to reset both properties to <br>defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14949/files#diff-f031122cd1b2509608a9690f15b207322ae8cb48fbe8e8728b128b3c38d650a2">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JabRefGuiPreferences.java</strong><dd><code>Call resetToDefaults in preferences clear method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java

<ul><li>Added call to getNameDisplayPreferences().resetToDefaults() in the <br>clear() method<br> <li> Ensures name display preferences are properly reset when user clears <br>all preferences</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14949/files#diff-399751abbbd663db3c226fdeaf03ef49fb7e00703de6d73f7c3b243b3db9e87b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

