### PR TITLE
fix(null): fix nullable warnings in CSLAdapter

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -15,27 +15,18 @@ import de.undercouch.citeproc.output.Bibliography;
 import de.undercouch.citeproc.output.Citation;
 import org.jspecify.annotations.Nullable;
 
-/// Provides an adapter class to CSL. It holds a CSL instance under the hood that is only recreated when
-/// the style changes.
+/// Synchronized wrapper around the CSL engine that caches the engine.
 ///
-/// Note on the API: The first call to {@link #makeBibliography} is expensive since the
-/// CSL instance will be created. As long as the style stays the same, we can reuse this instance. On style-change, the
-/// engine is re-instantiated. Therefore, the use-case of this class is many calls to {@link #makeBibliography} with the
-/// same style. Changing the output format is cheap.
-///
-/// Note on the implementation:
-/// The main function {@link #makeBibliography} will enforce
-/// synchronized calling. The main CSL engine under the hood is not thread-safe. Since this class is usually called from
-/// a BackgroundTask, the only other option would be to create several CSL instances which is wasting a lot of resources and very slow.
-/// In the current scheme, {@link #makeBibliography} can be called as usual
-/// background task and to the best of my knowledge, concurrent calls will pile up and processed sequentially.
+/// The cache is needed because the creation of a CSL instance is expensive. On style-change, the
+/// engine is re-instantiated, so it is recommended to use this class when you need to generate many bibliographies in one style.
+/// Changing the output format is inexpensive.
 public class CSLAdapter {
 
     private final JabRefItemDataProvider dataProvider = new JabRefItemDataProvider();
 
-    @Nullable private String cachedStyle;
-    @Nullable private CitationStyleOutputFormat cachedFormat;
-    @Nullable private CSL cachedCslInstance;
+    @Nullable private String storedStyle;
+    @Nullable private CitationStyleOutputFormat storedFormat;
+    @Nullable private CSL storedCslInstance;
 
     /// Creates the bibliography of the provided items. This method needs to run synchronized because the underlying
     /// CSL engine is not thread-safe.
@@ -44,7 +35,7 @@ public class CSLAdapter {
     public synchronized List<String> makeBibliography(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) throws IOException, IllegalArgumentException {
         dataProvider.setData(bibEntries, databaseContext, entryTypesManager);
 
-        CSL cslInstance = initialize(style, outputFormat);
+        CSL cslInstance = getCslInstance(style, outputFormat);
         cslInstance.registerCitationItems(dataProvider.getIds());
 
         Bibliography bibliography = cslInstance.makeBibliography();
@@ -54,31 +45,31 @@ public class CSLAdapter {
     public synchronized Citation makeCitation(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) throws IOException {
         dataProvider.setData(bibEntries, databaseContext, entryTypesManager);
 
-        CSL cslInstance = initialize(style, outputFormat);
+        CSL cslInstance = getCslInstance(style, outputFormat);
         cslInstance.registerCitationItems(dataProvider.getIds());
 
         return cslInstance.makeCitation(bibEntries.stream().map(entry -> entry.getCitationKey().orElse("")).toList()).getFirst();
     }
 
-    /// Initialized the static CSL instance if needed.
+    /// Return the stored CSL instance (if the same style is used) or reinitialize it.
     ///
     /// @param newStyle  journal style of the output
     /// @param newFormat usually HTML or RTF.
     /// @return the initialized CSL instance (or a cached one)
     /// @throws IOException An error occurred in the underlying framework
-    private CSL initialize(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
-        if (cachedCslInstance == null || !Objects.equals(newStyle, cachedStyle)) {
+    private CSL getCslInstance(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
+        if (storedCslInstance == null || !Objects.equals(newStyle, storedStyle)) {
             // lang and forceLang are set to the default values of other CSL constructors
-            cachedCslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), new DefaultAbbreviationProvider(), newStyle, "en-US");
-            cachedStyle = newStyle;
-            cachedFormat = null; // To trigger the output format update below.
+            storedCslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), new DefaultAbbreviationProvider(), newStyle, "en-US");
+            storedStyle = newStyle;
+            storedFormat = null; // To trigger the output format update below.
         }
 
-        if (!Objects.equals(newFormat, cachedFormat)) {
-            cachedCslInstance.setOutputFormat(newFormat.getFormat());
-            cachedFormat = newFormat;
+        if (!Objects.equals(newFormat, storedFormat)) {
+            storedCslInstance.setOutputFormat(newFormat.getFormat());
+            storedFormat = newFormat;
         }
 
-        return cachedCslInstance;
+        return storedCslInstance;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -15,7 +15,7 @@ import de.undercouch.citeproc.output.Bibliography;
 import de.undercouch.citeproc.output.Citation;
 import org.jspecify.annotations.Nullable;
 
-/// Synchronized wrapper around the CSL engine that caches the engine.
+/// Thread-safe wrapper around the CSL engine that caches the engine.
 ///
 /// The cache is needed because the creation of a CSL instance is expensive. On style-change, the
 /// engine is re-instantiated, so it is recommended to use this class when you need to generate many bibliographies in one style.
@@ -24,12 +24,11 @@ public class CSLAdapter {
 
     private final JabRefItemDataProvider dataProvider = new JabRefItemDataProvider();
 
-    @Nullable private String storedStyle;
-    @Nullable private CitationStyleOutputFormat storedFormat;
-    @Nullable private CSL storedCslInstance;
+    @Nullable private String currentStyle;
+    @Nullable private CitationStyleOutputFormat currentFormat;
+    @Nullable private CSL currentCslInstance;
 
-    /// Creates the bibliography of the provided items. This method needs to run synchronized because the underlying
-    /// CSL engine is not thread-safe.
+    /// Creates the bibliography of the provided items.
     ///
     /// @param databaseContext {@link BibDatabaseContext} is used to be able to resolve fields and their aliases
     public synchronized List<String> makeBibliography(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) throws IOException, IllegalArgumentException {
@@ -58,18 +57,18 @@ public class CSLAdapter {
     /// @return the initialized CSL instance (or a cached one)
     /// @throws IOException An error occurred in the underlying framework
     private CSL getCslInstance(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
-        if (storedCslInstance == null || !Objects.equals(newStyle, storedStyle)) {
+        if (currentCslInstance == null || !Objects.equals(newStyle, currentStyle)) {
             // lang and forceLang are set to the default values of other CSL constructors
-            storedCslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), new DefaultAbbreviationProvider(), newStyle, "en-US");
-            storedStyle = newStyle;
-            storedFormat = null; // To trigger the output format update below.
+            currentCslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), new DefaultAbbreviationProvider(), newStyle, "en-US");
+            currentStyle = newStyle;
+            currentFormat = null; // To trigger the output format update below.
         }
 
-        if (!Objects.equals(newFormat, storedFormat)) {
-            storedCslInstance.setOutputFormat(newFormat.getFormat());
-            storedFormat = newFormat;
+        if (!Objects.equals(newFormat, currentFormat)) {
+            currentCslInstance.setOutputFormat(newFormat.getFormat());
+            currentFormat = newFormat;
         }
 
-        return storedCslInstance;
+        return currentCslInstance;
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -17,8 +17,10 @@ import org.jspecify.annotations.Nullable;
 
 /// Thread-safe wrapper around the CSL engine that caches the engine.
 ///
-/// The cache is needed because the creation of a CSL instance is expensive. On style-change, the
-/// engine is re-instantiated, so it is recommended to use this class when you need to generate many bibliographies in one style.
+/// The creation of a CSL instance is expensive, so the first call to [#makeBibliography] would take some amount of time.
+/// For this reason the class stores the instance and reuses it if the style does not change.
+///
+/// It is recommended to use this class when you need to generate many bibliographies in one style.
 /// Changing the output format is inexpensive.
 public class CSLAdapter {
 

--- a/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/jablib/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -13,6 +13,7 @@ import de.undercouch.citeproc.CSL;
 import de.undercouch.citeproc.DefaultAbbreviationProvider;
 import de.undercouch.citeproc.output.Bibliography;
 import de.undercouch.citeproc.output.Citation;
+import org.jspecify.annotations.Nullable;
 
 /// Provides an adapter class to CSL. It holds a CSL instance under the hood that is only recreated when
 /// the style changes.
@@ -31,9 +32,10 @@ import de.undercouch.citeproc.output.Citation;
 public class CSLAdapter {
 
     private final JabRefItemDataProvider dataProvider = new JabRefItemDataProvider();
-    private String style;
-    private CitationStyleOutputFormat format;
-    private CSL cslInstance;
+
+    @Nullable private String cachedStyle;
+    @Nullable private CitationStyleOutputFormat cachedFormat;
+    @Nullable private CSL cachedCslInstance;
 
     /// Creates the bibliography of the provided items. This method needs to run synchronized because the underlying
     /// CSL engine is not thread-safe.
@@ -41,16 +43,20 @@ public class CSLAdapter {
     /// @param databaseContext {@link BibDatabaseContext} is used to be able to resolve fields and their aliases
     public synchronized List<String> makeBibliography(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) throws IOException, IllegalArgumentException {
         dataProvider.setData(bibEntries, databaseContext, entryTypesManager);
-        initialize(style, outputFormat);
+
+        CSL cslInstance = initialize(style, outputFormat);
         cslInstance.registerCitationItems(dataProvider.getIds());
-        final Bibliography bibliography = cslInstance.makeBibliography();
+
+        Bibliography bibliography = cslInstance.makeBibliography();
         return Arrays.asList(bibliography.getEntries());
     }
 
     public synchronized Citation makeCitation(List<BibEntry> bibEntries, String style, CitationStyleOutputFormat outputFormat, BibDatabaseContext databaseContext, BibEntryTypesManager entryTypesManager) throws IOException {
         dataProvider.setData(bibEntries, databaseContext, entryTypesManager);
-        initialize(style, outputFormat);
+
+        CSL cslInstance = initialize(style, outputFormat);
         cslInstance.registerCitationItems(dataProvider.getIds());
+
         return cslInstance.makeCitation(bibEntries.stream().map(entry -> entry.getCitationKey().orElse("")).toList()).getFirst();
     }
 
@@ -58,19 +64,21 @@ public class CSLAdapter {
     ///
     /// @param newStyle  journal style of the output
     /// @param newFormat usually HTML or RTF.
+    /// @return the initialized CSL instance (or a cached one)
     /// @throws IOException An error occurred in the underlying framework
-    private void initialize(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
-        final boolean newCslInstanceNeedsToBeCreated = (cslInstance == null) || !Objects.equals(newStyle, style);
-        if (newCslInstanceNeedsToBeCreated) {
+    private CSL initialize(String newStyle, CitationStyleOutputFormat newFormat) throws IOException {
+        if (cachedCslInstance == null || !Objects.equals(newStyle, cachedStyle)) {
             // lang and forceLang are set to the default values of other CSL constructors
-            cslInstance = new CSL(dataProvider, new JabRefLocaleProvider(),
-                    new DefaultAbbreviationProvider(), newStyle, "en-US");
-            style = newStyle;
+            cachedCslInstance = new CSL(dataProvider, new JabRefLocaleProvider(), new DefaultAbbreviationProvider(), newStyle, "en-US");
+            cachedStyle = newStyle;
+            cachedFormat = null; // To trigger the output format update below.
         }
 
-        if (newCslInstanceNeedsToBeCreated || (!Objects.equals(newFormat, format))) {
-            cslInstance.setOutputFormat(newFormat.getFormat());
-            format = newFormat;
+        if (!Objects.equals(newFormat, cachedFormat)) {
+            cachedCslInstance.setOutputFormat(newFormat.getFormat());
+            cachedFormat = newFormat;
         }
+
+        return cachedCslInstance;
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

No related issues - continuous improving.

### PR Description

Just fixing nullaway warnings in one class - CLSAdapter. This one didn't have a trivial solution.

IMHO, something is horrendously wrong with this class... The ideal solution:

1. Rewrite without this caching logic or somehow make the caching to be more explicit, so that linters would understand that it is null-safe.
2. Add `checkerframework` and use `@EnsureNotNull("cslInstance")` - I like this variant more. I didn't understand how to add it properly to jabref and asked claude - and he made a gigantic plan... I don't know if it's easy to add it, or it really needs a whole setup.

### Steps to test

Run CSL generation tests. Should be green.

### AI usage

No AI models were used to generate/edit code.

AI models (Google Gemini Pro 3.1, ChatGPT) were used only for consultation purposes.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
