### PR TITLE
Improve styles for main table

### DIFF
--- a/jabgui/src/main/resources/org/jabref/gui/jabref-javafx.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-javafx.css
@@ -8,7 +8,7 @@
 @media (prefers-color-scheme: light) {
     * {
         -jr-theme: #50618F;
-        -jr-accent: #a3b7e6;
+        -jr-accent: #A3B7E6;
         -jr-accent-alt: derive(-jr-accent, 15%);
 
         -jr-row-odd-background: -fx-control-inner-background-alt;
@@ -18,23 +18,17 @@
         -jr-selected: -jr-accent;
 
         -jr-hover: #0002;
-        -jr-hover-text: -fx-focused-text-base-color;
 
         -jr-base: #ebebeb;
 
         -jr-background-alt: -fx-background;
         -jr-search-background: derive(-jr-base, 80%);
-        -jr-toolbar: derive(-jr-base, 46.4%);
 
-        -jr-menu-background: derive(-jr-base, 46.4%);
-        -jr-menu-background-active: -jr-hover;
-        -jr-menu-foreground: -fx-dark-text-color;
-        -jr-menu-item-foreground: -fx-dark-text-color;
+        -jr-menu-background: derive(-jr-base, 46%);
         -jr-menu-forground-active: -fx-dark-text-color;
 
-        -jr-head-fg: -fx-text-inner-color;
-
-        -jr-theme-text: -jr-theme;
+        -jr-text-foreground: -fx-dark-text-color;
+        -jr-toolbar: derive(-jr-base, 46%);
 
         -jr-icon-background: transparent;
         -jr-icon-background-active: #0001;
@@ -52,22 +46,18 @@
         -jr-tooltip-bg: -jr-accent;
         -jr-tooltip-fg: #000;
 
-        -jr-sidepane-background: #dddddd;
-        -jr-sidepane-header-background: #dddddd;
-        -jr-sidepane-header-color: -jr-theme-text;
+        -jr-sidepane-background: #DDDDDD;
+        -jr-sidepane-header-background: #DDDDDD;
 
         -jr-scrollbar-thumb: derive(-fx-outer-border, -30%);
         -jr-scrollbar-track: derive(-fx-control-inner-background, -10%);
 
         -jr-separator: derive(-fx-color, -5%);
 
-        -jr-search-text: -fx-text-base-color;
-
         -jr-drag-target: -jr-purple;
         -jr-drag-target-hover: derive(-jr-purple, 80%);
 
         -jr-inner-bg: derive(-fx-base, 95%);
-        -jr-inner-bg-alt: derive(-fx-control-inner-background, -6%);
         -jr-mid-text-color: #404040;
         -jr-light-text-color: #ffffff;
         -jr-outer-border: derive(-fx-color, -5%);
@@ -78,28 +68,13 @@
         -jr-red: #ee5253;
         -jr-light-red: #ff6b6b;
         -jr-orange: #ff9f43;
-
-        -jr-match-1-odd: -jr-row-odd-background;
-        -jr-match-1-even: -jr-row-even-background;
-        -jr-match-1-text-color: -fx-mid-text-color;
-
-        -jr-match-2-odd: derive(-jr-theme, 100%);
-        -jr-match-2-even: derive(-jr-match-2-odd, 10%);
-        -jr-match-2-text-color: -fx-mid-text-color;
-
-        -jr-match-3-odd: derive(-jr-theme, 50%);
-        -jr-match-3-even: derive(-jr-match-3-odd, 10%);
-        -jr-match-3-text-color: derive(-jr-accent, 30%);
-
-        -jr-match-4-odd: -jr-theme;
-        -jr-match-4-even: derive(-jr-match-4-odd, 10%);
-        -jr-match-4-text-color: -jr-accent;
     }
 }
 
 @media (prefers-color-scheme: dark) {
     * {
-        -jr-theme: #2c9490;
+        -jr-theme: #2C9490;
+
         -jr-accent: #255652;
         -jr-accent-alt: derive(-jr-accent, 15%);
 
@@ -110,25 +85,18 @@
         -jr-selected: -jr-accent;
 
         -jr-hover: #fff1;
-        -jr-hover-text: -fx-focused-text-base-color;
 
         -jr-base: #141824;
 
         -jr-background-alt: #151924;
         -jr-sidepane-background: #212330;
-        -jr-search-background: #2c2e3b;
+        -jr-search-background: #2C2E3B;
 
         -jr-menu-background: #141824;
-        -jr-menu-background-active: -jr-hover;
-        -jr-menu-foreground: -fx-light-text-color;
-        -jr-menu-item-foreground: -fx-light-text-color;
         -jr-menu-forground-active: derive(-fx-light-text-color, 50%);
 
+        -jr-text-foreground: -fx-light-text-color;
         -jr-toolbar: -jr-menu-background;
-
-        -jr-head-fg: -fx-text-inner-color;
-
-        -jr-theme-text: -jr-theme;
 
         -jr-icon-background: transparent;
         -jr-icon-background-active: -jr-hover;
@@ -141,20 +109,16 @@
         -jr-tooltip-fg: derive(-fx-light-text-color, 50%);
 
         -jr-sidepane-header-background: -jr-background-alt;
-        -jr-sidepane-header-color: -jr-theme-text;
 
         -jr-scrollbar-thumb: -fx-light-text-color;
         -jr-scrollbar-track: derive(-fx-control-inner-background, -90%);
 
         -jr-separator: #333744;
 
-        -jr-search-text: -fx-text-base-color;
-
         -jr-drag-target: -jr-accent;
         -jr-drag-target-hover: -jr-accent;
 
         -jr-inner-bg: #272b38;
-        -jr-inner-bg-alt: -fx-control-inner-background;
         -jr-mid-text-color: #7d8591;
         -jr-light-text-color: #e5e7ea;
         -jr-outer-border: #424758;
@@ -165,22 +129,6 @@
         -jr-red: #b71c1f;
         -jr-light-red: #db1d2b;
         -jr-orange: #b77620;
-
-        -jr-match-1-odd: -jr-row-odd-background;
-        -jr-match-1-even: -jr-row-even-background;
-        -jr-match-1-text-color: -fx-mid-text-color;
-
-        -jr-match-2-odd: derive(-jr-theme, 100%);
-        -jr-match-2-even: derive(-jr-match-2-odd, 10%);
-        -jr-match-2-text-color: -fx-mid-text-color;
-
-        -jr-match-3-odd: derive(-jr-theme, 50%);
-        -jr-match-3-even: derive(-jr-match-3-odd, 10%);
-        -jr-match-3-text-color: derive(-jr-accent, 30%);
-
-        -jr-match-4-odd: -jr-theme;
-        -jr-match-4-even: derive(-jr-match-4-odd, 10%);
-        -jr-match-4-text-color: -jr-accent;
     }
 }
 
@@ -191,7 +139,7 @@
     -fx-background: derive(-fx-base, 26%);
 
     -fx-control-inner-background: -jr-inner-bg;
-    -fx-control-inner-background-alt: -jr-inner-bg-alt;
+    -fx-control-inner-background-alt: derive(-fx-control-inner-background, -5%);
 
     -fx-dark-text-color: #000;
     -fx-mid-text-color: -jr-mid-text-color;
@@ -260,8 +208,7 @@
 .list-view:focused,
 .tree-view:focused,
 .table-view:focused,
-.tree-table-view:focused,
-.html-editor:contains-focus {
+.tree-table-view:focused {
     -fx-background-color: -fx-control-inner-background;
     -fx-background-insets: 0;
     -fx-background-radius: 0;
@@ -496,8 +443,8 @@ TextFlow > .tooltip-text-monospaced {
 .menu-bar > .container > .menu-button:hover,
 .menu-bar > .container > .menu-button:focused,
 .menu-bar > .container > .menu-button:showing {
-    -fx-background-color: -jr-menu-background-active;
-    -fx-background: -jr-menu-background-active;
+    -fx-background-color: -jr-hover;
+    -fx-background: -jr-hover;
 }
 
 .menu-bar > .container > .menu-button:hover > .label,
@@ -511,13 +458,13 @@ TextFlow > .tooltip-text-monospaced {
 }
 
 .menu-item > .label {
-    -fx-text-fill: -jr-menu-item-foreground;
+    -fx-text-fill: -jr-text-foreground;
 }
 
 .menu-item:focused {
-    -fx-text-fill: -jr-menu-background-active;
-    -fx-background: -jr-menu-background-active;
-    -fx-background-color: -jr-menu-background-active;
+    -fx-text-fill: -jr-hover;
+    -fx-background: -jr-hover;
+    -fx-background-color: -jr-hover;
 }
 
 .menu-item:focused > .label {
@@ -560,7 +507,7 @@ TextFlow > .tooltip-text-monospaced {
     -fx-border-color: -fx-outer-border;
     -fx-border-width: 0.5 0.5 0.5 0.5;
     -fx-padding: 0.3em 0.9em 0.3em 0.9em;
-    -fx-pref-height: -jr-header-height;
+    -fx-pref-height: 3em;
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab .tab-label {
@@ -569,8 +516,8 @@ TextFlow > .tooltip-text-monospaced {
 
 .tab-pane > .tab-header-area > .headers-region > .control-buttons-tab {
     -fx-border-color: -jr-theme;
-    -fx-fill: -jr-theme-text;
-    -fx-text-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab:selected {
@@ -580,12 +527,12 @@ TextFlow > .tooltip-text-monospaced {
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab:selected .tab-label {
-    -fx-fill: -jr-theme-text;
-    -fx-text-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab:selected .tab-close-button {
-    -fx-background-color: -jr-theme-text;
+    -fx-background-color: -jr-theme;
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab:selected .glyph-icon {
@@ -621,8 +568,8 @@ TextFlow > .tooltip-text-monospaced {
 }
 
 .tab-pane > .tab-header-area > .headers-region > .tab:selected .glyph-icon {
-    -fx-fill: -jr-theme-text;
-    -fx-text-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
 }
 
 .tab-pane > .tab-header-area {
@@ -858,6 +805,9 @@ TextFlow > .tooltip-text-monospaced {
 .tree-table-view {
     -fx-background-insets: 0;
     -fx-padding: 0;
+    -fx-border-width: 0;
+    -fx-border-insets: 0;
+    -fx-table-cell-border-color: transparent;
 }
 
 .table-view:focused,
@@ -865,13 +815,21 @@ TextFlow > .tooltip-text-monospaced {
     -fx-background-insets: 0;
 }
 
-.table-row-cell:hover,
-.tree-table-row-cell:hover,
-.table-row-cell:hover:even,
-.tree-table-row-cell:hover:even {
+.table-cell,
+.tree-table-cell {
+    -fx-cell-size: 4.0em;
+    -fx-padding: 0.5em 1em 0.5em 1em;
+    -fx-fill: -fx-text-background-color;
+    -fx-text-fill: -fx-text-background-color;
+}
+
+.table-row-cell:filled:hover,
+.tree-table-row-cell:filled:hover,
+.table-row-cell:filled:hover,
+.tree-table-row-cell:filled:hover {
     -fx-background-color: -jr-hover;
-    -fx-fill: -jr-hover-text;
-    -fx-text-fill: -jr-hover-text;
+    -fx-fill: -fx-focused-text-base-color;
+    -fx-text-fill: -fx-focused-text-base-color;
 }
 
 .tree-table-row-cell:selected > .tree-table-cell > .glyph-icon {
@@ -879,8 +837,8 @@ TextFlow > .tooltip-text-monospaced {
     -fx-text-fill: white;
 }
 
-.table-view > .virtual-flow > .clipped-container > .sheet > .table-row-cell .table-cell:selected,
-.tree-table-view > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell .tree-table-cell:selected {
+.table-view > .virtual-flow > .clipped-container > .sheet > .table-row-cell .table-cell:filled:selected,
+.tree-table-view > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell .tree-table-cell:filled:selected {
     -fx-border-color: transparent;
     -fx-background-insets: 0;
 }
@@ -890,8 +848,8 @@ TextFlow > .tooltip-text-monospaced {
 .tree-view:focused > .virtual-flow > .clipped-container > .sheet > .tree-cell:filled:selected,
 .table-view:focused > .virtual-flow > .clipped-container > .sheet > .table-row-cell:filled:selected,
 .tree-table-view:focused > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell:filled:selected,
-.table-view:focused > .virtual-flow > .clipped-container > .sheet > .table-row-cell .table-cell:selected,
-.tree-table-view:focused > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell .tree-table-cell:selected {
+.table-view:focused > .virtual-flow > .clipped-container > .sheet > .table-row-cell .table-cell:filled:selected,
+.tree-table-view:focused > .virtual-flow > .clipped-container > .sheet > .tree-table-row-cell .tree-table-cell:filled:selected {
     -fx-background: -jr-selected;
     -fx-background-color: -jr-selected;
     -fx-table-cell-border-color: transparent;
@@ -904,19 +862,10 @@ TextFlow > .tooltip-text-monospaced {
 .tree-cell:filled:selected,
 .table-row-cell:filled:selected,
 .tree-table-row-cell:filled:selected,
-.table-row-cell:filled > .table-cell:selected,
-.tree-table-row-cell:filled > .tree-table-cell:selected {
+.table-row-cell:filled > .table-cell:filled:selected,
+.tree-table-row-cell:filled > .tree-table-cell:filled:selected {
     -fx-background: -jr-selected;
     -fx-background-color: -jr-selected;
-    -fx-table-cell-border-color: transparent;
-}
-
-
-.table-view,
-.tree-table-view {
-    -fx-border-width: 0;
-    -fx-padding: 0;
-    -fx-border-insets: 0;
     -fx-table-cell-border-color: transparent;
 }
 
@@ -943,15 +892,7 @@ TextFlow > .tooltip-text-monospaced {
 .column-header > .label {
     -fx-padding: 0 1em 0 1em;
     -fx-alignment: center-left;
-    -fx-text-fill: -jr-head-fg;
-}
-
-.table-cell,
-.tree-table-cell {
-    -fx-cell-size: 4.0em;
-    -fx-padding: 0.5em 1em 0.5em 1em;
-    -fx-fill: -fx-text-background-color;
-    -fx-text-fill: -fx-text-background-color;
+    -fx-text-fill: -fx-text-inner-color;
 }
 
 /* JavaFX WebView */

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -17,11 +17,29 @@
     -jr-error: -jr-light-red;
     -jr-success: -jr-green;
 
+    /* Generic colors */
     -jr-white: #ffffff;
     -jr-gray-1: #dddddd;
     -jr-gray-2: #808080;
     -jr-gray-3: #404040;
     -jr-black: #000;
+
+    /* Main Table Matching */
+    -jr-match-1-odd: -jr-row-odd-background;
+    -jr-match-1-even: -jr-row-even-background;
+    -jr-match-1-text-color: -jr-text-foreground;
+
+    -jr-match-2-odd: derive(-jr-row-odd-background, -40%);
+    -jr-match-2-even: derive(-jr-row-even-background, -40%);
+    -jr-match-2-text-color: derive(-jr-text-foreground, -40%);
+
+    -jr-match-3-odd: derive(-jr-row-odd-background, -50%);
+    -jr-match-3-even: derive(-jr-row-even-background, -50%);
+    -jr-match-3-text-color: derive(-jr-text-foreground, -50%);
+
+    -jr-match-4-odd: derive(-jr-row-odd-background, -60%);
+    -jr-match-4-even: derive(-jr-row-even-background, -60%);
+    -jr-match-4-text-color: derive(-jr-text-foreground, -60%);
 
     /* Used only in Code inside setStyle(..) */
     -jr-ai-message-user: derive(-jr-accent, 50%);
@@ -67,7 +85,7 @@
 }
 
 .global-search-bar .toggle-button .glyph-icon {
-    -fx-icon-color: derive(-jr-search-text, 80%);
+    -fx-icon-color: derive(-fx-text-base-color, 80%);
 }
 
 .rating > .container > .button {
@@ -79,7 +97,7 @@
 }
 
 .file-row-text {
-    -fx-fill: -jr-search-text;
+    -fx-fill: -fx-text-base-color;
 }
 
 .walkthrough-spotlight {
@@ -213,7 +231,7 @@
 }
 
 .file-row-text:opacity {
-    -fx-fill: derive(-jr-search-text, 70%);
+    -fx-fill: derive(-fx-text-base-color, 70%);
 }
 
 .sidePaneComponentHeader {
@@ -223,17 +241,17 @@
 }
 
 .sidePaneComponentHeader > .label {
-    -fx-text-fill: -jr-sidepane-header-color;
+    -fx-text-fill: -jr-theme;
     -fx-font-weight: bold;
     -fx-padding: 0.3em 0.9em 0.3em 0.9em;
 }
 
 .sidePaneComponentHeader .glyph-icon,
 .sidePaneComponentHeader .ikonli-font-icon {
-    -fx-fill: -jr-sidepane-header-color;
-    -fx-text-fill: -jr-sidepane-header-color;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
     -fx-font-size: 1.0em;
-    -fx-icon-color: -jr-theme-text;
+    -fx-icon-color: -jr-theme;
 }
 
 .progress-indicatorToolbar {
@@ -250,12 +268,12 @@
 }
 
 .mainMenu > .container > .menu-button > .label {
-    -fx-text-fill: -jr-menu-foreground;
+    -fx-text-fill: -jr-text-foreground;
 }
 
 .menu-item .glyph-icon {
-    -fx-fill: -jr-menu-item-foreground;
-    -fx-text-fill: -jr-menu-item-foreground;
+    -fx-fill: -jr-text-foreground;
+    -fx-text-fill: -jr-text-foreground;
 }
 
 .menu-item:focused .glyph-icon {
@@ -281,9 +299,9 @@
 .mainToolbar .ikonli-font-icon {
     /* `!important` is override library's default font size */
     -fx-font-size: 1.7em!important;
-    -fx-fill: -jr-theme-text;
-    -fx-text-fill: -jr-theme-text;
-    -fx-icon-color: -jr-theme-text;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
+    -fx-icon-color: -jr-theme;
 }
 
 .mainToolbar .progress-indicator {
@@ -296,13 +314,13 @@
     -fx-border-width: 1;
     -fx-border-color: -jr-separator;
     -fx-border-radius: 2;
-    -fx-fill: -jr-search-text;
+    -fx-fill: -fx-text-base-color;
 }
 
 .search-field .button .glyph-icon {
-    -fx-fill: -jr-search-text;
-    -fx-text-fill: -jr-search-text;
-    -fx-icon-color: -jr-search-text;
+    -fx-fill: -fx-text-base-color;
+    -fx-text-fill: -fx-text-base-color;
+    -fx-icon-color: -fx-text-base-color;
 }
 
 /*
@@ -310,7 +328,7 @@
  * Currently, hits "Web search" and "Groups" only (not the searchbar on the top).
 */
 .search-field-icon {
-    -fx-icon-color: -jr-search-text;
+    -fx-icon-color: -fx-text-base-color;
     -fx-font-size: 1.7em;
 }
 
@@ -325,7 +343,7 @@
 }
 
 .global-search-bar .toggle-button:selected .glyph-icon {
-    -fx-icon-color: -jr-search-text;
+    -fx-icon-color: -fx-text-base-color;
 }
 
 /* search text */
@@ -345,17 +363,17 @@
 /* The little arrow that shows up when not all tool-bar icons fit into the tool-bar.
 We want to have a look that matches our icons in the tool-bar */
 .mainToolbar .tool-bar-overflow-button > .arrow {
-    -fx-background-color: -jr-theme-text;
+    -fx-background-color: -jr-theme;
 }
 
 .mainToolbar .tool-bar-overflow-button:hover > .arrow {
-    -fx-background-color: -fx-mark-highlight-color, derive(-jr-theme-text, -30%);
+    -fx-background-color: -fx-mark-highlight-color, derive(-jr-theme, -30%);
 }
 
 .column-header .glyph-icon {
     -fx-alignment: baseline-center;
-    -fx-text-fill: -jr-head-fg;
-    -fx-fill: -jr-head-fg;
+    -fx-text-fill: -fx-text-inner-color;
+    -fx-fill: -fx-text-inner-color;
 }
 
 .table-cell .glyph-icon,
@@ -387,7 +405,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 /* Improve the context menu of the main toolbar, when icons don't fit and you have to press the little arrow to see them */
 .mainToolbar .context-menu .glyph-icon {
-    -fx-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
 }
 
 .mainToolbar .context-menu .glyph-icon:hover {
@@ -653,152 +671,147 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: -2 0 0 0;
 }
 
-/** even and odd are swapped around somehow. Below "odd" matches lines 2, 4, ... **/
+/* matching-search-and-groups */
 
-.main-table .table-row-cell:matching-search-and-groups {
+.main-table .table-row-cell:matching-search-and-groups:even {
     -fx-background-color: -jr-match-1-even;
-}
-.main-table .table-row-cell:matching-search-and-groups > .table-cell {
-    -fx-text-fill: -jr-match-1-text-color;
-}
-.main-table .table-row-cell:matching-search-and-groups:focused > .table-cell {
-    -fx-text-fill: -fx-focused-text-base-color;
-}
-.main-table .table-row-cell:matching-search-and-groups:focused:hover > .table-cell {
-    -fx-text-fill: -jr-white;
-}
-.main-table .table-row-cell:matching-search-and-groups:focused:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-white;
-}
-.main-table .table-row-cell:matching-search-and-groups:hover > .table-cell {
-    -fx-text-fill: -jr-hover-text;
-}
-.main-table .table-row-cell:matching-search-and-groups > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-match-1-text-color;
-}
-.main-table .table-row-cell:matching-search-and-groups:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-hover-text;
 }
 .main-table .table-row-cell:matching-search-and-groups:odd {
     -fx-background-color: -jr-match-1-odd;
 }
-.main-table .table-row-cell:matching-search-and-groups:selected,
-.main-table .table-row-cell:matching-search-and-groups:focused,
-.main-table .table-row-cell:matching-search-and-groups:focused:hover {
+
+.main-table .table-row-cell:matching-search-and-groups:selected {
     -fx-background-color: -jr-selected;
 }
+
+.main-table .table-row-cell:matching-search-and-groups:selected:hover,
 .main-table .table-row-cell:matching-search-and-groups:hover {
-    -fx-background-color: -jr-hover;
+    -fx-background-color: -jr-hover
 }
 
-.main-table .table-row-cell:matching-search-not-groups {
+.main-table .table-row-cell:matching-search-and-groups > .table-cell,
+.main-table .table-row-cell:matching-search-and-groups > .table-cell > .ikonli-font-icon {
+    -fx-text-fill: -jr-match-1-text-color;
+}
+
+.main-table .table-row-cell:matching-search-and-groups:hover > .table-cell,
+.main-table .table-row-cell:matching-search-and-groups:focused:hover > .table-cell,
+.main-table .table-row-cell:matching-search-and-groups:selected:focused:hover > .table-cell {
+    -fx-text-fill: derive(-jr-match-1-text-color, 10%);
+}
+
+.main-table .table-row-cell:matching-search-and-groups:focused:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-search-and-groups:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-search-and-groups:selected:focused:hover > .table-cell > .ikonli-font-icon {
+    -fx-icon-color: derive(-jr-match-1-text-color, 10%);
+}
+
+/* matching-search-not-groups */
+
+.main-table .table-row-cell:matching-search-not-groups:even {
     -fx-background-color: -jr-match-2-even;
 }
-.main-table .table-row-cell:matching-search-not-groups > .table-cell {
-    -fx-text-fill: -jr-match-2-text-color;
-}
-.main-table .table-row-cell:matching-search-not-groups:focused > .table-cell {
-    -fx-text-fill: -fx-focused-text-base-color;
-}
-.main-table .table-row-cell:matching-search-not-groups:focused:hover > .table-cell {
-    -fx-text-fill: -jr-white;
-}
-.main-table .table-row-cell:matching-search-not-groups:focused:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-white;
-}
-.main-table .table-row-cell:matching-search-not-groups:hover > .table-cell {
-    -fx-text-fill: -jr-hover-text;
-}
-.main-table .table-row-cell:matching-search-not-groups > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-match-2-text-color;
-}
-.main-table .table-row-cell:matching-search-not-groups:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-hover-text;
-}
+
 .main-table .table-row-cell:matching-search-not-groups:odd {
     -fx-background-color: -jr-match-2-odd;
 }
-.main-table .table-row-cell:matching-search-not-groups:selected,
-.main-table .table-row-cell:matching-search-not-groups:focused,
-.main-table .table-row-cell:matching-search-not-groups:focused:hover,
-.main-table .table-row-cell:matching-search-not-groups:hover {
+
+.main-table .table-row-cell:matching-search-not-groups:selected {
     -fx-background-color: -jr-selected;
 }
+
+.main-table .table-row-cell:matching-search-not-groups:selected:hover,
 .main-table .table-row-cell:matching-search-not-groups:hover {
     -fx-background-color: -jr-hover;
 }
 
-.main-table .table-row-cell:matching-groups-not-search {
+.main-table .table-row-cell:matching-search-not-groups > .table-cell,
+.main-table .table-row-cell:matching-search-not-groups > .table-cell > .ikonli-font-icon {
+    -fx-text-fill: -jr-match-2-text-color;
+}
+
+.main-table .table-row-cell:matching-search-not-groups:hover > .table-cell,
+.main-table .table-row-cell:matching-search-not-groups:focused:hover > .table-cell,
+.main-table .table-row-cell:matching-search-not-groups:selected:focused:hover > .table-cell {
+    -fx-text-fill: derive(-jr-match-2-text-color, 10%);
+}
+
+.main-table .table-row-cell:matching-search-not-groups:focused:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-search-not-groups:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-search-not-groups:selected:focused:hover > .table-cell > .ikonli-font-icon {
+    -fx-icon-color: derive(-jr-match-2-text-color, 10%);
+}
+
+/* matching-groups-not-search */
+
+.main-table .table-row-cell:matching-groups-not-search:even {
     -fx-background-color: -jr-match-3-even;
 }
-.main-table .table-row-cell:matching-groups-not-search > .table-cell {
-    -fx-text-fill: -jr-match-3-text-color;
-}
-.main-table .table-row-cell:matching-groups-not-search:focused > .table-cell {
-    -fx-text-fill: -fx-focused-text-base-color;
-}
-.main-table .table-row-cell:matching-groups-not-search:focused:hover > .table-cell {
-    -fx-text-fill: -jr-white;
-}
-.main-table .table-row-cell:matching-groups-not-search:focused:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-white;
-}
-.main-table .table-row-cell:matching-groups-not-search:hover > .table-cell {
-    -fx-text-fill: -jr-hover-text;
-}
-.main-table .table-row-cell:matching-groups-not-search > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-match-3-text-color;
-}
-.main-table .table-row-cell:matching-groups-not-search:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-hover-text;
-}
+
 .main-table .table-row-cell:matching-groups-not-search:odd {
     -fx-background-color: -jr-match-3-odd;
 }
-.main-table .table-row-cell:matching-groups-not-search:selected,
-.main-table .table-row-cell:matching-groups-not-search:focused,
-.main-table .table-row-cell:matching-groups-not-search:focused:hover,
-.main-table .table-row-cell:matching-groups-not-search:hover {
+
+.main-table .table-row-cell:matching-groups-not-search:selected {
     -fx-background-color: -jr-selected;
 }
+
+.main-table .table-row-cell:matching-groups-not-search:selected:hover,
 .main-table .table-row-cell:matching-groups-not-search:hover {
     -fx-background-color: -jr-hover;
 }
 
-.main-table .table-row-cell:not-matching-search-and-groups {
+.main-table .table-row-cell:matching-groups-not-search > .table-cell,
+.main-table .table-row-cell:matching-groups-not-search > .table-cell > .ikonli-font-icon {
+    -fx-text-fill: -jr-match-3-text-color;
+}
+
+.main-table .table-row-cell:matching-groups-not-search:hover > .table-cell,
+.main-table .table-row-cell:matching-groups-not-search:focused:hover > .table-cell,
+.main-table .table-row-cell:matching-groups-not-search:selected:focused:hover > .table-cell {
+    -fx-text-fill: derive(-jr-match-3-text-color, 10%);
+}
+
+.main-table .table-row-cell:matching-groups-not-search:focused:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-groups-not-search:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:matching-groups-not-search:selected:focused:hover > .table-cell > .ikonli-font-icon {
+    -fx-icon-color: derive(-jr-match-3-text-color, 10%);
+}
+
+/* not-matching-search-and-groups */
+
+.main-table .table-row-cell:not-matching-search-and-groups:even {
     -fx-background-color: -jr-match-4-even;
 }
-.main-table .table-row-cell:not-matching-search-and-groups > .table-cell {
-    -fx-text-fill: -jr-match-4-text-color;
-}
-.main-table .table-row-cell:not-matching-search-and-groups:focused > .table-cell {
-    -fx-text-fill: -fx-focused-text-base-color;
-}
-.main-table .table-row-cell:not-matching-search-and-groups:focused:hover > .table-cell {
-    -fx-text-fill: -jr-white;
-}
-.main-table .table-row-cell:not-matching-search-and-groups:focused:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-white;
-}
-.main-table .table-row-cell:not-matching-search-and-groups:hover > .table-cell {
-    -fx-text-fill: -jr-hover-text;
-}
-.main-table .table-row-cell:not-matching-search-and-groups > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-match-4-text-color;
-}
-.main-table.table-row-cell:not-matching-search-and-groups:hover > .table-cell > .ikonli-font-icon {
-    -fx-icon-color: -jr-hover-text;
-}
+
 .main-table .table-row-cell:not-matching-search-and-groups:odd {
     -fx-background-color: -jr-match-4-odd;
 }
-.main-table .table-row-cell:not-matching-search-and-groups:selected,
-.main-table .table-row-cell:not-matching-search-and-groups:focused,
-.main-table .table-row-cell:not-matching-search-and-groups:focused:hover {
+
+.main-table .table-row-cell:not-matching-search-and-groups:selected {
     -fx-background-color: -jr-selected;
 }
+
+.main-table .table-row-cell:not-matching-search-and-groups:selected:hover,
 .main-table .table-row-cell:not-matching-search-and-groups:hover {
     -fx-background-color: -jr-hover;
+}
+
+.main-table .table-row-cell:not-matching-search-and-groups > .table-cell,
+.main-table .table-row-cell:not-matching-search-and-groups > .table-cell > .ikonli-font-icon {
+    -fx-text-fill: -jr-match-4-text-color;
+}
+
+.main-table .table-row-cell:not-matching-search-and-groups:hover > .table-cell,
+.main-table .table-row-cell:not-matching-search-and-groups:focused:hover > .table-cell,
+.main-table .table-row-cell:not-matching-search-and-groups:selected:focused:hover > .table-cell {
+    -fx-text-fill: derive(-jr-match-4-text-color, 10%);
+}
+
+.main-table .table-row-cell:not-matching-search-and-groups:focused:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:not-matching-search-and-groups:hover > .table-cell > .ikonli-font-icon,
+.main-table .table-row-cell:not-matching-search-and-groups:selected:focused:hover > .table-cell > .ikonli-font-icon {
+    -fx-icon-color: derive(-jr-match-4-text-color, 10%);
 }
 
 .rating > .container {
@@ -821,7 +834,7 @@ We want to have a look that matches our icons in the tool-bar */
 
 .welcome-label {
     -fx-font-size: 2.75em;
-    -fx-text-fill: -jr-theme-text;
+    -fx-text-fill: -jr-theme;
     -fx-font-family: "Arial";
 }
 
@@ -834,7 +847,7 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
     -fx-font-family: "Arial";
-    -fx-text-fill: -jr-head-fg;
+    -fx-text-fill: -fx-text-inner-color;
 }
 
 .welcome-no-recent-label {
@@ -1085,7 +1098,7 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0.1em;
     -fx-font-size: 1.166667em;
     -fx-font-weight: bold;
-    -fx-text-fill: -jr-theme-text;
+    -fx-text-fill: -jr-theme;
 }
 
 #entryEditor #typeLabel:hover {
@@ -1125,8 +1138,8 @@ We want to have a look that matches our icons in the tool-bar */
 #entryEditor .tool-bar .glyph-icon {
     -glyph-size: 1.0em;
     -fx-font-size: 2em;
-    -fx-fill: -jr-theme-text;
-    -fx-text-fill: -jr-theme-text;
+    -fx-fill: -jr-theme;
+    -fx-text-fill: -jr-theme;
 }
 
 #entryEditor .warning-icon {
@@ -1256,8 +1269,7 @@ We want to have a look that matches our icons in the tool-bar */
 #errorConsole .info-section .glyph-icon,
 #errorConsole .exception .glyph-icon,
 #errorConsole .output .glyph-icon,
-#errorConsole .log .glyph-icon
-{
+#errorConsole .log .glyph-icon {
     -fx-font-size: 1.5em;
 }
 
@@ -1759,7 +1771,7 @@ journalInfo .grid-cell-b {
 .three-way-merge .field-name .glyph-icon,
 .three-way-merge .field-name .ikonli-font-icon {
     -fx-icon-size: 17;
-    -fx-icon-color: -jr-theme-text;
+    -fx-icon-color: -jr-theme;
 }
 
 /* Miscellaneous */
@@ -1838,8 +1850,8 @@ journalInfo .grid-cell-b {
 
 .quick-settings-button .glyph-icon,
 .quick-settings-button .ikonli-font-icon {
-    -fx-icon-color: -jr-theme-text;
-    -fx-fill: -jr-theme-text;
+    -fx-icon-color: -jr-theme;
+    -fx-fill: -jr-theme;
     -fx-font-size: 1.1em;
 }
 
@@ -2015,8 +2027,8 @@ journalInfo .grid-cell-b {
 
 .detected-application .glyph-icon,
 .detected-application .ikonli-font-icon {
-    -fx-icon-color: -jr-theme-text;
-    -fx-fill: -jr-theme-text;
+    -fx-icon-color: -jr-theme;
+    -fx-fill: -jr-theme;
 }
 
 /* Quick Settings: Online Fetchers */


### PR DESCRIPTION
### Related issues and pull requests

Follow up from: https://github.com/JabRef/jabref/pull/15573

### PR Description

- Empty row highlighting is now fixed
- Table Matching colors are improved and will be calculated based of the original even/odd colors. Could probably be improved further
- Remove variables that are always the same -fx-XXX variable, use the -fx-XXX variable directly instead. So we have less `-jr-XXX` variables we actually don't need to maintain
  - Example: `-jr-theme-text` was always the same as `-jr-theme`

<img width="1275" height="547" alt="image" src="https://github.com/user-attachments/assets/d4ef622b-fba7-4c47-a93f-629d42e50db2" />

<img width="1275" height="526" alt="image" src="https://github.com/user-attachments/assets/9591595b-a194-4b3e-9592-b7948dbdeb3c" />

https://github.com/user-attachments/assets/97c62d2b-337a-4aaa-9d9c-47d40d5abe93

### Steps to test

Open JabRef, load a Library and check the Main Table. Use the Search `TextField` to see the maching colors.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
