### PR TITLE
Refactored the comments for UnlinkedFilesCrawler

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesCrawler.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/UnlinkedFilesCrawler.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 /// Util class for searching files on the file system which are not linked to a provided {@link org.jabref.model.database.BibDatabase}.
 ///
-/// The result is used to create *new* entries. The user has then to use the duplicate check to merge the entries.
+/// The result is used to determine whether to link the files to an existing related entry or to create a new entry, according to the user's choice.
 ///
 /// Related: {@link org.jabref.gui.externalfiles.AutoSetFileLinksUtil#findAssociatedNotLinkedFiles}
 public class UnlinkedFilesCrawler extends BackgroundTask<FileNodeViewModel> {


### PR DESCRIPTION
### Related issues and pull requests

Related to https://github.com/JabRef/jabref/pull/15110

### PR Description

Refactored the comments for `UnlinkedFilesCrawler' to match the current behavior of the class.


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
