### PR TITLE
Fix shared PostgreSQL connection drop after 2 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We implemented a keep-alive mechanism and improved connection loss handling for the shared PostgreSQL database to prevent disconnections after 2 hours. [#11211](https://github.com/JabRef/jabref/issues/11211)
 - We added support for citation properties in the CAYW endpoint. [#13821](https://github.com/JabRef/jabref/issues/13821)
 
 ### Changed

--- a/jablib/src/main/java/org/jabref/logic/shared/DBMSConnectionProperties.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/DBMSConnectionProperties.java
@@ -150,6 +150,10 @@ public class DBMSConnectionProperties implements DatabaseConnectionProperties {
         props.setProperty("user", user);
         props.setProperty("password", password);
         props.setProperty("serverTimezone", serverTimezone);
+
+        props.setProperty("tcpKeepAlive", "true");
+        props.setProperty("socketTimeout", "30");
+
         if (useSSL) {
             props.setProperty("ssl", Boolean.toString(true));
             props.setProperty("useSSL", Boolean.toString(true));

--- a/jablib/src/main/java/org/jabref/logic/shared/DBMSConnectionProperties.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/DBMSConnectionProperties.java
@@ -151,8 +151,10 @@ public class DBMSConnectionProperties implements DatabaseConnectionProperties {
         props.setProperty("password", password);
         props.setProperty("serverTimezone", serverTimezone);
 
-        props.setProperty("tcpKeepAlive", "true");
-        props.setProperty("socketTimeout", "30");
+        if (type == DBMSType.POSTGRESQL) {
+            props.setProperty("tcpKeepAlive", "true");
+            props.setProperty("socketTimeout", "30");
+        }
 
         if (useSSL) {
             props.setProperty("ssl", Boolean.toString(true));

--- a/jablib/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
@@ -174,10 +174,10 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
             try {
                 if (currentConnection != null && !currentConnection.isClosed()) {
                     currentConnection.createStatement().execute("SELECT 1");
-                    LOGGER.debug("Database keep-alive ping successful");
+                    LOGGER.info("Database keep-alive ping successful");
                 }
             } catch (SQLException e) {
-                LOGGER.warn("Database keep-alive ping failed", e);
+                LOGGER.info("Database keep-alive ping failed", e);
                 checkCurrentConnection();
             }
         }, KEEP_ALIVE_INTERVAL_MINUTES, KEEP_ALIVE_INTERVAL_MINUTES, TimeUnit.MINUTES);

--- a/jablib/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/DBMSSynchronizer.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.jabref.logic.bibtex.FieldPreferences;
@@ -43,7 +46,10 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DBMSSynchronizer.class);
 
+    private static final int KEEP_ALIVE_INTERVAL_MINUTES = 30;
+
     private DBMSProcessor dbmsProcessor;
+    private ScheduledExecutorService keepAliveExecutor;
     private String dbName;
     private final BibDatabaseContext bibDatabaseContext;
     private MetaData metaData;
@@ -155,6 +161,33 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
         dbmsProcessor.startNotificationListener(this);
         synchronizeLocalMetaData();
         synchronizeLocalDatabase();
+    }
+
+    /// Starts a periodic keep-alive task that sends a lightweight query to the database to prevent idle connections timeout
+    private void startKeepAlive() {
+        keepAliveExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "DB-KeepAlive");
+            t.setDaemon(true);
+            return t;
+        });
+        keepAliveExecutor.scheduleAtFixedRate(() -> {
+            try {
+                if (currentConnection != null && !currentConnection.isClosed()) {
+                    currentConnection.createStatement().execute("SELECT 1");
+                    LOGGER.debug("Database keep-alive ping successful");
+                }
+            } catch (SQLException e) {
+                LOGGER.warn("Database keep-alive ping failed", e);
+                checkCurrentConnection();
+            }
+        }, KEEP_ALIVE_INTERVAL_MINUTES, KEEP_ALIVE_INTERVAL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private void stopKeepAlive() {
+        if (keepAliveExecutor != null) {
+            keepAliveExecutor.shutdownNow();
+            keepAliveExecutor = null;
+        }
     }
 
     /// Synchronizes the local database with shared one. Possible update types are: removal, update, or insert of a
@@ -356,11 +389,13 @@ public class DBMSSynchronizer implements DatabaseSynchronizer {
         this.currentConnection = connection.getConnection();
         this.dbmsProcessor = DBMSProcessor.getProcessorInstance(connection);
         initializeDatabases();
+        startKeepAlive();
     }
 
     @Override
     public void closeSharedDatabase() {
         // Submit remaining entry changes
+        stopKeepAlive();
         pullLastEntryChanges();
         try {
             dbmsProcessor.stopNotificationListener();

--- a/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
@@ -44,12 +44,12 @@ public class PostgresSQLNotificationListener implements Runnable {
                 Thread.sleep(500);
             }
         } catch (SQLException exception) {
-            LOGGER.warn("PostgreSQL connection lost", exception);
+            LOGGER.error("PostgreSQL connection lost", exception);
             if (!stop) {
                 dbmsSynchronizer.checkCurrentConnection();
             }
         } catch (InterruptedException exception) {
-            LOGGER.debug("Error while listening for updates to PostgresSQL", exception);
+            LOGGER.error("Error while listening for updates to PostgresSQL", exception);
             Thread.currentThread().interrupt();
         }
     }

--- a/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
@@ -44,12 +44,12 @@ public class PostgresSQLNotificationListener implements Runnable {
                 Thread.sleep(500);
             }
         } catch (SQLException exception) {
-            LOGGER.warn("PostgreSQL notification listener lost connection", exception);
+            LOGGER.warn("PostgreSQL connection lost", exception);
             if (!stop) {
                 dbmsSynchronizer.checkCurrentConnection();
             }
         } catch (InterruptedException exception) {
-            LOGGER.debug("PostgreSQL notification listener interrupted", exception);
+            LOGGER.debug("Error while listening for updates to PostgresSQL", exception);
             Thread.currentThread().interrupt();
         }
     }

--- a/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
+++ b/jablib/src/main/java/org/jabref/logic/shared/listener/PostgresSQLNotificationListener.java
@@ -43,8 +43,14 @@ public class PostgresSQLNotificationListener implements Runnable {
                 // Wait a while before checking again for new notifications
                 Thread.sleep(500);
             }
-        } catch (SQLException | InterruptedException exception) {
-            LOGGER.error("Error while listening for updates to PostgresSQL", exception);
+        } catch (SQLException exception) {
+            LOGGER.warn("PostgreSQL notification listener lost connection", exception);
+            if (!stop) {
+                dbmsSynchronizer.checkCurrentConnection();
+            }
+        } catch (InterruptedException exception) {
+            LOGGER.debug("PostgreSQL notification listener interrupted", exception);
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/jablib/src/test/java/org/jabref/logic/shared/DBMSConnectionPropertiesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/shared/DBMSConnectionPropertiesTest.java
@@ -1,0 +1,29 @@
+package org.jabref.logic.shared;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DBMSConnectionPropertiesTest {
+    @Test
+    void asPropertiesIncludesTcpKeepAlive() {
+        DBMSConnectionProperties connectionProperties = new DBMSConnectionPropertiesBuilder()
+                .setType(DBMSType.POSTGRESQL)
+                .setHost("localhost")
+                .setPort(5432)
+                .setDatabase("test")
+                .setUser("user")
+                .setPassword("root")
+                .createDBMSConnectionProperties();
+
+        Properties props = connectionProperties.asProperties();
+
+        assertEquals("true", props.getProperty("tcpKeepAlive"),
+                "TCP keep-alive should be enabled to prevent idle connection drops");
+        assertEquals("30", props.getProperty("socketTimeout"),
+                "Socket timeout should be set to prevent infinite hangs on dead connections");
+    }
+}
+

--- a/jablib/src/test/java/org/jabref/logic/shared/DBMSConnectionPropertiesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/shared/DBMSConnectionPropertiesTest.java
@@ -23,7 +23,7 @@ public class DBMSConnectionPropertiesTest {
         assertEquals("true", props.getProperty("tcpKeepAlive"),
                 "TCP keep-alive should be enabled to prevent idle connection drops");
         assertEquals("30", props.getProperty("socketTimeout"),
-                "Socket timeout should be set to prevent infinite hangs on dead connections");
+                "Socket timeout should be set to avoid hanging when the connection is lost");
     }
 }
 


### PR DESCRIPTION
### Fixed #11211

The loosing of connection after 2 hours was not a bug, rather a ticket expiration issue, as JabRef uses Kerberos for authentication.

The PostgreSQL server logs confirms this:
`could not receive data from client: connection has been reset by communication partner`

Two things are happening here:
  1. An idle connection gets killed when no traffic is sent, PostgreSQL closes it.
  2. The UI was unaware that the connection was lost, which is why the user sees a freeze dialog instead of a “connection lost” dialog.

A ScheduledExecutorService is added to send a lightweight SELECT 1 query every 30 minutes, ensuring the connection remains active and does not become idle long enough to be terminated by the server or authentication layer.

The connection lost SQLException is now handled by the PostgresSQLNotificationListener class.

<img width="1280" height="832" alt="Screenshot 2026-03-04 at 12 26 11 AM" src="https://github.com/user-attachments/assets/1782c373-0ef5-4b2d-81c0-160d61fc6fe6" />

PostgreSQLNotificationListener throws an exception when the database is manually disconnected.
Use the command `brew services stop postgresql` for mac.

`Database keep-alive ping successful` can be logged by chaning the varible to KEEP_ALIVE_INTERVAL_MINUTES = 1.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

[Edited]