### PR TITLE
Document LocalizationConsistencyTest output as actionable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,10 @@ Both comments must not be added.
 #### Localization
 
 - Fix localization before committing. See `docs/code-howtos/localization.md`
+- The `LocalizationConsistencyTest` failure output is actionable — follow it literally instead of guessing:
+  - `findMissingLocalizationKeys` failing → its output lists ready-to-paste `key=value` lines to **add** to `jablib/src/main/resources/l10n/JabRef_en.properties`. Place each near semantically related keys; reuse an existing similar key when one exists.
+  - `findObsoleteLocalizationKeys` failing → its output lists keys to **remove** from `JabRef_en.properties` (after confirming each is truly unused).
+  - Only edit `JabRef_en.properties`. Translated `JabRef_<lang>.properties` files are maintained by translators via Crowdin — never hand-edit them.
 - JabRef is a multilingual program, When you write any user-facing text, it should be localized.
 
    To do this in Java code, call `Localization.lang` method, like this:

--- a/docs/code-howtos/localization.md
+++ b/docs/code-howtos/localization.md
@@ -61,6 +61,13 @@ The tests in `org.jabref.logic.l10n.LocalizationConsistencyTest` check whether t
 3. Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
 4. Please do not add translations for other languages directly in the properties. They will be overwritten by [Crowdin](https://crowdin.com/project/jabref)
 
+## Removing an obsolete key
+
+1. Remove the `Localization.lang("KEY")` call (or `%KEY` from FXML). Run the `org.jabref.logic.l10n.LocalizationConsistencyTest`.
+2. The `findObsoleteLocalizationKeys` test fails. The test output lists the keys that are no longer referenced.
+3. Confirm each listed key is really unused, then remove it from the English translation file at `src/main/resources/l10n/JabRef_en.properties`.
+4. Do not remove the key from the other language properties files. They are managed by [Crowdin](https://crowdin.com/project/jabref).
+
 ## Adding a new Language
 
 1. Add the new Language to the Language enum in [https://github.com/JabRef/jabref/blob/main/jablib/src/main/java/org/jabref/logic/l10n/Language.java](https://github.com/JabRef/jabref/blob/main/jablib/src/main/java/org/jabref/logic/l10n/Language.java)

--- a/docs/code-howtos/localization.md
+++ b/docs/code-howtos/localization.md
@@ -56,7 +56,7 @@ The tests in `org.jabref.logic.l10n.LocalizationConsistencyTest` check whether t
 
 ## Adding a new key
 
-1. Add new `Localization.lang("KEY")` to Java file. Run the `org.jabref.logic.LocalizationConsistencyTest`.
+1. Add new `Localization.lang("KEY")` to Java file. Run the `org.jabref.logic.l10n.LocalizationConsistencyTest`.
 2. Tests fail. In the test output a snippet is generated which must be added to the English translation file.
 3. Add snippet to English translation file located at `jablib/src/main/resources/l10n/JabRef_en.properties`
 4. Please do not add translations for other languages directly in the properties. They will be overwritten by [Crowdin](https://crowdin.com/project/jabref)

--- a/docs/code-howtos/localization.md
+++ b/docs/code-howtos/localization.md
@@ -58,14 +58,14 @@ The tests in `org.jabref.logic.l10n.LocalizationConsistencyTest` check whether t
 
 1. Add new `Localization.lang("KEY")` to Java file. Run the `org.jabref.logic.LocalizationConsistencyTest`.
 2. Tests fail. In the test output a snippet is generated which must be added to the English translation file.
-3. Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
+3. Add snippet to English translation file located at `jablib/src/main/resources/l10n/JabRef_en.properties`
 4. Please do not add translations for other languages directly in the properties. They will be overwritten by [Crowdin](https://crowdin.com/project/jabref)
 
 ## Removing an obsolete key
 
 1. Remove the `Localization.lang("KEY")` call (or `%KEY` from FXML). Run the `org.jabref.logic.l10n.LocalizationConsistencyTest`.
 2. The `findObsoleteLocalizationKeys` test fails. The test output lists the keys that are no longer referenced.
-3. Confirm each listed key is really unused, then remove it from the English translation file at `src/main/resources/l10n/JabRef_en.properties`.
+3. Confirm each listed key is really unused, then remove it from the English translation file at `jablib/src/main/resources/l10n/JabRef_en.properties`.
 4. Do not remove the key from the other language properties files. They are managed by [Crowdin](https://crowdin.com/project/jabref).
 
 ## Adding a new Language


### PR DESCRIPTION
### Related issues and pull requests

No related issue — documentation/agent-guidance improvement.

### PR Description

`LocalizationConsistencyTest` already emits actionable failure output: the exact `key=value` lines to add and the keys to remove from `JabRef_en.properties`. This PR makes that explicit in `AGENTS.md` so agents apply the test output literally instead of guessing, and adds a "Removing an obsolete key" section to `docs/code-howtos/localization.md`, which previously documented only the add-key flow.

### Steps to test

1. Open `AGENTS.md` — the Localization section now describes the `findMissingLocalizationKeys` and `findObsoleteLocalizationKeys` output.
2. Open `docs/code-howtos/localization.md` — a new "Removing an obsolete key" section sits between "Adding a new key" and "Adding a new Language".
3. Docs-only change; no build or runtime behavior affected.

### AI usage

Claude Code (model claude-opus-4-7) — used to draft the documentation wording. Reviewed and owned by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
