### PR TITLE
Fix casing in Automatic Field Editor labels

### DIFF
--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2600,7 +2600,7 @@ Server\ not\ available=Server not available
 Look\ up\ identifier=Look up identifier
 
 Edit\ content=Edit content
-Copy\ or\ Move\ content=Copy or Move content
+Copy\ or\ Move\ content=Copy or move content
 Overwrite\ field\ content=Overwrite field content
 Set=Set
 Append=Append
@@ -2616,7 +2616,7 @@ Swap\ content=Swap content
 Copy\ or\ move\ the\ content\ of\ one\ field\ to\ another=Copy or move the content of one field to another
 Automatic\ field\ editor=Automatic field editor
 From=From
-Keep\ Modifications=Keep Modifications
+Keep\ Modifications=Keep modifications
 To=To
 Open\ Link=Open Link
 Highlight\ words=Highlight words


### PR DESCRIPTION
Closes #15068

I fixed the capitalization errors in "Keep modifications" and "Copy or move content" labels in the Automatic Field Editor dialog as requested.

### Steps to test
1. Open Automatic Field Editor.
2. Verify that labels are now correctly cased ("Keep modifications" and "Copy or move content").

### Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (verified via code inspection)
- [/] I added JUnit tests for changes (not applicable for typo fix)
- [/] I added screenshots in the PR description (text only change)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number.
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user
- [/] I checked the [user documentation](https://docs.jabref.org/)