### PR TITLE
Try to install wix6

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -449,11 +449,6 @@ jobs:
           dotnet tool update --global wix --version 6.0.2
           wix extension add -g WixToolset.Util.wixext/6.0.2
           wix extension add -g WixToolset.Ui.wixext/6.0.2
-      - name: Remove wix3
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: cmd
-        run: |
-          rmdir /s /q "C:\Program Files (x86)\WiX Toolset v3.11\"
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -444,8 +444,9 @@ jobs:
       - name: Install wix6
         if: ${{ matrix.os == 'windows-latest' }}
         # background: true
+        # Update to v7 requries extra EULA check - see https://github.com/wixtoolset/issues/issues/9196
         run: |
-          dotnet tool update --global wix
+          dotnet tool update --global wix --version 6.0.2
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -453,7 +453,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         shell: cmd
         run: |
-          deltree "C:\Program Files (x86)\WiX Toolset v3.11\"
+          rmdir /s /q "C:\Program Files (x86)\WiX Toolset v3.11\"
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -449,6 +449,11 @@ jobs:
           dotnet tool update --global wix --version 6.0.2
           wix extension add -g WixToolset.Util.wixext/6.0.2
           wix extension add -g WixToolset.Ui.wixext/6.0.2
+      - name: Remove wix3
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: cmd
+        run: |
+          deltree "C:\Program Files (x86)\WiX Toolset v3.11\"
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:
@@ -638,7 +643,7 @@ jobs:
           cp buildres/windows/JabRef.ico . # Windows
 
       - name: Check WiX Version
-        run: candle -?
+        run: wix -?
         if: startsWith(matrix.os, 'windows')
 
       # jars already exists - thus, these calls will build on the jar result (hopefully).

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -447,6 +447,8 @@ jobs:
         # Update to v7 requries extra EULA check - see https://github.com/wixtoolset/issues/issues/9196
         run: |
           dotnet tool update --global wix --version 6.0.2
+          wix extension add -g WixToolset.Util.wixext/6.0.2
+          wix extension add -g WixToolset.Ui.wixext/6.0.2
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -441,6 +441,11 @@ jobs:
       url: ${{ steps.url.outputs.url }}
     name: ${{ matrix.displayName }} installer and portable version
     steps:
+      - name: Install wix6
+        if: ${{ matrix.os == 'windows-latest' }}
+        # background: true
+        run: |
+          dotnet tool update --global wix
       - name: Fetch all history for all tags and branches
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### Related issues and pull requests

- https://github.com/JabRef/jabref/pull/14969
- https://bugs.openjdk.org/browse/JDK-8356592

> All WiX v3 versions are out of community service as of February 6th, 2025. There will be no additional fixes, even for security issues for consumers of WiX v3.

Source: https://docs.firegiant.com/wix/wix3/

### PR Description

Updates wix to v6 - https://github.com/wixtoolset/wix/releases/tag/v6.0.2

```
Run dotnet tool update --global wix
You can invoke the tool using the following command: wix
Tool 'wix' (version '6.0.2') was successfully installed.
```

### Steps to test

Windows: See installer working

Workflow: https://github.com/JabRef/jabref/actions/workflows/binaries.yml

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
