### PR TITLE
Fix garbled BibEntry Javadoc example

### DIFF
--- a/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/jablib/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -68,7 +68,13 @@ import static java.util.function.Predicate.not;
 ///
 /// Example:
 ///
-///     Some commment={fieldValue},otherFieldName ={otherFieldValue}
+/// ```bibtex
+/// Some comment
+/// @misc{key,
+///   fieldName = {fieldValue},
+///   otherFieldName = {otherFieldValue}
+/// }
+/// ```
 ///
 /// Then,
 ///


### PR DESCRIPTION
### PR Description

The class-level Javadoc on `BibEntry` showed a single garbled example line (`Some commment={fieldValue},otherFieldName ={otherFieldValue}`). The original multi-line BibTeX block was collapsed when the Javadoc was converted from HTML to Markdown (commit fb5a3e7b1b), leaving the surrounding bullets referencing `misc`, `key`, `fieldName`, and `otherFieldName` without anything in the example to match. This PR restores the multi-line BibTeX example inside a fenced ```` ```bibtex ```` code block so the example matches the explanatory text below it.

### Steps to test

1. Open `jablib/src/main/java/org/jabref/model/entry/BibEntry.java` in an IDE.
2. Hover the class name or open the Javadoc preview.
3. Confirm the example renders as a multi-line BibTeX code block and matches the bulleted explanation underneath.

### AI usage

Claude Code (model claude-opus-4-7)

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
