### PR TITLE
Include generated key in citation key deviation check

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -159,8 +159,8 @@ jobs:
 
           LINE_COUNT=$(echo "$BOXES" | wc -l)
 
-          if [ "$LINE_COUNT" -ne 7 ]; then
-            echo "❌ Found $LINE_COUNT lines instead of 7 required lines"
+          if [ "$LINE_COUNT" -ne 8 ]; then
+            echo "❌ Found $LINE_COUNT lines instead of 8 required lines"
             exit 1
           fi
 

--- a/.jbang/JabSrvLauncher.java
+++ b/.jbang/JabSrvLauncher.java
@@ -69,6 +69,7 @@
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LibraryQueryResult.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/dto/LinkedPdfFileDTO.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/JabrefMediaType.java
+//SOURCES ../jabsrv/src/main/java/org/jabref/http/AbstractSrvStateManager.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/JabRefSrvStateManager.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/SrvStateManager.java
 //SOURCES ../jabsrv/src/main/java/org/jabref/http/server/cayw/CAYWQueryParams.java

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The "Make/Sync bibliography" button in OO/LO panel now refreshes citations before generating bibliographies. [#14387](https://github.com/JabRef/jabref/issues/14387)
 - Improved responsiveness and user interface of refresh button in Citation Relations tab. [#12247](https://github.com/JabRef/jabref/issues/12247)
 - JabRef keeps the field `review` in BibTeX files. [#15609](https://github.com/JabRef/jabref/pull/15609)
+- The citation key integrity check now includes the generated citation key in its warning message.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,11 @@ Since JabRef is driven by volunteers in their spare time, reviews may take more 
 The pull request may be approved immediately, or a reviewer may request changes and/or have discussions regarding your approach.
 In that case, you are expected to answer any questions and implement the requested changes.
 
+> [!IMPORTANT]
+> Do **not** resolve review discussions yourself after addressing the feedback.
+> Resolving a conversation is reserved for the maintainer who started it, so they can verify the fix.
+> As a contributor, reply to the comment to indicate it has been addressed, then leave the conversation open.
+
 Please – **never ever close a pull request and open a new one** -
 This causes unnecessary work on our side, and is not in the style of the GitHub Open Source community.
 You can push any changes you need to make to the branch your pull request is *from*.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("org.jabref.gradle.base.repositories")
     id("org.jabref.gradle.feature.compile") // for openrewrite
     id("org.openrewrite.rewrite") version "7.32.2"
-    id("org.itsallcode.openfasttrace") version "3.1.1"
+    id("org.itsallcode.openfasttrace") version "3.1.2"
     id("org.cyclonedx.bom") version "3.2.4"
 }
 

--- a/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
+++ b/jabgui/src/main/java/org/jabref/gui/LibraryTab.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.swing.undo.UndoManager;
@@ -340,9 +341,9 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
     }
 
     public void createSearchContext() {
-        java.util.function.Supplier<SearchBackend> sqlFactory = () ->
+        Supplier<SearchBackend> sqlFactory = () ->
                 new SqlSearchBackend(new IndexManager(bibDatabaseContext, taskExecutor, preferences, Injector.instantiateModelOrService(PostgreServer.class)));
-        java.util.function.Supplier<SearchBackend> inMemoryFactory = () ->
+        Supplier<SearchBackend> inMemoryFactory = () ->
                 new InMemorySearchBackend(bibDatabaseContext, preferences.getBibEntryPreferences());
         searchContext = new SearchContext(
                 preferences.getSearchPreferences().usePostgresSearchProperty(),
@@ -370,15 +371,15 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
 
     private void setDatabaseContext(@NonNull BibDatabaseContext bibDatabaseContext) {
         TabPane tabPane = this.getTabPane();
+        boolean isSelectedTab = false;
 
         if (tabPane == null) {
             LOGGER.debug("User interrupted loading. Not showing any library.");
             return;
         }
-        if (tabPane.getSelectionModel().selectedItemProperty().get().equals(this)) {
-            LOGGER.debug("This case should not happen.");
-            stateManager.setActiveDatabase(bibDatabaseContext);
-            stateManager.activeTabProperty().set(Optional.of(this));
+        Tab selectedTab = tabPane.getSelectionModel().getSelectedItem();
+        if (selectedTab == this) {
+            isSelectedTab = true;
         }
 
         // Remove existing dummy BibDatabaseContext and add correct BibDatabaseContext from ParserResult to trigger changes in the openDatabases list in the stateManager
@@ -390,6 +391,12 @@ public class LibraryTab extends Tab implements CommandSelectionTab {
         stateManager.getOpenDatabases().add(bibDatabaseContext);
 
         initializeComponentsAndListeners(false);
+
+        if (isSelectedTab) {
+            stateManager.setActiveDatabase(bibDatabaseContext);
+            stateManager.activeTabProperty().set(Optional.of(this));
+        }
+
         installAutosaveManagerAndBackupManager();
     }
 

--- a/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDeviationChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDeviationChecker.java
@@ -38,7 +38,7 @@ public class CitationKeyDeviationChecker implements EntryChecker {
 
         if (!Objects.equals(key, generatedKey)) {
             return List.of(new IntegrityMessage(
-                    Localization.lang("Citation key deviates from generated key"), entry, InternalField.KEY_FIELD));
+                    Localization.lang("Citation key deviates from generated key %0", generatedKey), entry, InternalField.KEY_FIELD));
         }
 
         return List.of();

--- a/jablib/src/main/java/org/jabref/model/study/Study.java
+++ b/jablib/src/main/java/org/jabref/model/study/Study.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.NonNull;
 // The user might add arbitrary content to the YAML
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Study {
-    public static final String CURRENT_SCHEMA_VERSION = "2.0";
+    public static final String CURRENT_SCHEMA_VERSION = "2.0.0";
 
     @JsonProperty("version")
     private String version;

--- a/jablib/src/main/resources/l10n/JabRef_de.properties
+++ b/jablib/src/main/resources/l10n/JabRef_de.properties
@@ -719,7 +719,6 @@ Unable\ to\ write\ to\ %0.=Kann nicht nach %0 schreiben.
 
 
 Move\ file=Datei verschoben
-Move\ file\ to\ file\ directory\ and\ rename\ file=Datei in Verzeichnis verschieben und Datei umbenennen
 Rename\ file=Datei umbenennen
 
 Directory=Verzeichnis
@@ -753,7 +752,6 @@ File\ not\ found=Datei nicht gefunden
 %0\ file(s)=%0 Datei(en)
 Open\ file(s)=Datei(en) öffnen
 Download\ file(s)=Datei(en) herunterladen
-Move\ file(s)\ to\ file\ directory=Datei(en) in das Dateiverzeichnis kopieren
 Redownload\ file(s)=Datei(en) erneut herunterladen
 Copy\ linked\ file(s)=Verknüpfte Datei(en) kopieren
 # TODO: "folder" vs. "directory" consistency

--- a/jablib/src/main/resources/l10n/JabRef_el.properties
+++ b/jablib/src/main/resources/l10n/JabRef_el.properties
@@ -600,7 +600,6 @@ Unable\ to\ write\ to\ %0.=Δεν είναι δυνατή η εγγραφή στ
 
 
 Move\ file=Μετακίνηση αρχείου
-Move\ file\ to\ file\ directory\ and\ rename\ file=Μετακίνηση αρχείου στο φάκελο αρχείων και μετονομασία του
 Rename\ file=Μετονομασία αρχείου
 
 Directory=Κατάλογος

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1954,7 +1954,7 @@ File\ directory\ pattern=File directory pattern
 Update\ with\ bibliographic\ information\ from\ the\ web=Update with bibliographic information from the web
 
 Could\ not\ find\ any\ bibliographic\ information.=Could not find any bibliographic information.
-Citation\ key\ deviates\ from\ generated\ key=Citation key deviates from generated key
+Citation\ key\ deviates\ from\ generated\ key\ %0=Citation key deviates from generated key %0
 
 Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences\:=Select all customized types to be stored in local preferences\:
 Different\ customization,\ current\ settings\ will\ be\ overwritten=Different customization, current settings will be overwritten

--- a/jablib/src/main/resources/l10n/JabRef_es.properties
+++ b/jablib/src/main/resources/l10n/JabRef_es.properties
@@ -718,7 +718,6 @@ Unable\ to\ write\ to\ %0.=No se puede escribir en %0.
 
 
 Move\ file=Mover archivo
-Move\ file\ to\ file\ directory\ and\ rename\ file=Mover el archivo al directorio de archivos y renombrar el archivo
 Rename\ file=renombrar archivo
 
 Directory=Directorio
@@ -751,7 +750,6 @@ File\ not\ found=No se ha encontrado el archivo
 %0\ file(s)=%0 archivo(s)
 Open\ file(s)=Abrir archivo(s)
 Download\ file(s)=Descargar archivo(s)
-Move\ file(s)\ to\ file\ directory=Mover archivo(s) al directorio de archivos
 Redownload\ file(s)=Archivo(s) rebajado(s)
 Copy\ linked\ file(s)=Copiar archivo(s) enlazados
 # TODO: "folder" vs. "directory" consistency

--- a/jablib/src/main/resources/l10n/JabRef_fr.properties
+++ b/jablib/src/main/resources/l10n/JabRef_fr.properties
@@ -754,7 +754,8 @@ BibTeX=BibTeX
 File\ %0\ not\ found.=Fichier %0 non trouvé.
 
 Move\ file=Déplacer fichier
-Move\ file\ to\ file\ directory\ and\ rename\ file=Déplacer le fichier vers le répertoire de fichiers et renommer le fichier
+Move\ file(s)\ to\ directory=Déplacer le(s) fichier(s) vers le répertoire
+Move\ file\ to\ directory\ and\ rename\ file=Déplacer le fichier vers le répertoire et renommer le fichier
 Rename\ file=Renommer le fichier
 
 Directory=Répertoire
@@ -791,7 +792,6 @@ File(s)\ %0\ not\ found.=Fichier(s) %0 non trouvé.
 %0\ file(s)=%0 fichier(s)
 Open\ file(s)=Ouvrir le(s) fichier(s)
 Download\ file(s)=Télécharger le(s) fichier(s)
-Move\ file(s)\ to\ file\ directory=Déplacer le(s) fichier(s) vers un répertoire
 Redownload\ file(s)=Télécharger à nouveau le(s) fichier(s)
 Copy\ linked\ file(s)=Copier le(s) fichier(s) lié(s)
 # TODO: "folder" vs. "directory" consistency
@@ -1089,6 +1089,8 @@ LaTeX\ file\ directory=Répertoire de fichiers LaTeX
 LaTeX\ file\ directory\:\ %0=Répertoire de fichiers LaTeX \: %0
 User-specific\ file\ directory=Répertoire de fichiers spécifique à l'utilisateur
 User-specific\ file\ directory\:\ %0=Répertoire spécifique des fichiers de l'utilisateur \: %0
+Next\ to\ library\ file\:\ %0=À côté du fichier bibliographique \: %0
+Unavailable=Indisponible
 
 Path\ %0\ could\ not\ be\ resolved.\ Using\ working\ directory.=Le chemin %0 n'a pas pu être trouvé. Utilisation du répertoire de travail.
 Switch\ to\ absolute\ path\:\ converts\ the\ path\ to\ an\ absolute\ path.=Basculer vers un chemin absolu \: convertit le chemin vers un chemin absolu.
@@ -1587,6 +1589,7 @@ Clears\ the\ field\ completely.=Effacer complétement le champ.
 
 Open\ folder=Ouvrir le répertoire
 Main\ file\ directory=Répertoire principal des documents
+Main\ file\ directory\:\ %0=Répertoire principal des fichiers \: %0
 Main\ file\ directory\ '%0'\ not\ found.\nCheck\ the\ tab\ "Linked\ files".=Le répertoire principal des documents '%0' n'a pas été trouvé. Vérifiez l'onglet "Documents liés".
 The\ file\ directory\ '%0'\ for\ the\ %1\ file\ path\ is\ not\ found\ or\ is\ inaccessible.=Le répertoire de fichiers '%0' pour le chemin du fichier %1 est introuvable ou est inaccessible.
 Invalid\ path\:\ '%0'.\nCheck\ "%1".=Chemin d'accès invalide \: '%0'.\nVérifier "%1".
@@ -2871,6 +2874,7 @@ your\ search\ history\ is\ empty=Votre historique de recherche est vide
 Clear\ history=Effacer l'historique
 
 Create\ backup=Créer une sauvegarde
+Experimental\ search\ (Postgres)=Recherche expérimentale (Postgres)
 Automatically\ search\ and\ show\ unlinked\ files\ in\ the\ entry\ editor=Rechercher et afficher automatiquement les documents non liés dans l'éditeur d'entrée
 
 File\ "%0"\ cannot\ be\ added\!=Le fichier "%" ne peut pas être ajouté \!
@@ -3532,3 +3536,5 @@ Query\ sent\ as\ raw\ search\ term=Requête envoyée en tant que terme de recher
 
 The\ default\ entry\ type\ will\ be\ used\ since\ the\ invalid\ key\ was\ passed.=Le type d'entrée par défaut sera utilisé, car la clef invalide a été passée.
 
+Catalog\ Reason=Motif du catalogue
+Click\ a\ cell\ to\ edit\ the\ reason=Cliquez sur une cellule pour modifier le motif

--- a/jablib/src/main/resources/l10n/JabRef_it.properties
+++ b/jablib/src/main/resources/l10n/JabRef_it.properties
@@ -754,7 +754,8 @@ BibTeX=BibTeX
 File\ %0\ not\ found.=File %0 non trovato/i.
 
 Move\ file=Sposta file
-Move\ file\ to\ file\ directory\ and\ rename\ file=Sposta il file nella cartella del file e rinomina il file
+Move\ file(s)\ to\ directory=Sposta il/i file nella cartella
+Move\ file\ to\ directory\ and\ rename\ file=Sposta il file nella cartella e rinominalo
 Rename\ file=Rinomina il file
 
 Directory=Cartella
@@ -791,7 +792,6 @@ File(s)\ %0\ not\ found.=File %0 non trovato/i.
 %0\ file(s)=%0 file(s)
 Open\ file(s)=Apri il/i file
 Download\ file(s)=Scarica file
-Move\ file(s)\ to\ file\ directory=Sposta il/i file nella cartella dei file
 Redownload\ file(s)=Scarica nuovamente il/i file
 Copy\ linked\ file(s)=Copia il/i file collegato/i
 # TODO: "folder" vs. "directory" consistency
@@ -1089,6 +1089,8 @@ LaTeX\ file\ directory=Cartella dei file LaTeX
 LaTeX\ file\ directory\:\ %0=Directory file LaTeX\: %0
 User-specific\ file\ directory=Cartella dei file specifica dell'utente
 User-specific\ file\ directory\:\ %0=Directory file specifica dell'utente\: %0
+Next\ to\ library\ file\:\ %0=Accanto al file di libreria\: %0
+Unavailable=Non disponibile
 
 Path\ %0\ could\ not\ be\ resolved.\ Using\ working\ directory.=Il percorso %0 non può essere risolto. Utilizzo della directory di lavoro.
 Switch\ to\ absolute\ path\:\ converts\ the\ path\ to\ an\ absolute\ path.=Passa al percorso assoluto\: converte il percorso in un percorso assoluto.
@@ -1586,6 +1588,7 @@ Clears\ the\ field\ completely.=Azzera completamente il campo.
 
 Open\ folder=Apri cartella
 Main\ file\ directory=Cartella dei file principale
+Main\ file\ directory\:\ %0=Cartella del file principale\: %0
 Main\ file\ directory\ '%0'\ not\ found.\nCheck\ the\ tab\ "Linked\ files".=Directory file principale '%0' non trovata.\nControlla la scheda "File collegati".
 Invalid\ path\:\ '%0'.\nCheck\ "%1".=
 
@@ -3446,3 +3449,5 @@ Query\ sent\ as\ raw\ search\ term=Interrogazione inviata come termine di ricerc
 
 The\ default\ entry\ type\ will\ be\ used\ since\ the\ invalid\ key\ was\ passed.=Il tipo di voce predefinito verrà utilizzato dal momento che la chiave non valida è stata passata.
 
+Catalog\ Reason=Motivo Del Catalogo
+Click\ a\ cell\ to\ edit\ the\ reason=Fare clic su una cella per modificare il motivo

--- a/jablib/src/main/resources/l10n/JabRef_ja.properties
+++ b/jablib/src/main/resources/l10n/JabRef_ja.properties
@@ -574,7 +574,6 @@ Overwrite\ file=ファイルを上書き
 
 
 Move\ file=ファイルを移動
-Move\ file\ to\ file\ directory\ and\ rename\ file=ファイルをファイルディレクトリに移動して改名
 Rename\ file=ファイルを改名
 
 Directory=ディレクトリ

--- a/jablib/src/main/resources/l10n/JabRef_ko.properties
+++ b/jablib/src/main/resources/l10n/JabRef_ko.properties
@@ -535,7 +535,6 @@ Overwrite\ file=파일 덮어쓰기
 
 
 Move\ file=파일 이동
-Move\ file\ to\ file\ directory\ and\ rename\ file=파일을 파일 디렉토리로 이동하고 파일 이름 바꾸기
 Rename\ file=파일 이름 변경
 
 Directory=디렉토리

--- a/jablib/src/main/resources/l10n/JabRef_nl.properties
+++ b/jablib/src/main/resources/l10n/JabRef_nl.properties
@@ -596,7 +596,6 @@ Unable\ to\ write\ to\ %0.=Kan niet schrijven naar %0.
 
 
 Move\ file=Bestand verplaatsen
-Move\ file\ to\ file\ directory\ and\ rename\ file=Verplaats bestand naar bestandsmap en hernoem bestand
 Rename\ file=Bestand hernoemen
 
 Directory=Map

--- a/jablib/src/main/resources/l10n/JabRef_pl.properties
+++ b/jablib/src/main/resources/l10n/JabRef_pl.properties
@@ -626,7 +626,6 @@ Unable\ to\ write\ to\ %0.=Nie można zapisać do %0.
 
 
 Move\ file=Przenieś plik
-Move\ file\ to\ file\ directory\ and\ rename\ file=Przenieś plik do katalogu plików i zmień nazwę pliku
 Rename\ file=Zmień nazwę pliku
 
 Directory=Katalog

--- a/jablib/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/jablib/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -714,7 +714,6 @@ Unable\ to\ write\ to\ %0.=Não foi possível gravar em %0.
 
 
 Move\ file=Mover arquivo
-Move\ file\ to\ file\ directory\ and\ rename\ file=Mover arquivo para o diretório de arquivos e renomear arquivo
 Rename\ file=Renomear arquivo
 
 Directory=Diretório
@@ -747,7 +746,6 @@ File\ not\ found=Arquivo não encontrado
 %0\ file(s)=Arquivo(s) %0
 Open\ file(s)=Abrir arquivo(s)
 Download\ file(s)=Baixar arquivo(s)
-Move\ file(s)\ to\ file\ directory=Mover arquivo(s) para o diretório de arquivos
 Redownload\ file(s)=Baixar novamente o(s) arquivo(s)
 Copy\ linked\ file(s)=Copiar arquivo(s) vinculado(s)
 # TODO: "folder" vs. "directory" consistency

--- a/jablib/src/main/resources/l10n/JabRef_ru.properties
+++ b/jablib/src/main/resources/l10n/JabRef_ru.properties
@@ -589,7 +589,6 @@ Overwrite\ file=Перезаписать файл
 
 
 Move\ file=Переместить файл
-Move\ file\ to\ file\ directory\ and\ rename\ file=Переместить файл в каталог файлов и переименовать
 Rename\ file=Ппереименовать файл
 
 Directory=Директория

--- a/jablib/src/main/resources/l10n/JabRef_tr.properties
+++ b/jablib/src/main/resources/l10n/JabRef_tr.properties
@@ -610,7 +610,6 @@ Unable\ to\ write\ to\ %0.=%0'e yazılamadı.
 
 
 Move\ file=Dosya Taşı adlandır
-Move\ file\ to\ file\ directory\ and\ rename\ file=Dosyayı dosya dizinine taşı ve yeniden adlandır
 Rename\ file=Yeniden adlandır
 
 Directory=Dizin

--- a/jablib/src/main/resources/l10n/JabRef_zh_CN.properties
+++ b/jablib/src/main/resources/l10n/JabRef_zh_CN.properties
@@ -753,7 +753,6 @@ BibTeX=BibTex
 File\ %0\ not\ found.=未找到文件 %0。
 
 Move\ file=移动文件
-Move\ file\ to\ file\ directory\ and\ rename\ file=移动文件到文件目录重命名文件
 Rename\ file=重命名文件
 
 Directory=目录
@@ -790,7 +789,6 @@ File(s)\ %0\ not\ found.=未找到文件 %0。
 %0\ file(s)=%0 个文件
 Open\ file(s)=打开文件
 Download\ file(s)=下载文件
-Move\ file(s)\ to\ file\ directory=将文件移动到文件目录
 Redownload\ file(s)=重新下载文件
 Copy\ linked\ file(s)=复制链接文件
 # TODO: "folder" vs. "directory" consistency

--- a/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/crawler/StudyYamlParserTest.java
@@ -33,7 +33,7 @@ class StudyYamlParserTest {
         URL studyDefinition = StudyYamlParser.class.getResource(StudyRepository.STUDY_DEFINITION_FILE_NAME);
         FileUtil.copyFile(Path.of(studyDefinition.toURI()), destination, true);
 
-        List<String> authors = List.of("Jab Ref");
+        List<String> authors = List.of("Haruki Murakami");
         String studyName = "TestStudyName";
         List<String> researchQuestions = List.of("Question1", "Question2");
         List<StudyQuery> queryEntries = List.of(new StudyQuery("Quantum"), new StudyQuery("Cloud Computing"), new StudyQuery("\"Software Engineering\""));
@@ -41,7 +41,7 @@ class StudyYamlParserTest {
                 new StudyCatalog("Medline/PubMed", true), new StudyCatalog("IEEEXplore", false));
 
         expectedStudy = new Study(authors, studyName, researchQuestions, queryEntries, libraryEntries);
-        expectedStudy.setVersion("2.0");
+        expectedStudy.setVersion("2.0.0");
     }
 
     @Test
@@ -74,8 +74,8 @@ class StudyYamlParserTest {
 
         Study study = new StudyYamlParser().parseStudyYamlFile(Path.of(studyDefinition.toURI()));
 
-        assertEquals("2.0", study.getVersion());
-        assertEquals(List.of("Jab Ref"), study.getAuthors());
+        assertEquals("2.0.0", study.getVersion());
+        assertEquals(List.of("Donna Tartt", "Virginia Woolf"), study.getAuthors());
         assertEquals("TestStudyName", study.getTitle());
         assertEquals(List.of("Question1", "Question2"), study.getResearchQuestions());
         assertEquals(3, study.getQueries().size());
@@ -100,7 +100,7 @@ class StudyYamlParserTest {
                 "IEEEXplore", "(Document Title:Quantum)",
                 "ACM Portal", "[Title: Quantum]"));
         Study original = new Study(
-                List.of("Jab Ref"),
+                List.of("Oscar Wilde"),
                 "Round-trip Study",
                 List.of("Q1"),
                 List.of(queryWithOverrides, new StudyQuery("Cloud Computing")),

--- a/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDeviationCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDeviationCheckerTest.java
@@ -2,51 +2,37 @@ package org.jabref.logic.integrity;
 
 import java.util.List;
 
-import org.jabref.logic.citationkeypattern.AbstractCitationKeyPatterns;
+import org.jabref.logic.citationkeypattern.CitationKeyGeneratorTestUtils;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.metadata.MetaData;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ResourceLock("Localization.lang")
 class CitationKeyDeviationCheckerTest {
 
-    private final BibDatabaseContext bibDatabaseContext = mock(BibDatabaseContext.class);
-    private final BibDatabase bibDatabase = mock(BibDatabase.class);
-    private final MetaData metaData = mock(MetaData.class);
-    private final AbstractCitationKeyPatterns abstractCitationKeyPatterns = mock(AbstractCitationKeyPatterns.class);
-    private final GlobalCitationKeyPatterns globalCitationKeyPatterns = mock(GlobalCitationKeyPatterns.class);
-    private final CitationKeyPatternPreferences citationKeyPatternPreferences = mock(CitationKeyPatternPreferences.class);
-    private final CitationKeyDeviationChecker checker = new CitationKeyDeviationChecker(bibDatabaseContext, citationKeyPatternPreferences);
-
-    @BeforeEach
-    void setUp() {
-        when(bibDatabaseContext.getMetaData()).thenReturn(metaData);
-        when(citationKeyPatternPreferences.getKeyPatterns()).thenReturn(globalCitationKeyPatterns);
-        when(metaData.getCiteKeyPatterns(citationKeyPatternPreferences.getKeyPatterns())).thenReturn(abstractCitationKeyPatterns);
-        when(bibDatabaseContext.getDatabase()).thenReturn(bibDatabase);
-    }
+    private final CitationKeyPatternPreferences citationKeyPatternPreferences = CitationKeyGeneratorTestUtils.getInstanceForTesting();
 
     @Test
     void citationKeyDeviatesFromGeneratedKey() {
-        BibEntry entry = new BibEntry().withField(InternalField.KEY_FIELD, "Knuth2014")
+        BibEntry entry = new BibEntry().withField(InternalField.KEY_FIELD, "WrongKey")
                                        .withField(StandardField.AUTHOR, "Knuth")
                                        .withField(StandardField.YEAR, "2014");
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntry(entry);
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(bibDatabase);
+        CitationKeyDeviationChecker checker = new CitationKeyDeviationChecker(bibDatabaseContext, citationKeyPatternPreferences);
+
         List<IntegrityMessage> expected = List.of(new IntegrityMessage(
-                Localization.lang("Citation key deviates from generated key"), entry, InternalField.KEY_FIELD));
+                Localization.lang("Citation key deviates from generated key %0", "Knuth2014"), entry, InternalField.KEY_FIELD));
         assertEquals(expected, checker.check(entry));
     }
 }

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-jabref-5.7.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-jabref-5.7.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Haruki Murakami
 title: TestStudyName
 last-search-date: 2020-11-26
 research-questions:

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full-expected.yml
@@ -1,6 +1,6 @@
-version: 2.0
+version: 2.0.0
 authors:
-- Jab Ref
+- Oscar Wilde
 title: TestStudyName
 research-questions:
 - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-full.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Oscar Wilde
 title: TestStudyName
 research-questions:
   - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-minimal-expected.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v1-minimal-expected.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.0.0
 catalogs:
 - name: ACM Portal
   enabled: true

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study-v2-full.yml
@@ -1,6 +1,7 @@
-version: "2.0"
+version: "2.0.0"
 authors:
-  - Jab Ref
+  - Donna Tartt
+  - Virginia Woolf
 title: TestStudyName
 research-questions:
   - Question1

--- a/jablib/src/test/resources/org/jabref/logic/crawler/study.yml
+++ b/jablib/src/test/resources/org/jabref/logic/crawler/study.yml
@@ -1,5 +1,5 @@
 authors:
-  - Jab Ref
+  - Haruki Murakami
 title: TestStudyName
 research-questions:
   - Question1

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies.constraints {
     api("io.github.adr:e-adr:2.0.0")
     api("io.github.darvil82:terminal-text-formatter:2.3.0c")
     api("io.github.classgraph:classgraph:4.8.184")
-    api("io.github.java-diff-utils:java-diff-utils:4.16")
+    api("io.github.java-diff-utils:java-diff-utils:4.17")
     api("io.github.stefanbratanov:jvm-openai:0.11.0")
     api("io.github.thibaultmeyer:cuid:2.0.5")
     api("io.zonky.test.postgres:embedded-postgres-binaries-darwin-arm64v8")

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -150,5 +150,5 @@ dependencies.constraints {
     api("org.xmlunit:xmlunit-core:2.11.0")
     api("org.xmlunit:xmlunit-matchers:2.11.0")
     api("org.yaml:snakeyaml:2.6")
-    api("tech.units:indriya:2.2.3")
+    api("tech.units:indriya:2.2.4")
 }

--- a/versions/build.gradle.kts
+++ b/versions/build.gradle.kts
@@ -20,7 +20,7 @@ val pdfbox = "3.0.7"
 
 dependencies {
     api(platform("ai.djl:bom:0.36.0"))
-    api(platform("dev.langchain4j:langchain4j-bom:1.14.1"))
+    api(platform("dev.langchain4j:langchain4j-bom:1.15.0"))
     api(enforcedPlatform("io.zonky.test.postgres:embedded-postgres-binaries-bom:18.3.0"))
     api(platform("org.junit:junit-bom:6.0.3"))
     api(platform("org.glassfish.grizzly:grizzly-bom:5.0.1"))


### PR DESCRIPTION
### Related issues and pull requests

Stacked on `refine-http-import` (PR base).

### PR Description

The citation key integrity check previously reported only `Citation key deviates from generated key`. It now appends the actually generated key, e.g. `Citation key deviates from generated key Knuth2014`, so users immediately see what the key should be without re-running key generation.

The change touches `CitationKeyDeviationChecker` (passes the generated key into the localized message via a `%0` placeholder) and the corresponding English localization key. The unit test was reworked to use a real `BibDatabaseContext` instead of an all-mock setup, since the mocks produced an empty generated key and never exercised the new behaviour.

### Steps to test

1. Open a library and add an entry whose citation key does not match the configured key pattern.
2. Run the integrity check.
3. The warning for the key field now shows the generated key, e.g. `Citation key deviates from generated key Knuth2014`.

### AI usage

Claude Code (model claude-opus-4-7). All generated code was reviewed and is owned by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
