### PR TITLE
Supress JavaFX VirtualFlow Info log noise for large libraries (10k+).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Changed
 
-- We no longer show JavaFX internal 'index exceeds maxCellCount' warnings in the error console as these stem from a known upstream JavaFX bug and were causing a StackOverflowError when the error console was open. [#12534](https://github.com/JabRef/jabref/issues/12534)
 - We removed the restart prompt when accepting Mr. DLib privacy settings or hiding the Related articles tab in the entry editor. [#15195](https://github.com/JabRef/jabref/issues/15195)
 - We replaced the unlinked files dialog with a wizard-based interface for searching and importing files. [#12709](https://github.com/JabRef/jabref/issues/12709)
 - We replaced the various notifications for file changes, tasks and popup toasts with a new info center. [#14762](https://github.com/JabRef/jabref/issues/14762)


### PR DESCRIPTION
### Related issues and pull requests

Closes #12534 

### PR Description

When we opened any large library with around 10k entries, console ListView triggers an info level log message from JavaFX's VirtualFlow ("index exceeds maxCellCount") due to a known upstream JavaFX bug ([JDK-8089472](https://bugs.openjdk.org/browse/JDK-8089472), [JDK-8296871](https://bugs.openjdk.org/browse/JDK-8296871)) that occurs when scrollTo is called while the list is still being populated. Since this cannot be fixed in JabRef itself this PR suppresses the noisy log message by adding a single line to tinylog.properties to set VirtualFlow's log level to warn.

### Steps to test

1. Open JabRef
2. Load a .bib file with 10k+ entries ( You can generate one using a python script )
3. Notice that no "index exceeds maxCellCount" message appears in the console output

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
