### PR TITLE
Add scoped preferences import/export functionality and enhance automa…

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -342,7 +342,8 @@ public class ImportHandler {
         UpdateField.setAutomaticFields(
                 entries,
                 preferences.getOwnerPreferences(),
-                preferences.getTimestampPreferences()
+                preferences.getTimestampPreferences(),
+                targetBibDatabaseContext.getMetaData()
         );
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/MainMenu.java
@@ -187,6 +187,10 @@ public class MainMenu extends MenuBar {
                         factory.createMenuItem(StandardActions.EXPORT_ALL, new ExportCommand(ExportCommand.ExportMethod.EXPORT_ALL, stateManager, dialogService, preferences, abbreviationRepository, taskExecutor)),
                         factory.createMenuItem(StandardActions.EXPORT_SELECTED, new ExportCommand(ExportCommand.ExportMethod.EXPORT_SELECTED, stateManager, dialogService, preferences, abbreviationRepository, taskExecutor)),
                         factory.createMenuItem(StandardActions.SAVE_SELECTED_AS_PLAIN_BIBTEX, new SaveAction(SaveAction.SaveMethod.SAVE_SELECTED, frame::getCurrentLibraryTab, dialogService, preferences, stateManager))),
+                
+                new SeparatorMenuItem(),
+
+                createScopedJsonMenu(),
 
                 new SeparatorMenuItem(),
 
@@ -426,6 +430,19 @@ public class MainMenu extends MenuBar {
                 view,
                 help);
         setUseSystemMenuBar(true);
+    }
+
+    private Menu createScopedJsonMenu() {
+        Menu menu = new Menu("Scoped Preferences JSON");
+        
+        MenuItem exportItem = new MenuItem("Export JSON...");
+        exportItem.setOnAction(e -> new org.jabref.gui.preferences.ScopedPreferencesExportCommand(dialogService, stateManager, preferences).execute());
+        
+        MenuItem importItem = new MenuItem("Import JSON...");
+        importItem.setOnAction(e -> new org.jabref.gui.preferences.ScopedPreferencesImportCommand(dialogService, stateManager, preferences).execute());
+        
+        menu.getItems().addAll(exportItem, importItem);
+        return menu;
     }
 
     private Menu createSendSubMenu(ActionFactory factory,

--- a/jabgui/src/main/java/org/jabref/gui/preferences/ScopedPreferencesExportCommand.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/ScopedPreferencesExportCommand.java
@@ -1,0 +1,62 @@
+package org.jabref.gui.preferences;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.preferences.ScopedPreferenceExporter;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.metadata.MetaData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScopedPreferencesExportCommand extends SimpleCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScopedPreferencesExportCommand.class);
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private final CliPreferences preferences;
+
+    public ScopedPreferencesExportCommand(DialogService dialogService, StateManager stateManager, CliPreferences preferences) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.preferences = preferences;
+    }
+
+    @Override
+    public void execute() {
+        FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
+                .addExtensionFilter(StandardFileType.JSON)
+                .withDefaultExtension(StandardFileType.JSON)
+                .withInitialDirectory(preferences.getFilePreferences().getWorkingDirectory())
+                .build();
+
+        Optional<Path> exportPath = dialogService.showFileSaveDialog(fileDialogConfiguration);
+        if (exportPath.isEmpty()) {
+            return;
+        }
+
+        Map<String, MetaData> libraries = new HashMap<>();
+        for (BibDatabaseContext ctx : stateManager.getOpenDatabases()) {
+            String name = ctx.getDatabasePath().map(Path::getFileName).map(Path::toString).orElse("untitled");
+            libraries.put(name, ctx.getMetaData());
+        }
+
+        try {
+            ScopedPreferenceExporter.exportToJson(exportPath.get(), preferences, libraries);
+            dialogService.notify("Exported scoped preferences successfully.");
+        } catch (IOException e) {
+            LOGGER.error("Could not export preferences", e);
+            dialogService.showErrorDialogAndWait("Error exporting preferences", e);
+        }
+    }
+}

--- a/jabgui/src/main/java/org/jabref/gui/preferences/ScopedPreferencesImportCommand.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/ScopedPreferencesImportCommand.java
@@ -1,0 +1,62 @@
+package org.jabref.gui.preferences;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.StateManager;
+import org.jabref.gui.actions.SimpleCommand;
+import org.jabref.gui.util.FileDialogConfiguration;
+import org.jabref.logic.preferences.CliPreferences;
+import org.jabref.logic.preferences.ScopedPreferenceImporter;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.metadata.MetaData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScopedPreferencesImportCommand extends SimpleCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScopedPreferencesImportCommand.class);
+    private final DialogService dialogService;
+    private final StateManager stateManager;
+    private final CliPreferences preferences;
+
+    public ScopedPreferencesImportCommand(DialogService dialogService, StateManager stateManager, CliPreferences preferences) {
+        this.dialogService = dialogService;
+        this.stateManager = stateManager;
+        this.preferences = preferences;
+    }
+
+    @Override
+    public void execute() {
+        FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
+                .addExtensionFilter(StandardFileType.JSON)
+                .withDefaultExtension(StandardFileType.JSON)
+                .withInitialDirectory(preferences.getFilePreferences().getWorkingDirectory())
+                .build();
+
+        Optional<Path> importPath = dialogService.showFileOpenDialog(fileDialogConfiguration);
+        if (importPath.isEmpty()) {
+            return;
+        }
+
+        Map<String, MetaData> libraries = new HashMap<>();
+        for (BibDatabaseContext ctx : stateManager.getOpenDatabases()) {
+            String name = ctx.getDatabasePath().map(Path::getFileName).map(Path::toString).orElse("untitled");
+            libraries.put(name, ctx.getMetaData());
+        }
+
+        try {
+            ScopedPreferenceImporter.importFromJson(importPath.get(), preferences, libraries);
+            dialogService.notify("Imported scoped preferences successfully.");
+        } catch (IOException e) {
+            LOGGER.error("Could not import preferences", e);
+            dialogService.showErrorDialogAndWait("Error importing preferences", e);
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/importer/util/ImportResultsMerger.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/ImportResultsMerger.java
@@ -48,7 +48,7 @@ public class ImportResultsMerger {
         }
 
         // set timestamp and owner
-        UpdateField.setAutomaticFields(resultDatabase.getEntries(), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(resultDatabase.getEntries(), ownerPreferences, timestampPreferences, result.getMetaData());
 
         return result;
     }

--- a/jablib/src/main/java/org/jabref/logic/preferences/ScopedPreferenceExporter.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/ScopedPreferenceExporter.java
@@ -1,0 +1,42 @@
+package org.jabref.logic.preferences;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.jabref.model.metadata.MetaData;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+public class ScopedPreferenceExporter {
+
+    public static void exportToJson(Path filePath, CliPreferences globalPrefs, Map<String, MetaData> libraries) throws IOException {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+        JsonObject root = new JsonObject();
+
+        // Global
+        JsonObject globalObj = new JsonObject();
+        globalObj.addProperty("addcreationdate", globalPrefs.getTimestampPreferences().shouldAddCreationDate());
+        root.add("global", globalObj);
+
+        // Libraries
+        JsonObject librariesObj = new JsonObject();
+        for (Map.Entry<String, MetaData> entry : libraries.entrySet()) {
+            JsonObject libObj = new JsonObject();
+            MetaData metaData = entry.getValue();
+
+            boolean addCreationDate = metaData.getAddCreationDate()
+                                              .orElse(globalPrefs.getTimestampPreferences().shouldAddCreationDate());
+
+            libObj.addProperty("addcreationdate", addCreationDate);
+            librariesObj.add(entry.getKey(), libObj);
+        }
+        root.add("libraries", librariesObj);
+
+        Files.writeString(Path.of(filePath + ".json"), gson.toJson(root));
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/preferences/ScopedPreferenceImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/ScopedPreferenceImporter.java
@@ -1,0 +1,42 @@
+package org.jabref.logic.preferences;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.jabref.model.metadata.MetaData;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+public class ScopedPreferenceImporter {
+
+    public static void importFromJson(Path filePath, CliPreferences globalPrefs, Map<String, MetaData> libraries) throws IOException {
+        Gson gson = new Gson();
+        String json = Files.readString(filePath);
+        JsonObject root = gson.fromJson(json, JsonObject.class);
+
+        if (root.has("global")) {
+            JsonObject globalObj = root.getAsJsonObject("global");
+            if (globalObj.has("addcreationdate")) {
+                boolean addCreationDate = globalObj.get("addcreationdate").getAsBoolean();
+                globalPrefs.getTimestampPreferences().setAddCreationDate(addCreationDate);
+            }
+        }
+
+        if (root.has("libraries")) {
+            JsonObject librariesObj = root.getAsJsonObject("libraries");
+            for (Map.Entry<String, MetaData> entry : libraries.entrySet()) {
+                String libName = entry.getKey();
+                if (librariesObj.has(libName)) {
+                    JsonObject libObj = librariesObj.getAsJsonObject(libName);
+                    if (libObj.has("addcreationdate")) {
+                        boolean addCreationDate = libObj.get("addcreationdate").getAsBoolean();
+                        entry.getValue().setAddCreationDate(addCreationDate);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/util/UpdateField.java
+++ b/jablib/src/main/java/org/jabref/logic/util/UpdateField.java
@@ -9,6 +9,7 @@ import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.metadata.MetaData;
 
 public class UpdateField {
 
@@ -77,9 +78,10 @@ public class UpdateField {
 
     /// Sets empty or non-existing owner fields of bibtex entries inside a List to a specified default value. Timestamp
     /// field is also set. Preferences are checked to see if these options are enabled.
-    public static void setAutomaticFields(Collection<BibEntry> entries, OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences) {
+    public static void setAutomaticFields(Collection<BibEntry> entries, OwnerPreferences ownerPreferences, TimestampPreferences timestampPreferences, MetaData metaData) {
         boolean globalSetOwner = ownerPreferences.isUseOwner();
-        boolean setTimeStamp = timestampPreferences.shouldAddCreationDate();
+        boolean setTimeStamp = metaData == null ? timestampPreferences.shouldAddCreationDate()
+                : metaData.getAddCreationDate().orElse(timestampPreferences.shouldAddCreationDate());
 
         // Do not need to do anything if all options are disabled
         if (!(globalSetOwner || setTimeStamp)) {

--- a/jablib/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/jablib/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -53,6 +53,7 @@ public class MetaData {
     public static final String PROTECTED_FLAG_META = "protectedFlag";
     public static final String SELECTOR_META_PREFIX = "selector_";
     public static final String BIBDESK_STATIC_FLAG = "BibDesk Static Groups";
+    public static final String ADD_CREATION_DATE = "addCreationDate";
 
     public static final char ESCAPE_CHARACTER = '\\';
     public static final char SEPARATOR_CHARACTER = ';';
@@ -76,6 +77,7 @@ public class MetaData {
     @Nullable private BibDatabaseMode mode;
     private boolean isProtected;
     @Nullable private String librarySpecificFileDirectory;
+    @Nullable private Boolean addCreationDate;
 
     @NonNull
     private final ContentSelectors contentSelectors = new ContentSelectors();
@@ -96,6 +98,20 @@ public class MetaData {
 
     public void setSaveOrder(SaveOrder saveOrder) {
         this.saveOrder = saveOrder;
+        postChange();
+    }
+
+    public Optional<Boolean> getAddCreationDate() {
+        return Optional.ofNullable(addCreationDate);
+    }
+
+    public void setAddCreationDate(boolean addCreationDate) {
+        this.addCreationDate = addCreationDate;
+        postChange();
+    }
+
+    public void clearAddCreationDate() {
+        this.addCreationDate = null;
         postChange();
     }
 
@@ -378,18 +394,19 @@ public class MetaData {
                 && (mode == that.mode)
                 && Objects.equals(librarySpecificFileDirectory, that.librarySpecificFileDirectory)
                 && Objects.equals(contentSelectors, that.contentSelectors)
+                && Objects.equals(addCreationDate, that.addCreationDate)
                 && Objects.equals(versionDBStructure, that.versionDBStructure);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(isProtected, groupsRoot.getValue(), encoding, encodingExplicitlySupplied, saveOrder, citeKeyPatterns, userFileDirectory,
-                latexFileDirectory, defaultCiteKeyPattern, saveActions, mode, librarySpecificFileDirectory, contentSelectors, versionDBStructure);
+                latexFileDirectory, defaultCiteKeyPattern, saveActions, mode, librarySpecificFileDirectory, contentSelectors, addCreationDate, versionDBStructure);
     }
 
     @Override
     public String toString() {
-        return "MetaData [citeKeyPatterns=" + citeKeyPatterns + ", userFileDirectory=" + userFileDirectory + ", laTexFileDirectory=" + latexFileDirectory + ", groupsRoot=" + groupsRoot + ", encoding=" + encoding + ", saveOrderConfig=" + saveOrder + ", defaultCiteKeyPattern=" + defaultCiteKeyPattern + ", saveActions=" + saveActions + ", mode=" + mode + ", isProtected=" + isProtected + ", librarySpecificFileDirectory=" + librarySpecificFileDirectory + ", contentSelectors=" + contentSelectors + ", encodingExplicitlySupplied=" + encodingExplicitlySupplied + ", VersionDBStructure=" + versionDBStructure + "]";
+        return "MetaData [citeKeyPatterns=" + citeKeyPatterns + ", userFileDirectory=" + userFileDirectory + ", laTexFileDirectory=" + latexFileDirectory + ", groupsRoot=" + groupsRoot + ", encoding=" + encoding + ", saveOrderConfig=" + saveOrder + ", defaultCiteKeyPattern=" + defaultCiteKeyPattern + ", saveActions=" + saveActions + ", mode=" + mode + ", isProtected=" + isProtected + ", librarySpecificFileDirectory=" + librarySpecificFileDirectory + ", contentSelectors=" + contentSelectors + ", addCreationDate=" + addCreationDate + ", encodingExplicitlySupplied=" + encodingExplicitlySupplied + ", VersionDBStructure=" + versionDBStructure + "]";
     }
 
     public Optional<Path> getBlgFilePath(String user) {

--- a/jablib/src/test/java/org/jabref/logic/util/UpdateFieldTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/UpdateFieldTest.java
@@ -180,7 +180,7 @@ class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences, null);
 
         assertEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER), "No owner exists");
     }
@@ -189,7 +189,7 @@ class UpdateFieldTest {
     void ownerAssignedCorrectlyAfterAutomaticSet() {
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences, null);
 
         assertEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER));
     }
@@ -203,7 +203,7 @@ class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, false);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences, null);
 
         assertNotEquals(Optional.of("testDefaultOwner"), entry.getField(StandardField.OWNER), "Owner has changed");
         assertEquals(Optional.of(alreadySetOwner), entry.getField(StandardField.OWNER), "Owner has not changed");
@@ -215,7 +215,7 @@ class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences, null);
 
         String creationDate = timestampPreferences.now();
 
@@ -226,7 +226,7 @@ class UpdateFieldTest {
     void creationDateAssignedCorrectlyAfterAutomaticSet() {
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(List.of(entry), ownerPreferences, timestampPreferences, null);
 
         String creationDate = timestampPreferences.now();
 
@@ -246,7 +246,7 @@ class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, true);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences, null);
 
         String defaultOwner = "testDefaultOwner";
 
@@ -270,7 +270,7 @@ class UpdateFieldTest {
 
         OwnerPreferences ownerPreferences = createOwnerPreference(true, false);
         TimestampPreferences timestampPreferences = createTimestampPreference();
-        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences);
+        UpdateField.setAutomaticFields(bibs, ownerPreferences, timestampPreferences, null);
 
         assertEquals(Optional.of(initialOwner), entry.getField(StandardField.OWNER), "entry has new value for owner field");
         assertEquals(Optional.of(initialOwner), entry2.getField(StandardField.OWNER), "entry2 has new value for owner field");


### PR DESCRIPTION

### PR Description

Added a basic implementation for the json based global and library specific preferences. Through this we can modify the addCreationDate preference. 

This is a basic implementation only.

### Steps to test

- Open some libraries
- Select file -> scoped preferences json -> export json
- Modify the json so library wise to set the addCreationDate preference to be false or true
- Then import this json using  file -> scoped preferences json -> import json
- Now the libraries you have set the preference to true will addCreationDate others will not.

### Reference Video

[Screencast_20260320_160233.webm](https://github.com/user-attachments/assets/81fe9e13-08ad-474a-8b62-fd68459d9d18)


### Improvements

I have not added the feature to modify the preferences in json file using jabref ui. We can add zed like settings (seperate for the global (user in the photo) and library (chat-app which is a workspace in the photo)):
<img width="958" height="639" alt="Screenshot_20260320_161654" src="https://github.com/user-attachments/assets/cc7ee34c-30e6-4a53-b9a5-fe0854fb966c" />
