### PR TITLE
Fix duplicate finder progress counter incrementing on empty queue polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We fixed the Hayagriva YAML exporter to correctly nest DOI, ISBN, and ISSN under `serial-number` as required by the Hayagriva file format specification. [#15713](https://github.com/JabRef/jabref/issues/15713)
 - We fixed an issue where newly added entries could not be found in search. [#15719](https://github.com/JabRef/jabref/issues/15719)
+- We fixed an issue where the duplicate finder progress counter displayed incorrect values, not reflecting the actual number of duplicate pairs reviewed by the user. [#11848](https://github.com/JabRef/jabref/issues/11848)
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
+++ b/jabgui/src/main/java/org/jabref/gui/duplicationFinder/DuplicateSearch.java
@@ -123,8 +123,6 @@ public class DuplicateSearch extends SimpleCommand {
         DuplicateSearchResult result = new DuplicateSearchResult();
 
         while (!libraryAnalyzed.get() || !duplicates.isEmpty()) {
-            duplicateProgress.set(duplicateProgress.getValue() + 1);
-
             List<BibEntry> dups;
             try {
                 // poll with timeout in case the library is not analyzed completely, but contains no more duplicates
@@ -152,6 +150,8 @@ public class DuplicateSearch extends SimpleCommand {
 
                 DuplicateResolverType resolverType = askAboutExact ? DuplicateResolverType.DUPLICATE_SEARCH_WITH_EXACT : DuplicateResolverType.DUPLICATE_SEARCH;
 
+                // Increment only when a pair is actually shown to the user
+                duplicateProgress.set(duplicateProgress.getValue() + 1);
                 UiTaskExecutor.runAndWaitInJavaFXThread(() -> askResolveStrategy(result, first, second, resolverType));
             }
         }
@@ -162,7 +162,7 @@ public class DuplicateSearch extends SimpleCommand {
     private void askResolveStrategy(DuplicateSearchResult result, BibEntry first, BibEntry second, DuplicateResolverType resolverType) {
         DuplicateResolverDialog dialog = new DuplicateResolverDialog(first, second, resolverType, stateManager, dialogService, preferences);
 
-        dialog.titleProperty().bind(Bindings.concat(dialog.getTitle()).concat(" (").concat(duplicateProgress.getValue()).concat("/").concat(duplicateTotal).concat(")"));
+        dialog.titleProperty().bind(Bindings.concat(dialog.getTitle()).concat(" (").concat(duplicateProgress).concat("/").concat(duplicateTotal).concat(")"));
 
         DuplicateResolverResult resolverResult;
 


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref/issues/11848

### PR Description

The duplicate finder progress counter in DuplicateSearch.java was being incremented on every iteration of the polling loop, including iterations where the queue was empty and no pair was shown to the user. This fix moves the increment to the point where a duplicate pair is actually presented to the user, and corrects the title binding to use the observable property directly instead of a static captured value

<img width="1364" height="718" alt="image" src="https://github.com/user-attachments/assets/2ec11e31-cfaa-4bba-82b6-e5598fd6b3c7" />


### Steps to test

1. Open a library with several duplicate entries (at least 50+ total entries so the search takes a moment)
2. Go to Quality -> Find Duplicates
3. Observe the counter in the dialog title, it should now start at (1/N) and increment sequentially as you resolve each pair
4. Before this fix, the counter would start at a number higher than 1 (e.g. 5/10) due to empty queue poll iterations being counted

<img width="1357" height="684" alt="Captura de tela 2026-05-19 001640" src="https://github.com/user-attachments/assets/52026158-19c8-4a8a-89bc-3f0d10001d36" />
(Screenshots: before fix showing 5/10 on first dialog, after fix showing 1/10)
<img width="1362" height="688" alt="Captura de tela 2026-05-19 010900" src="https://github.com/user-attachments/assets/8a83586f-232a-49f6-9b2d-0fc3c2b971dc" />

### AI usage

Claude Code (claude-sonnet-4-6) -> Only used to find the source of the problem and a way to correct it

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [x] I added screenshots in the PR description (if change is visible to the user)
- [x] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
