### PR TITLE
PDF import keep merge dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed the merge dialog closing immediately when only one PDF importer returns metadata during PDF drag-and-drop import. [#15127](https://github.com/JabRef/jabref/issues/15127)
 - We fixed an issue where pressing ESC now properly closes the global search dialog. [#15133](https://github.com/JabRef/jabref/issues/15133)
 - We fixed the Citavi XML importer to preserve citation keys defined in Citavi (previously all imported entries had empty citation keys). [#14658](https://github.com/JabRef/jabref/issues/14658)
 - We fixed an issue where LaTeX to Unicode conversion replaced tildes with standard spaces instead of non-break spaces. [#15158](https://github.com/JabRef/jabref/issues/15158)

--- a/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntriesView.java
+++ b/jabgui/src/main/java/org/jabref/gui/mergeentries/multiwaymerge/MultiMergeEntriesView.java
@@ -59,7 +59,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MultiMergeEntriesView extends BaseDialog<BibEntry> {
-    public static final int ACTIVE_COLUMNS_MINIMUM = 2;
+    public static final int ACTIVE_COLUMNS_MINIMUM = 1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MultiMergeEntriesView.class);
 

--- a/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/UiTaskExecutor.java
@@ -157,7 +157,7 @@ public class UiTaskExecutor implements TaskExecutor {
         Task<V> javaTask = new Task<>() {
             {
                 this.updateMessage(task.messageProperty().get());
-                this.updateTitle(task.titleProperty().get());
+                this.updateTitle(java.util.Objects.toString(task.titleProperty().get(), ""));
                 BindingsHelper.subscribeFuture(task.progressProperty(), progress -> updateProgress(progress.workDone(), progress.max()));
                 BindingsHelper.subscribeFuture(task.messageProperty(), this::updateMessage);
                 BindingsHelper.subscribeFuture(task.titleProperty(), this::updateTitle);


### PR DESCRIPTION
### Related issues and pull requests

Closes #15127

### PR Description

When dragging and dropping a PDF into JabRef, the merge dialog was closing instantly before the user could interact with it which resulted in entries being created with only the filename and no metadata or DOI. The root cause was that MultiMergeEntriesView was configured with ACTIVE_COLUMNS_MINIMUM = 2 meaning the dialog would automatically close if fewer than 2 PDF importers returned metadata. For many valid PDFs only 1 importer like XMP succeeds, so the dialog was dismissing itself immediately.

This PR changes ACTIVE_COLUMNS_MINIMUM from 2 to 1 so the merge dialog stays open as long as at least one importer returns data. Only when zero sources succeed does it close and fall back to creating an empty entry with just the filename.

Note: The NullPointerException in Notifications.java that was also triggered during PDF import has already been fixed in main via hotfix #15288 by @calixtus.

### Steps to test

1. Download the open access PDF for DOI 10.1063/5.0266356. Here's the link https://pubs.aip.org/aip/apl/article/126/12/120401/3340873/Ultra-wide-bandgap-semiconductors-for-extreme

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0478639a-2875-40c6-b929-4bc55534fd51" />


2. Run JabRef and drag the PDF onto the application


https://github.com/user-attachments/assets/9cd6bd48-8ca1-4f38-a134-01791ecf14a4

3. The merge dialog should appear and stay open
4. After clicking Merge Entries the resulting entry should contain real metadata including a clean DOI (10.1063/5.0266356) with no .org/ prefix or trailing dot.
5. No Null Pointer Exception occurs as well as stated in #15288  


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
