### PR TITLE
Fix for CAYW popup dark mode readability

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/Dark.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Dark.css
@@ -80,12 +80,6 @@
     -jr-match-4-odd: derive(-jr-black, 10%);
     -jr-match-4-even: -jr-background-alt;
     -jr-match-4-text-color: derive(-jr-match-3-text-color, -15%);
-
-    /* CAYW styles*/
-    -jr-white: #ffffff;
-    -jr-light-gray: #e0e0e0;
-    -jr-dark-gray: #3a3a3a;
-    -jr-black: #000000;
 }
 
 .unchanged {


### PR DESCRIPTION
 Fixes #14281
 
### **User description**
Added overrides in Dark.css file for search dialog, chip item and list cell. Used scenic view to confirm classes of each Node.

Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... Summarize changes and DO NOT list modified classes one-by-one. (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of JabRef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT TO FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
<img width="683" height="411" alt="image" src="https://github.com/user-attachments/assets/bec64ce5-3689-4000-845e-16715c900c12" />


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed dark mode readability in CAYW popup dialog

- Added CSS overrides for search dialog background color

- Styled list cells with proper dark mode text/fill colors

- Enhanced chip style with border and button styling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dark.css"] -->|"Add search-dialog styling"| B["Search Dialog Background"]
  A -->|"Add list-cell styling"| C["List Cell Text/Fill Colors"]
  A -->|"Add hover/selected states"| D["Interactive States"]
  A -->|"Add chip-style styling"| E["Chip Component Styling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dark.css</strong><dd><code>Dark mode styling fixes for CAYW popup components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jabgui/src/main/resources/org/jabref/gui/Dark.css

<ul><li>Added <code>.search-dialog</code> rule with dark background color override<br> <li> Added <code>.list-cell</code> rules for text and fill colors in dark mode<br> <li> Added <code>.list-cell:hover</code> and <code>.list-cell:selected</code> states with dark <br>backgrounds and white text<br> <li> Added nested text/label/search-result styling for list cells<br> <li> Added <code>.chip-style</code> rule with border radius, white border, and <br>transparent button styling</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/14960/files#diff-90ea643041ae66e0944be0fcc58b7fe6ec17ea3d8309b7953dfd4c080054f46e">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

