### PR TITLE
Fix typo in OOBibBaseConnect comment

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
@@ -1,4 +1,4 @@
-﻿package org.jabref.gui.openoffice;
+package org.jabref.gui.openoffice;
 
 import java.io.IOException;
 import java.nio.file.Path;


### PR DESCRIPTION
### Related issues and pull requests

### PR Description
Fixes a typo in a source code comment where "teh connection" was misspelled.
Corrected it to "the connection" to improve code clarity and maintain code quality standards.

### Steps to test
1. Open the file:
   jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBaseConnect.java
2. Locate the comment mentioning connection testing.
3. Confirm the text now reads "the connection" instead of "teh connection".

### Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the user documentation for up to dateness and submitted a pull request to the documentation repository