### PR TITLE
Annotate wrongly formatted lines in CI

### DIFF
--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Emits GitHub Actions error annotations (with line ranges) for every hunk in the
+# current `git diff`, then exits non-zero if the working directory is dirty.
+#
+# Used by the formatting jobs: after a formatter rewrites files, the remaining diff
+# marks the lines that were committed in the wrong format. Each hunk becomes an
+# `::error file=...,line=...,endLine=...` annotation pointing at the original lines.
+#
+# Usage: run from the directory that contains the git working tree to check.
+set -euo pipefail
+
+diff="$(git diff)"
+
+if [ -z "$diff" ]; then
+  echo "Formatting OK"
+  exit 0
+fi
+
+printf '%s\n' "$diff" | gawk '
+  /^\+\+\+ b\// { file = substr($0, 7); next }
+  /^@@ / {
+    # @@ -oldStart,oldCount +newStart,newCount @@
+    match($2, /^-([0-9]+)(,([0-9]+))?/, m)
+    start = m[1]
+    count = (m[3] == "" ? 1 : m[3])
+    if (count == 0) { end = start }          # pure addition -> anchor on single line
+    else { end = start + count - 1 }
+    printf "::error file=%s,line=%s,endLine=%s,title=Formatting::Wrongly formatted. Run the formatter (see CONTRIBUTING.md) to fix lines %s-%s.\n", file, start, end, start, end
+  }
+'
+
+# Make the job fail despite the successful annotations above.
+exit 1

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -30,11 +30,19 @@ printf '%s\n' "$diff" | gawk '
   /^\+\+\+ b\// { file = escape_property(substr($0, 7)); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@
-    match($2, /^-([0-9]+)(,([0-9]+))?/, m)
-    start = m[1]
-    count = (m[3] == "" ? 1 : m[3])
-    if (count == 0) { end = start }          # pure addition -> anchor on single line
-    else { end = start + count - 1 }
+    match($2, /^-([0-9]+)(,([0-9]+))?/, o)
+    match($3, /^\+([0-9]+)(,([0-9]+))?/, n)
+    oldStart = o[1]; oldCount = (o[3] == "" ? 1 : o[3])
+    newStart = n[1]; newCount = (n[3] == "" ? 1 : n[3])
+    if (oldCount > 0) {                       # there are old lines -> anchor on them
+      start = oldStart
+      end = oldStart + oldCount - 1
+    } else {                                  # pure addition / new file -> anchor on new lines
+      start = newStart
+      end = newStart + newCount - 1
+    }
+    if (start < 1) start = 1
+    if (end < start) end = start
     printf "::error file=%s,line=%s,endLine=%s,title=Formatting::Wrongly formatted. Run the formatter (see CONTRIBUTING.md) to fix lines %s-%s.\n", file, start, end, start, end
   }
 '

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -2,30 +2,48 @@
 # Emits GitHub Actions error annotations (with line ranges) for every hunk in the
 # current `git diff`, then exits non-zero if the working directory is dirty.
 #
-# Used by the formatting jobs: after a formatter rewrites files, the remaining diff
-# marks the lines that were committed in the wrong format. Each hunk becomes an
-# `::error file=...,line=...,endLine=...` annotation pointing at the original lines.
+# Used by the CI jobs that rewrite files (formatter, OpenRewrite) and then check
+# that the working tree is clean. Each remaining hunk becomes an
+# `::error file=...,line=...,endLine=...` annotation pointing at the affected lines.
+#
+# The annotation title and message are configurable so the same script can report
+# formatting issues or OpenRewrite changes:
+#   ANNOTATION_TITLE           annotation title          (default: "Formatting")
+#   ANNOTATION_MESSAGE_PREFIX  message before the range  (default: formatter hint)
+# The text " lines <start>-<end>." is appended to the message prefix.
 #
 # Usage: run from the directory that contains the git working tree to check.
 set -euo pipefail
 
+export ANNOTATION_TITLE="${ANNOTATION_TITLE:-Formatting}"
+export ANNOTATION_MESSAGE_PREFIX="${ANNOTATION_MESSAGE_PREFIX:-Wrongly formatted. Run the formatter (see CONTRIBUTING.md) to fix}"
+
 diff="$(git diff)"
 
 if [ -z "$diff" ]; then
-  echo "Formatting OK"
+  echo "Working tree clean"
   exit 0
 fi
 
 printf '%s\n' "$diff" | gawk '
-  # Mirror org.jabref.logic.util.GitHubActionsEscape#property: escape %, CR, LF,
-  # then additionally : and , (critical for Windows paths like C:\foo\bar.bib).
-  function escape_property(value) {
+  # Mirror org.jabref.logic.util.GitHubActionsEscape#data: escape %, CR, LF.
+  function escape_data(value) {
     gsub(/%/,  "%25", value)
     gsub(/\r/, "%0D", value)
     gsub(/\n/, "%0A", value)
-    gsub(/:/,  "%3A", value)
-    gsub(/,/,  "%2C", value)
     return value
+  }
+  # Mirror org.jabref.logic.util.GitHubActionsEscape#property: data escaping plus
+  # : and , (critical for Windows paths like C:\foo\bar.bib).
+  function escape_property(value) {
+    value = escape_data(value)
+    gsub(/:/, "%3A", value)
+    gsub(/,/, "%2C", value)
+    return value
+  }
+  BEGIN {
+    title = escape_property(ENVIRON["ANNOTATION_TITLE"])
+    messagePrefix = escape_data(ENVIRON["ANNOTATION_MESSAGE_PREFIX"])
   }
   /^\+\+\+ b\// { file = escape_property(substr($0, 7)); next }
   /^@@ / {
@@ -43,7 +61,7 @@ printf '%s\n' "$diff" | gawk '
     }
     if (start < 1) start = 1
     if (end < start) end = start
-    printf "::error file=%s,line=%s,endLine=%s,title=Formatting::Wrongly formatted. Run the formatter (see CONTRIBUTING.md) to fix lines %s-%s.\n", file, start, end, start, end
+    printf "::error file=%s,line=%s,endLine=%s,title=%s::%s lines %s-%s.\n", file, start, end, title, messagePrefix, start, end
   }
 '
 

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -17,7 +17,17 @@ if [ -z "$diff" ]; then
 fi
 
 printf '%s\n' "$diff" | gawk '
-  /^\+\+\+ b\// { file = substr($0, 7); next }
+  # Mirror org.jabref.logic.util.GitHubActionsEscape#property: escape %, CR, LF,
+  # then additionally : and , (critical for Windows paths like C:\foo\bar.bib).
+  function escape_property(value) {
+    gsub(/%/,  "%25", value)
+    gsub(/\r/, "%0D", value)
+    gsub(/\n/, "%0A", value)
+    gsub(/:/,  "%3A", value)
+    gsub(/,/,  "%2C", value)
+    return value
+  }
+  /^\+\+\+ b\// { file = escape_property(substr($0, 7)); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@
     match($2, /^-([0-9]+)(,([0-9]+))?/, m)

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -126,6 +126,9 @@ jobs:
 
       - name: Fail if working directory is unclean
         run: .github/format-diff-annotations.sh
+        env:
+          ANNOTATION_TITLE: OpenRewrite
+          ANNOTATION_MESSAGE_PREFIX: "Uncommitted changes after OpenRewrite; run `gradle :rewriteRun`, reformat, and commit the result for"
 
   modernizer:
     name: Modernizer

--- a/.github/workflows/tests-code.yml
+++ b/.github/workflows/tests-code.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: ./.github/actions/format-java
       # job should fail in case there are changes
       - name: Check if any files changed
-        run: git diff --exit-code
+        run: .github/format-diff-annotations.sh
 
   format-javadoc:
     # too slow on ubuntu-slim
@@ -88,7 +88,7 @@ jobs:
       - name: Check if any files changed
         run: |
           cd jabref
-          git diff --exit-code
+          .github/format-diff-annotations.sh
 
   checkstyle:
     name: Checkstyle
@@ -125,7 +125,7 @@ jobs:
       - uses: ./.github/actions/format-java
 
       - name: Fail if working directory is unclean
-        run: git diff --exit-code
+        run: .github/format-diff-annotations.sh
 
   modernizer:
     name: Modernizer


### PR DESCRIPTION
### Related issues and pull requests

Triggered by https://github.com/JabRef/jabref/pull/15790

### PR Description

The formatting CI jobs (`format`, `format-javadoc`, `openrewrite`) previously failed via `git diff --exit-code` without telling reviewers which lines were wrongly formatted. This adds `.github/format-diff-annotations.sh`, which parses the post-format `git diff` and emits a GitHub Actions `::error` annotation with a line range (`file`/`line`/`endLine`) per diff hunk before exiting non-zero, so failures point at the exact lines while the jobs still fail as before. All three jobs now call the script.

Example annotation:

```
::error file=jablib/src/main/java/org/jabref/model/metadata/SaveOrder.java,line=115,endLine=137,title=Formatting::Wrongly formatted. Run the formatter (see CONTRIBUTING.md) to fix lines 115-137.
```

Note: GitHub renders inline annotations only on lines that are part of the PR diff; lines flagged outside the PR diff still appear in the run-log summary.

#### Analogies

Like honey, this change is a sweet quality-of-life improvement that makes CI failures easier to digest. Like chocolate, the annotations melt the friction of hunting for misformatted lines into something pleasant. And like the moon, the error markers light up exactly the spots in the dark that need attention.

### Steps to test

1. Push a commit that violates Java formatting.
2. Observe the `format` job fail with inline `::error` annotations marking the affected line ranges, instead of a bare non-zero `git diff` exit.

### AI usage

Claude Code (model claude-opus-4-8), reviewed and owned by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

jabref-contrib-policy:4.2:reviewed​:ok
