### PR TITLE
Fix casing in JavaDoc

### DIFF
--- a/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
+++ b/jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
@@ -8,7 +8,7 @@ import com.github.tomtung.latex2unicode.LaTeX2Unicode;
 import fastparse.Parsed;
 import org.jspecify.annotations.NonNull;
 
-/// Adapter class for the latex2unicode lib. This is an alternative to our LatexToUnicode class
+/// Adapter class for the latex2unicode lib. This is an alternative to our LatexToUnicode class.
 public class LatexToUnicodeAdapter {
 
     private static final Pattern UNDERSCORE_MATCHER = Pattern.compile("_(?!\\{)");
@@ -17,10 +17,10 @@ public class LatexToUnicodeAdapter {
 
     private static final Pattern UNDERSCORE_PLACEHOLDER_MATCHER = Pattern.compile(REPLACEMENT_CHAR);
 
-    /// Attempts to resolve all LaTeX in the String.
+    /// Attempts to resolve all LaTeX in the given string.
     ///
-    /// @param inField a String containing LaTeX
-    /// @return a String with LaTeX resolved into Unicode, or the original String if the LaTeX could not be parsed
+    /// @param inField a string containing LaTeX
+    /// @return a string with LaTeX resolved into Unicode, or the original string if the LaTeX could not be parsed.
     public static String format(@NonNull String inField) {
         return parse(inField).orElse(Normalizer.normalize(inField, Normalizer.Form.NFC));
     }


### PR DESCRIPTION
### **User description**
### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Documentation


___

### **Description**
- Fix JavaDoc casing inconsistencies in LatexToUnicodeAdapter

- Change "String" to lowercase "string" in parameter and return descriptions

- Add missing period at end of JavaDoc comment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JavaDoc Comments"] -->|"Fix casing"| B["String → string"]
  A -->|"Add punctuation"| C["Add period"]
  B --> D["Updated LatexToUnicodeAdapter"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LatexToUnicodeAdapter.java</strong><dd><code>Fix JavaDoc casing and punctuation in LatexToUnicodeAdapter</code></dd></summary>
<hr>

jablib/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java

<ul><li>Fixed JavaDoc comment casing: changed "String" to lowercase "string" <br>in <code>@param</code> and <code>@return</code> tags<br> <li> Added missing period at end of class-level JavaDoc comment<br> <li> Improved clarity in method documentation by specifying "given string" <br>instead of just "String"</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/15002/files#diff-ff15dd357c0cbc6baa2ab41dfbab04f4aa82637ea2bfccc9618d1296ff264d49">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

