### PR TITLE
Fix group chat history bleeding across libraries with same group name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2016,6 +2016,9 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
 - We fixed an issue when importing resulted in an exception [#7343](https://github.com/JabRef/jabref/issues/7343)
 - We fixed an issue where the field in the Field formatter dropdown selection were sorted in random order. [#7710](https://github.com/JabRef/jabref/issues/7710)
+- We fixed an issue where opening a group chat window in one library could show the chat history from a group in a different library, given the two groups had the same name[#14641]
+
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)
 - We introduced a leightweight search engine without fulltext search in linked files as default variant. [#15599](https://github.com/JabRef/jabref/pull/15599)
-- We fixed an issue where opening a group chat window in one library could show the chat history from a group in a different library, given the two groups had the same name[#14641]
+- We fixed an issue where opening a group chat window in one library could show the chat history from a group in a different library, given the two groups had the same name[#14641](https://github.com/JabRef/jabref/issues/14641)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 
 - We made the `Move file to directory` operation for Linked Files show every configured JabRef directory as possible options. [#12287](https://github.com/JabRef/jabref/issues/12287)
 - We introduced a leightweight search engine without fulltext search in linked files as default variant. [#15599](https://github.com/JabRef/jabref/pull/15599)
+- We fixed an issue where opening a group chat window in one library could show the chat history from a group in a different library, given the two groups had the same name[#14641]
 
 ### Fixed
 
@@ -2016,9 +2017,6 @@ Note that this project **does not** adhere to [Semantic Versioning](https://semv
 - We fixed an issue where opening the menu 'Library properties' marked the library as modified [#6451](https://github.com/JabRef/jabref/issues/6451)
 - We fixed an issue when importing resulted in an exception [#7343](https://github.com/JabRef/jabref/issues/7343)
 - We fixed an issue where the field in the Field formatter dropdown selection were sorted in random order. [#7710](https://github.com/JabRef/jabref/issues/7710)
-- We fixed an issue where opening a group chat window in one library could show the chat history from a group in a different library, given the two groups had the same name[#14641]
-
-
 
 ### Removed
 

--- a/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
+++ b/jabgui/src/main/java/org/jabref/gui/JabRefGuiStateManager.java
@@ -79,7 +79,7 @@ public class JabRefGuiStateManager extends AbstractSrvStateManager implements St
     private final ObservableMap<String, DialogWindowState> dialogWindowStates = FXCollections.observableHashMap();
     private final ObservableList<SidePaneType> visibleSidePanes = FXCollections.observableArrayList();
     private final ObservableList<String> searchHistory = FXCollections.observableArrayList();
-    private final Map<BibDatabaseContext, Map<String, AiGroupChatWindow>> groupAiChatWindows = new HashMap<>();
+    private final Map<String, Map<String, AiGroupChatWindow>> groupAiChatWindows = new HashMap<>();
     private final BooleanProperty editorShowing = new SimpleBooleanProperty(false);
     private final OptionalObjectProperty<Walkthrough> activeWalkthrough = OptionalObjectProperty.empty();
     private final BooleanProperty canGoBack = new SimpleBooleanProperty(false);
@@ -252,23 +252,23 @@ public class JabRefGuiStateManager extends AbstractSrvStateManager implements St
 
     @Override
     public Optional<AiGroupChatWindow> getAiChatWindowForGroup(BibDatabaseContext context, String groupName) {
-        return Optional.ofNullable(groupAiChatWindows.get(context))
+        return Optional.ofNullable(groupAiChatWindows.get(context.getUid()))
                        .flatMap(innerMap -> Optional.ofNullable(innerMap.get(groupName)));
     }
 
     @Override
     public void setAiChatWindowForGroup(BibDatabaseContext context, String groupName, AiGroupChatWindow aiGroupChatWindow) {
-        groupAiChatWindows.computeIfAbsent(context, k -> new HashMap<>())
+        groupAiChatWindows.computeIfAbsent(context.getUid(), k -> new HashMap<>())
                           .put(groupName, aiGroupChatWindow);
     }
 
     @Override
     public void removeAiChatWindowForGroup(BibDatabaseContext context, String groupName) {
-        Map<String, AiGroupChatWindow> innerMap = groupAiChatWindows.get(context);
+        Map<String, AiGroupChatWindow> innerMap = groupAiChatWindows.get(context.getUid());
         if (innerMap != null) {
             innerMap.remove(groupName);
             if (innerMap.isEmpty()) {
-                groupAiChatWindows.remove(context);
+                groupAiChatWindows.remove(context.getUid());
             }
         }
     }

--- a/jablib/src/test/java/org/jabref/logic/ai/chatting/InMemoryChatHistoryCacheTest.java
+++ b/jablib/src/test/java/org/jabref/logic/ai/chatting/InMemoryChatHistoryCacheTest.java
@@ -123,6 +123,28 @@ class InMemoryChatHistoryCacheTest {
     }
 
     @Test
+    void getForGroupReturnsSeparateHistoriesForSameGroupNameInDifferentLibraries() {
+        MetaData metaDataA = new MetaData();
+        metaDataA.setAiLibraryId("library-id-A");
+        BibDatabaseContext contextA = new BibDatabaseContext(new BibDatabase(), metaDataA);
+        GroupTreeNode groupA = GroupTreeNode.fromGroup(new AllEntriesGroup("TestGroup"));
+        contextA.getMetaData().setGroups(groupA);
+
+        MetaData metaDataB = new MetaData();
+        metaDataB.setAiLibraryId("library-id-B");
+        BibDatabaseContext contextB = new BibDatabaseContext(new BibDatabase(), metaDataB);
+        GroupTreeNode groupB = GroupTreeNode.fromGroup(new AllEntriesGroup("TestGroup"));
+        contextB.getMetaData().setGroups(groupB);
+
+        var historyA = cache.getForGroup(contextA, groupA);
+        historyA.add(ChatMessage.userMessage("Hello from Library A"));
+
+        var historyB = cache.getForGroup(contextB, groupB);
+
+        assertTrue(historyB.isEmpty(), "Library B's group chat should not contain Library A's messages");
+    }
+
+    @Test
     void closeFlushesGroupChatsToRepository() {
         GroupTreeNode root = GroupTreeNode.fromGroup(new AllEntriesGroup("All Entries"));
         databaseContext.getMetaData().setGroups(root);


### PR DESCRIPTION
### Related issues and pull requests
Closes #14641

### PR Description
Group chat windows were bleeding across libraries that had groups with the same name, due to `JabRefGuiStateManager` using `BibDatabaseContext` as a `HashMap` key. Fixed by using `context.getUid()` as the key instead, similar to how `selectedGroups` currently works.

jabref-contrib-policy:4.2:reviewed:ok

Analogies: Creating two groups in libraries with the same name is like putting honey and chocolate in two different jars, but labeling these jars with the same name. When the moon people come to take from these offering jars (in the form of creating chats), they will sometimes become confused, and end up mixing the contents of these jars, so that when you wake up the next day, the honey jar might be full of chocolate. I fixed it by making the moon people recognize the difference between these jars not based on the labeling of the jars, but by looking at the jars' material composition. Since no two jars' composition is exactly alike, the moon people no longer make this mistake.

### Steps to test
1. Create two libraries
2. Create entries in each library
3. Attach PDF files in each library
4. Enable AI https://docs.jabref.org/ai/preferences
5. Chat with a group in the first library
6. Switch to the other library
7. Start chat with a group with the same name

You should see that the new group does not contain any chat history from the first library's group.

### AI usage
Claude Sonnet 4.6 (claude.ai) — used for debugging assistance and code review. All code reviewed, understood, and owned by the contributor.

### Checklist
- [x] I own the copyright of the code submitted and I license it under the [[MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [x] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [[user documentation](https://docs.jabref.org/)](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [[user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)](https://github.com/JabRef/user-documentation/tree/main/en)