### PR TITLE
Fix: Added missing installer bitmaps and updated jpackage configurati…

### DIFF
--- a/jabgui/buildres/windows/main.wxs
+++ b/jabgui/buildres/windows/main.wxs
@@ -101,7 +101,8 @@
     <Icon Id="JpARPPRODUCTICON" SourceFile="$(var.JpIcon)"/>
     <?endif?>
 
-    <!-- <WixVariable Id="WixUIBannerBmp" Value="$(var.JpConfigDir)/JabRefTopBanner.bmp"> -->
+    <WixVariable Id="WixUIBannerBmp" Value="$(var.JpConfigDir)\JabRefTopBanner.bmp" />
+    <WixVariable Id="WixUIDialogBmp" Value="$(var.JpConfigDir)\JabRefDialog.bmp" />
 
     <UIRef Id="JpUI"/>
 


### PR DESCRIPTION
Description
The Windows MSI installer was not showing the JabRef icon in the installer UI (sidebar and header). This was because the WiX variables for the installer bitmaps were not set.

Changes:

jabgui/buildres/windows/main.wxs: Enabled WixUIBannerBmp and set WixUIDialogBmp.

The installer now correctly uses JabRefTopBanner.bmp (top banner) and JabRefDialog.bmp (sidebar/dialog) from the jpackage config directory.

These files are used when building the Windows installer via gradlew :jabgui:jpackage.

Related Issues:
Closes #14965