### PR TITLE
Fix ShadowJar config

### DIFF
--- a/build-logic/src/main/kotlin/org.jabref.gradle.feature.shadowjar.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.feature.shadowjar.gradle.kts
@@ -3,5 +3,7 @@ plugins {
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>().configureEach {
+    mergeServiceFiles()
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     isZip64 = true
 }


### PR DESCRIPTION
With this patch:

```
 java -jar ../../../../../libs/jabgui-100.0.0-all.jar
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:/C:/git-repositories/JabRef/jabgui/build/libs/jabgui-100.0.0-all.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

2026-02-10 12:01:50 [main] org.jabref.Launcher.main()
INFO: Starting JabRef v100.0.0
```

Without this patch:

    Error: JavaFX runtime components are missing, and are required to run this application

### Steps to test

1. `./gradlew :jabgui:shadowJar`
2. `java -jar jabgui/build/libs/jabgui-100.0.0-all.jar`

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number.
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
