### PR TITLE
Fix typo

### DIFF
--- a/docs/code-howtos/dependency-management.md
+++ b/docs/code-howtos/dependency-management.md
@@ -3,7 +3,7 @@ parent: Code Howtos
 ---
 # Dependency management
 
-The structrue and dependency management in the JabRef project uses the
+The structure and dependency management in the JabRef project uses the
 [Java Module System (JPMS)](https://www.oracle.com/corporate/features/understanding-java-9-modules.html)
 as the primary system for defining _modules_ and their _dependencies_. For a smooth integration of JPMS and Gradle's
 dependency management, the `org.gradlex.java-module-dependencies` plugin, and the additional notations it provides, are
@@ -55,8 +55,7 @@ If you use a 3rd party module like `tools.jackson.databind`, a version for that 
 be selected. For this, the `versions/build.gradle.kts`
 defines a so-called _Gradle platform_ (also called BOM) that contains the versions of all 3rd party
 modules used. If you want to upgrade the version of a module, do this here. If you need to use a new 3rd party module
-in a `src/main/java/module-info.java` file, you need to
-add the version here.
+in a `src/main/java/module-info.java` file, you need to add the version here.
 (If the new module is not completely JPMS compatible, you may also need to add or modify
 [patching rules](#patching-3rd-party-modules)).
 

--- a/docs/code-howtos/dependency-management.md
+++ b/docs/code-howtos/dependency-management.md
@@ -76,10 +76,10 @@ If an issue in this area occurs after modifying dependency versions, you will se
 ```
 
 In these cases, first determine if adding the new 3rd party module is really needed/intended.
-If yes, there are three levels of patching that can be performed:
+If yes, there are three levels of mapping/patching that can be performed:
 
 1. Add missing mapping to `modules.properties`:
-   In case the module is a real Java module, but not loaded by Gradle, you need it to put the mapping into `gradle/modules.properties`.
+   In case the module is a real Java module, but not found by Gradle, you need to put a mapping from the _Module Name_ to the _Maven Coordinates_ (`group:name`) into `gradle/modules.properties`.
    Furthermore, if it is a module available on Maven Central, file a pull request against [java-module-dependencies/.../modules.properties](https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties)
 2. Add missing (or modify existing) `module-info.class`:
    This is done through the `org.gradlex.extra-java-module-info` plugin.

--- a/docs/code-howtos/dependency-management.md
+++ b/docs/code-howtos/dependency-management.md
@@ -78,7 +78,7 @@ If an issue in this area occurs after modifying dependency versions, you will se
 In these cases, first determine if adding the new 3rd party module is really needed/intended.
 If yes, there are three levels of patching that can be performed:
 
-1. Add missing mappint to `modules.properties`:
+1. Add missing mapping to `modules.properties`:
    In case the module is a real java module, but not loaded by gradle, you need it to put the mapping into `gradle/modules.properties`.
    Furthermore, if it is a module available on Maven Central, file a pull request against [java-module-dependencies/.../modules.properties](https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties)
 2. Add missing (or modify existing) `module-info.class`:

--- a/docs/code-howtos/dependency-management.md
+++ b/docs/code-howtos/dependency-management.md
@@ -79,7 +79,7 @@ In these cases, first determine if adding the new 3rd party module is really nee
 If yes, there are three levels of patching that can be performed:
 
 1. Add missing mapping to `modules.properties`:
-   In case the module is a real java module, but not loaded by gradle, you need it to put the mapping into `gradle/modules.properties`.
+   In case the module is a real Java module, but not loaded by Gradle, you need it to put the mapping into `gradle/modules.properties`.
    Furthermore, if it is a module available on Maven Central, file a pull request against [java-module-dependencies/.../modules.properties](https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties)
 2. Add missing (or modify existing) `module-info.class`:
    This is done through the `org.gradlex.extra-java-module-info` plugin.

--- a/docs/code-howtos/dependency-management.md
+++ b/docs/code-howtos/dependency-management.md
@@ -76,15 +76,18 @@ If an issue in this area occurs after modifying dependency versions, you will se
 ```
 
 In these cases, first determine if adding the new 3rd party module is really needed/intended.
-If yes, there are two levels of patching that can be performed:
+If yes, there are three levels of patching that can be performed:
 
-1. Add missing (or modify existing) `module-info.class`:
+1. Add missing mappint to `modules.properties`:
+   In case the module is a real java module, but not loaded by gradle, you need it to put the mapping into `gradle/modules.properties`.
+   Furthermore, if it is a module available on Maven Central, file a pull request against [java-module-dependencies/.../modules.properties](https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties)
+2. Add missing (or modify existing) `module-info.class`:
    This is done through the `org.gradlex.extra-java-module-info` plugin.
    Often it is sufficient to add a simple entry for the affected library. For example, to address the error
    above, you can add `module("javax.inject:javax.inject", "javax.inject")` to the `extraJavaModuleInfo` block.
    For more details, refer to the
    [org.gradlex.extra-java-module-info plugin documentation](https://github.com/gradlex-org/extra-java-module-info).
-2. Adjust metadata (POM file) of dependency:
+3. Adjust metadata (POM file) of dependency:
    This is required to solve more severe issues with the metadata of a library using the Gradle concept of
    _Component Metadata Rules_. For a convenient definition of such rules, we use the `patch` notation provided by the
    `org.gradlex.jvm-dependency-conflict-resolution` plugin.


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Improve dependency management howto wording and patching guidance
<code>📝 Documentation</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

:) 

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fix spelling and tighten wording in dependency management documentation.
• Clarify that version additions are required when introducing new JPMS modules.
• Expand guidance from two to three mapping/patching levels, adding <b><i>modules.properties</i></b> mapping
  step.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["dependency-management.md"] --> B["gradle/modules.properties"] --> C["JPMS module mapping"]
  A --> D["extra-java-module-info plugin"] --> E["module-info.class patching"]
  A --> F["Component Metadata Rules"] --> G["POM metadata fixes"]

  subgraph Legend
    direction LR
    _doc["Doc"] ~~~ _cfg["Gradle config"] ~~~ _mech["Mechanism"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR’s approach (tighten wording and explicitly document the missing mapping step before patching) is appropriate for a docs-only change. Alternatives like adding more examples or screenshots could help, but aren’t necessary for this incremental improvement.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>dependency-management.md</strong> <code>Fix typo and expand JPMS dependency troubleshooting steps</code> <code>+8/-6</code></summary>

<br/>

>Fix typo and expand JPMS dependency troubleshooting steps
>
><pre>
>• Fixes a spelling error and consolidates a wrapped sentence for readability. Updates the troubleshooting section to describe three levels of mapping/patching, adding explicit guidance to map module names in &#x27;gradle/modules.properties&#x27; and upstream the mapping to gradlex when applicable.
></pre>
>
><a href='https://github.com/JabRef/jabref/pull/15876/files#diff-60b0c0b6ba909e080892201722bf5d83740899a2bf243954f2faaec35e8e9ba6'>docs/code-howtos/dependency-management.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>