### PR TITLE
Replace inline styles with CSS classes

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/CitationKeyPatternsPanel.java
@@ -121,17 +121,19 @@ public class CitationKeyPatternsPanel extends TableView<CitationKeyPatternsPanel
     }
 
     private static class HighlightTableRow extends TableRow<CitationKeyPatternsPanelItemModel> {
+        private static final String DEFAULT_ROW_STYLE_CLASS = "citation-key-pattern-default-row";
+
         @Override
         public void updateItem(CitationKeyPatternsPanelItemModel item, boolean empty) {
+            // Style used to highlight the default entry type row
             super.updateItem(item, empty);
-            if (item == null || item.getEntryType() == null) {
-                setStyle("");
-            } else if (isSelected()) {
-                setStyle("-fx-background-color: -fx-selection-bar");
-            } else if (CitationKeyPatternsPanelViewModel.ENTRY_TYPE_DEFAULT_NAME.equals(item.getEntryType().getName())) {
-                setStyle("-fx-background-color: -fx-default-button");
-            } else {
-                setStyle("");
+
+            getStyleClass().remove(DEFAULT_ROW_STYLE_CLASS);
+            // Reapply the style only for the default entry type row
+            if (item != null
+                    && item.getEntryType() != null
+                    && CitationKeyPatternsPanelViewModel.ENTRY_TYPE_DEFAULT_NAME.equals(item.getEntryType().getName())) {
+                getStyleClass().add(DEFAULT_ROW_STYLE_CLASS);
             }
         }
     }

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -110,7 +110,7 @@ public class LatexCitationsTab extends EntryEditorTab {
         Text latexDirectoryText = new Text(Localization.lang("Current search directory:"));
         Text latexDirectoryPath = new Text();
         latexDirectoryPath.textProperty().bind(viewModel.directoryProperty().asString());
-        latexDirectoryPath.setStyle("-fx-font-family:monospace;-fx-font-weight: bold;");
+        latexDirectoryPath.getStyleClass().add("latex-citations-directory-path");
         Button latexDirectoryButton = new Button(Localization.lang("Set LaTeX file directory"));
         latexDirectoryButton.setGraphic(IconTheme.JabRefIcons.LATEX_FILE_DIRECTORY.getGraphicNode());
         latexDirectoryButton.setOnAction(event -> viewModel.setLatexDirectory());
@@ -122,7 +122,7 @@ public class LatexCitationsTab extends EntryEditorTab {
     private VBox getCitationsPane() {
         VBox citationsBox = new VBox(30, citationsDisplay);
         VBox.setVgrow(citationsDisplay, Priority.ALWAYS);
-        citationsBox.setStyle("-fx-padding: 0;");
+        citationsBox.getStyleClass().add("latex-citations-box");
         return citationsBox;
     }
 
@@ -134,17 +134,17 @@ public class LatexCitationsTab extends EntryEditorTab {
         notFoundText.getStyleClass().add("description");
 
         VBox notFoundBox = new VBox(30, titleLabel, notFoundText);
-        notFoundBox.setStyle("-fx-padding: 30 0 0 30;");
+        notFoundBox.getStyleClass().add("latex-citations-message-box");
         return notFoundBox;
     }
 
     private VBox getErrorPane() {
         Label titleLabel = new Label(Localization.lang("Error"));
-        titleLabel.setStyle("-fx-font-size: 1.5em;-fx-font-weight: bold;-fx-text-fill: -fx-accent;");
+        titleLabel.getStyleClass().add("latex-citations-error-label");
         Text errorMessageText = new Text();
         errorMessageText.textProperty().bind(viewModel.searchErrorProperty());
         VBox errorMessageBox = new VBox(30, titleLabel, errorMessageText);
-        errorMessageBox.setStyle("-fx-padding: 30 0 0 30;");
+        errorMessageBox.getStyleClass().add("latex-citations-message-box");
         return errorMessageBox;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/LatexCitationsTab.java
@@ -122,7 +122,7 @@ public class LatexCitationsTab extends EntryEditorTab {
     private VBox getCitationsPane() {
         VBox citationsBox = new VBox(30, citationsDisplay);
         VBox.setVgrow(citationsDisplay, Priority.ALWAYS);
-        citationsBox.getStyleClass().add("latex-citations-box");
+        citationsBox.getStyleClass().add("padding-0");
         return citationsBox;
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -668,7 +668,7 @@ public class CitationRelationsTab extends EntryEditorTab {
     /// @param label       label to style
     /// @param tooltipText tooltip text
     private void styleLabel(Label label, String tooltipText) {
-        label.getStyleClass().add("padded-label");
+        label.getStyleClass().add("padding-5px");
         label.setAlignment(Pos.CENTER);
         label.setTooltip(new Tooltip(tooltipText));
         label.setMaxWidth(Double.MAX_VALUE);
@@ -814,7 +814,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
         hBox.setSpacing(2d);
-        hBox.getStyleClass().add("centered-container");
+        hBox.getStyleClass().add("align-center");
         hBox.setFillHeight(true);
 
         citationComponents.listView().getItems().clear();

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -205,7 +205,7 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         VBox vBox = new VBox();
         vBox.getChildren().add(progressIndicator);
-        vBox.getStyleClass().add("centered-container");
+        vBox.getStyleClass().add("align-center");
 
         sciteResultsPane.add(vBox, 0, 0);
 
@@ -225,7 +225,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         vBox.getChildren().add(progressIndicator);
         vBox.getChildren().add(label);
         vBox.setSpacing(2d);
-        vBox.getStyleClass().add("centered-container");
+        vBox.getStyleClass().add("align-center");
 
         sciteResultsPane.add(vBox, 0, 0);
 
@@ -247,7 +247,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
         hBox.setSpacing(2d);
-        hBox.getStyleClass().add("centered-container");
+        hBox.getStyleClass().add("align-center");
 
         sciteResultsPane.add(hBox, 0, 0);
 

--- a/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/entryeditor/citationrelationtab/CitationRelationsTab.java
@@ -205,7 +205,7 @@ public class CitationRelationsTab extends EntryEditorTab {
 
         VBox vBox = new VBox();
         vBox.getChildren().add(progressIndicator);
-        vBox.setStyle("-fx-alignment: center;");
+        vBox.getStyleClass().add("centered-container");
 
         sciteResultsPane.add(vBox, 0, 0);
 
@@ -225,7 +225,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         vBox.getChildren().add(progressIndicator);
         vBox.getChildren().add(label);
         vBox.setSpacing(2d);
-        vBox.setStyle("-fx-alignment: center;");
+        vBox.getStyleClass().add("centered-container");
 
         sciteResultsPane.add(vBox, 0, 0);
 
@@ -247,7 +247,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
         hBox.setSpacing(2d);
-        hBox.setStyle("-fx-alignment: center;");
+        hBox.getStyleClass().add("centered-container");
 
         sciteResultsPane.add(hBox, 0, 0);
 
@@ -668,7 +668,7 @@ public class CitationRelationsTab extends EntryEditorTab {
     /// @param label       label to style
     /// @param tooltipText tooltip text
     private void styleLabel(Label label, String tooltipText) {
-        label.setStyle("-fx-padding: 5px");
+        label.getStyleClass().add("padded-label");
         label.setAlignment(Pos.CENTER);
         label.setTooltip(new Tooltip(tooltipText));
         label.setMaxWidth(Double.MAX_VALUE);
@@ -814,7 +814,7 @@ public class CitationRelationsTab extends EntryEditorTab {
         hBox.getChildren().add(label);
         hBox.getChildren().add(link);
         hBox.setSpacing(2d);
-        hBox.setStyle("-fx-alignment: center;");
+        hBox.getStyleClass().add("centered-container");
         hBox.setFillHeight(true);
 
         citationComponents.listView().getItems().clear();

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/FileSelectionPage.java
@@ -69,7 +69,7 @@ public class FileSelectionPage extends WizardPane {
         BorderPane mainLayout = new BorderPane();
 
         progressPane = new VBox(10);
-        progressPane.setStyle("-fx-alignment: center; -fx-padding: 20;");
+        progressPane.getStyleClass().add("file-selection-progress-pane");
 
         progressIndicator = new ProgressIndicator();
         progressIndicator.progressProperty().bind(viewModel.progressValueProperty());
@@ -82,7 +82,7 @@ public class FileSelectionPage extends WizardPane {
         contentPane = new VBox(10);
 
         fileCountLabel = new Label();
-        fileCountLabel.setStyle("-fx-font-weight: bold;");
+        fileCountLabel.getStyleClass().add("bold");
 
         unlinkedFilesList = new CheckTreeView<>();
         unlinkedFilesList.setCellFactory(_ -> new UnlinkedFilesCellFactory(stateManager, viewModel));

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportResultsPage.java
@@ -53,7 +53,7 @@ public class ImportResultsPage extends WizardPane {
 
         /// Progress pane
         progressPane = new VBox(10);
-        progressPane.setStyle("-fx-alignment: center; -fx-padding: 20;");
+        progressPane.getStyleClass().add("file-selection-progress-pane");
         progressPane.setMaxWidth(Double.MAX_VALUE);
         progressPane.setMaxHeight(Double.MAX_VALUE);
 
@@ -73,7 +73,7 @@ public class ImportResultsPage extends WizardPane {
         contentPane.setPrefSize(550, 450);
 
         summaryLabel = new Label();
-        summaryLabel.setStyle("-fx-font-weight: bold;");
+        summaryLabel.getStyleClass().add("bold");
 
         /// TableView with explicit size constraints
         resultsTable = new TableView<>();

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -173,7 +173,7 @@ public class MainTableColumnFactory {
         header.getStyleClass().add("mainTable-header");
         Tooltip.install(header, new Tooltip(MainTableColumnModel.Type.INDEX.getDisplayName()));
         column.setGraphic(header);
-        column.setStyle("-fx-alignment: CENTER-RIGHT;");
+        column.getStyleClass().add("right-aligned-column");
         column.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(
                 String.valueOf(cellData.getTableView().getItems().indexOf(cellData.getValue()) + 1)));
         new ValueTableCellFactory<BibEntryTableViewModel, String>()
@@ -196,7 +196,7 @@ public class MainTableColumnFactory {
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupColorRegion)
                 .install(column);
-        column.setStyle("-fx-padding: 0 0 0 0;");
+        column.getStyleClass().add("main-table-column-no-padding");
         column.setSortable(true);
         return column;
     }
@@ -213,7 +213,7 @@ public class MainTableColumnFactory {
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupIconRegion)
                 .install(column);
-        column.setStyle("-fx-padding: 0 0 0 0;");
+        column.getStyleClass().add("main-table-column-no-padding");
         column.setSortable(true);
         return column;
     }

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableColumnFactory.java
@@ -173,7 +173,7 @@ public class MainTableColumnFactory {
         header.getStyleClass().add("mainTable-header");
         Tooltip.install(header, new Tooltip(MainTableColumnModel.Type.INDEX.getDisplayName()));
         column.setGraphic(header);
-        column.getStyleClass().add("right-aligned-column");
+        column.getStyleClass().add("align-center-right");
         column.setCellValueFactory(cellData -> new ReadOnlyObjectWrapper<>(
                 String.valueOf(cellData.getTableView().getItems().indexOf(cellData.getValue()) + 1)));
         new ValueTableCellFactory<BibEntryTableViewModel, String>()
@@ -196,7 +196,7 @@ public class MainTableColumnFactory {
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupColorRegion)
                 .install(column);
-        column.getStyleClass().add("main-table-column-no-padding");
+        column.getStyleClass().add("padding-0");
         column.setSortable(true);
         return column;
     }
@@ -213,7 +213,7 @@ public class MainTableColumnFactory {
         new ValueTableCellFactory<BibEntryTableViewModel, List<AbstractGroup>>()
                 .withGraphic(this::createGroupIconRegion)
                 .install(column);
-        column.getStyleClass().add("main-table-column-no-padding");
+        column.getStyleClass().add("padding-0");
         column.setSortable(true);
         return column;
     }

--- a/jabgui/src/main/java/org/jabref/gui/texparser/ParseLatexResultView.java
+++ b/jabgui/src/main/java/org/jabref/gui/texparser/ParseLatexResultView.java
@@ -55,7 +55,7 @@ public class ParseLatexResultView extends BaseDialog<Void> {
                 .withGraphic(reference -> {
                     Text referenceText = new Text(reference.getDisplayText());
                     if (reference.isHighlighted()) {
-                        referenceText.setStyle("-fx-fill: -fx-accent");
+                        referenceText.getStyleClass().add("parse-latex-reference-text");
                     }
                     return referenceText;
                 })

--- a/jabgui/src/main/java/org/jabref/gui/util/TextFlowLimited.java
+++ b/jabgui/src/main/java/org/jabref/gui/util/TextFlowLimited.java
@@ -24,7 +24,7 @@ public class TextFlowLimited extends TextFlow {
         this.setPrefWidth(Region.USE_PREF_SIZE);
 
         moreLink.setOnAction(event -> expand());
-        moreLink.setStyle("-fx-background-color: white");
+        moreLink.getStyleClass().add("text-flow-more-link");
 
         this.setOnMouseClicked(event -> expand());
     }

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -1260,10 +1260,6 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-font-weight: bold;
 }
 
-#entryEditor .latex-citations-box {
-    -fx-padding: 0;
-}
-
 #entryEditor .latex-citations-message-box {
     -fx-padding: 30 0 0 30;
 }
@@ -1688,11 +1684,11 @@ We want to have a look that matches our icons in the tool-bar */
 
 /* CitationRelationsTab */
 
-#citationRelationsTab .padding-5px {
+.padding-5px {
     -fx-padding: 5px;
 }
 
-#citationRelationsTab .align-center {
+.align-center {
     -fx-alignment: center;
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -647,11 +647,11 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-padding: 0;
 }
 
-.main-table-column-no-padding {
+.padding-0 {
     -fx-padding: 0;
 }
 
-.right-aligned-column {
+.align-center-right {
     -fx-alignment: CENTER-RIGHT;
 }
 
@@ -1271,7 +1271,7 @@ We want to have a look that matches our icons in the tool-bar */
 #entryEditor .latex-citations-error-label {
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
-    -fx-text-fill: -jr-error;
+    -fx-text-fill: -fx-accent;
 }
 
 /* ErrorConsole */
@@ -1688,11 +1688,11 @@ We want to have a look that matches our icons in the tool-bar */
 
 /* CitationRelationsTab */
 
-#citationRelationsTab .padded-label {
+#citationRelationsTab .padding-5px {
     -fx-padding: 5px;
 }
 
-#citationRelationsTab .centered-container {
+#citationRelationsTab .align-center {
     -fx-alignment: center;
 }
 

--- a/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
+++ b/jabgui/src/main/resources/org/jabref/gui/jabref-theme.css
@@ -63,6 +63,10 @@
     -rtfx-background-color: -jr-error;
 }
 
+.bold {
+    -fx-font-weight: bold;
+}
+
 .merge-header-cell {
     -fx-border-color: -fx-outer-border;
     -fx-background-color: -jr-row-odd-background;
@@ -630,11 +634,25 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-background-color: transparent;
 }
 
+/* CitationKeyPatternsPanel */
+
+.citation-key-pattern-default-row {
+    -fx-background-color: -fx-default-button;
+}
+
 /* MainTable */
 
 .main-table .column-icon {
     -fx-alignment: baseline-center;
     -fx-padding: 0;
+}
+
+.main-table-column-no-padding {
+    -fx-padding: 0;
+}
+
+.right-aligned-column {
+    -fx-alignment: CENTER-RIGHT;
 }
 
 .main-table .column-header.column-icon > .label {
@@ -1237,6 +1255,25 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-text-fill: -jr-error;
 }
 
+#entryEditor .latex-citations-directory-path {
+    -fx-font-family: monospace;
+    -fx-font-weight: bold;
+}
+
+#entryEditor .latex-citations-box {
+    -fx-padding: 0;
+}
+
+#entryEditor .latex-citations-message-box {
+    -fx-padding: 30 0 0 30;
+}
+
+#entryEditor .latex-citations-error-label {
+    -fx-font-size: 1.5em;
+    -fx-font-weight: bold;
+    -fx-text-fill: -jr-error;
+}
+
 /* ErrorConsole */
 #errorConsole .list-content {
     -fx-padding: 0em;
@@ -1516,6 +1553,10 @@ We want to have a look that matches our icons in the tool-bar */
     -fx-border-color: -jr-sidepane-background;
 }
 
+#parseLatexResultDialog .parse-latex-reference-text {
+    -fx-fill: -fx-accent;
+}
+
 /* PreferenceDialog */
 #preferencesDialog #sidepane {
     -fx-background-color: -jr-sidepane-background;
@@ -1646,6 +1687,14 @@ We want to have a look that matches our icons in the tool-bar */
 }
 
 /* CitationRelationsTab */
+
+#citationRelationsTab .padded-label {
+    -fx-padding: 5px;
+}
+
+#citationRelationsTab .centered-container {
+    -fx-alignment: center;
+}
 
 #citationRelationsTab .addEntryButton {
     -fx-font-size: 2em;
@@ -2194,6 +2243,19 @@ journalInfo .grid-cell-b {
     -fx-spacing: 1em;
     -fx-max-width: 48em;
     -fx-fill-width: true;
+}
+
+/* FileSelectionPage */
+
+.file-selection-progress-pane {
+    -fx-alignment: center;
+    -fx-padding: 20;
+}
+
+/* TextFlowLimited */
+
+.text-flow-more-link {
+    -fx-background-color: -jr-white;
 }
 
 /* Markdown styles */


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/15686
Closes #15686


### PR Description

This PR replaces several inline setStyle(...) calls with CSS style classes in order to move styling logic from Java code into the theme files.

After running a grep search for color-related setStyle(...) calls, only two files remained:

--> WelcomeTab.java
--> ChatMessageComponent.java

I intentionally did not modify them because WelcomeTab.java already contains a comment explaining that a CSS class was insufficient in that specific case, and ChatMessageComponent.java uses dynamically generated colors. Since I am still relatively new to JavaFX and the project's styling system, I preferred not to touch the more complex cases to avoid accidentally breaking existing behavior.

Apart from these two files, I made sure that all remaining color-related inline styles were replaced with CSS classes. I also replaced most of the simpler setStyle(...) calls related to padding, alignment, font weight, and similar properties.

### Steps to test
1-  Run JabRef locally.
2 - Switch between light and dark themes.
3 - Open the affected UI areas and verify that the styling and layout still behave correctly.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
