### PR TITLE
Fix hash warning

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/FieldWriter.java
@@ -191,16 +191,16 @@ public class FieldWriter {
                 pos2 = -1;
             } else {
                 pos2 = content.indexOf(BIBTEX_STRING_START_END_SYMBOL, pos1 + 1);
-            }
 
-            if (pos2 == -1) {
-                pos1 = content.length();
-                LOGGER.warn("The character {} is not allowed in BibTeX strings unless escaped as in '\\\\{}'. "
-                                + "In JabRef, use pairs of # characters to indicate a string. "
-                                + "Field value: {}",
-                        BIBTEX_STRING_START_END_SYMBOL,
-                        BIBTEX_STRING_START_END_SYMBOL,
-                        content);
+                if (pos2 == -1) {
+                    pos1 = content.length();
+                    LOGGER.warn("The character {} is not allowed in BibTeX strings unless escaped as in '\\\\{}'. "
+                                    + "In JabRef, use pairs of # characters to indicate a string. "
+                                    + "Field value: {}",
+                            BIBTEX_STRING_START_END_SYMBOL,
+                            BIBTEX_STRING_START_END_SYMBOL,
+                            content);
+                }
             }
 
             if (pos1 > pivot) {


### PR DESCRIPTION
### Related issues and pull requests

Follow up to #15559 
Fixes https://github.com/JabRef/jabref-issue-melting-pot/issues/1279
Fixes #15586 

### PR Description

See qodo

### Steps to test

Run JabRef, write something in entry editor, see no warning about hashes

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
