### PR TITLE
Added "group" between dropdowns at import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
+- We added "group" to address clarity for the second drop down. [#15567](https://github.com/JabRef/jabref/issues/15567)
 - We added a related work text extractor, which finds and inserts the related work text into bib entries from references in the texts. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We added a hover button on group rows to quickly add a new group or subgroup. [#12289](https://github.com/JabRef/jabref/issues/12289)
 - We added a shorthand for protecting terms in the fields: user can now select a text and type a opening curling brace to quickly wrap the selection in braces. [#15442](https://github.com/JabRef/jabref/pull/15442)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added "group" to address clarity for the second drop down. [#15567](https://github.com/JabRef/jabref/issues/15567)
+- We added "group" between dropdowns at import. [#15567](https://github.com/JabRef/jabref/issues/15567)
 - We added a related work text extractor, which finds and inserts the related work text into bib entries from references in the texts. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We added a hover button on group rows to quickly add a new group or subgroup. [#12289](https://github.com/JabRef/jabref/issues/12289)
 - We added a shorthand for protecting terms in the fields: user can now select a text and type a opening curling brace to quickly wrap the selection in braces. [#15442](https://github.com/JabRef/jabref/pull/15442)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Added
 
-- We added "group" between dropdowns at import. [#15567](https://github.com/JabRef/jabref/issues/15567)
+- We added a label to the Group dropdown in the Import Dialog. [#15567](https://github.com/JabRef/jabref/issues/15567)
 - We added a related work text extractor, which finds and inserts the related work text into bib entries from references in the texts. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We added a hover button on group rows to quickly add a new group or subgroup. [#12289](https://github.com/JabRef/jabref/issues/12289)
 - We added a shorthand for protecting terms in the fields: user can now select a text and type a opening curling brace to quickly wrap the selection in braces. [#15442](https://github.com/JabRef/jabref/pull/15442)

--- a/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -44,6 +44,7 @@
                     <HBox spacing="4" alignment="CENTER_LEFT">
                         <Label text="%Library to import into"/>
                         <ComboBox fx:id="libraryListView" layoutX="16.0" layoutY="52.0"/>
+                        <Label text="group"/>
                         <ComboBox fx:id="groupListView" layoutX="16.0" layoutY="52.0"/>
                     </HBox>
                 </VBox>

--- a/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -44,7 +44,7 @@
                     <HBox spacing="4" alignment="CENTER_LEFT">
                         <Label text="%Library to import into"/>
                         <ComboBox fx:id="libraryListView" layoutX="16.0" layoutY="52.0"/>
-                        <Label text="group"/>
+                        <Label text="%group"/>
                         <ComboBox fx:id="groupListView" layoutX="16.0" layoutY="52.0"/>
                     </HBox>
                 </VBox>

--- a/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
+++ b/jabgui/src/main/resources/org/jabref/gui/importer/ImportEntriesDialog.fxml
@@ -44,7 +44,7 @@
                     <HBox spacing="4" alignment="CENTER_LEFT">
                         <Label text="%Library to import into"/>
                         <ComboBox fx:id="libraryListView" layoutX="16.0" layoutY="52.0"/>
-                        <Label text="%group"/>
+                        <Label text="%Group"/>
                         <ComboBox fx:id="groupListView" layoutX="16.0" layoutY="52.0"/>
                     </HBox>
                 </VBox>

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2848,6 +2848,8 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 
 Library\ to\ import\ into=Library to import into
 
+group=group
+
 Enable\ web\ search=Enable web search
 Web\ search\ disabled=Web search disabled
 

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -2848,7 +2848,7 @@ Use\ the\ field\ FJournal\ to\ store\ the\ full\ journal\ name\ for\ (un)abbrevi
 
 Library\ to\ import\ into=Library to import into
 
-group=group
+Group=Group
 
 Enable\ web\ search=Enable web search
 Web\ search\ disabled=Web search disabled


### PR DESCRIPTION
### Related issues and pull requests

Closes #15567

### PR Description

I added a text label saying "group" inbetween the "libraryListView" and "groupListView" drop down box in the ImportEntriesDialog.fxml to give clarity to the function of the "groupListView" drop down box.
<img width="1920" height="1033" alt="task-for-issue-15567" src="https://github.com/user-attachments/assets/73d718f7-3e73-436f-8c9e-35f965baabd3" />

### Steps to test

1. Create an empty library
2. Click the file button in the top left
3. Click Import
4. Click Import to current Library
5. Select a file
6. See that the change is there

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
