### PR TITLE
Fix CAYW endpoint failing with JavaFX version mismatch

### DIFF
--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -12,6 +12,14 @@
 // see  https://github.com/gradlex-org/extra-java-module-info/issues/237 why we include e-adr here
 //DEPS io.github.adr:e-adr:2.0.0
 
+// Pin JavaFX 26 to override afterburner.fx 2.0.0's transitive javafx-*:20 (Maven nearest-wins).
+// Required because jabsrv CAYW endpoint calls Platform.startup(); mixing javafx.graphics:20 with
+// javafx.base:26 fails with NoClassDefFoundError: javafx/util/FXPermission (removed in javafx 25+).
+//DEPS org.openjfx:javafx-base:26.0.1:${os.detected.jfxname}
+//DEPS org.openjfx:javafx-graphics:26.0.1:${os.detected.jfxname}
+//DEPS org.openjfx:javafx-controls:26.0.1:${os.detected.jfxname}
+//DEPS org.openjfx:javafx-fxml:26.0.1:${os.detected.jfxname}
+
 // from jabsrv-cli
 //DEPS info.picocli:picocli:4.7.7
 

--- a/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
+++ b/build-logic/src/main/kotlin/org.jabref.gradle.base.dependency-rules.gradle.kts
@@ -98,6 +98,11 @@ jvmDependencyConflicts.patch {
         addRuntimeOnlyDependency("com.knuddels:jtokkit")
     }
     module("org.jabref:afterburner.fx") {
+        // POM pins javafx-* to 20; strip and re-add without version so :versions platform resolves them to current
+        removeDependency("org.openjfx:javafx-controls")
+        removeDependency("org.openjfx:javafx-fxml")
+        removeDependency("org.openjfx:javafx-swing")
+        removeDependency("org.openjfx:javafx-web")
         // metadata decared these as runtime only, but they are 'requires transitive' in module-info
         addApiDependency("org.openjfx:javafx-fxml")
         addApiDependency("org.openjfx:javafx-controls")

--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
@@ -43,6 +43,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -235,25 +236,40 @@ public class CAYWResource {
 
     private synchronized void initializeGUI() {
         // TODO: Implement a better way to handle the window popup since this is a bit hacky.
-        if (!initialized) {
-            if (!(srvStateManager instanceof JabRefSrvStateManager)) {
-                LOGGER.debug("Running inside JabRef UI, no need to initialize JavaFX for CAYW resource.");
-                initialized = true;
-                return;
-            }
-            LOGGER.debug("Initializing JavaFX for CAYW resource.");
-            CountDownLatch latch = new CountDownLatch(1);
+        if (initialized) {
+            return;
+        }
+        if (!(srvStateManager instanceof JabRefSrvStateManager)) {
+            LOGGER.debug("Running inside JabRef UI, no need to initialize JavaFX for CAYW resource.");
+            initialized = true;
+            return;
+        }
+        LOGGER.debug("Initializing JavaFX for CAYW resource.");
+        CountDownLatch latch = new CountDownLatch(1);
+        try {
             Platform.startup(() -> {
                 Platform.setImplicitExit(false);
-                initialized = true;
                 latch.countDown();
             });
-            try {
-                latch.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("JavaFX initialization interrupted", e);
-            }
+        } catch (IllegalStateException alreadyInitialized) {
+            LOGGER.debug("JavaFX runtime already initialized.", alreadyInitialized);
+            initialized = true;
+            return;
+        } catch (Throwable e) {
+            // Catches NoClassDefFoundError/UnsatisfiedLinkError when the JavaFX runtime is missing or version-mismatched
+            // (e.g., javafx.graphics from an older version paired with a newer javafx.base where javafx.util.FXPermission was removed).
+            LOGGER.error("Could not initialize JavaFX runtime for CAYW resource.", e);
+            throw new WebApplicationException(
+                    Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                           .entity("CAYW unavailable: JavaFX runtime could not be initialized (" + e.getClass().getName() + ": " + e.getMessage() + "). The CAYW endpoint requires a working, version-consistent JavaFX runtime on the module path.")
+                           .build());
+        }
+        try {
+            latch.await();
+            initialized = true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("JavaFX initialization interrupted", e);
         }
     }
 

--- a/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
+++ b/jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWResource.java
@@ -261,8 +261,8 @@ public class CAYWResource {
             LOGGER.error("Could not initialize JavaFX runtime for CAYW resource.", e);
             throw new WebApplicationException(
                     Response.status(Response.Status.SERVICE_UNAVAILABLE)
-                           .entity("CAYW unavailable: JavaFX runtime could not be initialized (" + e.getClass().getName() + ": " + e.getMessage() + "). The CAYW endpoint requires a working, version-consistent JavaFX runtime on the module path.")
-                           .build());
+                            .entity("CAYW unavailable: JavaFX runtime could not be initialized (" + e.getClass().getName() + ": " + e.getMessage() + "). The CAYW endpoint requires a working, version-consistent JavaFX runtime on the module path.")
+                            .build());
         }
         try {
             latch.await();


### PR DESCRIPTION
Start JabSrv using jbang:

    jbang .jbang/JabSrvLauncher.java

Before:

```
$ curl http://127.0.0.1:23119/better-bibtex/cayw
Internal Server Error
```

After:

```
$ curl http://127.0.0.1:23119/better-bibtex/cayw
\autocite{Ding_2006}
```

---

We could fix afterburner maybe, but I think, this is harder than doing this.


The `/better-bibtex/cayw` endpoint returned HTTP 500 "Internal Server Error" because `Platform.startup()` threw `NoClassDefFoundError: javafx/util/FXPermission`. `afterburner.fx 2.0.0`'s POM pins `javafx-*` to version 20, while the rest of the project resolves to 26.0.1, causing a version split (`javafx.graphics:20` against `javafx.base:26`, where `FXPermission` was removed in JavaFX 25). This PR forces a single, consistent JavaFX version across both the Gradle build and the JBang `jabsrv` launcher, and additionally hardens `CAYWResource` so a future runtime mismatch produces a clear `503` response instead of an opaque crash.


### Steps to test

1. Ensure that you had some libraries opened in JabRef. Close JabRef.
1. Start `jabsrv` via the JBang launcher `jbang .jbang/JabSrvLauncher.java`.
3. Run `curl http://127.0.0.1:23119/better-bibtex/cayw` from another terminal.
4. The JavaFX picker dialog opens; pick an entry; the curl call returns a citation string (e.g. `\autocite{Ding_2006}`).

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)