### PR TITLE
Fix #15109: Use StandardField.GROUPS in merge dialog

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/FieldRowView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/FieldRowView.java
@@ -46,11 +46,9 @@ public class FieldRowView {
     public FieldRowView(Field field, BibEntry leftEntry, BibEntry rightEntry, BibEntry mergedEntry, FieldMergerFactory fieldMergerFactory, GuiPreferences preferences, StateManager stateManager, int rowIndex) {
         viewModel = new FieldRowViewModel(field, leftEntry, rightEntry, mergedEntry, fieldMergerFactory);
 
-        fieldNameCell = new FieldNameCell(FieldTextMapper.getDisplayName(field), rowIndex);
-        leftValueCell = new FieldValueCell(viewModel.getLeftFieldValue(), rowIndex, preferences, stateManager);
+        fieldNameCell = new FieldNameCell(field, FieldTextMapper.getDisplayName(field), rowIndex);        leftValueCell = new FieldValueCell(viewModel.getLeftFieldValue(), rowIndex, preferences, stateManager);
         rightValueCell = new FieldValueCell(viewModel.getRightFieldValue(), rowIndex, preferences, stateManager);
-        mergedValueCell = new MergedFieldCell(viewModel.getMergedFieldValue(), rowIndex);
-
+        mergedValueCell = new MergedFieldCell(field, viewModel.getMergedFieldValue(), rowIndex);
         // As a workaround we need to have a reference to the parent grid pane to be able to show/hide the row.
         // This won't be necessary when https://bugs.openjdk.org/browse/JDK-8136901 is fixed.
         leftValueCell.parentProperty().addListener(e -> {

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/ThreeWayMergeView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/ThreeWayMergeView.java
@@ -19,6 +19,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldProperty;
+import org.jabref.model.entry.field.StandardField;
 
 public class ThreeWayMergeView extends VBox {
     public static final int GRID_COLUMN_MIN_WIDTH = 250;
@@ -107,7 +108,8 @@ public class ThreeWayMergeView extends VBox {
     private void updateDiff() {
         if (toolbar.shouldShowDiffs()) {
             for (FieldRowView row : fieldRows) {
-                if ("Groups".equals(row.getFieldNameCell().getText()) && (row.getLeftValueCell().getText().contains(keywordSeparator) || row.getRightValueCell().getText().contains(keywordSeparator))) {
+                Field field = row.getFieldNameCell().getField();
+                if (field == StandardField.GROUPS) {
                     row.showDiff(new ShowDiffConfig(toolbar.getDiffView(), new GroupDiffMode(keywordSeparator)));
                 } else {
                     row.showDiff(new ShowDiffConfig(toolbar.getDiffView(), toolbar.getDiffHighlightingMethod()));
@@ -156,10 +158,27 @@ public class ThreeWayMergeView extends VBox {
         Field field = getFieldAtIndex(fieldIndex);
 
         FieldRowView fieldRow;
+
         if (field.getProperties().contains(FieldProperty.PERSON_NAMES)) {
-            fieldRow = new PersonsNameFieldRowView(field, getLeftEntry(), getRightEntry(), getMergedEntry(), fieldMergerFactory, preferences, stateManager, fieldIndex);
+            fieldRow = new PersonsNameFieldRowView(
+                    field,
+                    getLeftEntry(),
+                    getRightEntry(),
+                    getMergedEntry(),
+                    fieldMergerFactory,
+                    preferences,
+                    stateManager,
+                    fieldIndex);
         } else {
-            fieldRow = new FieldRowView(field, getLeftEntry(), getRightEntry(), getMergedEntry(), fieldMergerFactory, preferences, stateManager, fieldIndex);
+            fieldRow = new FieldRowView(
+                    field,
+                    getLeftEntry(),
+                    getRightEntry(),
+                    getMergedEntry(),
+                    fieldMergerFactory,
+                    preferences,
+                    stateManager,
+                    fieldIndex);
         }
 
         fieldRows.add(fieldIndex, fieldRow);

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldNameCell.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/threewaymerge/cell/FieldNameCell.java
@@ -5,6 +5,8 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
+import org.jabref.model.entry.field.Field;
+
 /// A readonly cell used to display the name of some field.
 public class FieldNameCell extends ThreeWayMergeCell {
     public static final String DEFAULT_STYLE_CLASS = "field-name";
@@ -13,9 +15,16 @@ public class FieldNameCell extends ThreeWayMergeCell {
 
     private final HBox labelBox = new HBox(label);
 
-    public FieldNameCell(String text, int rowIndex) {
+    private final Field field;
+
+    public FieldNameCell(Field field, String text, int rowIndex) {
         super(text, rowIndex);
+        this.field = field;
         initialize();
+    }
+
+    public Field getField() {
+        return field;
     }
 
     private void initialize() {


### PR DESCRIPTION
Closes #15109

Replaced string-based detection of the "Groups" field in the merge dialog with a type-safe check using StandardField.GROUPS.

This avoids localization issues and improves robustness of the merge diff logic. GroupDiffMode is now correctly applied without relying on display text comparison.

Steps to test:
1. Start JabRef
2. Open an entry containing a Groups field
3. Trigger merge dialog
4. Enable diff view
5. Verify that Groups field diff works correctly

Checklist:
- [x] I manually tested my changes in running JabRef
- [ ] I added JUnit tests (not applicable)
- [ ] I described the change in CHANGELOG.md (not applicable)
<img width="1460" height="951" alt="Screenshot 2026-02-24 at 9 36 23 AM" src="https://github.com/user-attachments/assets/d4698b7d-3b14-4a1e-80cf-c8f3f8f2c429" />
