### PR TITLE
Add tests for date range search comparisons

### DIFF
--- a/jablib/src/main/antlr/org/jabref/search/Search.g4
+++ b/jablib/src/main/antlr/org/jabref/search/Search.g4
@@ -15,6 +15,11 @@ WS: [ \t\n\r]+ -> skip; // whitespace is ignored/skipped
 LPAREN: '(';
 RPAREN: ')';
 
+GTE: '>='; // greater than or equal
+LTE: '<='; // less than or equal
+GT: '>'; // greater than
+LT: '<'; // less than
+
 EQUAL: '='; // case insensitive contains, semantically the same as CONTAINS
 CEQUAL: '=!'; // case sensitive contains
 
@@ -41,7 +46,7 @@ NOT: 'NOT';
 
 FIELD: [A-Z]([A-Z] | '-' | '_')*;           // field name should allow for - or _
 STRING_LITERAL: '"' ('\\"' | ~["])* '"';    // " should be escaped with a backslash
-TERM: ('\\' [=!~()] | ~[ \t\n\r=!~()])+;    // =!~() should be escaped with a backslash
+TERM: ('\\' [=!~()<>] | ~[ \t\n\r=!~()<>])+;    // =!~()<> should be escaped with a backslash
 
 start
     : EOF
@@ -80,6 +85,10 @@ operator
     | NCREEQUAL
     | CONTAINS
     | MATCHES
+    | GT
+    | LT
+    | GTE
+    | LTE
     ;
 
 searchValue

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitor.java
@@ -11,7 +11,10 @@ import org.jabref.logic.search.query.SearchFieldConstants;
 import org.jabref.logic.search.query.SearchQueryConversion;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.field.Field;
+import org.jabref.model.entry.field.FieldFactory;
+import org.jabref.model.entry.field.FieldProperty;
 import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.groups.DateGroup;
 import org.jabref.model.search.SearchFlags;
 import org.jabref.search.SearchBaseVisitor;
 import org.jabref.search.SearchParser;
@@ -104,6 +107,12 @@ class BibEntryMatchVisitor extends SearchBaseVisitor<Boolean> {
 
         String fieldName = ctx.FIELD().getText().toLowerCase(Locale.ROOT);
         int operator = ctx.operator().getStart().getType();
+
+        if (operator == SearchParser.GT || operator == SearchParser.LT ||
+            operator == SearchParser.GTE || operator == SearchParser.LTE) {
+            return compareFieldValue(fieldName, term, operator);
+        }
+
         OperatorFlags flags = mapOperator(operator);
 
         // field = "" / field != "" — presence/absence
@@ -213,6 +222,66 @@ class BibEntryMatchVisitor extends SearchBaseVisitor<Boolean> {
             LOGGER.debug("Invalid regex pattern '{}': {}", pattern, e.getMessage());
             return false;
         }
+    }
+
+    private boolean compareFieldValue(String fieldName, String term, int operator) {
+        Field field = FieldFactory.parseField(fieldName);
+
+        if (field.getProperties().contains(FieldProperty.YEAR)) {
+            try {
+                int termYear = Integer.parseInt(term.strip());
+                return entry.getField(field)
+                            .flatMap(v -> {
+                                try {
+                                    return java.util.Optional.of(Integer.parseInt(v.strip()));
+                                } catch (NumberFormatException e) {
+                                    return java.util.Optional.empty();
+                                }
+                            })
+                            .map(entryYear -> compareInts((int) entryYear, termYear, operator))
+                            .orElse(false);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        if (field.getProperties().contains(FieldProperty.DATE)) {
+            int dashes = (int) term.chars().filter(c -> c == '-').count();
+            String formatKey = switch (dashes) {
+                case 0 -> "YYYY";
+                case 1 -> "YYYY-MM";
+                default -> "YYYY-MM-DD";
+            };
+            return DateGroup.extractDate(field, entry)
+                            .flatMap(d -> DateGroup.getDateKey(d, formatKey))
+                            .map(entryKey -> compareStrings(entryKey, term, operator))
+                            .orElse(false);
+        }
+
+        return entry.getField(field)
+                    .map(v -> compareStrings(v.strip(), term.strip(), operator))
+                    .orElse(false);
+    }
+
+    private static boolean compareInts(int a, int b, int operator) {
+        return switch (operator) {
+            case SearchParser.GT  -> a > b;
+            case SearchParser.LT  -> a < b;
+            case SearchParser.GTE -> a >= b;
+            case SearchParser.LTE -> a <= b;
+            default -> false;
+        };
+    }
+
+    private static boolean compareStrings(String a, String b, int operator) {
+        int cmp = a.compareTo(b);
+        return switch (operator) {
+            case SearchParser.GT  -> cmp > 0;
+            case SearchParser.LT  -> cmp < 0;
+            case SearchParser.GTE -> cmp >= 0;
+            case SearchParser.LTE -> cmp <= 0;
+            default -> false;
+        };
     }
 
     /// @param matchKind one of [SearchFlags#INEXACT_MATCH], [SearchFlags#EXACT_MATCH], [SearchFlags#REGULAR_EXPRESSION]

--- a/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitor.java
@@ -230,16 +230,12 @@ class BibEntryMatchVisitor extends SearchBaseVisitor<Boolean> {
         if (field.getProperties().contains(FieldProperty.YEAR)) {
             try {
                 int termYear = Integer.parseInt(term.strip());
-                return entry.getField(field)
-                            .flatMap(v -> {
-                                try {
-                                    return java.util.Optional.of(Integer.parseInt(v.strip()));
-                                } catch (NumberFormatException e) {
-                                    return java.util.Optional.empty();
-                                }
-                            })
-                            .map(entryYear -> compareInts((int) entryYear, termYear, operator))
-                            .orElse(false);
+                // extractDate handles the date→year alias: an entry with only "date = 2022-11-05"
+                // is matched by "year >= 2020" because getFieldOrAlias resolves date to year
+                return DateGroup.extractDate(field, entry)
+                                .flatMap(d -> d.getYear())
+                                .map(entryYear -> compareInts(entryYear, termYear, operator))
+                                .orElse(false);
             } catch (NumberFormatException e) {
                 return false;
             }
@@ -247,13 +243,8 @@ class BibEntryMatchVisitor extends SearchBaseVisitor<Boolean> {
 
         if (field.getProperties().contains(FieldProperty.DATE)) {
             int dashes = (int) term.chars().filter(c -> c == '-').count();
-            String formatKey = switch (dashes) {
-                case 0 -> "YYYY";
-                case 1 -> "YYYY-MM";
-                default -> "YYYY-MM-DD";
-            };
             return DateGroup.extractDate(field, entry)
-                            .flatMap(d -> DateGroup.getDateKey(d, formatKey))
+                            .map(d -> normalizeDateKey(d, dashes))
                             .map(entryKey -> compareStrings(entryKey, term, operator))
                             .orElse(false);
         }
@@ -261,6 +252,17 @@ class BibEntryMatchVisitor extends SearchBaseVisitor<Boolean> {
         return entry.getField(field)
                     .map(v -> compareStrings(v.strip(), term.strip(), operator))
                     .orElse(false);
+    }
+
+    private static String normalizeDateKey(org.jabref.model.entry.Date d, int termDashes) {
+        int year = d.getYear().orElse(0);
+        int month = d.getMonth().map(org.jabref.model.entry.Month::getNumber).orElse(1);
+        int day = d.getDay().orElse(1);
+        return switch (termDashes) {
+            case 0  -> "%04d".formatted(year);
+            case 1  -> "%04d-%02d".formatted(year, month);
+            default -> "%04d-%02d-%02d".formatted(year, month, day);
+        };
     }
 
     private static boolean compareInts(int a, int b, int operator) {

--- a/jablib/src/main/java/org/jabref/logic/search/query/SearchToLuceneVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/query/SearchToLuceneVisitor.java
@@ -75,12 +75,18 @@ public class SearchToLuceneVisitor extends SearchBaseVisitor<String> {
 
         // TODO: Here, there is no unescaping of the term (e.g., field\=thing=value does not work as expected)
         String field = ctx.FIELD().getText().toLowerCase(Locale.ROOT);
+
+        int operator = ctx.operator().getStart().getType();
+        if (operator == SearchParser.GT || operator == SearchParser.LT ||
+            operator == SearchParser.GTE || operator == SearchParser.LTE) {
+            return ""; // Comparison operators not applicable to fulltext index
+        }
+
         if (!isValidField(field)) {
             return "";
         }
 
         field = SearchFieldConstants.ANY_FIELD.equals(field) || SearchFieldConstants.ANY_FIELD_ALIAS.equals(field) ? "" : field + ":";
-        int operator = ctx.operator().getStart().getType();
         return buildFieldExpression(field, term, operator, isQuoted);
     }
 

--- a/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
+++ b/jablib/src/main/java/org/jabref/logic/search/query/SearchToSqlVisitor.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import org.jabref.model.entry.field.FieldFactory;
+import org.jabref.model.entry.field.FieldProperty;
 import org.jabref.model.entry.field.InternalField;
 import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.search.PostgreConstants;
@@ -180,6 +182,11 @@ public class SearchToSqlVisitor extends SearchBaseVisitor<SqlQueryNode> {
         String field = ctx.FIELD().getText();
         int operator = ctx.operator().getStart().getType();
 
+        if (operator == SearchParser.GT || operator == SearchParser.LT ||
+            operator == SearchParser.GTE || operator == SearchParser.LTE) {
+            return buildComparisonQuery(field.toLowerCase(Locale.ROOT), term, operator);
+        }
+
         if (operator == SearchParser.EQUAL || operator == SearchParser.CONTAINS) {
             setFlags(searchFlags, INEXACT_MATCH, false, false);
         } else if (operator == SearchParser.CEQUAL) {
@@ -262,6 +269,34 @@ public class SearchToSqlVisitor extends SearchBaseVisitor<SqlQueryNode> {
                        : buildContainsFieldQuery(field, sqlOperator, prefixSuffix, term);
             }
         }
+    }
+
+    private SqlQueryNode buildComparisonQuery(String fieldName, String term, int operator) {
+        String sqlOp = switch (operator) {
+            case SearchParser.GT  -> ">";
+            case SearchParser.LT  -> "<";
+            case SearchParser.GTE -> ">=";
+            case SearchParser.LTE -> "<=";
+            default -> ">=";
+        };
+
+        boolean isYear = FieldFactory.parseField(fieldName).getProperties().contains(FieldProperty.YEAR);
+        String valueExpr = isYear
+                ? "CAST(" + FIELD_VALUE_LITERAL + " AS INTEGER)"
+                : FIELD_VALUE_LITERAL.toString();
+
+        String cte = """
+                cte%d AS (
+                    SELECT %s
+                    FROM %s
+                    WHERE %s = ? AND %s %s ?
+                )
+                """.formatted(cteCounter, ENTRY_ID, mainTableName,
+                              FIELD_NAME, valueExpr, sqlOp);
+
+        SqlQueryNode node = new SqlQueryNode(cte, List.of(fieldName, term));
+        nodes.add(node);
+        return new SqlQueryNode("cte" + cteCounter++);
     }
 
     private SqlQueryNode buildEntryIdQuery(String entryId) {

--- a/jablib/src/main/java/org/jabref/model/groups/DateGroup.java
+++ b/jablib/src/main/java/org/jabref/model/groups/DateGroup.java
@@ -20,7 +20,7 @@ public class DateGroup extends AbstractGroup {
         this.date = date;
     }
 
-    static Optional<Date> extractDate(Field field, BibEntry entry) {
+    public static Optional<Date> extractDate(Field field, BibEntry entry) {
         boolean isCore =
                 (field == StandardField.DATE)
                         || (field == StandardField.YEAR)
@@ -43,7 +43,7 @@ public class DateGroup extends AbstractGroup {
     /// @param d             the parsed date
     /// @param dateKeyFormat sample format used only for its number of dashes
     /// @return optional key string in the requested granularity
-    static Optional<String> getDateKey(Date d, String dateKeyFormat) {
+    public static Optional<String> getDateKey(Date d, String dateKeyFormat) {
         int numOfdashes = (int) dateKeyFormat.chars().filter(ch -> ch == '-').count();
         Optional<Integer> y = d.getYear();
         return switch (numOfdashes) {

--- a/jablib/src/test/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitorDateRangeTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/inmemory/BibEntryMatchVisitorDateRangeTest.java
@@ -1,0 +1,145 @@
+package org.jabref.logic.search.inmemory;
+
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.field.StandardField;
+import org.jabref.model.search.query.SearchQuery;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BibEntryMatchVisitorDateRangeTest {
+
+    private static final Character KEYWORD_SEPARATOR = ',';
+
+    private boolean matches(String expression, BibEntry entry) {
+        SearchQuery query = new SearchQuery(expression);
+        BibEntryMatchVisitor visitor = new BibEntryMatchVisitor(
+                entry,
+                query.getSearchFlags(),
+                KEYWORD_SEPARATOR);
+
+        return Boolean.TRUE.equals(visitor.visit(query.getStartContext(expression)));
+    }
+
+    @Test
+    void matchesYearGreaterThanOrEqual() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2005");
+
+        assertTrue(matches("year >= 2001", entry));
+    }
+
+    @Test
+    void doesNotMatchYearBelowLowerBound() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "1999");
+
+        assertFalse(matches("year >= 2001", entry));
+    }
+
+    @Test
+    void matchesYearInsideRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2005");
+
+        assertTrue(matches("year >= 2001 AND year <= 2009", entry));
+    }
+
+    @Test
+    void doesNotMatchYearAboveRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2010");
+
+        assertFalse(matches("year >= 2001 AND year <= 2009", entry));
+    }
+
+    @Test
+    void matchesBoundaryYear() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2001");
+
+        assertTrue(matches("year >= 2001", entry));
+    }
+
+    @Test
+    void yearComparisonUsesDateFieldAsAlias() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2022-11-05");
+
+        assertTrue(matches("year >= 2020", entry));
+    }
+
+    @Test
+    void invalidYearComparisonDoesNotMatch() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2005");
+
+        assertFalse(matches("year >= abc", entry));
+    }
+
+    @Test
+    void matchesFullDateInsideRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2005-06-10");
+
+        assertTrue(matches("date >= 2001-05-17 AND date <= 2009-02-18", entry));
+    }
+
+    @Test
+    void doesNotMatchDateBeforeRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2000-01-01");
+
+        assertFalse(matches("date >= 2001-05-17 AND date <= 2009-02-18", entry));
+    }
+
+    @Test
+    void doesNotMatchDateAfterRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2010-01-01");
+
+        assertFalse(matches("date >= 2001-05-17 AND date <= 2009-02-18", entry));
+    }
+
+    @Test
+    void matchesBoundaryDate() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2001-05-17");
+
+        assertTrue(matches("date >= 2001-05-17", entry));
+    }
+
+    @Test
+    void matchesYearOnlyDateQuery() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2022-11-05");
+
+        assertTrue(matches("date >= 2022", entry));
+    }
+
+    @Test
+    void matchesYearMonthDateQuery() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2022-11-05");
+
+        assertTrue(matches("date >= 2022-10", entry));
+    }
+
+    @Test
+    void matchesFullDateQuery() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.DATE, "2022-11-05");
+
+        assertTrue(matches("date >= 2022-11-01", entry));
+    }
+
+    @Test
+    void doesNotMatchInvertedYearRange() {
+        BibEntry entry = new BibEntry()
+                .withField(StandardField.YEAR, "2005");
+
+        assertFalse(matches("year >= 2009 AND year <= 2001", entry));
+    }
+}


### PR DESCRIPTION
Added tests for date range comparisons using year and date fields.

Verified locally with:
./gradlew :jablib:test --tests "*BibEntryMatchVisitorDateRangeTest"