### PR TITLE
Fix casing in Automatic Field Editor labels (#15068)

### DIFF
--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2599,7 +2599,7 @@ Server\ not\ available=Server not available
 Look\ up\ identifier=Look up identifier
 
 Edit\ content=Edit content
-Copy\ or\ Move\ content=Copy or Move content
+Copy\ or\ Move\ content=Copy or move content
 Overwrite\ field\ content=Overwrite field content
 Set=Set
 Append=Append
@@ -2615,7 +2615,7 @@ Swap\ content=Swap content
 Copy\ or\ move\ the\ content\ of\ one\ field\ to\ another=Copy or move the content of one field to another
 Automatic\ field\ editor=Automatic field editor
 From=From
-Keep\ Modifications=Keep Modifications
+Keep\ Modifications=Keep modifications
 To=To
 Open\ Link=Open Link
 Highlight\ words=Highlight words


### PR DESCRIPTION
Closes #15068

This PR fixes the capitalization of two user-visible labels in the Automatic Field Editor to ensure consistent sentence-case wording across the dialog. The change improves UI text consistency and readability without affecting functionality.

### Steps to test

1. Run JabRef locally.
2. Open `Chocolate.bib`.
3. Select all entries (Ctrl + A).
4. Go to **Edit → Automatic field editor**.
5. Verify that the labels now read:
   - **Keep modifications**
   - **Copy or move content**

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the user documentation for necessary updates
<img width="1317" height="857" alt="Screenshot 2026-02-09 171204" src="https://github.com/user-attachments/assets/0ee5eaa2-9a59-4aff-8512-d5327f04fcb3" />
