### PR TITLE
Fix wrong usage of "key"

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/commonfxcontrols/SaveOrderPanelViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/commonfxcontrols/SaveOrderPanelViewModelTest.java
@@ -2,6 +2,7 @@ package org.jabref.gui.commonfxcontrols;
 
 import java.util.List;
 
+import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
@@ -12,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SaveOrderPanelViewModelTest {
 
-    SortCriterionViewModel sortCriterionKey = new SortCriterionViewModel(new SaveOrder.SortCriterion(StandardField.KEY, false));
+    SortCriterionViewModel sortCriterionKey = new SortCriterionViewModel(new SaveOrder.SortCriterion(InternalField.KEY_FIELD, false));
     SortCriterionViewModel sortCriterionAuthor = new SortCriterionViewModel(new SaveOrder.SortCriterion(StandardField.AUTHOR, false));
     SortCriterionViewModel sortCriterionTitle = new SortCriterionViewModel(new SaveOrder.SortCriterion(StandardField.TITLE, true));
 

--- a/jablib/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/EndnoteXmlExporter.java
@@ -27,6 +27,7 @@ import org.jabref.model.entry.AuthorList;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibEntryPreferences;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.field.UnknownField;
 import org.jabref.model.entry.types.EntryType;
@@ -84,7 +85,7 @@ public class EndnoteXmlExporter extends Exporter {
         STANDARD_FIELD_MAPPING.put(StandardField.NOTE, "notes");
         STANDARD_FIELD_MAPPING.put(StandardField.LABEL, "label");
         STANDARD_FIELD_MAPPING.put(StandardField.LANGUAGE, "language");
-        STANDARD_FIELD_MAPPING.put(StandardField.KEY, "foreign-keys");
+        STANDARD_FIELD_MAPPING.put(InternalField.KEY_FIELD, "foreign-keys");
         STANDARD_FIELD_MAPPING.put(new UnknownField("accession-num"), "accession-num");
     }
 

--- a/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDuplicationChecker.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/CitationKeyDuplicationChecker.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.entry.field.InternalField;
 
 import org.jspecify.annotations.NonNull;
 
@@ -28,7 +28,7 @@ public class CitationKeyDuplicationChecker implements EntryChecker {
         boolean isDuplicate = database.isDuplicateCitationKeyExisting(citeKey.get());
         if (isDuplicate) {
             return List.of(
-                    new IntegrityMessage(Localization.lang("Duplicate citation key"), entry, StandardField.KEY));
+                    new IntegrityMessage(Localization.lang("Duplicate citation key"), entry, InternalField.KEY_FIELD));
         }
         return List.of();
     }

--- a/jablib/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
@@ -27,6 +27,8 @@ public class FieldCheckers {
     private static Multimap<Field, ValueChecker> getAllMap(BibDatabaseContext databaseContext, FilePreferences filePreferences, JournalAbbreviationRepository abbreviationRepository, boolean allowIntegerEdition, String unwantedCharacters) {
         ArrayListMultimap<Field, ValueChecker> fieldCheckers = ArrayListMultimap.create(50, 10);
 
+        fieldCheckers.put(InternalField.KEY_FIELD, new ValidCitationKeyChecker(unwantedCharacters));
+
         for (Field field : FieldFactory.getPersonNameFields()) {
             fieldCheckers.put(field, new PersonNamesChecker(databaseContext));
         }
@@ -34,8 +36,12 @@ public class FieldCheckers {
         fieldCheckers.put(StandardField.BOOKTITLE, new BooktitleContainsYearChecker());
         fieldCheckers.put(StandardField.BOOKTITLE, new BooktitleContainsCountryChecker());
         fieldCheckers.put(StandardField.BOOKTITLE, new BooktitleContainsPagesChecker());
+        fieldCheckers.put(StandardField.BOOKTITLE, new NoURLChecker());
+
         fieldCheckers.put(StandardField.TITLE, new BracketChecker());
         fieldCheckers.put(StandardField.TITLE, new TitleChecker(databaseContext));
+        fieldCheckers.put(StandardField.TITLE, new NoURLChecker());
+
         fieldCheckers.put(StandardField.DOI, new DoiValidityChecker());
         fieldCheckers.put(StandardField.EDITION, new EditionChecker(databaseContext, allowIntegerEdition));
         fieldCheckers.put(StandardField.FILE, new FileChecker(databaseContext, filePreferences));
@@ -48,11 +54,6 @@ public class FieldCheckers {
         fieldCheckers.put(StandardField.PAGES, new PagesChecker(databaseContext));
         fieldCheckers.put(StandardField.URL, new UrlChecker());
         fieldCheckers.put(StandardField.YEAR, new YearChecker());
-        fieldCheckers.put(StandardField.KEY, new ValidCitationKeyChecker(unwantedCharacters));
-        fieldCheckers.put(InternalField.KEY_FIELD, new ValidCitationKeyChecker(unwantedCharacters));
-
-        fieldCheckers.put(StandardField.TITLE, new NoURLChecker());
-        fieldCheckers.put(StandardField.BOOKTITLE, new NoURLChecker());
 
         if (databaseContext.isBiblatexMode()) {
             fieldCheckers.put(StandardField.DATE, new DateChecker());

--- a/jablib/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
+++ b/jablib/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
@@ -98,6 +98,8 @@ public class MSBibMapping {
         BIBLATEX_TO_MS_BIB.put(new UnknownField("size"), BIBTEX_PREFIX + "Size");
         BIBLATEX_TO_MS_BIB.put(new UnknownField("intype"), BIBTEX_PREFIX + "InType");
         BIBLATEX_TO_MS_BIB.put(new UnknownField("paper"), BIBTEX_PREFIX + "Paper");
+
+        // This is **not** the citation key
         BIBLATEX_TO_MS_BIB.put(StandardField.KEY, BIBTEX_PREFIX + "Key");
 
         // MSBib only fields

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheck.java
@@ -33,6 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 public class BibliographyConsistencyCheck {
 
+    // TODO: This is BibTeX - See org.jabref.model.entry.EntryConverter for mapping to BibLaTeX
     private static final Set<Field> EXPLICITLY_EXCLUDED_FIELDS = Set.of(
             InternalField.KEY_FIELD, // Citation key
             StandardField.KEY,
@@ -128,7 +129,6 @@ public class BibliographyConsistencyCheck {
 
             Set<Field> differingFields = new HashSet<>(filteredFieldsInAnyEntry);
             differingFields.removeAll(fieldsInAllEntries);
-            assert fieldsInAllEntries != null;
 
             Optional<BibEntryType> typeDefOpt = entryTypeDefinitions.stream()
                                                                     .filter(def -> def.getType().equals(entryType))

--- a/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -192,7 +192,6 @@ public class BibEntry {
                 (targetField == StandardField.XREF) ||
                 (targetField == StandardField.ENTRYSET) ||
                 (targetField == StandardField.RELATED) ||
-                (targetField == StandardField.KEY) ||
                 (targetField == StandardField.SORTKEY)) {
             return Optional.empty();
         }

--- a/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -192,6 +192,7 @@ public class BibEntry {
                 (targetField == StandardField.XREF) ||
                 (targetField == StandardField.ENTRYSET) ||
                 (targetField == StandardField.RELATED) ||
+                (targetField == StandardField.KEY) ||
                 (targetField == StandardField.SORTKEY)) {
             return Optional.empty();
         }

--- a/jablib/src/main/java/org/jabref/model/entry/field/StandardField.java
+++ b/jablib/src/main/java/org/jabref/model/entry/field/StandardField.java
@@ -74,7 +74,11 @@ public enum StandardField implements Field {
     JOURNAL("journal", FieldProperty.JOURNAL_NAME),
     JOURNALSUBTITLE("journalsubtitle", FieldProperty.JOURNAL_NAME),
     JOURNALTITLE("journaltitle", FieldProperty.JOURNAL_NAME),
+
+    /// This is used for **sorting**, this is **not** the BibTeX key AKA Citation key. See [InternalField.KEY_FIELD] for that.
+    /// This is only used in very rare cases.
     KEY("key"),
+
     KEYWORDS("keywords"),
     LANGUAGE("language", FieldProperty.LANGUAGE),
     LANGUAGEID("langid", FieldProperty.LANGUAGE),
@@ -112,7 +116,11 @@ public enum StandardField implements Field {
     SHORTAUTHOR("shortauthor", FieldProperty.PERSON_NAMES),
     SHORTEDITOR("shorteditor", FieldProperty.PERSON_NAMES),
     SHORTTITLE("shorttitle"),
+
+    /// BibLaTeX field: "A field used to modify the sorting order of the bibliography" - see <https://texdoc.org/serve/biblatex/0>, page 30.
+    /// In BibTeX, this is "key".
     SORTKEY("sortkey"),
+
     SORTNAME("sortname", FieldProperty.PERSON_NAMES),
     SUBTITLE("subtitle"),
     TITLE("title"),

--- a/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDuplicationCheckerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/integrity/CitationKeyDuplicationCheckerTest.java
@@ -40,7 +40,7 @@ class CitationKeyDuplicationCheckerTest {
         CitationKeyDuplicationChecker checker = new CitationKeyDuplicationChecker(bibDatabase);
 
         List<IntegrityMessage> expected = List.of(
-                new IntegrityMessage(Localization.lang("Duplicate citation key"), entry, StandardField.KEY));
+                new IntegrityMessage(Localization.lang("Duplicate citation key"), entry, InternalField.KEY_FIELD));
         assertEquals(expected, checker.check(entry));
     }
 }


### PR DESCRIPTION
OMG, we used `org.jabref.model.entry.field.StandardField#KEY`.

I think, mostly not user-facing; but still...

### Steps to test

Some strang Endnote export

### AI usage

Just for the initial refacotring.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
