### PR TITLE
Add group pseudonymization support (fixes #14117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - When an imported entry has an empty citation key, it is generated. [#15624](https://github.com/JabRef/jabref/pull/15624)
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)
+- We extended library pseudonymization to also pseudonymize group names, not just the entries. [#14117](https://github.com/JabRef/jabref/issues/14117)
 - We introduced a leightweight search engine without fulltext search in linked files as default variant. [#15599](https://github.com/JabRef/jabref/pull/15599)
 
 ### Fixed

--- a/jabgui/src/main/java/org/jabref/gui/pseudonymize/PseudonymizeAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/pseudonymize/PseudonymizeAction.java
@@ -48,7 +48,7 @@ public class PseudonymizeAction extends SimpleCommand {
     private void pseudonymizeDatabase(Path outputFilePath) {
         BibDatabaseContext database = stateManager.getActiveDatabase().orElseThrow(() -> new IllegalStateException("No active database found."));
         Path inputFile = database.getDatabasePath().orElseThrow(() -> new IllegalStateException("Database has no file path"));
-        Pseudonymization.Result result = new Pseudonymization().pseudonymizeLibrary(database);
+        Pseudonymization.Result result = new Pseudonymization(preferences.getBibEntryPreferences().getKeywordSeparator()).pseudonymizeLibrary(database);
 
         String fileName = FileUtil.getBaseName(inputFile) + PSEUDO_SUFFIX;
         Path pseudoBibPath = outputFilePath.resolve(fileName + BIB_EXTENSION);

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Pseudonymize.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Pseudonymize.java
@@ -70,7 +70,8 @@ class Pseudonymize implements Callable<Integer> {
         }
 
         System.out.println(Localization.lang("Pseudonymizing library '%0'...", fileName));
-        Pseudonymization pseudonymization = new Pseudonymization();
+        Character keywordSeparator = argumentProcessor.cliPreferences.getBibEntryPreferences().getKeywordSeparator();
+        Pseudonymization pseudonymization = new Pseudonymization(keywordSeparator);
         BibDatabaseContext databaseContext = parserResult.get().getDatabaseContext();
         Pseudonymization.Result result = pseudonymization.pseudonymizeLibrary(databaseContext);
 

--- a/jablib/src/main/java/org/jabref/logic/pseudonymization/Pseudonymization.java
+++ b/jablib/src/main/java/org/jabref/logic/pseudonymization/Pseudonymization.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class Pseudonymization {
 
+    private static final String GROUP_PREFIX = "group-";
     private final Character keywordSeparator;
 
     public Pseudonymization(Character keywordSeparator) {
@@ -105,7 +106,7 @@ public class Pseudonymization {
             String originalName = keyword.toString();
             String pseudoName = groupNameMapping.get(originalName);
             if (pseudoName == null) {
-                pseudoName = "group-" + (groupNameMapping.size() + 1);
+                pseudoName = GROUP_PREFIX + (groupNameMapping.size() + 1);
                 groupNameMapping.put(originalName, pseudoName);
                 valueMapping.put(pseudoName, originalName);
             }
@@ -123,7 +124,7 @@ public class Pseudonymization {
                                                          int counter) {
         AbstractGroup originalGroup = node.getGroup();
         String originalName = originalGroup.getName();
-        String pseudoName = "group-" + counter;
+        String pseudoName = GROUP_PREFIX + counter;
         counter++;
         valueMapping.put(pseudoName, originalName);
         groupNameMapping.put(originalName, pseudoName);

--- a/jablib/src/main/java/org/jabref/logic/pseudonymization/Pseudonymization.java
+++ b/jablib/src/main/java/org/jabref/logic/pseudonymization/Pseudonymization.java
@@ -5,11 +5,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.Keyword;
+import org.jabref.model.entry.KeywordList;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.GroupTreeNode;
 
 import org.jspecify.annotations.NullMarked;
 
@@ -19,6 +25,12 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 public class Pseudonymization {
 
+    private final Character keywordSeparator;
+
+    public Pseudonymization(Character keywordSeparator) {
+        this.keywordSeparator = keywordSeparator;
+    }
+
     public record Result(BibDatabaseContext bibDatabaseContext, Map<String, String> valueMapping) {
     }
 
@@ -26,10 +38,19 @@ public class Pseudonymization {
         // TODO: Anonymize metadata
         // TODO: Anonymize strings
 
-        Map<Field, Map<String, Integer>> fieldToValueToIdMap = new HashMap<>();
-        List<BibEntry> newEntries = pseudonymizeEntries(bibDatabaseContext, fieldToValueToIdMap);
-
         Map<String, String> valueMapping = new HashMap<>();
+        Map<String, String> groupNameMapping = new HashMap<>();
+
+        Optional<GroupTreeNode> groups = bibDatabaseContext.getMetaData().getGroups();
+        Optional<GroupTreeNode> pseudonymizedGroups = Optional.empty();
+        if (groups.isPresent()) {
+            GroupTreeResult groupResult = pseudonymizeGroupTree(groups.get(), valueMapping, groupNameMapping, 1);
+            pseudonymizedGroups = Optional.of(groupResult.node());
+        }
+
+        Map<Field, Map<String, Integer>> fieldToValueToIdMap = new HashMap<>();
+        List<BibEntry> newEntries = pseudonymizeEntries(bibDatabaseContext, fieldToValueToIdMap, groupNameMapping, valueMapping);
+
         fieldToValueToIdMap.forEach((field, stringToIntMap) ->
                 stringToIntMap.forEach((value, id) -> valueMapping.put(field.getName().toLowerCase(Locale.ROOT) + "-" + id, value)));
 
@@ -37,11 +58,16 @@ public class Pseudonymization {
         BibDatabaseContext result = new BibDatabaseContext(bibDatabase);
         result.setMode(bibDatabaseContext.getMode());
 
+        pseudonymizedGroups.ifPresent(newGroups -> result.getMetaData().setGroups(newGroups));
+
         return new Result(result, valueMapping);
     }
 
     /// @param fieldToValueToIdMap map containing the mapping from field to value to id, will be filled by this method
-    private static List<BibEntry> pseudonymizeEntries(BibDatabaseContext bibDatabaseContext, Map<Field, Map<String, Integer>> fieldToValueToIdMap) {
+    private List<BibEntry> pseudonymizeEntries(BibDatabaseContext bibDatabaseContext,
+                                               Map<Field, Map<String, Integer>> fieldToValueToIdMap,
+                                               Map<String, String> groupNameMapping,
+                                               Map<String, String> valueMapping) {
         List<BibEntry> entries = bibDatabaseContext.getEntries();
         List<BibEntry> newEntries = new ArrayList<>(entries.size());
 
@@ -49,6 +75,14 @@ public class Pseudonymization {
             BibEntry newEntry = new BibEntry(entry.getType());
             newEntries.add(newEntry);
             for (Field field : entry.getFields()) {
+                if (field.equals(StandardField.GROUPS)) {
+                    String fieldContent = entry.getField(field).orElse("");
+                    if (!fieldContent.isBlank()) {
+                        newEntry.setField(field, pseudonymizeGroupsField(fieldContent, groupNameMapping, valueMapping));
+                    }
+                    continue;
+                }
+
                 Map<String, Integer> valueToIdMap = fieldToValueToIdMap.computeIfAbsent(field, k -> new HashMap<>());
                 // TODO: Use {@link org.jabref.model.entry.field.FieldProperty} to distinguish cases.
                 //       See {@link org.jabref.model.entry.field.StandardField} for usages.
@@ -58,5 +92,51 @@ public class Pseudonymization {
             }
         }
         return newEntries;
+    }
+
+    /// Pseudonymizes the {@link StandardField#GROUPS} field content.
+    /// Groups not present in the group tree are also pseudonymized.
+    private String pseudonymizeGroupsField(String fieldContent,
+                                           Map<String, String> groupNameMapping,
+                                           Map<String, String> valueMapping) {
+        KeywordList keywords = KeywordList.parse(fieldContent, keywordSeparator);
+        KeywordList pseudonymizedKeywords = new KeywordList();
+        for (Keyword keyword : keywords) {
+            String originalName = keyword.toString();
+            String pseudoName = groupNameMapping.get(originalName);
+            if (pseudoName == null) {
+                pseudoName = "group-" + (groupNameMapping.size() + 1);
+                groupNameMapping.put(originalName, pseudoName);
+                valueMapping.put(pseudoName, originalName);
+            }
+            pseudonymizedKeywords.add(pseudoName);
+        }
+        return pseudonymizedKeywords.getAsString(keywordSeparator);
+    }
+
+    private record GroupTreeResult(GroupTreeNode node, int counter) {
+    }
+
+    private static GroupTreeResult pseudonymizeGroupTree(GroupTreeNode node,
+                                                         Map<String, String> valueMapping,
+                                                         Map<String, String> groupNameMapping,
+                                                         int counter) {
+        AbstractGroup originalGroup = node.getGroup();
+        String originalName = originalGroup.getName();
+        String pseudoName = "group-" + counter;
+        counter++;
+        valueMapping.put(pseudoName, originalName);
+        groupNameMapping.put(originalName, pseudoName);
+
+        AbstractGroup newGroup = originalGroup.deepCopy();
+        newGroup.nameProperty().set(pseudoName);
+
+        GroupTreeNode newNode = new GroupTreeNode(newGroup);
+        for (GroupTreeNode child : node.getChildren()) {
+            GroupTreeResult childResult = pseudonymizeGroupTree(child, valueMapping, groupNameMapping, counter);
+            newNode.addChild(childResult.node());
+            counter = childResult.counter();
+        }
+        return new GroupTreeResult(newNode, counter);
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/pseudonymization/PseudonymizationTest.java
+++ b/jablib/src/test/java/org/jabref/logic/pseudonymization/PseudonymizationTest.java
@@ -119,8 +119,10 @@ class PseudonymizationTest {
         );
         root.addChild(child);
         context.getMetaData().setGroups(root);
+
         Pseudonymization.Result res =
                 new Pseudonymization(',').pseudonymizeLibrary(context);
+
         GroupTreeNode pseudonymizedRoot =
                 res.bibDatabaseContext().getMetaData().getGroups().orElseThrow();
         assertEquals("group-1", pseudonymizedRoot.getGroup().getName());

--- a/jablib/src/test/java/org/jabref/logic/pseudonymization/PseudonymizationTest.java
+++ b/jablib/src/test/java/org/jabref/logic/pseudonymization/PseudonymizationTest.java
@@ -21,6 +21,10 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.groups.AllEntriesGroup;
+import org.jabref.model.groups.ExplicitGroup;
+import org.jabref.model.groups.GroupHierarchyType;
+import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.SaveOrder;
 import org.jabref.model.util.DummyFileUpdateMonitor;
 
@@ -66,31 +70,78 @@ class PseudonymizationTest {
 
     @Test
     void pseudonymizeTwoEntries() {
-        BibEntry first = new BibEntry("first")
+        BibEntry first = new BibEntry()
+                .withCitationKey("first")
                 .withField(StandardField.AUTHOR, "Author One")
                 .withField(StandardField.PAGES, "some pages");
-        BibEntry second = new BibEntry("second")
+        BibEntry second = new BibEntry()
+                .withCitationKey("second")
                 .withField(StandardField.AUTHOR, "Author Two")
                 .withField(StandardField.PAGES, "some pages");
 
         BibDatabaseContext databaseContext = new BibDatabaseContext(new BibDatabase(List.of(first, second)));
 
-        Pseudonymization pseudonymization = new Pseudonymization();
+        Pseudonymization pseudonymization = new Pseudonymization(',');
         Pseudonymization.Result result = pseudonymization.pseudonymizeLibrary(databaseContext);
 
-        BibEntry firstPseudo = new BibEntry("citationkey-1")
+        BibEntry firstPseudo = new BibEntry()
+                .withCitationKey("citationkey-1")
                 .withField(StandardField.AUTHOR, "author-1")
                 .withField(StandardField.PAGES, "pages-1");
-        BibEntry secondPseudo = new BibEntry("citationkey-2")
+        BibEntry secondPseudo = new BibEntry()
+                .withCitationKey("citationkey-2")
                 .withField(StandardField.AUTHOR, "author-2")
                 .withField(StandardField.PAGES, "pages-1");
         BibDatabaseContext bibDatabaseContextExpected = new BibDatabaseContext(new BibDatabase(List.of(firstPseudo, secondPseudo)));
         bibDatabaseContextExpected.setMode(BibDatabaseMode.BIBLATEX);
         Pseudonymization.Result expected = new Pseudonymization.Result(
                 bibDatabaseContextExpected,
-                Map.of("author-1", "Author One", "author-2", "Author Two", "pages-1", "some pages", "citationkey-1", "first", "citationkey-2", "second"));
+                Map.of("author-1", "Author One",
+                        "author-2", "Author Two",
+                        "pages-1", "some pages",
+                        "citationkey-1", "first",
+                        "citationkey-2", "second"));
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldPseudonymizeGroupTree() {
+        BibEntry entry = new BibEntry()
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author");
+        BibDatabase db = new BibDatabase();
+        db.insertEntry(entry);
+        BibDatabaseContext context = new BibDatabaseContext(db);
+        GroupTreeNode root = GroupTreeNode.fromGroup(new AllEntriesGroup("All entries"));
+        GroupTreeNode child = GroupTreeNode.fromGroup(
+                new ExplicitGroup("Research", GroupHierarchyType.INDEPENDENT, ',')
+        );
+        root.addChild(child);
+        context.getMetaData().setGroups(root);
+        Pseudonymization.Result res =
+                new Pseudonymization(',').pseudonymizeLibrary(context);
+        GroupTreeNode pseudonymizedRoot =
+                res.bibDatabaseContext().getMetaData().getGroups().orElseThrow();
+        assertEquals("group-1", pseudonymizedRoot.getGroup().getName());
+        assertEquals("group-2",
+                pseudonymizedRoot.getChildren().getFirst().getGroup().getName());
+    }
+
+    @Test
+    void shouldPseudonymizeUnmappedGroups() {
+        BibEntry entry = new BibEntry()
+                .withCitationKey("test")
+                .withField(StandardField.AUTHOR, "Test Author")
+                .withField(StandardField.GROUPS, "not-in-tree");
+        BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(List.of(entry)));
+
+        Pseudonymization.Result result = new Pseudonymization(',').pseudonymizeLibrary(context);
+
+        BibEntry pseudoEntry = result.bibDatabaseContext().getEntries().getFirst();
+        String pseudoGroups = pseudoEntry.getField(StandardField.GROUPS).orElse("");
+        assertTrue(pseudoGroups.startsWith("group-"));
+        assertTrue(result.valueMapping().containsValue("not-in-tree"));
     }
 
     @Test
@@ -98,7 +149,7 @@ class PseudonymizationTest {
         Path path = Path.of(PseudonymizationTest.class.getResource("Chocolate.bib").toURI());
         BibDatabaseContext databaseContext = importer.importDatabase(path).getDatabaseContext();
 
-        Pseudonymization pseudonymization = new Pseudonymization();
+        Pseudonymization pseudonymization = new Pseudonymization(',');
         Pseudonymization.Result result = pseudonymization.pseudonymizeLibrary(databaseContext);
         databaseWriter.writeDatabase(result.bibDatabaseContext());
 
@@ -117,7 +168,7 @@ class PseudonymizationTest {
 
         BibDatabaseContext databaseContext = importer.importDatabase(path).getDatabaseContext();
 
-        Pseudonymization pseudonymization = new Pseudonymization();
+        Pseudonymization pseudonymization = new Pseudonymization(',');
         Pseudonymization.Result result = pseudonymization.pseudonymizeLibrary(databaseContext);
         databaseWriter.writeDatabase(result.bibDatabaseContext());
 

--- a/jablib/src/test/resources/org/jabref/logic/pseudonymization/Chocolate-pseudnomyized.bib
+++ b/jablib/src/test/resources/org/jabref/logic/pseudonymization/Chocolate-pseudnomyized.bib
@@ -77,7 +77,7 @@
   number       = {number-4},
   pages        = {pages-5},
   volume       = {volume-6},
-  groups       = {groups-1},
+  groups       = {group-8},
   publisher    = {publisher-6},
   readstatus   = {readstatus-2},
 }
@@ -93,7 +93,7 @@
   pages        = {pages-6},
   volume       = {volume-7},
   file         = {file-5},
-  groups       = {groups-1},
+  groups       = {group-8},
   publisher    = {publisher-7},
   readstatus   = {readstatus-2},
 }
@@ -123,7 +123,7 @@
   number       = {number-6},
   pages        = {pages-8},
   volume       = {volume-9},
-  groups       = {groups-1},
+  groups       = {group-8},
   publisher    = {publisher-6},
   readstatus   = {readstatus-2},
 }
@@ -177,7 +177,7 @@
   number       = {number-1},
   pages        = {pages-11},
   volume       = {volume-13},
-  groups       = {groups-1},
+  groups       = {group-8},
   publisher    = {publisher-4},
   readstatus   = {readstatus-2},
 }
@@ -190,7 +190,7 @@
   doi          = {doi-14},
   issn         = {issn-14},
   volume       = {volume-14},
-  groups       = {groups-1},
+  groups       = {group-8},
   publisher    = {publisher-10},
   readstatus   = {readstatus-2},
 }
@@ -211,3 +211,14 @@
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}
+
+@Comment{jabref-meta: grouping:
+0 AllEntriesGroup:;
+1 SearchGroup:group-2\;0\;groups !=~ .+\;0\;1\;1\;\;\;\;;
+1 SearchGroup:group-3\;0\;file !=~ .+\;0\;1\;1\;\;\;\;;
+1 StaticGroup:group-4\;0\;1\;\;\;\;;
+1 SearchGroup:group-5\;0\;groups !=~ .+ and readstatus !=~ .+\;0\;1\;1\;\;\;\;;
+1 KeywordGroup:group-6\;0\;readstatus\;skimmed\;0\;0\;1\;\;\;\;;
+1 KeywordGroup:group-7\;0\;readstatus\;read\;0\;0\;1\;\;\;\;;
+1 StaticGroup:group-8\;0\;1\;\;\;\;;
+}


### PR DESCRIPTION
## Description
added group pseudonymization before this only entries were pseudonymized now groups get pseudonymized too for eg group-1,group-2,...etc

## Changes
- added pseudonymizeGroupTree() method which uses deepCopy() and nameProperty().set() so in order the  original library stays unchanged and group types (SearchGroup, KeywordGroup etc) are been preserved
- extracted groups field handling into separate method named as pseudonymizeGroupsField() instead of manual splitting
- groups in entries which doesn't exist in the group tree also get pseudonymized  with a counter
- added changelog entry

## Testing
- All test pass
- Added shouldPseudonymizeGroupTree() test
- Added shouldPseudonymizeUnmappedGroups() test for edge case where group in entry doesnt exist in tree

Before (original groups):

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/bdc75b18-36a4-4ad8-b9aa-0bb7f4c34580" />

After (pseudonymized groups):

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/087560ec-576d-46d2-a95c-42c632e08284" />

Fixes #14117

### AI Disclosure
I used Chatgpt AI to assist with understanding the codebase and debugging.

### Checklist
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the user documentation for up to dateness and submitted a pull request to our user documentation repository