### PR TITLE
Hide deprecated options

### DIFF
--- a/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
+++ b/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
@@ -23,7 +23,7 @@ public class GuiCommandLine {
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"-importToOpen", "--importToOpen"}, description = "Same as --import, but will be imported to the opened tab.")
+    @Option(names = {"-importToOpen", "--importToOpen"}, description = "Same as --importBibtex, but will be imported to the opened tab.")
     public String importToOpen;
 
     @Option(names = {"-x", "--exportPreferences"}, paramLabel = "FILE", description = "Export preferences.")

--- a/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
+++ b/jabgui/src/main/java/org/jabref/cli/GuiCommandLine.java
@@ -18,12 +18,12 @@ public class GuiCommandLine {
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"--importBibtex"}, description = "Import bibtex string.")
+    @Option(names = {"--importBibtex"}, hidden = true, description = "Import bibtex string.")
     public String importBibtex;
 
     /// @deprecated used by the browser extension
     @Deprecated
-    @Option(names = {"-importToOpen", "--importToOpen"}, description = "Same as --importBibtex, but will be imported to the opened tab.")
+    @Option(names = {"-importToOpen", "--importToOpen"}, hidden = true, description = "Imports and appends the given file/url to the opened tab.")
     public String importToOpen;
 
     @Option(names = {"-x", "--exportPreferences"}, paramLabel = "FILE", description = "Export preferences.")


### PR DESCRIPTION
The comment at `--importToOpen` was misleading.

~~Just a quick fix.~~ Updated in DevCall

(Longer discussion is: How to import to the gui from another tool: a) http, b) JabGui CLI, c) JabKit (internally routing "somehow", d) native messaging

---

I just copy and paste Claude's reasoning on the interface. Maybe, we DO NOT remove native messaging -- https://github.com/JabRef/jabref/pull/14884

TL;DR: Claude implicitly says: We have to weight or tradeoffs and then decide. -- Strong point: Import from CLI (via file) is easier to implement client side than an HTTP endpoint. 

```
❯ 1. HTTP POST (recommended)
     WinHTTP POST to http://localhost:23119/libraries/{id}/entries, content-type application/x-bibtex. Non-deprecated, clean C++.
     Needs user to enable HTTP server in JabRef once.
  2. Spawn jabref --importBibtex
     CreateProcess JabRef.exe with --importBibtex flag; JabRef launcher self-routes to running instance. Zero protocol code, but flag
      is @Deprecated.
  3. TCP native remote
     Speak JabRef's port-6050 protocol directly. On by default, but wire format is Java ObjectOutputStream serialization — brittle to
      reimplement in C++.


  3 paths, facts

  ┌─────────────────────────────┬──────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────┐
  │            Path             │       Default on?        │                                            C++ cost                                            │                   Status                    │
  ├─────────────────────────────┼──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ TCP remote (port 6050)      │ ✅ yes                   │ ❌ high — wire format is Java ObjectOutputStream serialization (Protocol.java). Must           │ stable                                      │
  │                             │                          │ hand-craft Java-serialized enum + String[] bytes from C++. Brittle.                            │                                             │
  ├─────────────────────────────┼──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ HTTP server (port 23119)    │ ❌ off                   │ ✅ low — WinHTTP POST, ~30 lines                                                               │ active                                      │
  ├─────────────────────────────┼──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────┤
  │ Spawn JabRef.exe            │ n/a (launcher            │ ✅ low — CreateProcess                                                                         │ --importBibtex marked @Deprecated // used   │
  │ --importBibtex "..."        │ self-routes via TCP)     │                                                                                                │ by the browser extension                    │
  └─────────────────────────────┴──────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────┘

  Key finds

  - TCP "native messaging" = Java serialization. C++ client must reimplement ObjectOutputStream framing. Hostile. Skip.
  - HTTP server has purpose-built endpoint: POST /libraries/{id}/entries, Consumes application/x-bibtex (EntriesResource.java:60). Non-deprecated. Language-neutral. curl-testable. But enableHttpServer =
  false default → user toggles once in JabRef Settings → Remote.
  - Also POST /commands (JSON dispatch) on same HTTP server.
  - --importBibtex CLI flag works but deprecated — JabRef may remove it.

  Recommendation

  HTTP POST. Don't keep native messaging — TCP protocol is Java-serialization-locked, can't speak it cleanly from C++. One entry point, not several. Cost: one-time JabRef settings toggle (enableHttpServer),
  documented.

---

  Revised recommendation: spawn JabRef --importBibtex

  ┌───────────────────────────────┬──────────────────────────────────────────────┬─────────────────────────────────────┐
  │                               │                  Spawn CLI                   │              HTTP POST              │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Listening socket              │ none                                         │ localhost:23119                     │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Token needed                  │ no                                           │ yes — and not implemented in JabRef │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ CORS / webpage attack surface │ none                                         │ open (Origin: *) until token built  │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Trust boundary                │ OS process execution (local only)            │ network listener                    │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Protocol code in Sumatra      │ none — CreateProcessW                        │ WinHTTP client                      │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Routes to running instance    │ yes — JabRef launcher self-routes            │ yes                                 │
  ├───────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────┤
  │ Proven                        │ yes — browser extension uses this exact path │ endpoint exists, less exercised     │
  └───────────────────────────────┴──────────────────────────────────────────────┴─────────────────────────────────────┘

  Spawn-CLI wins on security precisely because of your token concern: no listener → no token → no CORS surface. Trust = "can run JabRef.exe", same as any local app.

  Cost of spawn-CLI:
  - Need JabRef install path — resolve like jabrefHost.py does (PATH lookup jabref/JabRef, or a configurable setting in SumatraPDF).
  - Spawn latency — minor; if JabRef already running, its launcher does the fast internal TCP handoff (JabRef speaks its own Java-serialization protocol, so we don't).
  - --importBibtex nominally deprecated, but extension-pinned → safe.

  HTTP would only win if you needed cross-machine or zero process spawn. Neither applies. And you'd have to build the token feature in JabRef first.

 Security points that still matter

  - CORS: current Access-Control-Allow-Origin: * means any webpage's JS can reach localhost:23119. The token in a custom/Authorization header is the real defense — that header forces a CORS preflight, and a
  malicious page cannot read the token, so it cannot forge the header. CSRF blocked even with *. Still: tighten CORS for the mutating verbs.
  - Bind to 127.0.0.1 only. Verify RemotePreferences.getIpAddress() is loopback, not 0.0.0.0 — else the token guards a LAN-exposed port.
  - Token at rest: stored in JabRef prefs (Java Preferences / config). Plaintext-ish. Acceptable for a localhost capability token; it is not a password.
  - Token is a bearer capability — anyone who can read JabRef prefs already has local code execution, so no worse than the spawn-CLI trust boundary.
```

### AI usage

Did it for myself

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
