### PR TITLE
Fix #14943: Improve keyboard shortcut handling in KeyBindingsTab

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/keybindings/KeyBindingsTab.java
@@ -67,9 +67,11 @@ public class KeyBindingsTab extends AbstractPreferenceTabView<KeyBindingsTabView
         keyBindingsTable.setOnKeyPressed(viewModel::setNewBindingForCurrent);
 
         keyBindingsTable.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
-            event.consume();
-            viewModel.setNewBindingForCurrent(event);
-        });
+    if (!event.isControlDown() && !event.isAltDown() && !event.isShiftDown()) {
+        event.consume();
+        viewModel.setNewBindingForCurrent(event);
+    }
+    });
 
         keyBindingsTable.rootProperty().bind(
                 EasyBind.map(viewModel.rootKeyBindingProperty(),


### PR DESCRIPTION
Fixes #14943

This PR improves keyboard shortcut handling in KeyBindingsTab.
The key event is now handled correctly when assigning shortcuts in the keyboard preferences tab.

Tested by:
1. Running JabRef locally
2. Opening Preferences → Keyboard Shortcuts
3. Assigning new shortcuts to actions
### Checklist
- [x] I have tested the changes locally
- [x] I have followed the JabRef contribution guidelines
- [x] I have checked that the build passes