### PR TITLE
Add test for clearing stale search results

### DIFF
--- a/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/maintable/MainTableDataModelTest.java
@@ -1,27 +1,44 @@
 package org.jabref.gui.maintable;
 
 import java.util.List;
+import java.util.Optional;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 
+import org.jabref.gui.groups.GroupsPreferences;
+import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.logic.bibtex.comparator.EntryComparator;
+import org.jabref.logic.search.SearchContext;
+import org.jabref.logic.search.SearchPreferences;
+import org.jabref.logic.search.inmemory.InMemorySearchBackend;
+import org.jabref.logic.util.CurrentThreadTaskExecutor;
+import org.jabref.logic.util.OptionalObjectProperty;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.BibEntryPreferences;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.groups.GroupTreeNode;
+import org.jabref.model.search.SearchDisplayMode;
+import org.jabref.model.search.query.SearchQuery;
 
 import com.tobiasdiez.easybind.EasyBind;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class MainTableDataModelTest {
 
@@ -61,5 +78,68 @@ class MainTableDataModelTest {
         assertTrue(changed[0]);
         result = entriesFilteredAndSorted.stream().map(BibEntryTableViewModel::getEntry).toList();
         assertEquals(List.of(bibEntryAuthorT, bibEntryNothingToZ), result);
+    }
+
+    @Test
+    void sequentialSearchWithNoMatchesClearsPreviousSearchMatches() {
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext();
+
+        BibEntry bibEntryA = new BibEntry()
+                .withCitationKey("A")
+                .withField(StandardField.AUTHOR, "Alice");
+
+        BibEntry bibEntryB = new BibEntry()
+                .withCitationKey("B")
+                .withField(StandardField.AUTHOR, "Bob");
+
+        bibDatabaseContext.getDatabase().insertEntries(List.of(bibEntryA, bibEntryB));
+
+        GuiPreferences preferences = mock(GuiPreferences.class);
+        when(preferences.getGroupsPreferences()).thenReturn(GroupsPreferences.getDefault());
+        when(preferences.getSearchPreferences()).thenReturn(
+                new SearchPreferences(SearchDisplayMode.FILTER, false, false, false, false, false, false, 0, 0, 0));
+        when(preferences.getNameDisplayPreferences()).thenReturn(NameDisplayPreferences.getDefault());
+
+        SimpleBooleanProperty usePostgres = new SimpleBooleanProperty(false);
+        SearchContext searchContext = new SearchContext(
+                usePostgres,
+                () -> new InMemorySearchBackend(bibDatabaseContext, new BibEntryPreferences(',')),
+                () -> new InMemorySearchBackend(bibDatabaseContext, new BibEntryPreferences(',')));
+
+        CurrentThreadTaskExecutor taskExecutor = new CurrentThreadTaskExecutor();
+
+        SimpleListProperty<GroupTreeNode> selectedGroups = new SimpleListProperty<>(FXCollections.observableArrayList());
+        OptionalObjectProperty<SearchQuery> searchQueryProperty = OptionalObjectProperty.empty();
+        IntegerProperty resultSize = new SimpleIntegerProperty();
+
+        MainTableDataModel model = new MainTableDataModel(
+                bibDatabaseContext,
+                preferences,
+                taskExecutor,
+                searchContext,
+                selectedGroups,
+                searchQueryProperty,
+                resultSize);
+
+        BibEntryTableViewModel vmA = model.getViewModelByCitationKey("A").orElseThrow();
+        BibEntryTableViewModel vmB = model.getViewModelByCitationKey("B").orElseThrow();
+
+        // First search matches Alice only.
+        searchQueryProperty.setValue(Optional.of(new SearchQuery("author=Alice")));
+
+        assertTrue(vmA.isMatchedBySearch().get());
+        assertFalse(vmB.isMatchedBySearch().get());
+        assertTrue(vmA.isVisibleBySearch().get());
+        assertFalse(vmB.isVisibleBySearch().get());
+        assertEquals(1, resultSize.get());
+
+        // Second search matches no entries. The old Alice result should not remain visible.
+        searchQueryProperty.setValue(Optional.of(new SearchQuery("author=Charlie")));
+
+        assertFalse(vmA.isMatchedBySearch().get());
+        assertFalse(vmB.isMatchedBySearch().get());
+        assertFalse(vmA.isVisibleBySearch().get());
+        assertFalse(vmB.isVisibleBySearch().get());
+        assertEquals(0, resultSize.get());
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

No related issue. This PR addes test for sequential search behavior in the main table.

### PR Description

This PR adds a test case to MainTableDataModelTest for the search/filter behavior in the main table.

The test verifies that when a first search query matches an entry and a second search query returns no matches, the previous search match is cleared. This helps ensure that the main table does not continue showing stale search results after the search query changes.

`jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run the following on terminal:
```bash
./gradlew :jabgui:test --tests "org.jabref.gui.maintable.MainTableDataModelTest.sequentialSearchWithNoMatchesClearsPreviousSearchMatches" -x :jablib:test
./gradlew :jabgui:test --tests "org.jabref.gui.maintable.MainTableDataModelTest" -x :jablib:test
```

### AI usage

Copilot(GPT-5 mini)
ChatGPT-5.5(Thinking)

### Checklist


- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
