### PR TITLE
Fix labels in Dockerfiles

### DIFF
--- a/Dockerfile.jabkit
+++ b/Dockerfile.jabkit
@@ -17,10 +17,9 @@ RUN mv jabkit/build/packages/*/* /dist
 # jpackage needs glibc; alpine does not work
 FROM debian:bookworm-slim AS runtime
 
-LABEL org.opencontainers.image.title="jabkit"
-LABEL org.opencontainers.image.description="JabRef's CLI tool"
-LABEL org.opencontainers.image.source=https://github.com/JabRef/jabref
-LABEL org.opencontainers.image.ref.name="jabref/jabkit"
+LABEL org.opencontainers.image.title="jabkit" \
+      org.opencontainers.image.description="JabRef's CLI tool" \
+      org.opencontainers.image.source=https://github.com/JabRef/jabref
 
 WORKDIR /work
 

--- a/Dockerfile.jabsrv
+++ b/Dockerfile.jabsrv
@@ -17,10 +17,9 @@ RUN mv jabsrv-cli/build/packages/*/* /dist
 # jpackage needs glibc; alpine does not work
 FROM debian:bookworm-slim AS runtime
 
-LABEL org.opencontainers.image.title="jabsrv"
-LABEL org.opencontainers.image.description="JabRef's HTTP server"
-LABEL org.opencontainers.image.source=https://github.com/JabRef/jabref
-LABEL org.opencontainers.image.ref.name="jabref/jabkit"
+LABEL org.opencontainers.image.title="jabsrv" \
+      org.opencontainers.image.description="JabRef's HTTP server" \
+      org.opencontainers.image.source=https://github.com/JabRef/jabref
 
 WORKDIR /work
 


### PR DESCRIPTION
### **User description**
While working on https://github.com/JabRef/jabref/pull/14950, I found out that our docker images might be wrongly labeld.

### Steps to test

See CI output and check https://hub.docker.com/u/jabref

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Bug fix


___

### **Description**
- Move Docker image labels to runtime stage in both Dockerfiles

- Labels were incorrectly placed in build stage, now in final runtime stage

- Update jabsrv EXPOSE port from 6050 to 23119 with descriptive comment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Stage"] -->|"Remove labels"| B["Build artifacts"]
  B -->|"Copy to runtime"| C["Runtime Stage"]
  C -->|"Add labels"| D["Final Docker image"]
  E["Port 6050"] -->|"Update to"| F["Port 23119"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.jabkit</strong><dd><code>Move labels to runtime stage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.jabkit

<ul><li>Removed image labels from build stage (lines 3-4)<br> <li> Added image labels to runtime stage (lines 20-21)<br> <li> Labels now applied to final image instead of intermediate build stage</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14958/files#diff-a9b3489a843916d149cb676f372388675a6a7244797e3081d7fdbc3e0ba4a1b6">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.jabsrv</strong><dd><code>Move labels and update port configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.jabsrv

<ul><li>Removed image labels from build stage (lines 3-4)<br> <li> Added image labels to runtime stage (lines 20-21)<br> <li> Updated EXPOSE port from 6050 to 23119 with HTTP Server comment<br> <li> Labels now applied to final image instead of intermediate build stage</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14958/files#diff-1795630cb6a15f0f11e033b8eb9a7b75cea8f6312fe3e0477becd48752cceae0">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

