### PR TITLE
Fix #15577: Add regex anchors to enforce exact month matching - Enforce 

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/integrity/MonthChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/MonthChecker.java
@@ -13,10 +13,10 @@ import org.jspecify.annotations.Nullable;
 
 public class MonthChecker implements ValueChecker {
 
-    private static final Predicate<String> ONLY_AN_INTEGER = Pattern.compile("[1-9]|10|11|12")
+    private static final Predicate<String> ONLY_AN_INTEGER = Pattern.compile("^([1-9]|10|11|12)$")
                                                                     .asPredicate();
     private static final Predicate<String> MONTH_NORMALIZED = Pattern
-            .compile("#jan#|#feb#|#mar#|#apr#|#may#|#jun#|#jul#|#aug#|#sep#|#oct#|#nov#|#dec#")
+            .compile("^(#jan#|#feb#|#mar#|#apr#|#may#|#jun#|#jul#|#aug#|#sep#|#oct#|#nov#|#dec#)$")
             .asPredicate();
 
     private final BibDatabaseContext bibDatabaseContextMonth;


### PR DESCRIPTION
### Related issues and pull requests

Closes #15577
https://github.com/JabRef/jabref/issues/15577

### PR Description

This PR updates the MonthChecker validation logic by adding start (^) and end ($) anchors to the underlying regular expressions. This change enforces exact string matching for month values, ensuring that only valid integers (1-12) or normalized BibTeX strings are accepted while preventing malformed partial matches from passing the validation layer.

### Steps to test

1. Open JabRef and create a new entry (e.g., an Article).
2. Locate a field that utilizes the Month validator (such as the Month field in the entry editor or the String Editor).
3. Enter a value that contains a valid month name but is incorrectly formatted (January123 or #jan#invalid).
4. Observe that the validator now correctly flags these as errors.
5. Enter a valid month (10 or #jan#) and verify it is still accepted.
6. 
<img width="1598" height="555" alt="AuthorScreenshot15577" src="https://github.com/user-attachments/assets/ff61db87-1c58-4876-8e19-50bd934f6b69" />


### Checklist
 
 - [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
 - [x] I manually tested my changes in running JabRef (always required)
 - [/] I added JUnit tests for changes (not applicable)
 - [/] I added screenshots in the PR description (if change is visible to the user)
 - [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
 - [x] I described the change in CHANGELOG.md in a way that can be understood by the average user (if change is visible to the user)
 - [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)