### PR TITLE
Fix reset and import of SearchPreferences

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -509,16 +509,6 @@ public class JabRefCliPreferences implements CliPreferences {
             LOGGER.warn("Could not import preferences from jabref.xml", e);
         }
 
-        defaults.put(SEARCH_DISPLAY_MODE, Boolean.TRUE);
-        defaults.put(SEARCH_CASE_SENSITIVE, Boolean.FALSE);
-        defaults.put(SEARCH_REG_EXP, Boolean.FALSE);
-        defaults.put(SEARCH_FULLTEXT, Boolean.FALSE);
-        defaults.put(SEARCH_USE_POSTGRES, Boolean.FALSE);
-        defaults.put(SEARCH_KEEP_SEARCH_STRING, Boolean.FALSE);
-        defaults.put(SEARCH_KEEP_GLOBAL_WINDOW_ON_TOP, Boolean.TRUE);
-        defaults.put(SEARCH_WINDOW_HEIGHT, 176.0);
-        defaults.put(SEARCH_WINDOW_WIDTH, 600.0);
-        defaults.put(SEARCH_WINDOW_DIVIDER_POS, 0.5);
         defaults.put(SEARCH_CATALOGS, convertListToString(List.of(
                 ACMPortalFetcher.FETCHER_NAME,
                 SpringerNatureWebFetcher.FETCHER_NAME,
@@ -971,6 +961,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 CitationKeyPatternPreferences.getDefault()
                                              .withKeywordDelimiter(getBibEntryPreferences().keywordSeparatorProperty()));
         getAiPreferences().setAll(AiPreferences.getDefault());
+        getSearchPreferences().setAll(SearchPreferences.getDefault());
     }
 
     /// Imports Preferences from an XML file.
@@ -996,6 +987,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getRemotePreferences().setAll(getRemotePreferencesFromBackingStore(getRemotePreferences()));
         getCitationKeyPatternPreferences().setAll(getCitationKeyPatternPreferencesFromBackingStore(getCitationKeyPatternPreferences()));
         getAiPreferences().setAll(getAiPreferencesFromBackingStore(getAiPreferences()));
+        getSearchPreferences().setAll(getSearchPreferencesFromBackingStore(getSearchPreferences()));
     }
 
     private static void importPreferencesToBackingStore(Path path) throws JabRefException {
@@ -2064,21 +2056,12 @@ public class JabRefCliPreferences implements CliPreferences {
             return searchPreferences;
         }
 
-        searchPreferences = new SearchPreferences(
-                getBoolean(SEARCH_DISPLAY_MODE) ? SearchDisplayMode.FILTER : SearchDisplayMode.FLOAT,
-                getBoolean(SEARCH_REG_EXP),
-                getBoolean(SEARCH_CASE_SENSITIVE),
-                getBoolean(SEARCH_FULLTEXT),
-                getBoolean(SEARCH_USE_POSTGRES),
-                getBoolean(SEARCH_KEEP_SEARCH_STRING),
-                getBoolean(SEARCH_KEEP_GLOBAL_WINDOW_ON_TOP),
-                getDouble(SEARCH_WINDOW_HEIGHT),
-                getDouble(SEARCH_WINDOW_WIDTH),
-                getDouble(SEARCH_WINDOW_DIVIDER_POS));
+        searchPreferences = getSearchPreferencesFromBackingStore(SearchPreferences.getDefault());
 
+        EasyBind.listen(searchPreferences.searchDisplayModeProperty(), (_, _, newValue) -> putBoolean(SEARCH_DISPLAY_MODE, newValue == SearchDisplayMode.FILTER));
         searchPreferences.getObservableSearchFlags().addListener((SetChangeListener<SearchFlags>) _ ->
                 putBoolean(SEARCH_FULLTEXT, searchPreferences.getObservableSearchFlags().contains(SearchFlags.FULLTEXT)));
-        EasyBind.listen(searchPreferences.searchDisplayModeProperty(), (_, _, newValue) -> putBoolean(SEARCH_DISPLAY_MODE, newValue == SearchDisplayMode.FILTER));
+        // Regular expression and case-sensitive search flags should always be set to default values on startup
         EasyBind.listen(searchPreferences.keepSearchStringProperty(), (_, _, newValue) -> putBoolean(SEARCH_KEEP_SEARCH_STRING, newValue));
         EasyBind.listen(searchPreferences.keepWindowOnTopProperty(), (_, _, _) -> putBoolean(SEARCH_KEEP_GLOBAL_WINDOW_ON_TOP, searchPreferences.shouldKeepWindowOnTop()));
         EasyBind.listen(searchPreferences.getSearchWindowHeightProperty(), (_, _, _) -> putDouble(SEARCH_WINDOW_HEIGHT, searchPreferences.getSearchWindowHeight()));
@@ -2087,6 +2070,20 @@ public class JabRefCliPreferences implements CliPreferences {
         EasyBind.listen(searchPreferences.usePostgresSearchProperty(), (_, _, newValue) -> putBoolean(SEARCH_USE_POSTGRES, newValue));
 
         return searchPreferences;
+    }
+
+    private SearchPreferences getSearchPreferencesFromBackingStore(SearchPreferences defaults) {
+        return new SearchPreferences(
+                getBoolean(SEARCH_DISPLAY_MODE, defaults.getSearchDisplayMode() == SearchDisplayMode.FILTER) ? SearchDisplayMode.FILTER : SearchDisplayMode.FLOAT,
+                getBoolean(SEARCH_REG_EXP, defaults.isRegularExpression()),
+                getBoolean(SEARCH_CASE_SENSITIVE, defaults.isCaseSensitive()),
+                getBoolean(SEARCH_FULLTEXT, defaults.isFulltext()),
+                getBoolean(SEARCH_USE_POSTGRES, defaults.shouldUsePostgresSearch()),
+                getBoolean(SEARCH_KEEP_SEARCH_STRING, defaults.shouldKeepSearchString()),
+                getBoolean(SEARCH_KEEP_GLOBAL_WINDOW_ON_TOP, defaults.shouldKeepWindowOnTop()),
+                getDouble(SEARCH_WINDOW_HEIGHT, defaults.getSearchWindowHeight()),
+                getDouble(SEARCH_WINDOW_WIDTH, defaults.getSearchWindowWidth()),
+                getDouble(SEARCH_WINDOW_DIVIDER_POS, defaults.getSearchWindowDividerPosition()));
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/logic/search/SearchPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/search/SearchPreferences.java
@@ -27,6 +27,21 @@ public class SearchPreferences {
     private final BooleanProperty keepSearchString;
     private final ObjectProperty<SearchDisplayMode> searchDisplayMode;
 
+    private SearchPreferences() {
+        this(
+                SearchDisplayMode.FILTER,  // Search display mode
+                false,                     // Regular expression
+                false,                     // Case sensitive
+                false,                     // Fulltext
+                false,                     // Use postgres search
+                false,                     // Keep search string
+                true,                      // Keep window on top
+                176.0,                     // Search window height
+                600.0,                     // Search window width
+                0.5                        // Search window divider position
+        );
+    }
+
     public SearchPreferences(SearchDisplayMode searchDisplayMode,
                              boolean isRegularExpression,
                              boolean isCaseSensitive,
@@ -60,6 +75,24 @@ public class SearchPreferences {
         this.searchWindowWidth = new SimpleDoubleProperty(searchWindowWidth);
         this.searchWindowDividerPosition = new SimpleDoubleProperty(searchWindowDividerPosition);
         this.keepSearchString = new SimpleBooleanProperty(keepSearchString);
+    }
+
+    public static SearchPreferences getDefault() {
+        return new SearchPreferences();
+    }
+
+    public void setAll(SearchPreferences preferences) {
+        this.searchDisplayMode.set(preferences.getSearchDisplayMode());
+        this.searchFlags.clear();
+        setSearchFlag(SearchFlags.REGULAR_EXPRESSION, preferences.isRegularExpression());
+        setSearchFlag(SearchFlags.CASE_SENSITIVE, preferences.isCaseSensitive());
+        setSearchFlag(SearchFlags.FULLTEXT, preferences.isFulltext());
+        this.usePostgresSearch.set(preferences.shouldUsePostgresSearch());
+        this.keepSearchString.set(preferences.shouldKeepSearchString());
+        this.keepWindowOnTop.set(preferences.shouldKeepWindowOnTop());
+        this.searchWindowHeight.set(preferences.getSearchWindowHeight());
+        this.searchWindowWidth.set(preferences.getSearchWindowWidth());
+        this.searchWindowDividerPosition.set(preferences.getSearchWindowDividerPosition());
     }
 
     public EnumSet<SearchFlags> getSearchFlags() {


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to #15847 

### PR Description

Run JabRef

- Migrated to fixed preferences pattern
- Added missing comment about not saved flags

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Open Preferences
Mess around with search preferences
Reset search preferences
See preferences reset
Mess around with search flags full text or filter/float
Open Preferences
Reset preferences
See search flags reset

### AI usage

Claude Code (model claude-sonnet-4-6)

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
