### PR TITLE
fix for 15710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 ### Added
 
 - Book covers now download automatically when you open an entry with an ISBN. [#14848](https://github.com/JabRef/jabref/issues/14848)
+- We added support for importing Hayagriva YAML files, the citation format used by the Typst typesetting system. [#15714](https://github.com/JabRef/jabref/pull/15714)
 - We added a new data format and property selection feature, enabling users to select one or more field properties for custom fields. [#9840](https://github.com/JabRef/jabref/issues/9840)
 - We fixed a glitch with the sidepane divider position on startup. [#15394](https://github.com/JabRef/jabref/issues/15394)
 - We added a label to the Group dropdown in the Import Dialog. [#15567](https://github.com/JabRef/jabref/issues/15567)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Fixed
 
+- We fixed an issue where previous search results would linger in the main table when a new search was performed rapidly. [#15710](https://github.com/JabRef/jabref/issues/15710)
 - We fixed an issue in the LibreOffice integration where the user could insert a CSL citation inside an existing one. [#15701](https://github.com/JabRef/jabref/issues/15701)
 - We fixed an issue where multiple entries are not cited as a single citation for CSL in-text. [#15703](https://github.com/JabRef/jabref/issues/15703)
 - We fixed an issue where the citation key generator did not show the date for child entries due to orphaned crossref links. [#9071](https://github.com/JabRef/jabref/issues/9071)

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -106,8 +106,8 @@ public class MainTableDataModel {
     private void updateSearchMatches(Optional<SearchQuery> query) {
         int myGeneration = searchGeneration.incrementAndGet();
         BackgroundTask.wrap(() -> query.isPresent()
-                ? Optional.of(indexManager.search(query.get()))
-                : Optional.<SearchResults>empty()
+                                  ? Optional.of(indexManager.search(query.get()))
+                                  : Optional.<SearchResults>empty()
         ).onSuccess(results -> {
             if (myGeneration == searchGeneration.get()) {
                 results.ifPresentOrElse(this::setSearchMatches, this::clearSearchMatches);

--- a/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/maintable/MainTableDataModel.java
@@ -2,6 +2,7 @@ package org.jabref.gui.maintable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.IntegerProperty;
@@ -66,6 +67,7 @@ public class MainTableDataModel {
     @Nullable private final IndexManager indexManager;
 
     private Optional<MatcherSet> groupsMatcher;
+    private final AtomicInteger searchGeneration = new AtomicInteger(0);
 
     public MainTableDataModel(BibDatabaseContext context,
                               GuiPreferences preferences,
@@ -102,13 +104,16 @@ public class MainTableDataModel {
     }
 
     private void updateSearchMatches(Optional<SearchQuery> query) {
-        BackgroundTask.wrap(() -> {
-            if (query.isPresent()) {
-                setSearchMatches(indexManager.search(query.get()));
-            } else {
-                clearSearchMatches();
+        int myGeneration = searchGeneration.incrementAndGet();
+        BackgroundTask.wrap(() -> query.isPresent()
+                ? Optional.of(indexManager.search(query.get()))
+                : Optional.<SearchResults>empty()
+        ).onSuccess(results -> {
+            if (myGeneration == searchGeneration.get()) {
+                results.ifPresentOrElse(this::setSearchMatches, this::clearSearchMatches);
+                FilteredListProxy.refilterListReflection(entriesFiltered);
             }
-        }).onSuccess(result -> FilteredListProxy.refilterListReflection(entriesFiltered)).executeWith(taskExecutor);
+        }).executeWith(taskExecutor);
     }
 
     /// Refresh the current search

--- a/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
@@ -1,27 +1,52 @@
 package org.jabref.gui.maintable;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 
+import org.jabref.gui.groups.GroupsPreferences;
+import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.bibtex.comparator.EntryComparator;
+import org.jabref.logic.search.IndexManager;
+import org.jabref.logic.search.SearchPreferences;
+import org.jabref.logic.util.BackgroundTask;
+import org.jabref.logic.util.DelayTaskThrottler;
+import org.jabref.logic.util.OptionalObjectProperty;
+import org.jabref.logic.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.search.SearchDisplayMode;
+import org.jabref.model.search.SearchFlags;
+import org.jabref.model.search.query.SearchQuery;
+import org.jabref.model.search.query.SearchResult;
+import org.jabref.model.search.query.SearchResults;
 
 import com.tobiasdiez.easybind.EasyBind;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MainTableDataModelTest {
 
@@ -61,5 +86,113 @@ class MainTableDataModelTest {
         assertTrue(changed[0]);
         result = entriesFilteredAndSorted.stream().map(BibEntryTableViewModel::getEntry).toList();
         assertEquals(List.of(bibEntryAuthorT, bibEntryNothingToZ), result);
+    }
+
+    @Test
+    void searchResultsDoNotLingerWhenQueryChangesRapidly() throws InterruptedException {
+        BibEntry quantumEntry = new BibEntry().withField(StandardField.TITLE, "Quantum Physics");
+        BibEntry organicEntry = new BibEntry().withField(StandardField.TITLE, "Organic Chemistry");
+
+        BibDatabaseContext context = new BibDatabaseContext();
+        context.getDatabase().insertEntry(quantumEntry);
+        context.getDatabase().insertEntry(organicEntry);
+
+        SearchResults quantumResults = new SearchResults();
+        quantumResults.addSearchResult(quantumEntry.getId(), new SearchResult());
+
+        SearchResults organicResults = new SearchResults();
+        organicResults.addSearchResult(organicEntry.getId(), new SearchResult());
+
+        // Quantum search sleeps 300ms so Organic always finishes first — Task A (Quantum) then
+        // overwrites Task B's (Organic) correct results, demonstrating the race condition.
+        IndexManager indexManager = mock(IndexManager.class);
+        when(indexManager.search(argThat(q -> q != null && q.getSearchExpression().contains("Quantum"))))
+                .thenAnswer(inv -> {
+                    Thread.sleep(300);
+                    return quantumResults;
+                });
+        when(indexManager.search(argThat(q -> q != null && q.getSearchExpression().contains("Organic"))))
+                .thenReturn(organicResults);
+
+        SearchPreferences searchPreferences = new SearchPreferences(
+                SearchDisplayMode.FILTER,
+                EnumSet.noneOf(SearchFlags.class),
+                false, false, 0, 0, 0);
+        GuiPreferences guiPreferences = mock(GuiPreferences.class);
+        when(guiPreferences.getSearchPreferences()).thenReturn(searchPreferences);
+        when(guiPreferences.getGroupsPreferences()).thenReturn(GroupsPreferences.getDefault());
+        when(guiPreferences.getNameDisplayPreferences()).thenReturn(
+                new NameDisplayPreferences(NameDisplayPreferences.DisplayStyle.AS_IS,
+                        NameDisplayPreferences.AbbreviationStyle.FULL));
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        TaskExecutor asyncExecutor = new TaskExecutor() {
+            @Override
+            public <V> Future<V> execute(BackgroundTask<V> task) {
+                return pool.submit(() -> {
+                    Runnable onRunning = task.getOnRunning();
+                    if (onRunning != null) {
+                        onRunning.run();
+                    }
+                    try {
+                        V result = task.call();
+                        Consumer<V> onSuccess = task.getOnSuccess();
+                        if (onSuccess != null) {
+                            onSuccess.accept(result);
+                        }
+                        return result;
+                    } catch (Exception e) {
+                        Consumer<Exception> onException = task.getOnException();
+                        if (onException != null) {
+                            onException.accept(e);
+                        }
+                        throw e;
+                    }
+                });
+            }
+
+            @Override
+            public <V> Future<?> schedule(BackgroundTask<V> task, long delay, TimeUnit unit) {
+                return execute(task);
+            }
+
+            @Override
+            public void shutdown() {
+                pool.shutdownNow();
+            }
+
+            @Override
+            public DelayTaskThrottler createThrottler(int delay) {
+                return new DelayTaskThrottler(delay);
+            }
+        };
+
+        OptionalObjectProperty<SearchQuery> searchQueryProperty = OptionalObjectProperty.empty();
+        SimpleListProperty<GroupTreeNode> selectedGroupsProperty =
+                new SimpleListProperty<>(FXCollections.observableArrayList());
+        SimpleIntegerProperty resultSizeProperty = new SimpleIntegerProperty();
+
+        MainTableDataModel model = new MainTableDataModel(
+                context, guiPreferences, asyncExecutor, indexManager,
+                selectedGroupsProperty, searchQueryProperty, resultSizeProperty);
+
+        searchQueryProperty.setValue(Optional.of(new SearchQuery("Quantum")));
+        searchQueryProperty.setValue(Optional.of(new SearchQuery("Organic")));
+
+        pool.shutdown();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+
+        List<BibEntry> matchedEntries = model.getEntriesFilteredAndSorted().stream()
+                .filter(vm -> vm.isMatchedBySearch().get())
+                .map(BibEntryTableViewModel::getEntry)
+                .toList();
+
+        model.unbind();
+
+        assertEquals(List.of(organicEntry), matchedEntries,
+                "Only the Organic entry should be matched after searching for 'Organic', but got: "
+                        + matchedEntries.stream()
+                                        .map(e -> e.getField(StandardField.TITLE).orElse("?"))
+                                        .toList());
     }
 }

--- a/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
@@ -183,9 +183,9 @@ class MainTableDataModelTest {
         pool.awaitTermination(2, TimeUnit.SECONDS);
 
         List<BibEntry> matchedEntries = model.getEntriesFilteredAndSorted().stream()
-                .filter(vm -> vm.isMatchedBySearch().get())
-                .map(BibEntryTableViewModel::getEntry)
-                .toList();
+                                             .filter(vm -> vm.isMatchedBySearch().get())
+                                             .map(BibEntryTableViewModel::getEntry)
+                                             .toList();
 
         model.unbind();
 

--- a/jablib/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -20,6 +20,7 @@ import org.jabref.logic.importer.fileformat.CitaviXmlImporter;
 import org.jabref.logic.importer.fileformat.CopacImporter;
 import org.jabref.logic.importer.fileformat.EndnoteImporter;
 import org.jabref.logic.importer.fileformat.EndnoteXmlImporter;
+import org.jabref.logic.importer.fileformat.HayagrivaYamlImporter;
 import org.jabref.logic.importer.fileformat.InspecImporter;
 import org.jabref.logic.importer.fileformat.IsiImporter;
 import org.jabref.logic.importer.fileformat.MedlineImporter;
@@ -96,6 +97,7 @@ public class ImportFormatReader {
         importers.add(new ReferImporter());
         importers.add(new RisImporter());
         importers.add(new CffImporter(citationKeyPatternPreferences));
+        importers.add(new HayagrivaYamlImporter());
         importers.add(new BiblioscapeImporter());
         importers.add(new CitaviXmlImporter());
 

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/HayagrivaYamlImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/HayagrivaYamlImporter.java
@@ -1,0 +1,390 @@
+package org.jabref.logic.importer.fileformat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jabref.logic.importer.Importer;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.UnknownField;
+import org.jabref.model.entry.types.EntryType;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+public class HayagrivaYamlImporter extends Importer {
+
+    private static final Map<String, EntryType> TYPES_MAP = Map.ofEntries(
+            Map.entry("article", StandardEntryType.Article),
+            Map.entry("book", StandardEntryType.Book),
+            Map.entry("chapter", StandardEntryType.InBook),
+            Map.entry("report", StandardEntryType.Report),
+            Map.entry("thesis", StandardEntryType.Thesis),
+            Map.entry("web", StandardEntryType.Online),
+            Map.entry("proceedings", StandardEntryType.Proceedings),
+            Map.entry("reference", StandardEntryType.Reference),
+            Map.entry("anthos", StandardEntryType.InCollection),
+            Map.entry("misc", StandardEntryType.Misc)
+    );
+
+    @Override
+    public String getId() {
+        return "hayagrivayaml";
+    }
+
+    @Override
+    public String getName() {
+        return "Hayagriva YAML";
+    }
+
+    @Override
+    public StandardFileType getFileType() {
+        return StandardFileType.YAML;
+    }
+
+    @Override
+    public String getDescription() {
+        return Localization.lang("Importer for the Hayagriva YAML format, which is used by the Typst typesetting system.");
+    }
+
+    // POJO classes for YAML deserialization
+
+    private static class HayagrivaEntry {
+        @JsonProperty("type")
+        String type;
+
+        // title may be a plain string or {value: "...", short: "...", verbatim: true, ...}
+        @JsonProperty("title")
+        Object title;
+
+        // author/editor may be a single string, a list of strings, or a list of objects (name/given-name)
+        @JsonProperty("author")
+        List<Object> author;
+
+        @JsonProperty("editor")
+        List<Object> editor;
+
+        @JsonProperty("date")
+        String date;
+
+        // url may be a plain string or {value: "...", date: "..."}
+        @JsonProperty("url")
+        Object url;
+
+        @JsonProperty("doi")
+        String doi;
+
+        @JsonProperty("isbn")
+        String isbn;
+
+        @JsonProperty("issn")
+        String issn;
+
+        @JsonProperty("page-range")
+        String pageRange;
+
+        @JsonProperty("edition")
+        String edition;
+
+        @JsonProperty("location")
+        String location;
+
+        @JsonProperty("organization")
+        String organization;
+
+        @JsonProperty("institution")
+        String institution;
+
+        @JsonProperty("note")
+        String note;
+
+        @JsonProperty("volume")
+        String volume;
+
+        @JsonProperty("issue")
+        String issue;
+
+        @JsonProperty("publisher")
+        String publisher;
+
+        @JsonProperty("abstract")
+        String abstractText;
+
+        @JsonProperty("serial-number")
+        Object serialNumber;
+
+        // parent may be a single object or a list of objects
+        @JsonProperty("parent")
+        List<HayagrivaParent> parent;
+
+        private final HashMap<String, String> unknownFields = new HashMap<>();
+
+        public HayagrivaEntry() {
+        }
+
+        @JsonAnySetter
+        private void setUnknownField(String key, Object value) {
+            if (value != null) {
+                unknownFields.put(key, value.toString());
+            }
+        }
+    }
+
+    private static class HayagrivaParent {
+        @JsonProperty("type")
+        String type;
+
+        // title may be a plain string or {value: "...", verbatim: true, ...}
+        @JsonProperty("title")
+        Object title;
+
+        @JsonProperty("volume")
+        String volume;
+
+        @JsonProperty("issue")
+        String issue;
+
+        @JsonProperty("publisher")
+        String publisher;
+
+        public HayagrivaParent() {
+        }
+    }
+
+    /// Returns the string value from a Hayagriva title or url field.
+    /// The field can be a plain string or a map containing a {@code value} key.
+    @Nullable
+    private static String extractStringValue(@Nullable Object field) {
+        if (field instanceof String s) {
+            return s;
+        }
+        if (field instanceof Map<?, ?> map) {
+            Object value = map.get("value");
+            if (value instanceof String s) {
+                return s;
+            }
+        }
+        return null;
+    }
+
+    /// Converts an author/editor value (scalar string or list of strings) to a list of name strings.
+    /// List elements that are maps (structured person objects) are skipped.
+    private static List<String> toStringList(@Nullable Object value) {
+        if (value == null) {
+            return List.of();
+        }
+        if (value instanceof String s) {
+            return List.of(s);
+        }
+        if (value instanceof List<?> list) {
+            return list.stream()
+                       .filter(item -> item instanceof String)
+                       .map(item -> (String) item)
+                       .toList();
+        }
+        return List.of();
+    }
+
+    private static ObjectMapper createMapper() {
+        return YAMLMapper.builder()
+                         .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                         .build();
+    }
+
+    @Override
+    public boolean isRecognizedFormat(@NonNull Reader reader) throws IOException {
+        ObjectMapper mapper = new YAMLMapper(new YAMLFactory());
+        try {
+            Map<String, Object> root = mapper.readValue(reader, new TypeReference<>() { });
+            if (root == null || root.isEmpty()) {
+                return false;
+            }
+            return root.values().stream()
+                       .anyMatch(v -> v instanceof Map<?, ?> entryMap
+                               && (entryMap.containsKey("title") || entryMap.containsKey("type")));
+        } catch (JacksonException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public ParserResult importDatabase(@NonNull BufferedReader reader) throws IOException {
+        ObjectMapper mapper = createMapper();
+        Map<String, HayagrivaEntry> entries = mapper.readValue(reader, new TypeReference<>() { });
+
+        if (entries == null) {
+            return new ParserResult();
+        }
+
+        List<BibEntry> bibEntries = new ArrayList<>();
+        for (Map.Entry<String, HayagrivaEntry> yamlEntry : entries.entrySet()) {
+            String citationKey = yamlEntry.getKey();
+            HayagrivaEntry data = yamlEntry.getValue();
+            bibEntries.add(toBibEntry(citationKey, data));
+        }
+        return new ParserResult(bibEntries);
+    }
+
+    private BibEntry toBibEntry(String citationKey, HayagrivaEntry data) {
+        EntryType entryType = data.type == null
+                ? StandardEntryType.Misc
+                : TYPES_MAP.getOrDefault(data.type.toLowerCase(), StandardEntryType.Misc);
+
+        Map<Field, String> fields = new HashMap<>();
+
+        String title = extractStringValue(data.title);
+        if (title != null) {
+            fields.put(StandardField.TITLE, title);
+        }
+        List<String> authors = toStringList(data.author);
+        if (!authors.isEmpty()) {
+            fields.put(StandardField.AUTHOR, String.join(" and ", authors));
+        }
+        List<String> editors = toStringList(data.editor);
+        if (!editors.isEmpty()) {
+            fields.put(StandardField.EDITOR, String.join(" and ", editors));
+        }
+        if (data.date != null) {
+            fields.put(StandardField.DATE, data.date);
+        }
+        String url = extractStringValue(data.url);
+        if (url != null) {
+            fields.put(StandardField.URL, url);
+        }
+        if (data.doi != null) {
+            fields.put(StandardField.DOI, data.doi);
+        }
+        if (data.isbn != null) {
+            fields.put(StandardField.ISBN, data.isbn);
+        }
+        if (data.issn != null) {
+            fields.put(StandardField.ISSN, data.issn);
+        }
+        if (data.pageRange != null) {
+            fields.put(StandardField.PAGES, data.pageRange);
+        }
+        if (data.edition != null) {
+            fields.put(StandardField.EDITION, data.edition);
+        }
+        if (data.location != null) {
+            fields.put(StandardField.ADDRESS, data.location);
+        }
+        if (data.organization != null) {
+            fields.put(StandardField.ORGANIZATION, data.organization);
+        }
+        if (data.institution != null) {
+            fields.put(StandardField.INSTITUTION, data.institution);
+        }
+        if (data.note != null) {
+            fields.put(StandardField.NOTE, data.note);
+        }
+        if (data.volume != null) {
+            fields.put(StandardField.VOLUME, data.volume);
+        }
+        if (data.issue != null) {
+            fields.put(StandardField.NUMBER, data.issue);
+        }
+        if (data.publisher != null) {
+            fields.put(StandardField.PUBLISHER, data.publisher);
+        }
+        if (data.abstractText != null) {
+            fields.put(StandardField.ABSTRACT, data.abstractText);
+        }
+
+        parseSerialNumber(data.serialNumber, fields);
+        parseParent(data.parent, entryType, fields);
+
+        for (Map.Entry<String, String> unknown : data.unknownFields.entrySet()) {
+            fields.put(new UnknownField(unknown.getKey()), unknown.getValue());
+        }
+
+        BibEntry entry = new BibEntry(entryType);
+        entry.setCitationKey(citationKey);
+        entry.setField(fields);
+        return entry;
+    }
+
+    /// Flattens the Hayagriva {@code parent} block into flat BibTeX fields.
+    /// A {@code periodical} parent provides the journal name, volume, issue, and publisher.
+    /// When the parent has no explicit type and the entry is an Article, it is treated as a periodical.
+    /// A {@code book} or {@code anthology} parent provides the booktitle.
+    /// Any other parent type has its title stored in the series field.
+    private void parseParent(@Nullable List<HayagrivaParent> parents, EntryType entryType, Map<Field, String> fields) {
+        if (parents == null || parents.isEmpty()) {
+            return;
+        }
+        HayagrivaParent parent = parents.getFirst();
+        String parentTitle = extractStringValue(parent.title);
+        String parentType = parent.type == null ? "" : parent.type.toLowerCase();
+
+        // Infer periodical when the parent has no type but the entry is clearly an article
+        if (parentType.isEmpty() && entryType == StandardEntryType.Article) {
+            parentType = "periodical";
+        }
+
+        if ("periodical".equals(parentType) || "newspaper".equals(parentType)) {
+            if (parentTitle != null) {
+                fields.put(StandardField.JOURNAL, parentTitle);
+            }
+            if (parent.volume != null) {
+                fields.putIfAbsent(StandardField.VOLUME, parent.volume);
+            }
+            if (parent.issue != null) {
+                fields.putIfAbsent(StandardField.NUMBER, parent.issue);
+            }
+            if (parent.publisher != null) {
+                fields.putIfAbsent(StandardField.PUBLISHER, parent.publisher);
+            }
+        } else if ("book".equals(parentType) || "anthology".equals(parentType)) {
+            if (parentTitle != null) {
+                fields.put(StandardField.BOOKTITLE, parentTitle);
+            }
+        } else {
+            if (parentTitle != null) {
+                fields.put(StandardField.SERIES, parentTitle);
+            }
+        }
+    }
+
+    /// Handles the {@code serial-number} field, which may be a plain string or a map of identifier types.
+    @SuppressWarnings("unchecked")
+    private void parseSerialNumber(@Nullable Object serialNumber, Map<Field, String> fields) {
+        if (serialNumber == null) {
+            return;
+        }
+        if (serialNumber instanceof Map<?, ?> idMap) {
+            Map<String, Object> ids = (Map<String, Object>) idMap;
+            if (ids.containsKey("doi")) {
+                fields.putIfAbsent(StandardField.DOI, ids.get("doi").toString());
+            }
+            if (ids.containsKey("isbn")) {
+                fields.putIfAbsent(StandardField.ISBN, ids.get("isbn").toString());
+            }
+            if (ids.containsKey("issn")) {
+                fields.putIfAbsent(StandardField.ISSN, ids.get("issn").toString());
+            }
+            if (ids.containsKey("pmid")) {
+                fields.putIfAbsent(StandardField.PMID, ids.get("pmid").toString());
+            }
+        }
+        // Plain string/number serial-numbers without a known type scheme are not mapped
+    }
+}

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -294,6 +294,7 @@ Verbatim\ BibTeX\ in\ PDF=Verbatim BibTeX in PDF
 
 Importer\ for\ COPAC\ format.=Importer for COPAC format.
 Importer\ for\ the\ CFF\ format,\ which\ is\ intended\ to\ make\ software\ and\ datasets\ citable.=Importer for the CFF format, which is intended to make software and datasets citable.
+Importer\ for\ the\ Hayagriva\ YAML\ format,\ which\ is\ used\ by\ the\ Typst\ typesetting\ system.=Importer for the Hayagriva YAML format, which is used by the Typst typesetting system.
 Importer\ for\ the\ Citavi\ XML\ format.=Importer for the Citavi XML format.
 Importer\ for\ the\ EndNote\ XML\ format.=Importer for the EndNote XML format.
 Import\ for\ the\ Refer/BibIX\ file.=Import for the Refer/BibIX file.

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTest.java
@@ -1,0 +1,218 @@
+package org.jabref.logic.importer.fileformat;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jabref.logic.util.StandardFileType;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.types.StandardEntryType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HayagrivaYamlImporterTest {
+
+    private HayagrivaYamlImporter importer;
+
+    @BeforeEach
+    void setUp() {
+        importer = new HayagrivaYamlImporter();
+    }
+
+    @Test
+    void getFormatName() {
+        assertEquals("Hayagriva YAML", importer.getName());
+    }
+
+    @Test
+    void getCLIId() {
+        assertEquals("hayagrivayaml", importer.getId());
+    }
+
+    @Test
+    void getExtensions() {
+        assertEquals(StandardFileType.YAML, importer.getFileType());
+    }
+
+    @Test
+    void getDescription() {
+        assertEquals("Importer for the Hayagriva YAML format, which is used by the Typst typesetting system.",
+                importer.getDescription());
+    }
+
+    @Test
+    void isRecognizedFormat() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestValid.yml").toURI());
+        assertTrue(importer.isRecognizedFormat(file));
+    }
+
+    @Test
+    void isRecognizedFormatReject() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestInvalid.yml").toURI());
+        assertFalse(importer.isRecognizedFormat(file));
+    }
+
+    @Test
+    void importBasicArticle() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestValid.yml").toURI());
+        BibEntry entry = importer.importDatabase(file).getDatabase().getEntries().getFirst();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("zygos")
+                .withField(StandardField.TITLE, "A Test Article")
+                .withField(StandardField.AUTHOR, "Smith, John and Doe, Jane")
+                .withField(StandardField.DATE, "2023-05-01")
+                .withField(StandardField.PAGES, "1-10")
+                .withField(StandardField.JOURNAL, "Journal of Testing")
+                .withField(StandardField.VOLUME, "5")
+                .withField(StandardField.NUMBER, "2");
+
+        assertEquals(expected, entry);
+    }
+
+    @Test
+    void importMultipleEntriesCount() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestMultipleEntries.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        assertEquals(2, entries.size());
+    }
+
+    @Test
+    void importMultipleEntriesArticle() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestMultipleEntries.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        BibEntry article = entries.stream()
+                                  .filter(e -> "article-entry".equals(e.getCitationKey().orElse("")))
+                                  .findFirst()
+                                  .orElseThrow();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("article-entry")
+                .withField(StandardField.TITLE, "An Article Entry")
+                .withField(StandardField.AUTHOR, "Smith, John")
+                .withField(StandardField.DATE, "2021-03-15")
+                .withField(StandardField.DOI, "10.1000/test")
+                .withField(StandardField.JOURNAL, "Testing Journal")
+                .withField(StandardField.VOLUME, "3")
+                .withField(StandardField.NUMBER, "1");
+
+        assertEquals(expected, article);
+    }
+
+    @Test
+    void importMultipleEntriesBook() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestMultipleEntries.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        BibEntry book = entries.stream()
+                               .filter(e -> "book-entry".equals(e.getCitationKey().orElse("")))
+                               .findFirst()
+                               .orElseThrow();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Book)
+                .withCitationKey("book-entry")
+                .withField(StandardField.TITLE, "A Book Entry")
+                .withField(StandardField.AUTHOR, "Jones, Alice")
+                .withField(StandardField.DATE, "2019")
+                .withField(StandardField.ISBN, "978-3-16-148410-0")
+                .withField(StandardField.PUBLISHER, "Test Publisher")
+                .withField(StandardField.ADDRESS, "Berlin");
+
+        assertEquals(expected, book);
+    }
+
+    @Test
+    void importSerialNumberDoi() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestSerialNumber.yml").toURI());
+        BibEntry entry = importer.importDatabase(file).getDatabase().getEntries().getFirst();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("serial-entry")
+                .withField(StandardField.TITLE, "Serial Number Test")
+                .withField(StandardField.AUTHOR, "Brown, Bob")
+                .withField(StandardField.DATE, "2022-11-01")
+                .withField(StandardField.DOI, "10.1128/MBio.00033-11")
+                .withField(StandardField.PMID, "12345678")
+                .withField(StandardField.JOURNAL, "Serial Journal")
+                .withField(StandardField.VOLUME, "2")
+                .withField(StandardField.NUMBER, "4");
+
+        assertEquals(expected, entry);
+    }
+
+    @Test
+    void importBasicYmlKinetics() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestBasic.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        BibEntry entry = entries.stream()
+                                .filter(e -> "kinetics".equals(e.getCitationKey().orElse("")))
+                                .findFirst()
+                                .orElseThrow();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("kinetics")
+                .withField(StandardField.TITLE, "Kinetics and luminescence of the excitations of a nonequilibrium polariton condensate")
+                .withField(StandardField.AUTHOR, "Doan, T. D. and Tran Thoai, D. B. and Haug, Hartmut")
+                .withField(StandardField.DOI, "10.1103/PhysRevB.102.165126")
+                .withField(StandardField.PAGES, "165126-165139")
+                .withField(StandardField.DATE, "2020-10-14")
+                .withField(StandardField.JOURNAL, "Physical Review B")
+                .withField(StandardField.VOLUME, "102")
+                .withField(StandardField.NUMBER, "16")
+                .withField(StandardField.PUBLISHER, "American Physical Society")
+                .withField(new org.jabref.model.entry.field.UnknownField("page-total"), "13");
+
+        assertEquals(expected, entry);
+    }
+
+    @Test
+    void importBasicYmlDonne() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestBasic.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        BibEntry entry = entries.stream()
+                                .filter(e -> "donne".equals(e.getCitationKey().orElse("")))
+                                .findFirst()
+                                .orElseThrow();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Book)
+                .withCitationKey("donne")
+                .withField(StandardField.TITLE, "The \"Anniversaries\" and the \"Epicedes and Obsequies\"")
+                .withField(StandardField.AUTHOR, "Donne, John")
+                .withField(StandardField.EDITOR, "Stringer, Gary A. and Pebworth, Ted-Larry")
+                .withField(StandardField.ADDRESS, "Bloomington")
+                .withField(StandardField.VOLUME, "6")
+                .withField(StandardField.PUBLISHER, "Indiana University Press")
+                .withField(StandardField.DATE, "1995")
+                .withField(StandardField.BOOKTITLE, "The Variorum Edition of the Poetry of John Donne");
+
+        assertEquals(expected, entry);
+    }
+
+    @Test
+    void importBasicYmlHouse() throws IOException, URISyntaxException {
+        Path file = Path.of(HayagrivaYamlImporterTest.class.getResource("HayagrivaYamlImporterTestBasic.yml").toURI());
+        List<BibEntry> entries = importer.importDatabase(file).getDatabase().getEntries();
+        BibEntry entry = entries.stream()
+                                .filter(e -> "house".equals(e.getCitationKey().orElse("")))
+                                .findFirst()
+                                .orElseThrow();
+
+        BibEntry expected = new BibEntry(StandardEntryType.Article)
+                .withCitationKey("house")
+                .withField(StandardField.TITLE, "Teaching medicine with the help of \"Dr. House\"")
+                .withField(StandardField.AUTHOR, "Jerrentrup, Andreas and Mueller, Tobias and Glowalla, Ulrich and Herder, Meike and Henrichs, Nadine and Neubauer, Andreas and Schaefer, Juergen R.")
+                .withField(StandardField.DOI, "10.1371/journal.pone.0193972")
+                .withField(StandardField.DATE, "2018-03-13")
+                .withField(StandardField.JOURNAL, "PLoS ONE")
+                .withField(StandardField.VOLUME, "13")
+                .withField(StandardField.NUMBER, "3");
+
+        assertEquals(expected, entry);
+    }
+}

--- a/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestBasic.yml
+++ b/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestBasic.yml
@@ -1,0 +1,463 @@
+zygos:
+    type: Article
+    author:
+        - Prekas, George
+        - Kogias, Marios
+        - Bugnion, Edouard
+    title:
+        value: "ZygOS: Achieving Low Tail Latency for Microsecond-Scale Networked Tasks"
+        verbatim: true
+    date: 2017
+    page-range: 325-341
+    serial-number:
+        doi: 10.1145/3132747.3132780
+    parent:
+        - type: Proceedings
+          title: Proceedings of the 26th Symposium on Operating Systems Principles
+          publisher: Association for Computing Machinery
+          location: New York, NY, USA
+          serial-number: { isbn: "978-1450350853" }
+
+wwdc-network:
+    type: Article
+    author:  ["Mehta, Jiten", "Kinnear, Eric"]
+    title: Boost Performance and Security with Modern Networking
+    date: 2020-06-26
+    parent:
+        - type: Conference
+          title:
+              value: "{World Wide Developer Conference 2020}"
+              short: WWDC 2020
+          organization: Apple Inc.
+          location: Mountain View, CA
+        - type: Video
+          runtime: "00:13:42"
+          url: { value: https://developer.apple.com/videos/play/wwdc2020/10111/, date: 2020-09-17 }
+
+omarova-libra:
+    type: Article
+    author: ["Omarova, Saule", "Steele, Graham"]
+    title:
+        value: There’s a Lot We Still Don’t Know About Libra
+        sentence-case: There’s a lot we still don’t know about Libra
+    date: 2019-11-04
+    url: https://www.nytimes.com/2019/11/04/opinion/facebook-libra-cryptocurrency.html
+    parent:
+        type: Newspaper
+        title:
+            value: The New York Times
+            verbatim: true
+        location: "New York, NY, USA"
+
+donne:
+    type: Book
+    title: The "Anniversaries" and the "Epicedes and Obsequies"
+    author: Donne, John
+    editor: ["Stringer, Gary A.", "Pebworth, Ted-Larry"]
+    location: Bloomington
+    volume: 6
+    publisher: Indiana University Press
+    date: 1995
+    parent:
+        type: Book
+        title: The Variorum Edition of the Poetry of John Donne
+        editor: Stringer, Gary A.
+
+swedish:
+    type: Article
+    editor: Brown, George C.
+    title:
+        value: "A Swedish Traveller in Early Wisconsin: The Observations of Fredrika Bremer"
+        short: Swedish Traveller
+    volume: 1-2
+    parent:
+        type: Periodical
+        title: Wisconsin Magazine of History
+        volume: 61-62
+        date: 1978
+        edition: 2
+
+harry:
+    type: Chapter
+    page-range: 135-139
+    serial-number: 3
+    parent:
+        title: Harry Potter and the Order of the Phoenix
+        author: Rowling, J. K.
+        volume: 5
+        volume-total: 7
+        serial-number: { isbn: 978-0747551003 }
+        page-total: 768
+        date: ~2003-06-21
+
+science-e-issue:
+    type: Web
+    title: Tokenization of + and - with scientific notation
+    url: https://github.com/typst/typstc/issues/3
+    serial-number: 3
+    author:
+        - name: "Mädje"
+          given-name: "Laurenz"
+          alias: "laurmaedje"
+    date: 2020-07-18
+    parent: 
+        type: Repository
+        title: Typst
+        url: https://github.com/typst/typst
+
+terminator-2:
+    type: Video
+    title: "Terminator 2: Judgment Day"
+    publisher: Carolco Pictures; Pacific Western Productions; Lightstorm Entertainment; Le Studio Canal+ S.A.
+    affiliated:
+        - role: director
+          names: Cameron, James
+        - role: cast-member
+          names: ["Schwarzenegger, Arnold", "Hamilton, Linda", "Patrick, Robert"]
+        - role: composer
+          names: Fiedel, Brad
+    date: 1991-07-01
+    runtime: "137:00"
+    time-range: "17:05-17:48"
+
+interior:
+    type: Video
+    title: "Conspiracy Theories and Interior Design"
+    affiliated:
+        - role: director
+          names: Davidson, Adam
+        - role: writer
+          names: McKenna, Chris
+    date: 2010-11-18
+    runtime: "22:00"
+    volume: 2
+    issue: 9
+    parent:
+        title: Community
+        affiliated:
+            - role: executive-producer
+              names: Harmon, Dan
+        publisher: Universal Television; Sony Pictures Television; Krasnoff Foster Productions; Harmonious Claptrap; Russo Brothers Film
+        volume-total: 6
+
+wire:
+    type: Video
+    title: The wire
+    date: 2002
+    publisher: Blown Deadline Productions
+    volume-total: 5
+    # From Wikipedia, the free encyclopedia: https://en.wikipedia.org/wiki/The_Wire
+    abstract: |
+        The Wire is an American crime drama television series created and
+        primarily written by American author and former police reporter David
+        Simon. The series was broadcast by the cable network HBO in the United
+        States. The Wire premiered on June 2, 2002, and ended on March 9, 2008,
+        comprising sixty episodes over five seasons. The idea for the show
+        started out as a police drama loosely based on the experiences of
+        Simon's writing partner Ed Burns, a former homicide detective and
+        public school teacher.
+    note: The Wire is noted to be solid
+    genre: Drama
+    affiliated:
+        - role: executive-producer
+          names: ["Simon, David", "Colesberry, Robert F.", "Noble, Nina Kostroff"]
+
+kinetics:
+    type: Article
+    title: Kinetics and luminescence of the excitations of a nonequilibrium polariton condensate
+    author: ["Doan, T. D.", "Tran Thoai, D. B.", "Haug, Hartmut"]
+    serial-number:
+        doi: 10.1103/PhysRevB.102.165126
+    page-total: 13
+    page-range: 165126-165139
+    date: 2020-10-14
+    parent:
+        title:
+            value: Physical Review B
+            verbatim: true
+        volume: 102
+        issue: 16
+        publisher: American Physical Society
+
+house:
+    type: Article
+    title: Teaching medicine with the help of "Dr. House"
+    author: ["Jerrentrup, Andreas", "Mueller, Tobias", "Glowalla, Ulrich", "Herder, Meike", "Henrichs, Nadine", "Neubauer, Andreas", "Schaefer, Juergen R."]
+    serial-number:
+        doi: 10.1371/journal.pone.0193972
+        serial: e0193972
+    date: 2018-03-13
+    parent:
+        title:
+            value: PLoS ONE
+            verbatim: true
+        volume: 13
+        issue: 3
+
+plaque:
+    type: Misc
+    title: Informational plaque about Jacoby's 1967 photos
+    publisher: Stiftung Reinbeckhallen
+    location: Berlin, Germany
+    date: 2020
+    parent:
+        type: Artwork
+        date: 1967
+        author: Jacoby, Max
+        parent:
+            type: Anthology
+            title: Bleibtreustraße
+            archive: Landesmuseum Koblenz
+            archive-location: Koblenz, Germany
+
+oiseau:
+    type: Exhibition
+    title: L'oiseau rare, de l'hirondelle au kakapo
+    date: 2020-12-18
+    organization: Musée des Confluences
+    location: Lyon, France
+    url:
+        value: https://www.museedesconfluences.fr/fr/evenements/l%E2%80%99oiseau-rare-de-l%E2%80%99hirondelle-au-kakapo
+        date: 2020-11-04
+
+renaissance:
+    type: Book
+    title:
+        value: Renaissance, Les Déracinés
+        translation: Renaissance, The Unrooted
+    language: fr-FR
+    author: Duval, Fred
+    affiliated:
+        - role: illustrator
+          names: ["Emem", "Blanchard, Fred"]
+    date: 2018
+    publisher: Dargaud
+    edition: 1
+    volume: 1
+    volume-total: 3
+
+gedanken:
+    type: Anthos
+    title: Gedanken-experiments on sequential machines
+    author: Moore, Edward F.
+    page-range: 129-153
+    parent:
+        type: Anthology
+        title: Automata studies
+        editor: ["Shannon, C. E.", "McCarthy, J."]
+        volume: 34
+        date: 1956-04
+        serial-number: { isbn: 978-0-691-07916-5 }
+        location: Princeton, NJ, USA
+        publisher: NBS
+        parent:
+            type: Anthology
+            title: Annals of Mathematics Studies
+
+georgia:
+    type: post
+    author: Silver, Nate
+    title: Trump's claim to have won Georgia is highly dubious. No network has called it. He's only ahead by 2.5 points there, and the outstanding votes are mostly mail votes in very blue counties, likely very Democratic. Biden may even be a slight favorite there.
+    url: https://twitter.com/NateSilver538/status/1323889051037028353
+    date: 2020-11-04
+
+really-habitable:
+    type: Article
+    title: Defining the Really Habitable Zone
+    author: ["Pedbost, Marven F.", "Pomalgu, Trillean", "Lintott, Chris", "Eisner, Nora", "Nicholson, Belinda"]
+    date: 2020
+    serial-number: 2003.13722
+    url: https://arxiv.org/abs/2003.13722
+    parent:
+        type: Repository
+        title: arXiv
+
+electronic-music:
+    type: Web
+    title: Ishkur's Guide to Electronic Music
+    serial-number: v2.5
+    author: Ishkur
+    url: { value: http://www.techno.org/electronic-music-guide/, date: 2020-11-12 }
+
+mattermost:
+    type: Web
+    title: Mattermost Privacy Policy
+    author: Mattermost
+    url:
+        value: https://mattermost.com/privacy-policy/
+        date: 2020-11-29
+    parent:
+        type: Web
+        title: Policies
+
+worth:
+    type: Blog
+    title: Jon Worth Euroblog
+    author: Worth, Jon
+    url: https://jonworth.eu/
+
+wrong:
+    type: Article
+    title: It is fast or it is wrong
+    date: 2018-12-29
+    author: Prokopov, Nikita
+    url: https://tonsky.me/blog/slow-wrong/
+    parent:
+        type: Blog
+        title: tonsky.me
+
+un-hdr:
+    type: Report
+    author: United Nations Development Programme
+    title: Human Development Report 2019
+    location: New York
+    serial-number: { issn: 2412-3129 }
+    url: http://hdr.undp.org/sites/default/files/hdr2019.pdf
+    date: 2019
+
+audio-descriptions:
+    type: Audio
+    title: Audio Descriptions
+    issue: 8
+    date: 2017-02-07
+    author: Barrows, Miellyn Fitzwater
+    affiliated:
+        - names: Taylor, Dallas
+          role: narrator
+    url: https://www.20k.org/episodes/audio
+    parent:
+        type: Audio
+        title: Twenty Thousand Hertz
+        author: Taylor, Dallas
+
+drill:
+    type: Artwork
+    title: Drill
+    author: Steyerl, Hito
+    date: 2019-06-20
+    location: New York
+    organization: Thompson Arts Center
+
+camb:
+    type: Entry
+    title: authoritative
+    url:
+        value: https://dictionary.cambridge.org/dictionary/english/authoritative
+        date: 2020-11-29
+    parent:
+        type: Reference
+        title: Cambridge Dictionary
+
+logician:
+    type: Entry
+    title: Logician
+    serial-number: n10269785
+    url:
+        value: http://image-net.org/api/text/wordnet.structure.hyponym?wnid=n10269785
+        date: 2019-12-02
+    parent:
+        type: Repository
+        title: ImageNet
+        url: http://image-net.org
+
+dns-encryption:
+    type: Reference
+    title: Secret Key Transaction Authentication for DNS
+    serial-number: RFC 2845
+    author: Internet Engineering Task Force
+    url: https://tools.ietf.org/html/rfc2845
+    date: 2000
+
+roe-wade:
+    type: Case
+    title: Roe v. Wade
+    serial-number: 93 S. Ct. 705
+    date: 1973
+
+foia:
+    type: Legislation
+    title: Freedom of Information Act
+    serial-number : Pub. L. No. 107-296, 80 Stat. 250
+    date: 1967
+
+overleaf:
+    type: Article
+    title: Celebrating over five million users, a quarter million daily actives, and over five years of dedicated user support
+    date: 2019-11-08
+    author: John
+    url: https://de.overleaf.com/blog/celebrating-over-five-million-users-and-a-quarter-million-daily-actives
+    parent:
+        type: Blog
+        title: Overleaf Blog
+
+latex-users:
+    type: Article
+    title: How many scholarly articles are written in LaTeX?
+    serial-number:
+        doi: 10.22541/au.148771883.35456290
+    author: Pepe, Alberto
+    date: 2017-02-21
+    parent:
+        type: Repository
+        title: Authorea
+
+editors:
+    type: Artwork
+    title: Types of Editors
+    author: Munroe, Randall
+    date: 2014-03-12
+    url: https://xkcd.com/1341/
+
+barb:
+    type: Book
+    title: Den Boden unter den Füßen verlieren
+    author: Günther-Haug, Barbara
+    date: 2020
+    publisher: MVG
+    location: München
+    language: de-DE
+
+lamb:
+    type: Book
+    title: The life of a friendly lamb
+    author: Kell-Nehrer, Felips
+    date: 2011
+    chapter: 20
+    volume: 10
+    page-range: 22-23
+    tongus: 2
+
+snail:
+    type: Book
+    title: A Snail Study
+    author: Kell-Nehrer, Felips
+    date: 2011
+    chapter: 2A
+    volume: 4B
+    page-range: 28
+
+lamb-chapter:
+    type: Chapter
+    page-range: 10-12
+    chapter: 3
+    parent:
+        type: Book
+        title: The life of a friendly lamb
+        author: Kell-Nehrer, Felips
+        date: 2011
+        chapter: 20
+        volume: 10
+        page-range: 22-23
+        tongus: 2
+
+snail-chapter:
+    type: Chapter
+    page-range: 10-12
+    serial-number: 3
+    parent:
+        type: Book
+        title: A Snail Study
+        author: Kell-Nehrer, Felips
+        date: 2011
+        volume: 4B
+        page-range: 28

--- a/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestInvalid.yml
+++ b/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestInvalid.yml
@@ -1,0 +1,6 @@
+- this
+- is
+- a
+- plain
+- list
+- not a hayagriva file

--- a/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestMultipleEntries.yml
+++ b/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestMultipleEntries.yml
@@ -1,0 +1,22 @@
+article-entry:
+  type: article
+  title: An Article Entry
+  author:
+    - Smith, John
+  date: 2021-03-15
+  doi: 10.1000/test
+  parent:
+    type: periodical
+    title: Testing Journal
+    volume: 3
+    issue: 1
+
+book-entry:
+  type: book
+  title: A Book Entry
+  author:
+    - Jones, Alice
+  date: 2019
+  isbn: 978-3-16-148410-0
+  publisher: Test Publisher
+  location: Berlin

--- a/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestSerialNumber.yml
+++ b/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestSerialNumber.yml
@@ -1,0 +1,14 @@
+serial-entry:
+  type: article
+  title: Serial Number Test
+  author:
+    - Brown, Bob
+  date: 2022-11-01
+  serial-number:
+    doi: 10.1128/MBio.00033-11
+    pmid: "12345678"
+  parent:
+    type: periodical
+    title: Serial Journal
+    volume: 2
+    issue: 4

--- a/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestValid.yml
+++ b/jablib/src/test/resources/org/jabref/logic/importer/fileformat/HayagrivaYamlImporterTestValid.yml
@@ -1,0 +1,13 @@
+zygos:
+  type: article
+  title: A Test Article
+  author:
+    - Smith, John
+    - Doe, Jane
+  date: 2023-05-01
+  page-range: 1-10
+  parent:
+    type: periodical
+    title: Journal of Testing
+    volume: 5
+    issue: 2


### PR DESCRIPTION

### Related issues and pull requests

Closes #15710


### PR Description
The background task in updateSearchMatches was a Runnable, meaning it both searched the index and applied the results to the UI in the same background thread. With a thread pool of multiple threads, consecutive searches could run simultaneously  whichever task finished last would overwrite the UI state, even if it was for an older query.
I changed Runnable to Callable<Optional<SearchResults>>,Added an AtomicInteger searchGeneration.
 

### Steps to test

 Run just your specific test

```bash./gradlew :jabgui:test --tests "org.jabref.gui.maintable.MainTableDataModelTest.searchResultsDoNotLingerWhenQueryChangesRapidly"```

 Run the full test class

```bash./gradlew :jabgui:test --tests "org.jabref.gui.maintable.MainTableDataModelTest"```

 
<img width="1205" height="421" alt="Screenshot 2026-05-16 at 11 18 40 PM" src="https://github.com/user-attachments/assets/b29415fb-3bb2-41a8-a099-197fe8c45429" />


### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
