### PR TITLE
Extract magic string to constant

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -41,7 +41,7 @@ import org.jspecify.annotations.NonNull;
 /// In some cases, the same macro-task may be achieved by two different orders of actions, which may look semantically the same overall, but one order may result into more UNO API calls.
 /// For example, see the comment inside {@link CSLCitationOOAdapter#insertCitation(XTextCursor, CitationStyle, List, BibDatabaseContext, BibEntryTypesManager) insertCitation}.
 public class CSLCitationOOAdapter {
-
+    private static final String CITATION_DELIMITER = ", ";
     private static final CitationStyleOutputFormat HTML_OUTPUT_FORMAT = CitationStyleOutputFormat.HTML;
     private static final Pattern CITATION_NUMBER_PATTERN = Pattern.compile("(\\D*)(\\d+)(\\D*)");
 
@@ -322,7 +322,7 @@ public class CSLCitationOOAdapter {
 
     /// Helper method for creating citation group for `insertInTextCitation` and `updateAllCitationsWithNewStyle`
     private @NonNull String createInTextCitationGroupText(CitationStyle style, boolean isAlphaNumericStyle, boolean isNumericStyle, List<BibEntry> entries, BibDatabaseContext bibDatabaseContext) {
-        StringJoiner citations = new StringJoiner(", ");
+        StringJoiner citations = new StringJoiner(CITATION_DELIMITER);
         for (BibEntry entry : entries) {
             citations.add(createInTextCitationText(style, isAlphaNumericStyle, isNumericStyle, entry, bibDatabaseContext));
         }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/oocsltext/CSLCitationOOAdapter.java
@@ -41,6 +41,7 @@ import org.jspecify.annotations.NonNull;
 /// In some cases, the same macro-task may be achieved by two different orders of actions, which may look semantically the same overall, but one order may result into more UNO API calls.
 /// For example, see the comment inside {@link CSLCitationOOAdapter#insertCitation(XTextCursor, CitationStyle, List, BibDatabaseContext, BibEntryTypesManager) insertCitation}.
 public class CSLCitationOOAdapter {
+
     private static final String CITATION_DELIMITER = ", ";
     private static final CitationStyleOutputFormat HTML_OUTPUT_FORMAT = CitationStyleOutputFormat.HTML;
     private static final Pattern CITATION_NUMBER_PATTERN = Pattern.compile("(\\D*)(\\d+)(\\D*)");


### PR DESCRIPTION
### Related issues and pull requests

Follow-up of #15706

### PR Description

Extract magic string `", "` to a constant `CITATION_DELIMITER `

### Checklist
- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
