### PR TITLE
Fix failed test on Windows

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkInserter.java
+++ b/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkInserter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import org.jabref.logic.os.OS;
 import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;

--- a/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkInserter.java
+++ b/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkInserter.java
@@ -74,7 +74,7 @@ public class RelatedWorkInserter {
 
         String updatedComment = existingComment
                 .filter(comment -> !comment.isBlank())
-                .map(comment -> StringUtil.unifyLineBreaks(comment.stripTrailing(), "\n") + "\n\n" + formattedComment)
+                .map(comment -> StringUtil.unifyLineBreaks(comment.stripTrailing(), OS.NEWLINE) + OS.NEWLINE + OS.NEWLINE + formattedComment)
                 .orElse(formattedComment);
 
         return matchedLibraryEntry.setField(userSpecificCommentField, updatedComment);

--- a/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkInserterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkInserterTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.relatedwork;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.os.OS;
+import org.jabref.logic.util.strings.StringUtil;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -58,7 +58,7 @@ class RelatedWorkInserterTest {
         List<RelatedWorkInsertionResult> insertionResults = inserter.insertMatchedRelatedWork(sourceEntry, List.of(matchResult), "koppor");
 
         assertInstanceOf(RelatedWorkInsertionResult.Inserted.class, insertionResults.getFirst());
-        assertEquals("[test]: blahblah" + OS.NEWLINE + OS.NEWLINE + "[LunaOstos_2024]: Colombia is a middle-income country with a population of approximately 50 million.",
+        assertEquals(StringUtil.unifyLineBreaks("[test]: blahblah".stripTrailing(), "\n") + "\n\n" + "[LunaOstos_2024]: Colombia is a middle-income country with a population of approximately 50 million.",
                 matchedLibraryEntry.getField(userSpecificCommentField).orElseThrow());
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkInserterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/relatedwork/RelatedWorkInserterTest.java
@@ -3,7 +3,7 @@ package org.jabref.logic.relatedwork;
 import java.util.List;
 import java.util.Optional;
 
-import org.jabref.logic.util.strings.StringUtil;
+import org.jabref.logic.os.OS;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.UserSpecificCommentField;
 import org.jabref.model.entry.types.StandardEntryType;
@@ -58,7 +58,7 @@ class RelatedWorkInserterTest {
         List<RelatedWorkInsertionResult> insertionResults = inserter.insertMatchedRelatedWork(sourceEntry, List.of(matchResult), "koppor");
 
         assertInstanceOf(RelatedWorkInsertionResult.Inserted.class, insertionResults.getFirst());
-        assertEquals(StringUtil.unifyLineBreaks("[test]: blahblah".stripTrailing(), "\n") + "\n\n" + "[LunaOstos_2024]: Colombia is a middle-income country with a population of approximately 50 million.",
+        assertEquals("[test]: blahblah" + OS.NEWLINE + OS.NEWLINE + "[LunaOstos_2024]: Colombia is a middle-income country with a population of approximately 50 million.",
                 matchedLibraryEntry.getField(userSpecificCommentField).orElseThrow());
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #15537

### PR Description
Add linebreak unifier to method in `RelatedWorkInserterTest`.

### Steps to test
On Windows, run test `insertMatchedRelatedWorkAppendsToExistingUserSpecificCommentField` in `RelatedWorkInserterTest`, it should pass now.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
