### PR TITLE
Enable Drag and Drop import for .ris Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - Added context menu entry "Sort tabs alphabetically" to the library tabs. [#15425](https://github.com/JabRef/jabref/pull/15425)
 - We added a "Merge" action in the File menu to compare the current library with a selected BibTeX file and review changes. [#15401](https://github.com/JabRef/jabref/issues/15401)
 - We added integrity checks that warn when the `booktitle` field contains a year, a country/location, or page numbers that should live in dedicated fields. [#12271](https://github.com/JabRef/jabref/issues/12271)
+- We extended drag-and-drop of library files onto the entry table to support all JabRef-supported import formats (e.g., `.ris`, `.enl`), not only `.bib` files. [#15391](https://github.com/JabRef/jabref/issues/15391)
 
 ### Changed
 

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -124,6 +124,12 @@ public class ImportHandler {
             @Override
             public List<ImportFilesResultItemViewModel> call() {
                 counter = 1;
+                ImportFormatReader importFormatReader = new ImportFormatReader(
+                        preferences.getImporterPreferences(),
+                        preferences.getImportFormatPreferences(),
+                        preferences.getCitationKeyPatternPreferences(),
+                        fileUpdateMonitor
+                );
                 CompoundEdit compoundEdit = new CompoundEdit();
                 for (final Path file : files) {
                     final List<BibEntry> entriesToAdd = new ArrayList<>();
@@ -193,12 +199,21 @@ public class ImportHandler {
                             }
                             addResultToList(file, success, message);
                         } else {
-                            BibEntry emptyEntryWithLink = createEmptyEntryWithLink(file);
-                            entriesToAdd.add(emptyEntryWithLink);
-                            addResultToList(file, false, Localization.lang("No BibTeX data was found. An empty entry was created with file link."));
+                            ImportResult importResult = importFormatReader.importWithAutoDetection(file);
+                            List<BibEntry> entries = importResult.parserResult().getDatabase().getEntries();
+
+                            if (entries.isEmpty()) {
+                                BibEntry emptyEntryWithLink = createEmptyEntryWithLink(file);
+                                entriesToAdd.add(emptyEntryWithLink);
+                                addResultToList(file, false, Localization.lang("No BibTeX data was found. An empty entry was created with file link."));
+                                continue;
+                            }
+
+                            entriesToAdd.addAll(entries);
+                            addResultToList(file, true, Localization.lang("File was successfully imported as a new entry"));
                         }
-                    } catch (IOException ex) {
-                        LOGGER.error("Error importing", ex);
+                    } catch (IOException | ImportException ex) {
+                        LOGGER.error("Error importing file {}", file, ex);
                         addResultToList(file, false, Localization.lang("Error from import: %0", ex.getLocalizedMessage()));
 
                         UiTaskExecutor.runInJavaFXThread(() -> updateMessage(Localization.lang("Error")));


### PR DESCRIPTION
### Related issues and pull requests

Closes #15391 

### PR Description

This PR extends the drag-and-drop import logic to support all bibliography formats (such as `.ris`,`.enl` or `.xml`) by
using the existing logic in `ImportFormatReader` for automatic file type detection within `ImportHandler`.
Dropped files will trigger the "Select the entries to be imported" dialog for user inspection.

### Steps to test

1. In your system's file explorer, go to a folder containing a supported library file.
2. Drag it into JabRef.
3 The "Select the entries to be imported" dialog should open and allow you to import entries into the currently opened library.
4. It should now appear as a new entry with the correct metadata in the table.

<img width="1441" height="712" alt="image" src="https://github.com/user-attachments/assets/d05e32eb-1e1c-4568-8b4f-5027c2625396" />


File examples for testing: https://github.com/JabRef/jabref-demonstration-libraries/blob/main/chocolate/Chocolate.bib

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
