### PR TITLE
Fix notification text visibility in dark mode

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/Dark.css
+++ b/jabgui/src/main/resources/org/jabref/gui/Dark.css
@@ -178,7 +178,21 @@
 }
 
 .notification-bar > .pane {
+    -fx-background-color: -jr-gray-3;
+}
+
+.notification-bar > .pane > .title,
+.notification-bar > .pane > .label,
+.notification-bar > .pane > .button-bar > .container > .action {
+    -fx-text-fill: -fx-light-text-color;
+}
+
+.notification-pane .notification-bar > .pane .close-button > .graphic {
     -fx-background-color: -fx-light-text-color;
+}
+
+.notification-bar > .pane > .label > .ikonli-font-icon {
+    -fx-icon-color: -fx-light-text-color;
 }
 
 .rating > .container > .button {


### PR DESCRIPTION
## Related issues/PRs
Closes #15560

## Description
Notifications in dark mode were showing white text on white backgrounds, making them impossible to read. Added proper text and icon colors to the notification styles so they display correctly in the dark theme.

## Steps to test
1. Switch to dark mode in settings
2. Trigger a notification (e.g., save library, close entry without saving)
3. Verify the text and close button are clearly visible

## Mandatory checklist
- [x] I own the copyright and license under MIT
- [x] Manually tested in running JabRef
- [ ] Added/updated JUnit tests (if applicable)
- [x] Screenshots provided (if visible change)
- [ ] Screenshot with single entry (issue number as title)
- [x] Updated CHANGELOG.md (if visible change)
- [ ] User documentation PR if needed