### PR TITLE
Add github-actions output format to jabkit check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The `jabkit` subcommands now accept the input file as a positional argument (e.g. `jabkit check integrity references.bib`); the `--input` option remains available as an alias. [#15759](https://github.com/JabRef/jabref/pull/15759)
 - We grouped the `jabkit` consistency and integrity checks under a new `check` command (`jabkit check consistency`, `jabkit check integrity`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 - The `jabkit check consistency` command now supports the `errorformat` output format (`file:line:column: message`), which is the default output format for both `check` subcommands. [#15759](https://github.com/JabRef/jabref/pull/15759)
-- The `jabkit check` subcommands now support a `github-actions` output format that emits findings as [GitHub Actions workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message), so findings show up as annotations on pull requests.
+- The `jabkit check` subcommands now support a `github-actions` output format that emits findings as [GitHub Actions workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message), so findings show up as annotations on pull requests [15789](https://github.com/JabRef/jabref/pull/15789).
 - The `jabkit check` command now runs both the consistency and integrity checks when given an input file without a subcommand (e.g. `jabkit check references.bib`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The `jabkit` subcommands now accept the input file as a positional argument (e.g. `jabkit check integrity references.bib`); the `--input` option remains available as an alias. [#15759](https://github.com/JabRef/jabref/pull/15759)
 - We grouped the `jabkit` consistency and integrity checks under a new `check` command (`jabkit check consistency`, `jabkit check integrity`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 - The `jabkit check consistency` command now supports the `errorformat` output format (`file:line:column: message`), which is the default output format for both `check` subcommands. [#15759](https://github.com/JabRef/jabref/pull/15759)
-- The `jabkit check` subcommands now support a `github-actions` output format that emits findings as [GitHub Actions workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message), so findings show up as annotations on pull requests [15789](https://github.com/JabRef/jabref/pull/15789).
+- The `jabkit check` subcommands now support a `github-actions` output format that emits findings as [GitHub Actions workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message), so findings show up as annotations on pull requests. [#15789](https://github.com/JabRef/jabref/pull/15789)
 - The `jabkit check` command now runs both the consistency and integrity checks when given an input file without a subcommand (e.g. `jabkit check references.bib`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - The `jabkit` subcommands now accept the input file as a positional argument (e.g. `jabkit check integrity references.bib`); the `--input` option remains available as an alias. [#15759](https://github.com/JabRef/jabref/pull/15759)
 - We grouped the `jabkit` consistency and integrity checks under a new `check` command (`jabkit check consistency`, `jabkit check integrity`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 - The `jabkit check consistency` command now supports the `errorformat` output format (`file:line:column: message`), which is the default output format for both `check` subcommands. [#15759](https://github.com/JabRef/jabref/pull/15759)
+- The `jabkit check` subcommands now support a `github-actions` output format that emits findings as [GitHub Actions workflow commands](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message), so findings show up as annotations on pull requests.
 - The `jabkit check` command now runs both the consistency and integrity checks when given an input file without a subcommand (e.g. `jabkit check references.bib`). [#15759](https://github.com/JabRef/jabref/pull/15759)
 
 ### Changed

--- a/docs/requirements/cli.md
+++ b/docs/requirements/cli.md
@@ -35,3 +35,16 @@ Entry-level findings (for example, on the citation key itself) carry only the ci
 Field-level findings additionally carry the affected field name.
 
 Needs: impl
+
+## GitHub Actions output of the `check` commands
+`req~jabkit.cli.check-github-actions-output~1`
+
+The `jabkit check` subcommands support an additional `github-actions` output format
+that emits each finding as a [GitHub Actions workflow command](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message)
+of the shape `::error file=<file>,line=<line>,col=<col>,title=<title>::<message>`.
+
+The `file`, `line`, `col`, and `title` property values are URL-encoded so that
+Windows-style paths (containing `:`) and titles (containing `:` between citation key and field name)
+are parsed correctly by the GitHub Actions runner.
+
+Needs: impl

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/Check.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/Check.java
@@ -21,9 +21,10 @@ class Check implements Callable<Integer> {
 
     /// Output formats accepted by `--output-format`. Kept lowercase so they can also serve as
     /// `case` labels for a switch over `outputFormat.toLowerCase(...)`.
-    static final String FORMAT_ERRORFORMAT = "errorformat";
-    static final String FORMAT_TXT = "txt";
     static final String FORMAT_CSV = "csv";
+    static final String FORMAT_ERRORFORMAT = "errorformat";
+    static final String FORMAT_GITHUB_ACTIONS = "github-actions";
+    static final String FORMAT_TXT = "txt";
 
     @ParentCommand
     protected JabKit jabKit;
@@ -37,7 +38,7 @@ class Check implements Callable<Integer> {
             description = "Input file. When given without a subcommand, both the consistency and integrity checks run.")
     private Path inputFile;
 
-    @Option(names = {"--output-format"}, description = "Output format: errorformat, txt or csv", defaultValue = FORMAT_ERRORFORMAT)
+    @Option(names = {"--output-format"}, description = "Output format: csv, errorformat, github-actions or txt", defaultValue = FORMAT_ERRORFORMAT)
     private String outputFormat;
 
     @Override

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/CheckConsistency.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/CheckConsistency.java
@@ -11,6 +11,7 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheck;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultCsvWriter;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultErrorFormatWriter;
+import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultGitHubActionsWriter;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultTxtWriter;
 import org.jabref.logic.quality.consistency.BibliographyConsistencyCheckResultWriter;
 import org.jabref.model.database.BibDatabaseContext;
@@ -35,7 +36,7 @@ class CheckConsistency implements Callable<Integer> {
     @Mixin
     private InputOption inputOption = new InputOption();
 
-    @Option(names = {"--output-format"}, description = "Output format: errorformat, txt or csv", defaultValue = Check.FORMAT_ERRORFORMAT)
+    @Option(names = {"--output-format"}, description = "Output format: csv, errorformat, github-actions or txt", defaultValue = Check.FORMAT_ERRORFORMAT)
     private String outputFormat;
 
     @Override
@@ -84,6 +85,15 @@ class CheckConsistency implements Callable<Integer> {
 
         if (Check.FORMAT_ERRORFORMAT.equalsIgnoreCase(outputFormat)) {
             checkResultWriter = new BibliographyConsistencyCheckResultErrorFormatWriter(
+                    result,
+                    writer,
+                    porcelain,
+                    jabKit.entryTypesManager,
+                    databaseContext.getMode(),
+                    parserResult,
+                    inputFile);
+        } else if (Check.FORMAT_GITHUB_ACTIONS.equalsIgnoreCase(outputFormat)) {
+            checkResultWriter = new BibliographyConsistencyCheckResultGitHubActionsWriter(
                     result,
                     writer,
                     porcelain,

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/CheckIntegrity.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/CheckIntegrity.java
@@ -13,6 +13,7 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.integrity.IntegrityCheck;
 import org.jabref.logic.integrity.IntegrityCheckResultCsvWriter;
 import org.jabref.logic.integrity.IntegrityCheckResultErrorFormatWriter;
+import org.jabref.logic.integrity.IntegrityCheckResultGitHubActionsWriter;
 import org.jabref.logic.integrity.IntegrityCheckResultWriter;
 import org.jabref.logic.integrity.IntegrityMessage;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -41,7 +42,7 @@ class CheckIntegrity implements Callable<Integer> {
     @Mixin
     private InputOption inputOption = new InputOption();
 
-    @Option(names = {"--output-format"}, description = "Output format: errorformat, txt or csv", defaultValue = Check.FORMAT_ERRORFORMAT)
+    @Option(names = {"--output-format"}, description = "Output format: csv, errorformat, github-actions or txt", defaultValue = Check.FORMAT_ERRORFORMAT)
     private String outputFormat;
 
     // in BibTeX it could be preferences.getEntryEditorPreferences().shouldAllowIntegerEditionBibtex()
@@ -93,6 +94,8 @@ class CheckIntegrity implements Callable<Integer> {
             case Check.FORMAT_ERRORFORMAT,
                  Check.FORMAT_TXT ->
                     checkResultWriter = new IntegrityCheckResultErrorFormatWriter(writer, messages, parserResult, inputFile);
+            case Check.FORMAT_GITHUB_ACTIONS ->
+                    checkResultWriter = new IntegrityCheckResultGitHubActionsWriter(writer, messages, parserResult, inputFile);
             case Check.FORMAT_CSV ->
                     checkResultWriter = new IntegrityCheckResultCsvWriter(writer, messages);
             default -> {

--- a/jabkit/src/test/java/org/jabref/toolkit/commands/JabKitTest.java
+++ b/jabkit/src/test/java/org/jabref/toolkit/commands/JabKitTest.java
@@ -62,6 +62,22 @@ class JabKitTest extends AbstractJabKitTest {
     }
 
     @Test
+    void checkConsistencyGitHubActionsFormat() {
+        Path testBib = getClassResourceAsPath("origin.bib");
+        String testBibFile = testBib.toAbsolutePath().toString();
+
+        List<String> args = List.of("check", "consistency", testBibFile, "--output-format", "github-actions", "--porcelain");
+
+        int executionResult = executeToLog(args.toArray(String[]::new));
+
+        // origin.bib has a single entry type, so no consistency findings are produced; the
+        // run is still expected to succeed and not emit any annotations.
+        String output = getStandardOutput();
+        assertEquals("", output);
+        assertEquals(0, executionResult);
+    }
+
+    @Test
     void checkConsistencyFailsWithoutInputFile() {
         int executionResult = executeToLog("check", "consistency");
 

--- a/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultGitHubActionsWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/integrity/IntegrityCheckResultGitHubActionsWriter.java
@@ -1,0 +1,46 @@
+package org.jabref.logic.integrity;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.util.GitHubActionsEscape;
+import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.InternalField;
+
+/// Outputs the findings in the
+/// [GitHub Actions workflow command format](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message)
+/// (`::error file=...,line=...,col=...::message`), so that findings show up as annotations on
+/// pull requests when `jabkit` runs inside a GitHub Actions workflow.
+public class IntegrityCheckResultGitHubActionsWriter extends IntegrityCheckResultWriter {
+
+    private final ParserResult parserResult;
+    private final Path inputFile;
+
+    public IntegrityCheckResultGitHubActionsWriter(Writer writer, List<IntegrityMessage> messages, ParserResult parserResult, Path inputFile) {
+        super(writer, messages);
+        this.parserResult = parserResult;
+        this.inputFile = inputFile;
+    }
+
+    // [impl->req~jabkit.cli.check-github-actions-output~1]
+    @Override
+    public void writeFindings() throws IOException {
+        for (IntegrityMessage message : messages) {
+            String location = message.entry().getCitationKey().orElse(message.entry().getAuthorTitleYear(5));
+            Field field = message.field();
+            ParserResult.Range fieldRange = parserResult.getFieldRange(message.entry(), field);
+            if (field != InternalField.KEY_FIELD) {
+                location += ":" + field.getName();
+            }
+            writer.append("::error file=%s,line=%d,col=%d,title=%s::%s%n".formatted(
+                    GitHubActionsEscape.property(inputFile.toString()),
+                    fieldRange.startLine(),
+                    fieldRange.startColumn(),
+                    GitHubActionsEscape.property(location),
+                    GitHubActionsEscape.data(message.message())));
+        }
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriter.java
+++ b/jablib/src/main/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriter.java
@@ -1,0 +1,68 @@
+package org.jabref.logic.quality.consistency;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.util.GitHubActionsEscape;
+import org.jabref.model.database.BibDatabaseMode;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.entry.field.Field;
+
+/// Outputs the findings in the
+/// [GitHub Actions workflow command format](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message)
+/// (`::error file=...,line=...,col=...::message`), so that findings show up as annotations on
+/// pull requests when `jabkit` runs inside a GitHub Actions workflow.
+public class BibliographyConsistencyCheckResultGitHubActionsWriter extends BibliographyConsistencyCheckResultWriter {
+
+    private final ParserResult parserResult;
+    private final Path inputFile;
+
+    public BibliographyConsistencyCheckResultGitHubActionsWriter(BibliographyConsistencyCheck.Result result,
+                                                                 Writer writer,
+                                                                 boolean isPorcelain,
+                                                                 BibEntryTypesManager entryTypesManager,
+                                                                 BibDatabaseMode bibDatabaseMode,
+                                                                 ParserResult parserResult,
+                                                                 Path inputFile) {
+        super(result, writer, isPorcelain, entryTypesManager, bibDatabaseMode);
+        this.parserResult = parserResult;
+        this.inputFile = inputFile;
+    }
+
+    // [impl->req~jabkit.cli.check-github-actions-output~1]
+    @Override
+    protected void writeBibEntry(BibEntry bibEntry, String entryType, Set<Field> requiredFields, Set<Field> optionalFields) throws IOException {
+        String citationKey = bibEntry.getCitationKey().orElse("");
+        for (Field field : allReportedFields) {
+            Optional<String> value = bibEntry.getField(field);
+            if (value.isPresent()) {
+                if (!requiredFields.contains(field) && !optionalFields.contains(field)) {
+                    write(parserResult.getFieldRange(bibEntry, field), citationKey, field,
+                            "unknown field for entry type %s".formatted(entryType));
+                }
+            } else {
+                write(parserResult.getCompleteEntryIndicator(bibEntry), citationKey, field,
+                        "field is absent but used by other entries of entry type %s".formatted(entryType));
+            }
+        }
+    }
+
+    private void write(ParserResult.Range range, String citationKey, Field field, String message) throws IOException {
+        String title = citationKey.isEmpty() ? field.getName() : citationKey + ":" + field.getName();
+        writer.append("::error file=%s,line=%d,col=%d,title=%s::%s%n".formatted(
+                GitHubActionsEscape.property(inputFile.toString()),
+                range.startLine(),
+                range.startColumn(),
+                GitHubActionsEscape.property(title),
+                GitHubActionsEscape.data(message)));
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/jablib/src/main/java/org/jabref/logic/util/GitHubActionsEscape.java
+++ b/jablib/src/main/java/org/jabref/logic/util/GitHubActionsEscape.java
@@ -1,0 +1,26 @@
+package org.jabref.logic.util;
+
+/// Escapes values for the
+/// [GitHub Actions workflow command](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-creating-an-annotation-for-an-error)
+/// format. Two escaping flavours are needed:
+///
+/// - {@link #data(String)} for the message body after `::`.
+/// - {@link #property(String)} for `key=value` properties (additionally escapes `:` and `,`,
+///   which is critical for Windows-style file paths such as `C:\foo\bar.bib`).
+public final class GitHubActionsEscape {
+
+    private GitHubActionsEscape() {
+    }
+
+    public static String data(String value) {
+        return value.replace("%", "%25")
+                    .replace("\r", "%0D")
+                    .replace("\n", "%0A");
+    }
+
+    public static String property(String value) {
+        return data(value)
+                .replace(":", "%3A")
+                .replace(",", "%2C");
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/quality/consistency/BibliographyConsistencyCheckResultGitHubActionsWriterTest.java
@@ -1,0 +1,70 @@
+package org.jabref.logic.quality.consistency;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.jabref.logic.importer.ImportFormatPreferences;
+import org.jabref.logic.importer.ParserResult;
+import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntryTypesManager;
+import org.jabref.model.util.DummyFileUpdateMonitor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.mockito.Answers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@ResourceLock("Localization.lang")
+class BibliographyConsistencyCheckResultGitHubActionsWriterTest {
+
+    private final BibtexImporter importer = new BibtexImporter(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS), new DummyFileUpdateMonitor());
+
+    @Test
+    void deviatingFieldsAreReportedAsGitHubActionsAnnotations(@TempDir Path tempDir) throws IOException {
+        Path bibFile = tempDir.resolve("library.bib");
+        Files.writeString(bibFile, """
+                @Article{first,
+                  author = {Author One},
+                  pages = {1--2},
+                }
+                @Article{second,
+                  author = {Author One},
+                  publisher = {A Publisher},
+                }
+                """);
+
+        ParserResult parserResult = importer.importDatabase(bibFile);
+        BibDatabaseContext bibContext = parserResult.getDatabaseContext();
+        BibliographyConsistencyCheck.Result result = new BibliographyConsistencyCheck()
+                .check(bibContext, new BibEntryTypesManager(), (_, _) -> {
+                });
+
+        Path outFile = tempDir.resolve("result.txt");
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(outFile));
+             BibliographyConsistencyCheckResultGitHubActionsWriter ghWriter =
+                     new BibliographyConsistencyCheckResultGitHubActionsWriter(result, writer, false,
+                             new BibEntryTypesManager(), bibContext.getMode(), parserResult, bibFile)) {
+            ghWriter.writeFindings();
+        }
+
+        List<String> lines = Files.readString(outFile).replace("\r\n", "\n").lines().toList();
+        assertEquals(3, lines.size(), "Expected one annotation per deviating field, but got: " + lines);
+        // Every line starts with the GitHub Actions error workflow command.
+        assertTrue(lines.stream().allMatch(line -> line.startsWith("::error file=")), lines.toString());
+        // Each annotation carries line, column, title (citation key + field), and the message.
+        assertTrue(lines.stream().allMatch(line -> line.contains(",line=") && line.contains(",col=") && line.contains(",title=")), lines.toString());
+        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::field is absent but used by other entries of entry type Article")), lines.toString());
+        assertTrue(lines.stream().anyMatch(line -> line.endsWith("::unknown field for entry type Article")), lines.toString());
+        // Windows drive-letter colon and the ":" between citation key and field name must be URL-encoded inside properties.
+        assertTrue(lines.stream().noneMatch(line -> line.matches(".*title=[^:]+:[^:]+::.*")), "title must not contain raw ':' separator: " + lines);
+    }
+}

--- a/jablib/src/test/java/org/jabref/logic/util/GitHubActionsEscapeTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/GitHubActionsEscapeTest.java
@@ -1,0 +1,41 @@
+package org.jabref.logic.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GitHubActionsEscapeTest {
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', textBlock = """
+            # percent must be encoded
+            100% done             | 100%25 done
+            # newlines are encoded
+            'first\nsecond'       | first%0Asecond
+            # carriage return is encoded
+            'first\rsecond'       | first%0Dsecond
+            # colon and comma are left untouched in data position
+            foo:bar,baz           | foo:bar,baz
+            # nothing to escape
+            hello world           | hello world
+            """)
+    void data(String input, String expected) {
+        assertEquals(expected, GitHubActionsEscape.data(input));
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', textBlock = """
+            # Windows-style drive letter and backslash path
+            C:\\foo\\bar.bib      | C%3A\\foo\\bar.bib
+            # comma is encoded so it cannot terminate the property
+            'a,b'                 | a%2Cb
+            # percent is encoded before colon so the %3A insertion is not re-escaped to %253A
+            '%:'                  | %25%3A
+            # newlines still encode in property position
+            'a\nb'                | a%0Ab
+            """)
+    void property(String input, String expected) {
+        assertEquals(expected, GitHubActionsEscape.property(input));
+    }
+}


### PR DESCRIPTION
### PR Description

Inspired by https://github.com/nbbrd/heylogs/issues/544

Adds a new `github-actions` value for the `--output-format` option of `jabkit check`, `jabkit check consistency`, and `jabkit check integrity`. Each finding is emitted as a [GitHub Actions workflow command](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message) (`::error file=...,line=...,col=...,title=...::message`) so consistency and integrity findings appear as inline annotations on pull requests when `jabkit` runs in CI. Property values are URL-encoded (`%`, `\r`, `\n`, `:`, `,`) so Windows-style paths like `C:\foo\bar.bib` and titles of the shape `citationKey:field` parse correctly on the runner.

### Steps to test

1. Run `jabkit check consistency path/to/library.bib --output-format github-actions` on a library that has consistency findings.
2. Confirm each finding is printed on its own line in the form `::error file=...,line=...,col=...,title=...::<message>`.
3. The same option also works on `jabkit check integrity` and on the parent `jabkit check` command (which runs both checks).
4. When the workflow that calls `jabkit` lives in `.github/workflows/`, the findings show up as inline PR annotations.

### AI usage

Claude Code (model claude-opus-4-7)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
