### PR TITLE
Update heylogs (and remove wrong GitHub actions marker)

### DIFF
--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -186,12 +186,11 @@ jobs:
         uses: jbangdev/setup-jbang@main
       - name: Lint CHANGELOG.md
         run: |
-          # run heylogs verification with GitHub Actions annotations
-          jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.0:bin check --format github-actions CHANGELOG.md | tee heylogs.txt || true
+          # the grep is needed to filter out an error about all h2 containing a version, which is not relevant for us, because we have an "Unreleased" section
+          jbang com.github.nbbrd.heylogs:heylogs-cli:0.18.1:bin check --format github-actions CHANGELOG.md | grep -v all-h2-contain-a-version | tee heylogs.txt || true
 
-          # We have one acceptable error
           error_count=$(grep -c '^::error' heylogs.txt || true)
-          if [ "$error_count" -ne 1 ]; then
+          if [ "$error_count" -ne 0 ]; then
             {
               echo "heylogs<<EOF"
               cat heylogs.txt


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to https://github.com/JabRef/jabref/pull/15786

### PR Description

We had following output

<img width="1621" height="316" alt="grafik" src="https://github.com/user-attachments/assets/0bea44a9-cced-4c9a-b13d-4061e37ebafb" />

This fixes it

### Steps to test

See CI passing

### AI usage

none

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
