### PR TITLE
ci: add missing actions/checkout to remove-reviewers workflow

### DIFF
--- a/.github/workflows/remove-reviewers.yml
+++ b/.github/workflows/remove-reviewers.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/pr-gate
         id: gate
         with:


### PR DESCRIPTION
## Summary

Fixes #15524.

The `guard-reviewers` job in `.github/workflows/remove-reviewers.yml` references the local composite action `./.github/actions/pr-gate` but never runs `actions/checkout` first. On `pull_request_target`, the runner starts with an empty workspace, so the local action cannot be located and the job fails with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/jabref/jabref/.github/actions/pr-gate'.
Did you forget to run actions/checkout before running your local action?
```

This one-line change adds `- uses: actions/checkout@v4` as the first step so the composite action in `.github/actions/pr-gate/action.yml` can be discovered and executed.

## Change

```diff
     steps:
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/pr-gate
         id: gate
```

## Test plan

- [x] Diff is limited to a single added line in `.github/workflows/remove-reviewers.yml`
- [x] No behavioral change for existing reviewers logic; the composite action is simply now resolvable
- [x] Maintainer verifies `guard-reviewers` runs green on a subsequent PR review request from a fork

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)