### PR TITLE
Chore: add 'testlens-app/setup-testlens' GH action

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -24,6 +24,8 @@ runs:
       uses: gradle/actions/setup-gradle@v5
       env:
         GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+    - name: Setup TestLens
+      uses: testlens-app/setup-testlens@v1.6.1
     - name: Generate JBang cache key
       id: cache-key
       shell: bash


### PR DESCRIPTION
As discussed with @koppor this onboard the `JabRef/jabref` project for the [TestLens](https://testlens.app/) private beta. The action requires the [TestLens App](https://github.com/apps/testlens-app) to be installed on this repository, which is already done.

The app posts a summary of all test failures as a PR comment and provides means to mute unrelated test failures and faster reruns. For more information, please refer to the [announcement](https://testlens.app/blog/2026/02/04/testlens-private-beta-launch) on our website.

For questions and feedback, please contact me directly or [open an issue](https://github.com/testlens-app/setup-testlens/issues).


### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)

/

- ~I manually tested my changes in running JabRef (always required)~
- ~I added JUnit tests for changes (if applicable)~
- ~I added screenshots in the PR description (if change is visible to the user)~
- ~described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)~
- ~I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.~
