### PR TITLE
Fix: reset NameDisplayPreferences on preferences reset

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java
@@ -32,24 +32,24 @@ public class NameDisplayPreferences {
         return displayStyle.get();
     }
 
-    public ObjectProperty<DisplayStyle> displayStyleProperty() {
-        return displayStyle;
-    }
-
     public void setDisplayStyle(DisplayStyle displayStyle) {
         this.displayStyle.set(displayStyle);
+    }
+
+    public ObjectProperty<DisplayStyle> displayStyleProperty() {
+        return displayStyle;
     }
 
     public AbbreviationStyle getAbbreviationStyle() {
         return abbreviationStyle.get();
     }
 
-    public ObjectProperty<AbbreviationStyle> abbreviationStyleProperty() {
-        return abbreviationStyle;
-    }
-
     public void setAbbreviationStyle(AbbreviationStyle abbreviationStyle) {
         this.abbreviationStyle.set(abbreviationStyle);
+    }
+
+    public ObjectProperty<AbbreviationStyle> abbreviationStyleProperty() {
+        return abbreviationStyle;
     }
 
     public void resetToDefaults() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -311,6 +311,30 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         return JabRefGuiPreferences.singleton;
     }
 
+    private static List<String> getColumnNamesAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(MainTableColumnModel::getName)
+                                .toList();
+    }
+
+    private static List<String> getColumnWidthsAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(column -> column.widthProperty().getValue().toString())
+                                .toList();
+    }
+
+    private static List<String> getColumnSortTypesAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumns().stream()
+                                .map(column -> column.sortTypeProperty().getValue().toString())
+                                .toList();
+    }
+
+    private static List<String> getColumnSortOrderAsStringList(ColumnPreferences columnPreferences) {
+        return columnPreferences.getColumnSortOrder().stream()
+                                .map(MainTableColumnModel::getName)
+                                .collect(Collectors.toList());
+    }
+
     public CopyToPreferences getCopyToPreferences() {
         if (copyToPreferences != null) {
             return copyToPreferences;
@@ -351,7 +375,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences().setAll(AutoCompletePreferences.getDefault());
         getSidePanePreferences().setAll(SidePanePreferences.getDefault());
         getNameDisplayPreferences().resetToDefaults();
-
     }
 
     @Override
@@ -376,6 +399,8 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         getAutoCompletePreferences().setAll(getAutoCompletePreferencesFromBackingStore(getAutoCompletePreferences()));
         getSidePanePreferences().setAll(getSidePanePreferencesFromBackingStore(getSidePanePreferences()));
     }
+
+    // endregion
 
     // region EntryEditorPreferences
     public EntryEditorPreferences getEntryEditorPreferences() {
@@ -463,7 +488,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
         getEntryEditorTabs();
     }
-
     // endregion
 
     @Override
@@ -499,6 +523,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                         get(DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES, defaults.getAllEntriesDuplicateResolverDecision().name()))
         );
     }
+    // endregion
 
     // region auto complete preferences
     @Override
@@ -546,7 +571,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 nameFormat,
                 getFieldSequencedSet(AUTOCOMPLETER_COMPLETE_FIELDS, defaults.getCompleteFields()));
     }
-    // endregion
 
     // region core GUI preferences
     public CoreGuiPreferences getGuiPreferences() {
@@ -577,7 +601,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getDouble(MAIN_WINDOW_SIDEPANE_WIDTH, defaults.getHorizontalDividerPosition()),
                 getDouble(MAIN_WINDOW_EDITOR_HEIGHT, defaults.getVerticalDividerPosition()));
     }
-    // endregion
 
     @Override
     public WorkspacePreferences getWorkspacePreferences() {
@@ -680,6 +703,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                 getInt(SELECTED_FETCHER_INDEX, defaults.getWebSearchFetcherSelected())
         );
     }
+    // endregion
 
     private Set<SidePaneType> getVisibleSidePanes(Set<SidePaneType> defaults) {
         Set<SidePaneType> visiblePanes = new HashSet<>();
@@ -741,7 +765,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         putStringList(SIDE_PANE_COMPONENT_NAMES, names);
         putStringList(SIDE_PANE_COMPONENT_PREFERRED_POSITIONS, positions);
     }
-    // endregion
 
     @Override
     public ExternalApplicationsPreferences getExternalApplicationsPreferences() {
@@ -868,6 +891,9 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         EasyBind.listen(previewPreferences.shouldDownloadCoversProperty(), (_, _, newValue) -> putBoolean(COVER_IMAGE_DOWNLOAD, newValue));
         return this.previewPreferences;
     }
+    // endregion
+
+    // region NameDisplayPreferences
 
     private void storeBstPaths(List<Path> bstPaths) {
         putStringList(PREVIEW_BST_LAYOUT_PATHS, bstPaths.stream().map(Path::toAbsolutePath).map(Path::toString).toList());
@@ -917,6 +943,10 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         );
     }
 
+    // endregion
+
+    // region: Main table, main table column, and search dialog column preferences
+
     private int getPreviewCyclePosition(List<PreviewLayout> layouts) {
         int storedCyclePos = getInt(CYCLE_PREVIEW_POS);
         if (storedCyclePos < layouts.size()) {
@@ -925,9 +955,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
             return 0; // fallback if stored position is no longer valid
         }
     }
-    // endregion
-
-    // region NameDisplayPreferences
 
     @Override
     public NameDisplayPreferences getNameDisplayPreferences() {
@@ -973,10 +1000,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
         }
         return displayStyle;
     }
-
-    // endregion
-
-    // region: Main table, main table column, and search dialog column preferences
 
     public MainTablePreferences getMainTablePreferences() {
         if (mainTablePreferences != null) {
@@ -1099,30 +1122,6 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
                                                                        .ifPresent(columnsOrdered::add));
 
         return columnsOrdered;
-    }
-
-    private static List<String> getColumnNamesAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(MainTableColumnModel::getName)
-                                .toList();
-    }
-
-    private static List<String> getColumnWidthsAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(column -> column.widthProperty().getValue().toString())
-                                .toList();
-    }
-
-    private static List<String> getColumnSortTypesAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumns().stream()
-                                .map(column -> column.sortTypeProperty().getValue().toString())
-                                .toList();
-    }
-
-    private static List<String> getColumnSortOrderAsStringList(ColumnPreferences columnPreferences) {
-        return columnPreferences.getColumnSortOrder().stream()
-                                .map(MainTableColumnModel::getName)
-                                .collect(Collectors.toList());
     }
     // endregion
 


### PR DESCRIPTION
### **User description**
Fixes #14951


### Steps to test

1. Open JabRef
2. Go to Preferences → Entry table → Format of author and editor names
3. Change the display style and abbreviation options
4. Click the global reset (⟲) button in Preferences
5. Verify that the name display settings are reset to their default values

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the user documentation: Is the information available and up to date?


### **PR Type
Bug fix, Enhancement


### **Description
- Add default constants and reset method to NameDisplayPreferences

- Implement resetToDefaults() in NameDisplayPreferences class

- Call resetToDefaults() when clearing preferences in JabRefGuiPreferences

- Reorganize code structure with proper region comments and method ordering

- Extract helper methods for column preference conversions


### Diagram Walkthrough


```mermaid
flowchart LR
  A["NameDisplayPreferences"] -->|"add DEFAULT constants"| B["Default values defined"]
  A -->|"add resetToDefaults()"| C["Reset method"]
  D["JabRefGuiPreferences.clear()"] -->|"call resetToDefaults()"| C
  E["Helper methods"] -->|"extract and relocate"| F["Column conversion utilities"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NameDisplayPreferences.java</strong><dd><code>Add reset functionality to NameDisplayPreferences</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/maintable/NameDisplayPreferences.java

<ul><li>Add public static final constants for default display and abbreviation <br>styles<br> <li> Initialize ObjectProperty fields with default values instead of null<br> <li> Add new resetToDefaults() method to reset preferences to defaults<br> <li> Reorder methods: move setDisplayStyle() before displayStyleProperty()<br> <li> Add missing setAbbreviationStyle() method implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14951/files#diff-f031122cd1b2509608a9690f15b207322ae8cb48fbe8e8728b128b3c38d650a2">+19/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JabRefGuiPreferences.java</strong><dd><code>Integrate NameDisplayPreferences reset and refactor helper methods</code></dd></summary>
<hr>

jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java

<ul><li>Call getNameDisplayPreferences().resetToDefaults() in clear() method<br> <li> Extract four helper methods for column preference conversions <br>(getColumnNamesAsStringList, getColumnWidthsAsStringList, <br>getColumnSortTypesAsStringList, getColumnSortOrderAsStringList)<br> <li> Relocate helper methods from end of file to getInstance() region<br> <li> Reorganize region comments for better code structure and clarity<br> <li> Fix region comment placement for NameDisplayPreferences, <br>PreviewPreferences, and other sections</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14951/files#diff-399751abbbd663db3c226fdeaf03ef49fb7e00703de6d73f7c3b243b3db9e87b">+36/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>


