### PR TITLE
fix: enforce full-string matching in MonthChecker and add correspondi…

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/integrity/MonthChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/MonthChecker.java
@@ -12,11 +12,11 @@ import org.jspecify.annotations.NonNull;
 
 public class MonthChecker implements ValueChecker {
 
-    private static final Predicate<String> ONLY_AN_INTEGER = Pattern.compile("[1-9]|10|11|12")
-                                                                    .asPredicate();
+    private static final Predicate<String> ONLY_AN_INTEGER = Pattern.compile("^([1-9]|10|11|12)$")
+                                                                    .asMatchPredicate();
     private static final Predicate<String> MONTH_NORMALIZED = Pattern
-            .compile("#jan#|#feb#|#mar#|#apr#|#may#|#jun#|#jul#|#aug#|#sep#|#oct#|#nov#|#dec#")
-            .asPredicate();
+            .compile("^(#jan#|#feb#|#mar#|#apr#|#may#|#jun#|#jul#|#aug#|#sep#|#oct#|#nov#|#dec#)$")
+            .asMatchPredicate();
 
     private final BibDatabaseContext bibDatabaseContextMonth;
 

--- a/jablib/src/test/java/org/jabref/logic/integrity/MonthCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/integrity/MonthCheckerTest.java
@@ -82,4 +82,17 @@ class MonthCheckerTest {
     void bibLaTexAcceptsInteger() {
         assertEquals(Optional.empty(), checkerBiblatex.checkValue("10"));
     }
+
+    @Test
+    void rejectsMixedIntegerMonth() {
+        assertEquals(Optional.of("should be an integer or normalized"), checkerBiblatex.checkValue("1abc"));
+        assertEquals(Optional.of("should be an integer or normalized"), checkerBiblatex.checkValue("123"));
+        assertEquals(Optional.of("should be an integer or normalized"), checkerBiblatex.checkValue("13"));
+    }
+
+    @Test
+    void rejectsPartialNormalizedMonth() {
+        assertNotEquals(Optional.empty(), checker.checkValue("#jan# trailing"));
+        assertNotEquals(Optional.empty(), checker.checkValue("prefix#feb#"));
+    }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes : #15577 
### PR Description

This pull request fixes a data validation bug where `MonthChecker` was incorrectly accepting invalid month values due to the use of a partial regex substring match. The regex pattern matching has been updated to enforce exact string boundaries, ensuring strict validation and preventing data invalidation during library operations. This logic improvement guarantees robust month parsing, definitively eliminating the risk of data invalidation from malformed text inputs.

### Steps to test

1. Open JabRef, create a new BibTeX library, and add a single entry.
2. Edit the entry to have an invalid `month` field value (e.g., `"1abc"` or `"#jan# foobar"`).
3. Run **Quality -> Check integrity** from the JabRef menu.
4. Verify that the system correctly flags the `month` field as being invalid, instead of silently passing.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
