### PR TITLE
Refine JavaDoc in LinkedFile

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -41,24 +41,32 @@ public class LinkedFile implements Serializable {
 
     private static final LinkedFile NULL_OBJECT = new LinkedFile("", Path.of(""), "");
 
-    // We have to mark these properties as transient because they can't be serialized directly
+    // We have to mark the followin properties as transient because they can't be serialized directly
+
     private transient StringProperty description = new SimpleStringProperty();
+
     private transient StringProperty link = new SimpleStringProperty();
+
     // This field is a {@link StringProperty}, and not an {@link ObjectProperty<FileType>}, as {@link LinkedFile} might
     // be a URI, where a file type might not be present.
     private transient StringProperty fileType = new SimpleStringProperty();
+
     private transient StringProperty sourceURL = new SimpleStringProperty();
 
+    /// @param description The description of the linked file
+    /// @param link        The path or URL to the linked file
+    /// @param fileType    The file type of the linked file. See [org.jabref.logic.util.StandardFileType] for common file types.
+    public LinkedFile(String description, String link, FileType fileType) {
+        this(description, link, fileType.getName());
+    }
+
+    /// Better use [LinkedFile(String description, String link, FileType fileType)] constructor
     public LinkedFile(String description, Path link, String fileType) {
         this(description, link.toString(), fileType);
     }
 
     public LinkedFile(String description, Path link, String fileType, String sourceUrl) {
         this(description, link.toString(), fileType, sourceUrl);
-    }
-
-    public LinkedFile(String description, String link, FileType fileType) {
-        this(description, link, fileType.getName());
     }
 
     /// Constructor can also be used for non-valid paths. We need to parse them, because the GUI needs to render it.


### PR DESCRIPTION
### **User description**
### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.


___

### **PR Type**
Documentation


___

### **Description**
- Refine JavaDoc comments with improved formatting

- Add new constructor overload for FileType parameter

- Reorganize constructor order for better usability

- Add blank lines for improved code readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LinkedFile class"] -->|"Add FileType constructor"| B["New overload with FileType"]
  A -->|"Reorganize constructors"| C["Better constructor ordering"]
  A -->|"Improve documentation"| D["Enhanced JavaDoc comments"]
  A -->|"Format code"| E["Added blank lines"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LinkedFile.java</strong><dd><code>Enhance JavaDoc and refactor LinkedFile constructors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jablib/src/main/java/org/jabref/model/entry/LinkedFile.java

<ul><li>Fixed typo in comment: "followin" instead of "following"<br> <li> Added new constructor overload accepting FileType parameter<br> <li> Moved FileType constructor before Path-based constructor<br> <li> Added JavaDoc comments with <code>///</code> syntax for constructors<br> <li> Inserted blank lines between field declarations for readability<br> <li> Added deprecation note directing to FileType constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/JabRef/jabref/pull/15004/files#diff-a71f9f3b0c64bbfdeb1659607ead9b58da245d8de5048af247316579f54c8ab8">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

