### PR TITLE
fix(ai): add listener to files changes to AiSummaryViewModel

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/ai/summary/AiSummaryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/ai/summary/AiSummaryViewModel.java
@@ -6,8 +6,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 
@@ -31,9 +33,11 @@ import org.jabref.logic.ai.util.TrackedBackgroundTask;
 import org.jabref.logic.util.ObservablesHelper;
 import org.jabref.model.ai.identifiers.FullBibEntry;
 import org.jabref.model.ai.summarization.AiSummary;
-import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.entry.event.FieldChangedEvent;
+import org.jabref.model.entry.field.StandardField;
 
-import com.tobiasdiez.easybind.EasyBind;
+import com.google.common.eventbus.Subscribe;
 import org.jspecify.annotations.Nullable;
 
 public class AiSummaryViewModel extends AbstractViewModel {
@@ -58,6 +62,12 @@ public class AiSummaryViewModel extends AbstractViewModel {
 
     private final ObjectProperty<GenerateSummaryTask> currentTask = new SimpleObjectProperty<>();
     private final ChangeListener<TrackedBackgroundTask.Status> taskStateListener = (_, _, value) -> updateByTaskState(value);
+
+    // These properties are used to control the NO_FILES and NO_SUPPORTED_FILE_TYPES states.
+    // They aare made as properties and not as bindings, as we need to listen to the chnages of files in an entry,
+    // which is made by listening to the even bus and manually updating the properties.
+    private final BooleanProperty filesEmpty = new SimpleBooleanProperty(true);
+    private final BooleanProperty noSupportedFileTypes = new SimpleBooleanProperty(true);
 
     private final AiPreferences aiPreferences;
     private final FilePreferences filePreferences;
@@ -95,17 +105,11 @@ public class AiSummaryViewModel extends AbstractViewModel {
                 ),
 
                 Map.entry(State.NO_FILES,
-                        entry.map(FullBibEntry::entry)
-                             .map(BibEntry::getFiles)
-                             .map(List::isEmpty)
+                        filesEmpty
                 ),
 
                 Map.entry(State.NO_SUPPORTED_FILE_TYPES,
-                        entry.map(FullBibEntry::entry)
-                             .map(BibEntry::getFiles)
-                             .map(l -> l.stream()
-                                        .map(f -> Path.of(f.getLink()))
-                                        .noneMatch(UniversalContentParser::isSupportedFileType))
+                        noSupportedFileTypes
                 ),
 
                 Map.entry(State.DONE,
@@ -154,8 +158,43 @@ public class AiSummaryViewModel extends AbstractViewModel {
     }
 
     private void setupListeners() {
-        EasyBind.subscribe(entry, _ -> prepareForEntry());
-        EasyBind.subscribe(entry, this::processEntry);
+        entry.addListener((_, oldVal, newVal) -> {
+            if (oldVal != null) {
+                oldVal.entry().unregisterListener(this);
+            }
+
+            if (newVal == null) {
+                filesEmpty.set(true);
+                noSupportedFileTypes.set(true);
+            } else {
+                newVal.entry().registerListener(this);
+                refreshFileState(newVal.entry().getFiles());
+            }
+        });
+
+        BindingsHelper.listen(this::prepareForEntry, entry);
+        BindingsHelper.listen(this::processEntry, entry, noSupportedFileTypes, filesEmpty);
+    }
+
+    @Subscribe
+    public void onFileFieldChanged(FieldChangedEvent event) {
+        if (!event.getField().equals(StandardField.FILE)) {
+            return;
+        }
+
+        FullBibEntry fullEntry = entry.get();
+        if (fullEntry == null) {
+            return;
+        }
+
+        UiTaskExecutor.runInJavaFXThread(() -> refreshFileState(fullEntry.entry().getFiles()));
+    }
+
+    private void refreshFileState(List<LinkedFile> files) {
+        filesEmpty.set(files.isEmpty());
+        noSupportedFileTypes.set(files.stream()
+                                      .map(f -> Path.of(f.getLink()))
+                                      .noneMatch(UniversalContentParser::isSupportedFileType));
     }
 
     /// Resets the chat model and summarizator to the default values from AI preferences.
@@ -196,8 +235,8 @@ public class AiSummaryViewModel extends AbstractViewModel {
         error.set(null);
     }
 
-    private void processEntry(FullBibEntry fullEntry) {
-        if (fullEntry == null || state.get() != State.READY) {
+    private void processEntry() {
+        if (entry.get() == null || state.get() != State.READY) {
             return;
         }
 
@@ -207,23 +246,24 @@ public class AiSummaryViewModel extends AbstractViewModel {
         // 3. Check if there is a running task.
         // 4. Otherwise, start a new task.
 
-        Optional<AiSummary> persistedSummary = fullEntry.toAiSummaryIdentifier()
-                                                        .flatMap(summariesRepository::get);
+        Optional<AiSummary> persistedSummary = entry.get().toAiSummaryIdentifier()
+                                                    .flatMap(summariesRepository::get);
         if (persistedSummary.isPresent()) {
             this.summary.set(persistedSummary.get());
             return;
         }
 
-        Optional<AiSummary> cachedSummary = inMemoryCache.get(fullEntry.entry());
+        Optional<AiSummary> cachedSummary = inMemoryCache.get(entry.get().entry());
         if (cachedSummary.isPresent()) {
             this.summary.set(cachedSummary.get());
             return;
         }
 
-        Optional<GenerateSummaryTask> runningTask = summarizationTaskAggregator.getTask(fullEntry.entry());
+        Optional<GenerateSummaryTask> runningTask = summarizationTaskAggregator.getTask(entry.get().entry());
         if (runningTask.isPresent()) {
             GenerateSummaryTask task = runningTask.get();
             currentTask.set(task);
+            summarizator.unbind();
             summarizator.set(task.getRequest().summarizator());
             chatModel.set(task.getRequest().chatModel());
 


### PR DESCRIPTION
### Related issues and pull requests

Closes <https://github.com/JabRef/jabref-issue-melting-pot/issues/597>

### PR Description
Previosuly AI summary component would update its state only when an entry is changed, but not the files. So if user is working on an entry and adding a file to it, a summary generation won't start. This PR fixes it (I hope).

### Steps to test

TODO

### AI usage

TODO
_____

   <!--
   DISCLOSE every AI tool used to produce this PR, including the exact model.
   Example: "Claude Code (model claude-opus-4-7)", "GitHub Copilot (GPT-4o)".
   Write "none" if no AI tool was used.
   -->

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [.] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
