### PR TITLE
Fix checkout

### DIFF
--- a/.github/actions/pr-gate/action.yml
+++ b/.github/actions/pr-gate/action.yml
@@ -30,8 +30,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-
     - name: Maintainer permission + PR link
       id: perm
       shell: bash

--- a/.github/workflows/remove-ready-for-review.yml
+++ b/.github/workflows/remove-ready-for-review.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/pr-gate
         id: gate
         with:

--- a/.github/workflows/remove-reviewers.yml
+++ b/.github/workflows/remove-reviewers.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
 
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/pr-gate
         id: gate
         with:


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/pull/15525

Using a composite action without checkout is not possible. Fixed by this PR.

### Steps to test

See two removal workflows working again.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
