### PR TITLE
Fix autolink and export preferences reset and import

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/SortCriterionViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/commonfxcontrols/SortCriterionViewModel.java
@@ -15,8 +15,8 @@ public class SortCriterionViewModel {
     private final BooleanProperty descendingProperty = new SimpleBooleanProperty();
 
     public SortCriterionViewModel(SaveOrder.SortCriterion criterion) {
-        this.fieldProperty.setValue(criterion.field);
-        this.descendingProperty.setValue(criterion.descending);
+        this.fieldProperty.setValue(criterion.field());
+        this.descendingProperty.setValue(criterion.descending());
     }
 
     public SortCriterionViewModel() {

--- a/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/JabRefGuiPreferences.java
@@ -47,6 +47,7 @@ import org.jabref.gui.theme.Theme;
 import org.jabref.logic.JabRefException;
 import org.jabref.logic.citationstyle.CSLStyleLoader;
 import org.jabref.logic.exporter.BibDatabaseWriter;
+import org.jabref.logic.exporter.ExportPreferences;
 import org.jabref.logic.exporter.SelfContainedSaveConfiguration;
 import org.jabref.logic.externalfiles.DateRange;
 import org.jabref.logic.externalfiles.ExternalFileSorter;
@@ -1219,7 +1220,7 @@ public class JabRefGuiPreferences extends JabRefCliPreferences implements GuiPre
 
     @Override
     public SelfContainedSaveConfiguration getSelfContainedExportConfiguration() {
-        SaveOrder exportSaveOrder = getExportSaveOrder();
+        SaveOrder exportSaveOrder = getExportSaveOrder(ExportPreferences.getDefault().getExportSaveOrder());
         SelfContainedSaveOrder saveOrder = switch (exportSaveOrder.getOrderType()) {
             case TABLE ->
                     this.getSelfContainedTableSaveOrder();

--- a/jabgui/src/main/java/org/jabref/gui/preferences/export/ExportTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/export/ExportTabViewModel.java
@@ -43,7 +43,7 @@ public class ExportTabViewModel implements PreferenceTabViewModel {
             case TABLE ->
                     exportInTableOrderProperty.setValue(true);
         }
-        sortCriteriaProperty.addAll(exportSaveOrder.getSortCriteria().stream()
+        sortCriteriaProperty.setAll(exportSaveOrder.getSortCriteria().stream()
                                                    .map(SortCriterionViewModel::new)
                                                    .toList());
 

--- a/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
+++ b/jabkit/src/main/java/org/jabref/toolkit/commands/GenerateCitationKeys.java
@@ -130,7 +130,7 @@ class GenerateCitationKeys implements Callable<Integer> {
                 keyPatternReplacement != null ? keyPatternReplacement : existingPreferences.getKeyPatternReplacement(),
                 unwantedCharacters != null ? unwantedCharacters : existingPreferences.getUnwantedCharacters(),
                 getKeyPatterns(keyPatterns, existingPreferences.getKeyPatterns()),
-                new SimpleObjectProperty<>(keywordDelimiter != null ? keywordDelimiter : existingPreferences.getKeywordDelimiter())
+                new SimpleObjectProperty<>(keywordDelimiter != null ? keywordDelimiter : existingPreferences.getKeywordSeparator())
         );
         return new CitationKeyGenerator(databaseContext, preferencesToUse);
     }

--- a/jablib/src/main/java/org/jabref/logic/bibtex/comparator/FieldComparator.java
+++ b/jablib/src/main/java/org/jabref/logic/bibtex/comparator/FieldComparator.java
@@ -37,7 +37,7 @@ public class FieldComparator implements Comparator<BibEntry> {
     }
 
     public FieldComparator(SaveOrder.SortCriterion sortCriterion) {
-        this(new OrFields(sortCriterion.field), sortCriterion.descending);
+        this(new OrFields(sortCriterion.field()), sortCriterion.descending());
     }
 
     public FieldComparator(OrFields fields, boolean descending) {

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyGenerator.java
@@ -236,7 +236,7 @@ public class CitationKeyGenerator extends BracketedPattern {
     /// @param entry the {@link BibEntry} that a citation key is generated for
     /// @return a cleaned citation key for the given {@link BibEntry}
     private Function<String, String> expandBracketContent(BibEntry entry) {
-        Character keywordDelimiter = citationKeyPatternPreferences.getKeywordDelimiter();
+        Character keywordDelimiter = citationKeyPatternPreferences.getKeywordSeparator();
 
         return (String bracket) -> {
             String expandedPattern;

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
@@ -30,7 +30,7 @@ public class CitationKeyPatternPreferences {
 
     private static final GlobalCitationKeyPatterns DEFAULT_CITATION_KEY_PATTERN = GlobalCitationKeyPatterns.fromPattern("[auth][year]");
 
-    private static final SimpleObjectProperty<Character> DEFAULT_KEYWORD_DELIMITER = new SimpleObjectProperty<>(',');
+    private static final SimpleObjectProperty<Character> DEFAULT_KEYWORD_SEPARATOR = new SimpleObjectProperty<>(',');
 
     private final BooleanProperty shouldTransliterateFieldsForCitationKey;
     private final BooleanProperty shouldAvoidOverwriteCiteKey;
@@ -41,9 +41,9 @@ public class CitationKeyPatternPreferences {
     private final StringProperty keyPatternReplacement;
     private final StringProperty unwantedCharacters;
     private final ObjectProperty<GlobalCitationKeyPatterns> keyPatterns;
-    private final SimpleObjectProperty<Character> keywordDelimiter;
+    private final SimpleObjectProperty<Character> keywordSeparator;
 
-    /// @param keywordDelimiter should always be BibEntryProperties#keyWordDelimiterProperty
+    /// @param keywordSeparator should always be BibEntryProperties#keyWordDelimiterProperty
     public CitationKeyPatternPreferences(boolean shouldTransliterateFieldsForCitationKey,
                                          boolean shouldAvoidOverwriteCiteKey,
                                          boolean shouldWarnBeforeOverwriteCiteKey,
@@ -53,7 +53,7 @@ public class CitationKeyPatternPreferences {
                                          String keyPatternReplacement,
                                          String unwantedCharacters,
                                          GlobalCitationKeyPatterns keyPatterns,
-                                         ReadOnlyObjectProperty<Character> keywordDelimiter) {
+                                         ReadOnlyObjectProperty<Character> keywordSeparator) {
 
         this.shouldTransliterateFieldsForCitationKey = new SimpleBooleanProperty(shouldTransliterateFieldsForCitationKey);
         this.shouldAvoidOverwriteCiteKey = new SimpleBooleanProperty(shouldAvoidOverwriteCiteKey);
@@ -65,8 +65,8 @@ public class CitationKeyPatternPreferences {
         this.unwantedCharacters = new SimpleStringProperty(unwantedCharacters);
         this.keyPatterns = new SimpleObjectProperty<>(keyPatterns);
 
-        this.keywordDelimiter = new SimpleObjectProperty<>();
-        this.keywordDelimiter.bind(keywordDelimiter);
+        this.keywordSeparator = new SimpleObjectProperty<>();
+        this.keywordSeparator.bind(keywordSeparator);
     }
 
     private CitationKeyPatternPreferences() {
@@ -83,7 +83,7 @@ public class CitationKeyPatternPreferences {
                 new SimpleObjectProperty<>()  // keywordDelimiter
         );
 
-        this.keywordDelimiter.bind(DEFAULT_KEYWORD_DELIMITER);
+        this.keywordSeparator.bind(DEFAULT_KEYWORD_SEPARATOR);
     }
 
     public static CitationKeyPatternPreferences getDefault() {
@@ -211,19 +211,15 @@ public class CitationKeyPatternPreferences {
         this.keyPatterns.set(keyPatterns);
     }
 
-    public Character getKeywordDelimiter() {
-        return keywordDelimiter.get();
+    public Character getKeywordSeparator() {
+        return keywordSeparator.get();
     }
 
-    public CitationKeyPatternPreferences withKeywordDelimiter(ReadOnlyObjectProperty<Character> newDelimiter) {
-        if (this.keywordDelimiter.isBound()) {
-            this.keywordDelimiter.unbind();
-        }
-
+    public CitationKeyPatternPreferences withKeywordSeparator(ReadOnlyObjectProperty<Character> newDelimiter) {
         if (newDelimiter == null) {
-            this.keywordDelimiter.bind(DEFAULT_KEYWORD_DELIMITER);
+            this.keywordSeparator.bind(DEFAULT_KEYWORD_SEPARATOR);
         } else {
-            this.keywordDelimiter.bind(newDelimiter);
+            this.keywordSeparator.bind(newDelimiter);
         }
 
         return this;

--- a/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/citationkeypattern/CitationKeyPatternPreferences.java
@@ -43,7 +43,7 @@ public class CitationKeyPatternPreferences {
     private final ObjectProperty<GlobalCitationKeyPatterns> keyPatterns;
     private final SimpleObjectProperty<Character> keywordSeparator;
 
-    /// @param keywordSeparator should always be BibEntryProperties#keyWordDelimiterProperty
+    /// @param keywordSeparator should always be org.jabref.model.entry.BibEntryPreferences#keywordSeparator
     public CitationKeyPatternPreferences(boolean shouldTransliterateFieldsForCitationKey,
                                          boolean shouldAvoidOverwriteCiteKey,
                                          boolean shouldWarnBeforeOverwriteCiteKey,

--- a/jablib/src/main/java/org/jabref/logic/exporter/ExportPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/ExportPreferences.java
@@ -46,7 +46,7 @@ public class ExportPreferences {
         this.lastExportExtension = new SimpleStringProperty(lastExportExtension);
         this.exportWorkingDirectory = new SimpleObjectProperty<>(exportWorkingDirectory);
         this.exportSaveOrder = new SimpleObjectProperty<>(exportSaveOrder);
-        this.customExporters = FXCollections.observableList(customExporters);
+        this.customExporters = FXCollections.observableArrayList(customExporters);
     }
 
     public static ExportPreferences getDefault() {

--- a/jablib/src/main/java/org/jabref/logic/exporter/ExportPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/exporter/ExportPreferences.java
@@ -10,14 +10,34 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import org.jabref.model.entry.field.InternalField;
+import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.metadata.SaveOrder;
 
 public class ExportPreferences {
+
+    private static final SaveOrder DEFAULT_EXPORT_SAVE_ORDER = new SaveOrder(
+            SaveOrder.OrderType.ORIGINAL,
+            List.of(
+                    new SaveOrder.SortCriterion(InternalField.KEY_FIELD, false),
+                    new SaveOrder.SortCriterion(StandardField.AUTHOR, false),
+                    new SaveOrder.SortCriterion(StandardField.TITLE, false)
+            )
+    );
 
     private final StringProperty lastExportExtension;
     private final ObjectProperty<Path> exportWorkingDirectory;
     private final ObjectProperty<SaveOrder> exportSaveOrder;
     private final ObservableList<TemplateExporter> customExporters;
+
+    private ExportPreferences() {
+        this(
+                "",                                       // Last export extension
+                Path.of(System.getProperty("user.home")), // Export working directory
+                DEFAULT_EXPORT_SAVE_ORDER,                // Export save order
+                List.of()                                 // Custom exporters
+        );
+    }
 
     public ExportPreferences(String lastExportExtension,
                              Path exportWorkingDirectory,
@@ -27,6 +47,17 @@ public class ExportPreferences {
         this.exportWorkingDirectory = new SimpleObjectProperty<>(exportWorkingDirectory);
         this.exportSaveOrder = new SimpleObjectProperty<>(exportSaveOrder);
         this.customExporters = FXCollections.observableList(customExporters);
+    }
+
+    public static ExportPreferences getDefault() {
+        return new ExportPreferences();
+    }
+
+    public void setAll(ExportPreferences preferences) {
+        this.lastExportExtension.set(preferences.getLastExportExtension());
+        this.exportWorkingDirectory.set(preferences.getExportWorkingDirectory());
+        this.exportSaveOrder.set(preferences.getExportSaveOrder());
+        this.customExporters.setAll(preferences.getCustomExporters());
     }
 
     public String getLastExportExtension() {
@@ -70,7 +101,6 @@ public class ExportPreferences {
     }
 
     public void setCustomExporters(List<TemplateExporter> exporters) {
-        customExporters.clear();
-        customExporters.addAll(exporters);
+        customExporters.setAll(exporters);
     }
 }

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -107,8 +107,6 @@ import org.jabref.model.entry.BibEntryType;
 import org.jabref.model.entry.BibEntryTypesManager;
 import org.jabref.model.entry.field.Field;
 import org.jabref.model.entry.field.FieldFactory;
-import org.jabref.model.entry.field.InternalField;
-import org.jabref.model.entry.field.StandardField;
 import org.jabref.model.entry.types.EntryType;
 import org.jabref.model.entry.types.EntryTypeFactory;
 import org.jabref.model.metadata.SaveOrder;
@@ -527,14 +525,6 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(EXPORT_IN_ORIGINAL_ORDER, Boolean.TRUE);
         defaults.put(EXPORT_IN_SPECIFIED_ORDER, Boolean.FALSE);
 
-        // export order: if EXPORT_IN_SPECIFIED_ORDER, then use following criteria
-        defaults.put(EXPORT_PRIMARY_SORT_FIELD, InternalField.KEY_FIELD.getName());
-        defaults.put(EXPORT_PRIMARY_SORT_DESCENDING, Boolean.FALSE);
-        defaults.put(EXPORT_SECONDARY_SORT_FIELD, StandardField.AUTHOR.getName());
-        defaults.put(EXPORT_SECONDARY_SORT_DESCENDING, Boolean.FALSE);
-        defaults.put(EXPORT_TERTIARY_SORT_FIELD, StandardField.TITLE.getName());
-        defaults.put(EXPORT_TERTIARY_SORT_DESCENDING, Boolean.FALSE);
-
         defaults.put(NEWLINE, System.lineSeparator());
 
         defaults.put(XMP_PRIVACY_FILTERS, "pdf;timestamp;keywords;owner;note;review");
@@ -894,6 +884,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getAutoLinkPreferences().setAll(
                 AutoLinkPreferences.getDefault()
                                    .withKeywordSeparator(getBibEntryPreferences().keywordSeparatorProperty()));
+        getExportPreferences().setAll(ExportPreferences.getDefault());
         getSSLPreferences().setAll(SSLPreferences.getDefault());
         getSearchPreferences().setAll(SearchPreferences.getDefault());
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences())).setAll(
@@ -927,6 +918,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getBibEntryPreferences().setAll(getBibEntryPreferencesFromBackingStore(getBibEntryPreferences()));
         getAiPreferences().setAll(getAiPreferencesFromBackingStore(getAiPreferences()));
         getAutoLinkPreferences().setAll(getAutoLinkPreferencesFromBackingStore(getAutoLinkPreferences()));
+        getExportPreferences().setAll(getExportPreferencesFromBackingStore(getExportPreferences()));
         getSSLPreferences().setAll(getSSLPreferencesFromBackingStore(getSSLPreferences()));
         getSearchPreferences().setAll(getSearchPreferencesFromBackingStore(getSearchPreferences()));
         JournalAbbreviationRepository repository = JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences());
@@ -1670,19 +1662,14 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
-    // region Import/Export preferences
-
+    // region ExportPreferences
     @Override
     public ExportPreferences getExportPreferences() {
         if (exportPreferences != null) {
             return exportPreferences;
         }
 
-        exportPreferences = new ExportPreferences(
-                get(LAST_USED_EXPORT),
-                Path.of(get(EXPORT_WORKING_DIRECTORY)),
-                getExportSaveOrder(),
-                getCustomExportFormats());
+        exportPreferences = getExportPreferencesFromBackingStore(ExportPreferences.getDefault());
 
         EasyBind.listen(exportPreferences.lastExportExtensionProperty(), (_, _, newValue) -> put(LAST_USED_EXPORT, newValue));
         EasyBind.listen(exportPreferences.exportWorkingDirectoryProperty(), (_, _, newValue) -> put(EXPORT_WORKING_DIRECTORY, newValue.toString()));
@@ -1692,21 +1679,43 @@ public class JabRefCliPreferences implements CliPreferences {
         return exportPreferences;
     }
 
-    protected SaveOrder getExportSaveOrder() {
+    private ExportPreferences getExportPreferencesFromBackingStore(ExportPreferences defaults) {
+        return new ExportPreferences(
+                get(LAST_USED_EXPORT, defaults.getLastExportExtension()),
+                Path.of(get(EXPORT_WORKING_DIRECTORY, defaults.getExportWorkingDirectory().toString())),
+                getExportSaveOrder(defaults.getExportSaveOrder()),
+                getCustomExportFormats(defaults.getCustomExporters()));
+    }
+
+    protected SaveOrder getExportSaveOrder(SaveOrder defaults) {
+        List<SaveOrder.SortCriterion> defaultCriteria = defaults.getSortCriteria();
         List<SaveOrder.SortCriterion> sortCriteria = new ArrayList<>();
 
-        if (!"".equals(get(EXPORT_PRIMARY_SORT_FIELD))) {
-            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(get(EXPORT_PRIMARY_SORT_FIELD)), getBoolean(EXPORT_PRIMARY_SORT_DESCENDING)));
+        String defaultPrimaryField = defaultCriteria.size() >= 1 ? defaultCriteria.get(0).field().getName() : "";
+        boolean defaultPrimaryDesc = defaultCriteria.size() >= 1 && defaultCriteria.get(0).descending();
+        String primaryField = get(EXPORT_PRIMARY_SORT_FIELD, defaultPrimaryField);
+        if (!"".equals(primaryField)) {
+            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(primaryField), getBoolean(EXPORT_PRIMARY_SORT_DESCENDING, defaultPrimaryDesc)));
         }
-        if (!"".equals(get(EXPORT_SECONDARY_SORT_FIELD))) {
-            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(get(EXPORT_SECONDARY_SORT_FIELD)), getBoolean(EXPORT_SECONDARY_SORT_DESCENDING)));
+
+        String defaultSecondaryField = defaultCriteria.size() >= 2 ? defaultCriteria.get(1).field().getName() : "";
+        boolean defaultSecondaryDesc = defaultCriteria.size() >= 2 && defaultCriteria.get(1).descending();
+        String secondaryField = get(EXPORT_SECONDARY_SORT_FIELD, defaultSecondaryField);
+        if (!"".equals(secondaryField)) {
+            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(secondaryField), getBoolean(EXPORT_SECONDARY_SORT_DESCENDING, defaultSecondaryDesc)));
         }
-        if (!"".equals(get(EXPORT_TERTIARY_SORT_FIELD))) {
-            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(get(EXPORT_TERTIARY_SORT_FIELD)), getBoolean(EXPORT_TERTIARY_SORT_DESCENDING)));
+
+        String defaultTertiaryField = defaultCriteria.size() >= 3 ? defaultCriteria.get(2).field().getName() : "";
+        boolean defaultTertiaryDesc = defaultCriteria.size() >= 3 && defaultCriteria.get(2).descending();
+        String tertiaryField = get(EXPORT_TERTIARY_SORT_FIELD, defaultTertiaryField);
+        if (!"".equals(tertiaryField)) {
+            sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(tertiaryField), getBoolean(EXPORT_TERTIARY_SORT_DESCENDING, defaultTertiaryDesc)));
         }
 
         return new SaveOrder(
-                SaveOrder.OrderType.fromBooleans(getBoolean(EXPORT_IN_SPECIFIED_ORDER), getBoolean(EXPORT_IN_ORIGINAL_ORDER)),
+                SaveOrder.OrderType.fromBooleans(
+                        getBoolean(EXPORT_IN_SPECIFIED_ORDER, defaults.getOrderType() == SaveOrder.OrderType.SPECIFIED),
+                        getBoolean(EXPORT_IN_ORIGINAL_ORDER, defaults.getOrderType() == SaveOrder.OrderType.ORIGINAL)),
                 sortCriteria
         );
     }
@@ -1717,22 +1726,22 @@ public class JabRefCliPreferences implements CliPreferences {
 
         long saveOrderCount = saveOrder.getSortCriteria().size();
         if (saveOrderCount >= 1) {
-            put(EXPORT_PRIMARY_SORT_FIELD, saveOrder.getSortCriteria().getFirst().field.getName());
-            putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, saveOrder.getSortCriteria().getFirst().descending);
+            put(EXPORT_PRIMARY_SORT_FIELD, saveOrder.getSortCriteria().get(0).field().getName());
+            putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(0).descending());
         } else {
             put(EXPORT_PRIMARY_SORT_FIELD, "");
             putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, false);
         }
         if (saveOrderCount >= 2) {
-            put(EXPORT_SECONDARY_SORT_FIELD, saveOrder.getSortCriteria().get(1).field.getName());
-            putBoolean(EXPORT_SECONDARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(1).descending);
+            put(EXPORT_SECONDARY_SORT_FIELD, saveOrder.getSortCriteria().get(1).field().getName());
+            putBoolean(EXPORT_SECONDARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(1).descending());
         } else {
             put(EXPORT_SECONDARY_SORT_FIELD, "");
             putBoolean(EXPORT_SECONDARY_SORT_DESCENDING, false);
         }
         if (saveOrderCount >= 3) {
-            put(EXPORT_TERTIARY_SORT_FIELD, saveOrder.getSortCriteria().get(2).field.getName());
-            putBoolean(EXPORT_TERTIARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(2).descending);
+            put(EXPORT_TERTIARY_SORT_FIELD, saveOrder.getSortCriteria().get(2).field().getName());
+            putBoolean(EXPORT_TERTIARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(2).descending());
         } else {
             put(EXPORT_TERTIARY_SORT_FIELD, "");
             putBoolean(EXPORT_TERTIARY_SORT_DESCENDING, false);
@@ -1742,7 +1751,7 @@ public class JabRefCliPreferences implements CliPreferences {
 
     @Override
     public SelfContainedSaveConfiguration getSelfContainedExportConfiguration() {
-        SaveOrder exportSaveOrder = getExportSaveOrder();
+        SaveOrder exportSaveOrder = getExportSaveOrder(ExportPreferences.getDefault().getExportSaveOrder());
         SelfContainedSaveOrder saveOrder = switch (exportSaveOrder.getOrderType()) {
             case TABLE -> {
                 LOGGER.warn("Table sort order requested, but JabRef is in CLI mode. Falling back to default save order");
@@ -1759,23 +1768,28 @@ public class JabRefCliPreferences implements CliPreferences {
                 .shouldAlwaysReformatOnSave());
     }
 
-    private List<TemplateExporter> getCustomExportFormats() {
+    private List<TemplateExporter> getCustomExportFormats(List<TemplateExporter> defaults) {
         LayoutFormatterPreferences layoutPreferences = getLayoutFormatterPreferences();
         SelfContainedSaveConfiguration saveConfiguration = getSelfContainedExportConfiguration();
-        List<TemplateExporter> formats = new ArrayList<>();
+        List<TemplateExporter> formatters = new ArrayList<>();
 
-        for (String toImport : getSeries(CUSTOM_EXPORT_FORMAT)) {
-            List<String> formatData = convertStringToList(toImport);
-            TemplateExporter format = new TemplateExporter(
+        List<String> rawFormats = getSeries(CUSTOM_EXPORT_FORMAT);
+        if (rawFormats.isEmpty()) {
+            return defaults;
+        }
+
+        for (String format : rawFormats) {
+            List<String> formatData = convertStringToList(format);
+            TemplateExporter exporter = new TemplateExporter(
                     formatData.get(EXPORTER_NAME_INDEX),
                     formatData.get(EXPORTER_FILENAME_INDEX),
                     formatData.get(EXPORTER_EXTENSION_INDEX),
                     layoutPreferences,
                     saveConfiguration.getSelfContainedSaveOrder());
-            format.setCustomExport(true);
-            formats.add(format);
+            exporter.setCustomExport(true);
+            formatters.add(exporter);
         }
-        return formats;
+        return formatters;
     }
 
     private void storeCustomExportFormats(List<TemplateExporter> exporters) {
@@ -1793,6 +1807,7 @@ public class JabRefCliPreferences implements CliPreferences {
             purgeSeries(CUSTOM_EXPORT_FORMAT, exporters.size());
         }
     }
+    // endregion
 
     // region Cleanup preferences
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -1691,8 +1691,8 @@ public class JabRefCliPreferences implements CliPreferences {
         List<SaveOrder.SortCriterion> defaultCriteria = defaults.getSortCriteria();
         List<SaveOrder.SortCriterion> sortCriteria = new ArrayList<>();
 
-        String defaultPrimaryField = defaultCriteria.size() >= 1 ? defaultCriteria.get(0).field().getName() : "";
-        boolean defaultPrimaryDesc = defaultCriteria.size() >= 1 && defaultCriteria.get(0).descending();
+        String defaultPrimaryField = !defaultCriteria.isEmpty() ? defaultCriteria.getFirst().field().getName() : "";
+        boolean defaultPrimaryDesc = !defaultCriteria.isEmpty() && defaultCriteria.getFirst().descending();
         String primaryField = get(EXPORT_PRIMARY_SORT_FIELD, defaultPrimaryField);
         if (!"".equals(primaryField)) {
             sortCriteria.add(new SaveOrder.SortCriterion(FieldFactory.parseField(primaryField), getBoolean(EXPORT_PRIMARY_SORT_DESCENDING, defaultPrimaryDesc)));
@@ -1726,8 +1726,8 @@ public class JabRefCliPreferences implements CliPreferences {
 
         long saveOrderCount = saveOrder.getSortCriteria().size();
         if (saveOrderCount >= 1) {
-            put(EXPORT_PRIMARY_SORT_FIELD, saveOrder.getSortCriteria().get(0).field().getName());
-            putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, saveOrder.getSortCriteria().get(0).descending());
+            put(EXPORT_PRIMARY_SORT_FIELD, saveOrder.getSortCriteria().getFirst().field().getName());
+            putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, saveOrder.getSortCriteria().getFirst().descending());
         } else {
             put(EXPORT_PRIMARY_SORT_FIELD, "");
             putBoolean(EXPORT_PRIMARY_SORT_DESCENDING, false);

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -561,16 +561,9 @@ public class JabRefCliPreferences implements CliPreferences {
 
         defaults.put(LAST_USED_EXPORT, "");
 
-        defaults.put(AUTOLINK_EXACT_KEY_ONLY, Boolean.FALSE);
-
-        defaults.put(ASK_AUTO_NAMING_PDFS_AGAIN, Boolean.TRUE);
         defaults.put(CLEANUP_JOBS, convertListToString(getDefaultCleanupJobs().stream().map(Enum::name).toList()));
         defaults.put(CLEANUP_FIELD_FORMATTERS_ENABLED, Boolean.FALSE);
         defaults.put(CLEANUP_FIELD_FORMATTERS, FieldFormatterCleanupActions.getMetaDataString(FieldFormatterCleanupActions.DEFAULT_SAVE_ACTIONS, OS.NEWLINE));
-
-        String defaultExpression = "**/.*[citationkey].*\\\\.[extension]";
-        defaults.put(AUTOLINK_REG_EXP_SEARCH_EXPRESSION_KEY, defaultExpression);
-        defaults.put(AUTOLINK_USE_REG_EXP_SEARCH_KEY, Boolean.FALSE);
 
         // Since some of the preference settings themselves use localized strings, we cannot set the language after
         // the initialization of the preferences in main
@@ -889,7 +882,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getBibEntryPreferences().setAll(BibEntryPreferences.getDefault());
         getCitationKeyPatternPreferences().setAll(
                 CitationKeyPatternPreferences.getDefault()
-                                             .withKeywordDelimiter(getBibEntryPreferences().keywordSeparatorProperty())
+                                             .withKeywordSeparator(getBibEntryPreferences().keywordSeparatorProperty())
         );
         getFilePreferences().setAll(FilePreferences.getDefault()
                                                    .withUserHostInfo(getInternalPreferences().getUserAndHostInfoProperty())
@@ -898,6 +891,9 @@ public class JabRefCliPreferences implements CliPreferences {
                                                    .withLastUsedDirectory(getDefaultPath())
         );
         getAiPreferences().setAll(AiPreferences.getDefault());
+        getAutoLinkPreferences().setAll(
+                AutoLinkPreferences.getDefault()
+                                   .withKeywordSeparator(getBibEntryPreferences().keywordSeparatorProperty()));
         getSSLPreferences().setAll(SSLPreferences.getDefault());
         getSearchPreferences().setAll(SearchPreferences.getDefault());
         getOpenOfficePreferences(JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences())).setAll(
@@ -930,6 +926,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getFilePreferences().setAll(getFilePreferencesFromBackingStore(getFilePreferences()));
         getBibEntryPreferences().setAll(getBibEntryPreferencesFromBackingStore(getBibEntryPreferences()));
         getAiPreferences().setAll(getAiPreferencesFromBackingStore(getAiPreferences()));
+        getAutoLinkPreferences().setAll(getAutoLinkPreferencesFromBackingStore(getAutoLinkPreferences()));
         getSSLPreferences().setAll(getSSLPreferencesFromBackingStore(getSSLPreferences()));
         getSearchPreferences().setAll(getSearchPreferencesFromBackingStore(getSearchPreferences()));
         JournalAbbreviationRepository repository = JournalAbbreviationLoader.loadRepository(getJournalAbbreviationPreferences());
@@ -1633,17 +1630,14 @@ public class JabRefCliPreferences implements CliPreferences {
     }
     // endregion
 
+    // region AutoLinkPreferences
     @Override
     public AutoLinkPreferences getAutoLinkPreferences() {
         if (autoLinkPreferences != null) {
             return autoLinkPreferences;
         }
 
-        autoLinkPreferences = new AutoLinkPreferences(
-                getAutoLinkKeyDependency(),
-                get(AUTOLINK_REG_EXP_SEARCH_EXPRESSION_KEY),
-                getBoolean(ASK_AUTO_NAMING_PDFS_AGAIN),
-                bibEntryPreferences.keywordSeparatorProperty());
+        autoLinkPreferences = getAutoLinkPreferencesFromBackingStore(AutoLinkPreferences.getDefault());
 
         EasyBind.listen(autoLinkPreferences.citationKeyDependencyProperty(), (_, _, newValue) -> {
             // Starts bibtex only omitted, as it is not being saved
@@ -1658,16 +1652,23 @@ public class JabRefCliPreferences implements CliPreferences {
         return autoLinkPreferences;
     }
 
-    private AutoLinkPreferences.CitationKeyDependency getAutoLinkKeyDependency() {
-        AutoLinkPreferences.CitationKeyDependency citationKeyDependency =
-                AutoLinkPreferences.CitationKeyDependency.START; // default
-        if (getBoolean(AUTOLINK_EXACT_KEY_ONLY)) {
-            citationKeyDependency = AutoLinkPreferences.CitationKeyDependency.EXACT;
-        } else if (getBoolean(AUTOLINK_USE_REG_EXP_SEARCH_KEY)) {
-            citationKeyDependency = AutoLinkPreferences.CitationKeyDependency.REGEX;
-        }
-        return citationKeyDependency;
+    private AutoLinkPreferences getAutoLinkPreferencesFromBackingStore(AutoLinkPreferences defaults) {
+        return new AutoLinkPreferences(
+                getAutoLinkKeyDependency(defaults.getCitationKeyDependency()),
+                get(AUTOLINK_REG_EXP_SEARCH_EXPRESSION_KEY, defaults.getRegularExpression()),
+                getBoolean(ASK_AUTO_NAMING_PDFS_AGAIN, defaults.shouldAskAutoNamingPdfs()),
+                bibEntryPreferences.keywordSeparatorProperty());
     }
+
+    private AutoLinkPreferences.CitationKeyDependency getAutoLinkKeyDependency(AutoLinkPreferences.CitationKeyDependency defaultDependency) {
+        if (getBoolean(AUTOLINK_EXACT_KEY_ONLY, defaultDependency == AutoLinkPreferences.CitationKeyDependency.EXACT)) {
+            return AutoLinkPreferences.CitationKeyDependency.EXACT;
+        } else if (getBoolean(AUTOLINK_USE_REG_EXP_SEARCH_KEY, defaultDependency == AutoLinkPreferences.CitationKeyDependency.REGEX)) {
+            return AutoLinkPreferences.CitationKeyDependency.REGEX;
+        }
+        return AutoLinkPreferences.CitationKeyDependency.START;
+    }
+    // endregion
 
     // region Import/Export preferences
 

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -1691,7 +1691,8 @@ public class JabRefCliPreferences implements CliPreferences {
         List<SaveOrder.SortCriterion> defaultCriteria = defaults.getSortCriteria();
         List<SaveOrder.SortCriterion> sortCriteria = new ArrayList<>();
 
-        String defaultPrimaryField = !defaultCriteria.isEmpty() ? defaultCriteria.getFirst().field().getName() : "";
+        // OpenRewrite requires strange rewritings, ideally should follow the pattern for SECONDARY and TERTIARY
+        String defaultPrimaryField = defaultCriteria.isEmpty() ? "" : defaultCriteria.getFirst().field().getName();
         boolean defaultPrimaryDesc = !defaultCriteria.isEmpty() && defaultCriteria.getFirst().descending();
         String primaryField = get(EXPORT_PRIMARY_SORT_FIELD, defaultPrimaryField);
         if (!"".equals(primaryField)) {

--- a/jablib/src/main/java/org/jabref/logic/util/io/AutoLinkPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/util/io/AutoLinkPreferences.java
@@ -16,19 +16,32 @@ public class AutoLinkPreferences {
         REGEX // Filenames matching a regular expression pattern
     }
 
+    private static final SimpleObjectProperty<Character> DEFAULT_KEYWORD_SEPARATOR = new SimpleObjectProperty<>(',');
+
     private final ObjectProperty<CitationKeyDependency> citationKeyDependency;
     private final StringProperty regularExpression;
     private final BooleanProperty askAutoNamingPdfs;
-    private final ReadOnlyObjectProperty<Character> keywordSeparator;
+    private final SimpleObjectProperty<Character> keywordSeparator;
+
+    private AutoLinkPreferences() {
+        this(
+                CitationKeyDependency.START,            // Citation key dependency
+                "**/.*[citationkey].*\\\\.[extension]", // Regular expression
+                true,                                   // Ask auto naming PDFs
+                DEFAULT_KEYWORD_SEPARATOR               // Keyword separator
+        );
+    }
 
     public AutoLinkPreferences(CitationKeyDependency citationKeyDependency,
                                String regularExpression,
                                boolean askAutoNamingPdfs,
-                               ObjectProperty<Character> keywordSeparatorProperty) {
+                               ReadOnlyObjectProperty<Character> keywordSeparatorProperty) {
         this.citationKeyDependency = new SimpleObjectProperty<>(citationKeyDependency);
         this.regularExpression = new SimpleStringProperty(regularExpression);
         this.askAutoNamingPdfs = new SimpleBooleanProperty(askAutoNamingPdfs);
-        this.keywordSeparator = keywordSeparatorProperty;
+
+        this.keywordSeparator = new SimpleObjectProperty<>();
+        this.keywordSeparator.bind(keywordSeparatorProperty);
     }
 
     /// For testing purpose
@@ -40,6 +53,16 @@ public class AutoLinkPreferences {
         this.regularExpression = new SimpleStringProperty(regularExpression);
         this.askAutoNamingPdfs = new SimpleBooleanProperty(askAutoNamingPdfs);
         this.keywordSeparator = new SimpleObjectProperty<>(keywordSeparator);
+    }
+
+    public static AutoLinkPreferences getDefault() {
+        return new AutoLinkPreferences();
+    }
+
+    public void setAll(AutoLinkPreferences preferences) {
+        this.citationKeyDependency.set(preferences.getCitationKeyDependency());
+        this.regularExpression.set(preferences.getRegularExpression());
+        this.askAutoNamingPdfs.set(preferences.shouldAskAutoNamingPdfs());
     }
 
     public CitationKeyDependency getCitationKeyDependency() {
@@ -80,5 +103,15 @@ public class AutoLinkPreferences {
 
     public Character getKeywordSeparator() {
         return keywordSeparator.getValue();
+    }
+
+    public AutoLinkPreferences withKeywordSeparator(ReadOnlyObjectProperty<Character> newSeparator) {
+        if (newSeparator == null) {
+            this.keywordSeparator.bind(DEFAULT_KEYWORD_SEPARATOR);
+        } else {
+            this.keywordSeparator.bind(newSeparator);
+        }
+
+        return this;
     }
 }

--- a/jablib/src/main/java/org/jabref/model/metadata/SaveOrder.java
+++ b/jablib/src/main/java/org/jabref/model/metadata/SaveOrder.java
@@ -115,23 +115,23 @@ public class SaveOrder {
 
     public record
     SortCriterion(Field field, boolean descending) {
-            /// Given field sorted ascending
-            public SortCriterion(Field field) {
-                this(field, false);
-            }
+        /// Given field sorted ascending
+        public SortCriterion(Field field) {
+            this(field, false);
+        }
 
-            /// @param field      The field
-            /// @param descending Must be a boolean value as string, e.g. "true", "false"
-            public SortCriterion(Field field, String descending) {
-                this(field, Boolean.parseBoolean(descending));
-            }
+        /// @param field      The field
+        /// @param descending Must be a boolean value as string, e.g. "true", "false"
+        public SortCriterion(Field field, String descending) {
+            this(field, Boolean.parseBoolean(descending));
+        }
 
         @Override
-            public @NonNull String toString() {
-                return "SortCriterion{" + "field='" + field + '\'' +
-                        ", descending=" + descending +
-                        '}';
-            }
+        public @NonNull String toString() {
+            return "SortCriterion{" + "field='" + field + '\'' +
+                    ", descending=" + descending +
+                    '}';
+        }
     }
 
     public enum OrderType {

--- a/jablib/src/main/java/org/jabref/model/metadata/SaveOrder.java
+++ b/jablib/src/main/java/org/jabref/model/metadata/SaveOrder.java
@@ -113,53 +113,25 @@ public class SaveOrder {
         return res;
     }
 
-    public static class SortCriterion {
-
-        public final Field field;
-
-        public final boolean descending;
-
-        /// Given field sorted ascending
-        public SortCriterion(Field field) {
-            this(field, false);
-        }
-
-        /// @param field      The field
-        /// @param descending Must be a boolean value as string, e.g. "true", "false"
-        public SortCriterion(Field field, String descending) {
-            this.field = field;
-            this.descending = Boolean.parseBoolean(descending);
-        }
-
-        public SortCriterion(Field field, boolean descending) {
-            this.field = field;
-            this.descending = descending;
-        }
-
-        @Override
-        public String toString() {
-            return "SortCriterion{" + "field='" + field + '\'' +
-                    ", descending=" + descending +
-                    '}';
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
+    public record
+    SortCriterion(Field field, boolean descending) {
+            /// Given field sorted ascending
+            public SortCriterion(Field field) {
+                this(field, false);
             }
-            if ((o == null) || (getClass() != o.getClass())) {
-                return false;
+
+            /// @param field      The field
+            /// @param descending Must be a boolean value as string, e.g. "true", "false"
+            public SortCriterion(Field field, String descending) {
+                this(field, Boolean.parseBoolean(descending));
             }
-            SortCriterion that = (SortCriterion) o;
-            return Objects.equals(descending, that.descending) &&
-                    Objects.equals(field, that.field);
-        }
 
         @Override
-        public int hashCode() {
-            return Objects.hash(field, descending);
-        }
+            public @NonNull String toString() {
+                return "SortCriterion{" + "field='" + field + '\'' +
+                        ", descending=" + descending +
+                        '}';
+            }
     }
 
     public enum OrderType {


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to #15862

### PR Description

- Fixed comments
- Migrated AutoLinkPreferences and ExportPreferences to new prefs pattern
- Converted SortCriterion to record
- Renamed KeywordDelimiter to KeywordSeparator in various places for consistency with AutoLinkPreferences (more precise, character between keywords, delimiter is more general, could also mean the quotes at beginning and end of a string)
- Reworded some variables for clarification
- Fix bug in ui

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run JabRef
Open Preferences
Mess around with AutoLinkPreferences and ExportPreferences
Save
Reopen
Reset
See preferences reset

### AI usage

"Claude Code (model claude-sonnet-4-6)"

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
