### PR TITLE
Hide LLM variants in plain citation parsing if AI is disabled

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/newentry/NewEntryViewModel.java
@@ -141,6 +141,9 @@ public class NewEntryViewModel {
                 ValidationMessage.error(Localization.lang("You must specify one (or more) citations.")));
         interpretParsers = new SimpleListProperty<>(FXCollections.observableArrayList());
         interpretParsers.addAll(PlainCitationParserChoice.values());
+        if (!preferences.getAiPreferences().getEnableAi()) {
+            interpretParsers.remove(PlainCitationParserChoice.LLM);
+        }
         interpretParser = new SimpleObjectProperty<>();
         interpretWorker = null;
 


### PR DESCRIPTION
### Related issues and pull requests

Closes https://github.com/JabRef/jabref-issue-melting-pot/issues/1003

But it actually solves a bigger problem.

### PR Description

Just a very simple code addition. Remove the LLM variant from plain citation parsing variants if AI is disabled.

I think no need for changelog entry.

### Steps to test

2 main cases:

1. Turn on AI -> new entry -> plain citation parsing -> see that LLM variant is present.
2. Turn off AI -> new entry -> plain citation parsing -> there should be no LLM variant.

### AI usage

With proudness - I have used NO AI to fix this issue and to write the code. Even for consultation purposes.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
