### PR TITLE
macos-15-intel should run on main only

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -341,13 +341,16 @@ jobs:
           fi
 
   compute-matrix:
+    needs: conditions
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.set.outputs.matrix }}
     steps:
       - id: set
-        shell: bash
         name: Compute Matrix
+        shell: bash
+        env:
+          SHOULD_NOTARIZE: ${{ needs.conditions.outputs.should-notarize }}
         run: |
           # if you change the os version rename all other occurrences
           # ./gradlew on Windows is because of https://github.com/gradle/gradle/pull/34227
@@ -406,11 +409,9 @@ jobs:
             ]
           }'
 
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            # drop macos-15-intel on non-main
+          if [[ "$GITHUB_REF" != "refs/heads/main" && "$SHOULD_NOTARIZE" != "true" ]]; then
+            # drop macos-15-intel
             MATRIX_JSON="$(jq -c ' .include |= map(select(.os != "macos-15-intel")) ' <<<"$MATRIX_JSON")"
-          else
-            MATRIX_JSON="$(jq -c . <<<"$MATRIX_JSON")"
           fi
 
           echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Build on (old) macOS intel only on main. The risk that something is wrong on Intel macOS is very low. We accept it.

Removed macOS intel from required checks.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
