### PR TITLE
Quick fix: remove tabs and unused AI exports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ requirementTracing {
         )
     )
 
-	filteredArtifactTypes =
+    filteredArtifactTypes =
         listOf(
             "impl",
             "utest",
@@ -61,7 +61,7 @@ requirementTracing {
             "pp",
             "feat",
             "req"
-		)
+        )
 
     // TODO: Short Tag Importer: https://github.com/itsallcode/openfasttrace-gradle#configuring-the-short-tag-importer
 }

--- a/jablib/src/main/java/module-info.java
+++ b/jablib/src/main/java/module-info.java
@@ -94,7 +94,6 @@ open module org.jabref.jablib {
     exports org.jabref.model.openoffice.uno;
     exports org.jabref.model.openoffice.util;
     exports org.jabref.logic.importer.plaincitation;
-    exports org.jabref.logic.ai.templates;
     exports org.jabref.logic.bst;
     exports org.jabref.model.study;
     exports org.jabref.logic.shared.security;
@@ -121,23 +120,18 @@ open module org.jabref.jablib {
 
     // region: AI
     exports org.jabref.logic.ai;
-    exports org.jabref.logic.ai.models;
     exports org.jabref.logic.ai.chatting;
     exports org.jabref.logic.ai.util;
     exports org.jabref.logic.ai.summarization;
     exports org.jabref.logic.ai.summarization.repositories;
     exports org.jabref.logic.ai.ingestion;
     exports org.jabref.logic.ai.ingestion.logic.documentsplitting;
-    exports org.jabref.logic.ai.ingestion.logic.ingestion;
     exports org.jabref.logic.ai.ingestion.logic.parsing;
     exports org.jabref.logic.ai.summarization.tasks;
-    exports org.jabref.logic.ai.summarization.logic;
     exports org.jabref.logic.ai.summarization.logic.summarizationalgorithms;
-    exports org.jabref.logic.ai.ingestion.tasks;
     exports org.jabref.logic.ai.ingestion.repositories;
     exports org.jabref.logic.ai.ingestion.logic;
     exports org.jabref.logic.ai.chatting.tasks;
-    exports org.jabref.logic.ai.chatting.repositories;
     exports org.jabref.logic.ai.preferences;
     exports org.jabref.model.ai.chatting;
     exports org.jabref.model.ai.pipeline;
@@ -152,16 +146,12 @@ open module org.jabref.jablib {
     exports org.jabref.logic.ai.ingestion.tasks.generateembeddingsforseveral;
     exports org.jabref.logic.ai.ingestion.tasks.generateembeddings;
     exports org.jabref.logic.ai.rag.util;
-    exports org.jabref.logic.ai.tokenization.logic;
     exports org.jabref.logic.ai.ingestion.util;
     exports org.jabref.logic.ai.followup.tasks;
     exports org.jabref.model.ai;
     exports org.jabref.logic.ai.chatting.exporters;
     exports org.jabref.logic.ai.summarization.exporters;
-    exports org.jabref.logic.ai.chatting.migrations;
-    exports org.jabref.logic.ai.summarization.migration;
     exports org.jabref.logic.ai.summarization.util;
-    exports org.jabref.logic.ai.tokenization.util;
     // endregion
 
     requires java.base;


### PR DESCRIPTION
### Related issues and pull requests

No related issue.

### PR Description

Just quick changes:

1. Remove tabs in `build gradle` file.
2. Remove unused exports from jablib related to AI features.

### Steps to test

Run `checkAllModuleInfo` - should be green.

### AI usage

No AI usage (though originally discovered not by me, I think by a user that used AI to find this).

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)