### PR TITLE
Add cursor area awareness to CSL citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where inserting a citation inside another citation could break the original citation. [#15701](https://github.com/JabRef/jabref/issues/15701)
+- We fixed an issue in the LibreOffice integration where the user could insert a CSL citation inside an existing one. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)
 - We fixed an issue with the `Normalize date` save action truncating date ranges. [#8902](https://github.com/JabRef/jabref/issues/8902)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where users could cite inside another citations, which break the integrity. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)
 - We fixed an issue with the `Normalize date` save action truncating date ranges. [#8902](https://github.com/JabRef/jabref/issues/8902)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
-- We fixed an issue where users could cite inside another citations, which break the integrity. [#15701](https://github.com/JabRef/jabref/issues/15701)
+- We fixed an issue where inserting a citation inside another citation could break the original citation. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)
 - We fixed an issue with the `Normalize date` save action truncating date ranges. [#8902](https://github.com/JabRef/jabref/issues/8902)

--- a/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/jabgui/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -225,7 +225,7 @@ public class OOBibBase {
         }
     }
 
-    private static OOVoidResult<OOError> checkRangeOverlapsWithCursor(XTextDocument doc, OOFrontend frontend) {
+    private static OOVoidResult<OOError> checkRangeOverlapsWithCursor(XTextDocument doc, OOFrontend frontend, OOStyle style) {
         final String errorTitle = "Ranges overlapping with cursor";
 
         List<RangeForOverlapCheck<CitationGroupId>> userRanges;
@@ -236,7 +236,8 @@ public class OOBibBase {
         try {
             res = frontend.checkRangeOverlapsWithCursor(doc,
                     userRanges,
-                    requireSeparation);
+                    requireSeparation,
+                    style);
         } catch (NoDocumentException ex) {
             return OOVoidResult.error(OOError.from(ex).setTitle(errorTitle));
         } catch (WrappedTargetException ex) {
@@ -541,7 +542,7 @@ public class OOBibBase {
             return;
         }
 
-        if (testDialog(errorTitle, checkRangeOverlapsWithCursor(doc, frontend.get()))) {
+        if (testDialog(errorTitle, checkRangeOverlapsWithCursor(doc, frontend.get(), style))) {
             return;
         }
 

--- a/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/ReferenceMark.java
@@ -120,6 +120,10 @@ public class ReferenceMark {
         return citationType;
     }
 
+    public static boolean isReferenceMarkName(String name) {
+        return REFERENCE_MARK_FORMAT.matcher(name).matches();
+    }
+
     public static Optional<ReferenceMark> of(String name) {
         ReferenceMark mark = new ReferenceMark(name);
         return mark.citationKeys.isEmpty() ? Optional.empty() : Optional.of(mark);

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.openoffice.ReferenceMark;
 import org.jabref.logic.openoffice.backend.Backend52;
 import org.jabref.logic.openoffice.style.JStyle;
 import org.jabref.logic.openoffice.style.OOStyle;
@@ -300,6 +301,10 @@ public class OOFrontend {
         List<RangeForOverlapCheck<CitationGroupId>> result = new ArrayList<>();
 
         for (String name : UnoReferenceMark.getListOfNames(doc)) {
+            if (!ReferenceMark.isReferenceMarkName(name)) {
+                continue;
+            }
+
             Optional<XTextRange> range = UnoReferenceMark.getAnchor(doc, name);
             if (range.isEmpty()) {
                 continue;

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -273,7 +273,7 @@ public class OOFrontend {
     }
 
     /// @return A RangeForOverlapCheck for each citation group. result.size() == nRefMarks
-    public List<RangeForOverlapCheck<CitationGroupId>> JStyleCitationRanges(XTextDocument doc)
+    public List<RangeForOverlapCheck<CitationGroupId>> getJStyleCitationRanges(XTextDocument doc)
             throws
             NoDocumentException,
             WrappedTargetException {
@@ -292,7 +292,7 @@ public class OOFrontend {
         return result;
     }
 
-    private List<RangeForOverlapCheck<CitationGroupId>> CSLCitationRanges(XTextDocument doc)
+    private List<RangeForOverlapCheck<CitationGroupId>> getCSLCitationRanges(XTextDocument doc)
             throws
             NoDocumentException,
             WrappedTargetException {
@@ -426,9 +426,9 @@ public class OOFrontend {
 
         List<RangeForOverlapCheck<CitationGroupId>> citationRanges;
         if (style instanceof JStyle) {
-            citationRanges = JStyleCitationRanges(doc);
+            citationRanges = getJStyleCitationRanges(doc);
         } else {
-            citationRanges = CSLCitationRanges(doc);
+            citationRanges = getCSLCitationRanges(doc);
         }
 
         List<RangeForOverlapCheck<CitationGroupId>> ranges = new ArrayList<>();
@@ -461,7 +461,7 @@ public class OOFrontend {
             NoDocumentException,
             WrappedTargetException {
 
-        List<RangeForOverlapCheck<CitationGroupId>> citationRanges = JStyleCitationRanges(doc);
+        List<RangeForOverlapCheck<CitationGroupId>> citationRanges = getJStyleCitationRanges(doc);
         List<RangeForOverlapCheck<CitationGroupId>> ranges = new ArrayList<>();
         ranges.addAll(userRanges);
         ranges.addAll(bibliographyRanges(doc));

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.openoffice.backend.Backend52;
+import org.jabref.logic.openoffice.style.JStyle;
+import org.jabref.logic.openoffice.style.OOStyle;
 import org.jabref.model.openoffice.CitationEntry;
 import org.jabref.model.openoffice.ootext.OOText;
 import org.jabref.model.openoffice.rangesort.FunctionalTextViewCursor;
@@ -28,6 +30,7 @@ import org.jabref.model.openoffice.style.OODataModel;
 import org.jabref.model.openoffice.uno.CreationException;
 import org.jabref.model.openoffice.uno.NoDocumentException;
 import org.jabref.model.openoffice.uno.UnoCursor;
+import org.jabref.model.openoffice.uno.UnoReferenceMark;
 import org.jabref.model.openoffice.uno.UnoTextRange;
 import org.jabref.model.openoffice.util.OOListUtil;
 import org.jabref.model.openoffice.util.OOVoidResult;
@@ -270,7 +273,7 @@ public class OOFrontend {
     }
 
     /// @return A RangeForOverlapCheck for each citation group. result.size() == nRefMarks
-    public List<RangeForOverlapCheck<CitationGroupId>> citationRanges(XTextDocument doc)
+    public List<RangeForOverlapCheck<CitationGroupId>> JStyleCitationRanges(XTextDocument doc)
             throws
             NoDocumentException,
             WrappedTargetException {
@@ -280,12 +283,35 @@ public class OOFrontend {
 
         for (CitationGroup group : citationGroups.getCitationGroupsUnordered()) {
             XTextRange range = this.getMarkRange(doc, group).orElseThrow(IllegalStateException::new);
-            String description = group.groupId.citationGroupIdAsString();
+            String description = range.getString();
             result.add(new RangeForOverlapCheck<>(range,
                     group.groupId,
                     RangeForOverlapCheck.REFERENCE_MARK_KIND,
                     description));
         }
+        return result;
+    }
+
+    private List<RangeForOverlapCheck<CitationGroupId>> CSLCitationRanges(XTextDocument doc)
+            throws
+            NoDocumentException,
+            WrappedTargetException {
+
+        List<RangeForOverlapCheck<CitationGroupId>> result = new ArrayList<>();
+
+        for (String name : UnoReferenceMark.getListOfNames(doc)) {
+            Optional<XTextRange> range = UnoReferenceMark.getAnchor(doc, name);
+            if (range.isEmpty()) {
+                continue;
+            }
+
+            String description = range.get().getString();
+            result.add(new RangeForOverlapCheck<>(range.get(),
+                    new CitationGroupId(name),
+                    RangeForOverlapCheck.REFERENCE_MARK_KIND,
+                    description));
+        }
+
         return result;
     }
 
@@ -391,12 +417,19 @@ public class OOFrontend {
     public OOVoidResult<JabRefException>
     checkRangeOverlapsWithCursor(XTextDocument doc,
                                  List<RangeForOverlapCheck<CitationGroupId>> userRanges,
-                                 boolean requireSeparation)
+                                 boolean requireSeparation,
+                                 OOStyle style)
             throws
             NoDocumentException,
             WrappedTargetException {
 
-        List<RangeForOverlapCheck<CitationGroupId>> citationRanges = citationRanges(doc);
+        List<RangeForOverlapCheck<CitationGroupId>> citationRanges;
+        if (style instanceof JStyle) {
+            citationRanges = JStyleCitationRanges(doc);
+        } else {
+            citationRanges = CSLCitationRanges(doc);
+        }
+
         List<RangeForOverlapCheck<CitationGroupId>> ranges = new ArrayList<>();
 
         // ranges.addAll(userRanges);
@@ -427,7 +460,7 @@ public class OOFrontend {
             NoDocumentException,
             WrappedTargetException {
 
-        List<RangeForOverlapCheck<CitationGroupId>> citationRanges = citationRanges(doc);
+        List<RangeForOverlapCheck<CitationGroupId>> citationRanges = JStyleCitationRanges(doc);
         List<RangeForOverlapCheck<CitationGroupId>> ranges = new ArrayList<>();
         ranges.addAll(userRanges);
         ranges.addAll(bibliographyRanges(doc));

--- a/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/frontend/OOFrontend.java
@@ -305,8 +305,9 @@ public class OOFrontend {
                 continue;
             }
 
-            String description = range.get().getString();
-            result.add(new RangeForOverlapCheck<>(range.get(),
+            XTextRange textRange = range.get();
+            String description = textRange.getString();
+            result.add(new RangeForOverlapCheck<>(textRange,
                     new CitationGroupId(name),
                     RangeForOverlapCheck.REFERENCE_MARK_KIND,
                     description));

--- a/jablib/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
+++ b/jablib/src/test/java/org/jabref/logic/openoffice/ReferenceMarkTest.java
@@ -95,4 +95,19 @@ class ReferenceMarkTest {
                 )
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void isReferenceMarkName(String name, boolean expected) {
+        assertEquals(expected, ReferenceMark.isReferenceMarkName(name));
+    }
+
+    private static Stream<Arguments> isReferenceMarkName() {
+        return Stream.of(
+                Arguments.of("JABREF_Smith2000 CID_12345 uniqueId1 NORMAL", true),
+                Arguments.of("JABREF_John2026 CID_7 uniqueId8 IN_TEXT", true),
+                Arguments.of("JR_cite0_1_key1", false),
+                Arguments.of("Unrelated citations", false)
+        );
+    }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #15701

### PR Description
This PR adds a new function `CSLCitationRanges` which collects the ranges of existing CSL citations,  so that CSL citations can also have cursor area awareness.

### Steps to test
1. Open JabRef and a LibreOffice Writer document
2. Open Chocolate.bib in JabRef
3. Connect to the running LO instance
4. Select any CSL
5. Select any entry and cite it in the document
6. Click anywhere in between the citation area (can be visualized by ctrl+f8)
7. Select any other entry and try to cite
8. Observe the following error ("the cursor is in a protected area"):
<img width="944" height="395" alt="image" src="https://github.com/user-attachments/assets/7ce8a814-ed65-4e7e-9959-82712fd7c725" />


### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
