### PR TITLE
Set IntelliJ format action version to 2025.3.1

### DIFF
--- a/.github/actions/format-java/action.yml
+++ b/.github/actions/format-java/action.yml
@@ -4,7 +4,7 @@ description: Reformat Java sources using IntelliJ IDEA's code style
 runs:
   using: composite
   steps:
-    - uses: leventeBajczi/intellij-idea-format@master
+    - uses: leventeBajczi/intellij-idea-format@idea-2025.3.1
       with:
         file-mask: "*.java"
         settings-file: ".idea/codeStyles/Project.xml"


### PR DESCRIPTION
With `2025.3.5`, strange diffs are introduced:

```diff

diff --git a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChange.java b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChange.java
index 2f776e9..addc86a 100644
--- a/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChange.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/groupchange/GroupChange.java
@@ -18,7 +18,7 @@ public final class GroupChange extends DatabaseChange {
         super(databaseContext, databaseChangeResolverFactory);
         this.groupDiff = groupDiff;
         setChangeName(groupDiff.getOriginalGroupRoot() == null ? Localization.lang("Removed all groups") : Localization
-                                                                                                           .lang("Modified groups tree"));
+                .lang("Modified groups tree"));
     }
 
     @Override
```

See https://github.com/JabRef/jabref/pull/15599

Trying to go back to `2025.3.1` for the format check.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
