### PR TITLE
Update heylogs to 0.18.0 and use github-actions format

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -186,11 +186,12 @@ jobs:
         uses: jbangdev/setup-jbang@main
       - name: Lint CHANGELOG.md
         run: |
-          # run heylogs verification
-          jbang com.github.nbbrd.heylogs:heylogs-cli:0.17.1:bin check CHANGELOG.md | tee heylogs.txt || true
+          # run heylogs verification with GitHub Actions annotations
+          jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.0:bin check --format github-actions CHANGELOG.md | tee heylogs.txt || true
 
-          # We have two acceptable errors
-          if ! grep -q "1 problem" heylogs.txt; then
+          # We have one acceptable error
+          error_count=$(grep -c '^::error' heylogs.txt || true)
+          if [ "$error_count" -ne 1 ]; then
             {
               echo "heylogs<<EOF"
               cat heylogs.txt


### PR DESCRIPTION
### Related issues and pull requests

None.

### PR Description

Bumps the heylogs CLI used by the `CHANGELOG.md` lint job in `tests-code.yml` from 0.17.1 to 0.18.0 and switches it to the new `--format github-actions` output so changelog issues now show up as inline PR annotations on the offending line and column instead of being buried in the workflow log. The previous `grep -q "1 problem"` summary-string check is replaced with a count of `::error` annotations, since the new format emits no summary line; the inline comment is also corrected from "two acceptable errors" to "one acceptable error" to match the actual gate.

### Steps to test

1. Open the PR and confirm the `tests-code.yml` → `CHANGELOG.md` job passes.
2. In the PR "Files changed" view of `CHANGELOG.md`, confirm the pre-existing acceptable error appears as an inline annotation at `CHANGELOG.md:2035:1` (`Missing ref link (all-h2-contain-a-version)`).
3. Optional local check:

   ```
   jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.0:bin check --format github-actions CHANGELOG.md
   ```

   Should print exactly one line:

   ```
   ::error file=CHANGELOG.md,line=2035,col=1::Missing ref link (all-h2-contain-a-version)
   ```

4. To verify the gate still fails on regressions, temporarily introduce an extra changelog issue locally and confirm `error_count != 1` causes the workflow step to exit non-zero.

### AI usage

Claude Code (model claude-opus-4-7)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
