### PR TITLE
Cite multiple entries as a single citation for CSL in-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)
 - We fixed an issue with the `Normalize date` save action truncating date ranges. [#8902](https://github.com/JabRef/jabref/issues/8902)
 - We fixed an issue where removed CSL files were not immediately cleared from the UI upon style removal. [#15438](https://github.com/JabRef/jabref/issues/15438)

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -320,6 +320,7 @@ public class CSLCitationOOAdapter {
         return CSLFormatUtils.transformHTML(citation);
     }
 
+    /// Helper method for creating citation group for `insertInTextCitation` and `updateAllCitationsWithNewStyle`
     private @NonNull String createInTextCitationGroupText(CitationStyle style, boolean isAlphaNumericStyle, boolean isNumericStyle, List<BibEntry> entries, BibDatabaseContext bibDatabaseContext) {
         StringJoiner citations = new StringJoiner(", ");
         for (BibEntry entry : entries) {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -135,21 +136,9 @@ public class CSLCitationOOAdapter {
 
         boolean isNumericStyle = selectedStyle.isNumericStyle();
         boolean isAlphanumericStyle = selectedStyle.isAlphanumericStyle();
-
-        Iterator<BibEntry> iterator = entries.iterator();
-        while (iterator.hasNext()) {
-            BibEntry currentEntry = iterator.next();
-
-            String citation = createInTextCitationText(selectedStyle, isAlphanumericStyle, isNumericStyle, currentEntry, bibDatabaseContext);
-            String finalText = citation;
-
-            if (iterator.hasNext()) {
-                finalText += ",";
-            }
-
-            OOText ooText = OOFormat.setLocaleNone(OOText.fromString(finalText));
-            insertReferences(cursor, List.of(currentEntry), ooText, isNumericStyle, CSLCitationType.IN_TEXT);
-        }
+        String citation = createInTextCitationGroupText(selectedStyle, isAlphanumericStyle, isNumericStyle, entries, bibDatabaseContext);
+        OOText ooText = OOFormat.setLocaleNone(OOText.fromString(citation));
+        insertReferences(cursor, entries, ooText, isNumericStyle, CSLCitationType.IN_TEXT);
     }
 
     /// Inserts "empty" citations for a list of entries at the cursor to the document.
@@ -298,24 +287,8 @@ public class CSLCitationOOAdapter {
                                                      .map(unifiedDatabase::getEntryByCitationKey)
                                                      .flatMap(Optional::stream)
                                                      .toList();
-
-                StringBuilder finalText = new StringBuilder();
-                Iterator<BibEntry> iterator = entries.iterator();
-
-                while (iterator.hasNext()) {
-                    BibEntry currentEntry = iterator.next();
-
-                    // We re-generate the citation in the new style and update it in the document
-                    String citation = createInTextCitationText(style, isAlphaNumericStyle, isNumericStyle, currentEntry, unifiedBibDatabaseContext);
-
-                    finalText.append(citation);
-
-                    if (iterator.hasNext()) {
-                        finalText.append(",");
-                    }
-                }
-
-                markManager.updateMarkAndTextWithNewStyle(mark, finalText.toString(), CSLCitationType.IN_TEXT);
+                String citation = createInTextCitationGroupText(style, isAlphaNumericStyle, isNumericStyle, entries, unifiedBibDatabaseContext);
+                markManager.updateMarkAndTextWithNewStyle(mark, citation, CSLCitationType.IN_TEXT);
             }
         } else {
             // Same flow as above - for each such reference mark, we get the entries to be updated
@@ -345,6 +318,15 @@ public class CSLCitationOOAdapter {
         }
 
         return CSLFormatUtils.transformHTML(citation);
+    }
+
+    private @NonNull String createInTextCitationGroupText(CitationStyle style, boolean isAlphaNumericStyle, boolean isNumericStyle, List<BibEntry> entries, BibDatabaseContext bibDatabaseContext) {
+        StringJoiner citations = new StringJoiner(", ");
+        for (BibEntry entry : entries) {
+            citations.add(createInTextCitationText(style, isAlphaNumericStyle, isNumericStyle, entry, bibDatabaseContext));
+        }
+
+        return citations.toString();
     }
 
     ///  Helper method for creating in-text citations for `updateAllCitationsWithNewStyle` and `insertInTextCitation`.


### PR DESCRIPTION
### Related issues and pull requests

Closes #15703 

### PR Description

When insert multiple references at once using CSL in-text, entries are seperated into multiple reference marks instead of one single reference mark.

This PR adds a `createInTextCitationGroupText` method to create a single in-text citation.

### Steps to test

1. Open JabRef and a LibreOffice Writer document
2. Open Chocolate.bib in JabRef
3. Connect to the running LO instance
4. Select any CSL style
5. Select multiple entries and press in-text cite

Observe they are cited as a single reference mark.
<img width="943" height="117" alt="image" src="https://github.com/user-attachments/assets/d5b43763-db93-472a-86d0-3a8c76f6c37c" />


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
