### PR TITLE
Fix ImporterPreferences reset and import

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTabViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/preferences/websearch/WebSearchTabViewModel.java
@@ -254,6 +254,7 @@ public class WebSearchTabViewModel implements PreferenceTabViewModel {
                                                      .map(fetcherViewModel -> new FetcherApiKey(fetcherViewModel.getName(), fetcherViewModel.shouldUseCustomApiKey(), fetcherViewModel.getApiKey()))
                                                      .toList();
 
+        // Must be set before keys are set
         importerPreferences.setPersistCustomKeys(apikeyPersistProperty.get());
         importerPreferences.getApiKeys().clear();
         if (apikeyPersistAvailableProperty.get()) {

--- a/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
@@ -2,6 +2,7 @@ package org.jabref.logic.importer;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -17,9 +18,20 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 
+import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
+import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
+import org.jabref.logic.importer.fetcher.BiodiversityLibrary;
+import org.jabref.logic.importer.fetcher.DBLPFetcher;
+import org.jabref.logic.importer.fetcher.IEEE;
+import org.jabref.logic.importer.fetcher.Scopus;
+import org.jabref.logic.importer.fetcher.SpringerNatureWebFetcher;
+import org.jabref.logic.importer.fetcher.WileyFetcher;
+import org.jabref.logic.importer.fetcher.citation.semanticscholar.SemanticScholarCitationFetcher;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
 import org.jabref.logic.preferences.FetcherApiKey;
+import org.jabref.logic.util.BuildInfo;
+import org.jabref.logic.util.Directories;
 
 public class ImporterPreferences {
     private final BooleanProperty importerEnabled;
@@ -27,7 +39,6 @@ public class ImporterPreferences {
     private final BooleanProperty warnAboutDuplicatesOnImport;
     private final ObjectProperty<Path> importWorkingDirectory;
     private final ObservableSet<FetcherApiKey> apiKeys;
-    private final Map<String, String> defaultApiKeys;
     private final ObservableSet<CustomImporter> customImporters;
     private final BooleanProperty persistCustomKeys;
     private final ObservableList<String> catalogs;
@@ -35,13 +46,31 @@ public class ImporterPreferences {
     private final IntegerProperty citationsRelationsStoreTTL;
     private final Map<String, String> searchEngineUrlTemplates;
 
+    private ImporterPreferences() {
+        this(
+                true,                                          // Importers enabled
+                true,                                          // Generate new key on import
+                Directories.getUserDirectory(),                // Import working directory
+                true,                                          // Warn about duplicates on import
+                Set.of(),                                      // Custom importers
+                Set.of(),                                      // API keys
+                false,                                         // Persist custom keys
+                List.of(ACMPortalFetcher.FETCHER_NAME,         // Catalogs
+                        SpringerNatureWebFetcher.FETCHER_NAME,
+                        DBLPFetcher.FETCHER_NAME,
+                        IEEE.FETCHER_NAME),
+                PlainCitationParserChoice.RULE_BASED_GENERAL,  // Default plain citation parser
+                30,                                            // Citations relations store TTL
+                Map.of()                                       // Search engine URL templates
+        );
+    }
+
     public ImporterPreferences(boolean importerEnabled,
                                boolean generateNewKeyOnImport,
                                Path importWorkingDirectory,
                                boolean warnAboutDuplicatesOnImport,
                                Set<CustomImporter> customImporters,
                                Set<FetcherApiKey> apiKeys,
-                               Map<String, String> defaultApiKeys,
                                boolean persistCustomKeys,
                                List<String> catalogs,
                                PlainCitationParserChoice defaultPlainCitationParser,
@@ -52,14 +81,52 @@ public class ImporterPreferences {
         this.generateNewKeyOnImport = new SimpleBooleanProperty(generateNewKeyOnImport);
         this.importWorkingDirectory = new SimpleObjectProperty<>(importWorkingDirectory);
         this.warnAboutDuplicatesOnImport = new SimpleBooleanProperty(warnAboutDuplicatesOnImport);
-        this.customImporters = FXCollections.observableSet(customImporters);
-        this.apiKeys = FXCollections.observableSet(apiKeys);
-        this.defaultApiKeys = defaultApiKeys;
+        this.customImporters = FXCollections.observableSet(new HashSet<>(customImporters));
+        this.apiKeys = FXCollections.observableSet(new HashSet<>(apiKeys));
         this.persistCustomKeys = new SimpleBooleanProperty(persistCustomKeys);
         this.catalogs = FXCollections.observableArrayList(catalogs);
         this.defaultPlainCitationParser = new SimpleObjectProperty<>(defaultPlainCitationParser);
         this.citationsRelationsStoreTTL = new SimpleIntegerProperty(citationsRelationsStoreTTL);
         this.searchEngineUrlTemplates = new HashMap<>(searchEngineUrlTemplates);
+    }
+
+    public static ImporterPreferences getDefault() {
+        ImporterPreferences preferences = new ImporterPreferences();
+        preferences.setApiKeys(new HashSet<>(getDefaultFetcherKeys()
+                .entrySet().stream()
+                .map(entry -> new FetcherApiKey(entry.getKey(), false, entry.getValue()))
+                .toList()));
+        return preferences;
+    }
+
+    private static Map<String, String> getDefaultFetcherKeys() {
+        // To avoid including a heavy dependency tree with the current dependency injector of afterburner.fx, we
+        // instantiate "BuildInfo" directly.
+        BuildInfo buildInfo = new BuildInfo();
+
+        return Map.of(
+                AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey,
+                BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey,
+                Scopus.FETCHER_NAME, buildInfo.scopusApiKey,
+                SemanticScholarCitationFetcher.FETCHER_NAME, buildInfo.semanticScholarApiKey,
+                // SpringerLink uses the same key and fetcher name as SpringerFetcher
+                SpringerNatureWebFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey,
+                WileyFetcher.FETCHER_NAME, buildInfo.wileyTdmApiKey
+        );
+    }
+
+    public void setAll(ImporterPreferences preferences) {
+        this.importerEnabled.set(preferences.areImporterEnabled());
+        this.generateNewKeyOnImport.set(preferences.shouldGenerateNewKeyOnImport());
+        this.importWorkingDirectory.set(preferences.getImportWorkingDirectory());
+        this.warnAboutDuplicatesOnImport.set(preferences.shouldWarnAboutDuplicatesOnImport());
+        setCustomImporters(preferences.getCustomImporters());
+        setApiKeys(preferences.getApiKeys());
+        this.persistCustomKeys.set(preferences.shouldPersistCustomKeys());
+        this.catalogs.setAll(preferences.getCatalogs());
+        this.defaultPlainCitationParser.set(preferences.getDefaultPlainCitationParser());
+        this.citationsRelationsStoreTTL.set(preferences.getCitationsRelationsStoreTTL());
+        setSearchEngineUrlTemplates(preferences.getSearchEngineUrlTemplates());
     }
 
     public boolean areImporterEnabled() {
@@ -110,6 +177,11 @@ public class ImporterPreferences {
         this.warnAboutDuplicatesOnImport.set(warnAboutDuplicatesOnImport);
     }
 
+    public void setApiKeys(Set<FetcherApiKey> apiKeys) {
+        this.apiKeys.clear();
+        this.apiKeys.addAll(apiKeys);
+    }
+
     public ObservableSet<FetcherApiKey> getApiKeys() {
         return apiKeys;
     }
@@ -144,12 +216,11 @@ public class ImporterPreferences {
                       .filter(FetcherApiKey::shouldUse)
                       .findFirst()
                       .map(FetcherApiKey::getKey)
-                      .or(() -> Optional.ofNullable(defaultApiKeys.get(name)));
+                      .or(() -> Optional.ofNullable(getDefaultFetcherKeys().get(name)));
     }
 
     public void setCatalogs(List<String> catalogs) {
-        this.catalogs.clear();
-        this.catalogs.addAll(catalogs);
+        this.catalogs.setAll(catalogs);
     }
 
     public ObservableList<String> getCatalogs() {

--- a/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/ImporterPreferences.java
@@ -121,8 +121,8 @@ public class ImporterPreferences {
         this.importWorkingDirectory.set(preferences.getImportWorkingDirectory());
         this.warnAboutDuplicatesOnImport.set(preferences.shouldWarnAboutDuplicatesOnImport());
         setCustomImporters(preferences.getCustomImporters());
+        this.persistCustomKeys.set(preferences.shouldPersistCustomKeys()); // Before getApiKeys to avoid stale keys in keyring
         setApiKeys(preferences.getApiKeys());
-        this.persistCustomKeys.set(preferences.shouldPersistCustomKeys());
         this.catalogs.setAll(preferences.getCatalogs());
         this.defaultPlainCitationParser.set(preferences.getDefaultPlainCitationParser());
         this.citationsRelationsStoreTTL.set(preferences.getCitationsRelationsStoreTTL());

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -53,15 +53,6 @@ import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.git.preferences.GitPreferences;
 import org.jabref.logic.importer.ImportException;
 import org.jabref.logic.importer.ImporterPreferences;
-import org.jabref.logic.importer.fetcher.ACMPortalFetcher;
-import org.jabref.logic.importer.fetcher.AstrophysicsDataSystem;
-import org.jabref.logic.importer.fetcher.BiodiversityLibrary;
-import org.jabref.logic.importer.fetcher.DBLPFetcher;
-import org.jabref.logic.importer.fetcher.IEEE;
-import org.jabref.logic.importer.fetcher.Scopus;
-import org.jabref.logic.importer.fetcher.SpringerNatureWebFetcher;
-import org.jabref.logic.importer.fetcher.WileyFetcher;
-import org.jabref.logic.importer.fetcher.citation.semanticscholar.SemanticScholarCitationFetcher;
 import org.jabref.logic.importer.fileformat.CustomImporter;
 import org.jabref.logic.importer.plaincitation.PlainCitationParserChoice;
 import org.jabref.logic.importer.util.GrobidPreferences;
@@ -89,7 +80,6 @@ import org.jabref.logic.remote.RemotePreferences;
 import org.jabref.logic.search.SearchPreferences;
 import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.shared.security.Password;
-import org.jabref.logic.util.BuildInfo;
 import org.jabref.logic.util.Version;
 import org.jabref.logic.util.io.AutoLinkPreferences;
 import org.jabref.logic.util.io.FileHistory;
@@ -164,7 +154,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String XMP_PRIVACY_FILTERS = "xmpPrivacyFilters";
     public static final String USE_XMP_PRIVACY_FILTER = "useXmpPrivacyFilter";
 
-    public static final String IMPORT_WORKING_DIRECTORY = "importWorkingDirectory";
     public static final String LAST_USED_EXPORT = "lastUsedExport";
     public static final String EXPORT_WORKING_DIRECTORY = "exportWorkingDirectory";
     public static final String WORKING_DIRECTORY = "workingDirectory";
@@ -213,7 +202,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String DUPLICATE_RESOLVER_DECISION_RESULT_ALL_ENTRIES = "duplicateResolverDecisionResult";
 
     public static final String CUSTOM_EXPORT_FORMAT = "customExportFormat";
-    public static final String CUSTOM_IMPORT_FORMAT = "customImportFormat";
 
     public static final String MAIN_FILE_DIRECTORY = "fileDirectory";
 
@@ -227,11 +215,6 @@ public class JabRefCliPreferences implements CliPreferences {
     public static final String SEARCH_WINDOW_HEIGHT = "searchWindowHeight";
     public static final String SEARCH_WINDOW_WIDTH = "searchWindowWidth";
     public static final String SEARCH_WINDOW_DIVIDER_POS = "searchWindowDividerPos";
-    public static final String SEARCH_CATALOGS = "searchCatalogs";
-    public static final String DEFAULT_PLAIN_CITATION_PARSER = "defaultPlainCitationParser";
-    public static final String CITATIONS_RELATIONS_STORE_TTL = "citationsRelationsStoreTTL";
-    public static final String IMPORTERS_ENABLED = "importersEnabled";
-    public static final String GENERATE_KEY_ON_IMPORT = "generateKeyOnImport";
     public static final String GROBID_ENABLED = "grobidEnabled";
     public static final String GROBID_PREFERENCE = "grobidPreference";
     public static final String GROBID_URL = "grobidURL";
@@ -309,8 +292,6 @@ public class JabRefCliPreferences implements CliPreferences {
     // String delimiter
     public static final Character STRINGLIST_DELIMITER = ';';
 
-    protected static final String WARN_ABOUT_DUPLICATES_IN_INSPECTION = "warnAboutDuplicatesInInspection";
-
     // Helper string
     protected static final String USER_HOME = System.getProperty("user.home");
 
@@ -332,11 +313,6 @@ public class JabRefCliPreferences implements CliPreferences {
     // PROXY_PASSWORD = "proxyPassword" handled by KeyRing
     private static final String PROXY_PERSIST_PASSWORD = "persistPassword";
     // endregion
-
-    // Web search
-    private static final String FETCHER_CUSTOM_KEY_NAMES = "fetcherCustomKeyNames";
-    private static final String FETCHER_CUSTOM_KEY_USES = "fetcherCustomKeyUses";
-    private static final String FETCHER_CUSTOM_KEY_PERSIST = "fetcherCustomKeyPersist";
 
     // SSL
     private static final String SSL_TRUSTSTORE_PATH = "truststorePath";
@@ -436,6 +412,20 @@ public class JabRefCliPreferences implements CliPreferences {
     );
     // endregion
 
+    // region ImporterPreferences
+    private static final String IMPORTER_ENABLED = "importersEnabled";
+    private static final String IMPORTER_GENERATE_KEY_ON_IMPORT = "generateKeyOnImport";
+    private static final String IMPORTER_WORKING_DIRECTORY = "importWorkingDirectory";
+    private static final String IMPORTER_WARN_ABOUT_DUPLICATES = "warnAboutDuplicatesInInspection";
+    private static final String IMPORTER_CUSTOM_FORMAT = "customImportFormat";
+    private static final String FETCHER_CUSTOM_KEY_NAMES = "fetcherCustomKeyNames";
+    private static final String FETCHER_CUSTOM_KEY_USES = "fetcherCustomKeyUses";
+    private static final String FETCHER_CUSTOM_KEY_PERSIST = "fetcherCustomKeyPersist";
+    private static final String IMPORTER_CATALOGS = "searchCatalogs";
+    private static final String IMPORTER_DEFAULT_PLAIN_CITATION_PARSER = "defaultPlainCitationParser";
+    private static final String IMPORTER_CITATIONS_RELATIONS_STORE_TTL = "citationsRelationsStoreTTL";
+    // endregion
+
     // region Git
     private static final String GITHUB_PAT_KEY = "githubPersonalAccessToken";
     private static final String GITHUB_USERNAME_KEY = "githubUsername";
@@ -495,16 +485,6 @@ public class JabRefCliPreferences implements CliPreferences {
             LOGGER.warn("Could not import preferences from jabref.xml", e);
         }
 
-        defaults.put(SEARCH_CATALOGS, convertListToString(List.of(
-                ACMPortalFetcher.FETCHER_NAME,
-                SpringerNatureWebFetcher.FETCHER_NAME,
-                DBLPFetcher.FETCHER_NAME,
-                IEEE.FETCHER_NAME)));
-        defaults.put(DEFAULT_PLAIN_CITATION_PARSER, PlainCitationParserChoice.RULE_BASED_GENERAL.name());
-        defaults.put(IMPORTERS_ENABLED, Boolean.TRUE);
-        defaults.put(GENERATE_KEY_ON_IMPORT, Boolean.TRUE);
-        defaults.put(CITATIONS_RELATIONS_STORE_TTL, 30);
-
         // region Grobid
         defaults.put(GROBID_ENABLED, Boolean.FALSE);
         defaults.put(GROBID_PREFERENCE, Boolean.FALSE);
@@ -533,21 +513,12 @@ public class JabRefCliPreferences implements CliPreferences {
         defaults.put(EXPORT_WORKING_DIRECTORY, USER_HOME);
         defaults.put(LAST_USED_DIRECTORY, getDefaultPath().toString());
 
-        // Remembers working directory of last import
-        defaults.put(IMPORT_WORKING_DIRECTORY, USER_HOME);
-
         defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());
 
         defaults.put(PROTECTED_TERMS_ENABLED_INTERNAL, convertListToString(ProtectedTermsLoader.getInternalLists()));
         defaults.put(PROTECTED_TERMS_DISABLED_INTERNAL, "");
         defaults.put(PROTECTED_TERMS_ENABLED_EXTERNAL, "");
         defaults.put(PROTECTED_TERMS_DISABLED_EXTERNAL, "");
-
-        defaults.put(FETCHER_CUSTOM_KEY_NAMES, "Springer;IEEEXplore;SAO/NASA ADS;ScienceDirect;Biodiversity Heritage");
-        defaults.put(FETCHER_CUSTOM_KEY_USES, "FALSE;FALSE;FALSE;FALSE;FALSE");
-        defaults.put(FETCHER_CUSTOM_KEY_PERSIST, Boolean.FALSE);
-
-        defaults.put(WARN_ABOUT_DUPLICATES_IN_INSPECTION, Boolean.TRUE);
 
         defaults.put(LAST_USED_EXPORT, "");
 
@@ -881,6 +852,7 @@ public class JabRefCliPreferences implements CliPreferences {
                                                    .withLastUsedDirectory(getDefaultPath())
         );
         getAiPreferences().setAll(AiPreferences.getDefault());
+        getImporterPreferences().setAll(ImporterPreferences.getDefault());
         getAutoLinkPreferences().setAll(
                 AutoLinkPreferences.getDefault()
                                    .withKeywordSeparator(getBibEntryPreferences().keywordSeparatorProperty()));
@@ -917,6 +889,7 @@ public class JabRefCliPreferences implements CliPreferences {
         getFilePreferences().setAll(getFilePreferencesFromBackingStore(getFilePreferences()));
         getBibEntryPreferences().setAll(getBibEntryPreferencesFromBackingStore(getBibEntryPreferences()));
         getAiPreferences().setAll(getAiPreferencesFromBackingStore(getAiPreferences()));
+        getImporterPreferences().setAll(getImporterPreferencesFromBackingStore(getImporterPreferences()));
         getAutoLinkPreferences().setAll(getAutoLinkPreferencesFromBackingStore(getAutoLinkPreferences()));
         getExportPreferences().setAll(getExportPreferencesFromBackingStore(getExportPreferences()));
         getSSLPreferences().setAll(getSSLPreferencesFromBackingStore(getSSLPreferences()));
@@ -2117,52 +2090,53 @@ public class JabRefCliPreferences implements CliPreferences {
         return protectedTermsPreferences;
     }
 
+    // region ImporterPreferences
     @Override
     public ImporterPreferences getImporterPreferences() {
         if (importerPreferences != null) {
             return importerPreferences;
         }
 
-        PlainCitationParserChoice defaultPlainCitationParser;
-        try {
-            defaultPlainCitationParser = PlainCitationParserChoice.valueOf(get(DEFAULT_PLAIN_CITATION_PARSER));
-        } catch (IllegalArgumentException ex) {
-            defaultPlainCitationParser = PlainCitationParserChoice.RULE_BASED_GENERAL;
-        }
+        importerPreferences = getImporterPreferencesFromBackingStore(ImporterPreferences.getDefault());
 
-        importerPreferences = new ImporterPreferences(
-                getBoolean(IMPORTERS_ENABLED),
-                getBoolean(GENERATE_KEY_ON_IMPORT),
-                Path.of(get(IMPORT_WORKING_DIRECTORY)),
-                getBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION),
-                getCustomImportFormats(),
-                getFetcherKeys(),
-                getDefaultFetcherKeys(),
-                getBoolean(FETCHER_CUSTOM_KEY_PERSIST),
-                getStringList(SEARCH_CATALOGS),
-                defaultPlainCitationParser,
-                getInt(CITATIONS_RELATIONS_STORE_TTL),
-                Map.of()
-        );
-
-        EasyBind.listen(importerPreferences.importerEnabledProperty(), (_, _, newValue) -> putBoolean(IMPORTERS_ENABLED, newValue));
-        EasyBind.listen(importerPreferences.generateNewKeyOnImportProperty(), (_, _, newValue) -> putBoolean(GENERATE_KEY_ON_IMPORT, newValue));
-        EasyBind.listen(importerPreferences.importWorkingDirectoryProperty(), (_, _, newValue) -> put(IMPORT_WORKING_DIRECTORY, newValue.toString()));
-        EasyBind.listen(importerPreferences.warnAboutDuplicatesOnImportProperty(), (_, _, newValue) -> putBoolean(WARN_ABOUT_DUPLICATES_IN_INSPECTION, newValue));
+        EasyBind.listen(importerPreferences.importerEnabledProperty(), (_, _, newValue) -> putBoolean(IMPORTER_ENABLED, newValue));
+        EasyBind.listen(importerPreferences.generateNewKeyOnImportProperty(), (_, _, newValue) -> putBoolean(IMPORTER_GENERATE_KEY_ON_IMPORT, newValue));
+        EasyBind.listen(importerPreferences.importWorkingDirectoryProperty(), (_, _, newValue) -> put(IMPORTER_WORKING_DIRECTORY, newValue.toString()));
+        EasyBind.listen(importerPreferences.warnAboutDuplicatesOnImportProperty(), (_, _, newValue) -> putBoolean(IMPORTER_WARN_ABOUT_DUPLICATES, newValue));
         EasyBind.listen(importerPreferences.persistCustomKeysProperty(), (_, _, newValue) -> putBoolean(FETCHER_CUSTOM_KEY_PERSIST, newValue));
-        importerPreferences.getApiKeys().addListener((InvalidationListener) _ -> storeFetcherKeys(importerPreferences.getApiKeys()));
+        importerPreferences.getApiKeys().addListener((InvalidationListener) _ -> storeFetcherKeys(importerPreferences));
         importerPreferences.getCustomImporters().addListener((InvalidationListener) _ -> storeCustomImportFormats(importerPreferences.getCustomImporters()));
-        importerPreferences.getCatalogs().addListener((InvalidationListener) _ -> putStringList(SEARCH_CATALOGS, importerPreferences.getCatalogs()));
-        EasyBind.listen(importerPreferences.defaultPlainCitationParserProperty(), (_, _, newValue) -> put(DEFAULT_PLAIN_CITATION_PARSER, newValue.name()));
-        EasyBind.listen(importerPreferences.citationsRelationsStoreTTLProperty(), (_, _, newValue) -> put(CITATIONS_RELATIONS_STORE_TTL, newValue.toString()));
+        importerPreferences.getCatalogs().addListener((InvalidationListener) _ -> putStringList(IMPORTER_CATALOGS, importerPreferences.getCatalogs()));
+        EasyBind.listen(importerPreferences.defaultPlainCitationParserProperty(), (_, _, newValue) -> put(IMPORTER_DEFAULT_PLAIN_CITATION_PARSER, newValue.name()));
+        EasyBind.listen(importerPreferences.citationsRelationsStoreTTLProperty(), (_, _, newValue) -> put(IMPORTER_CITATIONS_RELATIONS_STORE_TTL, newValue.toString()));
 
         return importerPreferences;
     }
 
-    private Set<CustomImporter> getCustomImportFormats() {
+    private ImporterPreferences getImporterPreferencesFromBackingStore(ImporterPreferences defaults) {
+        return new ImporterPreferences(
+                getBoolean(IMPORTER_ENABLED, defaults.areImporterEnabled()),
+                getBoolean(IMPORTER_GENERATE_KEY_ON_IMPORT, defaults.shouldGenerateNewKeyOnImport()),
+                Path.of(get(IMPORTER_WORKING_DIRECTORY, defaults.getImportWorkingDirectory().toString())),
+                getBoolean(IMPORTER_WARN_ABOUT_DUPLICATES, defaults.shouldWarnAboutDuplicatesOnImport()),
+                getCustomImportFormats(defaults.getCustomImporters()),
+                getFetcherKeys(defaults.getApiKeys()),
+                getBoolean(FETCHER_CUSTOM_KEY_PERSIST, defaults.shouldPersistCustomKeys()),
+                getStringList(IMPORTER_CATALOGS),
+                getDefaultPlainCitationParser(defaults.getDefaultPlainCitationParser()),
+                getInt(IMPORTER_CITATIONS_RELATIONS_STORE_TTL, defaults.getCitationsRelationsStoreTTL()),
+                Map.of()
+        );
+    }
+
+    private Set<CustomImporter> getCustomImportFormats(Set<CustomImporter> defaults) {
+        if (!hasKey(IMPORTER_CUSTOM_FORMAT)) {
+            return defaults;
+        }
+
         Set<CustomImporter> importers = new TreeSet<>();
 
-        for (String toImport : getSeries(CUSTOM_IMPORT_FORMAT)) {
+        for (String toImport : getSeries(IMPORTER_CUSTOM_FORMAT)) {
             List<String> importerString = convertStringToList(toImport);
             try {
                 if (importerString.size() == 2) {
@@ -2181,19 +2155,28 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     private void storeCustomImportFormats(Set<CustomImporter> importers) {
-        purgeSeries(CUSTOM_IMPORT_FORMAT, 0);
+        purgeSeries(IMPORTER_CUSTOM_FORMAT, 0);
         CustomImporter[] importersArray = importers.toArray(new CustomImporter[0]);
         for (int i = 0; i < importersArray.length; i++) {
-            putStringList(CUSTOM_IMPORT_FORMAT + i, importersArray[i].getAsStringList());
+            putStringList(IMPORTER_CUSTOM_FORMAT + i, importersArray[i].getAsStringList());
         }
     }
 
-    private Set<FetcherApiKey> getFetcherKeys() {
+    private Set<FetcherApiKey> getFetcherKeys(Set<FetcherApiKey> defaults) {
+        if (!hasKey(FETCHER_CUSTOM_KEY_NAMES) || !hasKey(FETCHER_CUSTOM_KEY_USES)) {
+            return defaults;
+        }
+
         Set<FetcherApiKey> fetcherApiKeys = new HashSet<>();
 
         List<String> names = getStringList(FETCHER_CUSTOM_KEY_NAMES);
         List<String> uses = getStringList(FETCHER_CUSTOM_KEY_USES);
         List<String> keys = getFetcherKeysFromKeyring(names);
+
+        if (names.size() != uses.size() || names.size() != keys.size()) {
+            LOGGER.warn("Could not load fetcher keys from preferences. Will ignore.");
+            return defaults;
+        }
 
         for (int i = 0; i < names.size(); i++) {
             fetcherApiKeys.add(new FetcherApiKey(
@@ -2228,33 +2211,12 @@ public class JabRefCliPreferences implements CliPreferences {
         return keys;
     }
 
-    private Map<String, String> getDefaultFetcherKeys() {
-        // We do not want to have a dependency on afterburner.fx (because of huge JavaFX dependency tree). Therefore, we do not use following line, but instantiate "BuildInfo" directly.
-        // BuildInfo buildInfo = Injector.instantiateModelOrService(BuildInfo.class);
-        // if (buildInfo == null) {
-        //     LOGGER.warn("Could not instantiate BuildInfo.");
-        //     return Map.of();
-        // }
-        BuildInfo buildInfo = new BuildInfo();
-
-        Map<String, String> keys = new HashMap<>();
-        keys.put(AstrophysicsDataSystem.FETCHER_NAME, buildInfo.astrophysicsDataSystemAPIKey);
-        keys.put(BiodiversityLibrary.FETCHER_NAME, buildInfo.biodiversityHeritageApiKey);
-        keys.put(Scopus.FETCHER_NAME, buildInfo.scopusApiKey);
-        keys.put(SemanticScholarCitationFetcher.FETCHER_NAME, buildInfo.semanticScholarApiKey);
-        // SpringerLink uses the same key and fetcher name as SpringerFetcher
-        keys.put(SpringerNatureWebFetcher.FETCHER_NAME, buildInfo.springerNatureAPIKey);
-        keys.put(WileyFetcher.FETCHER_NAME, buildInfo.wileyTdmApiKey);
-
-        return keys;
-    }
-
-    private void storeFetcherKeys(Set<FetcherApiKey> fetcherApiKeys) {
+    private void storeFetcherKeys(ImporterPreferences defaults) {
         List<String> names = new ArrayList<>();
         List<String> uses = new ArrayList<>();
         List<String> keys = new ArrayList<>();
 
-        for (FetcherApiKey apiKey : fetcherApiKeys) {
+        for (FetcherApiKey apiKey : defaults.getApiKeys()) {
             names.add(apiKey.getName());
             uses.add(String.valueOf(apiKey.shouldUse()));
             keys.add(apiKey.getKey());
@@ -2263,7 +2225,7 @@ public class JabRefCliPreferences implements CliPreferences {
         putStringList(FETCHER_CUSTOM_KEY_NAMES, names);
         putStringList(FETCHER_CUSTOM_KEY_USES, uses);
 
-        if (getBoolean(FETCHER_CUSTOM_KEY_PERSIST)) {
+        if (defaults.shouldPersistCustomKeys()) {
             storeFetcherKeysToKeyring(names, keys);
         } else {
             clearCustomFetcherKeys();
@@ -2305,6 +2267,15 @@ public class JabRefCliPreferences implements CliPreferences {
             LOGGER.error("Unable to open key store");
         }
     }
+
+    private PlainCitationParserChoice getDefaultPlainCitationParser(PlainCitationParserChoice defaultPlainCitationParser) {
+        try {
+            return PlainCitationParserChoice.valueOf(get(IMPORTER_DEFAULT_PLAIN_CITATION_PARSER, defaultPlainCitationParser.name()));
+        } catch (IllegalArgumentException ex) {
+            return defaultPlainCitationParser;
+        }
+    }
+    // endregion
 
     @Override
     public GrobidPreferences getGrobidPreferences() {

--- a/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
+++ b/jablib/src/main/java/org/jabref/logic/preferences/JabRefCliPreferences.java
@@ -2122,7 +2122,7 @@ public class JabRefCliPreferences implements CliPreferences {
                 getCustomImportFormats(defaults.getCustomImporters()),
                 getFetcherKeys(defaults.getApiKeys()),
                 getBoolean(FETCHER_CUSTOM_KEY_PERSIST, defaults.shouldPersistCustomKeys()),
-                getStringList(IMPORTER_CATALOGS),
+                hasKey(IMPORTER_CATALOGS) ? getStringList(IMPORTER_CATALOGS) : defaults.getCatalogs(),
                 getDefaultPlainCitationParser(defaults.getDefaultPlainCitationParser()),
                 getInt(IMPORTER_CITATIONS_RELATIONS_STORE_TTL, defaults.getCitationsRelationsStoreTTL()),
                 Map.of()
@@ -2130,7 +2130,7 @@ public class JabRefCliPreferences implements CliPreferences {
     }
 
     private Set<CustomImporter> getCustomImportFormats(Set<CustomImporter> defaults) {
-        if (!hasKey(IMPORTER_CUSTOM_FORMAT)) {
+        if (!hasKey(IMPORTER_CUSTOM_FORMAT + "0")) {
             return defaults;
         }
 


### PR DESCRIPTION
### Related issues and pull requests

Follow-up to #15874

### PR Description

- Migrated ImporterPreferences to new pattern
- Reordered a static fields

        `jabref-contrib-policy:4.2:reviewed​:ok`

### Steps to test

Run JabRef
Open Preferences
Mess around with preferences
Save
Reopen
Reset
See preferences reset

### AI usage

Claude Code (model claude-sonnet-4-6) and a lot of human intelligence in refactoring and fixing

### Checklist

   <!--
   1. Go through the checklist below.
   2. Keep ALL the items.
   3. Replace the dots inside [.] and mark them as follows: 
      [x] done 
      [ ] TODO (yet to be done)
      [/] not applicable
   -->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] If AI tools were used, I disclosed them in the "AI usage" section and reviewed, understood, and take full ownership of all AI-generated code
- [x] I manually tested my changes in running JabRef (always required)
- [.] I added JUnit tests for changes (if applicable)
- [.] I added screenshots in the PR description (if change is visible to the user)
- [.] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [.] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [.] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)
