### PR TITLE
SLR: SEMVER schema version and test names

### DIFF
--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.NonNull;
 // The user might add arbitrary content to the YAML
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Study {
-    public static final String CURRENT_SCHEMA_VERSION = "2.0";
+    public static final String CURRENT_SCHEMA_VERSION = "2.0.0";
 
     @JsonProperty("version")
     private String version;

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -33,7 +33,7 @@ class StudyYamlParserTest {
         URL studyDefinition = StudyYamlParser.class.getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, true);
 
-        List<String> authors = List.of("Jab Ref");
+        List<String> authors = List.of("Haruki Murakami");
         String studyName = "TestStudyName";
         List<String> researchQuestions = List.of("Question1", "Question2");
         List<StudyQuery> queryEntries = List.of(new StudyQuery("Quantum"), new StudyQuery("Cloud Computing"), new StudyQuery("\"Software Engineering\""));
@@ -75,7 +75,7 @@ class StudyYamlParserTest {
         Study study = new StudyYamlParser().parseStudyYamlFile(Path.of(studyDefinition.toURI()));
 
         assertEquals("2.0.0", study.getVersion());
-        assertEquals(List.of("Jab Ref"), study.getAuthors());
+        assertEquals(List.of("Donna Tartt", "Virginia Woolf"), study.getAuthors());
         assertEquals("TestStudyName", study.getTitle());
         assertEquals(List.of("Question1", "Question2"), study.getResearchQuestions());
         assertEquals(3, study.getQueries().size());
@@ -100,7 +100,7 @@ class StudyYamlParserTest {
                 "IEEEXplore", "(Document Title:Quantum)",
                 "ACM Portal", "[Title: Quantum]"));
         Study original = new Study(
-                List.of("Jab Ref"),
+                List.of("Oscar Wilde"),
                 "Round-trip Study",
                 List.of("Q1"),
                 List.of(queryWithOverrides, new StudyQuery("Cloud Computing")),

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -41,7 +41,7 @@ class StudyYamlParserTest {
                 new StudyCatalog("Medline/PubMed", true), new StudyCatalog("IEEEXplore", false));
 
         expectedStudy = new Study(authors, studyName, researchQuestions, queryEntries, libraryEntries);
-        expectedStudy.setVersion("2.0");
+        expectedStudy.setVersion("2.0.0");
     }
 
     @Test
@@ -74,7 +74,7 @@ class StudyYamlParserTest {
 
         Study study = new StudyYamlParser().parseStudyYamlFile(Path.of(studyDefinition.toURI()));
 
-        assertEquals("2.0", study.getVersion());
+        assertEquals("2.0.0", study.getVersion());
         assertEquals(List.of("Jab Ref"), study.getAuthors());
         assertEquals("TestStudyName", study.getTitle());
         assertEquals(List.of("Question1", "Question2"), study.getResearchQuestions());

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-jabref-5.7.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-jabref-5.7.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Haruki Murakami
 title: TestStudyName
 last-search-date: 2020-11-26
 research-questions:

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.0.0
 authors:
 - Jab Ref
 title: TestStudyName

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
@@ -1,6 +1,6 @@
 version: 2.0.0
 authors:
-- Jab Ref
+- Oscar Wilde
 title: TestStudyName
 research-questions:
 - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Oscar Wilde
 title: TestStudyName
 research-questions:
   - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-minimal-expected.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-minimal-expected.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.0.0
 catalogs:
 - name: ACM Portal
   enabled: true

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
@@ -1,6 +1,7 @@
 version: "2.0.0"
 authors:
-  - Jab Ref
+  - Donna Tartt
+  - Virginia Woolf
 title: TestStudyName
 research-questions:
   - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
@@ -1,4 +1,4 @@
-version: "2.0"
+version: "2.0.0"
 authors:
   - Jab Ref
 title: TestStudyName

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Haruki Murakami
 title: TestStudyName
 research-questions:
   - Question1


### PR DESCRIPTION
### Related issues and pull requests

Follow Up on #15215 

### PR Description

1. Changed The Schema version to SEMVER format to use "2.0.0" instead of "2.0"
2. Renamed placeholder authors across tests 

### Steps to test

### AI usage

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)