### PR TITLE
Add --fresh for JBang

### DIFF
--- a/.jbang/README.md
+++ b/.jbang/README.md
@@ -13,7 +13,7 @@ Four use cases:
 ## Running `JabKit`
 
 ```bash
-$ jbang jabkit@jabref --help
+$ jbang --fresh jabkit@jabref --help
 
    &&&    &&&&&    &&&&&&&&   &&&&&&&&   &&&&&&&&& &&&&&&&&&
    &&&    &&&&&    &&&   &&&  &&&   &&&  &&&       &&&
@@ -49,10 +49,9 @@ Commands:
   search                  Search in a library.
 ```
 
-> [!NOTE]
-> Due to the high development pace, you need to sometimes refresh the dependencies
->
-> `jbang --fresh jabkit@jabref --help`
+> [!NOTE]`
+> Due to the high development pace, `--fresh` is used to update `org.jabref:jablib:6.0-SNAPSHOT`.
+> As soon as JabRef 6.0 is released, this won't be required any more.
 
 ### Installing and Running `JabKit` with JBang
 
@@ -93,19 +92,19 @@ Then you enable `alias jabkit='gg.cmd jbang jabkit@jabref`.
 In case you have [JBang installed], just run following command:
 
 ```terminal
-jbang jabls@jabref
+jbang --fresh jabls@jabref
 ```
 
 With `gg.cmd`:
 
 ```terminal
-sh ./gg.cmd jbang jabls@jabref
+sh ./gg.cmd jbang --fresh jabls@jabref
 ```
 
 With `npx`:
 
 ```terminal
-npx @jbangdev/jbang jabls@jabref
+npx @jbangdev/jbang --fresh jabls@jabref
 ```
 
 One can add `--help` to see available options.
@@ -121,18 +120,18 @@ jbang jabsrv@jabref
 With `gg.cmd`:
 
 ```terminal
-sh ./gg.cmd jbang jabsrv@jabref
+sh ./gg.cmd jbang --fresh jabsrv@jabref
 ```
 
 With `npx`:
 
 ```terminal
-npx @jbangdev/jbang jabsrv@jabref
+npx @jbangdev/jbang --fresh jabsrv@jabref
 ```
 
 One can add `--help` to see available options. E.g., how to set another port and how to specify served libraries.
 
-JBang installed: https://www.jbang.dev/download/
+JBang installed: <https://www.jbang.dev/download/>
 
 ## Try out any pull request
 


### PR DESCRIPTION
People get following

```
jbang jabkit@jabref --help
Error occurred during initialization of boot layer
java.lang.module.FindException: Module javafx.base not found, required by javafx.controls
```

The issue is that an **old** SNAPSHOT of jablib is used with a new version of the Java JBang script. With `--fresh`, it is ensured that always the latest version is used.

### Steps to test

Execute `jbang --fresh jabkit@jabref --help` and see that it shows the help.

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
