### PR TITLE
Fix side pane width not remembered after restart (#8907)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where the side pane (Groups/Web search) width was not remembered after restarting JabRef. [#8907](https://github.com/JabRef/jabref/issues/8907)
 - We fixed vertical cursor movement shortcuts (Command+Up/Down for document start/end, Option+Up/Down for paragraph start/end) not working correctly in the BibTeX source editor on macOS. [#5937](https://github.com/JabRef/jabref/issues/5937)
 - We fixed text cursor movement shortcuts (Command+Left/Right for line start/end, Option+Left/Right for word navigation) not working correctly in the BibTeX source editor on macOS. [#5937](https://github.com/JabRef/jabref/issues/5937)
 - We fixed PDF import to prefer the content extracted title over filename like XMP metadata titles. [#11999](https://github.com/JabRef/jabref/issues/11999)

--- a/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
+++ b/jabgui/src/main/java/org/jabref/gui/frame/JabRefFrame.java
@@ -306,8 +306,7 @@ public class JabRefFrame extends BorderPane implements LibraryTabContainer, UiMe
 
     public void updateHorizontalDividerPosition() {
         if (mainStage.isShowing() && !sidePane.getChildren().isEmpty()) {
-            horizontalSplit.setDividerPositions(preferences.getGuiPreferences()
-                                                           .getHorizontalDividerPosition() / horizontalSplit.getWidth());
+            horizontalSplit.setDividerPositions(preferences.getGuiPreferences().getHorizontalDividerPosition());
             horizontalDividerSubscription = EasyBind.valueAt(horizontalSplit.getDividers(), 0)
                                                     .mapObservable(SplitPane.Divider::positionProperty)
                                                     .listenToValues((_, newValue) ->


### PR DESCRIPTION
### Related issues and pull requests

Closes #8907

### PR Description

Fixed the side pane (Groups/Web search) width not being restored after restarting JabRef. The horizontal divider position was being saved as a normalized 0-1 value from JavaFX's `Divider.positionProperty`, but on restore it was incorrectly divided by the split pane's pixel width, causing it to collapse to near-zero on every startup. Removed the erroneous division so the horizontal divider is now restored the same way the vertical divider already is - using the normalized position directly.

## Before

https://github.com/user-attachments/assets/9890dd84-b565-498f-b9b1-479ce17a1fae

## After

https://github.com/user-attachments/assets/43830d90-2f4c-44c7-a383-82cff65e6880

On restarting Jabref:

https://github.com/user-attachments/assets/e00ffca7-d413-4434-9028-742c18b7a31f


### Steps to test

1. Open JabRef and ensure the Groups or Web Search side pane is visible (toggle via the View menu if needed).
2. Drag the divider between the side pane and the main entry table to resize it . make it noticeably wider or narrower than the default (Or click the up/down arrows as shown in the screenshot).
3. Close JabRef completely.
4. Reopen JabRef.
5. Verify the side pane width is restored to where you left it in step 2.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
