### PR TITLE
Potential fix for code scanning alert no. 131: Artifact poisoning

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -68,8 +68,21 @@ jobs:
             exit 0
           fi
 
-          PR_NUMBER="$(tr -d '[:space:]' < "$ARTIFACT_FILE")"
-          if ! echo "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+          if ! IFS= read -r PR_NUMBER < "$ARTIFACT_FILE"; then
+            echo "Invalid PR number in artifact"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER="${PR_NUMBER%$'\r'}"
+
+          if sed -n '2,$p' "$ARTIFACT_FILE" | grep -q '^'; then
+            echo "Invalid PR number in artifact"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "Invalid PR number in artifact"
             echo "pr_number=" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -53,6 +53,7 @@ jobs:
         continue-on-error: true
         with:
           name: pr_number
+          path: ${{ runner.temp }}/pr-artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
@@ -60,11 +61,23 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: read-pr_number
         run: |
-          touch pr_number.txt
-          PR_NUMBER=$(cat pr_number.txt)
+          ARTIFACT_FILE="${{ runner.temp }}/pr-artifacts/pr_number.txt"
+          if [ ! -f "$ARTIFACT_FILE" ]; then
+            echo "No pr_number.txt found in downloaded artifact"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER="$(tr -d '[:space:]' < "$ARTIFACT_FILE")"
+          if ! echo "$PR_NUMBER" | grep -Eq '^[0-9]+$'; then
+            echo "Invalid PR number in artifact"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "Read PR number $PR_NUMBER"
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "PR #" >> $GITHUB_STEP_SUMMARY
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "PR #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout
         # required for gh tool and .github/ghprcomment.yml


### PR DESCRIPTION
Potential fix for [https://github.com/JabRef/jabref/security/code-scanning/131](https://github.com/JabRef/jabref/security/code-scanning/131)

To fix artifact poisoning safely without changing intended behavior:

1. **Download artifact into a temp directory** (e.g., `${{ runner.temp }}/pr-artifacts`) instead of the repository workspace.
2. **Read `pr_number.txt` only from that temp directory**.
3. **Validate** the artifact content strictly (numeric PR number) before using it.
4. Keep existing gating/logic intact.

In `.github/workflows/pr-comment.yml`:
- Update the **“Download PR number”** step (`with:` block) to set `path: ${{ runner.temp }}/pr-artifacts`.
- Update the **“Read pr_number.txt”** step to read from `${{ runner.temp }}/pr-artifacts/pr_number.txt`, fail closed on invalid content, and only output a validated numeric value.

No new imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
