### PR TITLE
refactor(ai): put migrations into task and lower their logging level

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/AiService.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/AiService.java
@@ -32,6 +32,7 @@ import org.jabref.logic.ai.summarization.migration.SummariesMigrationV1;
 import org.jabref.logic.ai.summarization.repositories.MVStoreSummariesRepository;
 import org.jabref.logic.ai.summarization.repositories.SummariesRepository;
 import org.jabref.logic.ai.summarization.util.SummarizatorFactory;
+import org.jabref.logic.util.BackgroundTask;
 import org.jabref.logic.util.Directories;
 import org.jabref.logic.util.NotificationService;
 import org.jabref.logic.util.ObservablesHelper;
@@ -51,6 +52,7 @@ public class AiService implements AutoCloseable {
     private static final String FULLY_INGESTED_FILE_NAME = "fully-ingested.mv";
     private static final String SUMMARIES_FILE_NAME = "summaries.mv";
 
+    private final TaskExecutor taskExecutor;
     private final NotificationService notificationService;
 
     // Chatting components
@@ -81,6 +83,7 @@ public class AiService implements AutoCloseable {
             NotificationService notificationService,
             TaskExecutor taskExecutor
     ) {
+        this.taskExecutor = taskExecutor;
         this.notificationService = notificationService;
 
         // Chatting components
@@ -152,7 +155,8 @@ public class AiService implements AutoCloseable {
 
         if (!isDummyContext) {
             ensureAiLibraryIdPresent(context);
-            migrateDatabase(context);
+            BackgroundTask.wrap(() -> migrateDatabase(context))
+                          .executeWith(taskExecutor);
         }
     }
 

--- a/jablib/src/main/java/org/jabref/logic/ai/chatting/migrations/ChatHistoryMigrationV1.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/chatting/migrations/ChatHistoryMigrationV1.java
@@ -126,7 +126,7 @@ public final class ChatHistoryMigrationV1 {
                 return;
             }
 
-            LOGGER.info("Starting migration of {} chat history maps from v1 to v2", oldMapNames.size());
+            LOGGER.debug("Starting migration of {} chat history maps from v1 to v2", oldMapNames.size());
 
             for (String oldMapName : oldMapNames) {
                 try {
@@ -138,7 +138,7 @@ public final class ChatHistoryMigrationV1 {
                 }
             }
 
-            LOGGER.info("Successfully migrated {} of {} chat history maps",
+            LOGGER.debug("Successfully migrated {} of {} chat history maps",
                     migratedMapNames.size(), oldMapNames.size());
         } catch (Exception e) {
             LOGGER.error("Failed to migrate chat history from v1 to v2", e);

--- a/jablib/src/main/java/org/jabref/logic/ai/summarization/migration/SummariesMigrationV1.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/summarization/migration/SummariesMigrationV1.java
@@ -132,7 +132,7 @@ public final class SummariesMigrationV1 {
                 return;
             }
 
-            LOGGER.info("Starting migration of {} summaries from v1 to v2", oldMap.size());
+            LOGGER.debug("Starting migration of {} summaries from v1 to v2", oldMap.size());
 
             int migratedCount = 0;
             int failedCount = 0;
@@ -167,7 +167,7 @@ public final class SummariesMigrationV1 {
                 }
             }
 
-            LOGGER.info("Successfully migrated {} summaries, {} failed", migratedCount, failedCount);
+            LOGGER.debug("Successfully migrated {} summaries, {} failed", migratedCount, failedCount);
         } catch (Exception e) {
             LOGGER.error("Failed to migrate summaries from v1 to v2", e);
             notificationService.notify(Localization.lang("Failed to migrate AI summaries. See logs for details."));


### PR DESCRIPTION
### Related issues and pull requests

No related issue.

### PR Description

Just does 2 things:

1. Lowers the logging level for the AI migrations.
2. Puts AI migrations in a background task.

It's not the best approach (it should 1) log when a migration really happened, 2) perform migrations when needed), but for now, I think it solves the problem.

### Steps to test

1. Open JabRef (and wait till it fully loads).
2. See that there are no logs that clutter everything.
3. The startup time should decrease.

### AI usage

With proudness, NONE.

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [/] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [x] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
