### PR TITLE
Include generated citation key in citation key integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 ### Removed
 
+- The citation key integrity check now includes the generated citation key in its warning message. [#15776](https://github.com/JabRef/jabref/pull/15776)
+
 ## [6.0-alpha.6] – 2026-05-14
 
 ### Added
@@ -73,7 +75,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The "Make/Sync bibliography" button in OO/LO panel now refreshes citations before generating bibliographies. [#14387](https://github.com/JabRef/jabref/issues/14387)
 - Improved responsiveness and user interface of refresh button in Citation Relations tab. [#12247](https://github.com/JabRef/jabref/issues/12247)
 - JabRef keeps the field `review` in BibTeX files. [#15609](https://github.com/JabRef/jabref/pull/15609)
-- The citation key integrity check now includes the generated citation key in its warning message. [#15776](https://github.com/JabRef/jabref/pull/15776)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The "Make/Sync bibliography" button in OO/LO panel now refreshes citations before generating bibliographies. [#14387](https://github.com/JabRef/jabref/issues/14387)
 - Improved responsiveness and user interface of refresh button in Citation Relations tab. [#12247](https://github.com/JabRef/jabref/issues/12247)
 - JabRef keeps the field `review` in BibTeX files. [#15609](https://github.com/JabRef/jabref/pull/15609)
+- The citation key integrity check now includes the generated citation key in its warning message.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The "Make/Sync bibliography" button in OO/LO panel now refreshes citations before generating bibliographies. [#14387](https://github.com/JabRef/jabref/issues/14387)
 - Improved responsiveness and user interface of refresh button in Citation Relations tab. [#12247](https://github.com/JabRef/jabref/issues/12247)
 - JabRef keeps the field `review` in BibTeX files. [#15609](https://github.com/JabRef/jabref/pull/15609)
-- The citation key integrity check now includes the generated citation key in its warning message.
+- The citation key integrity check now includes the generated citation key in its warning message. [#15776](https://github.com/JabRef/jabref/pull/15776)
 
 ### Fixed
 

--- a/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDeviationChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDeviationChecker.java
@@ -38,7 +38,7 @@ public class CitationKeyDeviationChecker implements EntryChecker {
 
         if (!Objects.equals(key, generatedKey)) {
             return List.of(new IntegrityMessage(
-                    Localization.lang("Citation key deviates from generated key"), entry, InternalField.KEY_FIELD));
+                    Localization.lang("Citation key deviates from generated key %0", generatedKey), entry, InternalField.KEY_FIELD));
         }
 
         return List.of();

--- a/jablib/src/main/resources/l10n/JabRef_en.properties
+++ b/jablib/src/main/resources/l10n/JabRef_en.properties
@@ -1954,7 +1954,7 @@ File\ directory\ pattern=File directory pattern
 Update\ with\ bibliographic\ information\ from\ the\ web=Update with bibliographic information from the web
 
 Could\ not\ find\ any\ bibliographic\ information.=Could not find any bibliographic information.
-Citation\ key\ deviates\ from\ generated\ key=Citation key deviates from generated key
+Citation\ key\ deviates\ from\ generated\ key\ %0=Citation key deviates from generated key %0
 
 Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences\:=Select all customized types to be stored in local preferences\:
 Different\ customization,\ current\ settings\ will\ be\ overwritten=Different customization, current settings will be overwritten

--- a/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDeviationCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDeviationCheckerTest.java
@@ -2,51 +2,37 @@ package org.jabref.logic.integrity;
 
 import java.util.List;
 
-import org.jabref.logic.citationkeypattern.AbstractCitationKeyPatterns;
+import org.jabref.logic.citationkeypattern.CitationKeyGeneratorTestUtils;
 import org.jabref.logic.citationkeypattern.CitationKeyPatternPreferences;
-import org.jabref.logic.citationkeypattern.GlobalCitationKeyPatterns;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
-import org.jabref.model.metadata.MetaData;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ResourceLock("Localization.lang")
 class CitationKeyDeviationCheckerTest {
 
-    private final BibDatabaseContext bibDatabaseContext = mock(BibDatabaseContext.class);
-    private final BibDatabase bibDatabase = mock(BibDatabase.class);
-    private final MetaData metaData = mock(MetaData.class);
-    private final AbstractCitationKeyPatterns abstractCitationKeyPatterns = mock(AbstractCitationKeyPatterns.class);
-    private final GlobalCitationKeyPatterns globalCitationKeyPatterns = mock(GlobalCitationKeyPatterns.class);
-    private final CitationKeyPatternPreferences citationKeyPatternPreferences = mock(CitationKeyPatternPreferences.class);
-    private final CitationKeyDeviationChecker checker = new CitationKeyDeviationChecker(bibDatabaseContext, citationKeyPatternPreferences);
-
-    @BeforeEach
-    void setUp() {
-        when(bibDatabaseContext.getMetaData()).thenReturn(metaData);
-        when(citationKeyPatternPreferences.getKeyPatterns()).thenReturn(globalCitationKeyPatterns);
-        when(metaData.getCiteKeyPatterns(citationKeyPatternPreferences.getKeyPatterns())).thenReturn(abstractCitationKeyPatterns);
-        when(bibDatabaseContext.getDatabase()).thenReturn(bibDatabase);
-    }
+    private final CitationKeyPatternPreferences citationKeyPatternPreferences = CitationKeyGeneratorTestUtils.getInstanceForTesting();
 
     @Test
     void citationKeyDeviatesFromGeneratedKey() {
-        BibEntry entry = new BibEntry().withField(InternalField.KEY_FIELD, "Knuth2014")
+        BibEntry entry = new BibEntry().withField(InternalField.KEY_FIELD, "WrongKey")
                                        .withField(StandardField.AUTHOR, "Knuth")
                                        .withField(StandardField.YEAR, "2014");
+        BibDatabase bibDatabase = new BibDatabase();
+        bibDatabase.insertEntry(entry);
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(bibDatabase);
+        CitationKeyDeviationChecker checker = new CitationKeyDeviationChecker(bibDatabaseContext, citationKeyPatternPreferences);
+
         List<IntegrityMessage> expected = List.of(new IntegrityMessage(
-                Localization.lang("Citation key deviates from generated key"), entry, InternalField.KEY_FIELD));
+                Localization.lang("Citation key deviates from generated key %0", "Knuth2014"), entry, InternalField.KEY_FIELD));
         assertEquals(expected, checker.check(entry));
     }
 }


### PR DESCRIPTION
### PR Description

The citation key integrity check (`CitationKeyDeviationChecker`) now includes the generated citation key in its warning message, so users can see what key JabRef would have generated instead of only being told the existing key deviates. Localization strings and tests were updated accordingly.

### Steps to test

1. Open a library with an entry whose citation key does not match the configured key pattern.
2. Run the integrity check (Quality → Check integrity).
3. The deviation warning now shows the generated citation key in the message.

### AI usage

Claude Code (model claude-opus-4-7)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
