### PR TITLE
Feature/11368 linked filename patterns tabular UI

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
@@ -107,6 +107,10 @@ public class CitationKeyPatternsPanel extends TableView<CitationKeyPatternsPanel
         return viewModel.defaultKeyPatternProperty();
     }
 
+    public void setDefaultPattern(String defaultPattern) {
+        viewModel.setDefaultPattern(defaultPattern);
+    }
+
     private void jumpToSearchKey(KeyEvent keypressed) {
         if (keypressed.getCharacter() == null) {
             return;

--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanelViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanelViewModel.java
@@ -37,6 +37,7 @@ public class CitationKeyPatternsPanelViewModel {
 
     private final ListProperty<CitationKeyPatternsPanelItemModel> patternListProperty = new SimpleListProperty<>();
     private final ObjectProperty<CitationKeyPatternsPanelItemModel> defaultItemProperty = new SimpleObjectProperty<>();
+    private final ObjectProperty<String> defaultPatternProperty = new SimpleObjectProperty<>();
 
     private final CitationKeyPatternPreferences keyPatternPreferences;
 
@@ -70,12 +71,24 @@ public class CitationKeyPatternsPanelViewModel {
     }
 
     public void setItemToDefaultPattern(CitationKeyPatternsPanelItemModel item) {
-        item.setPattern(keyPatternPreferences.getDefaultPattern());
+        item.setPattern(getDefaultPattern());
     }
 
     public void resetAll() {
         patternListProperty.forEach(item -> item.setPattern(""));
-        defaultItemProperty.getValue().setPattern(keyPatternPreferences.getDefaultPattern());
+        defaultItemProperty.getValue().setPattern(getDefaultPattern());
+    }
+
+    public void setDefaultPattern(String defaultPattern) {
+        defaultPatternProperty.set(defaultPattern);
+    }
+
+    private String getDefaultPattern() {
+        if (defaultPatternProperty.get() != null) {
+            return defaultPatternProperty.get();
+        }
+
+        return keyPatternPreferences.getDefaultPattern();
     }
 
     public ListProperty<CitationKeyPatternsPanelItemModel> patternListProperty() {

--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanelViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanelViewModel.java
@@ -78,7 +78,7 @@ public class CitationKeyPatternsPanelViewModel {
         patternListProperty.forEach(item -> item.setPattern(""));
         defaultItemProperty.getValue().setPattern(getDefaultPattern());
     }
-
+    // Update the default pattern in the table when a user changes it in the text field.
     public void setDefaultPattern(String defaultPattern) {
         defaultPatternProperty.set(defaultPattern);
     }

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
@@ -43,7 +43,6 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
     @FXML private CheckBox fulltextIndex;
     @FXML private CheckBox autoRenameFilesOnChange;
 
-    @FXML private ComboBox<String> fileNamePattern;
     @FXML private CitationKeyPatternsPanel fileNamePatternTable;
     @FXML private TextField fileDirectoryPattern;
     @FXML private CheckBox confirmLinkedFileDelete;
@@ -84,8 +83,6 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
         autolinkRegexKey.disableProperty().bind(autolinkUseRegex.selectedProperty().not());
         fulltextIndex.selectedProperty().bindBidirectional(viewModel.fulltextIndexProperty());
         autoRenameFilesOnChange.selectedProperty().bindBidirectional(viewModel.autoRenameFilesOnChangeProperty());
-        fileNamePattern.valueProperty().bindBidirectional(viewModel.fileNamePatternProperty());
-        fileNamePattern.itemsProperty().bind(viewModel.defaultFileNamePatternsProperty());
         fileNamePatternTable.patternListProperty().bindBidirectional(viewModel.patternListProperty());
         fileNamePatternTable.defaultKeyPatternProperty().bindBidirectional(viewModel.defaultKeyPatternProperty());
         fileDirectoryPattern.textProperty().bindBidirectional(viewModel.fileDirectoryPatternProperty());

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.java
@@ -15,12 +15,16 @@ import org.jabref.gui.help.HelpAction;
 import org.jabref.gui.preferences.AbstractPreferenceTabView;
 import org.jabref.gui.preferences.PreferencesTab;
 import org.jabref.gui.util.IconValidationDecorator;
+import org.jabref.gui.commonfxcontrols.CitationKeyPatternsPanel;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.entry.BibEntryTypesManager;
 
+import com.airhacks.afterburner.injection.Injector;
 import com.airhacks.afterburner.views.ViewLoader;
 import com.tobiasdiez.easybind.EasyBind;
 import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
+
 
 public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabViewModel> implements PreferencesTab {
 
@@ -40,6 +44,7 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
     @FXML private CheckBox autoRenameFilesOnChange;
 
     @FXML private ComboBox<String> fileNamePattern;
+    @FXML private CitationKeyPatternsPanel fileNamePatternTable;
     @FXML private TextField fileDirectoryPattern;
     @FXML private CheckBox confirmLinkedFileDelete;
     @FXML private CheckBox moveToTrash;
@@ -81,6 +86,8 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
         autoRenameFilesOnChange.selectedProperty().bindBidirectional(viewModel.autoRenameFilesOnChangeProperty());
         fileNamePattern.valueProperty().bindBidirectional(viewModel.fileNamePatternProperty());
         fileNamePattern.itemsProperty().bind(viewModel.defaultFileNamePatternsProperty());
+        fileNamePatternTable.patternListProperty().bindBidirectional(viewModel.patternListProperty());
+        fileNamePatternTable.defaultKeyPatternProperty().bindBidirectional(viewModel.defaultKeyPatternProperty());
         fileDirectoryPattern.textProperty().bindBidirectional(viewModel.fileDirectoryPatternProperty());
         confirmLinkedFileDelete.selectedProperty().bindBidirectional(viewModel.confirmLinkedFileDeleteProperty());
         openFileExplorerInFilesDirectory.selectedProperty().bindBidirectional(viewModel.openFileExplorerInFilesDirectoryProperty());
@@ -100,6 +107,23 @@ public class LinkedFilesTab extends AbstractPreferenceTabView<LinkedFilesTabView
         validationVisualizer.setDecoration(new IconValidationDecorator());
         Platform.runLater(() -> validationVisualizer.initVisualization(viewModel.mainFileDirValidationStatus(), mainFileDirectory));
     }
+
+    @Override
+    public void setValues() {
+        super.setValues();
+
+        BibEntryTypesManager entryTypesManager = Injector.instantiateModelOrService(BibEntryTypesManager.class);
+        fileNamePatternTable.setDefaultPattern(viewModel.getDefaultFileNamePattern());
+        fileNamePatternTable.setValues(
+                entryTypesManager.getAllTypes(preferences.getLibraryPreferences().getDefaultBibDatabaseMode()),
+                viewModel.getFileNamePatterns());
+    }
+
+    @FXML
+    public void resetAllFileNamePatterns() {
+        fileNamePatternTable.resetAll();
+    }
+
 
     public void mainFileDirBrowse() {
         viewModel.mainFileDirBrowse();

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -8,9 +8,9 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -4,21 +4,28 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 
+import org.jabref.gui.commonfxcontrols.CitationKeyPatternsPanelItemModel;
+import org.jabref.gui.commonfxcontrols.CitationKeyPatternsPanelViewModel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
 import org.jabref.gui.util.DirectoryDialogConfiguration;
+import org.jabref.logic.externalfiles.GlobalLinkedFilePatterns;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.logic.FilePreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.AutoLinkPreferences;
+import org.jabref.logic.util.strings.StringUtil;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
@@ -40,6 +47,9 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty autoRenameFilesOnChangeProperty = new SimpleBooleanProperty();
     private final StringProperty fileNamePatternProperty = new SimpleStringProperty();
     private final StringProperty fileDirectoryPatternProperty = new SimpleStringProperty();
+    private final ListProperty<CitationKeyPatternsPanelItemModel> patternListProperty = new SimpleListProperty<>(FXCollections.observableArrayList());
+    private final ObjectProperty<CitationKeyPatternsPanelItemModel> defaultKeyPatternProperty = new SimpleObjectProperty<>(
+            new CitationKeyPatternsPanelItemModel(new CitationKeyPatternsPanelViewModel.DefaultEntryType(), ""));
     private final BooleanProperty confirmLinkedFileDeleteProperty = new SimpleBooleanProperty();
     private final BooleanProperty moveToTrashProperty = new SimpleBooleanProperty();
 
@@ -114,11 +124,31 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
 
     @Override
     public void storeSettings() {
+
+        GlobalLinkedFilePatterns newPatterns = new GlobalLinkedFilePatterns(filePreferences.getFileNamePatterns().getDefaultValue());
+        patternListProperty.forEach(item -> {
+            if (!CitationKeyPatternsPanelViewModel.ENTRY_TYPE_DEFAULT_NAME.equals(item.getEntryType().getName())
+                    && StringUtil.isNotBlank(item.getPattern())) {
+                newPatterns.addCitationKeyPattern(item.getEntryType(), item.getPattern());
+            }
+        });
+
+        String defaultPattern = defaultKeyPatternProperty.getValue().getPattern();
+        if (StringUtil.isBlank(defaultPattern)) {
+            defaultPattern = fileNamePatternProperty.getValue();
+        }
+        if (StringUtil.isBlank(defaultPattern)) {
+            defaultPattern = filePreferences.getLinkedFilePatternPreferences().getDefaultPattern();
+        }
+        newPatterns.setDefaultValue(defaultPattern);
+
         // External files preferences / Attached files preferences / File preferences
         filePreferences.setMainFileDirectory(mainFileDirectoryProperty.getValue());
         filePreferences.setStoreFilesRelativeToBibFile(useBibLocationAsPrimaryProperty.getValue());
         filePreferences.setAutoRenameFilesOnChange(autoRenameFilesOnChangeProperty.getValue());
         filePreferences.setFileNamePattern(fileNamePatternProperty.getValue());
+        filePreferences.setFileNamePattern(defaultPattern);
+        filePreferences.setFileNamePatterns(newPatterns);
         filePreferences.setFileDirectoryPattern(fileDirectoryPatternProperty.getValue());
         filePreferences.setFulltextIndexLinkedFiles(fulltextIndex.getValue());
         filePreferences.setOpenFileExplorerInFileDirectory(openFileExplorerInFilesDirectory.getValue());
@@ -202,6 +232,22 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
 
     public StringProperty fileNamePatternProperty() {
         return fileNamePatternProperty;
+    }
+
+    public ListProperty<CitationKeyPatternsPanelItemModel> patternListProperty() {
+        return patternListProperty;
+    }
+
+    public ObjectProperty<CitationKeyPatternsPanelItemModel> defaultKeyPatternProperty() {
+        return defaultKeyPatternProperty;
+    }
+
+    public GlobalLinkedFilePatterns getFileNamePatterns() {
+        return filePreferences.getFileNamePatterns();
+    }
+
+    public String getDefaultFileNamePattern() {
+        return filePreferences.getLinkedFilePatternPreferences().getDefaultPattern();
     }
 
     public StringProperty fileDirectoryPatternProperty() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/linkedfiles/LinkedFilesTabViewModel.java
@@ -25,7 +25,6 @@ import org.jabref.logic.FilePreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.util.io.AutoLinkPreferences;
-import org.jabref.logic.util.strings.StringUtil;
 
 import de.saxsys.mvvmfx.utils.validation.FunctionBasedValidator;
 import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
@@ -47,6 +46,7 @@ public class LinkedFilesTabViewModel implements PreferenceTabViewModel {
     private final BooleanProperty autoRenameFilesOnChangeProperty = new SimpleBooleanProperty();
     private final StringProperty fileNamePatternProperty = new SimpleStringProperty();
     private final StringProperty fileDirectoryPatternProperty = new SimpleStringProperty();
+    // New table model state for file name patterns.
     private final ListProperty<CitationKeyPatternsPanelItemModel> patternListProperty = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<CitationKeyPatternsPanelItemModel> defaultKeyPatternProperty = new SimpleObjectProperty<>(
             new CitationKeyPatternsPanelItemModel(new CitationKeyPatternsPanelViewModel.DefaultEntryType(), ""));

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -8,12 +8,17 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.ToggleGroup?>
 <?import javafx.scene.control.Tooltip?>
+
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import org.jabref.gui.icon.JabRefIconView?>
+<?import org.jabref.gui.commonfxcontrols.CitationKeyPatternsPanel?>
+
+
 <fx:root spacing="10.0" type="VBox"
          xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml"
          fx:controller="org.jabref.gui.preferences.linkedfiles.LinkedFilesTab">
@@ -83,6 +88,15 @@
         <TextField fx:id="fileDirectoryPattern" GridPane.columnIndex="1" GridPane.rowIndex="1"
                    prefWidth="300" minWidth="300" maxWidth="300"/>
     </GridPane>
+
+    <Label text="%Filename format pattern"/>
+    <Label text="%( Note: Press return to commit changes in the table! )"/>
+    <AnchorPane>
+        <CitationKeyPatternsPanel fx:id="fileNamePatternTable"
+                                  AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" prefHeight="180.0"/>
+        <Button text="%Reset All" onAction="#resetAllFileNamePatterns"
+                AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+    </AnchorPane>
 
     <Label styleClass="sectionHeader" text="%Attached files"/>
     <CheckBox fx:id="confirmLinkedFileDelete" text="%Show confirmation dialog when deleting attached files"/>

--- a/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/preferences/linkedfiles/LinkedFilesTab.fxml
@@ -71,23 +71,6 @@
 
     <Label styleClass="sectionHeader" text="%Linked file name conventions"/>
     <CheckBox fx:id="autoRenameFilesOnChange" text="%Auto rename files if entry changes"/>
-    <GridPane hgap="4.0" vgap="4.0">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" percentWidth="30.0"/>
-            <ColumnConstraints hgrow="SOMETIMES"/>
-        </columnConstraints>
-        <rowConstraints>
-            <RowConstraints vgrow="SOMETIMES"/>
-            <RowConstraints vgrow="SOMETIMES"/>
-        </rowConstraints>
-        <Label text="%Filename format pattern"/>
-        <ComboBox fx:id="fileNamePattern" promptText="%Choose pattern" GridPane.columnIndex="1" editable="true"
-                  prefWidth="300" minWidth="300" maxWidth="300"/>
-
-        <Label text="%File directory pattern" GridPane.rowIndex="1"/>
-        <TextField fx:id="fileDirectoryPattern" GridPane.columnIndex="1" GridPane.rowIndex="1"
-                   prefWidth="300" minWidth="300" maxWidth="300"/>
-    </GridPane>
 
     <Label text="%Filename format pattern"/>
     <Label text="%( Note: Press return to commit changes in the table! )"/>
@@ -97,6 +80,20 @@
         <Button text="%Reset All" onAction="#resetAllFileNamePatterns"
                 AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
     </AnchorPane>
+
+    <GridPane hgap="4.0" vgap="4.0">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" percentWidth="30.0"/>
+            <ColumnConstraints hgrow="SOMETIMES"/>
+        </columnConstraints>
+        <rowConstraints>
+            <RowConstraints vgrow="SOMETIMES"/>
+            <RowConstraints vgrow="SOMETIMES"/>
+        </rowConstraints>
+        <Label text="%File directory pattern" GridPane.rowIndex="1"/>
+        <TextField fx:id="fileDirectoryPattern" GridPane.columnIndex="1" GridPane.rowIndex="1"
+                   prefWidth="300" minWidth="300" maxWidth="300"/>
+    </GridPane>
 
     <Label styleClass="sectionHeader" text="%Attached files"/>
     <CheckBox fx:id="confirmLinkedFileDelete" text="%Show confirmation dialog when deleting attached files"/>

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.jabref.logic.citationkeypattern.CitationKeyGenerator.DEFAULT_UNWANTED_CHARACTERS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,6 +62,7 @@ class AutoRenameFileOnEntryChangeTest {
         when(guiPreferences.getFilePreferences()).thenReturn(filePreferences);
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
         when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
+        when(filePreferences.getFileNamePatternForEntryType(any())).thenReturn("[bibtexkey]");
 
         entry = new BibEntry(StandardEntryType.Article).withCitationKey("oldKey2081")
                                                        .withField(StandardField.AUTHOR, "oldKey")
@@ -102,6 +104,7 @@ class AutoRenameFileOnEntryChangeTest {
         Files.createFile(tempDir.resolve("oldKey2081.pdf"));
         entry.setFiles(List.of(new LinkedFile("", "oldKey2081.pdf", "PDF")));
         when(filePreferences.getFileNamePattern()).thenReturn("");
+        when(filePreferences.getFileNamePatternForEntryType(any())).thenReturn("");
         when(filePreferences.shouldAutoRenameFilesOnChange()).thenReturn(true);
         entry.setField(StandardField.AUTHOR, "newKey");
 

--- a/jabgui/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
@@ -58,6 +58,7 @@ class DownloadLinkedFileActionTest {
         when(preferences.getExternalApplicationsPreferences()).thenReturn(externalApplicationsPreferences);
         when(preferences.getFilePreferences()).thenReturn(filePreferences);
         when(preferences.getXmpPreferences()).thenReturn(mock(XmpPreferences.class));
+        when(filePreferences.getFileNamePatternForEntryType(any())).thenReturn("[citationkey]");
         Path tempFile = tempFolder.resolve("temporaryFile");
         Files.createFile(tempFile);
 

--- a/jablib/src/main/java/org/jabref/logic/FilePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/FilePreferences.java
@@ -10,7 +10,10 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
+import org.jabref.logic.externalfiles.GlobalLinkedFilePatterns;
+import org.jabref.logic.externalfiles.LinkedFilePatternPreferences;
 import org.jabref.logic.util.strings.StringUtil;
+import org.jabref.model.entry.types.EntryType;
 
 /// Preferences for the linked files
 public class FilePreferences {
@@ -25,6 +28,7 @@ public class FilePreferences {
     private final StringProperty fileDirectoryPattern = new SimpleStringProperty();
     private final BooleanProperty downloadLinkedFiles = new SimpleBooleanProperty();
     private final BooleanProperty fulltextIndexLinkedFiles = new SimpleBooleanProperty();
+    private final LinkedFilePatternPreferences linkedFilePatternPreferences;
     private final ObjectProperty<Path> workingDirectory = new SimpleObjectProperty<>();
     private final BooleanProperty createBackup = new SimpleBooleanProperty();
     private final ObjectProperty<Path> backupDirectory = new SimpleObjectProperty<>();
@@ -45,6 +49,7 @@ public class FilePreferences {
                            boolean storeFilesRelativeToBibFile,
                            boolean autoRenameFilesOnChange,
                            String fileNamePattern,
+                           LinkedFilePatternPreferences linkedFilePatternPreferences,
                            String fileDirectoryPattern,
                            boolean downloadLinkedFiles,
                            boolean fulltextIndexLinkedFiles,
@@ -65,6 +70,7 @@ public class FilePreferences {
         this.storeFilesRelativeToBibFile.setValue(storeFilesRelativeToBibFile);
         this.autoRenameFilesOnChange.setValue(autoRenameFilesOnChange);
         this.fileNamePattern.setValue(fileNamePattern);
+        this.linkedFilePatternPreferences = linkedFilePatternPreferences;
         this.fileDirectoryPattern.setValue(fileDirectoryPattern);
         this.downloadLinkedFiles.setValue(downloadLinkedFiles);
         this.fulltextIndexLinkedFiles.setValue(fulltextIndexLinkedFiles);
@@ -140,6 +146,36 @@ public class FilePreferences {
 
     public void setFileNamePattern(String fileNamePattern) {
         this.fileNamePattern.set(fileNamePattern);
+    }
+    
+    public GlobalLinkedFilePatterns getFileNamePatterns() {
+        return linkedFilePatternPreferences.getKeyPatterns();
+    }
+
+    public ObjectProperty<GlobalLinkedFilePatterns> fileNamePatternsProperty() {
+        return linkedFilePatternPreferences.keyPatternsProperty();
+    }
+
+    public void setFileNamePatterns(GlobalLinkedFilePatterns fileNamePatterns) {
+        linkedFilePatternPreferences.setKeyPatterns(fileNamePatterns);
+    }
+
+    public LinkedFilePatternPreferences getLinkedFilePatternPreferences() {
+        return linkedFilePatternPreferences;
+    }
+
+    public String getFileNamePatternForEntryType(EntryType entryType) {
+        GlobalLinkedFilePatterns fileNamePatterns = getFileNamePatterns();
+        if ((fileNamePatterns == null) || (fileNamePatterns.getValue(entryType) == null)) {
+            return getFileNamePattern();
+        }
+
+        String pattern = fileNamePatterns.getValue(entryType).stringRepresentation();
+        if (StringUtil.isBlank(pattern)) {
+            return getFileNamePattern();
+        }
+
+        return pattern;
     }
 
     public String getFileDirectoryPattern() {

--- a/jablib/src/main/java/org/jabref/logic/FilePreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/FilePreferences.java
@@ -28,6 +28,7 @@ public class FilePreferences {
     private final StringProperty fileDirectoryPattern = new SimpleStringProperty();
     private final BooleanProperty downloadLinkedFiles = new SimpleBooleanProperty();
     private final BooleanProperty fulltextIndexLinkedFiles = new SimpleBooleanProperty();
+    // The linked file pattern preferences used to store the global file name patterns
     private final LinkedFilePatternPreferences linkedFilePatternPreferences;
     private final ObjectProperty<Path> workingDirectory = new SimpleObjectProperty<>();
     private final BooleanProperty createBackup = new SimpleBooleanProperty();
@@ -135,7 +136,7 @@ public class FilePreferences {
     public void setAutoRenameFilesOnChange(boolean autoRenameFilesOnChange) {
         this.autoRenameFilesOnChange.set(autoRenameFilesOnChange);
     }
-
+    // Start region - Methods for handling file name patterns
     public String getFileNamePattern() {
         return fileNamePattern.get();
     }
@@ -165,11 +166,12 @@ public class FilePreferences {
     }
 
     public String getFileNamePatternForEntryType(EntryType entryType) {
+        // First check the entry-table patterns
         GlobalLinkedFilePatterns fileNamePatterns = getFileNamePatterns();
         if ((fileNamePatterns == null) || (fileNamePatterns.getValue(entryType) == null)) {
             return getFileNamePattern();
         }
-
+        // Fall back to the default if no pattern exist for the entry type
         String pattern = fileNamePatterns.getValue(entryType).stringRepresentation();
         if (StringUtil.isBlank(pattern)) {
             return getFileNamePattern();
@@ -177,6 +179,7 @@ public class FilePreferences {
 
         return pattern;
     }
+    // end region
 
     public String getFileDirectoryPattern() {
         return fileDirectoryPattern.get();

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/GlobalLinkedFilePatterns.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/GlobalLinkedFilePatterns.java
@@ -4,6 +4,7 @@ import org.jabref.logic.citationkeypattern.AbstractCitationKeyPatterns;
 import org.jabref.logic.citationkeypattern.CitationKeyPattern;
 import org.jabref.model.entry.types.EntryType;
 
+// Linked file pattern container class, re-use the same structure as the citation key patterns.  
 public class GlobalLinkedFilePatterns extends AbstractCitationKeyPatterns {
 
     public GlobalLinkedFilePatterns(CitationKeyPattern defaultPattern) {

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/GlobalLinkedFilePatterns.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/GlobalLinkedFilePatterns.java
@@ -1,0 +1,21 @@
+package org.jabref.logic.externalfiles;
+
+import org.jabref.logic.citationkeypattern.AbstractCitationKeyPatterns;
+import org.jabref.logic.citationkeypattern.CitationKeyPattern;
+import org.jabref.model.entry.types.EntryType;
+
+public class GlobalLinkedFilePatterns extends AbstractCitationKeyPatterns {
+
+    public GlobalLinkedFilePatterns(CitationKeyPattern defaultPattern) {
+        this.defaultPattern = defaultPattern;
+    }
+
+    public static GlobalLinkedFilePatterns fromPattern(String pattern) {
+        return new GlobalLinkedFilePatterns(new CitationKeyPattern(pattern));
+    }
+
+    @Override
+    public CitationKeyPattern getLastLevelCitationKeyPattern(EntryType entryType) {
+        return defaultPattern;
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFileHandler.java
@@ -241,7 +241,7 @@ public class LinkedFileHandler {
     /// @return the suggested filename, including extension
     public String getSuggestedFileName() {
         String filename = linkedFile.getFileName().orElse("file");
-        final String targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePattern())
+        final String targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePatternForEntryType(entry.getType()))
                                               .orElse(FileUtil.getBaseName(filename));
 
         return FileUtil.getValidFileName(FileUtil.getFileExtension(filename).map(ext -> targetFileName + "." + ext).orElse(targetFileName));
@@ -255,7 +255,7 @@ public class LinkedFileHandler {
     public String getSuggestedFileName(@NonNull String extension) {
         assert !StringUtil.isBlank(extension);
         String filename = linkedFile.getFileName().orElse("file");
-        final String targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePattern())
+        final String targetFileName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, filePreferences.getFileNamePatternForEntryType(entry.getType()))
                                               .orElse(FileUtil.getBaseName(filename));
 
         return FileUtil.getValidFileName(targetFileName + "." + extension);

--- a/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFilePatternPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/externalfiles/LinkedFilePatternPreferences.java
@@ -1,0 +1,38 @@
+package org.jabref.logic.externalfiles;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+
+/**
+ * Stores user preferences related to linked file patterns.
+ *
+ * This class wraps the global linked file patterns and a default pattern.
+ * It uses a JavaFX ObjectProperty to allow binding and observation in the UI layer.
+ */
+
+public class LinkedFilePatternPreferences {
+
+    private final ObjectProperty<GlobalLinkedFilePatterns> keyPatterns = new SimpleObjectProperty<>();
+    private final String defaultPattern;
+
+    public LinkedFilePatternPreferences(GlobalLinkedFilePatterns keyPatterns, String defaultPattern) {
+        this.keyPatterns.setValue(keyPatterns);
+        this.defaultPattern = defaultPattern;
+    }
+
+    public GlobalLinkedFilePatterns getKeyPatterns() {
+        return keyPatterns.get();
+    }
+
+    public ObjectProperty<GlobalLinkedFilePatterns> keyPatternsProperty() {
+        return keyPatterns;
+    }
+
+    public void setKeyPatterns(GlobalLinkedFilePatterns keyPatterns) {
+        this.keyPatterns.set(keyPatterns);
+    }
+
+    public String getDefaultPattern() {
+        return defaultPattern;
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -482,7 +482,6 @@ public class JabRefCliPreferences implements CliPreferences {
     private LastFilesOpenedPreferences lastFilesOpenedPreferences;
     private PushToApplicationPreferences pushToApplicationPreferences;
     private GitPreferences gitPreferences;
-    private LinkedFilePatternPreferences LinkedFilePatternPreferences;
 
     /// @implNote The constructor was made public because dependency injection via constructor
     /// required widespread refactoring, currently we are using reflection in some formatters
@@ -1670,6 +1669,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 getBoolean(STORE_RELATIVE_TO_BIB),
                 getBoolean(AUTO_RENAME_FILES_ON_CHANGE),
                 get(IMPORT_FILENAMEPATTERN),
+                // Set the global pattern as the default in case no specific pattern is set for an entry type.
                 new LinkedFilePatternPreferences(getGlobalLinkedFileNamePattern(), (String) defaults.get(IMPORT_FILENAMEPATTERN)),
                 get(IMPORT_FILEDIRPATTERN),
                 getBoolean(DOWNLOAD_LINKED_FILES),

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -482,6 +482,7 @@ public class JabRefCliPreferences implements CliPreferences {
     private LastFilesOpenedPreferences lastFilesOpenedPreferences;
     private PushToApplicationPreferences pushToApplicationPreferences;
     private GitPreferences gitPreferences;
+    private LinkedFilePatternPreferences LinkedFilePatternPreferences;
 
     /// @implNote The constructor was made public because dependency injection via constructor
     /// required widespread refactoring, currently we are using reflection in some formatters
@@ -1669,6 +1670,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 getBoolean(STORE_RELATIVE_TO_BIB),
                 getBoolean(AUTO_RENAME_FILES_ON_CHANGE),
                 get(IMPORT_FILENAMEPATTERN),
+                new LinkedFilePatternPreferences(getGlobalLinkedFileNamePattern(), (String) defaults.get(IMPORT_FILENAMEPATTERN)),
                 get(IMPORT_FILEDIRPATTERN),
                 getBoolean(DOWNLOAD_LINKED_FILES),
                 getBoolean(FULLTEXT_INDEX_LINKED_FILES),
@@ -1692,6 +1694,7 @@ public class JabRefCliPreferences implements CliPreferences {
         EasyBind.listen(filePreferences.storeFilesRelativeToBibFileProperty(), (_, _, newValue) -> putBoolean(STORE_RELATIVE_TO_BIB, newValue));
         EasyBind.listen(filePreferences.autoRenameFilesOnChangeProperty(), (_, _, newValue) -> putBoolean(AUTO_RENAME_FILES_ON_CHANGE, newValue));
         EasyBind.listen(filePreferences.fileNamePatternProperty(), (_, _, newValue) -> put(IMPORT_FILENAMEPATTERN, newValue));
+        EasyBind.listen(filePreferences.fileNamePatternsProperty(), (_, _, newValue) -> storeGlobalLinkedFileNamePattern(newValue));
         EasyBind.listen(filePreferences.fileDirectoryPatternProperty(), (_, _, newValue) -> put(IMPORT_FILEDIRPATTERN, newValue));
         EasyBind.listen(filePreferences.downloadLinkedFilesProperty(), (_, _, newValue) -> putBoolean(DOWNLOAD_LINKED_FILES, newValue));
         EasyBind.listen(filePreferences.fulltextIndexLinkedFilesProperty(), (_, _, newValue) -> putBoolean(FULLTEXT_INDEX_LINKED_FILES, newValue));
@@ -1702,7 +1705,6 @@ public class JabRefCliPreferences implements CliPreferences {
         EasyBind.listen(filePreferences.moveToTrashProperty(), (_, _, newValue) -> putBoolean(TRASH_INSTEAD_OF_DELETE, newValue));
         EasyBind.listen(filePreferences.adjustFileLinksOnTransferProperty(), (_, _, newValue) -> putBoolean(ADJUST_FILE_LINKS_ON_TRANSFER, newValue));
         EasyBind.listen(filePreferences.copyLinkedFilesOnTransferProperty(), (_, _, newValue) -> putBoolean(COPY_LINKED_FILES_ON_TRANSFER, newValue));
-        EasyBind.listen(filePreferences.moveLinkedFilesOnTransferPropertyProperty(), (_, _, newValue) -> putBoolean(MOVE_LINKED_FILES_ON_TRANSFER, newValue));
         EasyBind.listen(filePreferences.moveLinkedFilesOnTransferPropertyProperty(), (_, _, newValue) -> putBoolean(MOVE_LINKED_FILES_ON_TRANSFER, newValue));
         EasyBind.listen(filePreferences.shouldKeepDownloadUrlProperty(), (_, _, newValue) -> putBoolean(KEEP_DOWNLOAD_URL, newValue));
         EasyBind.listen(filePreferences.lastUsedDirectoryProperty(), (_, _, newValue) -> put(LAST_USED_DIRECTORY, newValue.toString()));

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -53,6 +53,8 @@ import org.jabref.logic.exporter.MetaDataSerializer;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.git.preferences.GitPreferences;
+import org.jabref.logic.externalfiles.GlobalLinkedFilePatterns;
+import org.jabref.logic.externalfiles.LinkedFilePatternPreferences;
 import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.ImporterPreferences;
 import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
@@ -295,6 +297,8 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String OO_ADD_SPACE_AFTER = "ooAddSpaceAfter";
     // Prefs node for CitationKeyPatterns
     public static final String CITATION_KEY_PATTERNS_NODE = "bibtexkeypatterns";
+    // Prefs node for linked-file name patterns
+    public static final String LINKED_FILE_NAME_PATTERNS_NODE = "linkedfilenamepatterns";
     // Prefs node for customized entry types
     public static final String CUSTOMIZED_BIBTEX_TYPES = "customizedBibtexTypes";
     public static final String CUSTOMIZED_BIBLATEX_TYPES = "customizedBiblatexTypes";
@@ -1430,7 +1434,25 @@ public class JabRefCliPreferences implements CliPreferences {
         return citationKeyPattern;
     }
     // endregion
+    // region LinkedFileNamePatternPreferences
+    private GlobalLinkedFilePatterns getGlobalLinkedFileNamePattern() {
+        GlobalLinkedFilePatterns linkedFileNamePatterns = GlobalLinkedFilePatterns.fromPattern(get(IMPORT_FILENAMEPATTERN));
+        Preferences preferences = PREFS_NODE.node(LINKED_FILE_NAME_PATTERNS_NODE);
+        try {
+            String[] keys = preferences.keys();
+            for (String key : keys) {
+                linkedFileNamePatterns.addCitationKeyPattern(
+                        EntryTypeFactory.parse(key),
+                        preferences.get(key, null));
+            }
+        } catch (BackingStoreException ex) {
+            LOGGER.info("BackingStoreException in JabRefPreferences.getGlobalLinkedFileNamePattern", ex);
+        }
 
+        return linkedFileNamePatterns;
+    }
+    // endregion
+    
     // public for use in PreferenceMigrations
     public void storeGlobalCitationKeyPattern(GlobalCitationKeyPatterns pattern) {
         if ((pattern.getDefaultValue() == null)
@@ -1451,6 +1473,28 @@ public class JabRefCliPreferences implements CliPreferences {
         for (EntryType entryType : pattern.getAllKeys()) {
             if (!pattern.isDefaultValue(entryType)) {
                 // first entry in the map is the full pattern
+                preferences.put(entryType.getName(), pattern.getValue(entryType).stringRepresentation());
+            }
+        }
+    }
+
+    public void storeGlobalLinkedFileNamePattern(GlobalLinkedFilePatterns pattern) {
+        if ((pattern.getDefaultValue() == null)
+                || pattern.getDefaultValue().equals(CitationKeyPattern.NULL_CITATION_KEY_PATTERN)) {
+            put(IMPORT_FILENAMEPATTERN, "");
+        } else {
+            put(IMPORT_FILENAMEPATTERN, pattern.getDefaultValue().stringRepresentation());
+        }
+
+        Preferences preferences = PREFS_NODE.node(LINKED_FILE_NAME_PATTERNS_NODE);
+        try {
+            preferences.clear();
+        } catch (BackingStoreException ex) {
+            LOGGER.info("BackingStoreException in JabRefPreferences::storeGlobalLinkedFileNamePattern", ex);
+        }
+
+        for (EntryType entryType : pattern.getAllKeys()) {
+            if (!pattern.isDefaultValue(entryType)) {
                 preferences.put(entryType.getName(), pattern.getValue(entryType).stringRepresentation());
             }
         }

--- a/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
@@ -10,6 +10,7 @@ import org.jabref.logic.preferences.CliPreferences;
 import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.LinkedFile;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +41,7 @@ class LinkedFileHandlerTest {
         databaseContext = new BibDatabaseContext();
 
         when(filePreferences.confirmDeleteLinkedFile()).thenReturn(true);
+        when(filePreferences.getFileNamePatternForEntryType(any())).thenReturn("[bibtexkey]");
         when(preferences.getFilePreferences()).thenReturn(filePreferences);
         when(preferences.getXmpPreferences()).thenReturn(mock(XmpPreferences.class));
     }
@@ -79,8 +82,6 @@ class LinkedFileHandlerTest {
                 asdf.pdf, path/to/file.pdf, pdf
             """)
     void getSuggestedFileName(String expectedFileName, String link, String extension) {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
-
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithCitationKeyAsdf, databaseContext, filePreferences);
 
@@ -112,8 +113,6 @@ class LinkedFileHandlerTest {
                 OAM-Webinar-V2.pdf, https://www.cncf.io/wp-content/uploads/2020/08/OAM-Webinar-V2.pdf, pdf
             """)
     void getSuggestedFileNameWithMissingKey(String expectedFileName, String link, String extension) {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
-
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithoutCitationKey, databaseContext, filePreferences);
 
@@ -133,8 +132,6 @@ class LinkedFileHandlerTest {
                 asdf.pdf, https://www.cncf.io/wp-content/uploads/2020/08/OAM-Webinar-V2.pdf
             """)
     void getSuggestedFileNameWithoutExtension(String expectedFileName, String link) {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
-
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithCitationKeyAsdf, databaseContext, filePreferences);
 
@@ -161,8 +158,6 @@ class LinkedFileHandlerTest {
                 OAM-Webinar-V2.pdf, https://www.cncf.io/wp-content/uploads/2020/08/OAM-Webinar-V2.pdf
             """)
     void getSuggestedFileNameWithoutExtensionWithMissingKey(String expectedFileName, String link) {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
-
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithoutCitationKey, databaseContext, filePreferences);
 
@@ -171,7 +166,6 @@ class LinkedFileHandlerTest {
 
     @Test
     void getSuggestedFileNameInDirectory() {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
         final String link = "path/to/other.txt".replace('/', File.separatorChar);
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithCitationKeyAsdf, databaseContext, filePreferences);
@@ -180,7 +174,6 @@ class LinkedFileHandlerTest {
 
     @Test
     void getSuggestedFileNameInDirectoryWithMissingKey() {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
         final String link = "path/to/other.txt".replace('/', File.separatorChar);
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithoutCitationKey, databaseContext, filePreferences);
@@ -189,7 +182,6 @@ class LinkedFileHandlerTest {
 
     @Test
     void getSuggestedFileNameWithoutExtensionInDirectory() {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
         final String link = "path/to/other.txt".replace('/', File.separatorChar);
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithCitationKeyAsdf, databaseContext, filePreferences);
@@ -198,10 +190,21 @@ class LinkedFileHandlerTest {
 
     @Test
     void getSuggestedFileNameWithoutExtensionWithMissingKeyInDirectory() {
-        when(filePreferences.getFileNamePattern()).thenReturn("[bibtexkey]");
         final String link = "path/to/other.txt".replace('/', File.separatorChar);
         final LinkedFile linkedFile = new LinkedFile("", link, "");
         final LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entryWithoutCitationKey, databaseContext, filePreferences);
         assertEquals("other.txt", linkedFileHandler.getSuggestedFileName(), "\"" + link + "\" should be \"other.txt\" for empty citation key");
+    }
+
+    @Test
+    void getSuggestedFileNameUsesEntryTypeSpecificPattern() {
+        BibEntry thesisEntry = new BibEntry().withCitationKey("ignored");
+        thesisEntry.setField(StandardField.TITLE, "Thesis Title");
+        when(filePreferences.getFileNamePatternForEntryType(any())).thenReturn("[title]");
+
+        LinkedFile linkedFile = new LinkedFile("", "file.pdf", "");
+        LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, thesisEntry, databaseContext, filePreferences);
+
+        assertEquals("Thesis Title.pdf", linkedFileHandler.getSuggestedFileName("pdf"));
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/11368

### PR Description

- Implemented a table-based Linked files → Filename format pattern preference that mirrors the existing citation-key pattern workflow, so users can define a default filename pattern and entry-type-specific overrides instead of repeatedly editing one global string. 
- Filename generation in linkedfile preference flow now resolves the effective pattern per entry type. 
- Tests were added and related tests were updated to validate the new resolution path.
- Video demonstrating the change -> https://drive.google.com/file/d/1013Qx3gbvORvs8TA4lCpnvvs4_kZIWxe/view?usp=sharing


### Steps to test
- Open Jabref and go to file, then open the "preferences" tab
- go to "linked files"
- fill out the new "filename format table" with relevant citation keys and save
- exit out of preferences tab and have a prepared library
- add resources as linked files to library entries. Their naming conventions should match the citation keys inputted into the preferences tab

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
