### PR TITLE
docs: Add documentation for Systematic Literature Review (SLR) tool

### DIFF
--- a/docs/code-howtos/systematic-literature-review.md
+++ b/docs/code-howtos/systematic-literature-review.md
@@ -1,0 +1,81 @@
+---
+parent: Code Howtos
+---
+# Systematic Literature Review (SLR) Tool
+The Systematic Literature Review (SLR) tool in JabRef helps researchers conduct structured literature reviews. It allows defining research questions, creating search queries, selecting academic catalogs, and collecting references in a reproducible way.
+This tool is especially useful for researchers who want to follow a structured and transparent review methodology.
+---
+## Starting a Systematic Literature Review
+1. Open JabRef.
+2. Navigate to **Tools → Start new systematic literature review**.
+3. The **Define study parameters** window opens.
+---
+## Authors and Title
+In the **Authors and Title** tab:
+- Enter the **study title**.
+- Add at least one **author**.
+Both fields are required before starting the survey.
+---
+## Research Questions
+In the **Research Questions** tab:
+- Define one or more research questions.
+- These questions guide the scope and purpose of the review.
+Each question should be clear and specific to ensure a focused search process.
+---
+## Queries
+In the **Queries** tab:
+- Add search queries used to retrieve relevant publications.
+- Queries typically combine keywords using Boolean operators.
+---
+## Catalogs
+In the **Catalogs** tab:
+- Select one or more academic catalogs to search in.
+- Examples include:
+  - ACM Portal
+  - arXiv
+  - DBLP
+  - Crossref
+  - IEEE Xplore
+- Choosing multiple catalogs increases coverage of the literature.
+These catalogs are used as data sources for retrieving publications.
+---
+## Finalize
+In the **Finalize** tab:
+- Select the directory where the study data will be stored.
+- JabRef creates the study structure in this folder.
+- Ensure all required fields are completed:
+  - Study title
+  - At least one author
+  - At least one research question
+  - At least one query
+When everything is set, click **Start survey**.
+---
+## After Starting the Survey
+Once the survey starts:
+- JabRef runs the defined queries on the selected catalogs.
+- Results are collected and stored in the study.
+- References can then be:
+  - Reviewed
+  - Filtered
+  - Tagged
+  - Exported
+This supports a structured and reproducible review workflow.
+---
+## Tips for Effective SLRs
+- Use clear and specific research questions.
+- Start with broader queries, then refine.
+- Combine keywords using Boolean operators:
+  - `AND`
+  - `OR`
+  - `NOT`
+- Document all queries for reproducibility.
+---
+## Summary
+The SLR tool in JabRef helps structure the entire review process:
+1. Define study metadata  
+2. Add research questions  
+3. Create search queries  
+4. Select catalogs  
+5. Run the survey and collect results  
+
+This makes literature reviews more systematic, transparent, and repeatable.


### PR DESCRIPTION
## Closes

Closes #1497

---

## Description

This PR adds user documentation for the **Systematic Literature Review (SLR) tool** in JabRef.  
The documentation explains how users can:

- Start a systematic literature review  
- Define research questions  
- Create search queries  
- Select academic catalogs  
- Finalize and run the survey  

The aim is to make the SLR feature easier to understand and more accessible for new users.

---

## Steps to test

1. Open JabRef.
2. Navigate to **Tools → Start new systematic literature review**.
3. The **Define study parameters** window should open.
4. Open the documentation section **Systematic Literature Review (SLR) Tool**.
5. Verify that all tabs are explained:
   - Authors and Title  
   - Research Questions  
   - Queries  
   - Catalogs  
   - Finalize  
6. Confirm that the workflow described in the documentation matches the actual UI behavior.

---

## Mandatory checks

[x] I own the copyright of the code submitted and I license it under the MIT license  
[x] I manually tested my changes in running JabRef (always required)  
[/] I added JUnit tests for changes (if applicable)  
[x] I added screenshots in the PR description (if change is visible to the user)  
[x] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)  
[x] I checked the user documentation. The information is available and up to date.
