### PR TITLE
Change OpenRewrite task to use rewriteDryRun

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -81,12 +81,18 @@ jobs:
           show-progress: 'false'
       - uses: ./.github/actions/setup-gradle
       - name: Run OpenRewrite
+        continue-on-error: true
+        run: |
+          gradle --no-configuration-cache :rewriteRun
+      - name: Output diff
+        run: |
+          if [ -f /home/runner/work/jabref/jabref/build/reports/rewrite/rewrite.patch ]; then
+            cat /home/runner/work/jabref/jabref/build/reports/rewrite/rewrite.patch
+            exit 1
+          fi
+      - name: Run OpenRewrite (fallback)
         run: |
           gradle --no-configuration-cache :rewriteDryRun
-      - name: Output diff
-        if: failure()
-        run: |
-          cat /home/runner/work/jabref/jabref/build/reports/rewrite/rewrite.patch
 
   format:
     # ubuntu-slim doesn't offer docker

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -81,18 +81,10 @@ jobs:
           show-progress: 'false'
       - uses: ./.github/actions/setup-gradle
       - name: Run OpenRewrite
-        continue-on-error: true
         run: |
           gradle --no-configuration-cache :rewriteRun
-      - name: Output diff
-        run: |
-          if [ -f /home/runner/work/jabref/jabref/build/reports/rewrite/rewrite.patch ]; then
-            cat /home/runner/work/jabref/jabref/build/reports/rewrite/rewrite.patch
-            exit 1
-          fi
-      - name: Run OpenRewrite (fallback)
-        run: |
-          gradle --no-configuration-cache :rewriteDryRun
+      - name: Fail if working directory is unclean
+        run: git diff --exit-code
 
   format:
     # ubuntu-slim doesn't offer docker

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: ./.github/actions/setup-gradle
       - name: Run OpenRewrite
         run: |
-          gradle --no-configuration-cache :rewriteRun
+          gradle --no-configuration-cache :rewriteDryRun
       - name: Output diff
         if: failure()
         run: |


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/1289

### PR Description

Fixes the OpenRewrite check. The problem was that when there are changes, the check is succeded. But if we change the task to the dry run, on changes it will fail (the same also happens locally, so I think on CI/CD it will also work like that).

### Steps to test

I don't know how to test the CI/CD changes. But you can locally run `rewriteRun` and `rewriteDryRun`.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
