### PR TITLE
Annotate only changed lines in CI formatting check

### DIFF
--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -45,28 +45,37 @@ printf '%s\n' "$diff" | gawk '
     title = escape_property(ENVIRON["ANNOTATION_TITLE"])
     messagePrefix = escape_data(ENVIRON["ANNOTATION_MESSAGE_PREFIX"])
   }
-  # Emit one annotation per contiguous run of changed lines, anchored on the
-  # old-side line numbers. The old side is the committed file the developer
-  # has to fix, so those are the line numbers worth pointing at. Context lines
-  # padded around each hunk are skipped, so the range matches the actual edit
-  # rather than the whole `@@` hunk.
+  # Emit one annotation per contiguous run of changed lines. A run that touches
+  # any old-side line (a removal, or a removal+addition reformat) is anchored on
+  # the old-side range: the committed line the developer has to fix. A run with
+  # only additions (`@@ -X,0 +Y,N @@` insertions) has no old-side line to point
+  # at, so it is anchored on the new-side range instead. Context lines padded
+  # around each hunk are skipped, so the range matches the actual edit rather
+  # than the whole `@@` hunk.
   function flush(  s, e) {
     if (!inRun) return
-    s = runStart; e = runEnd
+    if (hasOld) { s = oldStartLine; e = oldEndLine }
+    else        { s = newStartLine; e = newEndLine }
     if (e < s) e = s
     if (s < 1) s = 1
     printf "::error file=%s,line=%s,endLine=%s,title=%s::%s lines %s-%s.\n", file, s, e, title, messagePrefix, s, e
-    inRun = 0
+    inRun = 0; hasOld = 0; hasNew = 0
   }
   /^diff --git / { flush(); inHunk = 0; next }
-  /^--- /        { next }          # old-file header
+  # Old-file header. For deletions the new-file header is "+++ /dev/null", so the
+  # old side ("--- a/...") is the only place the path appears. Annotations are
+  # anchored on old-side line numbers anyway, so this is the right path to point at.
+  /^--- a\//     { flush(); inHunk = 0; file = escape_property(substr($0, 7)); next }
+  /^--- /        { next }          # "--- /dev/null" (new file); path comes from "+++ b/"
   /^index /      { next }
   /^\+\+\+ b\//  { flush(); inHunk = 0; file = escape_property(substr($0, 7)); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@
     flush()
     match($2, /^-([0-9]+)/, o)
+    match($3, /^\+([0-9]+)/, n)
     oldLine = o[1]
+    newLine = n[1]
     inHunk = 1
     next
   }
@@ -74,16 +83,21 @@ printf '%s\n' "$diff" | gawk '
     if (!inHunk) next
     c = substr($0, 1, 1)
     if (c == "-") {                           # removed/changed committed line
-      if (!inRun) { inRun = 1; runStart = oldLine }
-      runEnd = oldLine
+      inRun = 1
+      if (!hasOld) { hasOld = 1; oldStartLine = oldLine }
+      oldEndLine = oldLine
       oldLine++
-    } else if (c == "+") {                    # added line: does not consume an old line
-      if (!inRun) { inRun = 1; runStart = oldLine; runEnd = oldLine }
+    } else if (c == "+") {                    # added line: consumes a new-side line only
+      inRun = 1
+      if (!hasNew) { hasNew = 1; newStartLine = newLine }
+      newEndLine = newLine
+      newLine++
     } else if (c == "\\") {                   # "\ No newline at end of file"
       # ignore
     } else {                                  # context line -> ends the current run
       flush()
       oldLine++
+      newLine++
     }
   }
   END { flush() }

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -58,17 +58,17 @@ printf '%s\n' "$diff" | gawk '
     else        { s = newStartLine; e = newEndLine }
     if (e < s) e = s
     if (s < 1) s = 1
-    printf "::error file=%s,line=%s,endLine=%s,title=%s::%s lines %s-%s.\n", file, s, e, title, messagePrefix, s, e
+    printf "::error file=%s,line=%s,endLine=%s,title=%s::%s in file %s, lines %s-%s.\n", file, s, e, title, messagePrefix, escape_data(fileRaw), s, e
     inRun = 0; hasOld = 0; hasNew = 0
   }
   /^diff --git / { flush(); inHunk = 0; next }
   # Old-file header. For deletions the new-file header is "+++ /dev/null", so the
   # old side ("--- a/...") is the only place the path appears. Annotations are
   # anchored on old-side line numbers anyway, so this is the right path to point at.
-  /^--- a\//     { flush(); inHunk = 0; file = escape_property(substr($0, 7)); next }
+  /^--- a\//     { flush(); inHunk = 0; fileRaw = substr($0, 7); file = escape_property(fileRaw); next }
   /^--- /        { next }          # "--- /dev/null" (new file); path comes from "+++ b/"
   /^index /      { next }
-  /^\+\+\+ b\//  { flush(); inHunk = 0; file = escape_property(substr($0, 7)); next }
+  /^\+\+\+ b\//  { flush(); inHunk = 0; fileRaw = substr($0, 7); file = escape_property(fileRaw); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@
     flush()

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -52,8 +52,18 @@ printf '%s\n' "$diff" | gawk '
   # at, so it is anchored on the new-side range instead. Context lines padded
   # around each hunk are skipped, so the range matches the actual edit rather
   # than the whole `@@` hunk.
+  # git quotes paths containing unusual characters (e.g. spaces) in the diff
+  # headers: --- "a/config/Eclipse Code Style.epf". Strip the surrounding quote
+  # and undo the C-style backslash escaping git applies inside it.
+  function unquote(s) {
+    sub(/"$/, "", s)        # trailing quote
+    gsub(/\\"/, "\"", s)    # \" -> "
+    gsub(/\\\\/, "\\", s)   # \\ -> \
+    return s
+  }
   function flush(  s, e) {
     if (!inRun) return
+    if (file == "") { inRun = 0; hasOld = 0; hasNew = 0; return }
     if (hasOld) { s = oldStartLine; e = oldEndLine }
     else        { s = newStartLine; e = newEndLine }
     if (e < s) e = s
@@ -61,13 +71,16 @@ printf '%s\n' "$diff" | gawk '
     printf "::error file=%s,line=%s,endLine=%s,title=%s::%s in file %s, lines %s-%s.\n", file, s, e, title, messagePrefix, escape_data(fileRaw), s, e
     inRun = 0; hasOld = 0; hasNew = 0
   }
-  /^diff --git / { flush(); inHunk = 0; next }
+  # Reset the path so an unrecognized header can't reuse the previous file's name.
+  /^diff --git / { flush(); inHunk = 0; file = ""; fileRaw = ""; next }
   # Old-file header. For deletions the new-file header is "+++ /dev/null", so the
   # old side ("--- a/...") is the only place the path appears. Annotations are
   # anchored on old-side line numbers anyway, so this is the right path to point at.
+  /^--- "a\// { flush(); inHunk = 0; fileRaw = unquote(substr($0, 8)); file = escape_property(fileRaw); next }
   /^--- a\//     { flush(); inHunk = 0; fileRaw = substr($0, 7); file = escape_property(fileRaw); next }
   /^--- /        { next }          # "--- /dev/null" (new file); path comes from "+++ b/"
   /^index /      { next }
+  /^\+\+\+ "b\// { flush(); inHunk = 0; fileRaw = unquote(substr($0, 8)); file = escape_property(fileRaw); next }
   /^\+\+\+ b\//  { flush(); inHunk = 0; fileRaw = substr($0, 7); file = escape_property(fileRaw); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@

--- a/.github/format-diff-annotations.sh
+++ b/.github/format-diff-annotations.sh
@@ -45,24 +45,48 @@ printf '%s\n' "$diff" | gawk '
     title = escape_property(ENVIRON["ANNOTATION_TITLE"])
     messagePrefix = escape_data(ENVIRON["ANNOTATION_MESSAGE_PREFIX"])
   }
-  /^\+\+\+ b\// { file = escape_property(substr($0, 7)); next }
+  # Emit one annotation per contiguous run of changed lines, anchored on the
+  # old-side line numbers. The old side is the committed file the developer
+  # has to fix, so those are the line numbers worth pointing at. Context lines
+  # padded around each hunk are skipped, so the range matches the actual edit
+  # rather than the whole `@@` hunk.
+  function flush(  s, e) {
+    if (!inRun) return
+    s = runStart; e = runEnd
+    if (e < s) e = s
+    if (s < 1) s = 1
+    printf "::error file=%s,line=%s,endLine=%s,title=%s::%s lines %s-%s.\n", file, s, e, title, messagePrefix, s, e
+    inRun = 0
+  }
+  /^diff --git / { flush(); inHunk = 0; next }
+  /^--- /        { next }          # old-file header
+  /^index /      { next }
+  /^\+\+\+ b\//  { flush(); inHunk = 0; file = escape_property(substr($0, 7)); next }
   /^@@ / {
     # @@ -oldStart,oldCount +newStart,newCount @@
-    match($2, /^-([0-9]+)(,([0-9]+))?/, o)
-    match($3, /^\+([0-9]+)(,([0-9]+))?/, n)
-    oldStart = o[1]; oldCount = (o[3] == "" ? 1 : o[3])
-    newStart = n[1]; newCount = (n[3] == "" ? 1 : n[3])
-    if (oldCount > 0) {                       # there are old lines -> anchor on them
-      start = oldStart
-      end = oldStart + oldCount - 1
-    } else {                                  # pure addition / new file -> anchor on new lines
-      start = newStart
-      end = newStart + newCount - 1
-    }
-    if (start < 1) start = 1
-    if (end < start) end = start
-    printf "::error file=%s,line=%s,endLine=%s,title=%s::%s lines %s-%s.\n", file, start, end, title, messagePrefix, start, end
+    flush()
+    match($2, /^-([0-9]+)/, o)
+    oldLine = o[1]
+    inHunk = 1
+    next
   }
+  {
+    if (!inHunk) next
+    c = substr($0, 1, 1)
+    if (c == "-") {                           # removed/changed committed line
+      if (!inRun) { inRun = 1; runStart = oldLine }
+      runEnd = oldLine
+      oldLine++
+    } else if (c == "+") {                    # added line: does not consume an old line
+      if (!inRun) { inRun = 1; runStart = oldLine; runEnd = oldLine }
+    } else if (c == "\\") {                   # "\ No newline at end of file"
+      # ignore
+    } else {                                  # context line -> ends the current run
+      flush()
+      oldLine++
+    }
+  }
+  END { flush() }
 '
 
 # Make the job fail despite the successful annotations above.


### PR DESCRIPTION
### Related issues and pull requests

Triggered by annotations at https://github.com/JabRef/jabref/pull/15790

### PR Description

`.github/format-diff-annotations.sh` anchored each GitHub Actions error annotation on the whole git diff hunk (`oldStart` + `oldCount`), so the reported range included the context lines git pads around every change — a one-line formatting fix was reported as e.g. "lines 113-119". The script now walks the hunk body and emits one annotation per contiguous run of changed lines, anchored on old-side line numbers (the committed lines the developer actually fixes); a single hunk with two separate edits now yields two precise annotations. Also added `diff --git` / `--- ` / `index` guards so the `--- a/…` header line is not mistaken for removed content.

#### Analogies

Like honey, this change distills something sprawling down to its concentrated, useful core — the exact lines that matter. Like chocolate, the annotations are now broken into clean, individual squares rather than one undivided block. And like the moon, the script now reflects only the precise surface that was touched, no longer washing the whole hunk in borrowed light.

jabref-contrib-policy:4.2:reviewed​:ok

### Steps to test

1. Introduce a formatting violation on a single line and run the formatter in CI (or run `.github/format-diff-annotations.sh` against a dirty tree).
2. Confirm the emitted `::error` annotation points at the changed line(s) only, not the surrounding context lines.

### AI usage

Claude Code (model claude-opus-4-8). Code reviewed, understood, and owned by the contributor.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [/] I checked the user documentation for up to dateness
