### PR TITLE
Persist file notifications

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/DialogService.java
+++ b/jabgui/src/main/java/org/jabref/gui/DialogService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
 import javafx.print.PrinterJob;
 import javafx.scene.control.Alert;
@@ -263,6 +264,8 @@ public interface DialogService extends NotificationService {
     Optional<Path> showFileOpenFromArchiveDialog(Path archivePath) throws IOException;
 
     List<NotificationGroup<?, ? extends Notification<?>>> getNotificationGroups();
+
+    ObservableList<? extends Notification<?>> getPersistentNotifications();
 
     /// Notify the user in a non-blocking way (e.g. a toast).
     ///

--- a/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefDialogService.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import javafx.application.Platform;
+import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
 import javafx.print.PrinterJob;
 import javafx.scene.Group;
@@ -83,12 +84,15 @@ public class JabRefDialogService implements DialogService {
     private final NotificationGroup<Object, Notifications.UiNotification> uiNotifications = new NotificationGroup<>(Localization.lang("Preview"));
     private final NotificationGroup<Task<?>, Notifications.TaskNotification> taskNotifications = new NotificationGroup<>(Localization.lang("Tasks"));
 
+    private final ObservableList<Notification<?>> persistentNotifications;
+
     private final Window mainWindow;
 
     public JabRefDialogService(Window mainWindow) {
         this.mainWindow = mainWindow;
 
         taskNotifications.setViewFactory(Notifications.TaskNotificationView::new);
+        persistentNotifications = EasyBind.concat(fileNotifications.getNotifications());
     }
 
     private FXDialog createDialog(AlertType type, String title, String content) {
@@ -560,5 +564,9 @@ public class JabRefDialogService implements DialogService {
 
     public List<NotificationGroup<?, ? extends Notification<?>>> getNotificationGroups() {
         return List.of(undefinedNotifications, fileNotifications, uiNotifications, taskNotifications);
+    }
+
+    public ObservableList<? extends Notification<?>> getPersistentNotifications() {
+        return persistentNotifications;
     }
 }

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGUI.java
@@ -9,6 +9,7 @@ import javax.swing.undo.UndoManager;
 
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.concurrent.Task;
 import javafx.geometry.Rectangle2D;
@@ -322,6 +323,7 @@ public class JabRefGUI extends Application {
         Injector.setModelOrService(InfoCenterPane.class, powerpane.getInfoCenterPane());
         powerpane.setContent(JabRefGUI.mainFrame);
         powerpane.getInfoCenterPane().setInfoCenterViewPos(InfoCenterViewPos.BOTTOM_RIGHT);
+        powerpane.getInfoCenterPane().autoHideProperty().bind(Bindings.isEmpty(dialogService.getPersistentNotifications()));
 
         Scene scene = new Scene(powerpane);
 


### PR DESCRIPTION
### Related issues and pull requests

Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/1269

### PR Description

Easily extendeble by adding more to-keep-persistent lists in JabRefDialogService constructor.

### Steps to test

Open file in JabRef
Do external changes
See file notification until manually closed or hidden

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
