### PR TITLE
Wrap bracketed pairs in Javadoc with backticks

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/git/merge/execution/MergeBookkeeper.java
+++ b/jablib/src/main/java/org/jabref/logic/git/merge/execution/MergeBookkeeper.java
@@ -30,7 +30,7 @@ import org.eclipse.jgit.revwalk.RevCommit;
 /// Creates the right commit shape based on the merge graph:
 ///  - BEHIND: fast-forward if content equals remote;
 ///            otherwise create a new commit on top of `remote`.
-///  - DIVERGED: create a merge commit with parents [localHead, remote].
+///  - DIVERGED: create a merge commit with parents `[localHead, remote]`.
 ///
 /// Preconditions:
 ///  - GUI has already saved the final .bib file to disk.

--- a/jablib/src/main/java/org/jabref/logic/git/model/BookkeepingResult.java
+++ b/jablib/src/main/java/org/jabref/logic/git/model/BookkeepingResult.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 /// If "the local is strictly behind the remote and the file content is exactly the same as the remote" → fast-forward, no new commit is created;
 /// Otherwise:
 /// - BEHIND (local is an ancestor of remote): create a new single-parent commit (parent=remote) on top of remote;
-/// - DIVERGED: create a new dual-parent merge commit (parents=[local, remote]).
+/// - DIVERGED: create a new dual-parent merge commit (parents=`[local, remote]`).
 /// Notes: Because the statuses UP_TO_DATE / AHEAD / CONFLICT / UNTRACKED are already filtered out before prepareMerge by GitStatusChecker, they will not enter finalizeMerge.
 public final class BookkeepingResult {
     public enum Kind {

--- a/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyle.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyle.java
@@ -595,7 +595,7 @@ public class JStyle implements Comparable<JStyle>, OOStyle {
     }
 
     /// The String to add between author names except the last two:
-    /// "[Smith{, }Jones and Brown]"
+    /// `"[Smith{, }Jones and Brown]"`
     protected String getAuthorSeparator() {
         return getStringCitProperty(JStyle.AUTHOR_SEPARATOR);
     }

--- a/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyleGetNumCitationMarker.java
+++ b/jablib/src/main/java/org/jabref/logic/openoffice/style/JStyleGetNumCitationMarker.java
@@ -37,10 +37,10 @@ class JStyleGetNumCitationMarker {
     /// the optional "BracketBeforeInList" and "BracketAfterInList" strings
     /// to be used in the bibliography instead of "BracketBefore" and "BracketAfter"
     ///
-    /// @return "[${number}]" where
-    /// "[" stands for BRACKET_BEFORE_IN_LIST (with fallback BRACKET_BEFORE)
-    /// "]" stands for BRACKET_AFTER_IN_LIST (with fallback BRACKET_AFTER)
-    /// "${number}" stands for the formatted number.
+    /// @return `"[${number}]"` where
+    /// `"["` stands for `BRACKET_BEFORE_IN_LIST` (with fallback `BRACKET_BEFORE`)
+    /// `"]"` stands for `BRACKET_AFTER_IN_LIST` (with fallback `BRACKET_AFTER`)
+    /// `"${number}"` stands for the formatted number.
     public static OOText getNumCitationMarkerForBibliography(JStyle style,
                                                              CitationMarkerNumericBibEntry entry) {
         // prefer BRACKET_BEFORE_IN_LIST and BRACKET_AFTER_IN_LIST

--- a/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkTextParser.java
+++ b/jablib/src/main/java/org/jabref/logic/relatedwork/RelatedWorkTextParser.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class RelatedWorkTextParser {
-    /// Support [1] / [1-3] / [1, 2, 3]  / [1-3, 7, 9]
+    /// Support `[1]` / `[1-3]` / `[1, 2, 3]` / `[1-3, 7, 9]`
     private static final Pattern CITE_PATTERN = Pattern.compile("\\[(\\d{1,3}(?:\\s*(?:,|-|–)\\s*\\d{1,3})*)\\]");
     private static final Pattern SEGMENT_SPLIT_PATTERN = Pattern.compile("(?<=[.!?])\\s+|(?<=[.!?])(?=\\p{Lu})");
     private static final Pattern HYPHENATED_LINE_BREAK_PATTERN = Pattern.compile("-\\R");

--- a/jablib/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
+++ b/jablib/src/main/java/org/jabref/logic/util/strings/StringSimilarity.java
@@ -96,7 +96,7 @@ public class StringSimilarity {
     ///
     /// @param s1 The first string
     /// @param s2 The second string
-    /// @return a value in the interval [0, 1] indicating the degree of match.
+    /// @return a value in the interval `[0, 1]` indicating the degree of match.
     public static double correlateByWords(final String s1, final String s2) {
         final String[] w1 = s1.split("\\s");
         final String[] w2 = s2.split("\\s");

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
@@ -173,7 +173,7 @@ class IacrEprintFetcherTest {
     ///
     /// @param year  The year of the generated IDs (e.g. 1996)
     /// @param maxId The maximum ID to generate in the given year (e.g. 112)
-    /// @return A list of IDs in the from yyyy/iii (e.g. [1996/001, 1996/002, ..., 1996/112]
+    /// @return A list of IDs in the from yyyy/iii (e.g. `[1996/001, 1996/002, ..., 1996/112]`)
     private static List<String> getIdsFor(int year, int maxId) {
         List<String> result = new ArrayList<>();
         for (int i = 1; i <= maxId; i++) {


### PR DESCRIPTION
### PR Description

IntelliJ issue https://youtrack.jetbrains.com/issue/IDEA-389422/Markdown-Javadoc-formatter-strips-space-after-comma-inside-bracket-expressions-ident-ident

IntelliJ reformats unescaped `[x, y]` patterns inside Markdown Javadoc (`///`) as if they were links, mangling the comment. Wrapping these bracket groups in backticks keeps them as literal code spans so IntelliJ leaves them alone.

### Steps to test

1. Open one of the affected files (e.g. `MergeBookkeeper.java`, `BookkeepingResult.java`, `StringSimilarity.java`, `IacrEprintFetcherTest.java`).
2. Trigger IntelliJ's Reformat Code on the file.
3. Confirm the bracketed groups in the Javadoc remain intact instead of being rewritten as broken links.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)