### PR TITLE
docs: fix link formatting in ADR 0012

### DIFF
--- a/docs/decisions/0012-handle-different-bibEntry-formats-of-fetchers.md
+++ b/docs/decisions/0012-handle-different-bibEntry-formats-of-fetchers.md
@@ -23,7 +23,7 @@ How can this inconsistency between fetchers and their used formats be addressed?
 
 Chosen option: "Introduce a new layer between fetchers and caller, such as a FetcherHandler, that manages the conversion",
 because it can compose all steps required during importing, not only format conversion of fetched entries.
-As described in [PR #6687](https://github.com/JabRef/jabref/pull/6687)
+As described in the [PR #6687](https://github.com/JabRef/jabref/pull/6687)
 
 ## Pros and Cons of the Options
 


### PR DESCRIPTION
### Related issues and pull requests
Closes #14897

### PR Description
I have updated the link formatting in `docs/decisions/0012-handle-different-bibEntry-formats-of-fetchers.md`. I changed the raw URL to a standard Markdown link for PR #6687 to make the documentation cleaner and more consistent.

### Steps to test
1. Open the file `docs/decisions/0012-handle-different-bibEntry-formats-of-fetchers.md`.
2. Locate the "Decision Outcome" section to see the new formatted link.

### Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository