### PR TITLE
Replace openrewrite/format CI checks with manual fix-merge-main workflow

### DIFF
--- a/.github/ghprcomment.yml
+++ b/.github/ghprcomment.yml
@@ -39,13 +39,6 @@
 
     You can then run these tests in IntelliJ to reproduce the failing tests locally.
     We offer a quick test running howto in the section [Final build system checks](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-12-build.html#final-build-system-checks) in our setup guide.
-- jobName: format
-  workflowName: 'Source Code Tests'
-  message: >
-    Your code currently does not meet JabRef's code guidelines.
-    IntelliJ auto format covers some cases.
-    There seem to be issues with your code style and autoformat configuration.
-    Please reformat your code (<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>L</kbd>) and commit, then push.
 - jobName: format-javadoc
   workflowName: 'Source Code Tests'
   message: >
@@ -66,17 +59,6 @@
 
     Please carefully follow [the setup guide for the codestyle](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html).
     Afterwards, please [run checkstyle locally](https://devdocs.jabref.org/getting-into-the-code/guidelines-for-setting-up-a-local-workspace/intellij-13-code-style.html#run-checkstyle) and fix the issues, commit, and push.
-- jobName: OpenRewrite
-  workflowName: 'Source Code Tests'
-  message: >
-    Your code currently does not meet JabRef's code guidelines.
-    We use [OpenRewrite](https://docs.openrewrite.org/) to ensure "modern" Java coding practices.
-    You can see which checks are failing by locating the box "Some checks were not successful" on the pull request page.
-    To see the test output, locate "Source Code Tests / OpenRewrite (pull_request)" and click on it.
-
-
-    The issues found can be **automatically fixed**.
-    Please execute the gradle task *`rewriteRun`* from the [`rewrite` group of the Gradle Tool window](https://devdocs.jabref.org/code-howtos/faq.html#failing-openrewrite-tests) in IntelliJ, then check the results, reformat the code, commit, and push.
 - jobName: Modernizer
   workflowName: 'Source Code Tests'
   message: >

--- a/.github/workflows/fix-merge-main.yaml
+++ b/.github/workflows/fix-merge-main.yaml
@@ -1,4 +1,4 @@
-name: Run OpenRewrite
+name: Fix and merge main
 
 permissions:
   contents: write
@@ -7,11 +7,11 @@ permissions:
 on:
   pull_request:
     paths:
-      - '.github/workflows/run-openrewrite.yml'
+      - '.github/workflows/fix-merge-main.yaml'
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch name to run OpenRewrite on'
+        description: 'Branch name to run on'
         required: true
         type: string
 
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  rewrite:
+  fix-and-merge:
     if: github.event_name == 'workflow_dispatch' || github.repository == 'JabRef/jabref'
     runs-on: ubuntu-latest
 
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'true'
+          fetch-depth: 0
           ref: ${{ inputs.branch || github.event.pull_request.head.ref }}
           token: ${{ secrets.GH_TOKEN_JABREF_MACHINE_PR_APPROVE || github.token }}
 
@@ -51,3 +52,11 @@ jobs:
             git commit -m "Fix issues using OpenRewrite"
             git push
           fi
+
+      - name: Merge main
+        uses: maven-flow/merge@v1
+        with:
+          changelog-file: CHANGELOG.md
+          changelog-rebase: true
+          source-branch: ${{ github.ref_name }}
+          target-branch: 'main'

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -55,16 +55,6 @@ jobs:
       - name: Run checkAllModuleInfo using gradle
         run: gradle checkAllModuleInfo
 
-  format:
-    # ubuntu-slim doesn't offer docker
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/format-java
-      # job should fail in case there are changes
-      - name: Check if any files changed
-        run: git diff --exit-code
-
   format-javadoc:
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
@@ -94,7 +84,6 @@ jobs:
     name: Checkstyle
     # too slow on ubuntu-slim
     runs-on: ubuntu-latest
-    needs: format
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -104,28 +93,6 @@ jobs:
       - uses: ./.github/actions/setup-gradle
       - name: Run checkstyle using gradle
         run: gradle checkstyleMain checkstyleTest checkstyleJmh
-
-  openrewrite:
-    name: OpenRewrite
-    # too slow on ubuntu-slim
-    runs-on: ubuntu-latest
-    needs: checkstyle
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v6
-        with:
-          submodules: 'true'
-          show-progress: 'false'
-      - uses: ./.github/actions/setup-gradle
-      - name: Run OpenRewrite
-        run: |
-          gradle --no-configuration-cache :rewriteRun
-
-      # Reformat code (because OpenRewrite does different indents)
-      - uses: ./.github/actions/format-java
-
-      - name: Fail if working directory is unclean
-        run: git diff --exit-code
 
   modernizer:
     name: Modernizer


### PR DESCRIPTION
### PR Description

Manual trigger only. If we go this way:

- [ ] Automatic execution
- [ ] create comment if sth. was changed ("You need to pull")

Replaces the `format` and `OpenRewrite` jobs in `Source Code Tests` (and matching `ghprcomment.yml` entries) with a new manual workflow `fix-merge-main.yaml` (renamed from `run-openrewrite.yml`). The workflow runs OpenRewrite + format-java, commits any fixes, then merges `main` into the branch via the [maven-flow/merge](https://github.com/marketplace/actions/maven-flow-merge) action with `changelog-rebase: true` against `CHANGELOG.md`. This shifts those auto-fixable checks from blocking PR gates to a one-shot maintainer-triggered cleanup.

### Steps to test

1. Trigger the new workflow on a branch via "Actions → Fix and merge main → Run workflow", entering the branch name.
2. Verify that:
   - OpenRewrite and IntelliJ formatting fixes are committed on the branch.
   - The action [maven-flow/merge](https://github.com/marketplace/actions/maven-flow-merge) merges `main` and rebases the `CHANGELOG.md` entry under `## [Unreleased]`.
3. Open any PR and confirm `Source Code Tests` no longer schedules `format` or `OpenRewrite` jobs and the comment bot no longer posts their messages.

### AI usage

Claude Code (model claude-opus-4-7)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
